### PR TITLE
added test case to check for global array of pointers

### DIFF
--- a/regression/esbmc/github_154/main.c
+++ b/regression/esbmc/github_154/main.c
@@ -1,27 +1,33 @@
 #include <stdlib.h>
 #include <assert.h>
 
-typedef struct pthread_id_value {
+typedef struct pthread_id_value
+{
   int id;
   void *value;
 } pthread_id_valuet;
 
-pthread_id_valuet* __ESBMC_thread_keys[];
+/* This is an array with one element. */
+pthread_id_valuet *__ESBMC_thread_keys[];
 
 int main()
 {
-  pthread_id_valuet* id_val = (pthread_id_valuet *) malloc(sizeof(pthread_id_valuet));
-  __ESBMC_thread_keys[0] = (pthread_id_valuet *) malloc(sizeof(pthread_id_valuet));
-  
+  pthread_id_valuet *id_val =
+    (pthread_id_valuet *)malloc(sizeof(pthread_id_valuet));
+  __ESBMC_thread_keys[0] =
+    (pthread_id_valuet *)malloc(sizeof(pthread_id_valuet));
+
   id_val->id = 10;
   id_val->value = (void *)20;
   __ESBMC_thread_keys[0][0] = *id_val;
 
-  __ESBMC_thread_keys[1] = (pthread_id_valuet *) malloc(sizeof(pthread_id_valuet));
+  /* array bounds violated: array `__ESBMC_thread_keys' upper bound */
+  __ESBMC_thread_keys[1] =
+    (pthread_id_valuet *)malloc(sizeof(pthread_id_valuet));
   id_val->id = 40;
   id_val->value = (void *)50;
   __ESBMC_thread_keys[1][0] = *id_val;
-  
+
   pthread_id_valuet *tmp = &__ESBMC_thread_keys[0][0];
   assert(tmp->id == 10);
   assert(tmp->value == (void *)20);

--- a/regression/esbmc/github_154/main.c
+++ b/regression/esbmc/github_154/main.c
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+#include <assert.h>
+
+typedef struct pthread_id_value {
+  int id;
+  void *value;
+} pthread_id_valuet;
+
+pthread_id_valuet* __ESBMC_thread_keys[];
+
+int main()
+{
+  pthread_id_valuet* id_val = (pthread_id_valuet *) malloc(sizeof(pthread_id_valuet));
+  __ESBMC_thread_keys[0] = (pthread_id_valuet *) malloc(sizeof(pthread_id_valuet));
+  
+  id_val->id = 10;
+  id_val->value = (void *)20;
+  __ESBMC_thread_keys[0][0] = *id_val;
+
+  __ESBMC_thread_keys[1] = (pthread_id_valuet *) malloc(sizeof(pthread_id_valuet));
+  id_val->id = 40;
+  id_val->value = (void *)50;
+  __ESBMC_thread_keys[1][0] = *id_val;
+  
+  pthread_id_valuet *tmp = &__ESBMC_thread_keys[0][0];
+  assert(tmp->id == 10);
+  assert(tmp->value == (void *)20);
+
+  tmp = &__ESBMC_thread_keys[1][0];
+  assert(tmp->id == 40);
+  assert(tmp->value == (void *)50);
+
+  return 0;
+}

--- a/regression/esbmc/github_154/test.desc
+++ b/regression/esbmc/github_154/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_154/test.desc
+++ b/regression/esbmc/github_154/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
-
+--force-malloc-success
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_154_success/main.c
+++ b/regression/esbmc/github_154_success/main.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+#include <assert.h>
+
+typedef struct pthread_id_value
+{
+  int id;
+  void *value;
+} pthread_id_valuet;
+
+pthread_id_valuet *__ESBMC_thread_keys[4];
+
+int main()
+{
+  pthread_id_valuet *id_val =
+    (pthread_id_valuet *)malloc(sizeof(pthread_id_valuet));
+  __ESBMC_thread_keys[0] =
+    (pthread_id_valuet *)malloc(sizeof(pthread_id_valuet));
+
+  id_val->id = 10;
+  id_val->value = (void *)20;
+  __ESBMC_thread_keys[0][0] = *id_val;
+
+  __ESBMC_thread_keys[1] =
+    (pthread_id_valuet *)malloc(sizeof(pthread_id_valuet));
+  id_val->id = 40;
+  id_val->value = (void *)50;
+  __ESBMC_thread_keys[1][0] = *id_val;
+
+  pthread_id_valuet *tmp = &__ESBMC_thread_keys[0][0];
+  assert(tmp->id == 10);
+  assert(tmp->value == (void *)20);
+
+  tmp = &__ESBMC_thread_keys[1][0];
+  assert(tmp->id == 40);
+  assert(tmp->value == (void *)50);
+
+  return 0;
+}

--- a/regression/esbmc/github_154_success/test.desc
+++ b/regression/esbmc/github_154_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The current version of ESBMC available in the master f782770c92126f2800b857aca540412fc191e265 fixes this issue https://github.com/esbmc/esbmc/issues/154. I have added the program of this issue as a test case in our regression.