### PR TITLE
Fix undefined function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Get current folder and files
       run: pwd && ls
     - name: Configure CMake
-      run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=ON -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=On -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DGMP_DIR=$PWD/../gmp -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
+      run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=ON -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=On -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DGMP_DIR=$PWD/../gmp -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release -DCMAKE_BUILD_TYPE=Debug
     - name: Build ESBMC
       run: cd build && cmake --build . && ninja install
     - uses: actions/upload-artifact@v1
@@ -80,7 +80,7 @@ jobs:
       - name: Get current folder and files
         run: pwd && ls
       - name: Configure CMake
-        run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=On -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=ON -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
+        run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../clang9 -DLLVM_DIR=$PWD/../clang9 -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_MATHSAT=On -DMathsat_DIR=$PWD/../mathsat -DENABLE_YICES=ON -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release -DCMAKE_BUILD_TYPE=Debug
       - name: Build ESBMC
         run: cd build && cmake --build . && cmake --install .
       - uses: actions/upload-artifact@v1

--- a/.travis.sh
+++ b/.travis.sh
@@ -104,7 +104,7 @@ travis_script() {
         chmod +x regression/macos-wrapper.sh
     else
         if [ $ENABLE_COVERAGE = 1 ]; then
-            export COVERAGE_FLAGS="-DENABLE_COVERAGE=On"
+            export COVERAGE_FLAGS="-DENABLE_COVERAGE=On -DCMAKE_BUILD_TYPE=Debug"
         fi
         if [ $ENABLE_SANITIZER = 1 ]; then
             export SANITIZER_FLAGS="-DCMAKE_BUILD_TYPE=Sanitizer -DSANITIZER_TYPE=$SANITIZER"

--- a/src/goto-symex/symex_stack.cpp
+++ b/src/goto-symex/symex_stack.cpp
@@ -34,7 +34,7 @@ lessthanequal2tc goto_symex_statet::framet::process_stack_size(
 
 void goto_symex_statet::framet::decrease_stack_frame_size(const expr2tc &expr)
 {
-  const code_decl2t &decl_code = to_code_decl2t(expr);
+  const code_dead2t &decl_code = to_code_dead2t(expr);
 
   // Obtain the width of the dead expression and decrease it from the
   // total number of bits for a given stack frame.

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -4,6 +4,22 @@
 #include <util/c_types.h>
 #include <utility>
 
+static inline bool array_indexes_are_same(
+  const array_convt::idx_record_containert &a,
+  const array_convt::idx_record_containert &b)
+{
+  if(a.size() != b.size())
+    return false;
+
+  for(auto const &e : a)
+  {
+    if(b.find(e.idx) == b.end())
+      return false;
+  }
+
+  return true;
+}
+
 array_convt::array_convt(smt_convt *_ctx) : array_iface(true, true), ctx(_ctx)
 {
 }
@@ -946,8 +962,10 @@ void array_convt::add_array_equalities()
 
   for(auto &it = pair.first; it != pair.second; it++)
   {
+#ifndef NDEBUG
     assert(array_indexes_are_same(
       array_indexes[it->second.arr1_id], array_indexes[it->second.arr2_id]));
+#endif
 
     add_array_equality(
       it->second.arr1_id,
@@ -1173,8 +1191,10 @@ void array_convt::execute_array_joining_ite(
 
   ast_vect selects;
   selects.reserve(array_indexes[cur_id].size());
+#ifndef NDEBUG
   assert(array_indexes_are_same(
     array_indexes[cur_id], array_indexes[remote_ast->base_array_id]));
+#endif
 
   for(auto const &elem : array_indexes[remote_ast->base_array_id])
   {


### PR DESCRIPTION
Fix bug introduced by PR #285, where a function was deleted because it was only used inside an assert, and because our regressions are built in RelWithDebInfo mode, the issue was not triggered during compilation.

So add back the function and enable Debug mode during regression tests.