### PR TITLE
marked all text files as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# Flail doesn't like CRLF
+* text=auto eol=lf
+
 src/c2goto/headers/*.hs linguist-vendored
 src/clang-c-frontend/headers/*.hs linguist-vendored


### PR DESCRIPTION
This will mark all text files to be downloaded as LF when cloned, this is needed beccause the flailing doesn't work properly with CRLF and this affects remote development as well.