### PR TITLE
Trigger fetch array errors

### DIFF
--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -180,6 +180,7 @@ expr2tc smt_tuple_node_flattener::tuple_get_rec(tuple_node_smt_astt tuple)
       std::cerr << "Fetching array elements inside tuples currently "
                    "unimplemented, sorry"
                 << std::endl;
+      abort();
       res = expr2tc();
     }
     else


### PR DESCRIPTION
This PR just adds an abort after the "Fetching array elements inside tuples currently..." error. The idea is to trigger the errors on CI