### PR TITLE
added compact trace option

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -137,8 +137,14 @@ void bmct::error_trace(
 
   status("Building error trace");
 
+  bool is_compact_trace = true;
+  if(
+    options.get_bool_option("no-slice") &&
+    !options.get_bool_option("compact-trace"))
+    is_compact_trace = false;
+
   goto_tracet goto_trace;
-  build_goto_trace(eq, smt_conv, goto_trace);
+  build_goto_trace(eq, smt_conv, goto_trace, is_compact_trace);
 
   switch(ui)
   {

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -242,6 +242,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   else
     options.set_option("deadlock-check", false);
 
+  if(cmdline.isset("compact-trace"))
+    options.set_option("no-slice", true);
+
   if(cmdline.isset("smt-during-symex"))
   {
     std::cout << "Enabling --no-slice due to presence of --smt-during-symex";
@@ -1666,6 +1669,7 @@ void esbmc_parseoptionst::help()
        "\nTrace options\n"
        " --quiet                      do not print unwinding information "
        "during symbolic execution\n"
+       " --compact-trace              do not print hidden variables\n"
        " --symex-trace                print instructions during symbolic "
        "execution\n"
        " --symex-ssa-trace            print generated SSA during symbolic "

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -29,6 +29,7 @@ const struct opt_templ esbmc_options[] = {
 
   // Trace
   {0, "quiet", switc, ""},
+  {0, "compact-trace", switc, ""},
   {0, "symex-trace", switc, ""},
   {0, "ssa-trace", switc, ""},
   {0, "ssa-smt-trace", switc, ""},

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -52,13 +52,14 @@ expr2tc build_rhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &rhs)
 void build_goto_trace(
   const std::shared_ptr<symex_target_equationt> &target,
   std::shared_ptr<smt_convt> &smt_conv,
-  goto_tracet &goto_trace)
+  goto_tracet &goto_trace,
+  const bool &is_compact_trace)
 {
   unsigned step_nr = 0;
 
   for(auto const &SSA_step : target->SSA_steps)
   {
-    if(SSA_step.hidden)
+    if(SSA_step.hidden && is_compact_trace)
       continue;
 
     if(!smt_conv->l_get(SSA_step.guard_ast).is_true())

--- a/src/goto-symex/build_goto_trace.h
+++ b/src/goto-symex/build_goto_trace.h
@@ -18,7 +18,8 @@ Date: July 2005
 void build_goto_trace(
   const std::shared_ptr<symex_target_equationt> &target,
   std::shared_ptr<smt_convt> &smt_conv,
-  goto_tracet &goto_trace);
+  goto_tracet &goto_trace,
+  const bool &is_compact_trace);
 
 void build_successful_goto_trace(
   const std::shared_ptr<symex_target_equationt> &target,


### PR DESCRIPTION
Added `--compact-trace` to eliminate all non-user defined variables assignments in the counterexample. 