### PR TITLE
Use HINTS for solver searches

### DIFF
--- a/src/solvers/boolector/CMakeLists.txt
+++ b/src/solvers/boolector/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 if(ENABLE_BOOLECTOR)
     find_package(Boolector REQUIRED
-            PATHS ${Boolector_DIR}/lib/cmake $ENV{HOME}/boolector)
+            HINTS ${Boolector_DIR}/lib/cmake $ENV{HOME}/boolector)
 
     message(STATUS "Found Boolector at: ${Boolector_DIR}")
     message(STATUS "Boolector version: ${Boolector_VERSION}")

--- a/src/solvers/cvc4/CMakeLists.txt
+++ b/src/solvers/cvc4/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 if(ENABLE_CVC4)
     find_package(CVC4 REQUIRED
-            PATHS ${CVC4_DIR}/lib/cmake/CVC4 $ENV{HOME}/cvc4)
+            HINTS ${CVC4_DIR}/lib/cmake/CVC4 $ENV{HOME}/cvc4)
 
     message(STATUS "Found CVC4 at: ${CVC4_DIR}")
     message(STATUS "CVC4 version: ${CVC4_VERSION}")

--- a/src/solvers/mathsat/CMakeLists.txt
+++ b/src/solvers/mathsat/CMakeLists.txt
@@ -9,8 +9,8 @@ if(EXISTS $ENV{HOME}/mathsat)
 endif()
 
 if(ENABLE_MATHSAT)
-    find_library(Mathsat_LIB mathsat PATHS "${Mathsat_DIR}" $ENV{HOME}/mathsat PATH_SUFFIXES lib)
-    find_path(Mathsat_INCLUDE_DIRS mathsat.h PATHS ${Mathsat_DIR} $ENV{HOME}/mathsat PATH_SUFFIXES include)
+    find_library(Mathsat_LIB mathsat HINTS "${Mathsat_DIR}" $ENV{HOME}/mathsat PATH_SUFFIXES lib)
+    find_path(Mathsat_INCLUDE_DIRS mathsat.h HINTS ${Mathsat_DIR} $ENV{HOME}/mathsat PATH_SUFFIXES include)
 
     if(Mathsat_INCLUDE_DIRS STREQUAL "Mathsat_INCLUDE_DIRS-NOTFOUND")
         message(FATAL_ERROR "Could not find mathsat include headers, please check Mathsat_DIR")

--- a/src/solvers/yices/CMakeLists.txt
+++ b/src/solvers/yices/CMakeLists.txt
@@ -9,8 +9,8 @@ if(EXISTS $ENV{HOME}/yices)
 endif()
 
 if(ENABLE_YICES)
-    find_path(Yices_INCLUDE_DIRS yices.h PATHS "${Yices_DIR}" $ENV{HOME}/yices PATH_SUFFIXES include)
-    find_library(Yices_LIB yices NAMES yices PATHS "${Yices_DIR}" $ENV{HOME}/yices PATH_SUFFIXES lib)
+    find_path(Yices_INCLUDE_DIRS yices.h HINTS "${Yices_DIR}" $ENV{HOME}/yices PATH_SUFFIXES include)
+    find_library(Yices_LIB yices NAMES yices HINTS "${Yices_DIR}" $ENV{HOME}/yices PATH_SUFFIXES lib)
 
     if(Yices_INCLUDE_DIRS STREQUAL "Yices_INCLUDE_DIRS-NOTFOUND")
         message(FATAL_ERROR "Could not find yices headers, please check Yices_DIR")
@@ -50,7 +50,7 @@ if(ENABLE_YICES)
 
     # Hack needed for Ubuntu, since it is not linking with static libs from system
     if(DEFINED GMP_DIR)
-        find_library(LIBGMP_CUSTOM gmp NAMES libgmp.a PATHS ${GMP_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
+        find_library(LIBGMP_CUSTOM gmp NAMES libgmp.a HINTS ${GMP_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
         message(STATUS "Custom gmp found: ${LIBGMP_CUSTOM}")
         target_link_libraries(solveryices "${Yices_LIB}" "${LIBGMP_CUSTOM}")
     else ()

--- a/src/solvers/z3/CMakeLists.txt
+++ b/src/solvers/z3/CMakeLists.txt
@@ -10,8 +10,8 @@ endif()
 
 
 if(ENABLE_Z3)
-    find_library(Z3_LIB z3 PATHS ${Z3_DIR} $ENV{HOME}/z3 PATH_SUFFIXES lib bin)
-    find_path(Z3_INCLUDE_DIRS z3.h PATHS ${Z3_DIR} $ENV{HOME}/z3 PATH_SUFFIXES include)
+    find_library(Z3_LIB z3 HINTS ${Z3_DIR} $ENV{HOME}/z3 PATH_SUFFIXES lib bin)
+    find_path(Z3_INCLUDE_DIRS z3.h HINTS ${Z3_DIR} $ENV{HOME}/z3 PATH_SUFFIXES include)
 
     if(Z3_INCLUDE_DIRS STREQUAL "Z3_INCLUDE_DIRS-NOTFOUND")
         message(FATAL_ERROR "Could not find z3 include headers, please check Z3_DIR")


### PR DESCRIPTION
HINTS take precedence over system paths and PATHS don't.
If users specify a path on the cmake command line to a solver, we
should use that solver independently of the solvers installed on the
system.