### PR TITLE
Trigger benchexec from GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ spec:
           def built = build job: "Benchexec sv-benchmarks/high-res", parameters: [
             string(name: 'tool_url', value: "https://ssvlab.ddns.net/job/esbmc-master/job/${env.BRANCH_NAME}/$BUILD_NUMBER/artifact/esbmc.zip"),
             string(name: 'benchmark_url', value: "https://raw.githubusercontent.com/esbmc/esbmc/${env.BRANCH_NAME}/scripts/jenkins/benchmark.xml"),
-            string(name: 'prepare_environment_url', value: "https://raw.githubusercontent.com/rafaelsamenezes/esbmc/${env.BRANCH_NAME}/scripts/jenkins/prepare_environment.sh"),
+            string(name: 'prepare_environment_url', value: "https://raw.githubusercontent.com/esbmc/esbmc/${env.BRANCH_NAME}/scripts/jenkins/prepare_environment.sh"),
             string(name: 'timeout', value: "900"),
             string(name: 'category', value: userInput)
           ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,12 +37,10 @@ spec:
       }
       steps {
         script {
-          timeout(time: 5, unit: "MINUTES") { // Wait for user input for 5min
           def userInput = input(
             id: 'userInput', message: 'Type the category from benchmark file', parameters: [
               [$class: 'TextParameterDefinition', defaultValue: 'ConcurrencySafety-Main',  name: 'category']
             ])
-          }
 
           def built = build job: "Benchexec sv-benchmarks/high-res", parameters: [
             string(name: 'tool_url', value: "https://ssvlab.ddns.net/job/esbmc-master/job/${env.BRANCH_NAME}/$BUILD_NUMBER/artifact/esbmc.zip"),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,60 @@
+pipeline {
+  agent {
+    kubernetes {
+      yaml '''
+apiVersion: "v1"
+kind: "Pod"
+spec:
+  containers:
+    - name: "jnlp"
+      image: "rafaelsamenezes/esbmc-build:latest"
+      imagePullPolicy: "Always"
+'''
+    }
+
+  }
+  stages {
+    stage('Build ESBMC') {
+      when {
+        expression {
+          env.BRANCH_NAME.contains("benchexec")
+        }
+
+      }
+      steps {
+        sh 'mkdir build && cd build && cmake .. -GNinja -DClang_DIR=$CLANG_HOME -DLLVM_DIR=$CLANG_HOME -DBUILD_STATIC=On -DBoolector_DIR=$HOME/boolector-3.2.0 -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release'
+        sh 'cd build && cmake --build . && cpack && mv ESBMC-*.sh ESBMC-Linux.sh'
+        zip(zipFile: 'esbmc.zip', archive: true, glob: 'build/ESBMC-Linux.sh')
+      }
+    }
+
+    stage('Run Benchexec') {
+      when {
+        expression {
+          env.BRANCH_NAME.contains("benchexec")
+        }
+
+      }
+      steps {
+        script {
+          timeout(time: 5, unit: "MINUTES") { // Wait for user input for 5min
+          def userInput = input(
+            id: 'userInput', message: 'Type the category from benchmark file', parameters: [
+              [$class: 'TextParameterDefinition', defaultValue: 'ConcurrencySafety-Main',  name: 'category']
+            ])
+          }
+
+          def built = build job: "Benchexec sv-benchmarks/high-res", parameters: [
+            string(name: 'tool_url', value: "https://ssvlab.ddns.net/job/esbmc-master/job/${env.BRANCH_NAME}/$BUILD_NUMBER/artifact/esbmc.zip"),
+            string(name: 'benchmark_url', value: "https://raw.githubusercontent.com/esbmc/esbmc/${env.BRANCH_NAME}/scripts/jenkins/benchmark.xml"),
+            string(name: 'prepare_environment_url', value: "https://raw.githubusercontent.com/rafaelsamenezes/esbmc/${env.BRANCH_NAME}/scripts/jenkins/prepare_environment.sh"),
+            string(name: 'timeout', value: "900"),
+            string(name: 'category', value: userInput)
+          ]
+        }
+
+      }
+    }
+
+  }
+}

--- a/scripts/jenkins/Dockerfile
+++ b/scripts/jenkins/Dockerfile
@@ -1,0 +1,66 @@
+###################################
+# NOTES
+###################################
+
+# This docker environment will be used as a base to build ESBMC in static mode.
+# It currently works by providing an ubuntu 18.04 environment with the following tools:
+
+# - Clang 9
+# - Boolector
+
+###################################
+# START
+###################################
+FROM jenkins/jnlp-slave
+
+###################################
+# ROOT
+###################################
+USER root
+# Core Packages
+RUN apt-get update && apt-get install --no-install-recommends  -y  \
+    git \
+    build-essential \
+    wget \
+    bison \
+    flex \
+    unzip \
+    gcc-multilib \
+    linux-libc-dev \
+    libzip-dev \
+    libtinfo-dev \
+    libxml2-dev \
+    libboost-all-dev \
+    automake \
+    pkg-config \
+    libtool \
+# CMake Packages
+    cmake ninja-build \
+    gperf libgmp-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* 
+
+
+# Download Clang 9
+WORKDIR /usr/local/opt
+RUN  wget http://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && tar xf clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && mv clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04 clang9 && rm clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
+ENV CLANG_HOME=/usr/local/opt/clang9
+
+###################################
+# jenkins user
+###################################
+USER jenkins
+
+##################################
+# Building Boolector
+##################################
+WORKDIR /home/jenkins
+RUN git clone https://github.com/boolector/boolector && cd boolector && git reset --hard 3.2.0 && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh --prefix $HOME/boolector-3.2.0 && cd build && make -s -j4 && make install
+
+##################################
+# ENV Vars
+##################################
+ENV BTOR_DIR=/home/jenkins/boolector
+
+# Execute jenkins-slave
+ENTRYPOINT ["/usr/local/bin/jenkins-slave"]

--- a/scripts/jenkins/benchmark.xml
+++ b/scripts/jenkins/benchmark.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<benchmark tool="esbmc" timelimit="900 s" memlimit="15 GB" cpuCores="8">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
+
+  <resultfiles>**.graphml</resultfiles>
+  
+  <option name="-s">incr</option>
+  
+
+<rundefinition name="sv-comp19_prop-reachsafety">
+  <tasks name="ReachSafety-Arrays">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-BitVectors">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ControlFlow">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ECA">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Floats">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Heap">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Loops">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ProductLines">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Sequentialized">
+    <includesfile>/data/sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+
+  <tasks name="ConcurrencySafety-Main">
+    <includesfile>/data/sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  
+  <tasks name="SoftwareSystems-AWS-C-Common-ReachSafety">
+    <includesfile>/data/sv-benchmarks/c/SoftwareSystems-AWS-C-Common-ReachSafety.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+
+  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
+    <includesfile>/data/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="sv-comp19_prop-memsafety">
+  <tasks name="MemSafety-Arrays">
+    <includesfile>/data/sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Heap">
+    <includesfile>/data/sv-benchmarks/c/MemSafety-Heap.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-LinkedLists">
+    <includesfile>/data/sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Other">
+    <includesfile>/data/sv-benchmarks/c/MemSafety-Other.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-TerminCrafted">
+    <includesfile>/data/sv-benchmarks/c/MemSafety-TerminCrafted.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+  <tasks name="MemSafety-MemCleanup">
+    <includesfile>/data/sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-MemSafety">
+    <includesfile>/data/sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+  
+  <tasks name="SoftwareSystems-OpenBSD-MemSafety">
+    <includesfile>/data/sv-benchmarks/c/SoftwareSystems-OpenBSD-MemSafety.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+  <tasks name="SoftwareSystems-SQLite-MemSafety">
+    <includesfile>/data/sv-benchmarks/c/SoftwareSystems-SQLite-MemSafety.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="sv-comp19_prop-nooverflow">
+  <tasks name="NoOverflows-BitVectors">
+    <includesfile>/data/sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+  <tasks name="NoOverflows-Other">
+    <includesfile>/data/sv-benchmarks/c/NoOverflows-Other.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-NoOverflows">
+    <includesfile>/data/sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="sv-comp19_prop-termination">
+  <tasks name="Termination-MainControlFlow">
+    <includesfile>/data/sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+  <tasks name="Termination-MainHeap">
+    <includesfile>/data/sv-benchmarks/c/Termination-MainHeap.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    <option name="--arch">64</option>
+  </tasks>
+  <tasks name="Termination-Other">
+    <includesfile>/data/sv-benchmarks/c/Termination-Other.set</includesfile>
+    <propertyfile>/data/sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+</benchmark>

--- a/scripts/jenkins/prepare_environment.sh
+++ b/scripts/jenkins/prepare_environment.sh
@@ -1,0 +1,1 @@
+wget https://raw.githubusercontent.com/esbmc/esbmc/master/scripts/competitions/svcomp/esbmc-wrapper.py ; chmod +x esbmc-wrapper.py ; unzip esbmc.zip ; mv ./build/ESBMC-Linux.sh . ; chmod +x ESBMC-Linux.sh ; ./ESBMC-Linux.sh --skip-license ; mv bin/esbmc . ; chmod +x esbmc


### PR DESCRIPTION
In summary, this PR will:

- Enable Jenkins CI running in Manchester.
- Trigger on PRs from branches that contain "benchexec"
- Jenkins will build esbmc in static mode with Clang9 and Boolector 2.3.0
- The user can select which category to run from the benchmark inside the branch `script/jenkins/benchmark.xml`
- The benchexec environment can be further customized by changing the `script/jenkins/prepare_environment.sh`

Some caveats:

- ~In order to prevent issues, the user will have 5min AFTER the build is done (which takes 3min) to select which category to run. This will probably be changed in future to be used before the build.~ Timeout is not working with input.
- Currently, there is no simple way to change the wrapper besides creating a pastebin or something similar.