### PR TITLE
Integrating Bitwuzla into ESBMC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,12 @@ jobs:
       run: git clone https://github.com/SRI-CSL/yices2.git && cd yices2 && git checkout Yices-2.6.1 && autoreconf -fi && ./configure --prefix $PWD/../yices --with-static-gmp=$PWD/../gmp/lib/libgmp.a && make -j4 && make static-lib && make install && cp ./build/x86_64-pc-linux-gnu-release/static_lib/libyices.a ../yices/lib
     - name: Setup CVC4
       run: git clone https://github.com/CVC4/CVC4.git && cd CVC4 && git reset --hard b826fc8ae95fc && ./contrib/get-antlr-3.4 && ./configure.sh --optimized --prefix=../cvc4 --static --no-static-binary && cd build && make -j4 && make install
+    - name: Setup bitwuzla
+      run: git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install
     - name: Get current folder and files
       run: pwd && ls
     - name: Configure CMake
-      run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_YICES=On -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DGMP_DIR=$PWD/../gmp -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release -DCMAKE_BUILD_TYPE=Debug
+      run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_YICES=On -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DGMP_DIR=$PWD/../gmp -DBitwuzla_DIR=$PWD/../bitwuzla-release -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release -DCMAKE_BUILD_TYPE=Debug
     - name: Build ESBMC
       run: cd build && cmake --build . && ninja install
     - uses: actions/upload-artifact@v1
@@ -70,10 +72,12 @@ jobs:
         run: git clone https://github.com/SRI-CSL/yices2.git && cd yices2 && git checkout Yices-2.6.1 && autoreconf -fi && ./configure --prefix $PWD/../yices && make -j4 && make static-lib && make install && cp ./build/x86_64-apple-darwin*release/static_lib/libyices.a ../yices/lib
       - name: Setup CVC4
         run: git clone https://github.com/CVC4/CVC4.git && cd CVC4 && git reset --hard b826fc8ae95fc && ./contrib/get-antlr-3.4 && ./configure.sh --python3 --optimized --prefix=../cvc4 --static --no-static-binary && cd build && make -j4 && make install
+      - name: Setup bitwuzla
+        run: git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install
       - name: Get current folder and files
         run: pwd && ls
       - name: Configure CMake
-        run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_YICES=ON -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release -DCMAKE_BUILD_TYPE=Debug
+        run: mkdir build && cd build && cmake .. -GNinja -DENABLE_WERROR=On -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3 -DENABLE_YICES=ON -DYices_DIR=$PWD/../yices -DCVC4_DIR=$PWD/../cvc4 -DBitwuzla_DIR=$PWD/../bitwuzla-release -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release -DCMAKE_BUILD_TYPE=Debug
       - name: Build ESBMC
         run: cd build && cmake --build . && cmake --install .
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup CVC4
       run: git clone https://github.com/CVC4/CVC4.git && cd CVC4 && git reset --hard b826fc8ae95fc && ./contrib/get-antlr-3.4 && ./configure.sh --optimized --prefix=../cvc4 --static --no-static-binary && cd build && make -j4 && make install
     - name: Setup bitwuzla
-      run: git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install
+      run: git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install
     - name: Get current folder and files
       run: pwd && ls
     - name: Configure CMake
@@ -73,7 +73,7 @@ jobs:
       - name: Setup CVC4
         run: git clone https://github.com/CVC4/CVC4.git && cd CVC4 && git reset --hard b826fc8ae95fc && ./contrib/get-antlr-3.4 && ./configure.sh --python3 --optimized --prefix=../cvc4 --static --no-static-binary && cd build && make -j4 && make install
       - name: Setup bitwuzla
-        run: git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install
+        run: git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install
       - name: Get current folder and files
         run: pwd && ls
       - name: Configure CMake

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,7 +153,7 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
-git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,11 +153,7 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
-Linux:
 git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
-
-macOS:
-git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -148,6 +148,16 @@ If you are using macOS and have installed z3 using brew, you'll need to copy the
 cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 ```
 
+### Setting Up Bitwuzla
+
+We have wrapped the entire build and setup of Bitwuzla in the following command:
+
+```
+git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+```
+
+If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).
+
 Before proceeding to the next section, make sure you have clang, LLVM and all the solvers ready in your workspace:
 
 ```
@@ -168,6 +178,9 @@ Yices:
 
 Z3:
 <path_to_your_project>/ESBMC_Project/z3
+
+Bitwuzla:
+<path_to_your_project>/ESBMC_Project/bitwuzla
 ```
 
 The above paths will be used in ESBMC's build command in the next section.
@@ -188,10 +201,10 @@ First, we need to setup __cmake__, by using the following command in ESBMC_Proje
 
 ```
 Linux:
-cd esbmc && mkdir build && cd build && cmake .. -GNinja -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../../clang11 -DLLVM_DIR=$PWD/../../clang11 -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../../boolector-release -DZ3_DIR=$PWD/../../z3 -DENABLE_MATHSAT=ON -DMathsat_DIR=$PWD/../../mathsat -DENABLE_YICES=On -DYices_DIR=$PWD/../../yices -DCVC4_DIR=$PWD/../../cvc4 -DGMP_DIR=$PWD/../../gmp -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../../release
+cd esbmc && mkdir build && cd build && cmake .. -GNinja -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DClang_DIR=$PWD/../../clang11 -DLLVM_DIR=$PWD/../../clang11 -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../../boolector-release -DZ3_DIR=$PWD/../../z3 -DENABLE_MATHSAT=ON -DMathsat_DIR=$PWD/../../mathsat -DENABLE_YICES=On -DYices_DIR=$PWD/../../yices -DCVC4_DIR=$PWD/../../cvc4 -DGMP_DIR=$PWD/../../gmp -DBitwuzla_DIR=$PWD/../../bitwuzla-release -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../../release
 
 macOS:
-cd esbmc && mkdir build && cd build && cmake .. -GNinja -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../../clang11 -DLLVM_DIR=$PWD/../../clang11 -DBoolector_DIR=$PWD/../../boolector-release -DZ3_DIR=$PWD/../../z3 -DENABLE_MATHSAT=On -DMathsat_DIR=$PWD/../../mathsat -DENABLE_YICES=ON -DYices_DIR=$PWD/../../yices -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../../release
+cd esbmc && mkdir build && cd build && cmake .. -GNinja -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DBUILD_STATIC=On -DClang_DIR=$PWD/../../clang11 -DLLVM_DIR=$PWD/../../clang11 -DBoolector_DIR=$PWD/../../boolector-release -DZ3_DIR=$PWD/../../z3 -DENABLE_MATHSAT=On -DMathsat_DIR=$PWD/../../mathsat -DENABLE_YICES=ON -DYices_DIR=$PWD/../../yices -DC2GOTO_INCLUDE_DIR=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ -DBitwuzla_DIR=$PWD/../../bitwuzla-release -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../../release
 ```
 
 Finally, we can trigger the build process, by using the following command:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,7 +153,11 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
+Linux:
 git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+
+macOS:
+git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,7 +153,11 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
+Linux:
 git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+
+macOS:
+git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -153,7 +153,7 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
-git clone https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -26,12 +26,12 @@ endfunction()
 
 # NOTE: In order to make the best of the concurrency set sort the tests from the slowest to fastest.
 if(APPLE)
-    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc cbmc cstd llvm floats floats-regression k-induction k-induction-parallel nonz3)
+    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc cbmc cstd llvm floats floats-regression k-induction k-induction-parallel nonz3 bitwuzla)
 elseif(WIN32)
     # FUTURE: Add floats-regression esbmc-cpp/cpp
     set(REGRESSIONS esbmc cbmc cstd llvm floats  k-induction )
 else()
-    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc cbmc cstd llvm floats floats-regression k-induction esbmc-cpp/cpp csmith k-induction-parallel nonz3)
+    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc cbmc cstd llvm floats floats-regression k-induction esbmc-cpp/cpp csmith k-induction-parallel nonz3 bitwuzla)
 endif()
 
 foreach(regression IN LISTS REGRESSIONS)

--- a/regression/bitwuzla/buf-overflow-subobject/buf_over_subobject.c
+++ b/regression/bitwuzla/buf-overflow-subobject/buf_over_subobject.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+#define LEN 6
+
+struct my_type
+{
+  int array[LEN];
+  int num;
+} var;
+
+int main()
+{
+  var.num = 999999;
+  printf("var.num = %d\n", var.num);
+  int *ptr = &var.array;
+  for(size_t i = 0; i < LEN + 1; i++)
+    ptr++;
+
+  *ptr = 666666;
+  printf("var.num = %d\n", var.num);
+
+  return 0;
+}

--- a/regression/bitwuzla/buf-overflow-subobject/test.desc
+++ b/regression/bitwuzla/buf-overflow-subobject/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 buf_over_subobject.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/buf-overflow-subobject/test.desc
+++ b/regression/bitwuzla/buf-overflow-subobject/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+buf_over_subobject.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/buf-overflow/buf_overflow.c
+++ b/regression/bitwuzla/buf-overflow/buf_overflow.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <string.h>
+
+char buffer[10];
+
+int main(int argc, char **argv)
+{
+  int a = 10;
+  for(int i = 0; i < a + 1; i++)
+  {
+    printf("ptr[%d] = '%c'\n", i, buffer[i]);
+  }
+  return 0;
+}

--- a/regression/bitwuzla/buf-overflow/test.desc
+++ b/regression/bitwuzla/buf-overflow/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+buf_overflow.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/buf-overflow/test.desc
+++ b/regression/bitwuzla/buf-overflow/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 buf_overflow.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/builtin-alloca-bad/builtin_alloca_test_bad.c
+++ b/regression/bitwuzla/builtin-alloca-bad/builtin_alloca_test_bad.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+#include <stdio.h>
+void fun1()
+{
+  int *data;
+  data = (int *)__builtin_alloca(sizeof(*data));
+  data[0] = 0;
+  free((int *)data);
+}
+void fun2()
+{
+  int *data;
+  data = (int *)malloc(sizeof(*data));
+  if(data != (int *)0)
+  {
+    data[0] = 0;
+  }
+  free((int *)data);
+}
+int main()
+{
+  printf("Running fun1()");
+  fun1();
+  printf("Done");
+  printf("Running fun2()");
+  fun2();
+  printf("Done");
+  return 0;
+}

--- a/regression/bitwuzla/builtin-alloca-bad/test.desc
+++ b/regression/bitwuzla/builtin-alloca-bad/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 builtin_alloca_test_bad.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/builtin-alloca-bad/test.desc
+++ b/regression/bitwuzla/builtin-alloca-bad/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+builtin_alloca_test_bad.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/builtin-alloca-good-2/builtin_alloca_test_2.c
+++ b/regression/bitwuzla/builtin-alloca-good-2/builtin_alloca_test_2.c
@@ -1,0 +1,30 @@
+void fun1()
+{
+  int *data;
+  data = (int *)__builtin_alloca(sizeof(*data));
+  data[0] = 0;
+}
+
+void fun2()
+{
+  int *data;
+  data = (int *)malloc(sizeof(*data));
+  if(data != (int *)0)
+  {
+    data[0] = 0;
+  }
+  free((int *)data);
+}
+
+int main()
+{
+  puts("Running fun2()");
+  fun2();
+  puts("Done");
+
+  puts("Running fun1()");
+  fun1();
+  puts("Done");
+
+  return 0;
+}

--- a/regression/bitwuzla/builtin-alloca-good-2/test.desc
+++ b/regression/bitwuzla/builtin-alloca-good-2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 builtin_alloca_test_2.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/builtin-alloca-good-2/test.desc
+++ b/regression/bitwuzla/builtin-alloca-good-2/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+builtin_alloca_test_2.c
+--bitwuzla --result-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/builtin-alloca-good/builtin_alloca_test.c
+++ b/regression/bitwuzla/builtin-alloca-good/builtin_alloca_test.c
@@ -1,0 +1,30 @@
+void fun1()
+{
+  int *data;
+  data = (int *)__builtin_alloca(sizeof(*data));
+  data[0] = 0;
+}
+
+void fun2()
+{
+  int *data;
+  data = (int *)malloc(sizeof(*data));
+  if(data != (int *)0)
+  {
+    data[0] = 0;
+  }
+  free((int *)data);
+}
+
+int main()
+{
+  puts("Running fun1()");
+  fun1();
+  puts("Done");
+
+  puts("Running fun2()");
+  fun2();
+  puts("Done");
+
+  return 0;
+}

--- a/regression/bitwuzla/builtin-alloca-good/test.desc
+++ b/regression/bitwuzla/builtin-alloca-good/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 builtin_alloca_test.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/builtin-alloca-good/test.desc
+++ b/regression/bitwuzla/builtin-alloca-good/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+builtin_alloca_test.c
+--bitwuzla --result-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/double-free/double_free.c
+++ b/regression/bitwuzla/double-free/double_free.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main()
+{
+  int *i;
+  i = (int *)malloc(sizeof(*i));
+  printf("i=%p\n", i);
+  free(i);
+  printf("i=%p\n", i);
+  free(i);
+  printf("i=%p\n", i);
+
+  return 0;
+}

--- a/regression/bitwuzla/double-free/test.desc
+++ b/regression/bitwuzla/double-free/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 double_free.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/double-free/test.desc
+++ b/regression/bitwuzla/double-free/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+double_free.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/get_array_elem/get_array_elem.c
+++ b/regression/bitwuzla/get_array_elem/get_array_elem.c
@@ -5,7 +5,7 @@ union
   int *p0;
   int p1;
 } data;
- 
+
 void main(void)
 {
   data.p0 = (int *)malloc(sizeof(int));

--- a/regression/bitwuzla/get_array_elem/get_array_elem.c
+++ b/regression/bitwuzla/get_array_elem/get_array_elem.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+union
+{
+  int *p0;
+  int p1;
+} data;
+ 
+void main(void)
+{
+  data.p0 = (int *)malloc(sizeof(int));
+  data.p1 = 1;
+  void *ptr = data.p0;
+  free(ptr);
+}

--- a/regression/bitwuzla/get_array_elem/test.desc
+++ b/regression/bitwuzla/get_array_elem/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
-union-bad.c
+get_array_elem.c
 --bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/mem-leak/mem_leak.c
+++ b/regression/bitwuzla/mem-leak/mem_leak.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *i;
+  i = (int *)malloc(10);
+
+  //free(i);
+  //free(i);
+
+  return 0;
+}

--- a/regression/bitwuzla/mem-leak/test.desc
+++ b/regression/bitwuzla/mem-leak/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 mem_leak.c
---bitwuzla --result-only --memory-leak-check
+--bitwuzla --memory-leak-check
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/mem-leak/test.desc
+++ b/regression/bitwuzla/mem-leak/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+mem_leak.c
+--bitwuzla --result-only --memory-leak-check
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/memset-bad/memset-bad.c
+++ b/regression/bitwuzla/memset-bad/memset-bad.c
@@ -1,0 +1,31 @@
+typedef unsigned int __kernel_size_t;
+typedef __kernel_size_t size_t;
+typedef unsigned int __u32;
+
+struct compstat
+{
+  __u32 unc_bytes;
+  __u32 unc_packets;
+  __u32 comp_bytes;
+  __u32 comp_packets;
+  __u32 inc_bytes;
+  __u32 inc_packets;
+  __u32 in_count;
+  __u32 bytes_out;
+  double ratio;
+};
+
+struct ppp_comp_stats
+{
+  struct compstat c;
+  struct compstat d;
+};
+
+int main()
+{
+  struct ppp_comp_stats cstats;
+  void *point;
+  point = (void *)(&cstats);
+  memset(point, 0, 81UL);
+  return 0;
+}

--- a/regression/bitwuzla/memset-bad/test.desc
+++ b/regression/bitwuzla/memset-bad/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 memset-bad.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/memset-bad/test.desc
+++ b/regression/bitwuzla/memset-bad/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+memset-bad.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/memset-good/memset-good.c
+++ b/regression/bitwuzla/memset-good/memset-good.c
@@ -1,0 +1,31 @@
+typedef unsigned int __kernel_size_t;
+typedef __kernel_size_t size_t;
+typedef unsigned int __u32;
+
+struct compstat
+{
+  __u32 unc_bytes;
+  __u32 unc_packets;
+  __u32 comp_bytes;
+  __u32 comp_packets;
+  __u32 inc_bytes;
+  __u32 inc_packets;
+  __u32 in_count;
+  __u32 bytes_out;
+  double ratio;
+};
+
+struct ppp_comp_stats
+{
+  struct compstat c;
+  struct compstat d;
+};
+
+int main()
+{
+  struct ppp_comp_stats cstats;
+  void *point;
+  point = (void *)(&cstats);
+  memset(point, 0, 80UL);
+  return 0;
+}

--- a/regression/bitwuzla/memset-good/test.desc
+++ b/regression/bitwuzla/memset-good/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+memset-good.c
+--bitwuzla --result-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/memset-good/test.desc
+++ b/regression/bitwuzla/memset-good/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 memset-good.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/stack-access/stack_access.c
+++ b/regression/bitwuzla/stack-access/stack_access.c
@@ -1,0 +1,25 @@
+// This example allows getting the value of "a" in "fun2()" only when compiled without an optimisation flag
+
+#include <stdio.h>
+
+int *i;
+
+void fun()
+{
+  int a = 13;
+  i = &a;
+}
+
+void fun2()
+{
+  int a = 15;
+}
+
+int main()
+{
+  fun();
+  printf("*i = %d\n", *i);
+  fun2();
+  printf("*i = %d\n", *i);
+  return 0;
+}

--- a/regression/bitwuzla/stack-access/test.desc
+++ b/regression/bitwuzla/stack-access/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+stack_access.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/stack-access/test.desc
+++ b/regression/bitwuzla/stack-access/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 stack_access.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/bitwuzla/union-bad/test.desc
+++ b/regression/bitwuzla/union-bad/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+union-bad.c
+--bitwuzla --result-only
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/union-bad/union-bad.c
+++ b/regression/bitwuzla/union-bad/union-bad.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define SIZE 1
+
+void main(void)
+{
+  union
+  {
+    int *p0;
+    struct
+    {
+      char p1[SIZE];
+      int p2;
+    } str;
+  } data;
+  data.p0 = (int *)malloc(sizeof(int *));
+  data.str.p2 = 1;
+  free(data.p0);
+}

--- a/regression/bitwuzla/union-good-purecap-bad/test.desc
+++ b/regression/bitwuzla/union-good-purecap-bad/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 union-good-purecap-bad.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/union-good-purecap-bad/test.desc
+++ b/regression/bitwuzla/union-good-purecap-bad/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+union-good-purecap-bad.c
+--bitwuzla --result-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/union-good-purecap-bad/union-good-purecap-bad.c
+++ b/regression/bitwuzla/union-good-purecap-bad/union-good-purecap-bad.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define SIZE 5
+
+void main(void)
+{
+  union
+  {
+    int *p0;
+    struct
+    {
+      char p1[SIZE];
+      int p2;
+    } str;
+  } data;
+  data.p0 = (int *)malloc(sizeof(int *));
+  data.str.p2 = 1;
+  free(data.p0);
+}

--- a/regression/bitwuzla/union-good/test.desc
+++ b/regression/bitwuzla/union-good/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+union-good.c
+--bitwuzla --result-only
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/union-good/test.desc
+++ b/regression/bitwuzla/union-good/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 union-good.c
---bitwuzla --result-only
+--bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/union-good/union-good.c
+++ b/regression/bitwuzla/union-good/union-good.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define SIZE 13
+
+void main(void)
+{
+  union
+  {
+    int *p0;
+    struct
+    {
+      char p1[SIZE];
+      int p2;
+    } str;
+  } data;
+  data.p0 = (int *)malloc(sizeof(int *));
+  data.str.p2 = 1;
+  free(data.p0);
+}

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -139,6 +139,7 @@ const struct group_opt_templ all_cmd_options[] = {
     {"mathsat", NULL, "use MathSAT"},
     {"cvc", NULL, "use CVC4"},
     {"yices", NULL, "use Yices"},
+    {"bitwuzla", NULL, "use Bitwuzla"},
     {"bv", NULL, "use solver with bit-vector arithmetic"},
     {"ir", NULL, "use solver with integer/real arithmetic"},
     {"smtlib", NULL, "use SMT lib format"},

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -4,6 +4,7 @@ set (ESBMC_ENABLE_boolector 0)
 set (ESBMC_ENABLE_cvc4 0)
 set (ESBMC_ENABLE_mathsat 0)
 set (ESBMC_ENABLE_yices 0)
+set (ESBMC_ENABLE_bitwuzla 0)
 
 add_subdirectory(prop)
 add_subdirectory(smt)
@@ -26,6 +27,7 @@ add_subdirectory(boolector)
 add_subdirectory(cvc4)
 add_subdirectory(mathsat)
 add_subdirectory(yices)
+add_subdirectory(bitwuzla)
 
 set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS}" PARENT_SCOPE)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/solver_config.h.in"

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -20,8 +20,8 @@ if(ENABLE_BITWUZLA)
    
     add_library(solverbitw bitwuzla_conv.cpp)
     target_include_directories(solverbitw
+            PRIVATE ${Boost_INCLUDE_DIRS}
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    
     target_link_libraries(solverbitw Bitwuzla::bitwuzla)
 
     target_link_libraries(solvers INTERFACE solverbitw)

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -14,11 +14,15 @@ if(ENABLE_BITWUZLA)
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_DIR}")
     message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
+    #message(STATUS "Bitwuzla libs:" Bitwuzla::bitwuzla)
 
 	if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
         message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
     endif()
-    
+   
+	include_directories("${Bitwuzla_DIR}/src/api/c")
+	link_directories("${Bitwuzla_DIR}/build/lib")
+	 
     add_library(solverbitw bitwuzla_conv.cpp)
     target_include_directories(solverbitw
            # PRIVATE ${Boost_INCLUDE_DIRS}

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -9,22 +9,21 @@ if(EXISTS $ENV{HOME}/bitwuzla)
 endif()
 
 if(ENABLE_BITWUZLA)
-    #find_package(Bitwuzla REQUIRED
-    #        HINTS ${Bitwuzla_DIR}/cmake $ENV{HOME}/bitwuzla)
+    find_package(Bitwuzla REQUIRED
+            HINTS $ENV{HOME}/bitwuzla)
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_DIR}")
-    #message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
-    #if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
-    #    message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
-    #endif()
-    
-	#message(FATAL_ERROR "Bitwuzla support is not yet implemented")
+    message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
 
+	if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
+        message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
+    endif()
+    
     add_library(solverbitw bitwuzla_conv.cpp)
     target_include_directories(solverbitw
-    #        PRIVATE ${Boost_INCLUDE_DIRS}
+           # PRIVATE ${Boost_INCLUDE_DIRS}
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    #target_link_libraries(solverbitw Boolector::boolector)
+    target_link_libraries(solverbitw Bitwuzla::bitwuzla)
 
     target_link_libraries(solvers INTERFACE solverbitw)
 

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(Bitwuzla_MIN_VERSION "0.1")
+
+if(DEFINED Bitwuzla_DIR)
+    set(ENABLE_BITWUZLA ON)
+endif()
+
+if(EXISTS $ENV{HOME}/bitwuzla)
+    set(ENABLE_BITWUZLA ON)
+endif()
+
+if(ENABLE_BITWUZLA)
+    #find_package(Bitwuzla REQUIRED
+    #        HINTS ${Bitwuzla_DIR}/cmake $ENV{HOME}/bitwuzla)
+
+    message(STATUS "Found Bitwuzla at: ${Bitwuzla_DIR}")
+    #message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
+    #if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
+    #    message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
+    #endif()
+    
+	#message(FATAL_ERROR "Bitwuzla support is not yet implemented")
+
+    add_library(solverbitw bitwuzla_conv.cpp)
+    target_include_directories(solverbitw
+    #        PRIVATE ${Boost_INCLUDE_DIRS}
+            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    #target_link_libraries(solverbitw Boolector::boolector)
+
+    target_link_libraries(solvers INTERFACE solverbitw)
+
+    set(ESBMC_ENABLE_bitwuzla 1 PARENT_SCOPE)
+    set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS} bitwuzla" PARENT_SCOPE)
+endif()

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -10,23 +10,20 @@ endif()
 
 if(ENABLE_BITWUZLA)
     find_package(Bitwuzla REQUIRED
-            HINTS $ENV{HOME}/bitwuzla)
+            HINTS ${Bitwuzla_DIR}/lib/cmake $ENV{HOME}/bitwuzla)
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_DIR}")
     message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
-    #message(STATUS "Bitwuzla libs:" Bitwuzla::bitwuzla)
-
-	if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
+    if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
         message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
     endif()
    
-	include_directories("${Bitwuzla_DIR}/src/api/c")
-	link_directories("${Bitwuzla_DIR}/build/lib")
-	 
     add_library(solverbitw bitwuzla_conv.cpp)
     target_include_directories(solverbitw
            # PRIVATE ${Boost_INCLUDE_DIRS}
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    # We cannot link both Bitwuzla::bitwuzla and Boolector::boolector at the moment
+    # due to "multiple definition" errors
     target_link_libraries(solverbitw Bitwuzla::bitwuzla)
 
     target_link_libraries(solvers INTERFACE solverbitw)

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -20,10 +20,8 @@ if(ENABLE_BITWUZLA)
    
     add_library(solverbitw bitwuzla_conv.cpp)
     target_include_directories(solverbitw
-           # PRIVATE ${Boost_INCLUDE_DIRS}
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    # We cannot link both Bitwuzla::bitwuzla and Boolector::boolector at the moment
-    # due to "multiple definition" errors
+    
     target_link_libraries(solverbitw Bitwuzla::bitwuzla)
 
     target_link_libraries(solvers INTERFACE solverbitw)

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -681,7 +681,9 @@ bool bitwuzla_convt::get_bool(smt_astt a)
   abort();
 }
 
-BigInt bitwuzla_convt::get_bv(smt_astt a [[gnu::unused]], bool is_signed [[gnu::unused]])
+BigInt bitwuzla_convt::get_bv(
+  smt_astt a [[gnu::unused]],
+  bool is_signed [[gnu::unused]])
 {
   std::cerr << "Counter-example generation with Bitwuzla has not been fully "
                "implemented yet\n";

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -581,15 +581,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_FIXEDBV:
   case SMT_SORT_BVFP:
   case SMT_SORT_BVFP_RM:
-    node = bitwuzla_mk_const(
-      bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
-    break;
-
   case SMT_SORT_BOOL:
-    node = bitwuzla_mk_const(
-      bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
-    break;
-
   case SMT_SORT_ARRAY:
     node = bitwuzla_mk_const(
       bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -541,11 +541,10 @@ smt_astt bitwuzla_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 
 smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
-  BitwuzlaSort *bitwsort = bitwuzla_mk_bv_sort(bitw, s->get_data_width());
   return new_ast(
     bitwuzla_mk_bv_value(
       bitw,
-      bitwsort,
+      to_solver_smt_sort<BitwuzlaSort *>(s)->s,
       integer2binary(theint, s->get_data_width()).c_str(),
       BITWUZLA_BV_BASE_BIN),
     s);

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -1,15 +1,15 @@
 #include <bitwuzla_conv.h>
 #include <cstring>
 
-#define new_ast new_solver_ast<btor_smt_ast>
-/*
+#define new_ast new_solver_ast<bitw_smt_ast>
+
 void error_handler(const char *msg)
 {
   std::cerr << "Bitwuzla error encountered\n";
   std::cerr << msg << '\n';
   abort();
 }
-*/
+
 
 smt_convt *create_new_bitwuzla_solver(
   bool int_encoding,
@@ -18,518 +18,553 @@ smt_convt *create_new_bitwuzla_solver(
   array_iface **array_api,
   fp_convt **fp_api)
 {
-  std::cerr << "Bitwuzla support has not been yet implemented\n";
-  return NULL;
-  /*
-  boolector_convt *conv = new boolector_convt(int_encoding, ns);
+  //std::cerr << "Bitwuzla support has not been yet implemented\n";
+  //abort();
+  bitwuzla_convt *conv = new bitwuzla_convt(int_encoding, ns);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
-  */
 }
 
-/*
-boolector_convt::boolector_convt(bool int_encoding, const namespacet &ns)
+
+bitwuzla_convt::bitwuzla_convt(bool int_encoding, const namespacet &ns)
   : smt_convt(int_encoding, ns), array_iface(true, true), fp_convt(this)
 {
+  /*
   if(int_encoding)
   {
     std::cerr << "Boolector does not support integer encoding mode"
               << std::endl;
     abort();
   }
-
+  
   btor = boolector_new();
   boolector_set_opt(btor, BTOR_OPT_MODEL_GEN, 1);
   boolector_set_opt(btor, BTOR_OPT_AUTO_CLEANUP, 1);
   boolector_set_abort(error_handler);
+  */
+  bitw = bitwuzla_new();
+  bitwuzla_set_abort_callback(error_handler);
 }
 
-boolector_convt::~boolector_convt()
+bitwuzla_convt::~bitwuzla_convt()
 {
-  boolector_delete(btor);
-  btor = nullptr;
+  bitwuzla_delete(bitw);
+  bitw = nullptr;
 }
 
-smt_convt::resultt boolector_convt::dec_solve()
+smt_convt::resultt bitwuzla_convt::dec_solve()
 {
   pre_solve();
 
-  int result = boolector_sat(btor);
+  BitwuzlaResult result = bitwuzla_check_sat(bitw);
 
-  if(result == BOOLECTOR_SAT)
+  if(result == BITWUZLA_SAT)
     return P_SATISFIABLE;
 
-  if(result == BOOLECTOR_UNSAT)
+  if(result == BITWUZLA_UNSAT)
     return P_UNSATISFIABLE;
 
   return P_ERROR;
 }
 
-const std::string boolector_convt::solver_text()
+const std::string bitwuzla_convt::solver_text()
 {
-  std::string ss = "Boolector ";
-  ss += boolector_version(btor);
+  std::string ss = "Bitwuzla ";
+  ss += bitwuzla_version(bitw);
   return ss;
 }
 
-void boolector_convt::assert_ast(smt_astt a)
+void bitwuzla_convt::assert_ast(smt_astt a)
 {
-  boolector_assert(btor, to_solver_smt_ast<btor_smt_ast>(a)->a);
+  bitwuzla_assert(bitw, to_solver_smt_ast<bitw_smt_ast>(a)->a);
 }
 
-smt_astt boolector_convt::mk_bvadd(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvadd(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   return new_ast(
-    boolector_add(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_ADD,  
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvsub(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    boolector_sub(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
-    a->sort);
-}
-
-smt_astt boolector_convt::mk_bvmul(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvsub(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_mul(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SUB,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvsmod(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvmul(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_srem(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_MUL,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvumod(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvsmod(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_urem(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      //BITWUZLA_KIND_BV_SMOD,
+      BITWUZLA_KIND_BV_SREM,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvsdiv(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvumod(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_sdiv(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_UREM,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvudiv(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvsdiv(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_udiv(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SDIV,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvshl(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvudiv(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_sll(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_UDIV,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvashr(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvshl(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_sra(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SHL,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvlshr(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvashr(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_srl(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_ASHR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvneg(smt_astt a)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  return new_ast(
-    boolector_neg(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), a->sort);
-}
-
-smt_astt boolector_convt::mk_bvnot(smt_astt a)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  return new_ast(
-    boolector_not(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), a->sort);
-}
-
-smt_astt boolector_convt::mk_bvnxor(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvlshr(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_xnor(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SHR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvnor(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvneg(smt_astt a)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  return new_ast(
+    bitwuzla_mk_term1(bitw, BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a), a->sort);
+}
+
+smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  return new_ast(
+    bitwuzla_mk_term1(bitw, BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a), a->sort);
+}
+
+smt_astt bitwuzla_convt::mk_bvnxor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_nor(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_XNOR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvnand(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_nand(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_NOR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvxor(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvnand(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_xor(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_NAND,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvor(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvxor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_or(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_XOR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_bvand(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_and(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_OR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_implies(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvand(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_AND,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt bitwuzla_convt::mk_implies(smt_astt a, smt_astt b)
 {
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    boolector_implies(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_IMPLIES,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_xor(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_xor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    boolector_xor(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_XOR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_or(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_or(smt_astt a, smt_astt b)
 {
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    boolector_or(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_OR,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_and(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_and(smt_astt a, smt_astt b)
 {
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    boolector_and(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_AND,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_not(smt_astt a)
+smt_astt bitwuzla_convt::mk_not(smt_astt a)
 {
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    boolector_not(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), boolean_sort);
+    bitwuzla_mk_term1(bitw, BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a), boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvult(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvult(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_ult(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_ULT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvslt(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvslt(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_slt(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SLT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvugt(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvugt(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_ugt(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_UGT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvsgt(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvsgt(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_sgt(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SGT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvule(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvule(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_ulte(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_ULE,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvsle(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvsle(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_slte(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SLE,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvuge(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvuge(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_ugte(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_UGE,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_bvsge(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_bvsge(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_sgte(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_SGE,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_eq(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_eq(smt_astt a, smt_astt b)
 {
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_eq(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_EQUAL,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_neq(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_neq(smt_astt a, smt_astt b)
 {
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_ne(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_DISTINCT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     boolean_sort);
 }
 
-smt_astt boolector_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
+smt_astt bitwuzla_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
 {
   assert(a->sort->id == SMT_SORT_ARRAY);
   assert(a->sort->get_domain_width() == b->sort->get_data_width());
   assert(
     a->sort->get_range_sort()->get_data_width() == c->sort->get_data_width());
   return new_ast(
-    boolector_write(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a,
-      to_solver_smt_ast<btor_smt_ast>(c)->a),
+    bitwuzla_mk_term3(
+      bitw,
+      BITWUZLA_KIND_ARRAY_STORE,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a,
+      to_solver_smt_ast<bitw_smt_ast>(c)->a),
     a->sort);
 }
 
-smt_astt boolector_convt::mk_select(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
 {
   assert(a->sort->id == SMT_SORT_ARRAY);
   assert(a->sort->get_domain_width() == b->sort->get_data_width());
   return new_ast(
-    boolector_read(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_ARRAY_SELECT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort->get_range_sort());
 }
 
-smt_astt boolector_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
+smt_astt bitwuzla_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
   std::cerr << "Boolector can't create integer sorts" << std::endl;
   abort();
 }
 
-smt_astt boolector_convt::mk_smt_real(const std::string &str [[gnu::unused]])
+smt_astt bitwuzla_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
   std::cerr << "Boolector can't create Real sorts" << std::endl;
   abort();
 }
-
-smt_astt boolector_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
+/*
+smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   return new_ast(
     boolector_const(btor, integer2binary(theint, s->get_data_width()).c_str()),
     s);
 }
-
-smt_astt boolector_convt::mk_smt_bool(bool val)
+*/
+smt_astt bitwuzla_convt::mk_smt_bool(bool val)
 {
-  BoolectorNode *node = (val) ? boolector_true(btor) : boolector_false(btor);
+  BitwuzlaTerm *node = (val) ? bitwuzla_mk_true(bitw) : bitwuzla_mk_false(bitw);
   const smt_sort *sort = boolean_sort;
   return new_ast(node, sort);
 }
 
-smt_astt boolector_convt::mk_array_symbol(
+smt_astt bitwuzla_convt::mk_array_symbol(
   const std::string &name,
   const smt_sort *s,
   smt_sortt array_subtype [[gnu::unused]])
@@ -537,14 +572,13 @@ smt_astt boolector_convt::mk_array_symbol(
   return mk_smt_symbol(name, s);
 }
 
-smt_astt
-boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
+smt_astt bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 {
   symtable_type::iterator it = symtable.find(name);
   if(it != symtable.end())
     return it->second;
 
-  BoolectorNode *node;
+  BitwuzlaTerm *node;
 
   switch(s->id)
   {
@@ -552,18 +586,18 @@ boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_FIXEDBV:
   case SMT_SORT_BVFP:
   case SMT_SORT_BVFP_RM:
-    node = boolector_var(
-      btor, to_solver_smt_sort<BoolectorSort>(s)->s, name.c_str());
+    node = bitwuzla_mk_var(
+      bitw, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   case SMT_SORT_BOOL:
-    node = boolector_var(
-      btor, to_solver_smt_sort<BoolectorSort>(s)->s, name.c_str());
+    node = bitwuzla_mk_var(
+      bitw, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   case SMT_SORT_ARRAY:
-    node = boolector_array(
-      btor, to_solver_smt_sort<BoolectorSort>(s)->s, name.c_str());
+    node = bitwuzla_mk_const_array(
+      bitw, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   default:
@@ -577,61 +611,66 @@ boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   return ast;
 }
 
-smt_astt
-boolector_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
+/*
+smt_astt bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
 {
   smt_sortt s = mk_bv_sort(high - low + 1);
-  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BoolectorNode *b = boolector_slice(btor, ast->a, high, low);
   return new_ast(b, s);
 }
+*/
 
-smt_astt boolector_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
+smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
-  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
-  BoolectorNode *b = boolector_sext(btor, ast->a, topwidth);
+  const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
+  //BoolectorNode *b = boolector_sext(btor, ast->a, topwidth);
+  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(bitw, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
-smt_astt boolector_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
+smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
-  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
-  BoolectorNode *b = boolector_uext(btor, ast->a, topwidth);
+  const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
+  //BoolectorNode *b = boolector_uext(btor, ast->a, topwidth);
+  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(bitw, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
-smt_astt boolector_convt::mk_concat(smt_astt a, smt_astt b)
+smt_astt bitwuzla_convt::mk_concat(smt_astt a, smt_astt b)
 {
   smt_sortt s =
     mk_bv_sort(a->sort->get_data_width() + b->sort->get_data_width());
 
   return new_ast(
-    boolector_concat(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    bitwuzla_mk_term2(
+      bitw,
+      BITWUZLA_KIND_BV_CONCAT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a,
+      to_solver_smt_ast<bitw_smt_ast>(b)->a),
     s);
 }
 
-smt_astt boolector_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
+smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 {
   assert(cond->sort->id == SMT_SORT_BOOL);
   assert(t->sort->get_data_width() == f->sort->get_data_width());
 
   return new_ast(
-    boolector_cond(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(cond)->a,
-      to_solver_smt_ast<btor_smt_ast>(t)->a,
-      to_solver_smt_ast<btor_smt_ast>(f)->a),
+    bitwuzla_mk_term3(
+      bitw,
+      BITWUZLA_KIND_ITE,
+      to_solver_smt_ast<bitw_smt_ast>(cond)->a,
+      to_solver_smt_ast<bitw_smt_ast>(t)->a,
+      to_solver_smt_ast<bitw_smt_ast>(f)->a),
     t->sort);
 }
-
-bool boolector_convt::get_bool(smt_astt a)
+/*
+bool bitwuzla_convt::get_bool(smt_astt a)
 {
-  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   const char *result = boolector_bv_assignment(btor, ast->a);
 
   assert(result != NULL && "Boolector returned null bv assignment string");
@@ -654,9 +693,9 @@ bool boolector_convt::get_bool(smt_astt a)
   return res;
 }
 
-BigInt boolector_convt::get_bv(smt_astt a, bool is_signed)
+BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 {
-  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
 
   const char *result = boolector_bv_assignment(btor, ast->a);
   BigInt val = binary2integer(result, is_signed);
@@ -665,7 +704,7 @@ BigInt boolector_convt::get_bv(smt_astt a, bool is_signed)
   return val;
 }
 
-expr2tc boolector_convt::get_array_elem(
+expr2tc bitwuzla_convt::get_array_elem(
   smt_astt array,
   uint64_t index,
   const type2tc &subtype)
@@ -673,7 +712,7 @@ expr2tc boolector_convt::get_array_elem(
   // We do the cast directly here instead of using to_solver_smt_ast because
   // in release mode the dynamic_cast is converted to a static_cast, but we
   // want to catch if the conversion fails
-  const btor_smt_ast *ast = dynamic_cast<const btor_smt_ast *>(array);
+  const bitw_smt_ast *ast = dynamic_cast<const bitw_smt_ast *>(array);
   if(ast == nullptr)
     throw new type2t::symbolic_type_excp();
 
@@ -700,58 +739,65 @@ expr2tc boolector_convt::get_array_elem(
 
   return gen_zero(subtype);
 }
-
-smt_astt boolector_convt::overflow_arith(const expr2tc &expr)
+*/
+smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
 {
   const overflow2t &overflow = to_overflow2t(expr);
   const arith_2ops &opers = static_cast<const arith_2ops &>(*overflow.operand);
 
-  const btor_smt_ast *side1 =
-    to_solver_smt_ast<btor_smt_ast>(convert_ast(opers.side_1));
-  const btor_smt_ast *side2 =
-    to_solver_smt_ast<btor_smt_ast>(convert_ast(opers.side_2));
+  const bitw_smt_ast *side1 =
+    to_solver_smt_ast<bitw_smt_ast>(convert_ast(opers.side_1));
+  const bitw_smt_ast *side2 =
+    to_solver_smt_ast<bitw_smt_ast>(convert_ast(opers.side_2));
 
   // Guess whether we're performing a signed or unsigned comparison.
   bool is_signed =
     (is_signedbv_type(opers.side_1) || is_signedbv_type(opers.side_2));
 
-  BoolectorNode *res;
+  BitwuzlaTerm *res;
   if(is_add2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = boolector_saddo(btor, side1->a, side2->a);
+      //res = boolector_saddo(btor, side1->a, side2->a);
+      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = boolector_uaddo(btor, side1->a, side2->a);
+      //res = boolector_uaddo(btor, side1->a, side2->a);
+      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_sub2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = boolector_ssubo(btor, side1->a, side2->a);
+      //res = boolector_ssubo(btor, side1->a, side2->a);
+      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = boolector_usubo(btor, side1->a, side2->a);
+      //res = boolector_usubo(btor, side1->a, side2->a);
+      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_mul2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = boolector_smulo(btor, side1->a, side2->a);
+      //res = boolector_smulo(btor, side1->a, side2->a);
+      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = boolector_umulo(btor, side1->a, side2->a);
+      //res = boolector_umulo(btor, side1->a, side2->a);
+      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
-    res = boolector_sdivo(btor, side1->a, side2->a);
+    //res = boolector_sdivo(btor, side1->a, side2->a);
+    res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {
@@ -762,76 +808,77 @@ smt_astt boolector_convt::overflow_arith(const expr2tc &expr)
   return new_ast(res, s);
 }
 
+/*
 smt_astt
-boolector_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
+bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 {
   smt_sortt dom_sort = mk_int_bv_sort(domain_width);
   smt_sortt arrsort = mk_array_sort(dom_sort, init_val->sort);
 
   return new_ast(
-    boolector_const_array(
-      btor,
-      to_solver_smt_sort<BoolectorSort>(arrsort)->s,
-      to_solver_smt_ast<btor_smt_ast>(init_val)->a),
+    bitwuzla_mk_const_array(
+      bitw,
+      to_solver_smt_sort<BitwuzlaSort>(arrsort)->s,
+      to_solver_smt_ast<bitw_smt_ast>(init_val)->a),
     arrsort);
 }
-
-void boolector_convt::dump_smt()
+*/
+void bitwuzla_convt::dump_smt()
 {
-  boolector_dump_smt2(btor, stdout);
+  bitwuzla_dump_formula(bitw, const_cast<char *>("smt2"), stdout);
 }
 
-void btor_smt_ast::dump() const
+void bitw_smt_ast::dump() const
 {
-  boolector_dump_smt2_node(boolector_get_btor(a), stdout, a);
+  bitwuzla_term_dump(a, const_cast<char *>("smt2"), stdout);
   std::cout << std::flush;
 }
 
-void boolector_convt::print_model()
+void bitwuzla_convt::print_model()
 {
-  boolector_print_model(btor, const_cast<char *>("smt2"), stdout);
+  bitwuzla_print_model(bitw, const_cast<char *>("smt2"), stdout);
+}
+/*
+smt_sortt bitwuzla_convt::mk_bool_sort()
+{
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw), 1);
 }
 
-smt_sortt boolector_convt::mk_bool_sort()
+smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BoolectorSort>(
-    SMT_SORT_BOOL, boolector_bool_sort(btor), 1);
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw, width), width);
 }
 
-smt_sortt boolector_convt::mk_bv_sort(std::size_t width)
+smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BoolectorSort>(
-    SMT_SORT_BV, boolector_bitvec_sort(btor, width), width);
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw, width), width);
 }
 
-smt_sortt boolector_convt::mk_fbv_sort(std::size_t width)
+smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 {
-  return new solver_smt_sort<BoolectorSort>(
-    SMT_SORT_FIXEDBV, boolector_bitvec_sort(btor, width), width);
-}
+  auto domain_sort = to_solver_smt_sort<BitwuzlaSort>(domain);
+  auto range_sort = to_solver_smt_sort<BitwuzlaSort>(range);
 
-smt_sortt boolector_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
-{
-  auto domain_sort = to_solver_smt_sort<BoolectorSort>(domain);
-  auto range_sort = to_solver_smt_sort<BoolectorSort>(range);
-
-  auto t = boolector_array_sort(btor, domain_sort->s, range_sort->s);
-  return new solver_smt_sort<BoolectorSort>(
+  auto t = bitwuzla_mk_array_sort(bitw, domain_sort->s, range_sort->s);
+  return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
 
-smt_sortt boolector_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
+smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
-  return new solver_smt_sort<BoolectorSort>(
+  return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_BVFP,
-    boolector_bitvec_sort(btor, ew + sw + 1),
+    bitwuzla_mk_bv_sort(bitw, ew + sw + 1),
     ew + sw + 1,
     sw + 1);
 }
 
-smt_sortt boolector_convt::mk_bvfp_rm_sort()
+smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
-  return new solver_smt_sort<BoolectorSort>(
-    SMT_SORT_BVFP_RM, boolector_bitvec_sort(btor, 3), 3);
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw, 3), 3);
 }
 */

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -3,7 +3,7 @@
 
 #define new_ast new_solver_ast<bitw_smt_ast>
 
-void error_handler(const char *msg)
+void bitwuzla_error_handler(const char *msg)
 {
   std::cerr << "Bitwuzla error encountered\n";
   std::cerr << msg << '\n';
@@ -41,7 +41,7 @@ bitwuzla_convt::bitwuzla_convt(bool int_encoding, const namespacet &ns)
   */
   bitw = bitwuzla_new();
   bitwuzla_set_option(bitw, BITWUZLA_OPT_PRODUCE_MODELS, 1);
-  bitwuzla_set_abort_callback(error_handler);
+  bitwuzla_set_abort_callback(bitwuzla_error_handler);
 }
 
 bitwuzla_convt::~bitwuzla_convt()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -10,7 +10,6 @@ void error_handler(const char *msg)
   abort();
 }
 
-
 smt_convt *create_new_bitwuzla_solver(
   bool int_encoding,
   const namespacet &ns,
@@ -25,7 +24,6 @@ smt_convt *create_new_bitwuzla_solver(
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
 }
-
 
 bitwuzla_convt::bitwuzla_convt(bool int_encoding, const namespacet &ns)
   : smt_convt(int_encoding, ns), array_iface(true, true), fp_convt(this)
@@ -87,7 +85,7 @@ smt_astt bitwuzla_convt::mk_bvadd(smt_astt a, smt_astt b)
   return new_ast(
     bitwuzla_mk_term2(
       bitw,
-      BITWUZLA_KIND_BV_ADD,  
+      BITWUZLA_KIND_BV_ADD,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
     a->sort);
@@ -224,14 +222,18 @@ smt_astt bitwuzla_convt::mk_bvneg(smt_astt a)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
-    bitwuzla_mk_term1(bitw, BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a), a->sort);
+    bitwuzla_mk_term1(
+      bitw, BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+    a->sort);
 }
 
 smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
-    bitwuzla_mk_term1(bitw, BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a), a->sort);
+    bitwuzla_mk_term1(
+      bitw, BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+    a->sort);
 }
 
 smt_astt bitwuzla_convt::mk_bvnxor(smt_astt a, smt_astt b)
@@ -370,7 +372,9 @@ smt_astt bitwuzla_convt::mk_not(smt_astt a)
 {
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    bitwuzla_mk_term1(bitw, BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a), boolean_sort);
+    bitwuzla_mk_term1(
+      bitw, BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+    boolean_sort);
 }
 
 smt_astt bitwuzla_convt::mk_bvult(smt_astt a, smt_astt b)
@@ -555,7 +559,9 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
   // Fedor: double check the second argument of the function
   BitwuzlaSort *bitwsort = bitwuzla_mk_bv_sort(bitw, s->get_data_width());
   return new_ast(
-    bitwuzla_mk_const(bitw, bitwsort, integer2binary(theint, s->get_data_width()).c_str()), s);
+    bitwuzla_mk_const(
+      bitw, bitwsort, integer2binary(theint, s->get_data_width()).c_str()),
+    s);
 }
 
 smt_astt bitwuzla_convt::mk_smt_bool(bool val)
@@ -573,7 +579,8 @@ smt_astt bitwuzla_convt::mk_array_symbol(
   return mk_smt_symbol(name, s);
 }
 
-smt_astt bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
+smt_astt
+bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 {
   symtable_type::iterator it = symtable.find(name);
   if(it != symtable.end())
@@ -588,19 +595,19 @@ smt_astt bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *
   case SMT_SORT_BVFP:
   case SMT_SORT_BVFP_RM:
     node = bitwuzla_mk_var(
-      bitw, to_solver_smt_sort<BitwuzlaSort*>(s)->s, name.c_str());
+      bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
     break;
 
   case SMT_SORT_BOOL:
     node = bitwuzla_mk_var(
-      bitw, to_solver_smt_sort<BitwuzlaSort*>(s)->s, name.c_str());
+      bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
     break;
 
   case SMT_SORT_ARRAY:
     // Fedor: not entirely sure about this one here
     //node = bitwuzla_mk_const_array(bitw, to_solver_smt_sort<BitwuzlaSort*>(s)->s, name.c_str());
     node = bitwuzla_mk_var(
-      bitw, to_solver_smt_sort<BitwuzlaSort*>(s)->s, name.c_str());
+      bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
     break;
 
   default:
@@ -614,23 +621,24 @@ smt_astt bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *
   return ast;
 }
 
-
-smt_astt bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
+smt_astt
+bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
 {
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   //BoolectorNode *b = boolector_slice(btor, ast->a, high, low);
-  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed2(bitw, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
+  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed2(
+    bitw, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
-
 
 smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   //BoolectorNode *b = boolector_sext(btor, ast->a, topwidth);
-  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(bitw, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
+  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(
+    bitw, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -639,7 +647,8 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   //BoolectorNode *b = boolector_uext(btor, ast->a, topwidth);
-  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(bitw, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
+  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(
+    bitw, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -763,38 +772,45 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
   {
     if(is_signed)
     {
-      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_sub2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_mul2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
-    res = bitwuzla_mk_term2(bitw, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
+    res = bitwuzla_mk_term2(
+      bitw, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {
@@ -814,7 +830,7 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
   return new_ast(
     bitwuzla_mk_const_array(
       bitw,
-      to_solver_smt_sort<BitwuzlaSort*>(arrsort)->s,
+      to_solver_smt_sort<BitwuzlaSort *>(arrsort)->s,
       to_solver_smt_ast<bitw_smt_ast>(init_val)->a),
     arrsort);
 }
@@ -837,44 +853,40 @@ void bitwuzla_convt::print_model()
 
 smt_sortt bitwuzla_convt::mk_bool_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort*>(
+  return new solver_smt_sort<BitwuzlaSort *>(
     SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw), 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BitwuzlaSort*>(
+  return new solver_smt_sort<BitwuzlaSort *>(
     SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw, width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BitwuzlaSort*>(
+  return new solver_smt_sort<BitwuzlaSort *>(
     SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw, width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 {
-  auto domain_sort = to_solver_smt_sort<BitwuzlaSort*>(domain);
-  auto range_sort = to_solver_smt_sort<BitwuzlaSort*>(range);
+  auto domain_sort = to_solver_smt_sort<BitwuzlaSort *>(domain);
+  auto range_sort = to_solver_smt_sort<BitwuzlaSort *>(range);
 
   auto t = bitwuzla_mk_array_sort(bitw, domain_sort->s, range_sort->s);
-  return new solver_smt_sort<BitwuzlaSort*>(
+  return new solver_smt_sort<BitwuzlaSort *>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
-  return new solver_smt_sort<BitwuzlaSort*>(
-    SMT_SORT_BVFP,
-    bitwuzla_mk_bv_sort(bitw, ew + sw + 1),
-    ew + sw + 1,
-    sw + 1);
+  return new solver_smt_sort<BitwuzlaSort *>(
+    SMT_SORT_BVFP, bitwuzla_mk_bv_sort(bitw, ew + sw + 1), ew + sw + 1, sw + 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort*>(
+  return new solver_smt_sort<BitwuzlaSort *>(
     SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw, 3), 3);
 }
-

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -681,7 +681,7 @@ bool bitwuzla_convt::get_bool(smt_astt a)
   abort();
 }
 
-BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
+BigInt bitwuzla_convt::get_bv(smt_astt a [[gnu::unused]], bool is_signed [[gnu::unused]])
 {
   std::cerr << "Counter-example generation with Bitwuzla has not been fully "
                "implemented yet\n";
@@ -689,9 +689,9 @@ BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 }
 
 expr2tc bitwuzla_convt::get_array_elem(
-  smt_astt array,
-  uint64_t index,
-  const type2tc &subtype)
+  smt_astt array [[gnu::unused]],
+  uint64_t index [[gnu::unused]],
+  const type2tc &subtype [[gnu::unused]])
 {
   std::cerr << "Counter-example generation with Bitwuzla has not been fully "
                "implemented yet\n";

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -782,18 +782,18 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
 void bitwuzla_convt::dump_smt()
 {
-  bitwuzla_dump_formula(bitw, const_cast<char *>("smt2"), stdout);
+  bitwuzla_dump_formula(bitw, "smt2", stdout);
 }
 
 void bitw_smt_ast::dump() const
 {
-  bitwuzla_term_dump(a, const_cast<char *>("smt2"), stdout);
+  bitwuzla_term_dump(a, "smt2", stdout);
   std::cout << std::flush;
 }
 
 void bitwuzla_convt::print_model()
 {
-  bitwuzla_print_model(bitw, const_cast<char *>("smt2"), stdout);
+  bitwuzla_print_model(bitw, "smt2", stdout);
 }
 
 smt_sortt bitwuzla_convt::mk_bool_sort()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -529,13 +529,14 @@ smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
 
 smt_astt bitwuzla_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
-  std::cerr << "Bitwuzla can't create integer sorts" << std::endl;
+  std::cerr << "ESBMC can't create integer sorts with Bitwuzla yet"
+            << std::endl;
   abort();
 }
 
 smt_astt bitwuzla_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
-  std::cerr << "Bitwuzla can't create Real sorts" << std::endl;
+  std::cerr << "ESBMC can't create real sorts with Bitwuzla yet" << std::endl;
   abort();
 }
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -670,7 +670,7 @@ bool bitwuzla_convt::get_bool(smt_astt a)
   const char *result = bitwuzla_get_bv_value(bitw, ast->a);
 
   assert(result != NULL && "Bitwuzla returned null bv value string");
-  
+
   bool res;
   switch(*result)
   {
@@ -687,9 +687,7 @@ bool bitwuzla_convt::get_bool(smt_astt a)
   return res;
 }
 
-BigInt bitwuzla_convt::get_bv(
-  smt_astt a,
-  bool is_signed)
+BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   const char *result = bitwuzla_get_bv_value(bitw, ast->a);
@@ -708,7 +706,8 @@ expr2tc bitwuzla_convt::get_array_elem(
 
   size_t size;
   BitwuzlaTerm **indicies, **values, *default_value;
-  bitwuzla_get_array_value(bitw, ast->a, &indicies, &values, &size, &default_value);
+  bitwuzla_get_array_value(
+    bitw, ast->a, &indicies, &values, &size, &default_value);
 
   BigInt val = 0;
   if(size > 0)

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -1,0 +1,837 @@
+#include <bitwuzla_conv.h>
+#include <cstring>
+
+#define new_ast new_solver_ast<btor_smt_ast>
+/*
+void error_handler(const char *msg)
+{
+  std::cerr << "Bitwuzla error encountered\n";
+  std::cerr << msg << '\n';
+  abort();
+}
+*/
+
+smt_convt *create_new_bitwuzla_solver(
+  bool int_encoding,
+  const namespacet &ns,
+  tuple_iface **tuple_api [[gnu::unused]],
+  array_iface **array_api,
+  fp_convt **fp_api)
+{
+  std::cerr << "Bitwuzla support has not been yet implemented\n";
+  return NULL;
+  /*
+  boolector_convt *conv = new boolector_convt(int_encoding, ns);
+  *array_api = static_cast<array_iface *>(conv);
+  *fp_api = static_cast<fp_convt *>(conv);
+  return conv;
+  */
+}
+
+/*
+boolector_convt::boolector_convt(bool int_encoding, const namespacet &ns)
+  : smt_convt(int_encoding, ns), array_iface(true, true), fp_convt(this)
+{
+  if(int_encoding)
+  {
+    std::cerr << "Boolector does not support integer encoding mode"
+              << std::endl;
+    abort();
+  }
+
+  btor = boolector_new();
+  boolector_set_opt(btor, BTOR_OPT_MODEL_GEN, 1);
+  boolector_set_opt(btor, BTOR_OPT_AUTO_CLEANUP, 1);
+  boolector_set_abort(error_handler);
+}
+
+boolector_convt::~boolector_convt()
+{
+  boolector_delete(btor);
+  btor = nullptr;
+}
+
+smt_convt::resultt boolector_convt::dec_solve()
+{
+  pre_solve();
+
+  int result = boolector_sat(btor);
+
+  if(result == BOOLECTOR_SAT)
+    return P_SATISFIABLE;
+
+  if(result == BOOLECTOR_UNSAT)
+    return P_UNSATISFIABLE;
+
+  return P_ERROR;
+}
+
+const std::string boolector_convt::solver_text()
+{
+  std::string ss = "Boolector ";
+  ss += boolector_version(btor);
+  return ss;
+}
+
+void boolector_convt::assert_ast(smt_astt a)
+{
+  boolector_assert(btor, to_solver_smt_ast<btor_smt_ast>(a)->a);
+}
+
+smt_astt boolector_convt::mk_bvadd(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  return new_ast(
+    boolector_add(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvsub(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_sub(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvmul(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_mul(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvsmod(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_srem(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvumod(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_urem(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvsdiv(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_sdiv(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvudiv(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_udiv(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvshl(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_sll(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvashr(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_sra(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvlshr(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_srl(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvneg(smt_astt a)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  return new_ast(
+    boolector_neg(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), a->sort);
+}
+
+smt_astt boolector_convt::mk_bvnot(smt_astt a)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  return new_ast(
+    boolector_not(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), a->sort);
+}
+
+smt_astt boolector_convt::mk_bvnxor(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_xnor(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvnor(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_nor(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvnand(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_nand(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvxor(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_xor(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvor(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_or(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_bvand(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_and(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_implies(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    boolector_implies(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_xor(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    boolector_xor(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_or(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    boolector_or(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_and(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    boolector_and(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_not(smt_astt a)
+{
+  assert(a->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    boolector_not(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvult(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_ult(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvslt(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_slt(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvugt(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_ugt(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvsgt(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_sgt(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvule(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_ulte(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvsle(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_slte(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvuge(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_ugte(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_bvsge(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_sgte(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_eq(smt_astt a, smt_astt b)
+{
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_eq(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_neq(smt_astt a, smt_astt b)
+{
+  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_ne(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt boolector_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
+{
+  assert(a->sort->id == SMT_SORT_ARRAY);
+  assert(a->sort->get_domain_width() == b->sort->get_data_width());
+  assert(
+    a->sort->get_range_sort()->get_data_width() == c->sort->get_data_width());
+  return new_ast(
+    boolector_write(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a,
+      to_solver_smt_ast<btor_smt_ast>(c)->a),
+    a->sort);
+}
+
+smt_astt boolector_convt::mk_select(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_ARRAY);
+  assert(a->sort->get_domain_width() == b->sort->get_data_width());
+  return new_ast(
+    boolector_read(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    a->sort->get_range_sort());
+}
+
+smt_astt boolector_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
+{
+  std::cerr << "Boolector can't create integer sorts" << std::endl;
+  abort();
+}
+
+smt_astt boolector_convt::mk_smt_real(const std::string &str [[gnu::unused]])
+{
+  std::cerr << "Boolector can't create Real sorts" << std::endl;
+  abort();
+}
+
+smt_astt boolector_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
+{
+  return new_ast(
+    boolector_const(btor, integer2binary(theint, s->get_data_width()).c_str()),
+    s);
+}
+
+smt_astt boolector_convt::mk_smt_bool(bool val)
+{
+  BoolectorNode *node = (val) ? boolector_true(btor) : boolector_false(btor);
+  const smt_sort *sort = boolean_sort;
+  return new_ast(node, sort);
+}
+
+smt_astt boolector_convt::mk_array_symbol(
+  const std::string &name,
+  const smt_sort *s,
+  smt_sortt array_subtype [[gnu::unused]])
+{
+  return mk_smt_symbol(name, s);
+}
+
+smt_astt
+boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
+{
+  symtable_type::iterator it = symtable.find(name);
+  if(it != symtable.end())
+    return it->second;
+
+  BoolectorNode *node;
+
+  switch(s->id)
+  {
+  case SMT_SORT_BV:
+  case SMT_SORT_FIXEDBV:
+  case SMT_SORT_BVFP:
+  case SMT_SORT_BVFP_RM:
+    node = boolector_var(
+      btor, to_solver_smt_sort<BoolectorSort>(s)->s, name.c_str());
+    break;
+
+  case SMT_SORT_BOOL:
+    node = boolector_var(
+      btor, to_solver_smt_sort<BoolectorSort>(s)->s, name.c_str());
+    break;
+
+  case SMT_SORT_ARRAY:
+    node = boolector_array(
+      btor, to_solver_smt_sort<BoolectorSort>(s)->s, name.c_str());
+    break;
+
+  default:
+    std::cerr << "Unknown type for symbol\n";
+    abort();
+  }
+
+  smt_astt ast = new_ast(node, s);
+
+  symtable.insert(symtable_type::value_type(name, ast));
+  return ast;
+}
+
+smt_astt
+boolector_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
+{
+  smt_sortt s = mk_bv_sort(high - low + 1);
+  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  BoolectorNode *b = boolector_slice(btor, ast->a, high, low);
+  return new_ast(b, s);
+}
+
+smt_astt boolector_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
+{
+  smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
+  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  BoolectorNode *b = boolector_sext(btor, ast->a, topwidth);
+  return new_ast(b, s);
+}
+
+smt_astt boolector_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
+{
+  smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
+  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  BoolectorNode *b = boolector_uext(btor, ast->a, topwidth);
+  return new_ast(b, s);
+}
+
+smt_astt boolector_convt::mk_concat(smt_astt a, smt_astt b)
+{
+  smt_sortt s =
+    mk_bv_sort(a->sort->get_data_width() + b->sort->get_data_width());
+
+  return new_ast(
+    boolector_concat(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(a)->a,
+      to_solver_smt_ast<btor_smt_ast>(b)->a),
+    s);
+}
+
+smt_astt boolector_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
+{
+  assert(cond->sort->id == SMT_SORT_BOOL);
+  assert(t->sort->get_data_width() == f->sort->get_data_width());
+
+  return new_ast(
+    boolector_cond(
+      btor,
+      to_solver_smt_ast<btor_smt_ast>(cond)->a,
+      to_solver_smt_ast<btor_smt_ast>(t)->a,
+      to_solver_smt_ast<btor_smt_ast>(f)->a),
+    t->sort);
+}
+
+bool boolector_convt::get_bool(smt_astt a)
+{
+  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+  const char *result = boolector_bv_assignment(btor, ast->a);
+
+  assert(result != NULL && "Boolector returned null bv assignment string");
+
+  bool res;
+  switch(*result)
+  {
+  case '1':
+    res = true;
+    break;
+  case '0':
+    res = false;
+    break;
+  default:
+    std::cerr << "Can't get boolean value from Boolector\n";
+    abort();
+  }
+
+  boolector_free_bv_assignment(btor, result);
+  return res;
+}
+
+BigInt boolector_convt::get_bv(smt_astt a, bool is_signed)
+{
+  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(a);
+
+  const char *result = boolector_bv_assignment(btor, ast->a);
+  BigInt val = binary2integer(result, is_signed);
+  boolector_free_bv_assignment(btor, result);
+
+  return val;
+}
+
+expr2tc boolector_convt::get_array_elem(
+  smt_astt array,
+  uint64_t index,
+  const type2tc &subtype)
+{
+  // We do the cast directly here instead of using to_solver_smt_ast because
+  // in release mode the dynamic_cast is converted to a static_cast, but we
+  // want to catch if the conversion fails
+  const btor_smt_ast *ast = dynamic_cast<const btor_smt_ast *>(array);
+  if(ast == nullptr)
+    throw new type2t::symbolic_type_excp();
+
+  uint32_t size;
+  char **indicies, **values;
+  boolector_array_assignment(btor, ast->a, &indicies, &values, &size);
+
+  BigInt val = 0;
+  if(size > 0)
+  {
+    for(uint32_t i = 0; i < size; i++)
+    {
+      auto idx = string2integer(indicies[i], 2);
+      if(idx == index)
+      {
+        val = binary2integer(values[i], is_signedbv_type(subtype));
+        break;
+      }
+    }
+
+    boolector_free_array_assignment(btor, indicies, values, size);
+    return get_by_value(subtype, val);
+  }
+
+  return gen_zero(subtype);
+}
+
+smt_astt boolector_convt::overflow_arith(const expr2tc &expr)
+{
+  const overflow2t &overflow = to_overflow2t(expr);
+  const arith_2ops &opers = static_cast<const arith_2ops &>(*overflow.operand);
+
+  const btor_smt_ast *side1 =
+    to_solver_smt_ast<btor_smt_ast>(convert_ast(opers.side_1));
+  const btor_smt_ast *side2 =
+    to_solver_smt_ast<btor_smt_ast>(convert_ast(opers.side_2));
+
+  // Guess whether we're performing a signed or unsigned comparison.
+  bool is_signed =
+    (is_signedbv_type(opers.side_1) || is_signedbv_type(opers.side_2));
+
+  BoolectorNode *res;
+  if(is_add2t(overflow.operand))
+  {
+    if(is_signed)
+    {
+      res = boolector_saddo(btor, side1->a, side2->a);
+    }
+    else
+    {
+      res = boolector_uaddo(btor, side1->a, side2->a);
+    }
+  }
+  else if(is_sub2t(overflow.operand))
+  {
+    if(is_signed)
+    {
+      res = boolector_ssubo(btor, side1->a, side2->a);
+    }
+    else
+    {
+      res = boolector_usubo(btor, side1->a, side2->a);
+    }
+  }
+  else if(is_mul2t(overflow.operand))
+  {
+    if(is_signed)
+    {
+      res = boolector_smulo(btor, side1->a, side2->a);
+    }
+    else
+    {
+      res = boolector_umulo(btor, side1->a, side2->a);
+    }
+  }
+  else if(is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
+  {
+    res = boolector_sdivo(btor, side1->a, side2->a);
+  }
+  else
+  {
+    return smt_convt::overflow_arith(expr);
+  }
+
+  const smt_sort *s = boolean_sort;
+  return new_ast(res, s);
+}
+
+smt_astt
+boolector_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
+{
+  smt_sortt dom_sort = mk_int_bv_sort(domain_width);
+  smt_sortt arrsort = mk_array_sort(dom_sort, init_val->sort);
+
+  return new_ast(
+    boolector_const_array(
+      btor,
+      to_solver_smt_sort<BoolectorSort>(arrsort)->s,
+      to_solver_smt_ast<btor_smt_ast>(init_val)->a),
+    arrsort);
+}
+
+void boolector_convt::dump_smt()
+{
+  boolector_dump_smt2(btor, stdout);
+}
+
+void btor_smt_ast::dump() const
+{
+  boolector_dump_smt2_node(boolector_get_btor(a), stdout, a);
+  std::cout << std::flush;
+}
+
+void boolector_convt::print_model()
+{
+  boolector_print_model(btor, const_cast<char *>("smt2"), stdout);
+}
+
+smt_sortt boolector_convt::mk_bool_sort()
+{
+  return new solver_smt_sort<BoolectorSort>(
+    SMT_SORT_BOOL, boolector_bool_sort(btor), 1);
+}
+
+smt_sortt boolector_convt::mk_bv_sort(std::size_t width)
+{
+  return new solver_smt_sort<BoolectorSort>(
+    SMT_SORT_BV, boolector_bitvec_sort(btor, width), width);
+}
+
+smt_sortt boolector_convt::mk_fbv_sort(std::size_t width)
+{
+  return new solver_smt_sort<BoolectorSort>(
+    SMT_SORT_FIXEDBV, boolector_bitvec_sort(btor, width), width);
+}
+
+smt_sortt boolector_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
+{
+  auto domain_sort = to_solver_smt_sort<BoolectorSort>(domain);
+  auto range_sort = to_solver_smt_sort<BoolectorSort>(range);
+
+  auto t = boolector_array_sort(btor, domain_sort->s, range_sort->s);
+  return new solver_smt_sort<BoolectorSort>(
+    SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
+}
+
+smt_sortt boolector_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
+{
+  return new solver_smt_sort<BoolectorSort>(
+    SMT_SORT_BVFP,
+    boolector_bitvec_sort(btor, ew + sw + 1),
+    ew + sw + 1,
+    sw + 1);
+}
+
+smt_sortt boolector_convt::mk_bvfp_rm_sort()
+{
+  return new solver_smt_sort<BoolectorSort>(
+    SMT_SORT_BVFP_RM, boolector_bitvec_sort(btor, 3), 3);
+}
+*/

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -6,26 +6,28 @@
 #include <util/irep2.h>
 #include <util/namespace.h>
 
-/*
+
 extern "C"
 {
-#include <boolector/boolector.h>
+#include <bitwuzla/bitwuzla.h>
 }
 
-class btor_smt_ast : public solver_smt_ast<BoolectorNode *>
+
+class bitw_smt_ast : public solver_smt_ast<BitwuzlaTerm *>
 {
 public:
-  using solver_smt_ast<BoolectorNode *>::solver_smt_ast;
-  ~btor_smt_ast() override = default;
+  using solver_smt_ast<BitwuzlaTerm *>::solver_smt_ast;
+  ~bitw_smt_ast() override = default;
 
   void dump() const override;
 };
 
-class boolector_convt : public smt_convt, public array_iface, public fp_convt
+
+class bitwuzla_convt : public smt_convt, public array_iface, public fp_convt
 {
 public:
-  boolector_convt(bool int_encoding, const namespacet &ns);
-  ~boolector_convt() override;
+  bitwuzla_convt(bool int_encoding, const namespacet &ns);
+  ~bitwuzla_convt() override;
 
   resultt dec_solve() override;
   const std::string solver_text() override;
@@ -104,10 +106,10 @@ public:
   void print_model() override;
 
   // Members
-  Btor *btor;
+  Bitwuzla *bitw;
 
   typedef std::unordered_map<std::string, smt_astt> symtable_type;
   symtable_type symtable;
 };
-*/
+
 #endif /* _ESBMC_SOLVERS_BITWUZLA_BITWUZLA_CONV_H_ */

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -1,0 +1,113 @@
+#ifndef _ESBMC_SOLVERS_BITWUZLA_BITWUZLA_CONV_H_
+#define _ESBMC_SOLVERS_BITWUZLA_BITWUZLA_CONV_H_
+
+#include <cstdio>
+#include <solvers/smt/smt_conv.h>
+#include <util/irep2.h>
+#include <util/namespace.h>
+
+/*
+extern "C"
+{
+#include <boolector/boolector.h>
+}
+
+class btor_smt_ast : public solver_smt_ast<BoolectorNode *>
+{
+public:
+  using solver_smt_ast<BoolectorNode *>::solver_smt_ast;
+  ~btor_smt_ast() override = default;
+
+  void dump() const override;
+};
+
+class boolector_convt : public smt_convt, public array_iface, public fp_convt
+{
+public:
+  boolector_convt(bool int_encoding, const namespacet &ns);
+  ~boolector_convt() override;
+
+  resultt dec_solve() override;
+  const std::string solver_text() override;
+
+  void assert_ast(smt_astt a) override;
+
+  smt_astt mk_bvadd(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvsub(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvmul(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvsmod(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvumod(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvsdiv(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvudiv(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvshl(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvashr(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvlshr(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvneg(smt_astt a) override;
+  smt_astt mk_bvnot(smt_astt a) override;
+  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvxor(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvor(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvand(smt_astt a, smt_astt b) override;
+  smt_astt mk_implies(smt_astt a, smt_astt b) override;
+  smt_astt mk_xor(smt_astt a, smt_astt b) override;
+  smt_astt mk_or(smt_astt a, smt_astt b) override;
+  smt_astt mk_and(smt_astt a, smt_astt b) override;
+  smt_astt mk_not(smt_astt a) override;
+  smt_astt mk_bvult(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvslt(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvugt(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvsgt(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvule(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvsle(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvuge(smt_astt a, smt_astt b) override;
+  smt_astt mk_bvsge(smt_astt a, smt_astt b) override;
+  smt_astt mk_eq(smt_astt a, smt_astt b) override;
+  smt_astt mk_neq(smt_astt a, smt_astt b) override;
+  smt_astt mk_store(smt_astt a, smt_astt b, smt_astt c) override;
+  smt_astt mk_select(smt_astt a, smt_astt b) override;
+
+  smt_sortt mk_bool_sort() override;
+  smt_sortt mk_bv_sort(std::size_t width) override;
+  smt_sortt mk_array_sort(smt_sortt domain, smt_sortt range) override;
+  smt_sortt mk_fbv_sort(std::size_t width) override;
+  smt_sortt mk_bvfp_sort(std::size_t width, std::size_t swidth) override;
+  smt_sortt mk_bvfp_rm_sort() override;
+
+  smt_astt mk_smt_int(const BigInt &theint) override;
+  smt_astt mk_smt_real(const std::string &str) override;
+  smt_astt mk_smt_bv(const BigInt &theint, smt_sortt s) override;
+  smt_astt mk_smt_bool(bool val) override;
+  smt_astt mk_smt_symbol(const std::string &name, const smt_sort *s) override;
+  smt_astt mk_array_symbol(
+    const std::string &name,
+    const smt_sort *s,
+    smt_sortt array_subtype) override;
+  smt_astt mk_extract(smt_astt a, unsigned int high, unsigned int low) override;
+  smt_astt mk_sign_ext(smt_astt a, unsigned int topwidth) override;
+  smt_astt mk_zero_ext(smt_astt a, unsigned int topwidth) override;
+  smt_astt mk_concat(smt_astt a, smt_astt b) override;
+  smt_astt mk_ite(smt_astt cond, smt_astt t, smt_astt f) override;
+
+  smt_astt
+  convert_array_of(smt_astt init_val, unsigned long domain_width) override;
+
+  bool get_bool(smt_astt a) override;
+  BigInt get_bv(smt_astt a, bool is_signed) override;
+  expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
+    override;
+
+  smt_astt overflow_arith(const expr2tc &expr) override;
+
+  void dump_smt() override;
+  void print_model() override;
+
+  // Members
+  Btor *btor;
+
+  typedef std::unordered_map<std::string, smt_astt> symtable_type;
+  symtable_type symtable;
+};
+*/
+#endif /* _ESBMC_SOLVERS_BITWUZLA_BITWUZLA_CONV_H_ */

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -6,12 +6,10 @@
 #include <util/irep2.h>
 #include <util/namespace.h>
 
-
 extern "C"
 {
 #include <bitwuzla/bitwuzla.h>
 }
-
 
 class bitw_smt_ast : public solver_smt_ast<BitwuzlaTerm *>
 {
@@ -21,7 +19,6 @@ public:
 
   void dump() const override;
 };
-
 
 class bitwuzla_convt : public smt_convt, public array_iface, public fp_convt
 {

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -13,6 +13,7 @@ solver_creator create_new_boolector_solver;
 solver_creator create_new_cvc_solver;
 solver_creator create_new_mathsat_solver;
 solver_creator create_new_yices_solver;
+solver_creator create_new_bitwuzla_solver;
 
 const struct esbmc_solver_config esbmc_solvers[] = {
   {"smtlib", create_new_smtlib_solver},
@@ -32,12 +33,22 @@ const struct esbmc_solver_config esbmc_solvers[] = {
   {"mathsat", create_new_mathsat_solver},
 #endif
 #ifdef YICES
-  {"yices", create_new_yices_solver}
+  {"yices", create_new_yices_solver},
+#endif
+#ifdef BITWUZLA
+  {"bitwuzla", create_new_bitwuzla_solver}
 #endif
 };
 
-const std::string list_of_all_solvers[] =
-  {"z3", "smtlib", "minisat", "boolector", "mathsat", "cvc", "yices"};
+const std::string list_of_all_solvers[] = {
+  "z3",
+  "smtlib",
+  "minisat",
+  "boolector",
+  "mathsat",
+  "cvc",
+  "yices",
+  "bitwuzla"};
 
 const unsigned int total_num_of_solvers =
   sizeof(list_of_all_solvers) / sizeof(std::string);

--- a/src/solvers/solver_config.h.in
+++ b/src/solvers/solver_config.h.in
@@ -21,3 +21,7 @@
 #if @ESBMC_ENABLE_yices@
 #define YICES
 #endif
+
+#if @ESBMC_ENABLE_bitwuzla@
+#define BITWUZLA
+#endif


### PR DESCRIPTION
The counter-example generation in ESBMC with Bitwuzla is not supported (i.e., it will only work with --result-only flag at the moment) due to the limitations of the current version of Bitwuzla API.