### PR TITLE
Fixed overflow check for shift operations

### DIFF
--- a/regression/esbmc/overflow_23/main.c
+++ b/regression/esbmc/overflow_23/main.c
@@ -1,0 +1,51 @@
+// standard h files
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct struct1_s
+{
+  bool field0;
+  uint32_t field1;
+  uint32_t field2;
+  uint32_t field3;
+  uint64_t field4;
+} struct1_t;
+
+typedef union
+{
+  uint32_t raw32;
+
+  struct
+  {
+    uint32_t field0 : 2;
+    uint32_t field1 : 30;
+  };
+} struct2_t;
+
+extern struct2_t global_extern_var;
+
+uint64_t bar(bool bool_param1, bool bool_param2)
+{
+  uint64_t local_var1;
+  uint32_t local_var2 = ((global_extern_var.field0) << UINT64_C(0x0000000a));
+
+  if(bool_param1)
+    local_var1 = local_var2 + 0xFEB74400;
+
+  return local_var1;
+}
+
+void foo(struct1_t *struct1_var_ptr)
+{
+  bool bool_param1 = struct1_var_ptr->field0;
+  uint64_t local_var1 = bar(bool_param1, 0);
+}
+
+int main(void)
+{
+  0 << UINT64_C(0);
+  0 << (0ULL);
+  struct1_t struct1_var;
+  foo(&struct1_var);
+  return 0;
+}

--- a/regression/esbmc/overflow_23/test.desc
+++ b/regression/esbmc/overflow_23/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/overflow_24/main.c
+++ b/regression/esbmc/overflow_24/main.c
@@ -1,0 +1,48 @@
+// standard h files
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct struct1_s
+{
+  bool field0;
+  uint32_t field1;
+  uint32_t field2;
+  uint32_t field3;
+  uint64_t field4;
+} struct1_t;
+
+typedef union
+{
+  uint32_t raw32;
+
+  struct
+  {
+    uint32_t field0 : 2;
+    uint32_t field1 : 30;
+  };
+} struct2_t;
+
+extern struct2_t global_extern_var;
+
+uint64_t bar(bool bool_param1, bool bool_param2)
+{
+  int16_t local_var1 = nondet_int();
+  int32_t local_var2 = nondet_int() << 1;
+
+  local_var1 = local_var1 + local_var2;
+
+  return local_var1;
+}
+
+void foo(struct1_t *struct1_var_ptr)
+{
+  bool bool_param1 = struct1_var_ptr->field0;
+  uint64_t local_var1 = bar(bool_param1, 0);
+}
+
+int main(void)
+{
+  struct1_t struct1_var;
+  foo(&struct1_var);
+  return 0;
+}

--- a/regression/esbmc/overflow_24/test.desc
+++ b/regression/esbmc/overflow_24/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -104,9 +104,14 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     arg1_ext = is_signedbv_type(opers.side_1) ? mk_sign_ext(arg1_ext, sz)
                                               : mk_zero_ext(arg1_ext, sz);
 
-    smt_astt arg2_ext = convert_ast(opers.side_2);
-    arg2_ext = is_signedbv_type(opers.side_2) ? mk_sign_ext(arg2_ext, sz)
-                                              : mk_zero_ext(arg2_ext, sz);
+    expr2tc op2 = opers.side_2;
+    if(is_shl2t(overflow.operand))
+      if(opers.side_1->type->get_width() != opers.side_2->type->get_width())
+        op2 = typecast2tc(opers.side_1->type, opers.side_2);
+
+    smt_astt arg2_ext = convert_ast(op2);
+    arg2_ext = is_signedbv_type(op2) ? mk_sign_ext(arg2_ext, sz)
+                                     : mk_zero_ext(arg2_ext, sz);
 
     smt_astt result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
                                                  : mk_bvshl(arg1_ext, arg2_ext);


### PR DESCRIPTION
This PR fixes the bit-width of the second operand to comply with the SMT solver interface to check for arithmetic overflow. 