### PR TITLE
Avoid undefined behaviour in calloc

### DIFF
--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -29,7 +29,8 @@ __ESBMC_HIDE:;
 
   size_t total_size = nmemb * size;
   void *res = malloc(total_size);
-  memset(res, 0, total_size);
+  if(res)
+    memset(res, 0, total_size);
   return res;
 }
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

`calloc` should not call `memset` with a NULL pointer.