### PR TITLE
Added support for parallel SMT solving in our backend [EXPERIMENTAL & DO NOT MERGE]

### DIFF
--- a/regression/esbmc/parallel_solving_01/main.c
+++ b/regression/esbmc/parallel_solving_01/main.c
@@ -1,0 +1,314 @@
+/*************************************************************************/
+/*                                                                       */
+/*   SNU-RT Benchmark Suite for Worst Case Timing Analysis               */
+/*   =====================================================               */
+/*                              Collected and Modified by S.-S. Lim      */
+/*                                           sslim@archi.snu.ac.kr       */
+/*                                         Real-Time Research Group      */
+/*                                        Seoul National University      */
+/*                                                                       */
+/*                                                                       */
+/*        < Features > - restrictions for our experimental environment   */
+/*                                                                       */
+/*          1. Completely structured.                                    */
+/*               - There are no unconditional jumps.                     */
+/*               - There are no exit from loop bodies.                   */
+/*                 (There are no 'break' or 'return' in loop bodies)     */
+/*          2. No 'switch' statements.                                   */
+/*          3. No 'do..while' statements.                                */
+/*          4. Expressions are restricted.                               */
+/*               - There are no multiple expressions joined by 'or',     */
+/*                'and' operations.                                      */
+/*          5. No library calls.                                         */
+/*               - All the functions needed are implemented in the       */
+/*                 source file.                                          */
+/*                                                                       */
+/*                                                                       */
+/*************************************************************************/
+/*                                                                       */
+/*  FILE: fir.c                                                          */
+/*  SOURCE : C Algorithms for Real-Time DSP by P. M. Embree              */
+/*                                                                       */
+/*  DESCRIPTION :                                                        */
+/*                                                                       */
+/*     An example using FIR filter and Gaussian function.                */
+/*     algorithm.                                                        */
+/*     The function 'fir_filter' is for FIR filtering and the function   */
+/*     'gaussian' is for Gaussian number generation.                     */
+/*     The detailed description is above each function.                  */
+/*                                                                       */
+/*  REMARK :                                                             */
+/*                                                                       */
+/*  EXECUTION TIME :                                                     */
+/*                                                                       */
+/*                                                                       */
+/*************************************************************************/
+
+
+#define SAMPLE_RATE 11025
+#define RAND_MAX 32768
+#define PI 3.14159265358979323846
+
+
+
+/* function prototypes for fft and filter functions */
+float fir_filter(float input,float *coef,int n,float *history);
+
+static float gaussian(void);
+
+
+/* FILTER COEFFECIENTS FOR FILTER ROUTINES */
+
+/* FILTERS: 2 FIR AND 2 IIR */
+
+/* 35 point lowpass FIR filter cutoff at 0.19
+ designed using the Parks-McClellan program */
+
+  float  fir_lpf35[35] = {
+  -6.3600959e-03,  -7.6626200e-05,   7.6912856e-03,   5.0564148e-03,  -8.3598122e-03,
+  -1.0400905e-02,   8.6960020e-03,   2.0170502e-02,  -2.7560785e-03,  -3.0034777e-02,
+  -8.9075034e-03,   4.1715767e-02,   3.4108155e-02,  -5.0732918e-02,  -8.6097546e-02,
+   5.7914939e-02,   3.1170085e-01,   4.4029310e-01,   3.1170085e-01,   5.7914939e-02,
+  -8.6097546e-02,  -5.0732918e-02,   3.4108155e-02,   4.1715767e-02,  -8.9075034e-03,
+  -3.0034777e-02,  -2.7560785e-03,   2.0170502e-02,   8.6960020e-03,  -1.0400905e-02,
+  -8.3598122e-03,   5.0564148e-03,   7.6912856e-03,  -7.6626200e-05,  -6.3600959e-03
+                          };
+
+/* 37 point lowpass FIR filter cutoff at 0.19
+ designed using the KSRFIR.C program */
+
+  float  fir_lpf37[37] = {
+  -6.51000e-04,  -3.69500e-03,  -6.28000e-04,   6.25500e-03,   4.06300e-03,
+  -8.18900e-03,  -1.01860e-02,   7.84700e-03,   1.89680e-02,  -3.05100e-03,
+  -2.96620e-02,  -9.06500e-03,   4.08590e-02,   3.34840e-02,  -5.07550e-02,
+  -8.61070e-02,   5.75690e-02,   3.11305e-01,   4.40000e-01,   3.11305e-01,
+   5.75690e-02,  -8.61070e-02,  -5.07550e-02,   3.34840e-02,   4.08590e-02,
+  -9.06500e-03,  -2.96620e-02,  -3.05100e-03,   1.89680e-02,   7.84700e-03,
+  -1.01860e-02,  -8.18900e-03,   4.06300e-03,   6.25500e-03,  -6.28000e-04,
+  -3.69500e-03,  -6.51000e-04
+                          };
+
+
+/**************************************************************************
+
+fir_filter - Perform fir filtering sample by sample on floats
+
+Requires array of filter coefficients and pointer to history.
+Returns one output sample for each input sample.
+
+float fir_filter(float input,float *coef,int n,float *history)
+
+    float input        new float input sample
+    float *coef        pointer to filter coefficients
+    int n              number of coefficients in filter
+    float *history     history array pointer
+
+Returns float value giving the current output.
+
+*************************************************************************/
+
+int Cnt1, Cnt2, Cnt3, Cnt4;
+
+
+int rand()
+{
+  static unsigned long next = 1;
+
+  next = next * 1103515245 + 12345;
+  return (unsigned int)(next/65536) % 32768;
+}
+
+
+static float fabs(float n)
+{
+  float f;
+
+  if (n >= 0) f = n;
+  else f = -n;
+  return f;
+}
+
+
+static float sin(float rad)
+//float rad;
+{
+  float app;
+
+  float diff;
+  int inc = 1;
+
+  while (rad > 2*PI)
+	rad -= 2*PI;
+  while (rad < -2*PI)
+    rad += 2*PI;
+  app = diff = rad;
+   diff = (diff * (-(rad*rad))) /
+      ((2.0 * inc) * (2.0 * inc + 1.0));
+    app = app + diff;
+    inc++;
+  while(fabs(diff) >= 0.00001) {
+    diff = (diff * (-(rad*rad))) /
+      ((2.0 * inc) * (2.0 * inc + 1.0));
+    app = app + diff;
+    inc++;
+  }
+
+  return(app);
+}
+
+
+static float log(float r)
+//float r;
+{
+  return 4.5;
+}
+
+
+static float sqrt(float val)
+//float val;
+{
+  float x = val/10;
+
+  float dx;
+
+  double diff;
+  double min_tol = 0.00001;
+
+  int i, flag;
+
+  flag = 0;
+  if (val == 0 ) x = 0;
+  else {
+    for (i=1;i<20;i++)
+      {
+	if (!flag) {
+	  dx = (val - (x*x)) / (2.0 * x);
+	  x = x + dx;
+	  diff = val - (x*x);
+	  if (fabs(diff) <= min_tol) flag = 1;
+	}
+	else 
+	  x =x;
+      }
+  }
+  return (x);
+}
+
+
+float fir_filter(float input,float *coef,int n,float *history)
+{
+    int i;
+    float *hist_ptr,*hist1_ptr,*coef_ptr;
+    float output;
+
+    hist_ptr = history;
+    hist1_ptr = hist_ptr;             /* use for history update */
+    coef_ptr = coef + n - 1;          /* point to last coef */
+
+/* form output accumulation */
+    output = *hist_ptr++ * (*coef_ptr--);
+#ifdef DEBUG
+    if (n > Cnt2) Cnt2 = n;
+#endif
+    for(i = 2 ; i < n ; i++) {
+        *hist1_ptr++ = *hist_ptr;            /* update history array */
+        output += (*hist_ptr++) * (*coef_ptr--);
+    }
+    output += input * (*coef_ptr);           /* input tap */
+    *hist1_ptr = input;                      /* last history */
+
+    return(output);
+}
+
+
+/**************************************************************************
+
+gaussian - generates zero mean unit variance Gaussian random numbers
+
+Returns one zero mean unit variance Gaussian random numbers as a double.
+Uses the Box-Muller transformation of two uniform random numbers to
+Gaussian random numbers.
+
+float gaussian()
+
+*************************************************************************/
+
+static float gaussian()
+{
+    static int ready = 0;       /* flag to indicated stored value */
+    static float gstore;        /* place to store other value */
+    static float rconst1 = (float)(2.0/RAND_MAX);
+    static float rconst2 = (float)(RAND_MAX/2.0);
+    float v1,v2,r,fac;
+    float gaus;
+
+/* make two numbers if none stored */
+    if(ready == 0) {
+      v1 = (float)rand() - rconst2;
+      v2 = (float)rand() - rconst2;
+      v1 *= rconst1;
+      v2 *= rconst1;
+      r = v1*v1 + v2*v2;
+      while(r > 1.0f) {
+	v1 = (float)rand() - rconst2;
+	v2 = (float)rand() - rconst2;
+	v1 *= rconst1;
+	v2 *= rconst1;
+	r = v1*v1 + v2*v2;
+#ifdef DEBUG
+	printf("*");
+#endif
+      }        /* make radius less than 1 */
+
+/* remap v1 and v2 to two Gaussian numbers */
+      /*        fac = sqrt(-2.0f*log(r)/r);  */
+        fac = sqrt(-2.0f * 0.1);
+        gstore = v1*fac;        /* store one */
+        gaus = v2*fac;          /* return one */
+        ready = 1;              /* set ready flag */
+    }
+
+    else {
+        ready = 0;      /* reset ready flag for next pair */
+        gaus = gstore;  /* return the stored one */
+    }
+
+    return(gaus);
+}
+
+
+/***********************************************************************
+
+MKGWN.C - Gaussian Noise Filter Example
+
+This program filters a sine wave with added Gaussian noise.  It
+implements a 35 point FIR filter (stored in variable fir_lpf35)
+on an generated signal.  The filter is a LPF with 40 dB out of
+band rejection.  The 3 dB point is at a relative frequency of
+approximately .25*fs.
+
+************************************************************************/
+
+float sigma = 0.2;
+
+void main()
+{
+  int          i, j;
+  float x;
+  static float hist[34];
+/* first with filter */
+  for(i = 0 ; i < 10 ; i++) {
+      x = sin(0.05*2*PI*i) + sigma*gaussian();
+      x *= 25000.0;         /* scale for D/A converter */
+      fir_filter(x,fir_lpf35,35,hist);
+  }
+/* now without filter */
+  for(i = 0 ; i < 10 ; i++) {
+      x = sin(0.05*2*PI*i) + sigma*gaussian();
+      x *= 25000.0;         /* scale for D/A converter */
+  }
+
+#ifdef DEBUG
+	printf("n=%d\n",Cnt2);
+#endif
+}

--- a/regression/esbmc/parallel_solving_01/test.desc
+++ b/regression/esbmc/parallel_solving_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --overflow-check --parallel
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/parallel_solving_02/main.c
+++ b/regression/esbmc/parallel_solving_02/main.c
@@ -1,0 +1,314 @@
+/*************************************************************************/
+/*                                                                       */
+/*   SNU-RT Benchmark Suite for Worst Case Timing Analysis               */
+/*   =====================================================               */
+/*                              Collected and Modified by S.-S. Lim      */
+/*                                           sslim@archi.snu.ac.kr       */
+/*                                         Real-Time Research Group      */
+/*                                        Seoul National University      */
+/*                                                                       */
+/*                                                                       */
+/*        < Features > - restrictions for our experimental environment   */
+/*                                                                       */
+/*          1. Completely structured.                                    */
+/*               - There are no unconditional jumps.                     */
+/*               - There are no exit from loop bodies.                   */
+/*                 (There are no 'break' or 'return' in loop bodies)     */
+/*          2. No 'switch' statements.                                   */
+/*          3. No 'do..while' statements.                                */
+/*          4. Expressions are restricted.                               */
+/*               - There are no multiple expressions joined by 'or',     */
+/*                'and' operations.                                      */
+/*          5. No library calls.                                         */
+/*               - All the functions needed are implemented in the       */
+/*                 source file.                                          */
+/*                                                                       */
+/*                                                                       */
+/*************************************************************************/
+/*                                                                       */
+/*  FILE: fir.c                                                          */
+/*  SOURCE : C Algorithms for Real-Time DSP by P. M. Embree              */
+/*                                                                       */
+/*  DESCRIPTION :                                                        */
+/*                                                                       */
+/*     An example using FIR filter and Gaussian function.                */
+/*     algorithm.                                                        */
+/*     The function 'fir_filter' is for FIR filtering and the function   */
+/*     'gaussian' is for Gaussian number generation.                     */
+/*     The detailed description is above each function.                  */
+/*                                                                       */
+/*  REMARK :                                                             */
+/*                                                                       */
+/*  EXECUTION TIME :                                                     */
+/*                                                                       */
+/*                                                                       */
+/*************************************************************************/
+
+
+#define SAMPLE_RATE 11025
+#define RAND_MAX 32768
+#define PI 3.14159265358979323846
+
+
+
+/* function prototypes for fft and filter functions */
+float fir_filter(float input,float *coef,int n,float *history);
+
+static float gaussian(void);
+
+
+/* FILTER COEFFECIENTS FOR FILTER ROUTINES */
+
+/* FILTERS: 2 FIR AND 2 IIR */
+
+/* 35 point lowpass FIR filter cutoff at 0.19
+ designed using the Parks-McClellan program */
+
+  float  fir_lpf35[35] = {
+  -6.3600959e-03,  -7.6626200e-05,   7.6912856e-03,   5.0564148e-03,  -8.3598122e-03,
+  -1.0400905e-02,   8.6960020e-03,   2.0170502e-02,  -2.7560785e-03,  -3.0034777e-02,
+  -8.9075034e-03,   4.1715767e-02,   3.4108155e-02,  -5.0732918e-02,  -8.6097546e-02,
+   5.7914939e-02,   3.1170085e-01,   4.4029310e-01,   3.1170085e-01,   5.7914939e-02,
+  -8.6097546e-02,  -5.0732918e-02,   3.4108155e-02,   4.1715767e-02,  -8.9075034e-03,
+  -3.0034777e-02,  -2.7560785e-03,   2.0170502e-02,   8.6960020e-03,  -1.0400905e-02,
+  -8.3598122e-03,   5.0564148e-03,   7.6912856e-03,  -7.6626200e-05,  -6.3600959e-03
+                          };
+
+/* 37 point lowpass FIR filter cutoff at 0.19
+ designed using the KSRFIR.C program */
+
+  float  fir_lpf37[37] = {
+  -6.51000e-04,  -3.69500e-03,  -6.28000e-04,   6.25500e-03,   4.06300e-03,
+  -8.18900e-03,  -1.01860e-02,   7.84700e-03,   1.89680e-02,  -3.05100e-03,
+  -2.96620e-02,  -9.06500e-03,   4.08590e-02,   3.34840e-02,  -5.07550e-02,
+  -8.61070e-02,   5.75690e-02,   3.11305e-01,   4.40000e-01,   3.11305e-01,
+   5.75690e-02,  -8.61070e-02,  -5.07550e-02,   3.34840e-02,   4.08590e-02,
+  -9.06500e-03,  -2.96620e-02,  -3.05100e-03,   1.89680e-02,   7.84700e-03,
+  -1.01860e-02,  -8.18900e-03,   4.06300e-03,   6.25500e-03,  -6.28000e-04,
+  -3.69500e-03,  -6.51000e-04
+                          };
+
+
+/**************************************************************************
+
+fir_filter - Perform fir filtering sample by sample on floats
+
+Requires array of filter coefficients and pointer to history.
+Returns one output sample for each input sample.
+
+float fir_filter(float input,float *coef,int n,float *history)
+
+    float input        new float input sample
+    float *coef        pointer to filter coefficients
+    int n              number of coefficients in filter
+    float *history     history array pointer
+
+Returns float value giving the current output.
+
+*************************************************************************/
+
+int Cnt1, Cnt2, Cnt3, Cnt4;
+
+
+int rand()
+{
+  static unsigned long next = 1;
+
+  next = next * 1103515245 + 12345;
+  return (unsigned int)(next/65536) % 32768;
+}
+
+
+static float fabs(float n)
+{
+  float f;
+
+  if (n >= 0) f = n;
+  else f = -n;
+  return f;
+}
+
+
+static float sin(float rad)
+//float rad;
+{
+  float app;
+
+  float diff;
+  int inc = 1;
+
+  while (rad > 2*PI)
+	rad -= 2*PI;
+  while (rad < -2*PI)
+    rad += 2*PI;
+  app = diff = rad;
+   diff = (diff * (-(rad*rad))) /
+      ((2.0 * inc) * (2.0 * inc + 1.0));
+    app = app + diff;
+    inc++;
+  while(fabs(diff) >= 0.00001) {
+    diff = (diff * (-(rad*rad))) /
+      ((2.0 * inc) * (2.0 * inc + 1.0));
+    app = app + diff;
+    inc++;
+  }
+
+  return(app);
+}
+
+
+static float log(float r)
+//float r;
+{
+  return 4.5;
+}
+
+
+static float sqrt(float val)
+//float val;
+{
+  float x = val/10;
+
+  float dx;
+
+  double diff;
+  double min_tol = 0.00001;
+
+  int i, flag;
+
+  flag = 0;
+  if (val == 0 ) x = 0;
+  else {
+    for (i=1;i<20;i++)
+      {
+	if (!flag) {
+	  dx = (val - (x*x)) / (2.0 * x);
+	  x = x + dx;
+	  diff = val - (x*x);
+	  if (fabs(diff) <= min_tol) flag = 1;
+	}
+	else 
+	  x =x;
+      }
+  }
+  return (x);
+}
+
+
+float fir_filter(float input,float *coef,int n,float *history)
+{
+    int i;
+    float *hist_ptr,*hist1_ptr,*coef_ptr;
+    float output;
+
+    hist_ptr = history;
+    hist1_ptr = hist_ptr;             /* use for history update */
+    coef_ptr = coef + n - 1;          /* point to last coef */
+
+/* form output accumulation */
+    output = *hist_ptr++ * (*coef_ptr--);
+#ifdef DEBUG
+    if (n > Cnt2) Cnt2 = n;
+#endif
+    for(i = 2 ; i < n ; i++) {
+        *hist1_ptr++ = *hist_ptr;            /* update history array */
+        output += (*hist_ptr++) * (*coef_ptr--);
+    }
+    output += input * (*coef_ptr);           /* input tap */
+    *hist1_ptr = input;                      /* last history */
+
+    return(output);
+}
+
+
+/**************************************************************************
+
+gaussian - generates zero mean unit variance Gaussian random numbers
+
+Returns one zero mean unit variance Gaussian random numbers as a double.
+Uses the Box-Muller transformation of two uniform random numbers to
+Gaussian random numbers.
+
+float gaussian()
+
+*************************************************************************/
+
+static float gaussian()
+{
+    static int ready = 0;       /* flag to indicated stored value */
+    static float gstore;        /* place to store other value */
+    static float rconst1 = (float)(2.0/RAND_MAX);
+    static float rconst2 = (float)(RAND_MAX/2.0);
+    float v1,v2,r,fac;
+    float gaus;
+
+/* make two numbers if none stored */
+    if(ready == 0) {
+      v1 = (float)rand() - rconst2;
+      v2 = (float)rand() - rconst2;
+      v1 *= rconst1;
+      v2 *= rconst1;
+      r = v1*v1 + v2*v2;
+      while(r > 1.0f) {
+	v1 = (float)rand() - rconst2;
+	v2 = (float)rand() - rconst2;
+	v1 *= rconst1;
+	v2 *= rconst1;
+	r = v1*v1 + v2*v2;
+#ifdef DEBUG
+	printf("*");
+#endif
+      }        /* make radius less than 1 */
+
+/* remap v1 and v2 to two Gaussian numbers */
+      /*        fac = sqrt(-2.0f*log(r)/r);  */
+        fac = sqrt(-2.0f * 0.1);
+        gstore = v1*fac;        /* store one */
+        gaus = v2*fac;          /* return one */
+        ready = 1;              /* set ready flag */
+    }
+
+    else {
+        ready = 0;      /* reset ready flag for next pair */
+        gaus = gstore;  /* return the stored one */
+    }
+
+    return(gaus);
+}
+
+
+/***********************************************************************
+
+MKGWN.C - Gaussian Noise Filter Example
+
+This program filters a sine wave with added Gaussian noise.  It
+implements a 35 point FIR filter (stored in variable fir_lpf35)
+on an generated signal.  The filter is a LPF with 40 dB out of
+band rejection.  The 3 dB point is at a relative frequency of
+approximately .25*fs.
+
+************************************************************************/
+
+float sigma = 0.2;
+
+void main()
+{
+  int          i, j;
+  float x;
+  static float hist[34];
+/* first with filter */
+  for(i = 0 ; i < 10 ; i++) {
+      x = sin(0.05*2*PI*i) + sigma*gaussian();
+      x *= 25000.0;         /* scale for D/A converter */
+      fir_filter(x,fir_lpf35,35,hist);
+  }
+/* now without filter */
+  for(i = 0 ; i < 10 ; i++) {
+      x = sin(0.05*2*PI*i) + sigma*gaussian();
+      x *= 25000.0;         /* scale for D/A converter */
+  }
+
+#ifdef DEBUG
+	printf("n=%d\n",Cnt2);
+#endif
+}

--- a/regression/esbmc/parallel_solving_02/test.desc
+++ b/regression/esbmc/parallel_solving_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --nan-check --overflow-check --parallel
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -58,7 +58,11 @@ bmct::bmct(
   if(options.get_bool_option("smt-during-symex"))
   {
     runtime_solver = std::shared_ptr<smt_convt>(create_solver_factory(
-      "", opts.get_bool_option("int-encoding"), ns, options));
+      "",
+      opts.get_bool_option("int-encoding"),
+      opts.get_bool_option("parallel"),
+      ns,
+      options));
 
     symex = std::make_shared<reachability_treet>(
       funcs,
@@ -757,7 +761,11 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if(!options.get_bool_option("smt-during-symex"))
     {
       runtime_solver = std::shared_ptr<smt_convt>(create_solver_factory(
-        "", options.get_bool_option("int-encoding"), ns, options));
+        "",
+        options.get_bool_option("int-encoding"),
+        options.get_bool_option("parallel"),
+        ns,
+        options));
     }
 
     return run_decision_procedure(runtime_solver, eq);

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -218,6 +218,11 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("int-encoding", true);
   }
 
+  if(cmdline.isset("parallel"))
+  {
+    options.set_option("parallel", true);
+  }
+
   if(cmdline.isset("fixedbv"))
     options.set_option("fixedbv", true);
   else
@@ -1745,6 +1750,7 @@ void esbmc_parseoptionst::help()
        " --yices                      use Yices\n"
        " --bv                         use solver with bit-vector arithmetic\n"
        " --ir                         use solver with integer/real arithmetic\n"
+       " --parallel                   use parallel solver\n"
        " --smtlib                     use SMT lib format\n"
        " --smtlib-solver-prog         SMT lib program name\n"
        " --output <filename>          output VCCs in SMT lib format to given "

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -97,6 +97,7 @@ const struct opt_templ esbmc_options[] = {
   {0, "yices", switc, ""},
   {0, "bv", switc, ""},
   {0, "ir", switc, ""},
+  {0, "parallel", switc, ""},
   {0, "smtlib", switc, ""},
   {0, "smtlib-solver-prog", string, ""},
   {0, "output", string, ""},

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -12,24 +12,36 @@ void error_handler(const char *msg)
 
 smt_convt *create_new_boolector_solver(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
-  boolector_convt *conv = new boolector_convt(int_encoding, ns);
+  boolector_convt *conv = new boolector_convt(int_encoding, parallel, ns);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
 }
 
-boolector_convt::boolector_convt(bool int_encoding, const namespacet &ns)
-  : smt_convt(int_encoding, ns), array_iface(true, true), fp_convt(this)
+boolector_convt::boolector_convt(
+  bool int_encoding,
+  bool parallel,
+  const namespacet &ns)
+  : smt_convt(int_encoding, parallel, ns),
+    array_iface(true, true),
+    fp_convt(this)
 {
   if(int_encoding)
   {
     std::cerr << "Boolector does not support integer encoding mode"
               << std::endl;
+    abort();
+  }
+
+  if(parallel)
+  {
+    std::cerr << "Boolector does not support parallel solving yet" << std::endl;
     abort();
   }
 

--- a/src/solvers/boolector/boolector_conv.h
+++ b/src/solvers/boolector/boolector_conv.h
@@ -23,7 +23,7 @@ public:
 class boolector_convt : public smt_convt, public array_iface, public fp_convt
 {
 public:
-  boolector_convt(bool int_encoding, const namespacet &ns);
+  boolector_convt(bool int_encoding, bool parallel, const namespacet &ns);
   ~boolector_convt() override;
 
   resultt dec_solve() override;

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -5,19 +5,20 @@
 
 smt_convt *create_new_cvc_solver(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
-  cvc_convt *conv = new cvc_convt(int_encoding, ns);
+  cvc_convt *conv = new cvc_convt(int_encoding, parallel, ns);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
 }
 
-cvc_convt::cvc_convt(bool int_encoding, const namespacet &ns)
-  : smt_convt(int_encoding, ns),
+cvc_convt::cvc_convt(bool int_encoding, bool parallel, const namespacet &ns)
+  : smt_convt(int_encoding, parallel, ns),
     array_iface(false, false),
     fp_convt(this),
     to_bv_counter(0),
@@ -25,6 +26,12 @@ cvc_convt::cvc_convt(bool int_encoding, const namespacet &ns)
     smt(&em),
     sym_tab()
 {
+  if(parallel)
+  {
+    std::cerr << "CVC4 does not support parallel solving yet" << std::endl;
+    abort();
+  }
+
   // Already initialized stuff in the constructor list,
   smt.setOption("produce-models", true);
   smt.setOption("produce-assertions", true);

--- a/src/solvers/cvc4/cvc_conv.h
+++ b/src/solvers/cvc4/cvc_conv.h
@@ -15,7 +15,7 @@ public:
 class cvc_convt : public smt_convt, public array_iface, public fp_convt
 {
 public:
-  cvc_convt(bool int_encoding, const namespacet &ns);
+  cvc_convt(bool int_encoding, bool parallel, const namespacet &ns);
   ~cvc_convt() override = default;
 
   smt_convt::resultt dec_solve() override;

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -39,23 +39,32 @@ void mathsat_convt::check_msat_error(msat_term &r) const
 
 smt_convt *create_new_mathsat_solver(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
-  mathsat_convt *conv = new mathsat_convt(int_encoding, ns);
+  mathsat_convt *conv = new mathsat_convt(int_encoding, parallel, ns);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
 }
 
-mathsat_convt::mathsat_convt(bool int_encoding, const namespacet &ns)
-  : smt_convt(int_encoding, ns),
+mathsat_convt::mathsat_convt(
+  bool int_encoding,
+  bool parallel,
+  const namespacet &ns)
+  : smt_convt(int_encoding, parallel, ns),
     array_iface(false, false),
     fp_convt(this),
     use_fp_api(false)
 {
+  if(parallel)
+  {
+    std::cerr << "MathSAT does not support parallel solving yet" << std::endl;
+    abort();
+  }
   cfg = msat_parse_config(mathsat_config);
   msat_set_option(cfg, "model_generation", "true");
   env = msat_create_env(cfg);

--- a/src/solvers/mathsat/mathsat_conv.h
+++ b/src/solvers/mathsat/mathsat_conv.h
@@ -17,7 +17,7 @@ public:
 class mathsat_convt : public smt_convt, public array_iface, public fp_convt
 {
 public:
-  mathsat_convt(bool int_encoding, const namespacet &ns);
+  mathsat_convt(bool int_encoding, bool parallel, const namespacet &ns);
   ~mathsat_convt() override;
 
   resultt dec_solve() override;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -60,8 +60,12 @@ smt_convt::get_member_name_field(const type2tc &t, const expr2tc &name) const
   return get_member_name_field(t, str.value);
 }
 
-smt_convt::smt_convt(bool intmode, const namespacet &_ns)
-  : ctx_level(0), boolean_sort(nullptr), int_encoding(intmode), ns(_ns)
+smt_convt::smt_convt(bool intmode, bool parallelmode, const namespacet &_ns)
+  : ctx_level(0),
+    boolean_sort(nullptr),
+    int_encoding(intmode),
+    parallel(parallelmode),
+    ns(_ns)
 {
   tuple_api = nullptr;
   array_api = nullptr;

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -146,8 +146,9 @@ public:
    *  before the object is used as a solver converter.
    *
    *  @param int_encoding Whether nor not we should use QF_AUFLIRA or QF_AUFBV.
+   *  @param parallel Whether nor not we should use parallel solver.
    *  @param _ns Namespace for looking up the type of certain symbols. */
-  smt_convt(bool int_encoding, const namespacet &_ns);
+  smt_convt(bool int_encoding, bool parallel, const namespacet &_ns);
   ~smt_convt() override = default;
 
   /** Post-constructor setup method. We must create various pieces of memory
@@ -811,6 +812,8 @@ public:
   smt_sortt boolean_sort;
   /** Whether we are encoding expressions in integer mode or not. */
   bool int_encoding;
+  /** Whether we are running a parallel solver or not. */
+  bool parallel;
   /** A namespace containing all the types in the program. Used to resolve the
    *  rare case where we're doing some pointer arithmetic and need to have the
    *  concrete type of a pointer. */

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -98,19 +98,25 @@ extern sexpr *smtlib_output;
 
 smt_convt *create_new_smtlib_solver(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api [[gnu::unused]],
   array_iface **array_api,
   fp_convt **fp_api)
 {
-  smtlib_convt *conv = new smtlib_convt(int_encoding, ns);
+  smtlib_convt *conv = new smtlib_convt(int_encoding, parallel, ns);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
 }
 
-smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
-  : smt_convt(int_encoding, _ns), array_iface(false, false), fp_convt(this)
+smtlib_convt::smtlib_convt(
+  bool int_encoding,
+  bool parallel,
+  const namespacet &_ns)
+  : smt_convt(int_encoding, parallel, _ns),
+    array_iface(false, false),
+    fp_convt(this)
 {
   temp_sym_count.push_back(1);
   std::string cmd;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -172,7 +172,7 @@ public:
 class smtlib_convt : public smt_convt, public array_iface, public fp_convt
 {
 public:
-  smtlib_convt(bool int_encoding, const namespacet &_ns);
+  smtlib_convt(bool int_encoding, bool parallel, const namespacet &_ns);
   ~smtlib_convt() override;
 
   resultt dec_solve() override;

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -48,6 +48,7 @@ const unsigned int esbmc_num_solvers =
 static smt_convt *create_solver(
   const std::string &&the_solver,
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api,
   array_iface **array_api,
@@ -58,7 +59,7 @@ static smt_convt *create_solver(
     if(the_solver == esbmc_solver.name)
     {
       return esbmc_solver.create(
-        int_encoding, ns, tuple_api, array_api, fp_api);
+        int_encoding, parallel, ns, tuple_api, array_api, fp_api);
     }
   }
 
@@ -93,6 +94,7 @@ static const std::string pick_default_solver()
 
 static smt_convt *pick_solver(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   const optionst &options,
   tuple_iface **tuple_api,
@@ -120,12 +122,19 @@ static smt_convt *pick_solver(
     the_solver = pick_default_solver();
 
   return create_solver(
-    std::move(the_solver), int_encoding, ns, tuple_api, array_api, fp_api);
+    std::move(the_solver),
+    int_encoding,
+    parallel,
+    ns,
+    tuple_api,
+    array_api,
+    fp_api);
 }
 
 smt_convt *create_solver_factory1(
   const std::string &solver_name,
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   const optionst &options,
   tuple_iface **tuple_api,
@@ -134,15 +143,23 @@ smt_convt *create_solver_factory1(
 {
   if(solver_name == "")
     // Pick one based on options.
-    return pick_solver(int_encoding, ns, options, tuple_api, array_api, fp_api);
+    return pick_solver(
+      int_encoding, parallel, ns, options, tuple_api, array_api, fp_api);
 
   return create_solver(
-    std::move(solver_name), int_encoding, ns, tuple_api, array_api, fp_api);
+    std::move(solver_name),
+    int_encoding,
+    parallel,
+    ns,
+    tuple_api,
+    array_api,
+    fp_api);
 }
 
 smt_convt *create_solver_factory(
   const std::string &solver_name,
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   const optionst &options)
 {
@@ -150,7 +167,14 @@ smt_convt *create_solver_factory(
   array_iface *array_api = nullptr;
   fp_convt *fp_api = nullptr;
   smt_convt *ctx = create_solver_factory1(
-    solver_name, int_encoding, ns, options, &tuple_api, &array_api, &fp_api);
+    solver_name,
+    int_encoding,
+    parallel,
+    ns,
+    options,
+    &tuple_api,
+    &array_api,
+    &fp_api);
 
   bool node_flat = options.get_bool_option("tuple-node-flattener");
   bool sym_flat = options.get_bool_option("tuple-sym-flattener");

--- a/src/solvers/solve.h
+++ b/src/solvers/solve.h
@@ -8,6 +8,7 @@
 
 typedef smt_convt *(solver_creator)(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api,
   array_iface **array_api,
@@ -15,6 +16,7 @@ typedef smt_convt *(solver_creator)(
 
 typedef smt_convt *(*solver_creator_ptr)(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api,
   array_iface **array_api,
@@ -32,6 +34,7 @@ extern const unsigned int esbmc_num_solvers;
 smt_convt *create_solver_factory(
   const std::string &solver_name,
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   const optionst &options);
 

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -20,21 +20,30 @@
 
 smt_convt *create_new_yices_solver(
   bool int_encoding,
+  bool parallel,
   const namespacet &ns,
   tuple_iface **tuple_api,
   array_iface **array_api,
   fp_convt **fp_api)
 {
-  yices_convt *conv = new yices_convt(int_encoding, ns);
+  yices_convt *conv = new yices_convt(int_encoding, parallel, ns);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   *tuple_api = static_cast<tuple_iface *>(conv);
   return conv;
 }
 
-yices_convt::yices_convt(bool int_encoding, const namespacet &ns)
-  : smt_convt(int_encoding, ns), array_iface(false, false), fp_convt(this)
+yices_convt::yices_convt(bool int_encoding, bool parallel, const namespacet &ns)
+  : smt_convt(int_encoding, parallel, ns),
+    array_iface(false, false),
+    fp_convt(this)
 {
+  if(parallel)
+  {
+    std::cerr << "Yices does not support parallel solving yet" << std::endl;
+    abort();
+  }
+
   yices_init();
 
   yices_clear_error();

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -43,7 +43,7 @@ class yices_convt : public smt_convt,
                     public fp_convt
 {
 public:
-  yices_convt(bool int_encoding, const namespacet &ns);
+  yices_convt(bool int_encoding, bool parallel, const namespacet &ns);
   ~yices_convt() override;
 
   resultt dec_solve() override;

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -61,7 +61,11 @@ z3_convt::z3_convt(bool int_encoding, bool parallel, const namespacet &_ns)
 {
   z3::params p(z3_ctx);
   if(!parallel)
+  {
     p.set("relevancy", 0U);
+    p.set("model", true);
+    p.set("proof", false);
+  }
   solver.set(p);
 
   Z3_set_ast_print_mode(z3_ctx, Z3_PRINT_SMTLIB2_COMPLIANT);

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -33,7 +33,7 @@ class z3_convt : public smt_convt,
                  public fp_convt
 {
 public:
-  z3_convt(bool int_encoding, const namespacet &ns);
+  z3_convt(bool int_encoding, bool parallel, const namespacet &ns);
   ~z3_convt() override = default;
 
 public:


### PR DESCRIPTION
This PR adds support for parallel SMT solving in our backend. In particular, we allow Z3 to invoke the parallel solver engine using the option `--parallel`, while we abort for the remaining solvers.