### PR TITLE
Fix for libm cmake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ if(BUILD_STATIC)
   include(BuildStatic)
 endif()
 
-include(DefineLibM)
-
 # Copied from https://stackoverflow.com/questions/53877344/cannot-configure-cmake-to-look-for-homebrew-installed-version-of-bison
 # On macOS, search Homebrew for keg-only versions of Bison and Flex. Xcode does
 # not provide new enough versions for us to use.

--- a/scripts/cmake/DefineLibM.cmake
+++ b/scripts/cmake/DefineLibM.cmake
@@ -1,9 +1,0 @@
-# Sets LIBM
-
-if(ENABLE_LIBM)
-  set(LIBM_PATTERN "${PROJECT_SOURCE_DIR}/src/c2goto/library/libm/*.c")
-else()
-  set(LIBM_PATTERN "")
-endif()
-
-message(STATUS "LIBM: ${LIBM_PATTERN}")

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -37,7 +37,7 @@ function(mangle_clib output)
     if(ENABLE_LIBM)
       set(inputs_c ${c2goto_library_files} ${c2goto_libm_files})
     else()
-    set(inputs_c ${c2goto_library_files})
+      set(inputs_c ${c2goto_library_files})
     endif()
     set(CMD c2goto -I ${multiarch} ${OS_C2GOTO_FLAGS} ${inputs_c} ${in_flags} --output ${out_goto})
     add_custom_command(OUTPUT ${out_goto}

--- a/src/c2goto/CMakeLists.txt
+++ b/src/c2goto/CMakeLists.txt
@@ -33,7 +33,13 @@ function(mangle_clib output)
     string(REGEX REPLACE .c "" barename "${in_file}")
     set(out_goto "${CMAKE_CURRENT_BINARY_DIR}/${out_goto}")
     set(out_file "${CMAKE_CURRENT_BINARY_DIR}/${out_file}")
-    set(CMD c2goto -I ${multiarch} ${OS_C2GOTO_FLAGS} ${c2goto_library_files} ${c2goto_libm_files} ${in_flags} --output ${out_goto})
+
+    if(ENABLE_LIBM)
+      set(inputs_c ${c2goto_library_files} ${c2goto_libm_files})
+    else()
+    set(inputs_c ${c2goto_library_files})
+    endif()
+    set(CMD c2goto -I ${multiarch} ${OS_C2GOTO_FLAGS} ${inputs_c} ${in_flags} --output ${out_goto})
     add_custom_command(OUTPUT ${out_goto}
       COMMAND ${CMD}
       DEPENDS c2goto ${c2goto_library_files} ${c2goto_libm_files}


### PR DESCRIPTION
This should fix #408

This replaces the old script to only use the `ENABLE_LIBM` flag since the pattern was removed with the Windows PR