### PR TITLE
Improved modulus handling

### DIFF
--- a/regression/esbmc/github_28/main.c
+++ b/regression/esbmc/github_28/main.c
@@ -1,0 +1,13 @@
+long a;
+
+struct b {
+   long c;
+   char bytes[];
+};
+
+int main() {
+   __ESBMC_assume(a < ((18446744073709551615UL) - 1 - sizeof(struct b)));
+   struct b *d = malloc(sizeof(struct b) + a + 1);
+   d->bytes[a] = '\0';
+   assert(d->bytes[a] == 0);
+}

--- a/regression/esbmc/github_28/test.desc
+++ b/regression/esbmc/github_28/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1550,6 +1550,7 @@ void dereferencet::construct_struct_ref_from_dyn_offs_rec(
       mul2tc(sub_size->type, arr_type.array_size, sub_size);
     expr2tc lt = lessthan2tc(offs, arr_size_in_bytes);
     expr2tc range_guard = and2tc(accuml_guard, and2tc(gte, lt));
+    simplify(range_guard);
 
     construct_struct_ref_from_dyn_offs_rec(
       index, new_offset, type, range_guard, mode, output);

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -965,11 +965,11 @@ void dereferencet::construct_from_array(
     return;
   }
 
-  constant_int2tc subtype_sz_expr(pointer_type2(), BigInt(subtype_size));
+  constant_int2tc subtype_sz_expr(offset->type, BigInt(subtype_size));
   div2tc div(pointer_type2(), offset, subtype_sz_expr);
   simplify(div);
 
-  modulus2tc mod(pointer_type2(), offset, subtype_sz_expr);
+  modulus2tc mod(offset->type, offset, subtype_sz_expr);
   simplify(mod);
 
   if(is_structure_type(arr_subtype))

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -545,7 +545,7 @@ expr2tc modulus2t::do_simplify() const
   expr2tc simplied_side_1 = try_simplification(side_1);
   expr2tc simplied_side_2 = try_simplification(side_2);
 
-  if(!is_constant_expr(simplied_side_1) || !is_constant_expr(simplied_side_2))
+  if(!is_constant_expr(simplied_side_1) && !is_constant_expr(simplied_side_2))
   {
     // Were we able to simplify the sides?
     if((side_1 != simplied_side_1) || (side_2 != simplied_side_2))


### PR DESCRIPTION
We were creating a modulus operation where side1's and side2's type were different, crashing the backend.

Fixed the wrong type and a wrong simplification code. 

This PR fixes issue #28.