### PR TITLE
Removed compiler-specific code

### DIFF
--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -90,7 +90,7 @@ protected:
       return pos < array.operands().size();
     }
 
-    init_statet &operator++(int x __attribute__((unused)))
+    init_statet &operator++(int x [[gnu::unused]])
     {
       pos++;
       return *this;

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -88,7 +88,7 @@ void c_typecheck_baset::typecheck_code(codet &code)
   }
 }
 
-void c_typecheck_baset::typecheck_asm(codet &code __attribute__((unused)))
+void c_typecheck_baset::typecheck_asm(codet &code [[gnu::unused]])
 {
 }
 
@@ -360,7 +360,7 @@ void c_typecheck_baset::typecheck_switch_case(code_switch_caset &code)
   }
 }
 
-void c_typecheck_baset::typecheck_goto(codet &code __attribute__((unused)))
+void c_typecheck_baset::typecheck_goto(codet &code [[gnu::unused]])
 {
 }
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1658,7 +1658,7 @@ void c_typecheck_baset::typecheck_function_call_arguments(
 }
 
 void c_typecheck_baset::typecheck_expr_constant(exprt &expr
-                                                __attribute__((unused)))
+                                                [[gnu::unused]])
 {
   // Do nothing
 }
@@ -2022,6 +2022,6 @@ void c_typecheck_baset::make_constant_index(exprt &expr)
   }
 }
 
-void c_typecheck_baset::make_constant_rec(exprt &expr __attribute__((unused)))
+void c_typecheck_baset::make_constant_rec(exprt &expr [[gnu::unused]])
 {
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1657,8 +1657,7 @@ void c_typecheck_baset::typecheck_function_call_arguments(
   }
 }
 
-void c_typecheck_baset::typecheck_expr_constant(exprt &expr
-                                                [[gnu::unused]])
+void c_typecheck_baset::typecheck_expr_constant(exprt &expr [[gnu::unused]])
 {
   // Do nothing
 }

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -135,8 +135,8 @@ void ingest_symbol(
 
 #ifdef NO_CPROVER_LIBRARY
 void add_cprover_library(
-  contextt &context __attribute__((unused)),
-  message_handlert &message_handler __attribute__((unused)))
+  contextt &context [[gnu::unused]],
+  message_handlert &message_handler [[gnu::unused]])
 {
 }
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -231,16 +231,16 @@ bool clang_c_languaget::typecheck(
   return false;
 }
 
-void clang_c_languaget::show_parse(std::ostream &out __attribute__((unused)))
+void clang_c_languaget::show_parse(std::ostream &out [[gnu::unused]])
 {
   for(auto const &translation_unit : ASTs)
     (*translation_unit).getASTContext().getTranslationUnitDecl()->dump();
 }
 
 bool clang_c_languaget::preprocess(
-  const std::string &path __attribute__((unused)),
-  std::ostream &outstream __attribute__((unused)),
-  message_handlert &message_handler __attribute__((unused)))
+  const std::string &path [[gnu::unused]],
+  std::ostream &outstream [[gnu::unused]],
+  message_handlert &message_handler [[gnu::unused]])
 {
 // TODO: Check the preprocess situation.
 #if 0

--- a/src/clang-c-frontend/expr2c.cpp
+++ b/src/clang-c-frontend/expr2c.cpp
@@ -715,7 +715,7 @@ expr2ct::convert_statement_expression(const exprt &src, unsigned &precedence)
 std::string expr2ct::convert_function(
   const exprt &src,
   const std::string &name,
-  unsigned precedence __attribute__((unused)))
+  unsigned precedence [[gnu::unused]])
 {
   std::string dest = name;
   dest += '(';
@@ -911,14 +911,14 @@ expr2ct::convert_struct_member_value(const exprt &src, unsigned precedence)
 
 std::string expr2ct::convert_norep(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   return src.pretty(0);
 }
 
 std::string expr2ct::convert_symbol(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   const irep_idt &id = src.identifier();
   std::string dest;
@@ -936,7 +936,7 @@ std::string expr2ct::convert_symbol(
 
 std::string expr2ct::convert_nondet_symbol(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   const std::string &id = src.identifier().as_string();
   return "nondet_symbol(" + id + ")";
@@ -944,7 +944,7 @@ std::string expr2ct::convert_nondet_symbol(
 
 std::string expr2ct::convert_predicate_symbol(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   const std::string &id = src.identifier().as_string();
   return "ps(" + id + ")";
@@ -952,7 +952,7 @@ std::string expr2ct::convert_predicate_symbol(
 
 std::string expr2ct::convert_predicate_next_symbol(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   const std::string &id = src.identifier().as_string();
   return "pns(" + id + ")";
@@ -960,15 +960,15 @@ std::string expr2ct::convert_predicate_next_symbol(
 
 std::string expr2ct::convert_quantified_symbol(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   const std::string &id = src.identifier().as_string();
   return id;
 }
 
 std::string expr2ct::convert_nondet_bool(
-  const exprt &src __attribute__((unused)),
-  unsigned &precedence __attribute__((unused)))
+  const exprt &src [[gnu::unused]],
+  unsigned &precedence [[gnu::unused]])
 {
   return "nondet_bool()";
 }
@@ -1179,7 +1179,7 @@ std::string expr2ct::convert_union(const exprt &src, unsigned &precedence)
 
 std::string expr2ct::convert_array(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   std::string dest = "{ ";
 
@@ -1239,7 +1239,7 @@ std::string expr2ct::convert_array_list(const exprt &src, unsigned &precedence)
 
 std::string expr2ct::convert_function_call(
   const exprt &src,
-  unsigned &precedence __attribute__((unused)))
+  unsigned &precedence [[gnu::unused]])
 {
   if(src.operands().size() != 2)
   {
@@ -1309,7 +1309,7 @@ std::string expr2ct::indent_str(unsigned indent)
 }
 
 std::string expr2ct::convert_code_asm(
-  const codet &src __attribute__((unused)),
+  const codet &src [[gnu::unused]],
   unsigned indent)
 {
   std::string dest = indent_str(indent);
@@ -1438,7 +1438,7 @@ std::string expr2ct::convert_code_gcc_goto(const codet &src, unsigned indent)
 }
 
 std::string expr2ct::convert_code_break(
-  const codet &src __attribute__((unused)),
+  const codet &src [[gnu::unused]],
   unsigned indent)
 {
   std::string dest = indent_str(indent);
@@ -1488,7 +1488,7 @@ std::string expr2ct::convert_code_switch(const codet &src, unsigned indent)
 }
 
 std::string expr2ct::convert_code_continue(
-  const codet &src __attribute__((unused)),
+  const codet &src [[gnu::unused]],
   unsigned indent)
 {
   std::string dest = indent_str(indent);
@@ -1808,8 +1808,8 @@ std::string expr2ct::convert_code_unlock(const codet &src, unsigned indent)
 }
 
 std::string expr2ct::convert_code_function_call(
-  const code_function_callt &src __attribute__((unused)),
-  unsigned indent __attribute__((unused)))
+  const code_function_callt &src [[gnu::unused]],
+  unsigned indent [[gnu::unused]])
 {
   if(src.operands().size() != 3)
   {
@@ -2009,7 +2009,7 @@ std::string expr2ct::convert_extractbit(const exprt &src, unsigned precedence)
 
 std::string expr2ct::convert_sizeof(
   const exprt &src,
-  unsigned precedence __attribute__((unused)))
+  unsigned precedence [[gnu::unused]])
 {
   std::string dest = "sizeof(";
   dest += convert(static_cast<const typet &>(src.c_sizeof_type()));

--- a/src/clang-c-frontend/expr2c.cpp
+++ b/src/clang-c-frontend/expr2c.cpp
@@ -909,16 +909,14 @@ expr2ct::convert_struct_member_value(const exprt &src, unsigned precedence)
   return "." + src.name().as_string() + "=" + convert(src.op0());
 }
 
-std::string expr2ct::convert_norep(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string
+expr2ct::convert_norep(const exprt &src, unsigned &precedence [[gnu::unused]])
 {
   return src.pretty(0);
 }
 
-std::string expr2ct::convert_symbol(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string
+expr2ct::convert_symbol(const exprt &src, unsigned &precedence [[gnu::unused]])
 {
   const irep_idt &id = src.identifier();
   std::string dest;
@@ -1177,9 +1175,8 @@ std::string expr2ct::convert_union(const exprt &src, unsigned &precedence)
   return dest;
 }
 
-std::string expr2ct::convert_array(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string
+expr2ct::convert_array(const exprt &src, unsigned &precedence [[gnu::unused]])
 {
   std::string dest = "{ ";
 
@@ -1308,9 +1305,8 @@ std::string expr2ct::indent_str(unsigned indent)
   return dest;
 }
 
-std::string expr2ct::convert_code_asm(
-  const codet &src [[gnu::unused]],
-  unsigned indent)
+std::string
+expr2ct::convert_code_asm(const codet &src [[gnu::unused]], unsigned indent)
 {
   std::string dest = indent_str(indent);
   dest += "asm();\n";
@@ -1437,9 +1433,8 @@ std::string expr2ct::convert_code_gcc_goto(const codet &src, unsigned indent)
   return dest;
 }
 
-std::string expr2ct::convert_code_break(
-  const codet &src [[gnu::unused]],
-  unsigned indent)
+std::string
+expr2ct::convert_code_break(const codet &src [[gnu::unused]], unsigned indent)
 {
   std::string dest = indent_str(indent);
   dest += "break";
@@ -2007,9 +2002,8 @@ std::string expr2ct::convert_extractbit(const exprt &src, unsigned precedence)
   return dest;
 }
 
-std::string expr2ct::convert_sizeof(
-  const exprt &src,
-  unsigned precedence [[gnu::unused]])
+std::string
+expr2ct::convert_sizeof(const exprt &src, unsigned precedence [[gnu::unused]])
 {
   std::string dest = "sizeof(";
   dest += convert(static_cast<const typet &>(src.c_sizeof_type()));

--- a/src/clang-cpp-frontend/expr2cpp.cpp
+++ b/src/clang-cpp-frontend/expr2cpp.cpp
@@ -304,15 +304,15 @@ std::string expr2cppt::convert_rec(
 }
 
 std::string expr2cppt::convert_cpp_this(
-  const exprt &src __attribute__((unused)),
-  unsigned precedence __attribute__((unused)))
+  const exprt &src [[gnu::unused]],
+  unsigned precedence [[gnu::unused]])
 {
   return "this";
 }
 
 std::string expr2cppt::convert_cpp_new(
   const exprt &src,
-  unsigned precedence __attribute__((unused)))
+  unsigned precedence [[gnu::unused]])
 {
   std::string dest;
 

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -515,8 +515,8 @@ irep_idt cpp_declarator_convertert::get_pretty_name()
   return scope->prefix + base_name;
 }
 
-void cpp_declarator_convertert::operator_overloading_rules(
-  const symbolt &symbol [[gnu::unused]])
+void cpp_declarator_convertert::operator_overloading_rules(const symbolt &symbol
+                                                           [[gnu::unused]])
 {
   // TODO
 }

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -516,7 +516,7 @@ irep_idt cpp_declarator_convertert::get_pretty_name()
 }
 
 void cpp_declarator_convertert::operator_overloading_rules(
-  const symbolt &symbol __attribute__((unused)))
+  const symbolt &symbol [[gnu::unused]])
 {
   // TODO
 }

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -905,8 +905,7 @@ void cpp_typecheckt::typecheck_expr_delete(exprt &expr)
   expr.set("destructor", destructor_code);
 }
 
-void cpp_typecheckt::typecheck_expr_typecast(exprt &expr
-                                             [[gnu::unused]])
+void cpp_typecheckt::typecheck_expr_typecast(exprt &expr [[gnu::unused]])
 {
 // should not be called
 #if 0

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -906,7 +906,7 @@ void cpp_typecheckt::typecheck_expr_delete(exprt &expr)
 }
 
 void cpp_typecheckt::typecheck_expr_typecast(exprt &expr
-                                             __attribute__((unused)))
+                                             [[gnu::unused]])
 {
 // should not be called
 #if 0

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -921,7 +921,7 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
    extern.template.decl
    : EXTERN TEMPLATE declaration
 */
-bool Parser::rExternTemplateDecl(irept &decl __attribute__((unused)))
+bool Parser::rExternTemplateDecl(irept &decl [[gnu::unused]])
 {
   Token tk1, tk2;
 
@@ -1214,10 +1214,10 @@ bool Parser::rIntegralDeclaration(
 }
 
 bool Parser::rConstDeclaration(
-  cpp_declarationt &declaration __attribute__((unused)),
-  cpp_storage_spect &storage_spec __attribute__((unused)),
-  cpp_member_spect &member_spec __attribute__((unused)),
-  typet &cv_q __attribute__((unused)))
+  cpp_declarationt &declaration [[gnu::unused]],
+  cpp_storage_spect &storage_spec [[gnu::unused]],
+  cpp_member_spect &member_spec [[gnu::unused]],
+  typet &cv_q [[gnu::unused]])
 {
 #ifdef DEBUG
   std::cout << "Parser::rConstDeclaration\n";
@@ -2118,7 +2118,7 @@ bool Parser::rDeclaratorQualifier()
 bool Parser::rDeclarator(
   cpp_declaratort &declarator,
   DeclKind kind,
-  bool recursive __attribute__((unused)),
+  bool recursive [[gnu::unused]],
   bool should_be_declarator,
   bool is_statement)
 {
@@ -3560,7 +3560,7 @@ bool Parser::rClassMember(cpp_itemt &member)
   access.decl
   : name ';'                e.g. <qualified class>::<member name>;
 */
-bool Parser::rAccessDecl(irept &mem __attribute__((unused)))
+bool Parser::rAccessDecl(irept &mem [[gnu::unused]])
 {
   irept name;
   Token tk;

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -75,7 +75,7 @@ struct resultt
 };
 
 #ifndef _WIN32
-void timeout_handler(int dummy __attribute__((unused)))
+void timeout_handler(int dummy [[gnu::unused]])
 {
   std::cout << "Timed out" << std::endl;
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -407,7 +407,7 @@ void goto_convertt::cpp_new_initializer(
 }
 
 void goto_convertt::do_exit(
-  const exprt &lhs __attribute__((unused)),
+  const exprt &lhs [[gnu::unused]],
   const exprt &function,
   const exprt::operandst &arguments,
   goto_programt &dest)
@@ -426,7 +426,7 @@ void goto_convertt::do_exit(
 }
 
 void goto_convertt::do_abort(
-  const exprt &lhs __attribute__((unused)),
+  const exprt &lhs [[gnu::unused]],
   const exprt &function,
   const exprt::operandst &arguments,
   goto_programt &dest)

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -126,7 +126,7 @@ void goto_inlinet::parameter_assignments(
 void goto_inlinet::replace_return(
   goto_programt &dest,
   const exprt &lhs,
-  const exprt &constrain __attribute__((unused)) /* ndebug */)
+  const exprt &constrain [[gnu::unused]] /* ndebug */)
 {
   for(goto_programt::instructionst::iterator it = dest.instructions.begin();
       it != dest.instructions.end();

--- a/src/goto-programs/static_analysis.cpp
+++ b/src/goto-programs/static_analysis.cpp
@@ -233,7 +233,7 @@ void static_analysis_baset::do_function_call(
   locationt l_call,
   const goto_functionst &goto_functions,
   const goto_functionst::function_mapt::const_iterator f_it,
-  const std::vector<expr2tc> &arguments __attribute__((unused)), // XXX -- why?
+  const std::vector<expr2tc> &arguments [[gnu::unused]], // XXX -- why?
   statet &new_state)
 {
   const goto_functiont &goto_function = f_it->second;

--- a/src/goto-programs/static_analysis.h
+++ b/src/goto-programs/static_analysis.h
@@ -41,15 +41,15 @@ public:
   virtual ~abstract_domain_baset() = default;
 
   virtual void output(
-    const namespacet &ns __attribute__((unused)),
-    std::ostream &out __attribute__((unused))) const
+    const namespacet &ns [[gnu::unused]],
+    std::ostream &out [[gnu::unused]]) const
   {
   }
 
   virtual void get_reference_set(
-    const namespacet &ns __attribute__((unused)),
-    const expr2tc &expr __attribute__((unused)),
-    std::list<expr2tc> &dest __attribute__((unused)))
+    const namespacet &ns [[gnu::unused]],
+    const expr2tc &expr [[gnu::unused]],
+    std::list<expr2tc> &dest [[gnu::unused]])
   {
     assert(0);
   };

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -332,7 +332,7 @@ void goto_symext::symex_free(const expr2tc &expr)
 }
 
 void goto_symext::symex_printf(
-  const expr2tc &lhs __attribute__((unused)),
+  const expr2tc &lhs [[gnu::unused]],
   const expr2tc &rhs)
 {
   assert(is_code_printf2t(rhs));
@@ -428,7 +428,7 @@ void goto_symext::symex_cpp_new(const expr2tc &lhs, const sideeffect2t &code)
 }
 
 // XXX - implement as a call to free?
-void goto_symext::symex_cpp_delete(const expr2tc &code __attribute__((unused)))
+void goto_symext::symex_cpp_delete(const expr2tc &code [[gnu::unused]])
 {
   //bool do_array=code.statement()=="delete[]";
 }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -127,7 +127,7 @@ public:
     {
     }
 
-    goto_statet &operator=(const goto_statet &ref __attribute__((unused)))
+    goto_statet &operator=(const goto_statet &ref [[gnu::unused]])
     {
       abort();
     }

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -314,8 +314,8 @@ void violation_graphml_goto_trace(
 
 void correctness_graphml_goto_trace(
   optionst &options,
-  const namespacet &ns __attribute__((unused)),
-  const goto_tracet &goto_trace __attribute__((unused)))
+  const namespacet &ns [[gnu::unused]],
+  const goto_tracet &goto_trace [[gnu::unused]])
 {
   grapht graph(grapht::CORRECTNESS);
   graph.verified_file = verification_file;

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -783,8 +783,7 @@ reachability_treet::generate_schedule_formula()
       schedule_target, schedule_total_claims, schedule_remaining_claims));
 }
 
-bool reachability_treet::restore_from_dfs_state(void *_dfs
-                                                [[gnu::unused]])
+bool reachability_treet::restore_from_dfs_state(void *_dfs [[gnu::unused]])
 {
   abort();
 #if 0

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -784,7 +784,7 @@ reachability_treet::generate_schedule_formula()
 }
 
 bool reachability_treet::restore_from_dfs_state(void *_dfs
-                                                __attribute__((unused)))
+                                                [[gnu::unused]])
 {
   abort();
 #if 0
@@ -845,7 +845,7 @@ bool reachability_treet::restore_from_dfs_state(void *_dfs
 }
 
 void reachability_treet::save_checkpoint(const std::string &&fname
-                                         __attribute__((unused))) const
+                                         [[gnu::unused]]) const
 {
 #if 0
   reachability_treet::dfs_position pos(*this);

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -291,7 +291,7 @@ void renaming::level2t::dump() const
 void renaming::level2t::make_assignment(
   expr2tc &lhs_symbol,
   const expr2tc &const_value,
-  const expr2tc &assigned_value __attribute__((unused)))
+  const expr2tc &assigned_value [[gnu::unused]])
 {
   assert(
     to_symbol2t(lhs_symbol).rlevel == symbol2t::level1 ||

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -274,7 +274,7 @@ bool goto_symext::unexpected_handler()
 }
 
 void goto_symext::update_throw_target(
-  goto_symex_statet::exceptiont *except __attribute__((unused)),
+  goto_symex_statet::exceptiont *except [[gnu::unused]],
   goto_programt::const_targett target,
   const expr2tc &code)
 {

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/migrate.h>
 
 void symex_dereference_statet::dereference_failure(
-  const std::string &property __attribute__((unused)),
+  const std::string &property [[gnu::unused]],
   const std::string &msg,
   const guardt &guard)
 {

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -136,7 +136,7 @@ public:
    *  optimisation expansion in the future, it isn't currently used by anything.
    *  @param expr An expression to be renamed
    */
-  virtual void rename(expr2tc &expr __attribute__((unused)))
+  virtual void rename(expr2tc &expr [[gnu::unused]])
   {
   }
 
@@ -148,7 +148,7 @@ public:
   };
 
   virtual void dump_internal_state(const std::list<struct internal_item> &data
-                                   __attribute__((unused)))
+                                   [[gnu::unused]])
   {
   }
 

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -123,9 +123,7 @@ public:
       }
     }
 
-    explicit objectt(
-      bool offset_set [[gnu::unused]],
-      const BigInt &_offset)
+    explicit objectt(bool offset_set [[gnu::unused]], const BigInt &_offset)
       : offset(_offset), offset_is_set(true)
     {
       assert(offset_set);

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -124,7 +124,7 @@ public:
     }
 
     explicit objectt(
-      bool offset_set __attribute__((unused)),
+      bool offset_set [[gnu::unused]],
       const BigInt &_offset)
       : offset(_offset), offset_is_set(true)
     {

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -172,7 +172,7 @@ bool value_set_analysist::check_type(const typet &type)
 
 void value_set_analysist::convert(
   const goto_programt &goto_program,
-  const irep_idt &identifier __attribute__((unused)),
+  const irep_idt &identifier [[gnu::unused]],
   xmlt &dest) const
 {
   ::locationt previous_location;

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -44,8 +44,8 @@ public:
     return value_set->make_union(*other.value_set, keepnew);
   }
 
-  void output(const namespacet &ns [[gnu::unused]], std::ostream &out)
-    const override
+  void
+  output(const namespacet &ns [[gnu::unused]], std::ostream &out) const override
   {
     value_set->output(out);
   }

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -44,7 +44,7 @@ public:
     return value_set->make_union(*other.value_set, keepnew);
   }
 
-  void output(const namespacet &ns __attribute__((unused)), std::ostream &out)
+  void output(const namespacet &ns [[gnu::unused]], std::ostream &out)
     const override
   {
     value_set->output(out);
@@ -61,7 +61,7 @@ public:
   transform(const namespacet &ns, locationt from_l, locationt to_l) override;
 
   void get_reference_set(
-    const namespacet &ns __attribute__((unused)),
+    const namespacet &ns [[gnu::unused]],
     const expr2tc &expr,
     value_setst::valuest &dest) override
   {

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -13,7 +13,7 @@ void error_handler(const char *msg)
 smt_convt *create_new_boolector_solver(
   bool int_encoding,
   const namespacet &ns,
-  tuple_iface **tuple_api __attribute__((unused)),
+  tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
@@ -483,14 +483,14 @@ smt_astt boolector_convt::mk_select(smt_astt a, smt_astt b)
 }
 
 smt_astt boolector_convt::mk_smt_int(const BigInt &theint
-                                     __attribute__((unused)))
+                                     [[gnu::unused]])
 {
   std::cerr << "Boolector can't create integer sorts" << std::endl;
   abort();
 }
 
 smt_astt boolector_convt::mk_smt_real(const std::string &str
-                                      __attribute__((unused)))
+                                      [[gnu::unused]])
 {
   std::cerr << "Boolector can't create Real sorts" << std::endl;
   abort();
@@ -513,7 +513,7 @@ smt_astt boolector_convt::mk_smt_bool(bool val)
 smt_astt boolector_convt::mk_array_symbol(
   const std::string &name,
   const smt_sort *s,
-  smt_sortt array_subtype __attribute__((unused)))
+  smt_sortt array_subtype [[gnu::unused]])
 {
   return mk_smt_symbol(name, s);
 }

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -482,15 +482,13 @@ smt_astt boolector_convt::mk_select(smt_astt a, smt_astt b)
     a->sort->get_range_sort());
 }
 
-smt_astt boolector_convt::mk_smt_int(const BigInt &theint
-                                     [[gnu::unused]])
+smt_astt boolector_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
   std::cerr << "Boolector can't create integer sorts" << std::endl;
   abort();
 }
 
-smt_astt boolector_convt::mk_smt_real(const std::string &str
-                                      [[gnu::unused]])
+smt_astt boolector_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
   std::cerr << "Boolector can't create Real sorts" << std::endl;
   abort();

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -6,7 +6,7 @@
 smt_convt *create_new_cvc_solver(
   bool int_encoding,
   const namespacet &ns,
-  tuple_iface **tuple_api __attribute__((unused)),
+  tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -40,7 +40,7 @@ void mathsat_convt::check_msat_error(msat_term &r) const
 smt_convt *create_new_mathsat_solver(
   bool int_encoding,
   const namespacet &ns,
-  tuple_iface **tuple_api __attribute__((unused)),
+  tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
@@ -781,7 +781,7 @@ smt_astt mathsat_convt::mk_smt_bool(bool val)
 smt_astt mathsat_convt::mk_array_symbol(
   const std::string &name,
   const smt_sort *s,
-  smt_sortt array_subtype __attribute__((unused)))
+  smt_sortt array_subtype [[gnu::unused]])
 {
   return mk_smt_symbol(name, s);
 }

--- a/src/solvers/minisat/minisat_conv.cpp
+++ b/src/solvers/minisat/minisat_conv.cpp
@@ -7,9 +7,9 @@ smt_convt *create_new_minisat_solver(
   bool int_encoding,
   const namespacet &ns,
   const optionst &options,
-  tuple_iface **tuple_api __attribute__((unused)),
-  array_iface **array_api __attribute__((unused)),
-  fp_iface **fp_api __attribute__((unused)))
+  tuple_iface **tuple_api [[gnu::unused]],
+  array_iface **array_api [[gnu::unused]],
+  fp_iface **fp_api [[gnu::unused]])
 {
   minisat_convt *conv = new minisat_convt(int_encoding, ns, options);
   return conv;

--- a/src/solvers/sat/bitblast_conv.cpp
+++ b/src/solvers/sat/bitblast_conv.cpp
@@ -320,14 +320,14 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
 }
 
 smt_ast *bitblast_convt::mk_smt_int(const BigInt &intval
-                                    __attribute__((unused)))
+                                    [[gnu::unused]])
 {
   std::cerr << "Can't create integers in bitblast solver" << std::endl;
   abort();
 }
 
 smt_ast *bitblast_convt::mk_smt_real(const std::string &value
-                                     __attribute__((unused)))
+                                     [[gnu::unused]])
 {
   std::cerr << "Can't create reals in bitblast solver" << std::endl;
   abort();
@@ -391,7 +391,7 @@ smt_astt bitblast_convt::mk_smt_symbol(const std::string &name, smt_sortt sort)
 }
 
 smt_sort *bitblast_convt::mk_struct_sort(const type2tc &t
-                                         __attribute__((unused)))
+                                         [[gnu::unused]])
 {
   abort();
 }

--- a/src/solvers/sat/bitblast_conv.cpp
+++ b/src/solvers/sat/bitblast_conv.cpp
@@ -319,15 +319,13 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
   return s;
 }
 
-smt_ast *bitblast_convt::mk_smt_int(const BigInt &intval
-                                    [[gnu::unused]])
+smt_ast *bitblast_convt::mk_smt_int(const BigInt &intval [[gnu::unused]])
 {
   std::cerr << "Can't create integers in bitblast solver" << std::endl;
   abort();
 }
 
-smt_ast *bitblast_convt::mk_smt_real(const std::string &value
-                                     [[gnu::unused]])
+smt_ast *bitblast_convt::mk_smt_real(const std::string &value [[gnu::unused]])
 {
   std::cerr << "Can't create reals in bitblast solver" << std::endl;
   abort();
@@ -390,8 +388,7 @@ smt_astt bitblast_convt::mk_smt_symbol(const std::string &name, smt_sortt sort)
   return result;
 }
 
-smt_sort *bitblast_convt::mk_struct_sort(const type2tc &t
-                                         [[gnu::unused]])
+smt_sort *bitblast_convt::mk_struct_sort(const type2tc &t [[gnu::unused]])
 {
   abort();
 }

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -1312,8 +1312,7 @@ void array_convt::add_initial_ackerman_constraints(
   }
 }
 
-smt_astt
-array_ast::eq(smt_convt *ctx [[gnu::unused]], smt_astt sym) const
+smt_astt array_ast::eq(smt_convt *ctx [[gnu::unused]], smt_astt sym) const
 {
   const array_ast *other = array_downcast(sym);
 
@@ -1325,8 +1324,7 @@ array_ast::eq(smt_convt *ctx [[gnu::unused]], smt_astt sym) const
   return array_ctx->mk_bounded_array_equality(this, other);
 }
 
-void array_ast::assign(smt_convt *ctx [[gnu::unused]], smt_astt sym)
-  const
+void array_ast::assign(smt_convt *ctx [[gnu::unused]], smt_astt sym) const
 {
   array_ctx->convert_array_assign(this, sym);
 }
@@ -1344,9 +1342,8 @@ smt_astt array_ast::update(
   return array_ctx->mk_store(this, idx_expr, value, sort);
 }
 
-smt_astt array_ast::select(
-  smt_convt *ctx [[gnu::unused]],
-  const expr2tc &idx) const
+smt_astt
+array_ast::select(smt_convt *ctx [[gnu::unused]], const expr2tc &idx) const
 {
   // Look up the array subtype sort. If we're unbounded, use the base array id
   // to do that, otherwise pull the subtype out of an element.

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -223,7 +223,7 @@ smt_astt array_convt::mk_store(
 smt_astt array_convt::mk_unbounded_select(
   const array_ast *ma,
   const expr2tc &real_idx,
-  smt_sortt ressort __attribute__((unused)))
+  smt_sortt ressort [[gnu::unused]])
 {
   // Store everything about this select, and return a free variable, that then
   // gets constrained at the end of conversion to tie up with the correct
@@ -1313,7 +1313,7 @@ void array_convt::add_initial_ackerman_constraints(
 }
 
 smt_astt
-array_ast::eq(smt_convt *ctx __attribute__((unused)), smt_astt sym) const
+array_ast::eq(smt_convt *ctx [[gnu::unused]], smt_astt sym) const
 {
   const array_ast *other = array_downcast(sym);
 
@@ -1325,14 +1325,14 @@ array_ast::eq(smt_convt *ctx __attribute__((unused)), smt_astt sym) const
   return array_ctx->mk_bounded_array_equality(this, other);
 }
 
-void array_ast::assign(smt_convt *ctx __attribute__((unused)), smt_astt sym)
+void array_ast::assign(smt_convt *ctx [[gnu::unused]], smt_astt sym)
   const
 {
   array_ctx->convert_array_assign(this, sym);
 }
 
 smt_astt array_ast::update(
-  smt_convt *ctx __attribute__((unused)),
+  smt_convt *ctx [[gnu::unused]],
   smt_astt value,
   unsigned int idx,
   expr2tc idx_expr) const
@@ -1345,7 +1345,7 @@ smt_astt array_ast::update(
 }
 
 smt_astt array_ast::select(
-  smt_convt *ctx __attribute__((unused)),
+  smt_convt *ctx [[gnu::unused]],
   const expr2tc &idx) const
 {
   // Look up the array subtype sort. If we're unbounded, use the base array id
@@ -1360,7 +1360,7 @@ smt_astt array_ast::select(
 }
 
 smt_astt array_ast::ite(
-  smt_convt *ctx __attribute__((unused)),
+  smt_convt *ctx [[gnu::unused]],
   smt_astt cond,
   smt_astt falseop) const
 {

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2383,7 +2383,7 @@ smt_astt array_iface::default_convert_array_of(
 }
 
 smt_astt smt_convt::pointer_array_of(
-  const expr2tc &init_val __attribute__((unused)),
+  const expr2tc &init_val [[gnu::unused]],
   unsigned long array_width)
 {
   // Actually a tuple, but the operand is going to be a symbol, null.
@@ -2525,8 +2525,8 @@ smt_astt smt_ast::select(smt_convt *ctx, const expr2tc &idx) const
 }
 
 smt_astt smt_ast::project(
-  smt_convt *ctx __attribute__((unused)),
-  unsigned int idx __attribute__((unused))) const
+  smt_convt *ctx [[gnu::unused]],
+  unsigned int idx [[gnu::unused]]) const
 {
   std::cerr << "Projecting from non-tuple based AST\n";
   abort();

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -133,7 +133,7 @@ smt_astt tuple_node_smt_ast::update(
   smt_convt *ctx,
   smt_astt value,
   unsigned int idx,
-  expr2tc idx_expr __attribute__((unused)) /*ndebug*/) const
+  expr2tc idx_expr [[gnu::unused]] /*ndebug*/) const
 {
   smt_convt::ast_vec eqs;
   assert(
@@ -151,8 +151,8 @@ smt_astt tuple_node_smt_ast::update(
 }
 
 smt_astt tuple_node_smt_ast::select(
-  smt_convt *ctx __attribute__((unused)),
-  const expr2tc &idx __attribute__((unused))) const
+  smt_convt *ctx [[gnu::unused]],
+  const expr2tc &idx [[gnu::unused]]) const
 {
   std::cerr << "Select operation applied to tuple" << std::endl;
   abort();

--- a/src/solvers/smt/tuple/smt_tuple_sym.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym.cpp
@@ -66,7 +66,7 @@ smt_astt smt_tuple_sym_flattener::tuple_array_create(
   const type2tc &array_type,
   smt_astt *inputargs,
   bool const_array,
-  smt_sortt domain __attribute__((unused)))
+  smt_sortt domain [[gnu::unused]])
 {
   // Create a tuple array from a constant representation. This means that
   // either we have an array_of or a constant_array. Handle this by creating

--- a/src/solvers/smt/tuple/smt_tuple_sym_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym_ast.cpp
@@ -118,7 +118,7 @@ smt_astt tuple_sym_smt_ast::update(
   smt_convt *ctx,
   smt_astt value,
   unsigned int idx,
-  expr2tc idx_expr __attribute__((unused)) /*ndebug*/) const
+  expr2tc idx_expr [[gnu::unused]] /*ndebug*/) const
 {
   smt_convt::ast_vec eqs;
   assert(
@@ -158,8 +158,8 @@ smt_astt tuple_sym_smt_ast::update(
 }
 
 smt_astt tuple_sym_smt_ast::select(
-  smt_convt *ctx __attribute__((unused)),
-  const expr2tc &idx __attribute__((unused))) const
+  smt_convt *ctx [[gnu::unused]],
+  const expr2tc &idx [[gnu::unused]]) const
 {
   std::cerr << "Select operation applied to tuple" << std::endl;
   abort();

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -834,8 +834,7 @@ smt_astt smtlib_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   return a;
 }
 
-smt_sort *smtlib_convt::mk_struct_sort(const type2tc &type
-                                       [[gnu::unused]])
+smt_sort *smtlib_convt::mk_struct_sort(const type2tc &type [[gnu::unused]])
 {
   std::cerr << "Attempted to make struct type in smtlib conversion"
             << std::endl;

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -99,7 +99,7 @@ extern sexpr *smtlib_output;
 smt_convt *create_new_smtlib_solver(
   bool int_encoding,
   const namespacet &ns,
-  tuple_iface **tuple_api __attribute__((unused)),
+  tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
@@ -802,7 +802,7 @@ smt_astt smtlib_convt::mk_smt_bool(bool val)
 smt_astt smtlib_convt::mk_array_symbol(
   const std::string &name,
   const smt_sort *s,
-  smt_sortt array_subtype __attribute__((unused)))
+  smt_sortt array_subtype [[gnu::unused]])
 {
   return mk_smt_symbol(name, s);
 }
@@ -835,7 +835,7 @@ smt_astt smtlib_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 }
 
 smt_sort *smtlib_convt::mk_struct_sort(const type2tc &type
-                                       __attribute__((unused)))
+                                       [[gnu::unused]])
 {
   std::cerr << "Attempted to make struct type in smtlib conversion"
             << std::endl;
@@ -900,7 +900,7 @@ smt_astt smtlib_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
   return ast;
 }
 
-int smtliberror(int startsym __attribute__((unused)), const std::string &error)
+int smtliberror(int startsym [[gnu::unused]], const std::string &error)
 {
   std::cerr << "SMTLIB response parsing error: \"" << error << "\""
             << std::endl;

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -715,7 +715,7 @@ smt_astt yices_convt::mk_smt_symbol(const std::string &name, smt_sortt s)
 smt_astt yices_convt::mk_array_symbol(
   const std::string &name,
   smt_sortt s,
-  smt_sortt array_subtype __attribute__((unused)))
+  smt_sortt array_subtype [[gnu::unused]])
 {
   // For array symbols, store the symbol name in the ast to implement
   // assign semantics
@@ -944,7 +944,7 @@ smt_astt yices_convt::tuple_array_create(
   const type2tc &array_type,
   smt_astt *inputargs,
   bool const_array,
-  smt_sortt domain __attribute__((unused)))
+  smt_sortt domain [[gnu::unused]])
 {
   const array_type2t &arr_type = to_array_type(array_type);
   const constant_int2t &thesize = to_constant_int2t(arr_type.array_size);

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -906,7 +906,7 @@ smt_astt z3_convt::mk_smt_bool(bool val)
 smt_astt z3_convt::mk_array_symbol(
   const std::string &name,
   const smt_sort *s,
-  smt_sortt array_subtype __attribute__((unused)))
+  smt_sortt array_subtype [[gnu::unused]])
 {
   return mk_smt_symbol(name, s);
 }

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -879,15 +879,13 @@ type_poolt type_pool;
 static_assert(type2t::end_type_id <= 256, "Type id overflow");
 static_assert(expr2t::end_expr_id <= 256, "Expr id overflow");
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const bool &thebool, int indent __attribute__((unused)))
+static inline std::string type_to_string(const bool &thebool, int indent __attribute__((unused)))
 {
   return (thebool) ? "true" : "false";
 }
 
-static inline __attribute__((always_inline)) std::string type_to_string(
-  const sideeffect_data::allockind &data,
-  int indent __attribute__((unused)))
+static inline std::string
+type_to_string(const sideeffect_data::allockind &data, int indent __attribute__((unused)))
 {
   return (data == sideeffect_data::allockind::malloc)
            ? "malloc"
@@ -909,17 +907,15 @@ static inline __attribute__((always_inline)) std::string type_to_string(
                                        : "unknown";
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const unsigned int &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const unsigned int &theval, int indent __attribute__((unused)))
 {
   char buffer[64];
   snprintf(buffer, 63, "%d", theval);
   return std::string(buffer);
 }
 
-static inline __attribute__((always_inline)) std::string type_to_string(
-  const symbol_data::renaming_level &theval,
-  int indent __attribute__((unused)))
+static inline std::string
+type_to_string(const symbol_data::renaming_level &theval, int indent __attribute__((unused)))
 {
   switch(theval)
   {
@@ -939,8 +935,7 @@ static inline __attribute__((always_inline)) std::string type_to_string(
   }
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const BigInt &theint, int indent __attribute__((unused)))
+static inline std::string type_to_string(const BigInt &theint, int indent __attribute__((unused)))
 {
   char buffer[256], *buf;
 
@@ -948,19 +943,17 @@ type_to_string(const BigInt &theint, int indent __attribute__((unused)))
   return std::string(buf);
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const fixedbvt &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const fixedbvt &theval, int indent __attribute__((unused)))
 {
   return theval.to_ansi_c_string();
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const ieee_floatt &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const ieee_floatt &theval, int indent __attribute__((unused)))
 {
   return theval.to_ansi_c_string();
 }
 
-static inline __attribute__((always_inline)) std::string
+static inline std::string
 type_to_string(const std::vector<expr2tc> &theval, int indent)
 {
   char buffer[64];
@@ -980,7 +973,7 @@ type_to_string(const std::vector<expr2tc> &theval, int indent)
   return astring;
 }
 
-static inline __attribute__((always_inline)) std::string
+static inline std::string
 type_to_string(const std::vector<type2tc> &theval, int indent)
 {
   char buffer[64];
@@ -1000,9 +993,8 @@ type_to_string(const std::vector<type2tc> &theval, int indent)
   return astring;
 }
 
-static inline __attribute__((always_inline)) std::string type_to_string(
-  const std::vector<irep_idt> &theval,
-  int indent __attribute__((unused)))
+static inline std::string
+type_to_string(const std::vector<irep_idt> &theval, int indent)
 {
   char buffer[64];
   std::string astring = "\n";
@@ -1021,16 +1013,14 @@ static inline __attribute__((always_inline)) std::string type_to_string(
   return astring;
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const expr2tc &theval, int indent)
+static inline std::string type_to_string(const expr2tc &theval, int indent)
 {
   if(theval.get() != nullptr)
     return theval->pretty(indent + 2);
   return "";
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const type2tc &theval, int indent)
+static inline std::string type_to_string(const type2tc &theval, int indent)
 {
   if(theval.get() != nullptr)
     return theval->pretty(indent + 2);
@@ -1038,80 +1028,75 @@ type_to_string(const type2tc &theval, int indent)
     return "";
 }
 
-static inline __attribute__((always_inline)) std::string
-type_to_string(const irep_idt &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const irep_idt &theval, int indent __attribute__((unused)))
 {
   return theval.as_string();
 }
 
-static inline __attribute__((always_inline)) bool
-do_type_cmp(const bool &side1, const bool &side2)
+static inline bool do_type_cmp(const bool &side1, const bool &side2)
 {
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool
+static inline bool
 do_type_cmp(const unsigned int &side1, const unsigned int &side2)
 {
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
+static inline bool do_type_cmp(
   const sideeffect_data::allockind &side1,
   const sideeffect_data::allockind &side2)
 {
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
+static inline bool do_type_cmp(
   const symbol_data::renaming_level &side1,
   const symbol_data::renaming_level &side2)
 {
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool
-do_type_cmp(const BigInt &side1, const BigInt &side2)
+static inline bool do_type_cmp(const BigInt &side1, const BigInt &side2)
 {
   // BigInt has its own equality operator.
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool
-do_type_cmp(const fixedbvt &side1, const fixedbvt &side2)
+static inline bool do_type_cmp(const fixedbvt &side1, const fixedbvt &side2)
 {
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool
+static inline bool
 do_type_cmp(const ieee_floatt &side1, const ieee_floatt &side2)
 {
   return (side1 == side2) ? true : false;
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
+static inline bool do_type_cmp(
   const std::vector<expr2tc> &side1,
   const std::vector<expr2tc> &side2)
 {
   return (side1 == side2);
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
+static inline bool do_type_cmp(
   const std::vector<type2tc> &side1,
   const std::vector<type2tc> &side2)
 {
   return (side1 == side2);
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
+static inline bool do_type_cmp(
   const std::vector<irep_idt> &side1,
   const std::vector<irep_idt> &side2)
 {
   return (side1 == side2);
 }
 
-static inline __attribute__((always_inline)) bool
-do_type_cmp(const expr2tc &side1, const expr2tc &side2)
+static inline bool do_type_cmp(const expr2tc &side1, const expr2tc &side2)
 {
   if(side1.get() == side2.get())
     return true; // Catch null
@@ -1121,8 +1106,7 @@ do_type_cmp(const expr2tc &side1, const expr2tc &side2)
     return (side1 == side2);
 }
 
-static inline __attribute__((always_inline)) bool
-do_type_cmp(const type2tc &side1, const type2tc &side2)
+static inline bool do_type_cmp(const type2tc &side1, const type2tc &side2)
 {
   if(side1.get() == side2.get())
     return true; // both null ptr check
@@ -1131,28 +1115,24 @@ do_type_cmp(const type2tc &side1, const type2tc &side2)
   return (side1 == side2);
 }
 
-static inline __attribute__((always_inline)) bool
-do_type_cmp(const irep_idt &side1, const irep_idt &side2)
+static inline bool do_type_cmp(const irep_idt &side1, const irep_idt &side2)
 {
   return (side1 == side2);
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
-  const type2t::type_ids &id __attribute__((unused)),
-  const type2t::type_ids &id2 __attribute__((unused)))
+static inline bool
+do_type_cmp(const type2t::type_ids &id __attribute__((unused)), const type2t::type_ids &id2 __attribute__((unused)))
 {
   return true; // Dummy field comparison.
 }
 
-static inline __attribute__((always_inline)) bool do_type_cmp(
-  const expr2t::expr_ids &id __attribute__((unused)),
-  const expr2t::expr_ids &id2 __attribute__((unused)))
+static inline bool
+do_type_cmp(const expr2t::expr_ids &id __attribute__((unused)), const expr2t::expr_ids &id2 __attribute__((unused)))
 {
   return true; // Dummy field comparison.
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const bool &side1, const bool &side2)
+static inline int do_type_lt(const bool &side1, const bool &side2)
 {
   if(side1 < side2)
     return -1;
@@ -1162,7 +1142,7 @@ do_type_lt(const bool &side1, const bool &side2)
     return 0;
 }
 
-static inline __attribute__((always_inline)) int
+static inline int
 do_type_lt(const unsigned int &side1, const unsigned int &side2)
 {
   if(side1 < side2)
@@ -1173,7 +1153,7 @@ do_type_lt(const unsigned int &side1, const unsigned int &side2)
     return 0;
 }
 
-static inline __attribute__((always_inline)) int do_type_lt(
+static inline int do_type_lt(
   const sideeffect_data::allockind &side1,
   const sideeffect_data::allockind &side2)
 {
@@ -1185,7 +1165,7 @@ static inline __attribute__((always_inline)) int do_type_lt(
     return 0;
 }
 
-static inline __attribute__((always_inline)) int do_type_lt(
+static inline int do_type_lt(
   const symbol_data::renaming_level &side1,
   const symbol_data::renaming_level &side2)
 {
@@ -1197,15 +1177,13 @@ static inline __attribute__((always_inline)) int do_type_lt(
     return 0;
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const BigInt &side1, const BigInt &side2)
+static inline int do_type_lt(const BigInt &side1, const BigInt &side2)
 {
   // BigInt also has its own less than comparator.
   return side1.compare(side2);
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const fixedbvt &side1, const fixedbvt &side2)
+static inline int do_type_lt(const fixedbvt &side1, const fixedbvt &side2)
 {
   if(side1 < side2)
     return -1;
@@ -1214,8 +1192,7 @@ do_type_lt(const fixedbvt &side1, const fixedbvt &side2)
   return 0;
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const ieee_floatt &side1, const ieee_floatt &side2)
+static inline int do_type_lt(const ieee_floatt &side1, const ieee_floatt &side2)
 {
   if(side1 < side2)
     return -1;
@@ -1224,7 +1201,7 @@ do_type_lt(const ieee_floatt &side1, const ieee_floatt &side2)
   return 0;
 }
 
-static inline __attribute__((always_inline)) int
+static inline int
 do_type_lt(const std::vector<expr2tc> &side1, const std::vector<expr2tc> &side2)
 {
   int tmp = 0;
@@ -1239,7 +1216,7 @@ do_type_lt(const std::vector<expr2tc> &side1, const std::vector<expr2tc> &side2)
   return 0;
 }
 
-static inline __attribute__((always_inline)) int
+static inline int
 do_type_lt(const std::vector<type2tc> &side1, const std::vector<type2tc> &side2)
 {
   if(side1.size() < side2.size())
@@ -1259,7 +1236,7 @@ do_type_lt(const std::vector<type2tc> &side1, const std::vector<type2tc> &side2)
   return 0;
 }
 
-static inline __attribute__((always_inline)) int do_type_lt(
+static inline int do_type_lt(
   const std::vector<irep_idt> &side1,
   const std::vector<irep_idt> &side2)
 {
@@ -1270,8 +1247,7 @@ static inline __attribute__((always_inline)) int do_type_lt(
   return 0;
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const expr2tc &side1, const expr2tc &side2)
+static inline int do_type_lt(const expr2tc &side1, const expr2tc &side2)
 {
   if(side1.get() == side2.get())
     return 0; // Catch nulls
@@ -1283,8 +1259,7 @@ do_type_lt(const expr2tc &side1, const expr2tc &side2)
     return side1->ltchecked(*side2.get());
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const type2tc &side1, const type2tc &side2)
+static inline int do_type_lt(const type2tc &side1, const type2tc &side2)
 {
   if(*side1.get() == *side2.get())
     return 0; // Both may be null;
@@ -1296,8 +1271,7 @@ do_type_lt(const type2tc &side1, const type2tc &side2)
     return side1->ltchecked(*side2.get());
 }
 
-static inline __attribute__((always_inline)) int
-do_type_lt(const irep_idt &side1, const irep_idt &side2)
+static inline int do_type_lt(const irep_idt &side1, const irep_idt &side2)
 {
   if(side1 < side2)
     return -1;
@@ -1306,28 +1280,24 @@ do_type_lt(const irep_idt &side1, const irep_idt &side2)
   return 0;
 }
 
-static inline __attribute__((always_inline)) int do_type_lt(
-  const type2t::type_ids &id __attribute__((unused)),
-  const type2t::type_ids &id2 __attribute__((unused)))
+static inline int
+do_type_lt(const type2t::type_ids &id __attribute__((unused)), const type2t::type_ids &id2 __attribute__((unused)))
 {
   return 0; // Dummy field comparison
 }
 
-static inline __attribute__((always_inline)) int do_type_lt(
-  const expr2t::expr_ids &id __attribute__((unused)),
-  const expr2t::expr_ids &id2 __attribute__((unused)))
+static inline int
+do_type_lt(const expr2t::expr_ids &id __attribute__((unused)), const expr2t::expr_ids &id2 __attribute__((unused)))
 {
   return 0; // Dummy field comparison
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const bool &theval)
+static inline size_t do_type_crc(const bool &theval)
 {
   return boost::hash<bool>()(theval);
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const bool &thebool, crypto_hash &hash)
+static inline void do_type_hash(const bool &thebool, crypto_hash &hash)
 {
   if(thebool)
   {
@@ -1341,44 +1311,39 @@ do_type_hash(const bool &thebool, crypto_hash &hash)
   }
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const unsigned int &theval)
+static inline size_t do_type_crc(const unsigned int &theval)
 {
   return boost::hash<unsigned int>()(theval);
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const unsigned int &theval, crypto_hash &hash)
+static inline void do_type_hash(const unsigned int &theval, crypto_hash &hash)
 {
   hash.ingest((void *)&theval, sizeof(theval));
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const sideeffect_data::allockind &theval)
+static inline size_t do_type_crc(const sideeffect_data::allockind &theval)
 {
   return boost::hash<uint8_t>()(theval);
 }
 
-static inline __attribute__((always_inline)) void
+static inline void
 do_type_hash(const sideeffect_data::allockind &theval, crypto_hash &hash)
 {
   hash.ingest((void *)&theval, sizeof(theval));
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const symbol_data::renaming_level &theval)
+static inline size_t do_type_crc(const symbol_data::renaming_level &theval)
 {
   return boost::hash<uint8_t>()(theval);
 }
 
-static inline __attribute__((always_inline)) void
+static inline void
 do_type_hash(const symbol_data::renaming_level &theval, crypto_hash &hash)
 {
   hash.ingest((void *)&theval, sizeof(theval));
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const BigInt &theint)
+static inline size_t do_type_crc(const BigInt &theint)
 {
   if(theint.is_zero())
     return boost::hash<uint8_t>()(0);
@@ -1400,8 +1365,7 @@ do_type_crc(const BigInt &theint)
   return crc;
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const BigInt &theint, crypto_hash &hash)
+static inline void do_type_hash(const BigInt &theint, crypto_hash &hash)
 {
   // Zero has no data in bigints.
   if(theint.is_zero())
@@ -1425,32 +1389,27 @@ do_type_hash(const BigInt &theint, crypto_hash &hash)
   }
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const fixedbvt &theval)
+static inline size_t do_type_crc(const fixedbvt &theval)
 {
   return do_type_crc(BigInt(theval.to_ansi_c_string().c_str()));
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const fixedbvt &theval, crypto_hash &hash)
+static inline void do_type_hash(const fixedbvt &theval, crypto_hash &hash)
 {
   do_type_hash(BigInt(theval.to_ansi_c_string().c_str()), hash);
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const ieee_floatt &theval)
+static inline size_t do_type_crc(const ieee_floatt &theval)
 {
   return do_type_crc(theval.pack());
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const ieee_floatt &theval, crypto_hash &hash)
+static inline void do_type_hash(const ieee_floatt &theval, crypto_hash &hash)
 {
   do_type_hash(theval.pack(), hash);
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const std::vector<expr2tc> &theval)
+static inline size_t do_type_crc(const std::vector<expr2tc> &theval)
 {
   size_t crc = 0;
   for(auto const &it : theval)
@@ -1459,15 +1418,14 @@ do_type_crc(const std::vector<expr2tc> &theval)
   return crc;
 }
 
-static inline __attribute__((always_inline)) void
+static inline void
 do_type_hash(const std::vector<expr2tc> &theval, crypto_hash &hash)
 {
   for(auto const &it : theval)
     it->hash(hash);
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const std::vector<type2tc> &theval)
+static inline size_t do_type_crc(const std::vector<type2tc> &theval)
 {
   size_t crc = 0;
   for(auto const &it : theval)
@@ -1476,15 +1434,14 @@ do_type_crc(const std::vector<type2tc> &theval)
   return crc;
 }
 
-static inline __attribute__((always_inline)) void
+static inline void
 do_type_hash(const std::vector<type2tc> &theval, crypto_hash &hash)
 {
   for(auto const &it : theval)
     it->hash(hash);
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const std::vector<irep_idt> &theval)
+static inline size_t do_type_crc(const std::vector<irep_idt> &theval)
 {
   size_t crc = 0;
   for(auto const &it : theval)
@@ -1493,77 +1450,65 @@ do_type_crc(const std::vector<irep_idt> &theval)
   return crc;
 }
 
-static inline __attribute__((always_inline)) void
+static inline void
 do_type_hash(const std::vector<irep_idt> &theval, crypto_hash &hash)
 {
   for(auto const &it : theval)
     hash.ingest((void *)it.as_string().c_str(), it.as_string().size());
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const expr2tc &theval)
+static inline size_t do_type_crc(const expr2tc &theval)
 {
   if(theval.get() != nullptr)
     return theval->do_crc();
   return boost::hash<uint8_t>()(0);
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const expr2tc &theval, crypto_hash &hash)
+static inline void do_type_hash(const expr2tc &theval, crypto_hash &hash)
 {
   if(theval.get() != nullptr)
     theval->hash(hash);
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const type2tc &theval)
+static inline size_t do_type_crc(const type2tc &theval)
 {
   if(theval.get() != nullptr)
     return theval->do_crc();
   return boost::hash<uint8_t>()(0);
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const type2tc &theval, crypto_hash &hash)
+static inline void do_type_hash(const type2tc &theval, crypto_hash &hash)
 {
   if(theval.get() != nullptr)
     theval->hash(hash);
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const irep_idt &theval)
+static inline size_t do_type_crc(const irep_idt &theval)
 {
   return boost::hash<std::string>()(theval.as_string());
 }
 
-static inline __attribute__((always_inline)) void
-do_type_hash(const irep_idt &theval, crypto_hash &hash)
+static inline void do_type_hash(const irep_idt &theval, crypto_hash &hash)
 {
   hash.ingest((void *)theval.as_string().c_str(), theval.as_string().size());
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const type2t::type_ids &i)
+static inline size_t do_type_crc(const type2t::type_ids &i)
 {
   return boost::hash<uint8_t>()(i);
 }
 
-static inline __attribute__((always_inline)) void do_type_hash(
-  const type2t::type_ids &i __attribute__((unused)),
-  crypto_hash &hash __attribute__((unused)))
+static inline void do_type_hash(const type2t::type_ids &i __attribute__((unused)), crypto_hash &hash __attribute__((unused)))
 {
   // Dummy field crc
 }
 
-static inline __attribute__((always_inline)) size_t
-do_type_crc(const expr2t::expr_ids &i __attribute__((unused)))
+static inline size_t do_type_crc(const expr2t::expr_ids &i)
 {
   return boost::hash<uint8_t>()(i);
 }
 
-static inline __attribute__((always_inline)) void do_type_hash(
-  const expr2t::expr_ids &i __attribute__((unused)),
-  crypto_hash &hash __attribute__((unused)))
+static inline void do_type_hash(const expr2t::expr_ids &i __attribute__((unused)), crypto_hash &hash __attribute__((unused)))
 {
   // Dummy field crc
 }

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -879,13 +879,15 @@ type_poolt type_pool;
 static_assert(type2t::end_type_id <= 256, "Type id overflow");
 static_assert(expr2t::end_expr_id <= 256, "Expr id overflow");
 
-static inline std::string type_to_string(const bool &thebool, int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const bool &thebool, int indent [[gnu::unused]])
 {
   return (thebool) ? "true" : "false";
 }
 
-static inline std::string
-type_to_string(const sideeffect_data::allockind &data, int indent [[gnu::unused]])
+static inline std::string type_to_string(
+  const sideeffect_data::allockind &data,
+  int indent [[gnu::unused]])
 {
   return (data == sideeffect_data::allockind::malloc)
            ? "malloc"
@@ -907,15 +909,17 @@ type_to_string(const sideeffect_data::allockind &data, int indent [[gnu::unused]
                                        : "unknown";
 }
 
-static inline std::string type_to_string(const unsigned int &theval, int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const unsigned int &theval, int indent [[gnu::unused]])
 {
   char buffer[64];
   snprintf(buffer, 63, "%d", theval);
   return std::string(buffer);
 }
 
-static inline std::string
-type_to_string(const symbol_data::renaming_level &theval, int indent [[gnu::unused]])
+static inline std::string type_to_string(
+  const symbol_data::renaming_level &theval,
+  int indent [[gnu::unused]])
 {
   switch(theval)
   {
@@ -935,7 +939,8 @@ type_to_string(const symbol_data::renaming_level &theval, int indent [[gnu::unus
   }
 }
 
-static inline std::string type_to_string(const BigInt &theint, int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const BigInt &theint, int indent [[gnu::unused]])
 {
   char buffer[256], *buf;
 
@@ -943,12 +948,14 @@ static inline std::string type_to_string(const BigInt &theint, int indent [[gnu:
   return std::string(buf);
 }
 
-static inline std::string type_to_string(const fixedbvt &theval, int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const fixedbvt &theval, int indent [[gnu::unused]])
 {
   return theval.to_ansi_c_string();
 }
 
-static inline std::string type_to_string(const ieee_floatt &theval, int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const ieee_floatt &theval, int indent [[gnu::unused]])
 {
   return theval.to_ansi_c_string();
 }
@@ -1028,7 +1035,8 @@ static inline std::string type_to_string(const type2tc &theval, int indent)
     return "";
 }
 
-static inline std::string type_to_string(const irep_idt &theval, int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const irep_idt &theval, int indent [[gnu::unused]])
 {
   return theval.as_string();
 }
@@ -1120,14 +1128,16 @@ static inline bool do_type_cmp(const irep_idt &side1, const irep_idt &side2)
   return (side1 == side2);
 }
 
-static inline bool
-do_type_cmp(const type2t::type_ids &id [[gnu::unused]], const type2t::type_ids &id2 [[gnu::unused]])
+static inline bool do_type_cmp(
+  const type2t::type_ids &id [[gnu::unused]],
+  const type2t::type_ids &id2 [[gnu::unused]])
 {
   return true; // Dummy field comparison.
 }
 
-static inline bool
-do_type_cmp(const expr2t::expr_ids &id [[gnu::unused]], const expr2t::expr_ids &id2 [[gnu::unused]])
+static inline bool do_type_cmp(
+  const expr2t::expr_ids &id [[gnu::unused]],
+  const expr2t::expr_ids &id2 [[gnu::unused]])
 {
   return true; // Dummy field comparison.
 }
@@ -1280,14 +1290,16 @@ static inline int do_type_lt(const irep_idt &side1, const irep_idt &side2)
   return 0;
 }
 
-static inline int
-do_type_lt(const type2t::type_ids &id [[gnu::unused]], const type2t::type_ids &id2 [[gnu::unused]])
+static inline int do_type_lt(
+  const type2t::type_ids &id [[gnu::unused]],
+  const type2t::type_ids &id2 [[gnu::unused]])
 {
   return 0; // Dummy field comparison
 }
 
-static inline int
-do_type_lt(const expr2t::expr_ids &id [[gnu::unused]], const expr2t::expr_ids &id2 [[gnu::unused]])
+static inline int do_type_lt(
+  const expr2t::expr_ids &id [[gnu::unused]],
+  const expr2t::expr_ids &id2 [[gnu::unused]])
 {
   return 0; // Dummy field comparison
 }
@@ -1498,7 +1510,9 @@ static inline size_t do_type_crc(const type2t::type_ids &i)
   return boost::hash<uint8_t>()(i);
 }
 
-static inline void do_type_hash(const type2t::type_ids &i [[gnu::unused]], crypto_hash &hash [[gnu::unused]])
+static inline void do_type_hash(
+  const type2t::type_ids &i [[gnu::unused]],
+  crypto_hash &hash [[gnu::unused]])
 {
   // Dummy field crc
 }
@@ -1508,7 +1522,9 @@ static inline size_t do_type_crc(const expr2t::expr_ids &i)
   return boost::hash<uint8_t>()(i);
 }
 
-static inline void do_type_hash(const expr2t::expr_ids &i [[gnu::unused]], crypto_hash &hash [[gnu::unused]])
+static inline void do_type_hash(
+  const expr2t::expr_ids &i [[gnu::unused]],
+  crypto_hash &hash [[gnu::unused]])
 {
   // Dummy field crc
 }

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -700,7 +700,7 @@ type_poolt::type_poolt()
   // This space is deliberately left blank
 }
 
-type_poolt::type_poolt(bool yolo __attribute__((unused)))
+type_poolt::type_poolt(bool yolo [[gnu::unused]])
 {
   bool_type = type2tc(new bool_type2t());
   empty_type = type2tc(new empty_type2t());
@@ -765,7 +765,7 @@ type_poolt &type_poolt::operator=(type_poolt const &ref)
 // XXX investigate performance implications of this cache
 static const type2tc &get_type_from_pool(
   const typet &val,
-  std::map<typet, type2tc> &map __attribute__((unused)))
+  std::map<typet, type2tc> &map [[gnu::unused]])
 {
 #if 0
   std::map<const typet, type2tc>::const_iterator it = map.find(val);
@@ -879,13 +879,13 @@ type_poolt type_pool;
 static_assert(type2t::end_type_id <= 256, "Type id overflow");
 static_assert(expr2t::end_expr_id <= 256, "Expr id overflow");
 
-static inline std::string type_to_string(const bool &thebool, int indent __attribute__((unused)))
+static inline std::string type_to_string(const bool &thebool, int indent [[gnu::unused]])
 {
   return (thebool) ? "true" : "false";
 }
 
 static inline std::string
-type_to_string(const sideeffect_data::allockind &data, int indent __attribute__((unused)))
+type_to_string(const sideeffect_data::allockind &data, int indent [[gnu::unused]])
 {
   return (data == sideeffect_data::allockind::malloc)
            ? "malloc"
@@ -907,7 +907,7 @@ type_to_string(const sideeffect_data::allockind &data, int indent __attribute__(
                                        : "unknown";
 }
 
-static inline std::string type_to_string(const unsigned int &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const unsigned int &theval, int indent [[gnu::unused]])
 {
   char buffer[64];
   snprintf(buffer, 63, "%d", theval);
@@ -915,7 +915,7 @@ static inline std::string type_to_string(const unsigned int &theval, int indent 
 }
 
 static inline std::string
-type_to_string(const symbol_data::renaming_level &theval, int indent __attribute__((unused)))
+type_to_string(const symbol_data::renaming_level &theval, int indent [[gnu::unused]])
 {
   switch(theval)
   {
@@ -935,7 +935,7 @@ type_to_string(const symbol_data::renaming_level &theval, int indent __attribute
   }
 }
 
-static inline std::string type_to_string(const BigInt &theint, int indent __attribute__((unused)))
+static inline std::string type_to_string(const BigInt &theint, int indent [[gnu::unused]])
 {
   char buffer[256], *buf;
 
@@ -943,12 +943,12 @@ static inline std::string type_to_string(const BigInt &theint, int indent __attr
   return std::string(buf);
 }
 
-static inline std::string type_to_string(const fixedbvt &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const fixedbvt &theval, int indent [[gnu::unused]])
 {
   return theval.to_ansi_c_string();
 }
 
-static inline std::string type_to_string(const ieee_floatt &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const ieee_floatt &theval, int indent [[gnu::unused]])
 {
   return theval.to_ansi_c_string();
 }
@@ -1028,7 +1028,7 @@ static inline std::string type_to_string(const type2tc &theval, int indent)
     return "";
 }
 
-static inline std::string type_to_string(const irep_idt &theval, int indent __attribute__((unused)))
+static inline std::string type_to_string(const irep_idt &theval, int indent [[gnu::unused]])
 {
   return theval.as_string();
 }
@@ -1121,13 +1121,13 @@ static inline bool do_type_cmp(const irep_idt &side1, const irep_idt &side2)
 }
 
 static inline bool
-do_type_cmp(const type2t::type_ids &id __attribute__((unused)), const type2t::type_ids &id2 __attribute__((unused)))
+do_type_cmp(const type2t::type_ids &id [[gnu::unused]], const type2t::type_ids &id2 [[gnu::unused]])
 {
   return true; // Dummy field comparison.
 }
 
 static inline bool
-do_type_cmp(const expr2t::expr_ids &id __attribute__((unused)), const expr2t::expr_ids &id2 __attribute__((unused)))
+do_type_cmp(const expr2t::expr_ids &id [[gnu::unused]], const expr2t::expr_ids &id2 [[gnu::unused]])
 {
   return true; // Dummy field comparison.
 }
@@ -1281,13 +1281,13 @@ static inline int do_type_lt(const irep_idt &side1, const irep_idt &side2)
 }
 
 static inline int
-do_type_lt(const type2t::type_ids &id __attribute__((unused)), const type2t::type_ids &id2 __attribute__((unused)))
+do_type_lt(const type2t::type_ids &id [[gnu::unused]], const type2t::type_ids &id2 [[gnu::unused]])
 {
   return 0; // Dummy field comparison
 }
 
 static inline int
-do_type_lt(const expr2t::expr_ids &id __attribute__((unused)), const expr2t::expr_ids &id2 __attribute__((unused)))
+do_type_lt(const expr2t::expr_ids &id [[gnu::unused]], const expr2t::expr_ids &id2 [[gnu::unused]])
 {
   return 0; // Dummy field comparison
 }
@@ -1498,7 +1498,7 @@ static inline size_t do_type_crc(const type2t::type_ids &i)
   return boost::hash<uint8_t>()(i);
 }
 
-static inline void do_type_hash(const type2t::type_ids &i __attribute__((unused)), crypto_hash &hash __attribute__((unused)))
+static inline void do_type_hash(const type2t::type_ids &i [[gnu::unused]], crypto_hash &hash [[gnu::unused]])
 {
   // Dummy field crc
 }
@@ -1508,7 +1508,7 @@ static inline size_t do_type_crc(const expr2t::expr_ids &i)
   return boost::hash<uint8_t>()(i);
 }
 
-static inline void do_type_hash(const expr2t::expr_ids &i __attribute__((unused)), crypto_hash &hash __attribute__((unused)))
+static inline void do_type_hash(const expr2t::expr_ids &i [[gnu::unused]], crypto_hash &hash [[gnu::unused]])
 {
   // Dummy field crc
 }
@@ -1526,32 +1526,32 @@ void do_type2string(
 
 template <>
 void do_type2string<type2t::type_ids>(
-  const type2t::type_ids &thething __attribute__((unused)),
-  unsigned int idx __attribute__((unused)),
-  std::string (&names)[esbmct::num_type_fields] __attribute__((unused)),
-  list_of_memberst &vec __attribute__((unused)),
-  unsigned int indent __attribute__((unused)))
+  const type2t::type_ids &thething [[gnu::unused]],
+  unsigned int idx [[gnu::unused]],
+  std::string (&names)[esbmct::num_type_fields] [[gnu::unused]],
+  list_of_memberst &vec [[gnu::unused]],
+  unsigned int indent [[gnu::unused]])
 {
   // Do nothing; this is a dummy member.
 }
 
 template <>
 void do_type2string<const expr2t::expr_ids>(
-  const expr2t::expr_ids &thething __attribute__((unused)),
-  unsigned int idx __attribute__((unused)),
-  std::string (&names)[esbmct::num_type_fields] __attribute__((unused)),
-  list_of_memberst &vec __attribute__((unused)),
-  unsigned int indent __attribute__((unused)))
+  const expr2t::expr_ids &thething [[gnu::unused]],
+  unsigned int idx [[gnu::unused]],
+  std::string (&names)[esbmct::num_type_fields] [[gnu::unused]],
+  list_of_memberst &vec [[gnu::unused]],
+  unsigned int indent [[gnu::unused]])
 {
   // Do nothing; this is a dummy member.
 }
 
 template <class T>
 bool do_get_sub_expr(
-  const T &item __attribute__((unused)),
-  unsigned int idx __attribute__((unused)),
-  unsigned int &it __attribute__((unused)),
-  const expr2tc *&ptr __attribute__((unused)))
+  const T &item [[gnu::unused]],
+  unsigned int idx [[gnu::unused]],
+  unsigned int &it [[gnu::unused]],
+  const expr2tc *&ptr [[gnu::unused]])
 {
   return false;
 }
@@ -1598,10 +1598,10 @@ bool do_get_sub_expr<std::vector<expr2tc>>(
 
 template <class T>
 bool do_get_sub_expr_nc(
-  T &item __attribute__((unused)),
-  unsigned int idx __attribute__((unused)),
-  unsigned int &it __attribute__((unused)),
-  expr2tc *&ptr __attribute__((unused)))
+  T &item [[gnu::unused]],
+  unsigned int idx [[gnu::unused]],
+  unsigned int &it [[gnu::unused]],
+  expr2tc *&ptr [[gnu::unused]])
 {
   return false;
 }
@@ -1645,14 +1645,14 @@ bool do_get_sub_expr_nc<std::vector<expr2tc>>(
 }
 
 template <class T>
-unsigned int do_count_sub_exprs(T &item __attribute__((unused)))
+unsigned int do_count_sub_exprs(T &item [[gnu::unused]])
 {
   return 0;
 }
 
 template <>
 unsigned int do_count_sub_exprs<const expr2tc>(const expr2tc &item
-                                               __attribute__((unused)))
+                                               [[gnu::unused]])
 {
   return 1;
 }

--- a/src/util/irep2_expr.h
+++ b/src/util/irep2_expr.h
@@ -2222,10 +2222,7 @@ public:
     : bitnot_expr_methods(type, bitnot_id, v)
   {
   }
-  bitnot2t(
-    const type2tc &type,
-    const expr2tc &v,
-    const expr2tc &)
+  bitnot2t(const type2tc &type, const expr2tc &v, const expr2tc &)
     : bitnot_expr_methods(type, bitnot_id, v)
   {
   }

--- a/src/util/irep2_expr.h
+++ b/src/util/irep2_expr.h
@@ -2225,7 +2225,7 @@ public:
   bitnot2t(
     const type2tc &type,
     const expr2tc &v,
-    const expr2tc &__attribute__((unused)))
+    const expr2tc &)
     : bitnot_expr_methods(type, bitnot_id, v)
   {
   }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -32,14 +32,14 @@ public:
   // add modules provided by currently parsed file to set
 
   virtual void modules_provided(std::set<std::string> &modules
-                                __attribute__((unused)))
+                                [[gnu::unused]])
   {
   }
 
   // final adjustments, e.g., initialization and call to main()
   virtual bool final(
-    contextt &context __attribute__((unused)),
-    message_handlert &message_handler __attribute__((unused)))
+    contextt &context [[gnu::unused]],
+    message_handlert &message_handler [[gnu::unused]])
   {
     return false;
   }

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -31,8 +31,7 @@ public:
 
   // add modules provided by currently parsed file to set
 
-  virtual void modules_provided(std::set<std::string> &modules
-                                [[gnu::unused]])
+  virtual void modules_provided(std::set<std::string> &modules [[gnu::unused]])
   {
   }
 

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -125,7 +125,7 @@ bool language_filest::final(contextt &context)
   return false;
 }
 
-bool language_filest::interfaces(contextt &context __attribute__((unused)))
+bool language_filest::interfaces(contextt &context [[gnu::unused]])
 {
 #if 0
   for(filemapt::iterator it=filemap.begin();

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1332,7 +1332,7 @@ bool simplify_exprt::simplify_if(exprt &expr)
   return result;
 }
 
-bool simplify_exprt::simplify_switch(exprt &expr __attribute__((unused)))
+bool simplify_exprt::simplify_switch(exprt &expr [[gnu::unused]])
 {
   return true;
 }

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -1364,7 +1364,7 @@ expr2tc bitnxor2t::do_simplify() const
 expr2tc bitnot2t::do_simplify() const
 {
   std::function<int64_t(int64_t, int64_t)> op =
-    [](int64_t op1, int64_t op2 __attribute__((unused))) { return ~(op1); };
+    [](int64_t op1, int64_t op2 [[gnu::unused]]) { return ~(op1); };
 
   return do_bit_munge_operation<bitnot2t>(op, type, value, value);
 }

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -20,12 +20,12 @@ expr2tc expr2t::simplify() const
     // Corner case! Don't even try to simplify address of's operands, might end up
     // taking the address of some /completely/ arbitary pice of data, by
     // simplifiying an index to its data, discarding the symbol.
-    if(__builtin_expect((expr_id == address_of_id), 0)) // unlikely
+    if(expr_id == address_of_id) // unlikely
       return expr2tc();
 
     // And overflows too. We don't wish an add to distribute itself, for example,
     // when we're trying to work out whether or not it's going to overflow.
-    if(__builtin_expect((expr_id == overflow_id), 0))
+    if(expr_id == overflow_id)
       return expr2tc();
 
     // Try initial simplification

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -11,7 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 #include <util/string_container.h>
 
-string_containert string_container __attribute__((init_priority(101)));
+string_containert string_container [[gnu::init_priority(101)]];
 
 string_ptrt::string_ptrt(const char *_s) : s(_s), len(strlen(_s))
 {


### PR DESCRIPTION
- ~Removed `__attribute((unused))`~ Replace unused with `[[gnu::unused]]`
- Added gnu namespace for attributes e.g. `[[gnu::init_priority(101)]]`
- Removed `always_inline` attribute. This probably should be handled by the compiler
- Removed `_builtin_expect` for unlikely branchs.

That being said, if the code is a model, *.hs or a optimization between `#if GNU_C`, then it wasn't touched.