### PR TITLE
Empty union macos

### DIFF
--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -58,7 +58,8 @@ BigInt member_offset(const type2tc &type, const irep_idt &member)
   unsigned idx = 0;
 
   // empty union generate an array
-  if(!is_struct_type(type)) return result;
+  if(!is_struct_type(type))
+    return result;
   const struct_type2t &thetype = to_struct_type(type);
 
   for(auto const &it : thetype.members)

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -57,6 +57,8 @@ BigInt member_offset(const type2tc &type, const irep_idt &member)
   BigInt result = 0;
   unsigned idx = 0;
 
+  // empty union generate an array
+  if(!is_struct_type(type)) return result;
   const struct_type2t &thetype = to_struct_type(type);
 
   for(auto const &it : thetype.members)


### PR DESCRIPTION
When generating an empty union, the member_offset function may be reached with an array. This will make a check for struct before doing the typecast