### PR TITLE
Disable pointer relation check

### DIFF
--- a/regression/esbmc/no_pointer_check_1/main.c
+++ b/regression/esbmc/no_pointer_check_1/main.c
@@ -1,0 +1,8 @@
+// Checks if relation operations don't throw errors anymore
+int main(void) {
+    int* p = (int*) malloc(sizeof(int));
+    int q;
+
+    if(p < &q) return 1;
+    return 0;
+}

--- a/regression/esbmc/no_pointer_check_1/test.desc
+++ b/regression/esbmc/no_pointer_check_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_pointer_check_1_fail/main.c
+++ b/regression/esbmc/no_pointer_check_1_fail/main.c
@@ -1,0 +1,6 @@
+// Check if the flag don't disable other pointer checks
+int main(void) {
+    int* p = (int*) malloc(sizeof(int) *10); // --assume-malloc-success
+    int q;
+    return p[q];
+}

--- a/regression/esbmc/no_pointer_check_1_fail/test.desc
+++ b/regression/esbmc/no_pointer_check_1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/no_pointer_check_2/main.c
+++ b/regression/esbmc/no_pointer_check_2/main.c
@@ -1,0 +1,8 @@
+// Check if equality between heap and stack is correct
+int main(void) {
+  int* p = (int*) malloc(sizeof(int)); // Null or unique heap addr
+  int q; // unique stack addr
+
+  if(p == &q) __ESBMC_assert(0,"p shouldn't be equal to &q");
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_2/test.desc
+++ b/regression/esbmc/no_pointer_check_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_pointer_check_2_fail/main.c
+++ b/regression/esbmc/no_pointer_check_2_fail/main.c
@@ -1,0 +1,8 @@
+// Check if equality between heap and stack is correct
+int main(void) {
+  int* p = (int*) malloc(sizeof(int)); // Null or unique heap addr
+  int q; // unique stack addr
+
+  if(p != &q) __ESBMC_assert(0,"p should be different to &q");
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_2_fail/test.desc
+++ b/regression/esbmc/no_pointer_check_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/no_pointer_check_3/main.c
+++ b/regression/esbmc/no_pointer_check_3/main.c
@@ -1,0 +1,9 @@
+// Check if equality between heap and heap is correct
+int main(void) {
+  int* p = (int*) malloc(sizeof(int)); // Null or unique heap addr
+  int* q = (int*) malloc(sizeof(int)); // Null or unique heap addr
+
+  // Force-malloc-success
+  if(p == q) __ESBMC_assert(0,"p shouldn't be equal to q with malloc success");
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_3/test.desc
+++ b/regression/esbmc/no_pointer_check_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_pointer_check_3_fail/main.c
+++ b/regression/esbmc/no_pointer_check_3_fail/main.c
@@ -1,0 +1,9 @@
+// Check if equality between heap and heap is correct
+int main(void) {
+  int* p = (int*) malloc(sizeof(int)); // Null or unique heap addr
+  int* q = (int*) malloc(sizeof(int)); // Null or unique heap addr
+
+  // Force-malloc-success
+  if(p == q) __ESBMC_assert(0,"p shouldn't be equal to q with malloc success");
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_3_fail/test.desc
+++ b/regression/esbmc/no_pointer_check_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/no_pointer_check_4/main.c
+++ b/regression/esbmc/no_pointer_check_4/main.c
@@ -1,0 +1,9 @@
+// Check if comparation is nondet
+int main(void) {
+  int p; // unique stack addr
+  int q; // unique stack addr;
+
+  __ESBMC_assume(&p < &q);
+  if(&p > &q) __ESBMC_assert(0,"p shouldn't be greater than q");
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_4/test.desc
+++ b/regression/esbmc/no_pointer_check_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_pointer_check_4_fail/main.c
+++ b/regression/esbmc/no_pointer_check_4_fail/main.c
@@ -1,0 +1,8 @@
+// Check if comparation is nondet
+int main(void) {
+  int p; // unique stack addr
+  int q; // unique stack addr;
+
+  if(p > q) __ESBMC_assert(0,"p shouldn't be greater than q");
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_4_fail/test.desc
+++ b/regression/esbmc/no_pointer_check_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/no_pointer_check_issue_273/main.c
+++ b/regression/esbmc/no_pointer_check_issue_273/main.c
@@ -1,0 +1,49 @@
+#include <stdint.h>
+
+#define MAX_SIZE_IN_BYTES 1000
+
+typedef uint8_t UINT8;
+typedef uint16_t UINT16;
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+
+UINT8 nondet_uint8() {UINT8 val; return val;}
+UINT16 nondet_uint16() {UINT16 val; return val;}
+UINT32 nondet_uint32() {UINT32 val; return val;}
+UINT64 nondet_uint64() {UINT64 val; return val;}
+
+typedef struct {
+  UINT64           address;            
+  UINT32           size;               
+  UINT16           version;            
+  UINT8            checksum;           
+} struct_t;
+
+typedef union {
+  UINT8 bytes[MAX_SIZE_IN_BYTES + 0x100];
+} my_union_t;
+
+typedef union {
+    struct_t just_placeholder;
+    UINT8 bytes[MAX_SIZE_IN_BYTES + 0x300];
+} my_buffer_union_t;
+
+my_union_t MyBuffer;
+
+#define MyBufferPtr ((my_buffer_union_t *) MyBuffer.bytes)
+
+int main() {
+  struct_t * my_struct = (struct_t *) malloc(sizeof(struct_t));
+  my_struct ->address = nondet_uint64();
+  my_struct ->size = nondet_uint32();
+  my_struct ->version = nondet_uint16();
+  my_struct ->checksum = nondet_uint8();
+
+  if (MyBufferPtr->bytes == (UINT8 *) my_struct ->address)
+    return 1;
+
+  if (MyBufferPtr->bytes < (UINT8 *) my_struct ->address)
+    return 1;
+
+  return 0;
+}

--- a/regression/esbmc/no_pointer_check_issue_273/test.desc
+++ b/regression/esbmc/no_pointer_check_issue_273/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-pointer-relation-check --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1874,6 +1874,7 @@ void esbmc_parseoptionst::help()
        " --no-div-by-zero-check       do not do division by zero check\n"
        " --no-pointer-check           do not do pointer check\n"
        " --no-align-check             do not check pointer alignment\n"
+       " --no-pointer-relation-check  do not check pointer relations\n"
        " --memory-leak-check          enable memory leak check\n"
        " --nan-check                  check floating-point for NaN\n"
        " --overflow-check             enable arithmetic over- and underflow "

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -119,6 +119,7 @@ const struct opt_templ esbmc_options[] = {
   {0, "no-div-by-zero-check", switc, ""},
   {0, "no-pointer-check", switc, ""},
   {0, "no-align-check", switc, ""},
+  {0, "no-pointer-relation-check", switc, ""},
   {0, "nan-check", switc, ""},
   {0, "memory-leak-check", switc, ""},
   {0, "overflow-check", switc, ""},

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -26,6 +26,8 @@ public:
       disable_pointer_check(options.get_bool_option("no-pointer-check")),
       disable_div_by_zero_check(
         options.get_bool_option("no-div-by-zero-check")),
+      disable_pointer_relation_check(
+        options.get_bool_option("no-pointer-relation-check")),
       enable_overflow_check(options.get_bool_option("overflow-check")),
       enable_nan_check(options.get_bool_option("nan-check"))
   {
@@ -84,6 +86,7 @@ protected:
   bool disable_bounds_check;
   bool disable_pointer_check;
   bool disable_div_by_zero_check;
+  bool disable_pointer_relation_check;
   bool enable_overflow_check;
   bool enable_nan_check;
 };
@@ -251,7 +254,7 @@ void goto_checkt::pointer_rel_check(
   const guardt &guard,
   const locationt &loc)
 {
-  if(disable_pointer_check)
+  if(disable_pointer_check || disable_pointer_relation_check)
     return;
 
   assert(expr->get_num_sub_exprs() == 2);


### PR DESCRIPTION
Added the `no-pointer-relation-check` option to assume that all relation comparisons between pointer are legal