### PR TITLE
Initial actions for CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: ESBMC Build CI/CD
+
+on: [push]
+jobs:
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:      
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: sudo apt-get install cmake bison flex gcc-multilib linux-libc-dev libboost-all-dev ninja-build
+    - name: Download Clang 7
+      run: wget http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    - name: Extract Clang 7
+      run: tar xf clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04 clang7
+    - name: Setup boolector
+      run: git clone https://github.com/boolector/boolector && cd boolector && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh && cd build && make -j9
+    - name: Get current folder and files
+      run: pwd && ls
+    - name: Configure CMake
+      run: mkdir build && cd build && cmake .. -GNinja -DLLVM_DIR=../clang7 -DBTOR_DIR=$PWD/../boolector
+    - name: Build ESBMC
+      run: cd build && cmake --build .
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: brew install cmake boost ninja
+      - name: Download Clang 7
+        run: wget http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz
+      - name: Extract Clang 7
+        run: tar xf clang+llvm-7.0.0-x86_64-apple-darwin.tar.xz && mv clang+llvm-7.0.0-x86_64-apple-darwin clang7
+      - name: Setup boolector
+        run: git clone https://github.com/boolector/boolector && cd boolector && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh && cd build && make -j9
+      - name: Get current folder and files
+        run: pwd && ls
+      - name: Configure CMake
+        run: mkdir build && cd build && cmake .. -GNinja -DLLVM_DIR=../clang7 -DBTOR_DIR=$PWD/../boolector -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+      - name: Build ESBMC
+        run: cd build && cmake --build .


### PR DESCRIPTION
This adds the initial support for CI with github actions building ESBMC on ubuntu and macos with boolector.

 This should close #347.