### PR TITLE
Improve simplifications

### DIFF
--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/irep2_utils.h>
 #include <util/format_constant.h>
-#include <util/type_byte_size.h>
 
 const expr2tc
 printf_formattert::make_type(const expr2tc &src, const type2tc &dest)

--- a/src/solvers/smt/smt_byteops.cpp
+++ b/src/solvers/smt/smt_byteops.cpp
@@ -1,4 +1,5 @@
 #include <solvers/smt/smt_conv.h>
+#include <util/type_byte_size.h>
 
 smt_astt smt_convt::convert_byte_extract(const expr2tc &expr)
 {

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -12,7 +12,6 @@
 #include <util/message.h>
 #include <util/namespace.h>
 #include <util/threeval.h>
-#include <util/type_byte_size.h>
 
 /** @file smt_conv.h
  *  SMT conversion tools and utilities.

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -156,11 +156,7 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
     typet followed_type_old = ns.follow(migrate_type_back(ptr_type.subtype));
     type2tc followed_type;
     migrate_type(followed_type_old, followed_type);
-    BigInt type_size;
-    if(is_empty_type(followed_type))
-      type_size = 1;
-    else
-      type_size = type_byte_size(followed_type);
+    BigInt type_size = type_byte_size(followed_type);
 
     // Generate nonptr * constant.
     type2tc inttype = machine_ptr;

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
-#include <solvers/smt/smt_conv.h>
 #include <sstream>
+#include <solvers/smt/smt_conv.h>
+#include <util/type_byte_size.h>
 
 /** @file smt_memspace.cpp
  *  Modelling the memory address space of C isn't something that is handled

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -6,23 +6,6 @@
  \*******************************************************************/
 
 #include <cassert>
-#include <cctype>
-#include <fstream>
-#include <sstream>
-#include <util/arith_tools.h>
-#include <util/base_type.h>
-#include <util/c_types.h>
-#include <util/config.h>
-#include <util/expr_util.h>
-#include <util/fixedbv.h>
-#include <util/i2string.h>
-#include <util/irep2.h>
-#include <util/migrate.h>
-#include <util/prefix.h>
-#include <util/std_expr.h>
-#include <util/std_types.h>
-#include <util/string2array.h>
-#include <util/type_byte_size.h>
 #include <z3_conv.h>
 
 #define new_ast new_solver_ast<z3_smt_ast>

--- a/src/util/irep2_expr.h
+++ b/src/util/irep2_expr.h
@@ -1657,6 +1657,8 @@ public:
   }
   constant_struct2t(const constant_struct2t &ref) = default;
 
+  expr2tc do_simplify() const override;
+
   static std::string field_names[esbmct::num_type_fields];
 };
 
@@ -1701,6 +1703,8 @@ public:
   {
   }
   constant_array2t(const constant_array2t &ref) = default;
+
+  expr2tc do_simplify() const override;
 
   static std::string field_names[esbmct::num_type_fields];
 };
@@ -2734,6 +2738,8 @@ public:
   {
   }
   byte_update2t(const byte_update2t &ref) = default;
+
+  expr2tc do_simplify() const override;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -2747,6 +2747,10 @@ expr2tc byte_update2t::do_simplify() const
   unsigned int top_of_update = (8 * src_offset) + 8;
   unsigned int bottom_of_update = (8 * src_offset);
 
+  // Overflow? The backend will encode that
+  if(top_of_update > width_op0 || bottom_of_update < 0)
+    return expr2tc();
+
   std::string top;
   if(top_of_update == width_op0)
     top = value;

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -2745,7 +2745,7 @@ expr2tc byte_update2t::do_simplify() const
   }
 
   unsigned int top_of_update = (8 * src_offset) + 8;
-  unsigned int bottom_of_update = (8 * src_offset);
+  int bottom_of_update = (8 * src_offset);
 
   // Overflow? The backend will encode that
   if(top_of_update > width_op0 || bottom_of_update < 0)

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -1413,11 +1413,10 @@ expr2tc typecast2t::do_simplify() const
     // Casts from constant operands can be done here.
     if(is_bool_type(simp) && is_number_type(type))
     {
+      // bool to int
       if(is_bv_type(type))
-      {
-        // bool to int
         return constant_int2tc(type, BigInt(to_constant_bool2t(simp).value));
-      }
+
       if(is_fixedbv_type(type))
       {
         fixedbvt fbv;
@@ -1425,7 +1424,8 @@ expr2tc typecast2t::do_simplify() const
         fbv.from_integer(to_constant_bool2t(simp).value);
         return constant_fixedbv2tc(fbv);
       }
-      else if(is_floatbv_type(simp))
+
+      if(is_floatbv_type(simp))
       {
         if(!is_constant_int2t(rounding_mode))
           return expr2tc();
@@ -1458,6 +1458,7 @@ expr2tc typecast2t::do_simplify() const
 
         return constant_int2tc(type, new_number);
       }
+
       if(is_fixedbv_type(type))
       {
         fixedbvt fbv;
@@ -1465,12 +1466,14 @@ expr2tc typecast2t::do_simplify() const
         fbv.from_integer(theint.value);
         return constant_fixedbv2tc(fbv);
       }
-      else if(is_bool_type(type))
+
+      if(is_bool_type(type))
       {
         const constant_int2t &theint = to_constant_int2t(simp);
         return theint.value.is_zero() ? gen_false_expr() : gen_true_expr();
       }
-      else if(is_floatbv_type(type))
+
+      if(is_floatbv_type(type))
       {
         if(!is_constant_int2t(rounding_mode))
           return expr2tc();
@@ -1492,15 +1495,15 @@ expr2tc typecast2t::do_simplify() const
       fixedbvt fbv(to_constant_fixedbv2t(simp).value);
 
       if(is_bv_type(type))
-      {
         return constant_int2tc(type, fbv.to_integer());
-      }
+
       if(is_fixedbv_type(type))
       {
         fbv.round(to_fixedbv_type(migrate_type_back(type)));
         return constant_fixedbv2tc(fbv);
       }
-      else if(is_bool_type(type))
+
+      if(is_bool_type(type))
       {
         const constant_fixedbv2t &fbv = to_constant_fixedbv2t(simp);
         return fbv.value.is_zero() ? gen_false_expr() : gen_true_expr();
@@ -1518,18 +1521,16 @@ expr2tc typecast2t::do_simplify() const
       fpbv.rounding_mode = ieee_floatt::rounding_modet(rm_value.to_int64());
 
       if(is_bv_type(type))
-      {
         return constant_int2tc(type, fpbv.to_integer());
-      }
+
       if(is_floatbv_type(type))
       {
         fpbv.change_spec(to_floatbv_type(migrate_type_back(type)));
         return constant_floatbv2tc(fpbv);
       }
-      else if(is_bool_type(type))
-      {
+
+      if(is_bool_type(type))
         return fpbv.is_zero() ? gen_false_expr() : gen_true_expr();
-      }
     }
   }
   else if(is_bool_type(type))

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -811,23 +811,10 @@ expr2tc pointer_offset2t::do_simplify() const
       const index2t &index = to_index2t(addrof.ptr_obj);
       if(is_constant_int2t(index.index))
       {
-        if(is_symbol2t(index.source_value))
-        {
-          // We can reduce to that index offset.
-          const array_type2t &arr = to_array_type(index.source_value->type);
-          unsigned int widthbits = arr.subtype->get_width();
-          unsigned int widthbytes = widthbits / 8;
-          BigInt val = to_constant_int2t(index.index).value;
-          val *= widthbytes;
-          return constant_int2tc(type, val);
-        }
-
-        if(is_constant_string2t(index.source_value))
-        {
-          // This can also be simplified to an array offset. Just return the index,
-          // as the string elements are all 8 bit bytes.
-          return index.index;
-        }
+        expr2tc offs =
+          try_simplification(compute_pointer_offset(addrof.ptr_obj));
+        if(is_constant_int2t(offs))
+          return offs;
       }
     }
   }

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -862,8 +862,7 @@ expr2tc pointer_offset2t::do_simplify() const
     // And multiply the non pointer one by the type size.
     type2tc ptr_int_type = get_int_type(config.ansi_c.pointer_width);
     type2tc ptr_subtype = to_pointer_type(ptr_op->type).subtype;
-    BigInt thesize =
-      (is_empty_type(ptr_subtype)) ? 1 : type_byte_size(ptr_subtype);
+    BigInt thesize = type_byte_size(ptr_subtype);
     constant_int2tc type_size(type, thesize);
 
     // SV-Comp workaround

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -249,9 +249,11 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
 {
   if(is_symbol2t(expr))
     return gen_ulong(0);
+
   if(is_index2t(expr))
   {
     const index2t &index = to_index2t(expr);
+
     BigInt sub_size;
     if(is_array_type(index.source_value))
     {
@@ -294,7 +296,8 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
 
     return result;
   }
-  else if(is_member2t(expr))
+
+  if(is_member2t(expr))
   {
     const member2t &memb = to_member2t(expr);
 
@@ -315,24 +318,28 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
 
     return res_expr;
   }
-  else if(is_constant_expr(expr))
+
+  if(is_constant_expr(expr))
   {
     // This is a constant struct, array, union, string, etc. There's nothing
     // at a lower level; the offset is zero.
     return gen_ulong(0);
   }
-  else if(is_typecast2t(expr))
+
+  if(is_typecast2t(expr))
   {
     // Blast straight through.
     return compute_pointer_offset(to_typecast2t(expr).from);
   }
-  else if(is_dynamic_object2t(expr))
+
+  if(is_dynamic_object2t(expr))
   {
     // This is a dynamic object represented something allocated; from the static
     // pointer analysis. Assume that this is thet bottom of the expression.
     return gen_ulong(0);
   }
-  else if(is_dereference2t(expr))
+
+  if(is_dereference2t(expr))
   {
     // This is a dereference at the base of a set of index/members. Here, we
     // can in theory end up evaluating across a large set of object types. So
@@ -340,12 +347,10 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
     // it up to the caller to handle that.
     return gen_ulong(0);
   }
-  else
-  {
-    std::cerr << "compute_pointer_offset, unexpected irep:" << std::endl;
-    std::cerr << expr->pretty() << std::endl;
-    abort();
-  }
+
+  std::cerr << "compute_pointer_offset, unexpected irep:" << std::endl;
+  std::cerr << expr->pretty() << std::endl;
+  abort();
 }
 
 const expr2tc &get_base_object(const expr2tc &expr)


### PR DESCRIPTION
Implement new simplification for:
* `constant_struct2t`
* `constant_array2t`
* `byte_update2t`

and improve the simplification of:
* `index2t`

Also, some cleanup and code style improvements