### PR TITLE
Cmake build type options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,9 @@
 # Adds custom modules from ESBMC and default Options
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/src/scripts/cmake/")
 
+# Set a default build type if none was specified
+set(default_build_type "RelWithDebInfo")
+
 include(Options)
 include(SendFileHack)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/src/scripts/cmak
 
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 include(Options)
 include(SendFileHack)


### PR DESCRIPTION
Two changes:

* Set the default option for building ESBMC as RelWithDebInfo (-O2 -g).

* Limit the options for CMAKE_BUILD_TYPE in cmake-gui, you can simply press 'Enter' and it will cycle through Debug, Release, MinSizeRel and RelWithDebInfo.