### PR TITLE
Added WError

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Get current folder and files
       run: pwd && ls
     - name: Configure CMake
-      run: mkdir build && cd build && cmake .. -GNinja -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=ON -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=On -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DGMP_DIR=$PWD/../gmp -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
+      run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=ON -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=On -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DGMP_DIR=$PWD/../gmp -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
     - name: Build ESBMC
       run: cd build && cmake --build . && ninja install
     - uses: actions/upload-artifact@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ include(FindLLVM)
 
 # Optimization
 include(OptimizationCCache)
+include(WError)
 
 if(ENABLE_OLD_FRONTEND)
   add_definitions(-DENABLE_OLD_FRONTEND)

--- a/scripts/cmake/WError.cmake
+++ b/scripts/cmake/WError.cmake
@@ -2,5 +2,5 @@
 
 if(ENABLE_WERROR)
     message(STATUS "Compiling with Warnings are Errors")
-    add_compile_options(-Wall -Werror)    
+    add_compile_options(-Wall -Wextra -Werror)    
 endif()

--- a/scripts/cmake/WError.cmake
+++ b/scripts/cmake/WError.cmake
@@ -1,0 +1,6 @@
+# Configure and enable -Werror
+
+if(ENABLE_WERROR)
+    message(STATUS "Compiling with Warnings are Errors")
+    add_compile_options(-Wall -Werror)    
+endif()

--- a/src/clang-c-frontend/AST/build_ast.cpp
+++ b/src/clang-c-frontend/AST/build_ast.cpp
@@ -7,6 +7,8 @@
 
 #include <clang-c-frontend/AST/build_ast.h>
 #include <clang-c-frontend/AST/esbmc_action.h>
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/Basic/Version.inc>
 #include <clang/Driver/Compilation.h>
@@ -21,6 +23,7 @@
 #include <clang/Tooling/Tooling.h>
 #include <llvm/Option/ArgList.h>
 #include <llvm/Support/Path.h>
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 
 std::unique_ptr<clang::ASTUnit> buildASTs(

--- a/src/clang-c-frontend/AST/build_ast.cpp
+++ b/src/clang-c-frontend/AST/build_ast.cpp
@@ -7,6 +7,7 @@
 
 #include <clang-c-frontend/AST/build_ast.h>
 #include <clang-c-frontend/AST/esbmc_action.h>
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/Basic/Version.inc>
 #include <clang/Driver/Compilation.h>
 #include <clang/Driver/Driver.h>
@@ -20,6 +21,7 @@
 #include <clang/Tooling/Tooling.h>
 #include <llvm/Option/ArgList.h>
 #include <llvm/Support/Path.h>
+#pragma GCC diagnostic pop
 
 std::unique_ptr<clang::ASTUnit> buildASTs(
   const std::string &intrinsics,
@@ -113,5 +115,5 @@ std::unique_ptr<clang::ASTUnit> buildASTs(
       action));
   assert(unit);
 
-  return std::move(unit);
+  return unit;
 }

--- a/src/clang-c-frontend/AST/esbmc_action.h
+++ b/src/clang-c-frontend/AST/esbmc_action.h
@@ -8,10 +8,13 @@
 #ifndef CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 #define CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendActions.h>
 #include <clang/Lex/Preprocessor.h>
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #include <string>
 

--- a/src/clang-c-frontend/AST/esbmc_action.h
+++ b/src/clang-c-frontend/AST/esbmc_action.h
@@ -8,9 +8,11 @@
 #ifndef CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 #define CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendActions.h>
 #include <clang/Lex/Preprocessor.h>
+#pragma GCC diagnostic pop
 #include <string>
 
 #define __STDC_LIMIT_MACROS
@@ -33,9 +35,8 @@ public:
     return true;
   }
 
-  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
-    clang::CompilerInstance &CI,
-    llvm::StringRef InFile) override
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &, llvm::StringRef) override
   {
     return llvm::make_unique<clang::ASTConsumer>();
   }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1,8 +1,11 @@
+// Remove warnings from Clang headers
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/Attr.h>
 #include <clang/AST/QualTypeNames.h>
 #include <clang/Index/USRGeneration.h>
 #include <clang-c-frontend/clang_c_convert.h>
 #include <clang-c-frontend/typecast.h>
+#pragma GCC diagnostic pop
 #include <util/arith_tools.h>
 #include <util/bitvector.h>
 #include <util/c_types.h>
@@ -334,8 +337,8 @@ bool clang_c_convertert::get_struct_union_class_fields(
 }
 
 bool clang_c_convertert::get_struct_union_class_methods(
-  const clang::RecordDecl &recordd,
-  struct_union_typet &type)
+  const clang::RecordDecl &,
+  struct_union_typet &)
 {
   // We don't add methods to the struct in C
   return false;
@@ -419,9 +422,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   return false;
 }
 
-bool clang_c_convertert::get_function(
-  const clang::FunctionDecl &fd,
-  exprt &new_expr)
+bool clang_c_convertert::get_function(const clang::FunctionDecl &fd, exprt &)
 {
   // Don't convert if clang thinks that the functions was implicitly converted
   if(fd.isImplicit())

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1,10 +1,13 @@
 // Remove warnings from Clang headers
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/Attr.h>
 #include <clang/AST/QualTypeNames.h>
 #include <clang/Index/USRGeneration.h>
 #include <clang-c-frontend/clang_c_convert.h>
 #include <clang-c-frontend/typecast.h>
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #include <util/arith_tools.h>
 #include <util/bitvector.h>

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -4,10 +4,13 @@
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/Expr.h>
 #include <clang/AST/Type.h>
 #include <clang/Frontend/ASTUnit.h>
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #include <util/context.h>
 #include <util/namespace.h>

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -4,9 +4,11 @@
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/Expr.h>
 #include <clang/AST/Type.h>
 #include <clang/Frontend/ASTUnit.h>
+#pragma GCC diagnostic pop
 #include <util/context.h>
 #include <util/namespace.h>
 #include <util/std_types.h>

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1,11 +1,14 @@
 #include "clang_cpp_convert.h"
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/DeclFriend.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/ExprCXX.h>
 #include <clang/AST/StmtCXX.h>
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #include <util/expr_util.h>
 #include <util/std_code.h>

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1,10 +1,12 @@
 #include "clang_cpp_convert.h"
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/DeclFriend.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/ExprCXX.h>
 #include <clang/AST/StmtCXX.h>
+#pragma GCC diagnostic pop
 #include <util/expr_util.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
@@ -258,7 +260,7 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
 
 bool clang_cpp_convertert::get_struct_union_class_methods(
   const clang::RecordDecl &recordd,
-  struct_union_typet &type)
+  struct_union_typet &)
 {
   // If a struct is defined inside a extern C, it will be a RecordDecl
   const clang::CXXRecordDecl *cxxrd =
@@ -541,7 +543,7 @@ template <typename SpecializationDecl>
 bool clang_cpp_convertert::get_template_decl_specialization(
   const SpecializationDecl *D,
   bool DumpExplicitInst,
-  bool DumpRefOnly,
+  bool,
   exprt &new_expr)
 {
   for(auto *redecl_with_bad_type : D->redecls())

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -184,9 +184,6 @@ public:
      *  resulting function invocations with. */
     expr2tc orig_func_ptr_call;
 
-    /** The stack size of the frame. */
-    unsigned stack_frame_total;
-
     /**
      * Process a block adding the width of each symbol into the stack length
      * @param expr Expr to search for symbols.
@@ -220,6 +217,9 @@ public:
 
     /** Record if the function body is hidden */
     bool hidden;
+
+    /** The stack size of the frame. */
+    unsigned stack_frame_total;
 
     framet(unsigned int thread_id)
       : return_value(expr2tc()), hidden(false), stack_frame_total(0)

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -103,6 +103,8 @@ public:
   stack_framet(const irep_idt &func) : function(func), src(nullptr)
   {
   }
+
+  stack_framet &operator=(const stack_ framet &) = default;
   stack_framet(const stack_framet &ref)
   {
     *this = ref;

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -104,7 +104,7 @@ public:
   {
   }
 
-  stack_framet &operator=(const stack_ framet &) = default;
+  stack_framet& operator=(const stack_framet&) = default; 
   stack_framet(const stack_framet &ref)
   {
     *this = ref;

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -104,7 +104,7 @@ public:
   {
   }
 
-  stack_framet& operator=(const stack_framet&) = default; 
+  stack_framet &operator=(const stack_framet &) = default;
   stack_framet(const stack_framet &ref)
   {
     *this = ref;

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -173,6 +173,8 @@ public:
     {
     }
 
+    object_map_dt &operator=(const object_map_dt &other) = default;
+
     object_map_dt(const object_map_dt &ref)
     {
       *this = ref;

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -1113,7 +1113,7 @@ smt_astt cvc_convt::mk_smt_bool(bool val)
 smt_astt cvc_convt::mk_array_symbol(
   const std::string &name,
   const smt_sort *s,
-  smt_sortt array_subtype)
+  smt_sortt)
 {
   return mk_smt_symbol(name, s);
 }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -366,7 +366,7 @@ smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output)
     // Continue.
   }
 
-  for(auto i = 0; i < ast->args.size(); i++)
+  for(unsigned long int i = 0; i < ast->args.size(); i++)
     brace_level +=
       emit_ast(static_cast<const smtlib_smt_ast *>(ast->args[i]), args[i]);
 
@@ -394,7 +394,7 @@ smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output)
   }
 
   // Its operands
-  for(auto i = 0; i < ast->args.size(); i++)
+  for(unsigned long int i = 0; i < ast->args.size(); i++)
     fprintf(out_stream, " %s", args[i].c_str());
 
   // End func enclosing brace, then operand to let (two braces).

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -780,7 +780,7 @@ yices_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 }
 
 // Hack for GCC 7.3.0, in 9.3 this gives no warnings
-#pragma GCC diagnostics ignore "-Wunused-parameter"
+#pragma GCC diagnostic ignore "-Wunused-parameter"
 bool yices_convt::get_bool(smt_astt a)
 {
   int32_t val;
@@ -789,7 +789,7 @@ bool yices_convt::get_bool(smt_astt a)
   assert(!res && "Can't get boolean value from Yices");
   return val ? true : false;
 }
-#pragma GCC diagnostics pop
+#pragma GCC diagnostic pop
 
 BigInt yices_convt::get_bv(smt_astt a)
 {

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -780,7 +780,7 @@ yices_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 }
 
 // Hack for GCC 7.3.0, in 9.3 this gives no warnings
-#pragma GCC diagnostic ignore "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 bool yices_convt::get_bool(smt_astt a)
 {
   int32_t val;

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -655,6 +655,7 @@ smt_astt yices_convt::mk_select(smt_astt a, smt_astt b)
     a->sort->get_range_sort());
 }
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 smt_astt yices_convt::mk_isint(smt_astt a)
 {
   assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
@@ -662,6 +663,7 @@ smt_astt yices_convt::mk_isint(smt_astt a)
             << "therefore certain casts and operations don't work, sorry\n";
   abort();
 }
+#pragma GCC diagnostic pop
 
 smt_astt yices_convt::mk_smt_int(const BigInt &theint)
 {
@@ -781,6 +783,8 @@ yices_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
 // Hack for GCC 7.3.0, in 9.3 this gives no warnings
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 bool yices_convt::get_bool(smt_astt a)
 {
   int32_t val;
@@ -789,6 +793,7 @@ bool yices_convt::get_bool(smt_astt a)
   assert(!res && "Can't get boolean value from Yices");
   return val ? true : false;
 }
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 
 BigInt yices_convt::get_bv(smt_astt a)

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -779,6 +779,8 @@ yices_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
   return default_convert_array_of(init_val, domain_width, this);
 }
 
+// Hack for GCC 7.3.0, in 9.3 this gives no warnings
+#pragma GCC diagnostics ignore "-Wunused-parameter"
 bool yices_convt::get_bool(smt_astt a)
 {
   int32_t val;
@@ -787,6 +789,7 @@ bool yices_convt::get_bool(smt_astt a)
   assert(!res && "Can't get boolean value from Yices");
   return val ? true : false;
 }
+#pragma GCC diagnostics pop
 
 BigInt yices_convt::get_bv(smt_astt a)
 {

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <sstream>
 #include <yices_conv.h>
-
+#include <assert.h>
 // From yices 2.3 (I think) various API calls have had new non-binary
 // operand versions added. The maintainers have chosen to break backwards
 // compatibility in the process by moving the old functions to new names, and

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -19,10 +19,7 @@ class guardt
 public:
   // Default constructors
   guardt() = default;
-  guardt(const guardt &ref)
-  {
-    *this = ref;
-  }
+  guardt(const guardt &ref) = default;
 
   typedef std::vector<expr2tc> guard_listt;
 


### PR DESCRIPTION
## Summary

This PR will add `-Wall -Wextra -Werror"` compile flags when the ENABLE_WERROR option is ON.  The option will be enabled for Linux build on the CI.

This also fixes or ignore some issues:

- Clang headers contain lots of warnings. So I marked them to be ignored by using `#pragma GCC diagnostics ignore "-Wunused-parameter"`  and `#pragma GCC diagnostics ignore "-Wstrict-aliasing"` before the headers are included. After the inclusion, the warnings are reactivated. 

- Yices asserts are not considered a use of the variable or parameter. 

- Solved unused-parameter issues by removing the parameter in the definition. Some issues with unused variable were associated with not including the assert header

- Copy and attribution operations cannot be implicit since C++14. So I defined them as the default implementation. The issue is that something such as `*this = ref` cannot be done unless the `operator=` is explicitly defined.

- Solved a reordering issue in the stack size.

- Solved an auto variable that was being set as `int` instead of the correct type.

- Removed `std::move` from a local variable
