### PR TITLE
C2goto oldfrontend

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -87,7 +87,7 @@ travis_install() {
 travis_script() {
     # Compile ESBMC
 
-    export BASE_FLAGS="-DBUILD_TESTING=On -DENABLE_REGRESSION=On-DClang_DIR=$HOME/clang9 -DLLVM_DIR=$HOME/clang9 -DCMAKE_INSTALL_PREFIX:PATH=$HOME/release"
+    export BASE_FLAGS=" -DENABLE_OLD_FRONTEND=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On-DClang_DIR=$HOME/clang9 -DLLVM_DIR=$HOME/clang9 -DCMAKE_INSTALL_PREFIX:PATH=$HOME/release"
     export COVERAGE_FLAGS=""    
     export SANITIZER_FLAGS=""
     export SOLVERS="-DBoolector_DIR=$HOME/boolector-3.2.0 -DMathsat_DIR=$HOME/mathsat "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ include(FindLLVM)
 # Optimization
 include(OptimizationCCache)
 
+if(ENABLE_OLD_FRONTEND)
+  add_definitions(-DENABLE_OLD_FRONTEND)
+endif()
+
 add_subdirectory(src)
 
 # Generate ac_config.h. This must be generated after solvers

--- a/scripts/cmake/Options.cmake
+++ b/scripts/cmake/Options.cmake
@@ -21,6 +21,7 @@ option(BUILD_STATIC "Build ESBMC in static mode (default: OFF)" OFF)
 option(BUILD_DOC "Build ESBMC documentation" OFF)
 option(ENABLE_REGRESSION "Add Regressions Tests (default: OFF)" OFF)
 option(ENABLE_COVERAGE "Generate Coverage Report (default: OFF)" OFF)
+option(ENABLE_OLD_FRONTEND "Enable flex/bison language frontend (default: OFF)" OFF)
 
 #############################
 # SOLVERS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,13 @@
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_subdirectory (goto-programs)
 add_subdirectory (c2goto)
+
+if(ENABLE_OLD_FRONTEND)
 add_subdirectory (ansi-c)
-add_subdirectory (clang-c-frontend)
 add_subdirectory (cpp)
+endif()
+
+add_subdirectory (clang-c-frontend)
 add_subdirectory (pointer-analysis)
 add_subdirectory (langapi)
 add_subdirectory (util)

--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -1,6 +1,12 @@
+if(ENABLE_OLD_FRONTEND)
+  set(BUILD_OBJ_OLD_TARGETS ansicfrontend cppfrontend)
+else()
+set(BUILD_OBJ_OLD_TARGETS "")
+endif()
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.txt
   COMMAND ${CMAKE_SOURCE_DIR}/scripts/buildidobj.sh ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS main.cpp esbmc_parseoptions.cpp bmc.cpp globals.cpp document_subgoals.cpp show_vcc.cpp options.cpp ansicfrontend cppfrontend clangcfrontend clangcppfrontend symex pointeranalysis langapi util_esbmc bigint solvers clibs # Depends on... everything else linked into esbmc. Add more as necessary.
+  DEPENDS ${BUILD_OBJ_OLD_TARGETS} main.cpp esbmc_parseoptions.cpp bmc.cpp globals.cpp document_subgoals.cpp show_vcc.cpp options.cpp  clangcfrontend clangcppfrontend symex pointeranalysis langapi util_esbmc bigint solvers clibs # Depends on... everything else linked into esbmc. Add more as necessary.
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Generating ESBMC version ID"
   VERBATIM
@@ -20,6 +26,6 @@ target_include_directories(esbmc
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${Boost_INCLUDE_DIRS}
 )
-target_link_libraries(esbmc ansicfrontend cppfrontend clangcfrontend clangcppfrontend symex pointeranalysis langapi util_esbmc bigint solvers clibs)
+target_link_libraries(esbmc ${BUILD_OBJ_OLD_TARGETS} clangcfrontend clangcppfrontend symex pointeranalysis langapi util_esbmc bigint solvers clibs)
 
 install(TARGETS esbmc DESTINATION bin)

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1523,7 +1523,7 @@ void esbmc_parseoptionst::preprocessing()
     }
 #ifdef ENABLE_OLD_FRONTEND
     if(c_preprocess(filename, std::cout, false, *get_message_handler()))
-      error("PREPROCESSING ERROR");  
+      error("PREPROCESSING ERROR");
 #endif
   }
   catch(const char *e)
@@ -1794,15 +1794,15 @@ void esbmc_parseoptionst::help()
        " --i386-linux                 set Linux/I386 architecture\n"
        " --i386-win32                 set Windows/I386 architecture (default)\n"
 #elif __APPLE__
-         " --i386-macos                 set MACOS/I386 architecture (default)\n"
-         " --ppc-macos                  set PPC/I386 architecture\n"
-         " --i386-linux                 set Linux/I386 architecture\n"
-         " --i386-win32                 set Windows/I386 architecture\n"
+       " --i386-macos                 set MACOS/I386 architecture (default)\n"
+       " --ppc-macos                  set PPC/I386 architecture\n"
+       " --i386-linux                 set Linux/I386 architecture\n"
+       " --i386-win32                 set Windows/I386 architecture\n"
 #else
-         " --i386-macos                 set MACOS/I386 architecture\n"
-         " --ppc-macos                  set PPC/I386 architecture\n"
-         " --i386-linux                 set Linux/I386 architecture (default)\n"
-         " --i386-win32                 set Windows/I386 architecture\n"
+       " --i386-macos                 set MACOS/I386 architecture\n"
+       " --ppc-macos                  set PPC/I386 architecture\n"
+       " --i386-linux                 set Linux/I386 architecture (default)\n"
+       " --i386-win32                 set Windows/I386 architecture\n"
 #endif
        " --funsigned-char              make \"char\" unsigned by default\n"
        " --fms-extensions              enable microsoft C extensions\n"

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -26,7 +26,6 @@ extern "C"
 
 #include <esbmc/bmc.h>
 #include <esbmc/esbmc_parseoptions.h>
-#include <ansi-c/c_preprocess.h>
 #include <cctype>
 #include <clang-c-frontend/clang_c_language.h>
 #include <util/config.h>
@@ -56,6 +55,10 @@ extern "C"
 #include <util/symbol.h>
 #include <sys/wait.h>
 #include <util/time_stopping.h>
+
+#ifdef ENABLE_OLD_FRONTEND
+#include <ansi-c/c_preprocess.h>
+#endif
 
 enum PROCESS_TYPE
 {
@@ -1518,11 +1521,11 @@ void esbmc_parseoptionst::preprocessing()
       error("failed to open input file");
       return;
     }
-
+#ifdef ENABLE_OLD_FRONTEND
     if(c_preprocess(filename, std::cout, false, *get_message_handler()))
-      error("PREPROCESSING ERROR");
+      error("PREPROCESSING ERROR");  
+#endif
   }
-
   catch(const char *e)
   {
     error(e);
@@ -1791,15 +1794,15 @@ void esbmc_parseoptionst::help()
        " --i386-linux                 set Linux/I386 architecture\n"
        " --i386-win32                 set Windows/I386 architecture (default)\n"
 #elif __APPLE__
-       " --i386-macos                 set MACOS/I386 architecture (default)\n"
-       " --ppc-macos                  set PPC/I386 architecture\n"
-       " --i386-linux                 set Linux/I386 architecture\n"
-       " --i386-win32                 set Windows/I386 architecture\n"
+         " --i386-macos                 set MACOS/I386 architecture (default)\n"
+         " --ppc-macos                  set PPC/I386 architecture\n"
+         " --i386-linux                 set Linux/I386 architecture\n"
+         " --i386-win32                 set Windows/I386 architecture\n"
 #else
-       " --i386-macos                 set MACOS/I386 architecture\n"
-       " --ppc-macos                  set PPC/I386 architecture\n"
-       " --i386-linux                 set Linux/I386 architecture (default)\n"
-       " --i386-win32                 set Windows/I386 architecture\n"
+         " --i386-macos                 set MACOS/I386 architecture\n"
+         " --ppc-macos                  set PPC/I386 architecture\n"
+         " --i386-linux                 set Linux/I386 architecture (default)\n"
+         " --i386-win32                 set Windows/I386 architecture\n"
 #endif
        " --funsigned-char              make \"char\" unsigned by default\n"
        " --fms-extensions              enable microsoft C extensions\n"

--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -2,10 +2,10 @@
 
 const mode_table_et mode_table[] = {LANGAPI_HAVE_MODE_CLANG_C,
                                     LANGAPI_HAVE_MODE_CLANG_CPP,
-                                    #ifdef ENABLE_OLD_FRONTEND
+#ifdef ENABLE_OLD_FRONTEND
                                     LANGAPI_HAVE_MODE_C,
                                     LANGAPI_HAVE_MODE_CPP,
-                                    #endif
+#endif
                                     LANGAPI_HAVE_MODE_END};
 
 extern "C" uint8_t buildidstring_buf[1];

--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -1,9 +1,11 @@
 #include <langapi/mode.h>
 
 const mode_table_et mode_table[] = {LANGAPI_HAVE_MODE_CLANG_C,
-                                    LANGAPI_HAVE_MODE_C,
                                     LANGAPI_HAVE_MODE_CLANG_CPP,
+                                    #ifdef ENABLE_OLD_FRONTEND
+                                    LANGAPI_HAVE_MODE_C,
                                     LANGAPI_HAVE_MODE_CPP,
+                                    #endif
                                     LANGAPI_HAVE_MODE_END};
 
 extern "C" uint8_t buildidstring_buf[1];


### PR DESCRIPTION
Building the old-frontend shouldn't be enabled by default. Its usage should be limited to debugging and development. This closes https://github.com/esbmc/esbmc/issues/15

- Add the ENABLE_OLD_FRONTEND option in cmake
- Enabled this option on Travis build.

