### PR TITLE
Z3_get_bool_value can return UNDEF

### DIFF
--- a/regression/esbmc-unix2/20_flex/test.desc
+++ b/regression/esbmc-unix2/20_flex/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.c
 --unwind 1 --ir --z3
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/github_213_mutex_destroy_fail/test.desc
+++ b/regression/esbmc-unix2/github_213_mutex_destroy_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---lock-order-check --no-div-by-zero-check --force-malloc-success --context-bound 7 --state-hashing -Dldv_assume=__ESBMC_assume --floatbv --unlimited-k-steps --z3 --incremental-bmc --32 --no-pointer-check --no-bounds-check --error-label ERROR --32
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/01_cbmc_Fixedbv23/test.desc
+++ b/regression/esbmc/01_cbmc_Fixedbv23/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.c
 --fixedbv --no-slice --ir --z3
 ^VERIFICATION FAILED$

--- a/regression/esbmc/01_cbmc_Fixedbv24/test.desc
+++ b/regression/esbmc/01_cbmc_Fixedbv24/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.c
 --fixedbv --no-slice --ir --z3
 ^VERIFICATION FAILED$

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -640,6 +640,7 @@ bool boolector_convt::get_bool(smt_astt a)
     res = false;
     break;
   default:
+    std::cerr << "Can't get boolean value from Boolector\n";
     abort();
   }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1142,7 +1142,10 @@ expr2tc z3_convt::tuple_get(const expr2tc &expr)
 bool z3_convt::get_bool(smt_astt a)
 {
   const z3_smt_ast *za = to_solver_smt_ast<z3_smt_ast>(a);
-  z3::expr e = solver.get_model().eval(za->a, false);
+  // Set the model_completion to TRUE.
+  // Z3 will assign an interpretation to the Boolean constants,
+  // which are essentially don't cares.
+  z3::expr e = solver.get_model().eval(za->a, true);
 
   Z3_lbool result = Z3_get_bool_value(z3_ctx, e);
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1181,7 +1181,7 @@ BigInt z3_convt::get_bv(smt_astt a, bool is_signed)
 ieee_floatt z3_convt::get_fpbv(smt_astt a)
 {
   const z3_smt_ast *za = to_solver_smt_ast<z3_smt_ast>(a);
-  z3::expr e = solver.get_model().eval(za->a, false);
+  z3::expr e = solver.get_model().eval(za->a, true);
 
   assert(Z3_get_ast_kind(z3_ctx, e) == Z3_APP_AST);
 
@@ -1226,7 +1226,7 @@ z3_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
     idx = to_solver_smt_ast<z3_smt_ast>(
       mk_smt_bv(BigInt(index), mk_bv_sort(array_bound)));
 
-  z3::expr e = solver.get_model().eval(select(za->a, idx->a), false);
+  z3::expr e = solver.get_model().eval(select(za->a, idx->a), true);
   return get_by_ast(subtype, new_ast(e, convert_sort(subtype)));
 }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1156,6 +1156,7 @@ bool z3_convt::get_bool(smt_astt a)
     res = false;
     break;
   default:
+    std::cerr << "Can't get boolean value from Z3\n";
     abort();
   }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1144,10 +1144,22 @@ bool z3_convt::get_bool(smt_astt a)
   const z3_smt_ast *za = to_solver_smt_ast<z3_smt_ast>(a);
   z3::expr e = solver.get_model().eval(za->a, false);
 
-  if(Z3_get_bool_value(z3_ctx, e) == Z3_L_TRUE)
-    return true;
+  Z3_lbool result = Z3_get_bool_value(z3_ctx, e);
 
-  return false;
+  bool res;
+  switch(result)
+  {
+  case Z3_L_TRUE:
+    res = true;
+    break;
+  case Z3_L_FALSE:
+    res = false;
+    break;
+  default:
+    abort();
+  }
+
+  return res;
 }
 
 BigInt z3_convt::get_bv(smt_astt a, bool is_signed)


### PR DESCRIPTION
Check whether the return value of `Z3_get_bool_value` can return UNDEF. In particular, according to the Z3 API, there are three possible outcomes for `Z3_get_bool_value`: `TRUE`, `FALSE`, and `UNDEF`. 

```
    /**
       \brief Return \c Z3_L_TRUE if \c a is true, \c Z3_L_FALSE if it is false, and \c Z3_L_UNDEF otherwise.

       def_API('Z3_get_bool_value', INT, (_in(CONTEXT), _in(AST)))
    */
    Z3_lbool Z3_API Z3_get_bool_value(Z3_context c, Z3_ast a);
```

We should abort if that function returns `UNDEF`, as we do for the other solvers.