### PR TITLE
Changes for release 6.3

### DIFF
--- a/scripts/release-notes.txt
+++ b/scripts/release-notes.txt
@@ -1,5 +1,15 @@
 Release Notes of the ESBMC model checker
 
+*** Version 6.3
+* Stack property support
+* ESBMC now supports Microsoft extensions
+* -f an -W flags are forwarded into clang
+* Float models refactoring, which enabled macOS CI.
+* Fixed issue that caused a deref violation in VLAs.
+* Union bitfields no longer throws a segfault.
+* Unary sideeffects are handled properly.
+* CVC4 enconding for FPs is fixed.
+
 *** Version 6.2
 * Cmake is now the default build system
 * ESBMC now defaults to 64 bits mode

--- a/scripts/release-notes.txt
+++ b/scripts/release-notes.txt
@@ -1,7 +1,7 @@
 Release Notes of the ESBMC model checker
 
 *** Version 6.3
-* Stack property support
+* Stack property verification support
 * ESBMC now supports Microsoft extensions
 * -f an -W flags are forwarded into clang
 * Float models refactoring, which enabled macOS CI.


### PR DESCRIPTION
On release page:

Summary:
This release adds preliminary support to track the stack size during the execution of the C programs. In particular, this property checks whether for a given program there exists an execution path that exceeds a maximum limit for the stack.

Changes:
- Stack property support
- ESBMC now supports Microsoft extensions
- -f an -W flags are forwarded into clang
- Float models refactoring, which enabled macOS CI.

Fixes:
- Fixed issue that caused a deref violation in VLAs.
- Union bitfields no longer throws a segfault.
- Unary sideeffects are handled properly.
- CVC4 enconding for FPs is fixed.