### PR TITLE
Applied Clang Format

### DIFF
--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -8,11 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:      
     - uses: actions/checkout@v1    
-    - name: Download Clang 7
-      run: wget http://releases.llvm.org/7.0.1/clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-    - name: Extract Clang 7
-      run: tar xf clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04 clang7
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install clang-format
     - name: Run clang-format
-      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs ./clang7/bin/clang-format -style=file -i -fallback-style=none
+      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made
+      continue-on-error: true
       run: git diff --exit-code

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Extract Clang 9
       run: tar xf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang9
     - name: Run clang-format
-      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs ./clang9/bin/clang-format -style=file -i -fallback-style=none
+      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | grep -v src/solvers/z3/z3pp.h | xargs ./clang9/bin/clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made
       run: git diff --exit-code

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -9,7 +9,7 @@ jobs:
     steps:      
     - uses: actions/checkout@v1    
     - name: Install packages
-      run: sudo apt-get update && sudo apt-get install clang-format-9
+      run: sudo apt-get update && sudo apt-get install clang-format-8
     - name: Run clang-format
       run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -13,7 +13,6 @@ jobs:
     - name: Extract Clang 7
       run: tar xf clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-7.0.1-x86_64-linux-gnu-ubuntu-18.04 clang7
     - name: Run clang-format
-      run: ./clang7/bin/clang-format -i -style=file ./src/*/*.h && ./clang7/bin/clang-format -i -style=file ./src/*/*.cpp
+      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs ./clang7/bin/clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made
-      continue-on-error: true
       run: git diff --exit-code

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -8,10 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:      
     - uses: actions/checkout@v1    
-    - name: Install packages
-      run: sudo apt-get update && sudo apt-get install clang-format-8
+    - name: Download Clang 9
+      run: wget http://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+    - name: Extract Clang 9
+      run: tar xf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang9
     - name: Run clang-format
-      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format-8 -style=file -i -fallback-style=none
+      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs ./clang9/bin/clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made
       continue-on-error: true
       run: git diff --exit-code

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install packages
       run: sudo apt-get update && sudo apt-get install clang-format-8
     - name: Run clang-format
-      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format -style=file -i -fallback-style=none
+      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format-8 -style=file -i -fallback-style=none
     - name: Throws error if changes were made
       continue-on-error: true
       run: git diff --exit-code

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -15,5 +15,4 @@ jobs:
     - name: Run clang-format
       run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs ./clang9/bin/clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made
-      continue-on-error: true
       run: git diff --exit-code

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -9,7 +9,7 @@ jobs:
     steps:      
     - uses: actions/checkout@v1    
     - name: Install packages
-      run: sudo apt-get update && sudo apt-get install clang-format
+      run: sudo apt-get update && sudo apt-get install clang-format-9
     - name: Run clang-format
       run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made

--- a/.github/workflows/fast-check.yml
+++ b/.github/workflows/fast-check.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Extract Clang 9
       run: tar xf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang9
     - name: Run clang-format
-      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | grep -v src/solvers/z3/z3pp.h | xargs ./clang9/bin/clang-format -style=file -i -fallback-style=none
+      run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | grep -v src/solvers/z3/z3pp.h | grep -v src/ansi-c/cpp | xargs ./clang9/bin/clang-format -style=file -i -fallback-style=none
     - name: Throws error if changes were made
       run: git diff --exit-code

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -17,7 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/parser.h>
 #include <util/string_hash.h>
 
-typedef enum {
+typedef enum
+{
   ANSI_C_UNKNOWN,
   ANSI_C_SYMBOL,
   ANSI_C_TYPEDEF,

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -21,7 +21,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/i2string.h>
 #include <util/message_stream.h>
 
-extern "C" {
+extern "C"
+{
 #include <cpp/iface.h>
 }
 

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -483,23 +483,23 @@ __ESBMC_HIDE:;
   return 0;
 }
 
-int pthread_key_create(pthread_key_t *key, void (*destructor)(void*))
+int pthread_key_create(pthread_key_t *key, void (*destructor)(void *))
 {
 __ESBMC_HIDE:;
-    // TODO
-    return 0;
+  // TODO
+  return 0;
 }
 
 void *pthread_getspecific(pthread_key_t key)
 {
 __ESBMC_HIDE:;
-    // TODO
-    return NULL;
+  // TODO
+  return NULL;
 }
 
 int pthread_setspecific(pthread_key_t key, const void *value)
 {
 __ESBMC_HIDE:;
-    // TODO
-    return 0;
+  // TODO
+  return 0;
 }

--- a/src/clang-c-frontend/AST/build_ast.h
+++ b/src/clang-c-frontend/AST/build_ast.h
@@ -16,8 +16,9 @@
 #define __STDC_FORMAT_MACROS
 
 // Forward dec, to avoid bringing in clang headers
-namespace clang {
-  class ASTUnit;
+namespace clang
+{
+class ASTUnit;
 } // namespace clang
 
 std::unique_ptr<clang::ASTUnit> buildASTs(

--- a/src/cpp/cpp_id.h
+++ b/src/cpp/cpp_id.h
@@ -25,7 +25,8 @@ class cpp_idt
 public:
   cpp_idt();
 
-  typedef enum {
+  typedef enum
+  {
     UNKNOWN,
     SYMBOL,
     TYPEDEF,

--- a/src/cpp/cpp_typecheck_resolve.h
+++ b/src/cpp/cpp_typecheck_resolve.h
@@ -18,7 +18,12 @@ class cpp_typecheck_resolvet
 public:
   cpp_typecheck_resolvet(class cpp_typecheckt &_cpp_typecheck);
 
-  typedef enum { VAR, TYPE, BOTH } wantt;
+  typedef enum
+  {
+    VAR,
+    TYPE,
+    BOTH
+  } wantt;
 
   exprt resolve(
     const cpp_namet &cpp_name,

--- a/src/cpp/library/definitions.h
+++ b/src/cpp/library/definitions.h
@@ -3,7 +3,7 @@
 
 #include "cstddef"
 
-#define SIGINT  2
+#define SIGINT 2
 
 #define SEEK_SET 0
 #define SEEK_CUR 1
@@ -14,9 +14,9 @@
 #endif
 
 #ifdef _WIN64
-    typedef __int64 streamsize;
+typedef __int64 streamsize;
 #else
-    typedef unsigned int streamsize;
+typedef unsigned int streamsize;
 #endif
 
 unsigned int nondet_uint();
@@ -25,10 +25,12 @@ float nondet_float();
 double nondet_double();
 long double nondet_ldouble();
 bool nondet_bool();
-char* nondet_charPointer();
+char *nondet_charPointer();
 char nondet_char();
 unsigned nondet_unsigned();
-class smanip {};
+class smanip
+{
+};
 
 #define _SIZE_T_DEFINED
 

--- a/src/cpp/library/libstl.cpp
+++ b/src/cpp/library/libstl.cpp
@@ -6,11 +6,8 @@
  * 
 \*******************************************************************/
 
-
 #include <iostream>
-
 
 std::istream cin(0);
 std::ostream cout(0);
 std::ostream cerr(1);
-

--- a/src/cpp/library/string.h
+++ b/src/cpp/library/string.h
@@ -1,1 +1,1 @@
-#include<cstring>
+#include <cstring>

--- a/src/cpp/library/systemc/communication/sc_clock.h
+++ b/src/cpp/library/systemc/communication/sc_clock.h
@@ -3,10 +3,10 @@
 
 class sc_clock
 {
-	public :
-		sc_clock() {}
+public:
+  sc_clock()
+  {
+  }
 };
-
-
 
 #endif

--- a/src/cpp/library/systemc/communication/sc_signal.h
+++ b/src/cpp/library/systemc/communication/sc_signal.h
@@ -6,27 +6,26 @@
 #ifndef SC_SIGNAL
 #define SC_SIGNAL
 
-template<class T>
+template <class T>
 class sc_signal
 {
+public:
+  sc_signal()
+  {
+  } // not implemented
 
-    public :
-    
-    sc_signal () { } // not implemented
-  
-    void write(T arg)
-	{
-		signal = arg;
-	}
+  void write(T arg)
+  {
+    signal = arg;
+  }
 
-	T read()
-	{
-		return signal;
-	}
+  T read()
+  {
+    return signal;
+  }
 
-    private: 
-    	T signal;
-    
+private:
+  T signal;
 };
 
 #endif

--- a/src/cpp/library/systemc/communication/sc_signal_ports.h
+++ b/src/cpp/library/systemc/communication/sc_signal_ports.h
@@ -2,38 +2,39 @@
 #define SC_SIGNAL_PORTS_H
 
 #include "signal.h"
-template<class T> class sc_signal; // pre-declaration of sc_signal
+template <class T>
+class sc_signal; // pre-declaration of sc_signal
 
 #define sc_out sc_inout
 
 template <class T>
 class sc_inout
 {
-	public :
-    sc_inout() {};//not implemented
+public:
+  sc_inout(){}; //not implemented
 
-    void write(T arg)
-	{
-		signal.write( arg );
-	}
+  void write(T arg)
+  {
+    signal.write(arg);
+  }
 
-	T read()
-	{
-		return signal.read();
-	}
+  T read()
+  {
+    return signal.read();
+  }
 
- 	void operator()(sc_signal<T>& flag)
-    {
-		signal.write( flag.read() );
-	}
+  void operator()(sc_signal<T> &flag)
+  {
+    signal.write(flag.read());
+  }
 
-	void operator= ( T flag )
-	{
-		this->signal.write(flag);	
-	}
-	
-	private :
-	sc_signal<T> signal;
+  void operator=(T flag)
+  {
+    this->signal.write(flag);
+  }
+
+private:
+  sc_signal<T> signal;
 };
 
 #endif

--- a/src/cpp/library/systemc/kernel/sc_module.h
+++ b/src/cpp/library/systemc/kernel/sc_module.h
@@ -5,26 +5,28 @@
 #ifndef SC_MODULE_H
 #define SC_MODULE_H
 
-class sc_module {
-   
-    public :
+class sc_module
+{
+public:
+  sc_module()
+  {
+  }
 
-        
-        sc_module() {}
+  sc_module(const char *label)
+  {
+  }
 
-        sc_module( const char * label ) {}
-        
-        ~sc_module() {}  
-        
+  ~sc_module()
+  {
+  }
 };
-
 
 /* MACROS */
 /* The macros below define the base structs of a SystemC program */
 
 #define SC_MODULE(module_name) struct module_name : public sc_module
 
-#define SC_CTOR(module_name) module_name(const char * label)
+#define SC_CTOR(module_name) module_name(const char *label)
 
 /* END MACROS */
 

--- a/src/cpp/library/systemc/kernel/sc_sensitive.h
+++ b/src/cpp/library/systemc/kernel/sc_sensitive.h
@@ -3,25 +3,23 @@
 
 #include "../communication/sc_signal_ports.h"
 
-
-template <class T> class sc_inout; // pre-definition
+template <class T>
+class sc_inout; // pre-definition
 
 class sc_sensitive
 {
+public:
+  void operator<<(sc_inout<T> inout)
+  {
+  }
 
-	public :
-
-		void operator << ( sc_inout<T> inout )
-		{
-	
-		}
-
-	private :
-		sc_sensitive() {}
-		~sc_sensitive() {}
-
-	
-
+private:
+  sc_sensitive()
+  {
+  }
+  ~sc_sensitive()
+  {
+  }
 };
 
 extern sc_sensitive sensitive;

--- a/src/cpp/library/systemc/kernel/sc_wait.h
+++ b/src/cpp/library/systemc/kernel/sc_wait.h
@@ -1,6 +1,8 @@
 #ifndef SC_WAIT_H
 #define SC_WAIT_H
 
-void wait(){ /* nothing has been implemented yet */ }
+void wait()
+{ /* nothing has been implemented yet */
+}
 
 #endif

--- a/src/cpp/library/unistd.h
+++ b/src/cpp/library/unistd.h
@@ -1,6 +1,6 @@
 #ifndef _UNISTD_H
-#define _UNISTD_H 
+#define _UNISTD_H
 
-unsigned int getpid ();
+unsigned int getpid();
 
 #endif

--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -10,6 +10,7 @@ const mode_table_et mode_table[] = {LANGAPI_HAVE_MODE_CLANG_C,
 extern "C" uint8_t buildidstring_buf[1];
 uint8_t *esbmc_version_string = buildidstring_buf;
 
-extern "C" {
-uint64_t esbmc_version = ESBMC_VERSION_CONST;
+extern "C"
+{
+  uint64_t esbmc_version = ESBMC_VERSION_CONST;
 }

--- a/src/goto-programs/format_strings.h
+++ b/src/goto-programs/format_strings.h
@@ -17,7 +17,8 @@ Author: CM Wintersteiger
 class format_tokent
 {
 public:
-  typedef enum {
+  typedef enum
+  {
     UNKNOWN,
     TEXT,
     SIGNED_DEC,   // d, i
@@ -34,7 +35,8 @@ public:
     PERCENT       // %
   } token_typet;
 
-  typedef enum {
+  typedef enum
+  {
     ALTERNATE,
     ZERO_PAD,
     LEFT_ADJUST,
@@ -43,7 +45,14 @@ public:
     ASTERISK
   } flag_typet;
 
-  typedef enum { LEN_h, LEN_l, LEN_L, LEN_j, LEN_t } length_modifierst;
+  typedef enum
+  {
+    LEN_h,
+    LEN_l,
+    LEN_L,
+    LEN_j,
+    LEN_t
+  } length_modifierst;
 
   format_tokent(token_typet _type) : type(_type)
   {

--- a/src/goto-programs/interval_domain.cpp
+++ b/src/goto-programs/interval_domain.cpp
@@ -298,14 +298,12 @@ void interval_domaint::assume_rec(const expr2tc &cond, bool negation)
   else if(is_and2t(cond))
   {
     if(!negation)
-      cond->foreach_operand(
-        [this](const expr2tc &e) { assume_rec(e, false); });
+      cond->foreach_operand([this](const expr2tc &e) { assume_rec(e, false); });
   }
   else if(is_or2t(cond))
   {
     if(negation)
-      cond->foreach_operand(
-        [this](const expr2tc &e) { assume_rec(e, true); });
+      cond->foreach_operand([this](const expr2tc &e) { assume_rec(e, true); });
   }
 }
 

--- a/src/goto-symex/goto_trace.h
+++ b/src/goto-symex/goto_trace.h
@@ -53,7 +53,15 @@ public:
     return type == RENUMBER;
   }
 
-  typedef enum { ASSIGNMENT, ASSUME, ASSERT, OUTPUT, SKIP, RENUMBER } typet;
+  typedef enum
+  {
+    ASSIGNMENT,
+    ASSUME,
+    ASSERT,
+    OUTPUT,
+    SKIP,
+    RENUMBER
+  } typet;
   typet type;
 
   goto_programt::const_targett pc;

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -24,8 +24,9 @@ printf_formattert::make_type(const expr2tc &src, const type2tc &dest)
   return tmp;
 }
 
-void printf_formattert::
-operator()(const std::string &_format, const std::list<expr2tc> &_operands)
+void printf_formattert::operator()(
+  const std::string &_format,
+  const std::list<expr2tc> &_operands)
 {
   format = _format;
   operands = _operands;

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -24,9 +24,8 @@ printf_formattert::make_type(const expr2tc &src, const type2tc &dest)
   return tmp;
 }
 
-void printf_formattert::operator()(
-  const std::string &_format,
-  const std::list<expr2tc> &_operands)
+void printf_formattert::
+operator()(const std::string &_format, const std::list<expr2tc> &_operands)
 {
   format = _format;
   operands = _operands;

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -38,8 +38,8 @@ void goto_symext::symex_catch()
 
     // Fill the map with the catch type and the target
     unsigned i = 0;
-    for(goto_programt::targetst::const_iterator
-          it = instruction.targets.begin();
+    for(goto_programt::targetst::const_iterator it =
+          instruction.targets.begin();
         it != instruction.targets.end();
         it++, i++)
     {

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -193,13 +193,13 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
     identifier.as_string().substr(identifier.as_string().find_last_of('@') + 1);
 
   // Keep this block until the following pthread models are implemented
-  if(identifier.as_string() == "pthread_key_create"  ||
-     identifier.as_string() == "pthread_getspecific" ||
-     identifier.as_string() == "pthread_setspecific")
+  if(
+    identifier.as_string() == "pthread_key_create" ||
+    identifier.as_string() == "pthread_getspecific" ||
+    identifier.as_string() == "pthread_setspecific")
   {
-      std::cerr << "No model for `" + id2string(identifier) +
-                     "' function\n";
-      abort();
+    std::cerr << "No model for `" + id2string(identifier) + "' function\n";
+    abort();
   }
 
   // find code in function map

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -1,7 +1,8 @@
 #include <boolector_conv.h>
 #include <cstring>
 
-extern "C" {
+extern "C"
+{
 #include <btorcore.h>
 }
 

--- a/src/solvers/boolector/boolector_conv.h
+++ b/src/solvers/boolector/boolector_conv.h
@@ -6,7 +6,8 @@
 #include <util/irep2.h>
 #include <util/namespace.h>
 
-extern "C" {
+extern "C"
+{
 #include <boolector.h>
 }
 

--- a/src/solvers/boolector/try_btor.c
+++ b/src/solvers/boolector/try_btor.c
@@ -1,10 +1,10 @@
 #include <build/btorconfig.h>
 #include <src/boolector.h>
 
-int
-main() {
-    Btor *face = boolector_new();
-    (void) face;
-    printf("%s", BTOR_VERSION);
-    return 0;
+int main()
+{
+  Btor *face = boolector_new();
+  (void)face;
+  printf("%s", BTOR_VERSION);
+  return 0;
 }

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -278,9 +278,8 @@ cvc_convt::mk_smt_fpbv_fma(smt_astt v1, smt_astt v2, smt_astt v3, smt_astt rm)
     v1->sort);
 }
 
-smt_astt cvc_convt::mk_smt_typecast_from_fpbv_to_ubv(
-  smt_astt from,
-  std::size_t width)
+smt_astt
+cvc_convt::mk_smt_typecast_from_fpbv_to_ubv(smt_astt from, std::size_t width)
 {
   smt_sortt to = mk_bv_sort(width);
   return new_ast(
@@ -291,9 +290,8 @@ smt_astt cvc_convt::mk_smt_typecast_from_fpbv_to_ubv(
     to);
 }
 
-smt_astt cvc_convt::mk_smt_typecast_from_fpbv_to_sbv(
-  smt_astt from,
-  std::size_t width)
+smt_astt
+cvc_convt::mk_smt_typecast_from_fpbv_to_sbv(smt_astt from, std::size_t width)
 {
   smt_sortt to = mk_bv_sort(width);
   return new_ast(

--- a/src/solvers/cvc4/try_cvc4.cpp
+++ b/src/solvers/cvc4/try_cvc4.cpp
@@ -1,7 +1,8 @@
 #include <cvc4/cvc4.h>
 
-int main() {
-    CVC4::ExprManager em;
-    CVC4::SymbolTable sym_tab;
-    printf("%s", CVC4::Configuration::getVersionString().c_str());
+int main()
+{
+  CVC4::ExprManager em;
+  CVC4::SymbolTable sym_tab;
+  printf("%s", CVC4::Configuration::getVersionString().c_str());
 }

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -171,9 +171,12 @@ ieee_floatt mathsat_convt::get_fpbv(smt_astt a)
   mpz_get_str(buffer, 10, num);
 
   size_t ew, sw;
-  if(msat_is_fp_type(env, to_solver_smt_sort<msat_type>(a->sort)->s, &ew, &sw) != 0)
+  if(
+    msat_is_fp_type(env, to_solver_smt_sort<msat_type>(a->sort)->s, &ew, &sw) !=
+    0)
   {
-    std::cerr << "Non FP type passed to mathsat_convt::get_exp_width" << std::endl;
+    std::cerr << "Non FP type passed to mathsat_convt::get_exp_width"
+              << std::endl;
     abort();
   }
 
@@ -780,9 +783,8 @@ smt_ast *mathsat_convt::mk_array_symbol(
   return mk_smt_symbol(name, s);
 }
 
-smt_ast *mathsat_convt::mk_smt_symbol(
-  const std::string &name,
-  const smt_sort *s)
+smt_ast *
+mathsat_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 {
   // XXX - does 'd' leak?
   msat_decl d = msat_declare_function(

--- a/src/solvers/mathsat/mathsat_conv.h
+++ b/src/solvers/mathsat/mathsat_conv.h
@@ -143,8 +143,8 @@ public:
     uint64_t index,
     const type2tc &subtype) override;
 
-  const smt_ast *convert_array_of(smt_astt init_val, unsigned long domain_width)
-    override;
+  const smt_ast *
+  convert_array_of(smt_astt init_val, unsigned long domain_width) override;
 
   void add_array_constraints_for_solving() override;
   void push_array_ctx() override;

--- a/src/solvers/mathsat/try_msat.c
+++ b/src/solvers/mathsat/try_msat.c
@@ -1,8 +1,9 @@
 #include <mathsat.h>
 
-int main() {
-    const char *msat_version = msat_get_version();
-    printf("%s", msat_version);
-    msat_free(msat_version);
-    return 0;
+int main()
+{
+  const char *msat_version = msat_get_version();
+  printf("%s", msat_version);
+  msat_free(msat_version);
+  return 0;
 }

--- a/src/solvers/minisat/minisat_conv.h
+++ b/src/solvers/minisat/minisat_conv.h
@@ -22,7 +22,12 @@ typedef std::vector<literalt> bvt;
 class minisat_convt : public cnf_iface, public cnf_convt, public bitblast_convt
 {
 public:
-  typedef enum { LEFT, LRIGHT, ARIGHT } shiftt;
+  typedef enum
+  {
+    LEFT,
+    LRIGHT,
+    ARIGHT
+  } shiftt;
 
   minisat_convt(bool int_encoding, const namespacet &_ns, const optionst &opts);
   ~minisat_convt();

--- a/src/solvers/sat/bitblast_conv.h
+++ b/src/solvers/sat/bitblast_conv.h
@@ -46,7 +46,12 @@ public:
 class bitblast_convt : public smt_convt
 {
 public:
-  typedef enum { LEFT, LRIGHT, ARIGHT } shiftt;
+  typedef enum
+  {
+    LEFT,
+    LRIGHT,
+    ARIGHT
+  } shiftt;
 
   bitblast_convt(bool int_encoding, const namespacet &_ns, sat_iface *sat_api);
   ~bitblast_convt();

--- a/src/solvers/smt/tuple/smt_tuple.h
+++ b/src/solvers/smt/tuple/smt_tuple.h
@@ -39,9 +39,8 @@ public:
    *  @param Expression of tuple value to populate this array with.
    *  @param domain_width The size of array to create, in domain bits.
    *  @return An AST representing an array of the tuple value, init_value. */
-  virtual smt_astt tuple_array_of(
-    const expr2tc &init_value,
-    unsigned long domain_width) = 0;
+  virtual smt_astt
+  tuple_array_of(const expr2tc &init_value, unsigned long domain_width) = 0;
 
   /** Convert a symbol to a tuple_smt_ast */
   virtual smt_astt mk_tuple_symbol(const std::string &name, smt_sortt s) = 0;

--- a/src/solvers/yices/try_yices.c
+++ b/src/solvers/yices/try_yices.c
@@ -1,6 +1,7 @@
 #include <yices.h>
 
-int main() {
-    printf("%s", yices_version);
-    return 0;
+int main()
+{
+  printf("%s", yices_version);
+  return 0;
 }

--- a/src/solvers/z3/try_z3.c
+++ b/src/solvers/z3/try_z3.c
@@ -1,7 +1,8 @@
 #include <z3_version.h>
 #include <stdio.h>
 
-int main() {
-    printf(Z3_FULL_VERSION);
-    return 0;
+int main()
+{
+  printf(Z3_FULL_VERSION);
+  return 0;
 }

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1115,9 +1115,8 @@ smt_astt z3_convt::tuple_fresh(const smt_sort *s, std::string name)
   return new_ast(output, s);
 }
 
-const smt_ast *z3_convt::convert_array_of(
-  smt_astt init_val,
-  unsigned long domain_width)
+const smt_ast *
+z3_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 {
   smt_sortt dom_sort = mk_int_bv_sort(domain_width);
 

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -201,11 +201,11 @@ public:
 
   smt_astt mk_tuple_symbol(const std::string &name, smt_sortt s) override;
   smt_astt mk_tuple_array_symbol(const expr2tc &expr) override;
-  smt_astt tuple_array_of(const expr2tc &init, unsigned long domain_width)
-    override;
+  smt_astt
+  tuple_array_of(const expr2tc &init, unsigned long domain_width) override;
 
-  const smt_ast *convert_array_of(smt_astt init_val, unsigned long domain_width)
-    override;
+  const smt_ast *
+  convert_array_of(smt_astt init_val, unsigned long domain_width) override;
 
   void add_array_constraints_for_solving() override;
   void add_tuple_constraints_for_solving() override;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -42,10 +42,16 @@ public:
     // alignment (in structs) measured in bytes
     unsigned alignment;
 
-    typedef enum { NO_ENDIANESS, IS_LITTLE_ENDIAN, IS_BIG_ENDIAN } endianesst;
+    typedef enum
+    {
+      NO_ENDIANESS,
+      IS_LITTLE_ENDIAN,
+      IS_BIG_ENDIAN
+    } endianesst;
     endianesst endianess;
 
-    typedef enum {
+    typedef enum
+    {
       NO_OS,
       OS_I386_LINUX,
       OS_I386_MACOS,
@@ -57,7 +63,11 @@ public:
     std::list<std::string> defines;
     std::list<std::string> include_paths;
 
-    typedef enum { LIB_NONE, LIB_FULL } libt;
+    typedef enum
+    {
+      LIB_NONE,
+      LIB_FULL
+    } libt;
     libt lib;
   } ansi_c;
 

--- a/src/util/crypto_hash.cpp
+++ b/src/util/crypto_hash.cpp
@@ -2,9 +2,9 @@
 #include <boost/algorithm/hex.hpp>
 #include <boost/version.hpp>
 #if BOOST_VERSION >= 106600
-#  include <boost/uuid/detail/sha1.hpp>
+#include <boost/uuid/detail/sha1.hpp>
 #else
-#  include <boost/uuid/sha1.hpp>
+#include <boost/uuid/sha1.hpp>
 #endif
 #include <cstring>
 #include <util/crypto_hash.h>

--- a/src/util/format_spec.h
+++ b/src/util/format_spec.h
@@ -15,7 +15,12 @@ public:
   unsigned min_width;
   unsigned precision;
   bool zero_padding;
-  typedef enum { DECIMAL, SCIENTIFIC, AUTOMATIC } stylet;
+  typedef enum
+  {
+    DECIMAL,
+    SCIENTIFIC,
+    AUTOMATIC
+  } stylet;
   stylet style;
 
   format_spect()

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -81,7 +81,8 @@ bool operator!=(const ieee_float_spect &a, const ieee_float_spect &b);
 class ieee_floatt
 {
 public:
-  typedef enum {
+  typedef enum
+  {
     ROUND_TO_EVEN = 0,
     ROUND_TO_AWAY = 1,
     ROUND_TO_PLUS_INF = 2,

--- a/src/util/irep2_utils.h
+++ b/src/util/irep2_utils.h
@@ -125,13 +125,15 @@ inline bool is_true(const expr2tc &expr)
   if(is_constant_bool2t(expr) && to_constant_bool2t(expr).value)
     return true;
 
-  if (is_constant_int2t(expr) && !to_constant_int2t(expr).value.is_zero())
+  if(is_constant_int2t(expr) && !to_constant_int2t(expr).value.is_zero())
     return true;
 
-  if (is_constant_floatbv2t(expr) && !to_constant_floatbv2t(expr).value.is_zero())
+  if(
+    is_constant_floatbv2t(expr) && !to_constant_floatbv2t(expr).value.is_zero())
     return true;
 
-  if (is_constant_fixedbv2t(expr) && !to_constant_fixedbv2t(expr).value.is_zero())
+  if(
+    is_constant_fixedbv2t(expr) && !to_constant_fixedbv2t(expr).value.is_zero())
     return true;
 
   return false;
@@ -148,13 +150,13 @@ inline bool is_false(const expr2tc &expr)
   if(is_constant_bool2t(expr) && !to_constant_bool2t(expr).value)
     return true;
 
-  if (is_constant_int2t(expr) && to_constant_int2t(expr).value.is_zero())
+  if(is_constant_int2t(expr) && to_constant_int2t(expr).value.is_zero())
     return true;
 
-  if (is_constant_floatbv2t(expr) && to_constant_floatbv2t(expr).value.is_zero())
+  if(is_constant_floatbv2t(expr) && to_constant_floatbv2t(expr).value.is_zero())
     return true;
 
-  if (is_constant_fixedbv2t(expr) && to_constant_fixedbv2t(expr).value.is_zero())
+  if(is_constant_fixedbv2t(expr) && to_constant_fixedbv2t(expr).value.is_zero())
     return true;
 
   return false;

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2725,7 +2725,7 @@ bool simplify_exprt::simplify_node(exprt &expr)
 
 bool simplify_exprt::simplify_rec(exprt &expr)
 {
-// look up in cache
+  // look up in cache
 
 #ifdef USE_CACHE
   std::pair<simplify_expr_cachet::containert::iterator, bool> cache_result =

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -72,10 +72,10 @@ unsigned string_containert::get(const std::string &s)
   return r;
 }
 
-  // To avoid the static initialization order fiasco, it's important to have all
-  // the globals that interact with the string pool initialized in the same
-  // translation unit. This ensures that the string_container object is
-  // initialized before all of the attribute-name globals are. Somewhat miserable.
+// To avoid the static initialization order fiasco, it's important to have all
+// the globals that interact with the string pool initialized in the same
+// translation unit. This ensures that the string_container object is
+// initialized before all of the attribute-name globals are. Somewhat miserable.
 
 #include <expr.cpp>
 #include <irep.cpp>

--- a/src/util/threeval.h
+++ b/src/util/threeval.h
@@ -18,7 +18,12 @@ Author: Daniel Kroening, kroening@kroening.com
 class tvt
 {
 public:
-  typedef enum { TV_FALSE, TV_UNKNOWN, TV_TRUE } tv_enumt;
+  typedef enum
+  {
+    TV_FALSE,
+    TV_UNKNOWN,
+    TV_TRUE
+  } tv_enumt;
 
   bool is_true() const
   {

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -15,7 +15,13 @@ Author: Daniel Kroening, kroening@kroening.com
 class ui_message_handlert : public message_handlert
 {
 public:
-  typedef enum { PLAIN, OLD_GUI, XML_UI, GRAPHML } uit;
+  typedef enum
+  {
+    PLAIN,
+    OLD_GUI,
+    XML_UI,
+    GRAPHML
+  } uit;
 
   ui_message_handlert(uit __ui) : _ui(__ui)
   {


### PR DESCRIPTION
This will fix CS errors and activate the CI. Since different versions of `clang-format` gave different results I am using clang-format-9 in the CI.

- Executed `find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | xargs clang-format -style=file -i -fallback-style=none`.
- Removed continue-on-error from CI