### PR TITLE
Rework the out-of-scope support

### DIFF
--- a/regression/floats/Float22/test.desc
+++ b/regression/floats/Float22/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --floatbv
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1524,8 +1524,8 @@ void goto_convertt::convert_return(
     }
   }
 
-  // Need to process _entire_ destructor stack.
-  unwind_destructor_stack(code.location(), 0, dest);
+  goto_programt dummy;
+  unwind_destructor_stack(code.location(), 0, dummy);
 
   if(targets.has_return_value)
   {

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -97,10 +97,9 @@ bool symex_dereference_statet::is_live_variable(const expr2tc &symbol)
   // records for the lexical variable that have this activation record.
   for(auto it = state.call_stack.rbegin(); it != state.call_stack.rend(); it++)
   {
-    auto &local_vars = it->local_variables;
-    if(
-      local_vars.find(renaming::level2t::name_record(to_symbol2t(sym))) !=
-      local_vars.end())
+    auto const &name = renaming::level2t::name_record(to_symbol2t(sym));
+    auto const &local_vars = it->local_variables;
+    if(local_vars.find(name) != local_vars.end())
       return true;
   }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -90,12 +90,11 @@ bool symex_dereference_statet::is_live_variable(const expr2tc &symbol)
 
   // Level one names represent the storage for a variable, and this symbol
   // may have entered pointer tracking at any time the variable had its address
-  // taken (and subsequently been propagated from there). If the stack frame
-  // that that variable was in has now expired, it's an invalid pointer. Look
-  // up the stack frames currently active the corresponding thread to see
-  // whether there are any records for the lexical variable that have this
-  // activation record.
-
+  // taken (and subsequently been propagated from there, e.g., a variable passed
+  // as reference to a function). If the stack frame that the variable was in
+  //  has now expired, it's an invalid pointer. Look up the stack frames
+  // currently active the corresponding thread to see whether there are any
+  // records for the lexical variable that have this activation record.
   for(auto it = state.call_stack.rbegin(); it != state.call_stack.rend(); it++)
   {
     auto &local_vars = it->local_variables;

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -529,6 +529,19 @@ void goto_symext::pop_frame()
   // clear locals from L2 renaming
   for(auto const &it : frame.local_variables)
   {
+    type2tc ptr(new pointer_type2t(pointer_type2()));
+    symbol2tc l1_sym(ptr, it.base_name);
+    frame.level1.get_ident_name(l1_sym);
+
+    // Call free on alloca'd objects
+    if(
+      it.base_name.as_string().find("return_value$_alloca") !=
+      std::string::npos)
+      symex_free(code_free2tc(l1_sym));
+
+    // Erase from level 1 propagation
+    cur_state->value_set.erase(l1_sym->get_symbol_name());
+
     cur_state->level2.remove(it);
 
     // Construct an l1 name on the fly - this is a temporary hack for when


### PR DESCRIPTION
Re-implementation of support for dead instructions.

The first major change is the removal of dead instructions before returns: it was causing unions objects returned to a caller to always be flagged as dead (because unions objects are converted to arrays).

The second change is the destruction of all local variables when popping a frame. The code is similar to what we already with dead instructions.

Dead instructions were not removed because we need them to flag when a variable goes out of scope, e.g., in a nested scope inside a function.

I **think** this should fix issue #119, but I have no way of testing it.