### PR TITLE
Fix werror compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Get current folder and files
         run: pwd && ls
       - name: Configure CMake
-        run: mkdir build && cd build && cmake .. -GNinja -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=On -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=ON -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
+        run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=On -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=ON -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
       - name: Build ESBMC
         run: cd build && cmake --build . && cmake --install .
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           java-version: '9.0.4'
       - name: Install Dependencies
-        run: brew install gmp csmith cmake boost ninja python3 automake && pip3 install PySMT toml
+        run: brew install gmp csmith cmake boost ninja python3 automake bison flex && pip3 install PySMT toml
       - name: Download Clang 9
         run: wget https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/clang+llvm-9.0.1-x86_64-apple-darwin.tar.xz
       - name: Extract Clang 9

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Sanitizer")
 endif()
 
+include(CheckIncludeFile)
+check_include_file(unistd.h HAVE_UNISTD)
+
 include(Utils)
 include(Options)
 include(SendFileHack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,36 @@ endif()
 
 include(DefineLibM)
 
+# Copied from https://stackoverflow.com/questions/53877344/cannot-configure-cmake-to-look-for-homebrew-installed-version-of-bison
+# On macOS, search Homebrew for keg-only versions of Bison and Flex. Xcode does
+# not provide new enough versions for us to use.
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(
+        COMMAND brew --prefix bison
+        RESULT_VARIABLE BREW_BISON
+        OUTPUT_VARIABLE BREW_BISON_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_BISON EQUAL 0 AND EXISTS "${BREW_BISON_PREFIX}")
+        message(STATUS "Found Bison keg installed by Homebrew at ${BREW_BISON_PREFIX}")
+        set(BISON_EXECUTABLE "${BREW_BISON_PREFIX}/bin/bison")
+    endif()
+
+    execute_process(
+        COMMAND brew --prefix flex
+        RESULT_VARIABLE BREW_FLEX
+        OUTPUT_VARIABLE BREW_FLEX_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_FLEX EQUAL 0 AND EXISTS "${BREW_FLEX_PREFIX}")
+        message(STATUS "Found Flex keg installed by Homebrew at ${BREW_FLEX_PREFIX}")
+        set(FLEX_EXECUTABLE "${BREW_FLEX_PREFIX}/bin/flex")
+    endif()
+endif()
+
+find_package(BISON 2.6.1 REQUIRED)
+find_package(FLEX 2.6.1 REQUIRED)
+
 # This MUST be executed after BuildStatic since it sets Boost Static flags
 find_package(Boost REQUIRED COMPONENTS filesystem system date_time)
 include(FindLLVM)

--- a/scripts/cmake/cmake_config.in
+++ b/scripts/cmake/cmake_config.in
@@ -13,3 +13,6 @@
 #if @HAVE_SENDFILE_ESBMC@==1
 #define HAVE_SENDFILE_ESBMC "@HAVE_SENDFILE_ESBMC@"
 #endif
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD 1

--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_subdirectory(cpp)
 
-find_package(BISON)
-find_package(FLEX)
-
 BISON_TARGET(cparser parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parser.cpp COMPILE_FLAGS "-d -pyyansi_c")
 FLEX_TARGET(cscanner scanner.lpp ${CMAKE_CURRENT_BINARY_DIR}/scanner.cpp COMPILE_FLAGS "--header-file=scanner.hpp -Pyyansi_c")
 ADD_FLEX_BISON_DEPENDENCY(cscanner cparser)

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -90,7 +90,7 @@ protected:
       return pos < array.operands().size();
     }
 
-    init_statet &operator++(int x [[gnu::unused]])
+    init_statet &operator++(int)
     {
       pos++;
       return *this;

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -88,7 +88,7 @@ void c_typecheck_baset::typecheck_code(codet &code)
   }
 }
 
-void c_typecheck_baset::typecheck_asm(codet &code [[gnu::unused]])
+void c_typecheck_baset::typecheck_asm(codet &)
 {
 }
 
@@ -360,7 +360,7 @@ void c_typecheck_baset::typecheck_switch_case(code_switch_caset &code)
   }
 }
 
-void c_typecheck_baset::typecheck_goto(codet &code [[gnu::unused]])
+void c_typecheck_baset::typecheck_goto(codet &)
 {
 }
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1657,7 +1657,7 @@ void c_typecheck_baset::typecheck_function_call_arguments(
   }
 }
 
-void c_typecheck_baset::typecheck_expr_constant(exprt &expr [[gnu::unused]])
+void c_typecheck_baset::typecheck_expr_constant(exprt &)
 {
   // Do nothing
 }
@@ -2021,6 +2021,6 @@ void c_typecheck_baset::make_constant_index(exprt &expr)
   }
 }
 
-void c_typecheck_baset::make_constant_rec(exprt &expr [[gnu::unused]])
+void c_typecheck_baset::make_constant_rec(exprt &)
 {
 }

--- a/src/ansi-c/cpp/CMakeLists.txt
+++ b/src/ansi-c/cpp/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(BISON)
-find_package(FLEX)
 
 BISON_TARGET(cpy cpy.y ${CMAKE_CURRENT_BINARY_DIR}/cpy.c COMPILE_FLAGS "-pcpp -d --defines=cpy.h" DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/cpy.h)
 # For Coverage

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -134,9 +134,7 @@ void ingest_symbol(
 }
 
 #ifdef NO_CPROVER_LIBRARY
-void add_cprover_library(
-  contextt &context [[gnu::unused]],
-  message_handlert &message_handler [[gnu::unused]])
+void add_cprover_library(contextt &, message_handlert &)
 {
 }
 

--- a/src/clang-c-frontend/AST/build_ast.cpp
+++ b/src/clang-c-frontend/AST/build_ast.cpp
@@ -1,10 +1,4 @@
-/*
- * build_ast.cpp
- *
- *  Created on: Apr 14, 2017
- *      Author: mramalho
- */
-
+// Remove warnings from Clang headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/src/clang-c-frontend/AST/build_ast.cpp
+++ b/src/clang-c-frontend/AST/build_ast.cpp
@@ -5,10 +5,8 @@
  *      Author: mramalho
  */
 
-#include <clang-c-frontend/AST/build_ast.h>
-#include <clang-c-frontend/AST/esbmc_action.h>
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/Basic/Version.inc>
 #include <clang/Driver/Compilation.h>
@@ -24,7 +22,9 @@
 #include <llvm/Option/ArgList.h>
 #include <llvm/Support/Path.h>
 #pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
+
+#include <clang-c-frontend/AST/build_ast.h>
+#include <clang-c-frontend/AST/esbmc_action.h>
 
 std::unique_ptr<clang::ASTUnit> buildASTs(
   const std::string &intrinsics,

--- a/src/clang-c-frontend/AST/build_ast.h
+++ b/src/clang-c-frontend/AST/build_ast.h
@@ -1,10 +1,3 @@
-/*
- * build_ast.h
- *
- *  Created on: Apr 14, 2017
- *      Author: mramalho
- */
-
 #ifndef CLANG_C_FRONTEND_AST_BUILD_AST_H_
 #define CLANG_C_FRONTEND_AST_BUILD_AST_H_
 

--- a/src/clang-c-frontend/AST/esbmc_action.h
+++ b/src/clang-c-frontend/AST/esbmc_action.h
@@ -1,13 +1,7 @@
-/*
- * esbmcaction.h
- *
- *  Created on: Apr 25, 2017
- *      Author: mramalho
- */
-
 #ifndef CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 #define CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 
+// Remove warnings from Clang headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/src/clang-c-frontend/AST/esbmc_action.h
+++ b/src/clang-c-frontend/AST/esbmc_action.h
@@ -8,13 +8,12 @@
 #ifndef CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 #define CLANG_C_FRONTEND_AST_ESBMC_ACTION_H_
 
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendActions.h>
 #include <clang/Lex/Preprocessor.h>
-#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #include <string>
 

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -1,10 +1,3 @@
-/*
- * clang_c_adjust.h
- *
- *  Created on: Aug 30, 2015
- *      Author: mramalho
- */
-
 #ifndef CLANG_C_FRONTEND_CLANG_C_ADJUST_H_
 #define CLANG_C_FRONTEND_CLANG_C_ADJUST_H_
 

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -1,10 +1,3 @@
-/*
- * clang_c_adjust.cpp
- *
- *  Created on: Aug 30, 2015
- *      Author: mramalho
- */
-
 #include <clang-c-frontend/clang_c_adjust.h>
 #include <clang-c-frontend/typecast.h>
 #include <util/bitvector.h>

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1,10 +1,3 @@
-/*
- * clang_c_adjust.cpp
- *
- *  Created on: Aug 30, 2015
- *      Author: mramalho
- */
-
 #include <clang-c-frontend/clang_c_adjust.h>
 #include <clang-c-frontend/typecast.h>
 #include <util/arith_tools.h>

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1,14 +1,17 @@
 // Remove warnings from Clang headers
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/Attr.h>
+#include <clang/AST/Expr.h>
 #include <clang/AST/QualTypeNames.h>
+#include <clang/AST/Type.h>
 #include <clang/Index/USRGeneration.h>
+#include <clang/Frontend/ASTUnit.h>
+#pragma GCC diagnostic pop
+
 #include <clang-c-frontend/clang_c_convert.h>
 #include <clang-c-frontend/typecast.h>
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
 #include <util/arith_tools.h>
 #include <util/bitvector.h>
 #include <util/c_types.h>

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2976,8 +2976,7 @@ typet clang_c_convertert::fix_bitfields(const typet &_type)
   if(bitfield_fixed_type_map.find(type) != bitfield_fixed_type_map.end())
     return bitfield_fixed_type_map.find(type)->second;
 
-  typet new_type = type;
-  auto sutype = to_struct_union_type(new_type);
+  auto sutype = to_struct_union_type(type);
   auto &components = sutype.components(); // It's a vector of components
   std::decay<decltype(components)>::type new_components;
   bool is_packed = sutype.get("packed").as_string() == "true";
@@ -3049,7 +3048,7 @@ typet clang_c_convertert::fix_bitfields(const typet &_type)
   bitfield_fixed_type_map.insert(std::make_pair(type, sutype));
   bitfield_orig_type_map.insert(std::make_pair(sutype, type));
 
-  return sutype;
+  return std::move(sutype);
 }
 
 void clang_c_convertert::fix_constant_bitfields(exprt &expr)

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -325,7 +325,7 @@ bool clang_c_convertert::get_struct_union_class_fields(
   struct_union_typet &type)
 {
   // First, parse the fields
-  for(auto const &field : recordd.fields())
+  for(auto const *field : recordd.fields())
   {
     struct_typet::componentt comp;
     if(get_decl(*field, comp))

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -4,19 +4,41 @@
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
 
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <clang/AST/Expr.h>
-#include <clang/AST/Type.h>
-#include <clang/Frontend/ASTUnit.h>
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
 #include <util/context.h>
 #include <util/namespace.h>
 #include <util/std_types.h>
 
 #define BITFIELD_MAX_FIELD 64
+
+// Forward dec, to avoid bringing in clang headers
+namespace clang
+{
+class ASTUnit;
+class ASTContext;
+class SourceManager;
+class FunctionDecl;
+class Decl;
+class VarDecl;
+class ParmVarDecl;
+class RecordDecl;
+class QualType;
+class Type;
+class BuiltinType;
+class Stmt;
+class BinaryOperator;
+class CompoundAssignOperator;
+class UnaryOperator;
+class AtomicExpr;
+class CastExpr;
+class NamedDecl;
+class PresumedLoc;
+class SourceLocation;
+class CharacterLiteral;
+class StringLiteral;
+class IntegerLiteral;
+class FloatingLiteral;
+class TagDecl;
+} // namespace clang
 
 class clang_c_convertert
 {

--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -5,6 +5,12 @@
  *      Author: mramalho
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <clang/AST/Expr.h>
+#pragma GCC diagnostic pop
+
 #include <clang-c-frontend/clang_c_convert.h>
 #include <util/arith_tools.h>
 #include <util/bitvector.h>

--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -1,10 +1,4 @@
-/*
- * clang_c_convert_literals.cpp
- *
- *  Created on: Jul 23, 2015
- *      Author: mramalho
- */
-
+// Remove warnings from Clang headers
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -237,16 +237,16 @@ bool clang_c_languaget::typecheck(
   return false;
 }
 
-void clang_c_languaget::show_parse(std::ostream &out [[gnu::unused]])
+void clang_c_languaget::show_parse(std::ostream &)
 {
   for(auto const &translation_unit : ASTs)
     (*translation_unit).getASTContext().getTranslationUnitDecl()->dump();
 }
 
 bool clang_c_languaget::preprocess(
-  const std::string &path [[gnu::unused]],
-  std::ostream &outstream [[gnu::unused]],
-  message_handlert &message_handler [[gnu::unused]])
+  const std::string &,
+  std::ostream &,
+  message_handlert &)
 {
 // TODO: Check the preprocess situation.
 #if 0

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -6,6 +6,12 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 \*******************************************************************/
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <clang/Frontend/ASTUnit.h>
+#pragma GCC diagnostic pop
+
 #include <AST/build_ast.h>
 #include <ansi-c/c_preprocess.h>
 #include <boost/filesystem.hpp>

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -1,10 +1,3 @@
-/*
- * clang_main.cpp
- *
- *  Created on: Jul 29, 2015
- *      Author: mramalho
- */
-
 #include <cassert>
 #include <util/arith_tools.h>
 #include <util/c_types.h>

--- a/src/clang-c-frontend/clang_c_main.h
+++ b/src/clang-c-frontend/clang_c_main.h
@@ -1,10 +1,3 @@
-/*
- * clang_c_main.h
- *
- *  Created on: Jul 29, 2015
- *      Author: mramalho
- */
-
 #ifndef CLANG_C_FRONTEND_CLANG_MAIN_H_
 #define CLANG_C_FRONTEND_CLANG_MAIN_H_
 

--- a/src/clang-c-frontend/expr2c.cpp
+++ b/src/clang-c-frontend/expr2c.cpp
@@ -712,10 +712,8 @@ expr2ct::convert_statement_expression(const exprt &src, unsigned &precedence)
   return "(" + convert_code(to_code_block(to_code(src.op0())), 0) + ")";
 }
 
-std::string expr2ct::convert_function(
-  const exprt &src,
-  const std::string &name,
-  unsigned precedence [[gnu::unused]])
+std::string
+expr2ct::convert_function(const exprt &src, const std::string &name, unsigned)
 {
   std::string dest = name;
   dest += '(';
@@ -909,14 +907,12 @@ expr2ct::convert_struct_member_value(const exprt &src, unsigned precedence)
   return "." + src.name().as_string() + "=" + convert(src.op0());
 }
 
-std::string
-expr2ct::convert_norep(const exprt &src, unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_norep(const exprt &src, unsigned &)
 {
   return src.pretty(0);
 }
 
-std::string
-expr2ct::convert_symbol(const exprt &src, unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_symbol(const exprt &src, unsigned &)
 {
   const irep_idt &id = src.identifier();
   std::string dest;
@@ -932,41 +928,31 @@ expr2ct::convert_symbol(const exprt &src, unsigned &precedence [[gnu::unused]])
   return dest;
 }
 
-std::string expr2ct::convert_nondet_symbol(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_nondet_symbol(const exprt &src, unsigned &)
 {
   const std::string &id = src.identifier().as_string();
   return "nondet_symbol(" + id + ")";
 }
 
-std::string expr2ct::convert_predicate_symbol(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_predicate_symbol(const exprt &src, unsigned &)
 {
   const std::string &id = src.identifier().as_string();
   return "ps(" + id + ")";
 }
 
-std::string expr2ct::convert_predicate_next_symbol(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_predicate_next_symbol(const exprt &src, unsigned &)
 {
   const std::string &id = src.identifier().as_string();
   return "pns(" + id + ")";
 }
 
-std::string expr2ct::convert_quantified_symbol(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_quantified_symbol(const exprt &src, unsigned &)
 {
   const std::string &id = src.identifier().as_string();
   return id;
 }
 
-std::string expr2ct::convert_nondet_bool(
-  const exprt &src [[gnu::unused]],
-  unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_nondet_bool(const exprt &, unsigned &)
 {
   return "nondet_bool()";
 }
@@ -1175,8 +1161,7 @@ std::string expr2ct::convert_union(const exprt &src, unsigned &precedence)
   return dest;
 }
 
-std::string
-expr2ct::convert_array(const exprt &src, unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_array(const exprt &src, unsigned &)
 {
   std::string dest = "{ ";
 
@@ -1234,9 +1219,7 @@ std::string expr2ct::convert_array_list(const exprt &src, unsigned &precedence)
   return dest;
 }
 
-std::string expr2ct::convert_function_call(
-  const exprt &src,
-  unsigned &precedence [[gnu::unused]])
+std::string expr2ct::convert_function_call(const exprt &src, unsigned &)
 {
   if(src.operands().size() != 2)
   {
@@ -1305,8 +1288,7 @@ std::string expr2ct::indent_str(unsigned indent)
   return dest;
 }
 
-std::string
-expr2ct::convert_code_asm(const codet &src [[gnu::unused]], unsigned indent)
+std::string expr2ct::convert_code_asm(const codet &, unsigned indent)
 {
   std::string dest = indent_str(indent);
   dest += "asm();\n";
@@ -1433,8 +1415,7 @@ std::string expr2ct::convert_code_gcc_goto(const codet &src, unsigned indent)
   return dest;
 }
 
-std::string
-expr2ct::convert_code_break(const codet &src [[gnu::unused]], unsigned indent)
+std::string expr2ct::convert_code_break(const codet &, unsigned indent)
 {
   std::string dest = indent_str(indent);
   dest += "break";
@@ -1482,9 +1463,7 @@ std::string expr2ct::convert_code_switch(const codet &src, unsigned indent)
   return dest;
 }
 
-std::string expr2ct::convert_code_continue(
-  const codet &src [[gnu::unused]],
-  unsigned indent)
+std::string expr2ct::convert_code_continue(const codet &, unsigned indent)
 {
   std::string dest = indent_str(indent);
   dest += "continue";
@@ -1802,9 +1781,8 @@ std::string expr2ct::convert_code_unlock(const codet &src, unsigned indent)
   return indent_str(indent) + "UNLOCK(" + convert(src.op0()) + ");";
 }
 
-std::string expr2ct::convert_code_function_call(
-  const code_function_callt &src [[gnu::unused]],
-  unsigned indent [[gnu::unused]])
+std::string
+expr2ct::convert_code_function_call(const code_function_callt &src, unsigned)
 {
   if(src.operands().size() != 3)
   {
@@ -2002,8 +1980,7 @@ std::string expr2ct::convert_extractbit(const exprt &src, unsigned precedence)
   return dest;
 }
 
-std::string
-expr2ct::convert_sizeof(const exprt &src, unsigned precedence [[gnu::unused]])
+std::string expr2ct::convert_sizeof(const exprt &src, unsigned)
 {
   std::string dest = "sizeof(";
   dest += convert(static_cast<const typet &>(src.c_sizeof_type()));

--- a/src/clang-c-frontend/typecast.cpp
+++ b/src/clang-c-frontend/typecast.cpp
@@ -1,10 +1,3 @@
-/*
- * typecast.cpp
- *
- *  Created on: Sep 11, 2015
- *      Author: mramalho
- */
-
 #include <clang-c-frontend/typecast.h>
 #include <util/c_typecast.h>
 #include <util/c_types.h>

--- a/src/clang-c-frontend/typecast.h
+++ b/src/clang-c-frontend/typecast.h
@@ -1,10 +1,3 @@
-/*
- * typecast.h
- *
- *  Created on: Sep 11, 2015
- *      Author: mramalho
- */
-
 #ifndef TYPECAST_H_
 #define TYPECAST_H_
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -3,7 +3,11 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <clang/AST/Attr.h>
+#include <clang/AST/DeclCXX.h>
+#include <clang/AST/DeclFriend.h>
+#include <clang/AST/DeclTemplate.h>
 #include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
 #include <clang/AST/QualTypeNames.h>
 #include <clang/AST/Type.h>
 #include <clang/Index/USRGeneration.h>

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1,15 +1,16 @@
-#include "clang_cpp_convert.h"
-
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+// Remove warnings from Clang headers
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#include <clang/AST/DeclCXX.h>
-#include <clang/AST/DeclFriend.h>
-#include <clang/AST/DeclTemplate.h>
-#include <clang/AST/ExprCXX.h>
-#include <clang/AST/StmtCXX.h>
+#include <clang/AST/Attr.h>
+#include <clang/AST/Expr.h>
+#include <clang/AST/QualTypeNames.h>
+#include <clang/AST/Type.h>
+#include <clang/Index/USRGeneration.h>
+#include <clang/Frontend/ASTUnit.h>
 #pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
+
+#include <clang-cpp-frontend/clang_cpp_convert.h>
 #include <util/expr_util.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -243,7 +243,7 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
       assert(base != nullptr);
 
       // First, parse the fields
-      for(auto const &field : base->fields())
+      for(auto const *field : base->fields())
       {
         // We don't add if private
         if(field->getAccess() >= clang::AS_private)
@@ -276,7 +276,7 @@ bool clang_cpp_convertert::get_struct_union_class_methods(
   if(cxxrd == nullptr)
     return false;
 
-  for(const auto &decl : cxxrd->methods())
+  for(const auto *decl : cxxrd->methods())
   {
     exprt dummy;
     if(get_decl(*decl, dummy))

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -6,6 +6,13 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 \*******************************************************************/
 
+// Remove warnings from Clang headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <clang/Frontend/ASTUnit.h>
+#pragma GCC diagnostic pop
+
 #include <util/c_link.h>
 #include <c2goto/cprover_library.h>
 #include <clang-c-frontend/clang_c_main.h>

--- a/src/clang-cpp-frontend/expr2cpp.cpp
+++ b/src/clang-cpp-frontend/expr2cpp.cpp
@@ -303,16 +303,12 @@ std::string expr2cppt::convert_rec(
     return expr2ct::convert_rec(src, qualifiers, declarator);
 }
 
-std::string expr2cppt::convert_cpp_this(
-  const exprt &src [[gnu::unused]],
-  unsigned precedence [[gnu::unused]])
+std::string expr2cppt::convert_cpp_this(const exprt &, unsigned)
 {
   return "this";
 }
 
-std::string expr2cppt::convert_cpp_new(
-  const exprt &src,
-  unsigned precedence [[gnu::unused]])
+std::string expr2cppt::convert_cpp_new(const exprt &src, unsigned)
 {
   std::string dest;
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(BISON)
-find_package(FLEX)
 
 FLEX_TARGET(cppscanner scanner.lpp ${CMAKE_CURRENT_BINARY_DIR}/scanner.cpp COMPILE_FLAGS "--header-file=scanner.hpp -Pyycpp")
 

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -515,8 +515,7 @@ irep_idt cpp_declarator_convertert::get_pretty_name()
   return scope->prefix + base_name;
 }
 
-void cpp_declarator_convertert::operator_overloading_rules(const symbolt &symbol
-                                                           [[gnu::unused]])
+void cpp_declarator_convertert::operator_overloading_rules(const symbolt &)
 {
   // TODO
 }

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -905,7 +905,7 @@ void cpp_typecheckt::typecheck_expr_delete(exprt &expr)
   expr.set("destructor", destructor_code);
 }
 
-void cpp_typecheckt::typecheck_expr_typecast(exprt &expr [[gnu::unused]])
+void cpp_typecheckt::typecheck_expr_typecast(exprt &)
 {
 // should not be called
 #if 0

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -921,7 +921,7 @@ bool Parser::rTempArgDeclaration(cpp_declarationt &declaration)
    extern.template.decl
    : EXTERN TEMPLATE declaration
 */
-bool Parser::rExternTemplateDecl(irept &decl [[gnu::unused]])
+bool Parser::rExternTemplateDecl(irept &)
 {
   Token tk1, tk2;
 
@@ -1214,10 +1214,10 @@ bool Parser::rIntegralDeclaration(
 }
 
 bool Parser::rConstDeclaration(
-  cpp_declarationt &declaration [[gnu::unused]],
-  cpp_storage_spect &storage_spec [[gnu::unused]],
-  cpp_member_spect &member_spec [[gnu::unused]],
-  typet &cv_q [[gnu::unused]])
+  cpp_declarationt &,
+  cpp_storage_spect &,
+  cpp_member_spect &,
+  typet &)
 {
 #ifdef DEBUG
   std::cout << "Parser::rConstDeclaration\n";
@@ -2118,7 +2118,7 @@ bool Parser::rDeclaratorQualifier()
 bool Parser::rDeclarator(
   cpp_declaratort &declarator,
   DeclKind kind,
-  bool recursive [[gnu::unused]],
+  bool,
   bool should_be_declarator,
   bool is_statement)
 {
@@ -3560,7 +3560,7 @@ bool Parser::rClassMember(cpp_itemt &member)
   access.decl
   : name ';'                e.g. <qualified class>::<member name>;
 */
-bool Parser::rAccessDecl(irept &mem [[gnu::unused]])
+bool Parser::rAccessDecl(irept &)
 {
   irept name;
   Token tk;

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -75,7 +75,7 @@ struct resultt
 };
 
 #ifndef _WIN32
-void timeout_handler(int dummy [[gnu::unused]])
+void timeout_handler(int)
 {
   std::cout << "Timed out" << std::endl;
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -407,7 +407,7 @@ void goto_convertt::cpp_new_initializer(
 }
 
 void goto_convertt::do_exit(
-  const exprt &lhs [[gnu::unused]],
+  const exprt &,
   const exprt &function,
   const exprt::operandst &arguments,
   goto_programt &dest)
@@ -426,7 +426,7 @@ void goto_convertt::do_exit(
 }
 
 void goto_convertt::do_abort(
-  const exprt &lhs [[gnu::unused]],
+  const exprt &,
   const exprt &function,
   const exprt::operandst &arguments,
   goto_programt &dest)

--- a/src/goto-programs/goto_k_induction.h
+++ b/src/goto-programs/goto_k_induction.h
@@ -1,10 +1,3 @@
-/*
- * goto_unwind.h
- *
- *  Created on: Jun 3, 2015
- *      Author: mramalho
- */
-
 #ifndef GOTO_PROGRAMS_GOTO_K_INDUCTION_H_
 #define GOTO_PROGRAMS_GOTO_K_INDUCTION_H_
 

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -1,10 +1,3 @@
-/*
- * loopst.cpp
- *
- *  Created on: Jun 30, 2015
- *      Author: mramalho
- */
-
 #include <goto-programs/goto_loops.h>
 #include <util/expr_util.h>
 

--- a/src/goto-programs/goto_loops.h
+++ b/src/goto-programs/goto_loops.h
@@ -1,10 +1,3 @@
-/*
- * loopst.h
- *
- *  Created on: Jun 30, 2015
- *      Author: mramalho
- */
-
 #ifndef GOTO_PROGRAMS_GOTO_LOOPS_H_
 #define GOTO_PROGRAMS_GOTO_LOOPS_H_
 

--- a/src/goto-programs/loopst.cpp
+++ b/src/goto-programs/loopst.cpp
@@ -1,10 +1,3 @@
-/*
- * loopst.cpp
- *
- *  Created on: Jul 20, 2015
- *      Author: mramalho
- */
-
 #include <goto-programs/loopst.h>
 
 const loopst::loop_varst &loopst::get_modified_loop_vars() const

--- a/src/goto-programs/loopst.h
+++ b/src/goto-programs/loopst.h
@@ -1,10 +1,3 @@
-/*
- * loopst.h
- *
- *  Created on: Jul 20, 2015
- *      Author: mramalho
- */
-
 #ifndef GOTO_PROGRAMS_LOOPST_H_
 #define GOTO_PROGRAMS_LOOPST_H_
 

--- a/src/goto-programs/static_analysis.cpp
+++ b/src/goto-programs/static_analysis.cpp
@@ -233,7 +233,7 @@ void static_analysis_baset::do_function_call(
   locationt l_call,
   const goto_functionst &goto_functions,
   const goto_functionst::function_mapt::const_iterator f_it,
-  const std::vector<expr2tc> &arguments [[gnu::unused]], // XXX -- why?
+  const std::vector<expr2tc> &, // XXX -- why?
   statet &new_state)
 {
   const goto_functiont &goto_function = f_it->second;

--- a/src/goto-programs/static_analysis.h
+++ b/src/goto-programs/static_analysis.h
@@ -40,16 +40,12 @@ public:
 
   virtual ~abstract_domain_baset() = default;
 
-  virtual void output(
-    const namespacet &ns [[gnu::unused]],
-    std::ostream &out [[gnu::unused]]) const
+  virtual void output(const namespacet &, std::ostream &) const
   {
   }
 
-  virtual void get_reference_set(
-    const namespacet &ns [[gnu::unused]],
-    const expr2tc &expr [[gnu::unused]],
-    std::list<expr2tc> &dest [[gnu::unused]])
+  virtual void
+  get_reference_set(const namespacet &, const expr2tc &, std::list<expr2tc> &)
   {
     assert(0);
   };

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -331,9 +331,7 @@ void goto_symext::symex_free(const expr2tc &expr)
   symex_assign(code_assign2tc(valid_index_expr, falsity), true);
 }
 
-void goto_symext::symex_printf(
-  const expr2tc &lhs [[gnu::unused]],
-  const expr2tc &rhs)
+void goto_symext::symex_printf(const expr2tc &, const expr2tc &rhs)
 {
   assert(is_code_printf2t(rhs));
 
@@ -428,7 +426,7 @@ void goto_symext::symex_cpp_new(const expr2tc &lhs, const sideeffect2t &code)
 }
 
 // XXX - implement as a call to free?
-void goto_symext::symex_cpp_delete(const expr2tc &code [[gnu::unused]])
+void goto_symext::symex_cpp_delete(const expr2tc &)
 {
   //bool do_array=code.statement()=="delete[]";
 }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -127,7 +127,7 @@ public:
     {
     }
 
-    goto_statet &operator=(const goto_statet &ref [[gnu::unused]])
+    goto_statet &operator=(const goto_statet &)
     {
       abort();
     }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -72,6 +72,8 @@ public:
     renaming::level2t &l2,
     value_sett &vs);
 
+  goto_symex_statet(goto_symex_statet const &) = default;
+
   goto_symex_statet &operator=(const goto_symex_statet &state);
 
   // Types

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -314,8 +314,8 @@ void violation_graphml_goto_trace(
 
 void correctness_graphml_goto_trace(
   optionst &options,
-  const namespacet &ns [[gnu::unused]],
-  const goto_tracet &goto_trace [[gnu::unused]])
+  const namespacet &ns,
+  const goto_tracet &goto_trace)
 {
   grapht graph(grapht::CORRECTNESS);
   graph.verified_file = verification_file;

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -783,7 +783,7 @@ reachability_treet::generate_schedule_formula()
       schedule_target, schedule_total_claims, schedule_remaining_claims));
 }
 
-bool reachability_treet::restore_from_dfs_state(void *_dfs [[gnu::unused]])
+bool reachability_treet::restore_from_dfs_state(void *)
 {
   abort();
 #if 0
@@ -843,8 +843,7 @@ bool reachability_treet::restore_from_dfs_state(void *_dfs [[gnu::unused]])
   return false;
 }
 
-void reachability_treet::save_checkpoint(const std::string &&fname
-                                         [[gnu::unused]]) const
+void reachability_treet::save_checkpoint(const std::string &&) const
 {
 #if 0
   reachability_treet::dfs_position pos(*this);

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -291,7 +291,7 @@ void renaming::level2t::dump() const
 void renaming::level2t::make_assignment(
   expr2tc &lhs_symbol,
   const expr2tc &const_value,
-  const expr2tc &assigned_value [[gnu::unused]])
+  const expr2tc &)
 {
   assert(
     to_symbol2t(lhs_symbol).rlevel == symbol2t::level1 ||

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -4,22 +4,6 @@
 #include <util/c_types.h>
 #include <utility>
 
-static inline bool array_indexes_are_same(
-  const array_convt::idx_record_containert &a,
-  const array_convt::idx_record_containert &b)
-{
-  if(a.size() != b.size())
-    return false;
-
-  for(auto const &e : a)
-  {
-    if(b.find(e.idx) == b.end())
-      return false;
-  }
-
-  return true;
-}
-
 array_convt::array_convt(smt_convt *_ctx) : array_iface(true, true), ctx(_ctx)
 {
 }

--- a/src/solvers/smtlib/CMakeLists.txt
+++ b/src/solvers/smtlib/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(BISON)
-find_package(FLEX)
 
 BISON_TARGET(smtliby smtlib.ypp ${CMAKE_CURRENT_BINARY_DIR}/smtlib.cpp COMPILE_FLAGS "-d -psmtlib")
 FLEX_TARGET(smtlibl smtlib_tok.lpp ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp COMPILE_FLAGS "--header-file=smtlib_tok.hpp -Psmtlib_tok -osmtlib_tok.cpp")

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -655,15 +655,12 @@ smt_astt yices_convt::mk_select(smt_astt a, smt_astt b)
     a->sort->get_range_sort());
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-smt_astt yices_convt::mk_isint(smt_astt a)
+smt_astt yices_convt::mk_isint(smt_astt)
 {
-  assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
   std::cerr << "Yices does not support an is-integer operation on reals, "
             << "therefore certain casts and operations don't work, sorry\n";
   abort();
 }
-#pragma GCC diagnostic pop
 
 smt_astt yices_convt::mk_smt_int(const BigInt &theint)
 {

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -778,20 +778,17 @@ yices_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
   return default_convert_array_of(init_val, domain_width, this);
 }
 
-// Hack for GCC 7.3.0, in 9.3 this gives no warnings
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
 bool yices_convt::get_bool(smt_astt a)
 {
   int32_t val;
   const yices_smt_ast *ast = to_solver_smt_ast<yices_smt_ast>(a);
-  auto res = yices_get_bool_value(yices_get_model(yices_ctx, 1), ast->a, &val);
-  assert(!res && "Can't get boolean value from Yices");
+  if(!yices_get_bool_value(yices_get_model(yices_ctx, 1), ast->a, &val))
+  {
+    std::cerr << "Can't get boolean value from Yices\n";
+    abort();
+  }
   return val ? true : false;
 }
-#pragma GCC diagnostic pop
-#pragma GCC diagnostic pop
 
 BigInt yices_convt::get_bv(smt_astt a)
 {

--- a/src/util/c_types.cpp
+++ b/src/util/c_types.cpp
@@ -18,7 +18,7 @@ typet build_float_type(unsigned width)
     fixedbv_typet result;
     result.set_width(width);
     result.set_integer_bits(width / 2);
-    return result;
+    return std::move(result);
   }
   floatbv_typet result;
   result.set_width(width);
@@ -44,7 +44,7 @@ typet build_float_type(unsigned width)
     assert(false);
   }
 
-  return result;
+  return std::move(result);
 }
 
 type2tc build_float_type2(unsigned width)

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -700,7 +700,7 @@ type_poolt::type_poolt()
   // This space is deliberately left blank
 }
 
-type_poolt::type_poolt(bool yolo [[gnu::unused]])
+type_poolt::type_poolt(bool)
 {
   bool_type = type2tc(new bool_type2t());
   empty_type = type2tc(new empty_type2t());
@@ -763,9 +763,8 @@ type_poolt &type_poolt::operator=(type_poolt const &ref)
 }
 
 // XXX investigate performance implications of this cache
-static const type2tc &get_type_from_pool(
-  const typet &val,
-  std::map<typet, type2tc> &map [[gnu::unused]])
+static const type2tc &
+get_type_from_pool(const typet &val, std::map<typet, type2tc> &)
 {
 #if 0
   std::map<const typet, type2tc>::const_iterator it = map.find(val);
@@ -879,15 +878,13 @@ type_poolt type_pool;
 static_assert(type2t::end_type_id <= 256, "Type id overflow");
 static_assert(expr2t::end_expr_id <= 256, "Expr id overflow");
 
-static inline std::string
-type_to_string(const bool &thebool, int indent [[gnu::unused]])
+static inline std::string type_to_string(const bool &thebool, int)
 {
   return (thebool) ? "true" : "false";
 }
 
-static inline std::string type_to_string(
-  const sideeffect_data::allockind &data,
-  int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const sideeffect_data::allockind &data, int)
 {
   return (data == sideeffect_data::allockind::malloc)
            ? "malloc"
@@ -909,17 +906,15 @@ static inline std::string type_to_string(
                                        : "unknown";
 }
 
-static inline std::string
-type_to_string(const unsigned int &theval, int indent [[gnu::unused]])
+static inline std::string type_to_string(const unsigned int &theval, int)
 {
   char buffer[64];
   snprintf(buffer, 63, "%d", theval);
   return std::string(buffer);
 }
 
-static inline std::string type_to_string(
-  const symbol_data::renaming_level &theval,
-  int indent [[gnu::unused]])
+static inline std::string
+type_to_string(const symbol_data::renaming_level &theval, int)
 {
   switch(theval)
   {
@@ -939,8 +934,7 @@ static inline std::string type_to_string(
   }
 }
 
-static inline std::string
-type_to_string(const BigInt &theint, int indent [[gnu::unused]])
+static inline std::string type_to_string(const BigInt &theint, int)
 {
   char buffer[256], *buf;
 
@@ -948,14 +942,12 @@ type_to_string(const BigInt &theint, int indent [[gnu::unused]])
   return std::string(buf);
 }
 
-static inline std::string
-type_to_string(const fixedbvt &theval, int indent [[gnu::unused]])
+static inline std::string type_to_string(const fixedbvt &theval, int)
 {
   return theval.to_ansi_c_string();
 }
 
-static inline std::string
-type_to_string(const ieee_floatt &theval, int indent [[gnu::unused]])
+static inline std::string type_to_string(const ieee_floatt &theval, int)
 {
   return theval.to_ansi_c_string();
 }
@@ -1035,8 +1027,7 @@ static inline std::string type_to_string(const type2tc &theval, int indent)
     return "";
 }
 
-static inline std::string
-type_to_string(const irep_idt &theval, int indent [[gnu::unused]])
+static inline std::string type_to_string(const irep_idt &theval, int)
 {
   return theval.as_string();
 }
@@ -1128,16 +1119,14 @@ static inline bool do_type_cmp(const irep_idt &side1, const irep_idt &side2)
   return (side1 == side2);
 }
 
-static inline bool do_type_cmp(
-  const type2t::type_ids &id [[gnu::unused]],
-  const type2t::type_ids &id2 [[gnu::unused]])
+static inline bool
+do_type_cmp(const type2t::type_ids &, const type2t::type_ids &)
 {
   return true; // Dummy field comparison.
 }
 
-static inline bool do_type_cmp(
-  const expr2t::expr_ids &id [[gnu::unused]],
-  const expr2t::expr_ids &id2 [[gnu::unused]])
+static inline bool
+do_type_cmp(const expr2t::expr_ids &, const expr2t::expr_ids &)
 {
   return true; // Dummy field comparison.
 }
@@ -1290,16 +1279,12 @@ static inline int do_type_lt(const irep_idt &side1, const irep_idt &side2)
   return 0;
 }
 
-static inline int do_type_lt(
-  const type2t::type_ids &id [[gnu::unused]],
-  const type2t::type_ids &id2 [[gnu::unused]])
+static inline int do_type_lt(const type2t::type_ids &, const type2t::type_ids &)
 {
   return 0; // Dummy field comparison
 }
 
-static inline int do_type_lt(
-  const expr2t::expr_ids &id [[gnu::unused]],
-  const expr2t::expr_ids &id2 [[gnu::unused]])
+static inline int do_type_lt(const expr2t::expr_ids &, const expr2t::expr_ids &)
 {
   return 0; // Dummy field comparison
 }
@@ -1510,9 +1495,7 @@ static inline size_t do_type_crc(const type2t::type_ids &i)
   return boost::hash<uint8_t>()(i);
 }
 
-static inline void do_type_hash(
-  const type2t::type_ids &i [[gnu::unused]],
-  crypto_hash &hash [[gnu::unused]])
+static inline void do_type_hash(const type2t::type_ids &, crypto_hash &)
 {
   // Dummy field crc
 }
@@ -1522,9 +1505,7 @@ static inline size_t do_type_crc(const expr2t::expr_ids &i)
   return boost::hash<uint8_t>()(i);
 }
 
-static inline void do_type_hash(
-  const expr2t::expr_ids &i [[gnu::unused]],
-  crypto_hash &hash [[gnu::unused]])
+static inline void do_type_hash(const expr2t::expr_ids &, crypto_hash &)
 {
   // Dummy field crc
 }
@@ -1542,32 +1523,28 @@ void do_type2string(
 
 template <>
 void do_type2string<type2t::type_ids>(
-  const type2t::type_ids &thething [[gnu::unused]],
-  unsigned int idx [[gnu::unused]],
-  std::string (&names)[esbmct::num_type_fields] [[gnu::unused]],
-  list_of_memberst &vec [[gnu::unused]],
-  unsigned int indent [[gnu::unused]])
+  const type2t::type_ids &,
+  unsigned int,
+  std::string (&)[esbmct::num_type_fields],
+  list_of_memberst &,
+  unsigned int)
 {
   // Do nothing; this is a dummy member.
 }
 
 template <>
 void do_type2string<const expr2t::expr_ids>(
-  const expr2t::expr_ids &thething [[gnu::unused]],
-  unsigned int idx [[gnu::unused]],
-  std::string (&names)[esbmct::num_type_fields] [[gnu::unused]],
-  list_of_memberst &vec [[gnu::unused]],
-  unsigned int indent [[gnu::unused]])
+  const expr2t::expr_ids &,
+  unsigned int,
+  std::string (&)[esbmct::num_type_fields],
+  list_of_memberst &,
+  unsigned int)
 {
   // Do nothing; this is a dummy member.
 }
 
 template <class T>
-bool do_get_sub_expr(
-  const T &item [[gnu::unused]],
-  unsigned int idx [[gnu::unused]],
-  unsigned int &it [[gnu::unused]],
-  const expr2tc *&ptr [[gnu::unused]])
+bool do_get_sub_expr(const T &, unsigned int, unsigned int &, const expr2tc *&)
 {
   return false;
 }
@@ -1613,11 +1590,7 @@ bool do_get_sub_expr<std::vector<expr2tc>>(
 // Non-const versions of the above.
 
 template <class T>
-bool do_get_sub_expr_nc(
-  T &item [[gnu::unused]],
-  unsigned int idx [[gnu::unused]],
-  unsigned int &it [[gnu::unused]],
-  expr2tc *&ptr [[gnu::unused]])
+bool do_get_sub_expr_nc(T &, unsigned int, unsigned int &, expr2tc *&)
 {
   return false;
 }
@@ -1661,14 +1634,13 @@ bool do_get_sub_expr_nc<std::vector<expr2tc>>(
 }
 
 template <class T>
-unsigned int do_count_sub_exprs(T &item [[gnu::unused]])
+unsigned int do_count_sub_exprs(T &)
 {
   return 0;
 }
 
 template <>
-unsigned int do_count_sub_exprs<const expr2tc>(const expr2tc &item
-                                               [[gnu::unused]])
+unsigned int do_count_sub_exprs<const expr2tc>(const expr2tc &)
 {
   return 1;
 }

--- a/src/util/irep2_type.h
+++ b/src/util/irep2_type.h
@@ -1,10 +1,3 @@
-/*
- * irep2_type.h
- *
- *  Created on: Jun 2, 2017
- *      Author: mramalho
- */
-
 #ifndef IREP2_TYPE_H_
 #define IREP2_TYPE_H_
 

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -31,14 +31,12 @@ public:
 
   // add modules provided by currently parsed file to set
 
-  virtual void modules_provided(std::set<std::string> &modules [[gnu::unused]])
+  virtual void modules_provided(std::set<std::string> &)
   {
   }
 
   // final adjustments, e.g., initialization and call to main()
-  virtual bool final(
-    contextt &context [[gnu::unused]],
-    message_handlert &message_handler [[gnu::unused]])
+  virtual bool final(contextt &, message_handlert &)
   {
     return false;
   }

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -125,7 +125,7 @@ bool language_filest::final(contextt &context)
   return false;
 }
 
-bool language_filest::interfaces(contextt &context [[gnu::unused]])
+bool language_filest::interfaces(contextt &)
 {
 #if 0
   for(filemapt::iterator it=filemap.begin();

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2113,7 +2113,7 @@ typet migrate_type_back(const type2tc &ref)
     thetype.set("tag", irep_idt(ref2.name));
     if(ref2.packed)
       thetype.set("packed", irep_idt("true"));
-    return thetype;
+    return std::move(thetype);
   }
   case type2t::union_id:
   {
@@ -2136,7 +2136,7 @@ typet migrate_type_back(const type2tc &ref)
 
     thetype.components() = comps;
     thetype.set("tag", irep_idt(ref2.name));
-    return thetype;
+    return std::move(thetype);
   }
   case type2t::code_id:
   {
@@ -2161,7 +2161,7 @@ typet migrate_type_back(const type2tc &ref)
     if(ref2.ellipsis)
       code.make_ellipsis();
 
-    return code;
+    return std::move(code);
   }
   case type2t::array_id:
   {
@@ -2178,7 +2178,7 @@ typet migrate_type_back(const type2tc &ref)
       thetype.size() = migrate_expr_back(ref2.array_size);
     }
 
-    return thetype;
+    return std::move(thetype);
   }
   case type2t::pointer_id:
   {
@@ -2186,7 +2186,7 @@ typet migrate_type_back(const type2tc &ref)
 
     typet subtype = migrate_type_back(ref2.subtype);
     pointer_typet thetype(subtype);
-    return thetype;
+    return std::move(thetype);
   }
   case type2t::unsignedbv_id:
   {
@@ -2207,7 +2207,7 @@ typet migrate_type_back(const type2tc &ref)
     fixedbv_typet thetype;
     thetype.set_integer_bits(ref2.integer_bits);
     thetype.set_width(ref2.width);
-    return thetype;
+    return std::move(thetype);
   }
   case type2t::floatbv_id:
   {
@@ -2216,13 +2216,13 @@ typet migrate_type_back(const type2tc &ref)
     floatbv_typet thetype;
     thetype.set_f(ref2.fraction);
     thetype.set_width(ref2.get_width());
-    return thetype;
+    return std::move(thetype);
   }
   case type2t::string_id:
   {
     string_typet ret;
     ret.width(to_string_type(ref).get_length());
-    return ret;
+    return std::move(ret);
   }
   case type2t::cpp_name_id:
   {
@@ -2271,7 +2271,7 @@ exprt migrate_expr_back(const expr2tc &ref)
     constant_exprt theexpr(thetype);
     unsigned int width = atoi(thetype.width().as_string().c_str());
     theexpr.set_value(integer2binary(ref2.value, width));
-    return theexpr;
+    return std::move(theexpr);
   }
   case expr2t::constant_fixedbv_id:
   {
@@ -2357,7 +2357,7 @@ exprt migrate_expr_back(const expr2tc &ref)
       // Special case.
       constant_exprt const_expr(migrate_type_back(ref2.type));
       const_expr.set_value(ref2.get_symbol_name());
-      return const_expr;
+      return std::move(const_expr);
     }
     else if(ref2.thename == "INVALID")
     {
@@ -2376,7 +2376,7 @@ exprt migrate_expr_back(const expr2tc &ref)
 
     typecast_exprt new_expr(migrate_expr_back(ref2.from), thetype);
     new_expr.set("rounding_mode", migrate_expr_back(ref2.rounding_mode));
-    return new_expr;
+    return std::move(new_expr);
   }
   case expr2t::nearbyint_id:
   {
@@ -2397,7 +2397,7 @@ exprt migrate_expr_back(const expr2tc &ref)
       migrate_expr_back(ref2.true_value),
       migrate_expr_back(ref2.false_value));
     theif.type() = thetype;
-    return theif;
+    return std::move(theif);
   }
   case expr2t::equality_id:
   {

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1332,7 +1332,7 @@ bool simplify_exprt::simplify_if(exprt &expr)
   return result;
 }
 
-bool simplify_exprt::simplify_switch(exprt &expr [[gnu::unused]])
+bool simplify_exprt::simplify_switch(exprt &)
 {
   return true;
 }

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -1363,8 +1363,9 @@ expr2tc bitnxor2t::do_simplify() const
 
 expr2tc bitnot2t::do_simplify() const
 {
-  std::function<int64_t(int64_t, int64_t)> op =
-    [](int64_t op1, int64_t op2 [[gnu::unused]]) { return ~(op1); };
+  std::function<int64_t(int64_t, int64_t)> op = [](int64_t op1, int64_t) {
+    return ~(op1);
+  };
 
   return do_bit_munge_operation<bitnot2t>(op, type, value, value);
 }


### PR DESCRIPTION
Fixes the compilation of esbmc in both Linux and MacOS when Werror is enabled.

This PR also activates the -Werror flag for MacOS when doing regression tests.