### PR TITLE
Remove cout cerr

### DIFF
--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -55,7 +55,8 @@ public:
 
     if(!cmdline.isset("output"))
     {
-      std::cerr << "Must set output file" << std::endl;
+      std::cerr << "Must set output file"
+                << "\n";
       return 1;
     }
 
@@ -69,7 +70,8 @@ public:
 
     if(write_goto_binary(out, context, goto_functions))
     {
-      std::cerr << "Failed to write C library to binary obj" << std::endl;
+      std::cerr << "Failed to write C library to binary obj"
+                << "\n";
       return 1;
     }
 

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -55,8 +55,9 @@ public:
 
     if(!cmdline.isset("output"))
     {
-      std::cerr << "Must set output file"
-                << "\n";
+      ERROR(
+        "Must set output file"
+        << "\n");
       return 1;
     }
 
@@ -70,8 +71,9 @@ public:
 
     if(write_goto_binary(out, context, goto_functions))
     {
-      std::cerr << "Failed to write C library to binary obj"
-                << "\n";
+      ERROR(
+        "Failed to write C library to binary obj"
+        << "\n");
       return 1;
     }
 

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -187,14 +187,15 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
     }
 
     std::cerr << "No c library for bitwidth " << config.ansi_c.int_width
-              << std::endl;
+              << "\n";
     abort();
   }
 
   size = this_clib_ptrs[1] - this_clib_ptrs[0];
   if(size == 0)
   {
-    std::cerr << "error: Zero-lengthed internal C library" << std::endl;
+    std::cerr << "error: Zero-lengthed internal C library"
+              << "\n";
     abort();
   }
 
@@ -210,7 +211,8 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
   f = fopen(symname_buffer, "wb");
   if(fwrite(this_clib_ptrs[0], size, 1, f) != 1)
   {
-    std::cerr << "Couldn't manipulate internal C library" << std::endl;
+    std::cerr << "Couldn't manipulate internal C library"
+              << "\n";
     abort();
   }
   fclose(f);
@@ -273,7 +275,8 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
   if(c_link(context, store_ctx, message_handler, "<built-in-library>"))
   {
     // Merging failed
-    std::cerr << "Failed to merge C library" << std::endl;
+    std::cerr << "Failed to merge C library"
+              << "\n";
     abort();
   }
 }

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -186,16 +186,16 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
       return;
     }
 
-    std::cerr << "No c library for bitwidth " << config.ansi_c.int_width
-              << "\n";
+    ERROR("No c library for bitwidth " << config.ansi_c.int_width << "\n");
     abort();
   }
 
   size = this_clib_ptrs[1] - this_clib_ptrs[0];
   if(size == 0)
   {
-    std::cerr << "error: Zero-lengthed internal C library"
-              << "\n";
+    ERROR(
+      "error: Zero-lengthed internal C library"
+      << "\n");
     abort();
   }
 
@@ -211,8 +211,9 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
   f = fopen(symname_buffer, "wb");
   if(fwrite(this_clib_ptrs[0], size, 1, f) != 1)
   {
-    std::cerr << "Couldn't manipulate internal C library"
-              << "\n";
+    ERROR(
+      "Couldn't manipulate internal C library"
+      << "\n");
     abort();
   }
   fclose(f);
@@ -275,8 +276,9 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
   if(c_link(context, store_ctx, message_handler, "<built-in-library>"))
   {
     // Merging failed
-    std::cerr << "Failed to merge C library"
-              << "\n";
+    ERROR(
+      "Failed to merge C library"
+      << "\n");
     abort();
   }
 }

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -181,8 +181,8 @@ void add_cprover_library(contextt &context, message_handlert &message_handler)
   {
     if(config.ansi_c.word_size == 16)
     {
-      std::cerr << "Warning: this version of ESBMC does not have a C library ";
-      std::cerr << "for 16 bit machines";
+      ERROR("Warning: this version of ESBMC does not have a C library ");
+      ERROR("for 16 bit machines");
       return;
     }
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -9,6 +9,7 @@
 #include <util/ieee_float.h>
 #include <util/prefix.h>
 #include <util/std_code.h>
+#include <util/message.h>
 
 clang_c_adjust::clang_c_adjust(contextt &_context)
   : context(_context), ns(namespacet(context))
@@ -210,8 +211,8 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
     }
     else
     {
-      std::cout << "unknown side effect: " << statement;
-      std::cout << " at " << expr.location() << "\n";
+      PRINT("unknown side effect: " << statement);
+      PRINT(" at " << expr.location() << "\n");
       abort();
     }
   }
@@ -478,7 +479,7 @@ void clang_c_adjust::adjust_sizeof(exprt &expr)
 
   if(new_expr.is_nil())
   {
-    std::cout << "type has no size, " << type.name() << "\n";
+    PRINT("type has no size, " << type.name() << "\n");
     abort();
   }
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -470,8 +470,9 @@ void clang_c_adjust::adjust_sizeof(exprt &expr)
   }
   else
   {
-    std::cout << "sizeof operator expects zero or one operand, "
-              << "but got" << expr.operands().size() << "\n";
+    PRINT(
+      "sizeof operator expects zero or one operand, "
+      << "but got" << expr.operands().size() << "\n");
     abort();
   }
 
@@ -498,8 +499,9 @@ void clang_c_adjust::adjust_type(typet &type)
 
     if(s == nullptr)
     {
-      std::cout << "type symbol `" << identifier << "' not found"
-                << "\n";
+      PRINT(
+        "type symbol `" << identifier << "' not found"
+                        << "\n");
       abort();
     }
 
@@ -507,8 +509,9 @@ void clang_c_adjust::adjust_type(typet &type)
 
     if(!symbol.is_type)
     {
-      std::cout << "expected type symbol, but got "
-                << "\n";
+      PRINT(
+        "expected type symbol, but got "
+        << "\n");
       symbol.dump();
       abort();
     }
@@ -711,8 +714,9 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     {
       if(expr.arguments().size() != 2)
       {
-        std::cout << "same_object expects two operands"
-                  << "\n";
+        PRINT(
+          "same_object expects two operands"
+          << "\n");
         expr.dump();
         abort();
       }
@@ -725,8 +729,9 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     {
       if(expr.arguments().size() != 1)
       {
-        std::cout << "pointer_offset expects one argument"
-                  << "\n";
+        PRINT(
+          "pointer_offset expects one argument"
+          << "\n");
         expr.dump();
         abort();
       }
@@ -739,8 +744,9 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     {
       if(expr.arguments().size() != 1)
       {
-        std::cout << "pointer_object expects one argument"
-                  << "\n";
+        PRINT(
+          "pointer_object expects one argument"
+          << "\n");
         expr.dump();
         abort();
       }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -211,7 +211,7 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
     else
     {
       std::cout << "unknown side effect: " << statement;
-      std::cout << " at " << expr.location() << std::endl;
+      std::cout << " at " << expr.location() << "\n";
       abort();
     }
   }
@@ -470,7 +470,7 @@ void clang_c_adjust::adjust_sizeof(exprt &expr)
   else
   {
     std::cout << "sizeof operator expects zero or one operand, "
-              << "but got" << expr.operands().size() << std::endl;
+              << "but got" << expr.operands().size() << "\n";
     abort();
   }
 
@@ -478,7 +478,7 @@ void clang_c_adjust::adjust_sizeof(exprt &expr)
 
   if(new_expr.is_nil())
   {
-    std::cout << "type has no size, " << type.name() << std::endl;
+    std::cout << "type has no size, " << type.name() << "\n";
     abort();
   }
 
@@ -497,7 +497,8 @@ void clang_c_adjust::adjust_type(typet &type)
 
     if(s == nullptr)
     {
-      std::cout << "type symbol `" << identifier << "' not found" << std::endl;
+      std::cout << "type symbol `" << identifier << "' not found"
+                << "\n";
       abort();
     }
 
@@ -505,7 +506,8 @@ void clang_c_adjust::adjust_type(typet &type)
 
     if(!symbol.is_type)
     {
-      std::cout << "expected type symbol, but got " << std::endl;
+      std::cout << "expected type symbol, but got "
+                << "\n";
       symbol.dump();
       abort();
     }
@@ -708,7 +710,8 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     {
       if(expr.arguments().size() != 2)
       {
-        std::cout << "same_object expects two operands" << std::endl;
+        std::cout << "same_object expects two operands"
+                  << "\n";
         expr.dump();
         abort();
       }
@@ -721,7 +724,8 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     {
       if(expr.arguments().size() != 1)
       {
-        std::cout << "pointer_offset expects one argument" << std::endl;
+        std::cout << "pointer_offset expects one argument"
+                  << "\n";
         expr.dump();
         abort();
       }
@@ -734,7 +738,8 @@ void clang_c_adjust::do_special_functions(side_effect_expr_function_callt &expr)
     {
       if(expr.arguments().size() != 1)
       {
-        std::cout << "pointer_object expects one argument" << std::endl;
+        std::cout << "pointer_object expects one argument"
+                  << "\n";
         expr.dump();
         abort();
       }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -242,8 +242,9 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
 
   default:
     ERROR("**** ERROR: ");
-    std::cerr << "Unrecognized / unimplemented clang declaration "
-              << decl.getDeclKindName() << "\n";
+    ERROR(
+      "Unrecognized / unimplemented clang declaration "
+      << decl.getDeclKindName() << "\n");
     decl.dumpColor();
     return true;
   }
@@ -255,8 +256,9 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
 {
   if(rd.isInterface())
   {
-    std::cerr << "Interface is not supported"
-              << "\n";
+    ERROR(
+      "Interface is not supported"
+      << "\n");
     return true;
   }
 
@@ -378,8 +380,9 @@ bool clang_c_convertert::get_struct_union_class_fields(
           else
           {
             // I was not able to find an example to test this, so abort for now
-            std::cerr << "ESBMC currently does not support type alignments"
-                      << "\n";
+            ERROR(
+              "ESBMC currently does not support type alignments"
+              << "\n");
             aattr.getAlignmentType()->getType()->dump();
             return true;
           }
@@ -731,9 +734,10 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     llvm::APInt val = arr.getSize();
     if(val.getBitWidth() > 64)
     {
-      std::cerr << "ESBMC currently does not support integers bigger "
-                   "than 64 bits"
-                << "\n";
+      ERROR(
+        "ESBMC currently does not support integers bigger "
+        "than 64 bits"
+        << "\n");
       return true;
     }
 
@@ -1124,16 +1128,17 @@ bool clang_c_convertert::get_builtin_type(
   case clang::BuiltinType::Int128:
   case clang::BuiltinType::UInt128:
     // Various simplification / big-int related things use uint64_t's...
-    std::cerr << "ESBMC currently does not support integers bigger "
-              << "than 64 bits"
-              << "\n";
+    ERROR(
+      "ESBMC currently does not support integers bigger "
+      << "than 64 bits"
+      << "\n");
     bt.dump();
     return true;
 
   default:
-    std::cerr << "Unrecognized clang builtin type "
-              << bt.getName(clang::PrintingPolicy(clang::LangOptions())).str()
-              << "\n";
+    ERROR(
+      "Unrecognized clang builtin type "
+      << bt.getName(clang::PrintingPolicy(clang::LangOptions())).str() << "\n");
     bt.dump();
     return true;
   }
@@ -1301,8 +1306,9 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     bool res = offset.EvaluateAsInt(result, *ASTContext);
     if(!res)
     {
-      std::cerr << "Clang could not calculate offset"
-                << "\n";
+      ERROR(
+        "Clang could not calculate offset"
+        << "\n");
       offset.dumpColor();
       return true;
     }
@@ -1980,8 +1986,9 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     }
     else
     {
-      std::cerr << "ESBMC currently does not support indirect gotos"
-                << "\n";
+      ERROR(
+        "ESBMC currently does not support indirect gotos"
+        << "\n");
       stmt.dumpColor();
       return true;
 
@@ -2015,9 +2022,10 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     if(!current_functionDecl)
     {
-      std::cerr << "ESBMC could not find the parent scope for "
-                << "the following return statement:"
-                << "\n";
+      ERROR(
+        "ESBMC could not find the parent scope for "
+        << "the following return statement:"
+        << "\n");
       ret.dumpColor();
       return true;
     }
@@ -2066,8 +2074,9 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
   default:
     ERROR("Conversion of unsupported clang expr: \"");
-    std::cerr << stmt.getStmtClassName() << "\" to expression"
-              << "\n";
+    ERROR(
+      stmt.getStmtClassName() << "\" to expression"
+                              << "\n");
     stmt.dumpColor();
     return true;
   }
@@ -2109,8 +2118,9 @@ bool clang_c_convertert::get_decl_ref(const clang::Decl &d, exprt &new_expr)
   }
 
   ERROR("Conversion of unsupported clang decl ref: \"");
-  std::cerr << d.getDeclKindName() << "\" to expression"
-            << "\n";
+  ERROR(
+    d.getDeclKindName() << "\" to expression"
+                        << "\n");
   d.dumpColor();
   return true;
 }
@@ -2173,8 +2183,9 @@ bool clang_c_convertert::get_cast_expr(
 
   default:
     ERROR("Conversion of unsupported clang cast operator: \"");
-    std::cerr << cast.getCastKindName() << "\" to expression"
-              << "\n";
+    ERROR(
+      cast.getCastKindName() << "\" to expression"
+                             << "\n");
     cast.dumpColor();
     return true;
   }
@@ -2243,9 +2254,10 @@ bool clang_c_convertert::get_unary_operator_expr(
 
   default:
     ERROR("Conversion of unsupported clang unary operator: \"");
-    std::cerr << clang::UnaryOperator::getOpcodeStr(uniop.getOpcode()).str()
-              << "\" to expression"
-              << "\n";
+    ERROR(
+      clang::UnaryOperator::getOpcodeStr(uniop.getOpcode()).str()
+      << "\" to expression"
+      << "\n");
     uniop.dumpColor();
     return true;
   }
@@ -2428,8 +2440,9 @@ bool clang_c_convertert::get_compound_assign_expr(
 
   default:
     ERROR("Conversion of unsupported clang binary operator: \"");
-    std::cerr << compop.getOpcodeStr().str() << "\" to expression"
-              << "\n";
+    ERROR(
+      compop.getOpcodeStr().str() << "\" to expression"
+                                  << "\n");
     compop.dumpColor();
     return true;
   }
@@ -2590,8 +2603,9 @@ bool clang_c_convertert::get_atomic_expr(
     break;
 
   default:
-    std::cerr << "Unknown Atomic expression"
-              << "\n";
+    ERROR(
+      "Unknown Atomic expression"
+      << "\n");
     atm.dumpColor();
     return true;
   }
@@ -2895,8 +2909,7 @@ symbolt *clang_c_convertert::move_symbol_to_context(symbolt &symbol)
   {
     if(context.move(symbol, s))
     {
-      std::cerr << "Couldn't add symbol " << symbol.name
-                << " to symbol table\n";
+      ERROR("Couldn't add symbol " << symbol.name << " to symbol table\n");
       symbol.dump();
       abort();
     }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -242,7 +242,7 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   default:
     std::cerr << "**** ERROR: ";
     std::cerr << "Unrecognized / unimplemented clang declaration "
-              << decl.getDeclKindName() << std::endl;
+              << decl.getDeclKindName() << "\n";
     decl.dumpColor();
     return true;
   }
@@ -254,7 +254,8 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
 {
   if(rd.isInterface())
   {
-    std::cerr << "Interface is not supported" << std::endl;
+    std::cerr << "Interface is not supported"
+              << "\n";
     return true;
   }
 
@@ -377,7 +378,7 @@ bool clang_c_convertert::get_struct_union_class_fields(
           {
             // I was not able to find an example to test this, so abort for now
             std::cerr << "ESBMC currently does not support type alignments"
-                      << std::endl;
+                      << "\n";
             aattr.getAlignmentType()->getType()->dump();
             return true;
           }
@@ -731,7 +732,7 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     {
       std::cerr << "ESBMC currently does not support integers bigger "
                    "than 64 bits"
-                << std::endl;
+                << "\n";
       return true;
     }
 
@@ -1000,7 +1001,7 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
 
   default:
     std::cerr << "Conversion of unsupported clang type: \"";
-    std::cerr << the_type.getTypeClassName() << std::endl;
+    std::cerr << the_type.getTypeClassName() << "\n";
     the_type.dump();
     return true;
   }
@@ -1123,14 +1124,15 @@ bool clang_c_convertert::get_builtin_type(
   case clang::BuiltinType::UInt128:
     // Various simplification / big-int related things use uint64_t's...
     std::cerr << "ESBMC currently does not support integers bigger "
-              << "than 64 bits" << std::endl;
+              << "than 64 bits"
+              << "\n";
     bt.dump();
     return true;
 
   default:
     std::cerr << "Unrecognized clang builtin type "
               << bt.getName(clang::PrintingPolicy(clang::LangOptions())).str()
-              << std::endl;
+              << "\n";
     bt.dump();
     return true;
   }
@@ -1298,7 +1300,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     bool res = offset.EvaluateAsInt(result, *ASTContext);
     if(!res)
     {
-      std::cerr << "Clang could not calculate offset" << std::endl;
+      std::cerr << "Clang could not calculate offset"
+                << "\n";
       offset.dumpColor();
       return true;
     }
@@ -1977,7 +1980,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     else
     {
       std::cerr << "ESBMC currently does not support indirect gotos"
-                << std::endl;
+                << "\n";
       stmt.dumpColor();
       return true;
 
@@ -2012,7 +2015,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if(!current_functionDecl)
     {
       std::cerr << "ESBMC could not find the parent scope for "
-                << "the following return statement:" << std::endl;
+                << "the following return statement:"
+                << "\n";
       ret.dumpColor();
       return true;
     }
@@ -2061,7 +2065,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
   default:
     std::cerr << "Conversion of unsupported clang expr: \"";
-    std::cerr << stmt.getStmtClassName() << "\" to expression" << std::endl;
+    std::cerr << stmt.getStmtClassName() << "\" to expression"
+              << "\n";
     stmt.dumpColor();
     return true;
   }
@@ -2103,7 +2108,8 @@ bool clang_c_convertert::get_decl_ref(const clang::Decl &d, exprt &new_expr)
   }
 
   std::cerr << "Conversion of unsupported clang decl ref: \"";
-  std::cerr << d.getDeclKindName() << "\" to expression" << std::endl;
+  std::cerr << d.getDeclKindName() << "\" to expression"
+            << "\n";
   d.dumpColor();
   return true;
 }
@@ -2166,7 +2172,8 @@ bool clang_c_convertert::get_cast_expr(
 
   default:
     std::cerr << "Conversion of unsupported clang cast operator: \"";
-    std::cerr << cast.getCastKindName() << "\" to expression" << std::endl;
+    std::cerr << cast.getCastKindName() << "\" to expression"
+              << "\n";
     cast.dumpColor();
     return true;
   }
@@ -2236,7 +2243,8 @@ bool clang_c_convertert::get_unary_operator_expr(
   default:
     std::cerr << "Conversion of unsupported clang unary operator: \"";
     std::cerr << clang::UnaryOperator::getOpcodeStr(uniop.getOpcode()).str()
-              << "\" to expression" << std::endl;
+              << "\" to expression"
+              << "\n";
     uniop.dumpColor();
     return true;
   }
@@ -2419,7 +2427,8 @@ bool clang_c_convertert::get_compound_assign_expr(
 
   default:
     std::cerr << "Conversion of unsupported clang binary operator: \"";
-    std::cerr << compop.getOpcodeStr().str() << "\" to expression" << std::endl;
+    std::cerr << compop.getOpcodeStr().str() << "\" to expression"
+              << "\n";
     compop.dumpColor();
     return true;
   }
@@ -2580,7 +2589,8 @@ bool clang_c_convertert::get_atomic_expr(
     break;
 
   default:
-    std::cerr << "Unknown Atomic expression" << std::endl;
+    std::cerr << "Unknown Atomic expression"
+              << "\n";
     atm.dumpColor();
     return true;
   }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -22,6 +22,7 @@
 #include <util/mp_arith.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
+#include <util/message.h>
 
 clang_c_convertert::clang_c_convertert(
   contextt &_context,
@@ -240,7 +241,7 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
     break;
 
   default:
-    std::cerr << "**** ERROR: ";
+    ERROR("**** ERROR: ");
     std::cerr << "Unrecognized / unimplemented clang declaration "
               << decl.getDeclKindName() << "\n";
     decl.dumpColor();
@@ -1000,8 +1001,8 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
   }
 
   default:
-    std::cerr << "Conversion of unsupported clang type: \"";
-    std::cerr << the_type.getTypeClassName() << "\n";
+    ERROR("Conversion of unsupported clang type: \"");
+    ERROR(the_type.getTypeClassName() << "\n");
     the_type.dump();
     return true;
   }
@@ -2064,7 +2065,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
 
   default:
-    std::cerr << "Conversion of unsupported clang expr: \"";
+    ERROR("Conversion of unsupported clang expr: \"");
     std::cerr << stmt.getStmtClassName() << "\" to expression"
               << "\n";
     stmt.dumpColor();
@@ -2107,7 +2108,7 @@ bool clang_c_convertert::get_decl_ref(const clang::Decl &d, exprt &new_expr)
     return false;
   }
 
-  std::cerr << "Conversion of unsupported clang decl ref: \"";
+  ERROR("Conversion of unsupported clang decl ref: \"");
   std::cerr << d.getDeclKindName() << "\" to expression"
             << "\n";
   d.dumpColor();
@@ -2171,7 +2172,7 @@ bool clang_c_convertert::get_cast_expr(
     break;
 
   default:
-    std::cerr << "Conversion of unsupported clang cast operator: \"";
+    ERROR("Conversion of unsupported clang cast operator: \"");
     std::cerr << cast.getCastKindName() << "\" to expression"
               << "\n";
     cast.dumpColor();
@@ -2241,7 +2242,7 @@ bool clang_c_convertert::get_unary_operator_expr(
     return false;
 
   default:
-    std::cerr << "Conversion of unsupported clang unary operator: \"";
+    ERROR("Conversion of unsupported clang unary operator: \"");
     std::cerr << clang::UnaryOperator::getOpcodeStr(uniop.getOpcode()).str()
               << "\" to expression"
               << "\n";
@@ -2426,7 +2427,7 @@ bool clang_c_convertert::get_compound_assign_expr(
     break;
 
   default:
-    std::cerr << "Conversion of unsupported clang binary operator: \"";
+    ERROR("Conversion of unsupported clang binary operator: \"");
     std::cerr << compop.getOpcodeStr().str() << "\" to expression"
               << "\n";
     compop.dumpColor();
@@ -2765,7 +2766,7 @@ void clang_c_convertert::get_decl_name(
   default:
     if(name.empty())
     {
-      std::cerr << "Declaration has an empty name:\n";
+      ERROR("Declaration has an empty name:\n");
       nd.dumpColor();
       abort();
     }
@@ -2779,7 +2780,7 @@ void clang_c_convertert::get_decl_name(
   }
 
   // Otherwise, abort
-  std::cerr << "Unable to generate the USR for:\n";
+  ERROR("Unable to generate the USR for:\n");
   nd.dumpColor();
   abort();
 }

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -36,7 +36,7 @@ clang_c_languaget::clang_c_languaget()
   if(!boost::filesystem::exists(p) || !boost::filesystem::is_directory(p))
   {
     std::cerr << "Can't find temporary directory (needed to dump clang headers)"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -47,7 +47,7 @@ clang_c_languaget::clang_c_languaget()
   {
     std::cerr
       << "Can't create temporary directory (needed to dump clang headers)"
-      << std::endl;
+      << "\n";
     abort();
   }
 
@@ -74,7 +74,7 @@ void clang_c_languaget::build_compiler_args(const std::string &&tmp_dir)
     break;
 
   default:
-    std::cerr << "Unknown word size: " << config.ansi_c.word_size << std::endl;
+    std::cerr << "Unknown word size: " << config.ansi_c.word_size << "\n";
     abort();
   }
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -35,8 +35,9 @@ clang_c_languaget::clang_c_languaget()
   auto p = boost::filesystem::temp_directory_path();
   if(!boost::filesystem::exists(p) || !boost::filesystem::is_directory(p))
   {
-    std::cerr << "Can't find temporary directory (needed to dump clang headers)"
-              << "\n";
+    ERROR(
+      "Can't find temporary directory (needed to dump clang headers)"
+      << "\n");
     abort();
   }
 
@@ -45,9 +46,9 @@ clang_c_languaget::clang_c_languaget()
   boost::filesystem::create_directory(p);
   if(!boost::filesystem::is_directory(p))
   {
-    std::cerr
-      << "Can't create temporary directory (needed to dump clang headers)"
-      << "\n";
+    ERROR(
+      "Can't create temporary directory (needed to dump clang headers)"
+      << "\n");
     abort();
   }
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -74,7 +74,7 @@ void clang_c_languaget::build_compiler_args(const std::string &&tmp_dir)
     break;
 
   default:
-    std::cerr << "Unknown word size: " << config.ansi_c.word_size << "\n";
+    ERROR("Unknown word size: " << config.ansi_c.word_size << "\n");
     abort();
   }
 

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -79,8 +79,9 @@ bool clang_main(contextt &context, message_handlert &message_handler)
   {
     messaget message(message_handler);
     if(matches.size() == 2)
-      std::cerr << "warning: main symbol `" << main << "' is ambiguous"
-                << "\n";
+      ERROR(
+        "warning: main symbol `" << main << "' is ambiguous"
+                                 << "\n")
     else
     {
       message.error("main symbol `" + main + "' is ambiguous");

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -80,7 +80,7 @@ bool clang_main(contextt &context, message_handlert &message_handler)
     messaget message(message_handler);
     if(matches.size() == 2)
       std::cerr << "warning: main symbol `" << main << "' is ambiguous"
-                << std::endl;
+                << "\n";
     else
     {
       message.error("main symbol `" + main + "' is ambiguous");

--- a/src/clang-c-frontend/typecast.cpp
+++ b/src/clang-c-frontend/typecast.cpp
@@ -52,6 +52,6 @@ void gen_typecast_to_union(exprt &e, const typet &t)
    * however... we should prevent any funny things to happen */
   std::ostringstream msg;
   msg << "Couldn't map type " << e.type().pretty_name() << " into the union"
-      << std::endl;
+      << "\n";
   throw std::domain_error(msg.str());
 }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -106,11 +106,12 @@ void bmct::successful_trace()
   break;
 
   case ui_message_handlert::OLD_GUI:
-    std::cout << "SUCCESS"
-              << "\n"
-              << "Verification successful"
-              << "\n"
-              << "\n\n\n\n";
+    PRINT(
+      "SUCCESS"
+      << "\n"
+      << "Verification successful"
+      << "\n"
+      << "\n\n\n\n");
     break;
 
   case ui_message_handlert::PLAIN:
@@ -155,15 +156,24 @@ void bmct::error_trace(
     /* fallthrough */
 
   case ui_message_handlert::PLAIN:
-    std::cout << "\n"
-              << "Counterexample:"
-              << "\n";
-    show_goto_trace(std::cout, ns, goto_trace);
+    PRINT(
+      "\n"
+      << "Counterexample:"
+      << "\n");
+    {
+      std::stringstream output;
+      show_goto_trace(output, ns, goto_trace);
+      esbmc::global::_msg.print(output.str());
+    }
     break;
 
   case ui_message_handlert::OLD_GUI:
-    show_goto_trace_gui(std::cout, ns, goto_trace);
-    break;
+  {
+    std::stringstream output;
+    show_goto_trace_gui(output, ns, goto_trace);
+    esbmc::global::_msg.print(output.str());
+  }
+  break;
 
   case ui_message_handlert::XML_UI:
   {
@@ -242,18 +252,19 @@ void bmct::report_success()
   switch(ui)
   {
   case ui_message_handlert::OLD_GUI:
-    std::cout << "SUCCESS"
-              << "\n"
-              << "Verification successful"
-              << "\n"
-              << ""
-              << "\n"
-              << ""
-              << "\n"
-              << ""
-              << "\n"
-              << ""
-              << "\n";
+    PRINT(
+      "SUCCESS"
+      << "\n"
+      << "Verification successful"
+      << "\n"
+      << ""
+      << "\n"
+      << ""
+      << "\n"
+      << ""
+      << "\n"
+      << ""
+      << "\n");
     break;
 
   case ui_message_handlert::GRAPHML:
@@ -310,7 +321,11 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
   unsigned int count = 1;
 
   if(config.options.get_bool_option("ssa-symbol-table"))
-    ::show_symbol_table_plain(ns, std::cout);
+  {
+    std::stringstream output;
+    ::show_symbol_table_plain(ns, output);
+    esbmc::global::_msg.print(output.str());
+  }
 
   languagest languages(ns, MODE_C);
   PRINT("\nProgram constraints: \n");
@@ -487,8 +502,9 @@ smt_convt::resultt bmct::run(std::shared_ptr<symex_target_equationt> &eq)
   {
     if(++interleaving_number > 1)
     {
-      std::cout << "*** Thread interleavings " << interleaving_number << " ***"
-                << "\n";
+      PRINT(
+        "*** Thread interleavings " << interleaving_number << " ***"
+                                    << "\n");
     }
 
     fine_timet bmc_start = current_time();
@@ -691,8 +707,9 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory"
-              << "\n";
+    PRINT(
+      "Out of memory"
+      << "\n");
     return smt_convt::P_ERROR;
   }
 
@@ -749,7 +766,9 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 
     if(options.get_bool_option("document-subgoals"))
     {
-      document_subgoals(*eq.get(), std::cout);
+      std::stringstream output;
+      document_subgoals(*eq.get(), output);
+      esbmc::global::_msg.print(output.str());
       return smt_convt::P_SMTLIB;
     }
 
@@ -763,8 +782,9 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     {
       if(options.get_bool_option("smt-formula-only"))
       {
-        std::cout << "No VCC remaining, no SMT formula will be generated for"
-                  << " the program\n";
+        PRINT(
+          "No VCC remaining, no SMT formula will be generated for"
+          << " the program\n");
         return smt_convt::P_SMTLIB;
       }
 
@@ -794,8 +814,9 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory"
-              << "\n";
+    PRINT(
+      "Out of memory"
+      << "\n");
     return smt_convt::P_ERROR;
   }
 }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -120,8 +120,8 @@ void bmct::successful_trace()
   {
     xmlt xml("cprover-status");
     xml.data = "SUCCESS";
-    std::cout << xml;
-    std::cout << "\n";
+    PRINT(xml);
+    PRINT("\n");
   }
   break;
 
@@ -169,7 +169,7 @@ void bmct::error_trace(
   {
     xmlt xml;
     convert(ns, goto_trace, xml);
-    std::cout << xml << "\n";
+    PRINT(xml << "\n");
     break;
   }
 
@@ -193,7 +193,7 @@ smt_convt::resultt bmct::run_decision_procedure(
   else
     logic = "integer/real arithmetic";
 
-  std::cout << "Encoding remaining VCC(s) using " << logic << "\n";
+  PRINT("Encoding remaining VCC(s) using " << logic << "\n");
 
   smt_conv->set_message_handler(message_handler);
   smt_conv->set_verbosity(get_verbosity());
@@ -266,8 +266,8 @@ void bmct::report_success()
   {
     xmlt xml("cprover-status");
     xml.data = "SUCCESS";
-    std::cout << xml;
-    std::cout << "\n";
+    PRINT(xml);
+    PRINT("\n");
   }
   break;
 
@@ -292,8 +292,8 @@ void bmct::report_failure()
   {
     xmlt xml("cprover-status");
     xml.data = "FAILURE";
-    std::cout << xml;
-    std::cout << "\n";
+    PRINT(xml);
+    PRINT("\n");
   }
   break;
 
@@ -313,7 +313,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
     ::show_symbol_table_plain(ns, std::cout);
 
   languagest languages(ns, MODE_C);
-  std::cout << "\nProgram constraints: \n";
+  PRINT("\nProgram constraints: \n");
 
   bool sliced = config.options.get_bool_option("ssa-sliced");
 
@@ -325,42 +325,42 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
     if(it.ignore && !sliced)
       continue;
 
-    std::cout << "// " << it.source.pc->location_number << " ";
-    std::cout << it.source.pc->location.as_string();
+    PRINT("// " << it.source.pc->location_number << " ");
+    PRINT(it.source.pc->location.as_string());
     if(!it.comment.empty())
-      std::cout << " (" << it.comment << ")";
-    std::cout << '\n';
+      PRINT(" (" << it.comment << ")");
+    PRINT('\n');
 
-    std::cout << "/* " << count << "*/ ";
+    PRINT("/* " << count << "*/ ");
 
     std::string string_value;
     languages.from_expr(migrate_expr_back(it.cond), string_value);
 
     if(it.is_assignment())
     {
-      std::cout << string_value << "\n";
+      PRINT(string_value << "\n");
     }
     else if(it.is_assert())
     {
-      std::cout << "(assert)" << string_value << "\n";
+      PRINT("(assert)" << string_value << "\n");
     }
     else if(it.is_assume())
     {
-      std::cout << "(assume)" << string_value << "\n";
+      PRINT("(assume)" << string_value << "\n");
     }
     else if(it.is_renumber())
     {
-      std::cout << "renumber: " << from_expr(ns, "", it.lhs) << "\n";
+      PRINT("renumber: " << from_expr(ns, "", it.lhs) << "\n");
     }
 
     if(!migrate_expr_back(it.guard).is_true())
     {
       languages.from_expr(migrate_expr_back(it.guard), string_value);
-      std::cout << std::string(i2string(count).size() + 3, ' ');
-      std::cout << "guard: " << string_value << "\n";
+      PRINT(std::string(i2string(count).size() + 3, ' '));
+      PRINT("guard: " << string_value << "\n");
     }
 
-    std::cout << "\n";
+    PRINT("\n");
 
     count++;
   }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -106,8 +106,10 @@ void bmct::successful_trace()
   break;
 
   case ui_message_handlert::OLD_GUI:
-    std::cout << "SUCCESS" << std::endl
-              << "Verification successful" << std::endl
+    std::cout << "SUCCESS"
+              << "\n"
+              << "Verification successful"
+              << "\n"
               << "\n\n\n\n";
     break;
 
@@ -119,7 +121,7 @@ void bmct::successful_trace()
     xmlt xml("cprover-status");
     xml.data = "SUCCESS";
     std::cout << xml;
-    std::cout << std::endl;
+    std::cout << "\n";
   }
   break;
 
@@ -153,7 +155,9 @@ void bmct::error_trace(
     /* fallthrough */
 
   case ui_message_handlert::PLAIN:
-    std::cout << std::endl << "Counterexample:" << std::endl;
+    std::cout << "\n"
+              << "Counterexample:"
+              << "\n";
     show_goto_trace(std::cout, ns, goto_trace);
     break;
 
@@ -165,7 +169,7 @@ void bmct::error_trace(
   {
     xmlt xml;
     convert(ns, goto_trace, xml);
-    std::cout << xml << std::endl;
+    std::cout << xml << "\n";
     break;
   }
 
@@ -238,12 +242,18 @@ void bmct::report_success()
   switch(ui)
   {
   case ui_message_handlert::OLD_GUI:
-    std::cout << "SUCCESS" << std::endl
-              << "Verification successful" << std::endl
-              << "" << std::endl
-              << "" << std::endl
-              << "" << std::endl
-              << "" << std::endl;
+    std::cout << "SUCCESS"
+              << "\n"
+              << "Verification successful"
+              << "\n"
+              << ""
+              << "\n"
+              << ""
+              << "\n"
+              << ""
+              << "\n"
+              << ""
+              << "\n";
     break;
 
   case ui_message_handlert::GRAPHML:
@@ -257,7 +267,7 @@ void bmct::report_success()
     xmlt xml("cprover-status");
     xml.data = "SUCCESS";
     std::cout << xml;
-    std::cout << std::endl;
+    std::cout << "\n";
   }
   break;
 
@@ -283,7 +293,7 @@ void bmct::report_failure()
     xmlt xml("cprover-status");
     xml.data = "FAILURE";
     std::cout << xml;
-    std::cout << std::endl;
+    std::cout << "\n";
   }
   break;
 
@@ -478,7 +488,7 @@ smt_convt::resultt bmct::run(std::shared_ptr<symex_target_equationt> &eq)
     if(++interleaving_number > 1)
     {
       std::cout << "*** Thread interleavings " << interleaving_number << " ***"
-                << std::endl;
+                << "\n";
     }
 
     fine_timet bmc_start = current_time();
@@ -681,7 +691,8 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory" << std::endl;
+    std::cout << "Out of memory"
+              << "\n";
     return smt_convt::P_ERROR;
   }
 
@@ -783,7 +794,8 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory" << std::endl;
+    std::cout << "Out of memory"
+              << "\n";
     return smt_convt::P_ERROR;
   }
 }

--- a/src/esbmc/document_subgoals.cpp
+++ b/src/esbmc/document_subgoals.cpp
@@ -232,18 +232,19 @@ void document_subgoals(
     out << "\\claimlocation{File "
         << escape_latex(location.file().as_string(), false) << " function "
         << escape_latex(location.function().as_string(), false) << "}"
-        << std::endl;
+        << "\n";
 
-    out << std::endl;
+    out << "\n";
 
     for(const auto &s_it : it->second.comment_set)
-      out << "\\claim{" << escape_latex(s_it, false) << "}" << std::endl;
+      out << "\\claim{" << escape_latex(s_it, false) << "}"
+          << "\n";
 
-    out << std::endl;
+    out << "\n";
 
     out << "\\begin{alltt}\\claimcode\n" << code << "\\end{alltt}\n";
 
-    out << std::endl;
-    out << std::endl;
+    out << "\n";
+    out << "\n";
   }
 }

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -131,8 +131,9 @@ uint64_t esbmc_parseoptionst::read_time_spec(const char *str)
       mult = 86400;
       break;
     default:
-      std::cerr << "Unrecognized timeout suffix"
-                << "\n";
+      ERROR(
+        "Unrecognized timeout suffix"
+        << "\n");
       abort();
     }
   }
@@ -167,8 +168,9 @@ uint64_t esbmc_parseoptionst::read_mem_spec(const char *str)
       mult = 1024 * 1024 * 1024;
       break;
     default:
-      std::cerr << "Unrecognized memlimit suffix"
-                << "\n";
+      ERROR(
+        "Unrecognized memlimit suffix"
+        << "\n");
       abort();
     }
   }
@@ -260,9 +262,10 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   {
     if(!cmdline.isset("smt-during-symex"))
     {
-      std::cerr << "Please explicitly specify --smt-during-symex if you want "
-                   "to use features that involve encoding SMT during symex"
-                << "\n";
+      ERROR(
+        "Please explicitly specify --smt-during-symex if you want "
+        "to use features that involve encoding SMT during symex"
+        << "\n");
       abort();
     }
   }
@@ -279,9 +282,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     // check whether k-step is greater than max-k-step
     if(k_step_inc >= max_k_step)
     {
-      std::cerr
-        << "Please specify --k-step smaller than max-k-step if you want "
-           "to use incremental verification.\n";
+      ERROR(
+        "Please specify --k-step smaller than max-k-step if you want "
+        "to use incremental verification.\n");
       abort();
     }
   }
@@ -316,8 +319,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if(cmdline.isset("timeout"))
   {
 #ifdef _WIN32
-    std::cerr << "Timeout unimplemented on Windows, sorry"
-              << "\n";
+    ERROR(
+      "Timeout unimplemented on Windows, sorry"
+      << "\n");
     abort();
 #else
     const char *time = cmdline.getval("timeout");
@@ -330,8 +334,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if(cmdline.isset("memlimit"))
   {
 #ifdef _WIN32
-    std::cerr << "Can't memlimit on Windows, sorry"
-              << "\n";
+    ERROR(
+      "Can't memlimit on Windows, sorry"
+      << "\n");
     abort();
 #else
     uint64_t size = read_mem_spec(cmdline.getval("memlimit"));
@@ -509,8 +514,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
   if(process_type == PARENT && num_p != 3)
   {
-    std::cerr << "Child processes were not created sucessfully."
-              << "\n";
+    ERROR(
+      "Child processes were not created sucessfully."
+      << "\n");
     abort();
   }
 
@@ -573,10 +579,11 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         else
         {
           // Invalid size read.
-          std::cerr << "Short read communicating with kinduction children"
-                    << "\n";
-          std::cerr << "Size " << read_size << ", expected " << sizeof(resultt)
-                    << "\n";
+          ERROR(
+            "Short read communicating with kinduction children"
+            << "\n");
+          ERROR(
+            "Size " << read_size << ", expected " << sizeof(resultt) << "\n");
           abort();
         }
       }
@@ -669,9 +676,10 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         break;
 
       default:
-        std::cerr << "Message from unrecognized k-induction child "
-                  << "process"
-                  << "\n";
+        ERROR(
+          "Message from unrecognized k-induction child "
+          << "process"
+          << "\n");
         abort();
       }
 
@@ -867,10 +875,11 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         else
         {
           // Invalid size read.
-          std::cerr << "Short read communicating with kinduction parent"
-                    << "\n";
-          std::cerr << "Size " << read_size << ", expected " << sizeof(resultt)
-                    << "\n";
+          ERROR(
+            "Short read communicating with kinduction parent"
+            << "\n");
+          ERROR(
+            "Size " << read_size << ", expected " << sizeof(resultt) << "\n");
           abort();
         }
       }

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -203,14 +203,14 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("git-hash"))
   {
-    std::cout << esbmc_version_string << "\n";
+    PRINT(esbmc_version_string << "\n");
     exit(0);
   }
 
   if(cmdline.isset("list-solvers"))
   {
     // Generated for us by autoconf,
-    std::cout << "Available solvers: " << ESBMC_AVAILABLE_SOLVERS << "\n";
+    PRINT("Available solvers: " << ESBMC_AVAILABLE_SOLVERS << "\n");
     exit(0);
   }
 
@@ -250,8 +250,8 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("smt-during-symex"))
   {
-    std::cout << "Enabling --no-slice due to presence of --smt-during-symex";
-    std::cout << "\n";
+    PRINT("Enabling --no-slice due to presence of --smt-during-symex");
+    PRINT("\n");
     options.set_option("no-slice", true);
   }
 
@@ -805,7 +805,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
       bmc.options.set_option("unwind", integer2string(k_step));
 
-      std::cout << "*** Checking base case, k = " << k_step << '\n';
+      PRINT("*** Checking base case, k = " << k_step << '\n');
 
       // If an exception was thrown, we should abort the process
       int res = smt_convt::P_ERROR;
@@ -915,7 +915,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
       bmc.options.set_option("unwind", integer2string(k_step));
 
-      std::cout << "*** Checking forward condition, k = " << k_step << '\n';
+      PRINT("*** Checking forward condition, k = " << k_step << '\n');
 
       // If an exception was thrown, we should abort the process
       int res = smt_convt::P_ERROR;
@@ -986,7 +986,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
       bmc.options.set_option("unwind", integer2string(k_step));
 
-      std::cout << "*** Checking inductive step, k = " << k_step << '\n';
+      PRINT("*** Checking inductive step, k = " << k_step << '\n');
 
       // If an exception was thrown, we should abort the process
       int res = smt_convt::P_ERROR;
@@ -1222,7 +1222,7 @@ int esbmc_parseoptionst::do_base_case(
 
   bmc.options.set_option("unwind", integer2string(k_step));
 
-  std::cout << "*** Checking base case, k = " << k_step << '\n';
+  PRINT("*** Checking base case, k = " << k_step << '\n');
   switch(do_bmc(bmc))
   {
   case smt_convt::P_UNSATISFIABLE:
@@ -1231,11 +1231,11 @@ int esbmc_parseoptionst::do_base_case(
     break;
 
   case smt_convt::P_SATISFIABLE:
-    std::cout << "\nBug found (k = " << k_step << ")\n";
+    PRINT("\nBug found (k = " << k_step << ")\n");
     return true;
 
   default:
-    std::cout << "Unknown BMC result\n";
+    PRINT("Unknown BMC result\n");
     abort();
   }
 
@@ -1269,7 +1269,7 @@ int esbmc_parseoptionst::do_forward_condition(
 
   bmc.options.set_option("unwind", integer2string(k_step));
 
-  std::cout << "*** Checking forward condition, k = " << k_step << '\n';
+  PRINT("*** Checking forward condition, k = " << k_step << '\n');
   auto res = do_bmc(bmc);
 
   // Restore the no assertion flag, before checking the other steps
@@ -1283,12 +1283,13 @@ int esbmc_parseoptionst::do_forward_condition(
     break;
 
   case smt_convt::P_UNSATISFIABLE:
-    std::cout << "\nSolution found by the forward condition; "
-              << "all states are reachable (k = " << k_step << ")\n";
+    PRINT(
+      "\nSolution found by the forward condition; "
+      << "all states are reachable (k = " << k_step << ")\n");
     return false;
 
   default:
-    std::cout << "Unknown BMC result\n";
+    PRINT("Unknown BMC result\n");
     abort();
   }
 
@@ -1324,7 +1325,7 @@ int esbmc_parseoptionst::do_inductive_step(
 
   bmc.options.set_option("unwind", integer2string(k_step));
 
-  std::cout << "*** Checking inductive step, k = " << k_step << '\n';
+  PRINT("*** Checking inductive step, k = " << k_step << '\n');
   switch(do_bmc(bmc))
   {
   case smt_convt::P_SATISFIABLE:
@@ -1338,7 +1339,7 @@ int esbmc_parseoptionst::do_inductive_step(
     return false;
 
   default:
-    std::cout << "Unknown BMC result\n";
+    PRINT("Unknown BMC result\n");
     abort();
   }
 
@@ -1680,6 +1681,6 @@ int esbmc_parseoptionst::do_bmc(bmct &bmc)
 
 void esbmc_parseoptionst::help()
 {
-  std::cout << "\n* * *           ESBMC " ESBMC_VERSION "          * * *\n";
-  std::cout << cmdline.cmdline_options << "\n";
+  PRINT("\n* * *           ESBMC " ESBMC_VERSION "          * * *\n");
+  PRINT(cmdline.cmdline_options << "\n");
 }

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -80,8 +80,9 @@ struct resultt
 #ifndef _WIN32
 void timeout_handler(int)
 {
-  std::cout << "Timed out"
-            << "\n";
+  PRINT(
+    "Timed out"
+    << "\n");
 
   // Unfortunately some highly useful pieces of code hook themselves into
   // aexit and attempt to free some memory. That doesn't really make sense to
@@ -378,9 +379,10 @@ int esbmc_parseoptionst::doit()
   //
   // Print a banner
   //
-  std::cout << "ESBMC version " << ESBMC_VERSION " " << sizeof(void *) * 8
-            << "-bit " << config.this_architecture() << " "
-            << config.this_operating_system() << "\n";
+  PRINT(
+    "ESBMC version " << ESBMC_VERSION " " << sizeof(void *) * 8 << "-bit "
+                     << config.this_architecture() << " "
+                     << config.this_operating_system() << "\n");
 
   if(cmdline.isset("version"))
     return 0;
@@ -596,8 +598,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         }
         else
         {
-          std::cout << "**** WARNING: Base case process crashed."
-                    << "\n";
+          PRINT(
+            "**** WARNING: Base case process crashed."
+            << "\n");
           bc_finished = fc_finished = is_finished = true;
         }
       }
@@ -617,8 +620,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         }
         else
         {
-          std::cout << "**** WARNING: Forward condition process crashed."
-                    << "\n";
+          PRINT(
+            "**** WARNING: Forward condition process crashed."
+            << "\n");
 
           fc_finished = bc_finished = is_finished = true;
         }
@@ -639,8 +643,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         }
         else
         {
-          std::cout << "**** WARNING: Inductive step process crashed."
-                    << "\n";
+          PRINT(
+            "**** WARNING: Inductive step process crashed."
+            << "\n");
 
           is_finished = bc_finished = fc_finished = true;
         }
@@ -729,11 +734,13 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     // Check if a solution was found by the base case
     if(bc_finished && (bc_solution != 0) && (bc_solution != max_k_step))
     {
-      std::cout << "\n"
-                << "Bug found by the base case (k = " << bc_solution << ")"
-                << "\n";
-      std::cout << "VERIFICATION FAILED"
-                << "\n";
+      PRINT(
+        "\n"
+        << "Bug found by the base case (k = " << bc_solution << ")"
+        << "\n");
+      PRINT(
+        "VERIFICATION FAILED"
+        << "\n");
       return true;
     }
 
@@ -744,12 +751,14 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
       // and haven't crashed (if it crashed, bc_solution will be UINT_MAX
       if(bc_finished && (bc_solution != max_k_step))
       {
-        std::cout << "\n"
-                  << "Solution found by the forward condition; "
-                  << "all states are reachable (k = " << fc_solution << ")"
-                  << "\n";
-        std::cout << "VERIFICATION SUCCESSFUL"
-                  << "\n";
+        PRINT(
+          "\n"
+          << "Solution found by the forward condition; "
+          << "all states are reachable (k = " << fc_solution << ")"
+          << "\n");
+        PRINT(
+          "VERIFICATION SUCCESSFUL"
+          << "\n");
         return false;
       }
     }
@@ -761,20 +770,23 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
       // and haven't crashed (if it crashed, bc_solution will be UINT_MAX
       if(bc_finished && (bc_solution != max_k_step))
       {
-        std::cout << "\n"
-                  << "Solution found by the inductive step "
-                  << "(k = " << is_solution << ")"
-                  << "\n";
-        std::cout << "VERIFICATION SUCCESSFUL"
-                  << "\n";
+        PRINT(
+          "\n"
+          << "Solution found by the inductive step "
+          << "(k = " << is_solution << ")"
+          << "\n");
+        PRINT(
+          "VERIFICATION SUCCESSFUL"
+          << "\n");
         return false;
       }
     }
 
     // Couldn't find a bug or a proof for the current deepth
-    std::cout << "\n"
-              << "VERIFICATION UNKNOWN"
-              << "\n";
+    PRINT(
+      "\n"
+      << "VERIFICATION UNKNOWN"
+      << "\n");
     return false;
   }
 
@@ -828,8 +840,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        std::cout << "BASE CASE PROCESS FINISHED."
-                  << "\n";
+        PRINT(
+          "BASE CASE PROCESS FINISHED."
+          << "\n");
 
         return true;
       }
@@ -882,8 +895,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    std::cout << "BASE CASE PROCESS FINISHED."
-              << "\n";
+    PRINT(
+      "BASE CASE PROCESS FINISHED."
+      << "\n");
     return false;
   }
 
@@ -941,8 +955,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        std::cout << "FORWARD CONDITION PROCESS FINISHED."
-                  << "\n";
+        PRINT(
+          "FORWARD CONDITION PROCESS FINISHED."
+          << "\n");
         return false;
       }
     }
@@ -954,8 +969,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    std::cout << "FORWARD CONDITION PROCESS FINISHED."
-              << "\n";
+    PRINT(
+      "FORWARD CONDITION PROCESS FINISHED."
+      << "\n");
     return true;
   }
 
@@ -1012,8 +1028,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        std::cout << "INDUCTIVE STEP PROCESS FINISHED."
-                  << "\n";
+        PRINT(
+          "INDUCTIVE STEP PROCESS FINISHED."
+          << "\n");
         return false;
       }
     }
@@ -1025,8 +1042,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    std::cout << "INDUCTIVE STEP PROCESS FINISHED."
-              << "\n";
+    PRINT(
+      "INDUCTIVE STEP PROCESS FINISHED."
+      << "\n");
     return true;
   }
 
@@ -1334,8 +1352,9 @@ int esbmc_parseoptionst::do_inductive_step(
     break;
 
   case smt_convt::P_UNSATISFIABLE:
-    std::cout << "\nSolution found by the inductive step "
-              << "(k = " << k_step << ")\n";
+    PRINT(
+      "\nSolution found by the inductive step "
+      << "(k = " << k_step << ")\n");
     return false;
 
   default:
@@ -1404,7 +1423,9 @@ bool esbmc_parseoptionst::get_goto_program(
       {
         assert(language_files.filemap.size());
         languaget &language = *language_files.filemap.begin()->second.language;
-        language.show_parse(std::cout);
+        std::stringstream output;
+        language.show_parse(output);
+        esbmc::global::_msg.print(output.str());
 
         if(cmdline.isset("parse-tree-only"))
           return true;
@@ -1467,8 +1488,9 @@ bool esbmc_parseoptionst::get_goto_program(
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory"
-              << "\n";
+    PRINT(
+      "Out of memory"
+      << "\n");
     return true;
   }
 
@@ -1511,8 +1533,9 @@ void esbmc_parseoptionst::preprocessing()
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory"
-              << "\n";
+    PRINT(
+      "Out of memory"
+      << "\n");
   }
 }
 
@@ -1627,7 +1650,9 @@ bool esbmc_parseoptionst::process_goto_program(
       cmdline.isset("goto-functions-too") ||
       cmdline.isset("goto-functions-only"))
     {
-      goto_functions.output(ns, std::cout);
+      std::stringstream output;
+      goto_functions.output(ns, output);
+      PRINT(output.str());
       if(cmdline.isset("goto-functions-only"))
         return true;
     }
@@ -1647,8 +1672,9 @@ bool esbmc_parseoptionst::process_goto_program(
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory"
-              << "\n";
+    PRINT(
+      "Out of memory"
+      << "\n");
     return true;
   }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -80,7 +80,8 @@ struct resultt
 #ifndef _WIN32
 void timeout_handler(int)
 {
-  std::cout << "Timed out" << std::endl;
+  std::cout << "Timed out"
+            << "\n";
 
   // Unfortunately some highly useful pieces of code hook themselves into
   // aexit and attempt to free some memory. That doesn't really make sense to
@@ -129,7 +130,8 @@ uint64_t esbmc_parseoptionst::read_time_spec(const char *str)
       mult = 86400;
       break;
     default:
-      std::cerr << "Unrecognized timeout suffix" << std::endl;
+      std::cerr << "Unrecognized timeout suffix"
+                << "\n";
       abort();
     }
   }
@@ -164,7 +166,8 @@ uint64_t esbmc_parseoptionst::read_mem_spec(const char *str)
       mult = 1024 * 1024 * 1024;
       break;
     default:
-      std::cerr << "Unrecognized memlimit suffix" << std::endl;
+      std::cerr << "Unrecognized memlimit suffix"
+                << "\n";
       abort();
     }
   }
@@ -200,14 +203,14 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("git-hash"))
   {
-    std::cout << esbmc_version_string << std::endl;
+    std::cout << esbmc_version_string << "\n";
     exit(0);
   }
 
   if(cmdline.isset("list-solvers"))
   {
     // Generated for us by autoconf,
-    std::cout << "Available solvers: " << ESBMC_AVAILABLE_SOLVERS << std::endl;
+    std::cout << "Available solvers: " << ESBMC_AVAILABLE_SOLVERS << "\n";
     exit(0);
   }
 
@@ -248,7 +251,7 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if(cmdline.isset("smt-during-symex"))
   {
     std::cout << "Enabling --no-slice due to presence of --smt-during-symex";
-    std::cout << std::endl;
+    std::cout << "\n";
     options.set_option("no-slice", true);
   }
 
@@ -258,7 +261,7 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     {
       std::cerr << "Please explicitly specify --smt-during-symex if you want "
                    "to use features that involve encoding SMT during symex"
-                << std::endl;
+                << "\n";
       abort();
     }
   }
@@ -312,7 +315,8 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if(cmdline.isset("timeout"))
   {
 #ifdef _WIN32
-    std::cerr << "Timeout unimplemented on Windows, sorry" << std::endl;
+    std::cerr << "Timeout unimplemented on Windows, sorry"
+              << "\n";
     abort();
 #else
     const char *time = cmdline.getval("timeout");
@@ -325,7 +329,8 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if(cmdline.isset("memlimit"))
   {
 #ifdef _WIN32
-    std::cerr << "Can't memlimit on Windows, sorry" << std::endl;
+    std::cerr << "Can't memlimit on Windows, sorry"
+              << "\n";
     abort();
 #else
     uint64_t size = read_mem_spec(cmdline.getval("memlimit"));
@@ -375,7 +380,7 @@ int esbmc_parseoptionst::doit()
   //
   std::cout << "ESBMC version " << ESBMC_VERSION " " << sizeof(void *) * 8
             << "-bit " << config.this_architecture() << " "
-            << config.this_operating_system() << std::endl;
+            << config.this_operating_system() << "\n";
 
   if(cmdline.isset("version"))
     return 0;
@@ -502,7 +507,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
   if(process_type == PARENT && num_p != 3)
   {
-    std::cerr << "Child processes were not created sucessfully." << std::endl;
+    std::cerr << "Child processes were not created sucessfully."
+              << "\n";
     abort();
   }
 
@@ -566,9 +572,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         {
           // Invalid size read.
           std::cerr << "Short read communicating with kinduction children"
-                    << std::endl;
+                    << "\n";
           std::cerr << "Size " << read_size << ", expected " << sizeof(resultt)
-                    << std::endl;
+                    << "\n";
           abort();
         }
       }
@@ -590,7 +596,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         }
         else
         {
-          std::cout << "**** WARNING: Base case process crashed." << std::endl;
+          std::cout << "**** WARNING: Base case process crashed."
+                    << "\n";
           bc_finished = fc_finished = is_finished = true;
         }
       }
@@ -611,7 +618,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         else
         {
           std::cout << "**** WARNING: Forward condition process crashed."
-                    << std::endl;
+                    << "\n";
 
           fc_finished = bc_finished = is_finished = true;
         }
@@ -633,7 +640,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         else
         {
           std::cout << "**** WARNING: Inductive step process crashed."
-                    << std::endl;
+                    << "\n";
 
           is_finished = bc_finished = fc_finished = true;
         }
@@ -658,7 +665,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 
       default:
         std::cerr << "Message from unrecognized k-induction child "
-                  << "process" << std::endl;
+                  << "process"
+                  << "\n";
         abort();
       }
 
@@ -721,10 +729,11 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     // Check if a solution was found by the base case
     if(bc_finished && (bc_solution != 0) && (bc_solution != max_k_step))
     {
-      std::cout << std::endl
+      std::cout << "\n"
                 << "Bug found by the base case (k = " << bc_solution << ")"
-                << std::endl;
-      std::cout << "VERIFICATION FAILED" << std::endl;
+                << "\n";
+      std::cout << "VERIFICATION FAILED"
+                << "\n";
       return true;
     }
 
@@ -735,11 +744,12 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
       // and haven't crashed (if it crashed, bc_solution will be UINT_MAX
       if(bc_finished && (bc_solution != max_k_step))
       {
-        std::cout << std::endl
+        std::cout << "\n"
                   << "Solution found by the forward condition; "
                   << "all states are reachable (k = " << fc_solution << ")"
-                  << std::endl;
-        std::cout << "VERIFICATION SUCCESSFUL" << std::endl;
+                  << "\n";
+        std::cout << "VERIFICATION SUCCESSFUL"
+                  << "\n";
         return false;
       }
     }
@@ -751,16 +761,20 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
       // and haven't crashed (if it crashed, bc_solution will be UINT_MAX
       if(bc_finished && (bc_solution != max_k_step))
       {
-        std::cout << std::endl
+        std::cout << "\n"
                   << "Solution found by the inductive step "
-                  << "(k = " << is_solution << ")" << std::endl;
-        std::cout << "VERIFICATION SUCCESSFUL" << std::endl;
+                  << "(k = " << is_solution << ")"
+                  << "\n";
+        std::cout << "VERIFICATION SUCCESSFUL"
+                  << "\n";
         return false;
       }
     }
 
     // Couldn't find a bug or a proof for the current deepth
-    std::cout << std::endl << "VERIFICATION UNKNOWN" << std::endl;
+    std::cout << "\n"
+              << "VERIFICATION UNKNOWN"
+              << "\n";
     return false;
   }
 
@@ -814,7 +828,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        std::cout << "BASE CASE PROCESS FINISHED." << std::endl;
+        std::cout << "BASE CASE PROCESS FINISHED."
+                  << "\n";
 
         return true;
       }
@@ -840,9 +855,9 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         {
           // Invalid size read.
           std::cerr << "Short read communicating with kinduction parent"
-                    << std::endl;
+                    << "\n";
           std::cerr << "Size " << read_size << ", expected " << sizeof(resultt)
-                    << std::endl;
+                    << "\n";
           abort();
         }
       }
@@ -867,7 +882,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    std::cout << "BASE CASE PROCESS FINISHED." << std::endl;
+    std::cout << "BASE CASE PROCESS FINISHED."
+              << "\n";
     return false;
   }
 
@@ -925,7 +941,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        std::cout << "FORWARD CONDITION PROCESS FINISHED." << std::endl;
+        std::cout << "FORWARD CONDITION PROCESS FINISHED."
+                  << "\n";
         return false;
       }
     }
@@ -937,7 +954,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    std::cout << "FORWARD CONDITION PROCESS FINISHED." << std::endl;
+    std::cout << "FORWARD CONDITION PROCESS FINISHED."
+              << "\n";
     return true;
   }
 
@@ -994,7 +1012,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        std::cout << "INDUCTIVE STEP PROCESS FINISHED." << std::endl;
+        std::cout << "INDUCTIVE STEP PROCESS FINISHED."
+                  << "\n";
         return false;
       }
     }
@@ -1006,7 +1025,8 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    std::cout << "INDUCTIVE STEP PROCESS FINISHED." << std::endl;
+    std::cout << "INDUCTIVE STEP PROCESS FINISHED."
+              << "\n";
     return true;
   }
 
@@ -1446,7 +1466,8 @@ bool esbmc_parseoptionst::get_goto_program(
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory" << std::endl;
+    std::cout << "Out of memory"
+              << "\n";
     return true;
   }
 
@@ -1489,7 +1510,8 @@ void esbmc_parseoptionst::preprocessing()
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory" << std::endl;
+    std::cout << "Out of memory"
+              << "\n";
   }
 }
 
@@ -1624,7 +1646,8 @@ bool esbmc_parseoptionst::process_goto_program(
 
   catch(std::bad_alloc &)
   {
-    std::cout << "Out of memory" << std::endl;
+    std::cout << "Out of memory"
+              << "\n";
     return true;
   }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -454,7 +454,7 @@ int esbmc_parseoptionst::doit()
 int esbmc_parseoptionst::doit_k_induction_parallel()
 {
 #ifdef _WIN32
-  std::cerr << "Windows does not support parallel kind\n";
+  ERROR("Windows does not support parallel kind\n");
   abort();
 #else
   // Pipes for communication between processes

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -32,7 +32,10 @@ void bmct::show_vcc(
     assert(false);
   }
 
-  out << std::endl << "VERIFICATION CONDITIONS:" << std::endl << std::endl;
+  out << "\n"
+      << "VERIFICATION CONDITIONS:"
+      << "\n"
+      << "\n";
 
   languagest languages(ns, MODE_C);
 
@@ -44,10 +47,10 @@ void bmct::show_vcc(
       continue;
 
     if(it->source.pc->location.is_not_nil())
-      out << it->source.pc->location << std::endl;
+      out << it->source.pc->location << "\n";
 
     if(it->comment != "")
-      out << it->comment << std::endl;
+      out << it->comment << "\n";
 
     symex_target_equationt::SSA_stepst::const_iterator p_it =
       eq->SSA_steps.begin();
@@ -58,17 +61,18 @@ void bmct::show_vcc(
         {
           std::string string_value;
           languages.from_expr(migrate_expr_back(p_it->cond), string_value);
-          out << "{-" << count << "} " << string_value << std::endl;
+          out << "{-" << count << "} " << string_value << "\n";
           count++;
         }
 
-    out << "|--------------------------" << std::endl;
+    out << "|--------------------------"
+        << "\n";
 
     std::string string_value;
     languages.from_expr(migrate_expr_back(it->cond), string_value);
-    out << "{" << 1 << "} " << string_value << std::endl;
+    out << "{" << 1 << "} " << string_value << "\n";
 
-    out << std::endl;
+    out << "\n";
   }
 }
 
@@ -82,7 +86,7 @@ void bmct::show_vcc(std::shared_ptr<symex_target_equationt> &eq)
   {
     std::ofstream out(filename.c_str());
     if(!out)
-      std::cerr << "failed to open " << filename << std::endl;
+      std::cerr << "failed to open " << filename << "\n";
     else
       show_vcc(out, eq);
   }

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -81,7 +81,11 @@ void bmct::show_vcc(std::shared_ptr<symex_target_equationt> &eq)
   const std::string &filename = options.get_option("output");
 
   if(filename.empty() || filename == "-")
-    show_vcc(std::cout, eq);
+  {
+    std::stringstream output;
+    show_vcc(output, eq);
+    PRINT(output.str());
+  }
   else
   {
     std::ofstream out(filename.c_str());

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -86,7 +86,7 @@ void bmct::show_vcc(std::shared_ptr<symex_target_equationt> &eq)
   {
     std::ofstream out(filename.c_str());
     if(!out)
-      std::cerr << "failed to open " << filename << "\n";
+      ERROR("failed to open " << filename << "\n")
     else
       show_vcc(out, eq);
   }

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -30,7 +30,7 @@ static const std::string &get_string_constant(const exprt &expr)
     !expr.is_address_of() || expr.operands().size() != 1 ||
     !expr.op0().is_index() || expr.op0().operands().size() != 2)
   {
-    std::cerr << "expected string constant, but got:\n";
+    ERROR("expected string constant, but got:\n");
     expr.dump();
     abort();
   }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -54,7 +54,7 @@ void goto_convertt::finish_gotos(goto_programt &dest)
 
       if(l_it == targets.labels.end())
       {
-        std::cerr << "goto label " << goto_label << " not found";
+        ERROR("goto label " << goto_label << " not found");
         i.code->dump();
         abort();
       }
@@ -434,7 +434,7 @@ void goto_convertt::convert_expression(const codet &code, goto_programt &dest)
   if(code.operands().size() != 1)
   {
     err_location(code);
-    std::cerr << "expression statement takes one operand\n";
+    ERROR("expression statement takes one operand\n");
     abort();
   }
 

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -24,7 +24,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #ifdef DEBUG
 #define DEBUGLOC                                                               \
-  std::cout << std::endl << __FUNCTION__ << "[" << __LINE__ << "]" << std::endl;
+  std::cout << "\n"                                                            \
+            << __FUNCTION__ << "[" << __LINE__ << "]"                          \
+            << "\n";
 #else
 #define DEBUGLOC
 #endif

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -24,9 +24,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #ifdef DEBUG
 #define DEBUGLOC                                                               \
-  std::cout << "\n"                                                            \
-            << __FUNCTION__ << "[" << __LINE__ << "]"                          \
-            << "\n";
+  PRINT(                                                                       \
+    "\n"                                                                       \
+    << __FUNCTION__ << "[" << __LINE__ << "]"                                  \
+    << "\n");
 #else
 #define DEBUGLOC
 #endif

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -315,8 +315,9 @@ void goto_convert_functionst::rename_types(
       {
         // And if we fail
         ERROR("Can't resolve type symbol " << ident);
-        std::cerr << " at symbol squashing time"
-                  << "\n";
+        ERROR(
+          " at symbol squashing time"
+          << "\n");
         abort();
       }
     }

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -314,7 +314,7 @@ void goto_convert_functionst::rename_types(
       else
       {
         // And if we fail
-        std::cerr << "Can't resolve type symbol " << ident;
+        ERROR("Can't resolve type symbol " << ident);
         std::cerr << " at symbol squashing time"
                   << "\n";
         abort();

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -315,7 +315,8 @@ void goto_convert_functionst::rename_types(
       {
         // And if we fail
         std::cerr << "Can't resolve type symbol " << ident;
-        std::cerr << " at symbol squashing time" << std::endl;
+        std::cerr << " at symbol squashing time"
+                  << "\n";
         abort();
       }
     }

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -174,7 +174,9 @@ void goto_convertt::do_function_call_dereference(
 
 void goto_functionst::dump() const
 {
-  output(*migrate_namespace_lookup, std::cout);
+  std::stringstream str;
+  output(*migrate_namespace_lookup, str);
+  PRINT(str.str());
 }
 
 void goto_functionst::output(const namespacet &ns, std::ostream &out) const

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -71,8 +71,7 @@ void goto_convertt::do_function_call(
   else
   {
     err_location(function);
-    std::cerr << "unexpected function argument: " + new_function.id_string()
-              << "\n";
+    ERROR("unexpected function argument: " + new_function.id_string() << "\n");
     abort();
   }
 }

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -72,7 +72,7 @@ void goto_convertt::do_function_call(
   {
     err_location(function);
     std::cerr << "unexpected function argument: " + new_function.id_string()
-              << std::endl;
+              << "\n";
     abort();
   }
 }
@@ -183,11 +183,13 @@ void goto_functionst::output(const namespacet &ns, std::ostream &out) const
   {
     if(it.second.body_available)
     {
-      out << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
-      out << std::endl;
+      out << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+          << "\n";
+      out << "\n";
 
       const symbolt &symbol = ns.lookup(it.first);
-      out << symbol.name << " (" << symbol.id << "):" << std::endl;
+      out << symbol.name << " (" << symbol.id << "):"
+          << "\n";
       it.second.body.output(ns, symbol.id, out);
     }
   }

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -135,8 +135,7 @@ void goto_loopst::get_modified_variables(
 
     if(it == goto_functions.function_map.end())
     {
-      std::cerr << "failed to find `" + id2string(identifier) +
-                     "' in function_map";
+      ERROR("failed to find `" + id2string(identifier) + "' in function_map");
       abort();
     }
 

--- a/src/goto-programs/goto_main.cpp
+++ b/src/goto-programs/goto_main.cpp
@@ -62,7 +62,8 @@ void goto_convert(
   if(s == nullptr)
     throw "failed to find main symbol";
 
-  std::cout << "goto_convert : start converting symbol table to goto functions "
-            << "\n";
+  PRINT(
+    "goto_convert : start converting symbol table to goto functions "
+    << "\n");
   ::goto_convert(to_code(s->value), context, options, dest, message_handler);
 }

--- a/src/goto-programs/goto_main.cpp
+++ b/src/goto-programs/goto_main.cpp
@@ -63,6 +63,6 @@ void goto_convert(
     throw "failed to find main symbol";
 
   std::cout << "goto_convert : start converting symbol table to goto functions "
-            << std::endl;
+            << "\n";
   ::goto_convert(to_code(s->value), context, options, dest, message_handler);
 }

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -41,7 +41,7 @@ void goto_programt::instructiont::output_instruction(
       out << " " << label;
     }
 
-    out << std::endl;
+    out << "\n";
   }
 
   if(is_target())
@@ -52,7 +52,8 @@ void goto_programt::instructiont::output_instruction(
   switch(type)
   {
   case NO_INSTRUCTION_TYPE:
-    out << "NO INSTRUCTION TYPE SET" << std::endl;
+    out << "NO INSTRUCTION TYPE SET"
+        << "\n";
     break;
 
   case GOTO:
@@ -72,12 +73,12 @@ void goto_programt::instructiont::output_instruction(
       out << (*gt_it)->target_number;
     }
 
-    out << std::endl;
+    out << "\n";
     break;
 
   case FUNCTION_CALL:
     out << "FUNCTION_CALL:  " << from_expr(ns, "", migrate_expr_back(code))
-        << std::endl;
+        << "\n";
     break;
 
   case RETURN:
@@ -86,7 +87,7 @@ void goto_programt::instructiont::output_instruction(
     const code_return2t &ref = to_code_return2t(code);
     if(!is_nil_expr(ref.operand))
       arg = from_expr(ns, "", ref.operand);
-    out << "RETURN: " << arg << std::endl;
+    out << "RETURN: " << arg << "\n";
   }
   break;
 
@@ -94,7 +95,7 @@ void goto_programt::instructiont::output_instruction(
   case DEAD:
   case OTHER:
   case ASSIGN:
-    out << from_expr(ns, identifier, code) << std::endl;
+    out << from_expr(ns, identifier, code) << "\n";
     break;
 
   case ASSUME:
@@ -112,11 +113,12 @@ void goto_programt::instructiont::output_instruction(
         out << " // " << comment;
     }
 
-    out << std::endl;
+    out << "\n";
     break;
 
   case SKIP:
-    out << "SKIP" << std::endl;
+    out << "SKIP"
+        << "\n";
     break;
 
   case END_FUNCTION:
@@ -126,11 +128,12 @@ void goto_programt::instructiont::output_instruction(
       if(function != "")
         out << " // " << function;
     }
-    out << std::endl;
+    out << "\n";
     break;
 
   case LOCATION:
-    out << "LOCATION" << std::endl;
+    out << "LOCATION"
+        << "\n";
     break;
 
   case THROW:
@@ -149,7 +152,7 @@ void goto_programt::instructiont::output_instruction(
         out << ": " << from_expr(ns, identifier, throw_ref.operand);
     }
 
-    out << std::endl;
+    out << "\n";
     break;
 
   case CATCH:
@@ -170,15 +173,17 @@ void goto_programt::instructiont::output_instruction(
       }
     }
 
-    out << std::endl;
+    out << "\n";
     break;
 
   case ATOMIC_BEGIN:
-    out << "ATOMIC_BEGIN" << std::endl;
+    out << "ATOMIC_BEGIN"
+        << "\n";
     break;
 
   case ATOMIC_END:
-    out << "ATOMIC_END" << std::endl;
+    out << "ATOMIC_END"
+        << "\n";
     break;
 
   case THROW_DECL:
@@ -196,7 +201,7 @@ void goto_programt::instructiont::output_instruction(
       out << ")";
     }
 
-    out << std::endl;
+    out << "\n";
     break;
 
   case THROW_DECL_END:
@@ -217,7 +222,7 @@ void goto_programt::instructiont::output_instruction(
 
     out << ")";
 
-    out << std::endl;
+    out << "\n";
     break;
 
   default:

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -12,7 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void goto_programt::instructiont::dump() const
 {
-  output_instruction(*migrate_namespace_lookup, "", std::cout);
+  std::stringstream str;
+  output_instruction(*migrate_namespace_lookup, "", str);
+  PRINT(str.str());
 }
 
 void goto_programt::instructiont::output_instruction(
@@ -492,7 +494,9 @@ std::ostream &operator<<(std::ostream &out, goto_program_instruction_typet t)
 
 void goto_programt::dump() const
 {
-  output(*migrate_namespace_lookup, "", std::cout);
+  std::stringstream str;
+  output(*migrate_namespace_lookup, "", str);
+  PRINT(str.str());
 }
 
 void goto_programt::get_decl_identifiers(

--- a/src/goto-programs/goto_program_irep.cpp
+++ b/src/goto-programs/goto_program_irep.cpp
@@ -122,9 +122,10 @@ void convert(const irept &irep, goto_programt &program)
 
       if(fit == program.instructions.end())
       {
-        std::cout << "Warning: could not resolve target link "
-                  << "during irep->goto_program translation."
-                  << "\n";
+        PRINT(
+          "Warning: could not resolve target link "
+          << "during irep->goto_program translation."
+          << "\n");
         throw 0;
       }
     }

--- a/src/goto-programs/goto_program_irep.cpp
+++ b/src/goto-programs/goto_program_irep.cpp
@@ -123,7 +123,8 @@ void convert(const irept &irep, goto_programt &program)
       if(fit == program.instructions.end())
       {
         std::cout << "Warning: could not resolve target link "
-                  << "during irep->goto_program translation." << std::endl;
+                  << "during irep->goto_program translation."
+                  << "\n";
         throw 0;
       }
     }

--- a/src/goto-programs/interval_domain.h
+++ b/src/goto-programs/interval_domain.h
@@ -41,7 +41,9 @@ public:
 
   void dump() const
   {
-    output(std::cout);
+    std::stringstream str;
+    output(str);
+    PRINT(str.str());
   }
 
 protected:

--- a/src/goto-programs/loop_numbers.cpp
+++ b/src/goto-programs/loop_numbers.cpp
@@ -30,15 +30,15 @@ void show_loop_numbers(
         convert(instruction.location, l);
         l.name = "location";
 
-        std::cout << xml << "\n";
+        PRINT(xml << "\n");
       }
       else if(ui == ui_message_handlert::PLAIN)
       {
         std::cout << "Loop " << loop_id << ":"
                   << "\n";
 
-        std::cout << "  " << instruction.location << "\n";
-        std::cout << "\n";
+        PRINT("  " << instruction.location << "\n");
+        PRINT("\n");
       }
       else
         assert(false);

--- a/src/goto-programs/loop_numbers.cpp
+++ b/src/goto-programs/loop_numbers.cpp
@@ -34,8 +34,9 @@ void show_loop_numbers(
       }
       else if(ui == ui_message_handlert::PLAIN)
       {
-        std::cout << "Loop " << loop_id << ":"
-                  << "\n";
+        PRINT(
+          "Loop " << loop_id << ":"
+                  << "\n");
 
         PRINT("  " << instruction.location << "\n");
         PRINT("\n");

--- a/src/goto-programs/loop_numbers.cpp
+++ b/src/goto-programs/loop_numbers.cpp
@@ -30,14 +30,15 @@ void show_loop_numbers(
         convert(instruction.location, l);
         l.name = "location";
 
-        std::cout << xml << std::endl;
+        std::cout << xml << "\n";
       }
       else if(ui == ui_message_handlert::PLAIN)
       {
-        std::cout << "Loop " << loop_id << ":" << std::endl;
+        std::cout << "Loop " << loop_id << ":"
+                  << "\n";
 
-        std::cout << "  " << instruction.location << std::endl;
-        std::cout << std::endl;
+        std::cout << "  " << instruction.location << "\n";
+        std::cout << "\n";
       }
       else
         assert(false);

--- a/src/goto-programs/loopst.cpp
+++ b/src/goto-programs/loopst.cpp
@@ -1,4 +1,5 @@
 #include <goto-programs/loopst.h>
+#include <util/message.h>
 
 const loopst::loop_varst &loopst::get_modified_loop_vars() const
 {
@@ -44,15 +45,15 @@ void loopst::dump() const
 {
   unsigned n = get_original_loop_head()->location_number;
 
-  std::cout << n << " is head of (size: ";
-  std::cout << size;
-  std::cout << ") { ";
+  PRINT(n << " is head of (size: ");
+  PRINT(size);
+  PRINT(") { ");
 
   for(goto_programt::instructionst::iterator l_it = get_original_loop_head();
       l_it != get_original_loop_exit();
       ++l_it)
-    std::cout << (*l_it).location_number << ", ";
-  std::cout << get_original_loop_exit()->location_number;
+    PRINT((*l_it).location_number << ", ");
+  PRINT(get_original_loop_exit()->location_number);
 
   std::cout << " }"
             << "\n";
@@ -62,9 +63,9 @@ void loopst::dump() const
 
 void loopst::dump_loop_vars() const
 {
-  std::cout << "Loop variables:\n";
+  PRINT("Loop variables:\n");
   unsigned int i = 0;
   for(auto var : modified_loop_vars)
-    std::cout << ++i << ". \t" << to_symbol2t(var).thename << '\n';
-  std::cout << '\n';
+    PRINT(++i << ". \t" << to_symbol2t(var).thename << '\n');
+  PRINT('\n');
 }

--- a/src/goto-programs/loopst.cpp
+++ b/src/goto-programs/loopst.cpp
@@ -55,8 +55,9 @@ void loopst::dump() const
     PRINT((*l_it).location_number << ", ");
   PRINT(get_original_loop_exit()->location_number);
 
-  std::cout << " }"
-            << "\n";
+  PRINT(
+    " }"
+    << "\n");
 
   dump_loop_vars();
 }

--- a/src/goto-programs/loopst.cpp
+++ b/src/goto-programs/loopst.cpp
@@ -54,7 +54,8 @@ void loopst::dump() const
     std::cout << (*l_it).location_number << ", ";
   std::cout << get_original_loop_exit()->location_number;
 
-  std::cout << " }" << std::endl;
+  std::cout << " }"
+            << "\n";
 
   dump_loop_vars();
 }

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -49,7 +49,7 @@ bool read_bin_goto_object(
       }
       else
         message_stream.str << "`" << filename << "' is not a goto-binary."
-                           << std::endl;
+                           << "\n";
 
       message_stream.error();
 

--- a/src/goto-programs/show_claims.cpp
+++ b/src/goto-programs/show_claims.cpp
@@ -46,18 +46,19 @@ void show_claims(
         xml.new_element("expression").data =
           xmlt::escape(from_expr(ns, identifier, instruction.guard));
 
-        std::cout << xml << std::endl;
+        std::cout << xml << "\n";
       }
       else if(ui == ui_message_handlert::PLAIN)
       {
-        std::cout << "Claim " << count << ":" << std::endl;
+        std::cout << "Claim " << count << ":"
+                  << "\n";
 
-        std::cout << "  " << instruction.location << std::endl
-                  << "  " << description << std::endl;
+        std::cout << "  " << instruction.location << "\n"
+                  << "  " << description << "\n";
 
         std::cout << "  " << from_expr(ns, identifier, instruction.guard)
-                  << std::endl;
-        std::cout << std::endl;
+                  << "\n";
+        std::cout << "\n";
       }
       else
         assert(false);

--- a/src/goto-programs/show_claims.cpp
+++ b/src/goto-programs/show_claims.cpp
@@ -46,7 +46,7 @@ void show_claims(
         xml.new_element("expression").data =
           xmlt::escape(from_expr(ns, identifier, instruction.guard));
 
-        std::cout << xml << "\n";
+        PRINT(xml << "\n");
       }
       else if(ui == ui_message_handlert::PLAIN)
       {
@@ -58,7 +58,7 @@ void show_claims(
 
         std::cout << "  " << from_expr(ns, identifier, instruction.guard)
                   << "\n";
-        std::cout << "\n";
+        PRINT("\n");
       }
       else
         assert(false);

--- a/src/goto-programs/show_claims.cpp
+++ b/src/goto-programs/show_claims.cpp
@@ -50,14 +50,15 @@ void show_claims(
       }
       else if(ui == ui_message_handlert::PLAIN)
       {
-        std::cout << "Claim " << count << ":"
-                  << "\n";
+        PRINT(
+          "Claim " << count << ":"
+                   << "\n");
 
-        std::cout << "  " << instruction.location << "\n"
-                  << "  " << description << "\n";
+        PRINT(
+          "  " << instruction.location << "\n"
+               << "  " << description << "\n");
 
-        std::cout << "  " << from_expr(ns, identifier, instruction.guard)
-                  << "\n";
+        PRINT("  " << from_expr(ns, identifier, instruction.guard) << "\n");
         PRINT("\n");
       }
       else

--- a/src/goto-programs/static_analysis.cpp
+++ b/src/goto-programs/static_analysis.cpp
@@ -372,8 +372,8 @@ void static_analysis_baset::do_function_call_rec(
   }
   else
   {
-    std::cerr << "unexpected function_call argument: " << get_expr_id(function)
-              << "\n";
+    ERROR(
+      "unexpected function_call argument: " << get_expr_id(function) << "\n");
     abort();
   }
 }

--- a/src/goto-programs/static_analysis.cpp
+++ b/src/goto-programs/static_analysis.cpp
@@ -66,10 +66,12 @@ void static_analysis_baset::output(
 {
   for(const auto &f_it : goto_functions.function_map)
   {
-    out << "////" << std::endl;
-    out << "//// Function: " << f_it.first << std::endl;
-    out << "////" << std::endl;
-    out << std::endl;
+    out << "////"
+        << "\n";
+    out << "//// Function: " << f_it.first << "\n";
+    out << "////"
+        << "\n";
+    out << "\n";
 
     output(f_it.second.body, f_it.first, out);
   }
@@ -82,12 +84,12 @@ void static_analysis_baset::output(
 {
   forall_goto_program_instructions(i_it, goto_program)
   {
-    out << "**** " << i_it->location << std::endl;
+    out << "**** " << i_it->location << "\n";
 
     get_state(i_it).output(ns, out);
-    out << std::endl;
+    out << "\n";
     i_it->output_instruction(ns, identifier, out);
-    out << std::endl;
+    out << "\n";
   }
 }
 
@@ -371,7 +373,7 @@ void static_analysis_baset::do_function_call_rec(
   else
   {
     std::cerr << "unexpected function_call argument: " << get_expr_id(function)
-              << std::endl;
+              << "\n";
     abort();
   }
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -591,8 +591,9 @@ void goto_symext::intrinsic_spawn_thread(
 
   if(!it->second.body_available)
   {
-    std::cerr << "Spawning thread \"" << symname << "\": no body"
-              << "\n";
+    ERROR(
+      "Spawning thread \"" << symname << "\": no body"
+                           << "\n");
     abort();
   }
 

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -468,7 +468,7 @@ void goto_symext::intrinsic_switch_to(
   const expr2tc &num = call.operands[0];
   if(!is_constant_int2t(num))
   {
-    std::cerr << "Can't switch to non-constant thread id no";
+    ERROR("Can't switch to non-constant thread id no");
     abort();
   }
 
@@ -520,8 +520,8 @@ void goto_symext::intrinsic_set_thread_data(
 
   if(!is_constant_int2t(threadid))
   {
-    std::cerr << "__ESBMC_set_start_data received nonconstant thread id";
-    std::cerr << "\n";
+    ERROR("__ESBMC_set_start_data received nonconstant thread id");
+    ERROR("\n");
     abort();
   }
 
@@ -543,8 +543,8 @@ void goto_symext::intrinsic_get_thread_data(
 
   if(!is_constant_int2t(threadid))
   {
-    std::cerr << "__ESBMC_set_start_data received nonconstant thread id";
-    std::cerr << "\n";
+    ERROR("__ESBMC_set_start_data received nonconstant thread id");
+    ERROR("\n");
     abort();
   }
 
@@ -583,8 +583,8 @@ void goto_symext::intrinsic_spawn_thread(
     art.goto_functions.function_map.find(symname);
   if(it == art.goto_functions.function_map.end())
   {
-    std::cerr << "Spawning thread \"" << symname << "\": symbol not found";
-    std::cerr << "\n";
+    ERROR("Spawning thread \"" << symname << "\": symbol not found");
+    ERROR("\n");
     abort();
   }
 
@@ -634,8 +634,8 @@ void goto_symext::intrinsic_get_thread_state(
 
   if(!is_constant_int2t(threadid))
   {
-    std::cerr << "__ESBMC_get_thread_state received nonconstant thread id";
-    std::cerr << "\n";
+    ERROR("__ESBMC_get_thread_state received nonconstant thread id");
+    ERROR("\n");
     abort();
   }
 
@@ -698,8 +698,8 @@ void goto_symext::intrinsic_register_monitor(
 
   if(!is_constant_int2t(threadid))
   {
-    std::cerr << "__ESBMC_register_monitor received nonconstant thread id";
-    std::cerr << "\n";
+    ERROR("__ESBMC_register_monitor received nonconstant thread id");
+    ERROR("\n");
     abort();
   }
 
@@ -1009,7 +1009,7 @@ void goto_symext::intrinsic_memset(
       }
       else
       {
-        std::cerr << "Logic mismatch in memset intrinsic\n";
+        ERROR("Logic mismatch in memset intrinsic\n");
         abort();
       }
     }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -565,8 +565,9 @@ void goto_symext::intrinsic_spawn_thread(
     (k_induction || inductive_step) &&
     !options.get_bool_option("disable-inductive-step"))
   {
-    std::cout << "**** WARNING: k-induction does not support concurrency yet. "
-              << "Disabling inductive step\n";
+    PRINT(
+      "**** WARNING: k-induction does not support concurrency yet. "
+      << "Disabling inductive step\n");
 
     // Disable inductive step on multi threaded code
     options.set_option("disable-inductive-step", true);

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -521,7 +521,7 @@ void goto_symext::intrinsic_set_thread_data(
   if(!is_constant_int2t(threadid))
   {
     std::cerr << "__ESBMC_set_start_data received nonconstant thread id";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
 
@@ -544,7 +544,7 @@ void goto_symext::intrinsic_get_thread_data(
   if(!is_constant_int2t(threadid))
   {
     std::cerr << "__ESBMC_set_start_data received nonconstant thread id";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
 
@@ -584,13 +584,14 @@ void goto_symext::intrinsic_spawn_thread(
   if(it == art.goto_functions.function_map.end())
   {
     std::cerr << "Spawning thread \"" << symname << "\": symbol not found";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
 
   if(!it->second.body_available)
   {
-    std::cerr << "Spawning thread \"" << symname << "\": no body" << std::endl;
+    std::cerr << "Spawning thread \"" << symname << "\": no body"
+              << "\n";
     abort();
   }
 
@@ -634,7 +635,7 @@ void goto_symext::intrinsic_get_thread_state(
   if(!is_constant_int2t(threadid))
   {
     std::cerr << "__ESBMC_get_thread_state received nonconstant thread id";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
 
@@ -698,7 +699,7 @@ void goto_symext::intrinsic_register_monitor(
   if(!is_constant_int2t(threadid))
   {
     std::cerr << "__ESBMC_register_monitor received nonconstant thread id";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -237,7 +237,7 @@ void execution_statet::symex_step(reachability_treet &art)
 
   if(options.get_bool_option("show-symex-value-sets"))
   {
-    std::cout << '\n';
+    PRINT('\n');
     state.value_set.dump();
   }
 
@@ -1085,7 +1085,7 @@ void execution_statet::print_stack_traces(unsigned int indent) const
     std::cout << spaces << "Thread " << i++ << ":"
               << "\n";
     it->print_stack_trace(indent + 2);
-    std::cout << "\n";
+    PRINT("\n");
   }
 }
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -60,8 +60,9 @@ execution_statet::execution_statet(
     goto_functions.function_map.find("__ESBMC_main");
   if(it == goto_functions.function_map.end())
   {
-    std::cerr << "main symbol not found; please set an entry point"
-              << "\n";
+    ERROR(
+      "main symbol not found; please set an entry point"
+      << "\n");
     abort();
   }
 
@@ -1095,9 +1096,10 @@ void execution_statet::switch_to_monitor()
   {
     if(!mon_thread_warning)
     {
-      std::cerr << "Switching to ended monitor; you need to increase its "
-                   "context or prefix bound"
-                << "\n";
+      ERROR(
+        "Switching to ended monitor; you need to increase its "
+        "context or prefix bound"
+        << "\n");
       mon_thread_warning = true;
     }
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -222,8 +222,9 @@ void execution_statet::symex_step(reachability_treet &art)
 #ifndef _WIN32
     __asm__("int $3");
 #else
-    std::cerr << "Can't trap on windows, sorry"
-              << "\n";
+    ERROR(
+      "Can't trap on windows, sorry"
+      << "\n");
     abort();
 #endif
   }

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -243,7 +243,11 @@ void execution_statet::symex_step(reachability_treet &art)
   }
 
   if(symex_trace || options.get_bool_option("show-symex-value-sets"))
-    state.source.pc->output_instruction(ns, "", std::cout, false);
+  {
+    std::stringstream out;
+    state.source.pc->output_instruction(ns, "", out, false);
+    PRINT(out.str());
+  }
 
   switch(instruction.type)
   {
@@ -1083,8 +1087,9 @@ void execution_statet::print_stack_traces(unsigned int indent) const
   i = 0;
   for(it = threads_state.begin(); it != threads_state.end(); it++)
   {
-    std::cout << spaces << "Thread " << i++ << ":"
-              << "\n";
+    PRINT(
+      spaces << "Thread " << i++ << ":"
+             << "\n");
     it->print_stack_trace(indent + 2);
     PRINT("\n");
   }

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -61,7 +61,7 @@ execution_statet::execution_statet(
   if(it == goto_functions.function_map.end())
   {
     std::cerr << "main symbol not found; please set an entry point"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -221,7 +221,8 @@ void execution_statet::symex_step(reachability_treet &art)
 #ifndef _WIN32
     __asm__("int $3");
 #else
-    std::cerr << "Can't trap on windows, sorry" << std::endl;
+    std::cerr << "Can't trap on windows, sorry"
+              << "\n";
     abort();
 #endif
   }
@@ -1081,9 +1082,10 @@ void execution_statet::print_stack_traces(unsigned int indent) const
   i = 0;
   for(it = threads_state.begin(); it != threads_state.end(); it++)
   {
-    std::cout << spaces << "Thread " << i++ << ":" << std::endl;
+    std::cout << spaces << "Thread " << i++ << ":"
+              << "\n";
     it->print_stack_trace(indent + 2);
-    std::cout << std::endl;
+    std::cout << "\n";
   }
 }
 
@@ -1095,7 +1097,7 @@ void execution_statet::switch_to_monitor()
     {
       std::cerr << "Switching to ended monitor; you need to increase its "
                    "context or prefix bound"
-                << std::endl;
+                << "\n";
       mon_thread_warning = true;
     }
 

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -187,7 +187,7 @@ public:
   {
     if(tid >= thread_start_data.size())
     {
-      std::cerr << "Setting thread data for nonexistant thread " << tid << '\n';
+      ERROR("Setting thread data for nonexistant thread " << tid << '\n');
       abort();
     }
 
@@ -199,7 +199,7 @@ public:
   {
     if(tid >= thread_start_data.size())
     {
-      std::cerr << "Getting thread data for nonexistant thread " << tid << '\n';
+      ERROR("Getting thread data for nonexistant thread " << tid << '\n');
       abort();
     }
 

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -410,10 +410,10 @@ void goto_symex_statet::print_stack_trace(unsigned int indent) const
     }
     else
     {
-      std::cout << spaces << it->function_identifier.as_string();
-      std::cout << " at " << src.pc->location.get_file();
-      std::cout << " line " << src.pc->location.get_line();
-      std::cout << "\n";
+      PRINT(spaces << it->function_identifier.as_string());
+      PRINT(" at " << src.pc->location.get_file());
+      PRINT(" line " << src.pc->location.get_line());
+      PRINT("\n");
     }
 
     src = it->calling_location;

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -405,14 +405,15 @@ void goto_symex_statet::print_stack_trace(unsigned int indent) const
   {
     if(it->function_identifier == "")
     { // Top level call
-      std::cout << spaces << "init" << std::endl;
+      std::cout << spaces << "init"
+                << "\n";
     }
     else
     {
       std::cout << spaces << it->function_identifier.as_string();
       std::cout << " at " << src.pc->location.get_file();
       std::cout << " line " << src.pc->location.get_line();
-      std::cout << std::endl;
+      std::cout << "\n";
     }
 
     src = it->calling_location;
@@ -420,7 +421,8 @@ void goto_symex_statet::print_stack_trace(unsigned int indent) const
 
   if(!thread_ended)
   {
-    std::cout << spaces << "Next instruction to be executed:" << std::endl;
+    std::cout << spaces << "Next instruction to be executed:"
+              << "\n";
     source.pc->output_instruction(ns, "", std::cout);
   }
 }

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -405,8 +405,9 @@ void goto_symex_statet::print_stack_trace(unsigned int indent) const
   {
     if(it->function_identifier == "")
     { // Top level call
-      std::cout << spaces << "init"
-                << "\n";
+      PRINT(
+        spaces << "init"
+               << "\n");
     }
     else
     {
@@ -421,9 +422,12 @@ void goto_symex_statet::print_stack_trace(unsigned int indent) const
 
   if(!thread_ended)
   {
-    std::cout << spaces << "Next instruction to be executed:"
-              << "\n";
-    source.pc->output_instruction(ns, "", std::cout);
+    PRINT(
+      spaces << "Next instruction to be executed:"
+             << "\n");
+    std::stringstream out;
+    source.pc->output_instruction(ns, "", out);
+    PRINT(out.str());
   }
 }
 

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -30,7 +30,9 @@ void goto_tracet::output(const class namespacet &ns, std::ostream &out) const
 
 void goto_trace_stept::dump() const
 {
-  output(*migrate_namespace_lookup, std::cout);
+  std::stringstream out;
+  output(*migrate_namespace_lookup, out);
+  PRINT(out.str());
 }
 
 void goto_trace_stept::output(const namespacet &ns, std::ostream &out) const

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -58,10 +58,10 @@ void goto_trace_stept::output(const namespacet &ns, std::ostream &out) const
   if(type == ASSERT || type == ASSUME)
     out << " (" << guard << ")";
 
-  out << std::endl;
+  out << "\n";
 
   if(!pc->location.is_nil())
-    out << pc->location << std::endl;
+    out << pc->location << "\n";
 
   if(pc->is_goto())
     out << "GOTO   ";
@@ -78,7 +78,7 @@ void goto_trace_stept::output(const namespacet &ns, std::ostream &out) const
   else
     out << "(?)    ";
 
-  out << std::endl;
+  out << "\n";
 
   if(pc->is_other() || pc->is_assign())
   {
@@ -90,24 +90,25 @@ void goto_trace_stept::output(const namespacet &ns, std::ostream &out) const
       identifier = to_symbol2t(lhs).get_symbol_name();
 
     out << "  " << identifier << " = " << from_expr(ns, identifier, value)
-        << std::endl;
+        << "\n";
   }
   else if(pc->is_assert())
   {
     if(!guard)
     {
-      out << "Violated property:" << std::endl;
+      out << "Violated property:"
+          << "\n";
       if(pc->location.is_nil())
-        out << "  " << pc->location << std::endl;
+        out << "  " << pc->location << "\n";
 
       if(!comment.empty())
-        out << "  " << comment << std::endl;
-      out << "  " << from_expr(ns, "", pc->guard) << std::endl;
-      out << std::endl;
+        out << "  " << comment << "\n";
+      out << "  " << from_expr(ns, "", pc->guard) << "\n";
+      out << "\n";
     }
   }
 
-  out << std::endl;
+  out << "\n";
 }
 
 void counterexample_value(
@@ -159,7 +160,7 @@ void counterexample_value(
       }
     }
 
-    out << std::endl;
+    out << "\n";
   }
 }
 
@@ -176,12 +177,13 @@ void show_goto_trace_gui(
 
     if((step.type == goto_trace_stept::ASSERT) && !step.guard)
     {
-      out << "FAILED" << std::endl
-          << step.comment << std::endl // value
-          << std::endl                 // PC
-          << location.file() << std::endl
-          << location.line() << std::endl
-          << location.column() << std::endl;
+      out << "FAILED"
+          << "\n"
+          << step.comment << "\n" // value
+          << "\n"                 // PC
+          << location.file() << "\n"
+          << location.line() << "\n"
+          << location.column() << "\n";
     }
     else if(step.type == goto_trace_stept::ASSIGNMENT)
     {
@@ -199,14 +201,15 @@ void show_goto_trace_gui(
       if(!ns.lookup(identifier, symbol))
         base_name = symbol->name;
 
-      out << "TRACE" << std::endl;
+      out << "TRACE"
+          << "\n";
 
       out << identifier << "," << base_name << ","
-          << get_type_id(step.value->type) << "," << value_string << std::endl
-          << step.step_nr << std::endl
-          << step.pc->location.file() << std::endl
-          << step.pc->location.line() << std::endl
-          << step.pc->location.column() << std::endl;
+          << get_type_id(step.value->type) << "," << value_string << "\n"
+          << step.step_nr << "\n"
+          << step.pc->location.file() << "\n"
+          << step.pc->location.line() << "\n"
+          << step.pc->location.column() << "\n";
     }
     else if(location != previous_location)
     {
@@ -214,16 +217,18 @@ void show_goto_trace_gui(
 
       if(!location.file().empty())
       {
-        out << "TRACE" << std::endl;
+        out << "TRACE"
+            << "\n";
 
-        out << ","             // identifier
-            << ","             // base_name
-            << ","             // type
-            << "" << std::endl // value
-            << step.step_nr << std::endl
-            << location.file() << std::endl
-            << location.line() << std::endl
-            << location.column() << std::endl;
+        out << "," // identifier
+            << "," // base_name
+            << "," // type
+            << ""
+            << "\n" // value
+            << step.step_nr << "\n"
+            << location.file() << "\n"
+            << location.line() << "\n"
+            << location.column() << "\n";
       }
     }
 
@@ -237,10 +242,11 @@ void show_state_header(
   const locationt &location,
   unsigned step_nr)
 {
-  out << std::endl;
+  out << "\n";
   out << "State " << step_nr;
-  out << " " << location << " thread " << state.thread_nr << std::endl;
-  out << "----------------------------------------------------" << std::endl;
+  out << " " << location << " thread " << state.thread_nr << "\n";
+  out << "----------------------------------------------------"
+      << "\n";
 }
 
 void violation_graphml_goto_trace(
@@ -377,13 +383,14 @@ void show_goto_trace(
       if(!step.guard)
       {
         show_state_header(out, step, step.pc->location, step.step_nr);
-        out << "Violated property:" << std::endl;
+        out << "Violated property:"
+            << "\n";
         if(!step.pc->location.is_nil())
-          out << "  " << step.pc->location << std::endl;
-        out << "  " << step.comment << std::endl;
+          out << "  " << step.pc->location << "\n";
+        out << "  " << step.comment << "\n";
 
         if(step.pc->is_assert())
-          out << "  " << from_expr(ns, "", step.pc->guard) << std::endl;
+          out << "  " << from_expr(ns, "", step.pc->guard) << "\n";
 
         // Having printed a property violation, don't print more steps.
         return;
@@ -410,7 +417,7 @@ void show_goto_trace(
       printf_formattert printf_formatter;
       printf_formatter(step.format_string, step.output_args);
       printf_formatter.print(out);
-      out << std::endl;
+      out << "\n";
       break;
     }
 

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -396,8 +396,9 @@ bool reachability_treet::dfs_position::write_to_file(
   f = fopen(filename.c_str(), "wb");
   if(f == nullptr)
   {
-    std::cerr << "Couldn't open checkpoint output file"
-              << "\n";
+    ERROR(
+      "Couldn't open checkpoint output file"
+      << "\n");
     return true;
   }
 
@@ -445,8 +446,9 @@ bool reachability_treet::dfs_position::write_to_file(
   return false;
 
 fail:
-  std::cerr << "Write error writing checkpoint file"
-            << "\n";
+  ERROR(
+    "Write error writing checkpoint file"
+    << "\n");
   fclose(f);
   return true;
 }
@@ -463,8 +465,9 @@ bool reachability_treet::dfs_position::read_from_file(
   f = fopen(filename.c_str(), "rb");
   if(f == nullptr)
   {
-    std::cerr << "Couldn't open checkpoint input file"
-              << "\n";
+    ERROR(
+      "Couldn't open checkpoint input file"
+      << "\n");
     return true;
   }
 
@@ -473,8 +476,9 @@ bool reachability_treet::dfs_position::read_from_file(
 
   if(hdr.magic != htonl(file_magic))
   {
-    std::cerr << "Magic number indicates that this isn't a checkpoint file"
-              << "\n";
+    ERROR(
+      "Magic number indicates that this isn't a checkpoint file"
+      << "\n");
     fclose(f);
     return true;
   }
@@ -492,8 +496,9 @@ bool reachability_treet::dfs_position::read_from_file(
     assert(state.num_threads < 65536);
     if(state.cur_thread >= state.num_threads)
     {
-      std::cerr << "Inconsistent checkpoint data"
-                << "\n";
+      ERROR(
+        "Inconsistent checkpoint data"
+        << "\n");
       fclose(f);
       return true;
     }
@@ -516,8 +521,9 @@ bool reachability_treet::dfs_position::read_from_file(
   return false;
 
 fail:
-  std::cerr << "Read error on checkpoint file"
-            << "\n";
+  ERROR(
+    "Read error on checkpoint file"
+    << "\n");
   fclose(f);
   return true;
 }

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -531,7 +531,7 @@ void reachability_treet::print_ileave_trace() const
             << "\n";
   for(it = execution_states.begin(); it != execution_states.end(); it++, i++)
   {
-    std::cout << "Context switch point " << i << "\n";
+    PRINT("Context switch point " << i << "\n");
     (*it)->print_stack_traces(4);
   }
 }
@@ -542,8 +542,9 @@ int reachability_treet::get_ileave_direction_from_user() const
   unsigned int tid;
 
   if(get_cur_state().get_active_state().guard.is_false())
-    std::cout << "This trace's guard is false; it will not be evaulated."
-              << "\n";
+    PRINT(
+      "This trace's guard is false); it will not be evaulated."
+      << "\n");
 
   // First of all, are there actually any valid context switch targets?
   for(tid = 0; tid < get_cur_state().threads_state.size(); tid++)
@@ -556,10 +557,12 @@ int reachability_treet::get_ileave_direction_from_user() const
   if(tid == get_cur_state().threads_state.size())
     return get_cur_state().threads_state.size();
 
-  std::cout << "Context switch point encountered; please select a thread to run"
-            << "\n";
-  std::cout << "Current thread states:"
-            << "\n";
+  PRINT(
+    "Context switch point encountered; please select a thread to run"
+    << "\n");
+  PRINT(
+    "Current thread states:"
+    << "\n");
   execution_states.back()->print_stack_traces(4);
 
   while(std::cout << "Input: ", std::getline(std::cin, input))
@@ -590,7 +593,7 @@ int reachability_treet::get_ileave_direction_from_user() const
       }
       else if(tid >= get_cur_state().threads_state.size())
       {
-        std::cout << "Number out of range";
+        PRINT("Number out of range");
       }
       else
       {
@@ -602,7 +605,7 @@ int reachability_treet::get_ileave_direction_from_user() const
 
   if(std::cin.eof())
   {
-    std::cout << "\n";
+    PRINT("\n");
     exit(1);
   }
 
@@ -619,8 +622,9 @@ int reachability_treet::get_ileave_direction_from_scheduling() const
   // occur. So there's absolutely no reason exploring further.
   if(get_cur_state().get_active_state().guard.is_false())
   {
-    std::cout << "This trace's guard is false; it will not be evaulated."
-              << "\n";
+    PRINT(
+      "This trace's guard is false; it will not be evaulated."
+      << "\n");
     exit(1);
   }
 
@@ -685,7 +689,7 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
 #if 0
   if (por && !ex.is_thread_mpor_schedulable(tid)) {
     if (!quiet)
-      std::cout << "Thread unschedulable due to POR" << "\n";
+      PRINT("Thread unschedulable due to POR" << "\n");
     return false;
   }
 #endif

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -240,8 +240,8 @@ reachability_treet::decide_ileave_direction(execution_statet &ex_state)
 
   if(interactive_ileaves && tid != user_tid)
   {
-    std::cerr << "Ileave code selected different thread from user choice";
-    std::cerr << "\n";
+    ERROR("Ileave code selected different thread from user choice");
+    ERROR("\n");
   }
 
   return tid;
@@ -860,7 +860,7 @@ void reachability_treet::save_checkpoint(const std::string &&) const
 #if 0
   reachability_treet::dfs_position pos(*this);
   if (pos.write_to_file(fname))
-    std::cerr << "Couldn't save checkpoint; continuing" << "\n";
+    ERROR("Couldn't save checkpoint); continuing" << "\n";
 #endif
 
   abort();

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -241,7 +241,7 @@ reachability_treet::decide_ileave_direction(execution_statet &ex_state)
   if(interactive_ileaves && tid != user_tid)
   {
     std::cerr << "Ileave code selected different thread from user choice";
-    std::cerr << std::endl;
+    std::cerr << "\n";
   }
 
   return tid;
@@ -396,7 +396,8 @@ bool reachability_treet::dfs_position::write_to_file(
   f = fopen(filename.c_str(), "wb");
   if(f == nullptr)
   {
-    std::cerr << "Couldn't open checkpoint output file" << std::endl;
+    std::cerr << "Couldn't open checkpoint output file"
+              << "\n";
     return true;
   }
 
@@ -444,7 +445,8 @@ bool reachability_treet::dfs_position::write_to_file(
   return false;
 
 fail:
-  std::cerr << "Write error writing checkpoint file" << std::endl;
+  std::cerr << "Write error writing checkpoint file"
+            << "\n";
   fclose(f);
   return true;
 }
@@ -461,7 +463,8 @@ bool reachability_treet::dfs_position::read_from_file(
   f = fopen(filename.c_str(), "rb");
   if(f == nullptr)
   {
-    std::cerr << "Couldn't open checkpoint input file" << std::endl;
+    std::cerr << "Couldn't open checkpoint input file"
+              << "\n";
     return true;
   }
 
@@ -471,7 +474,7 @@ bool reachability_treet::dfs_position::read_from_file(
   if(hdr.magic != htonl(file_magic))
   {
     std::cerr << "Magic number indicates that this isn't a checkpoint file"
-              << std::endl;
+              << "\n";
     fclose(f);
     return true;
   }
@@ -489,7 +492,8 @@ bool reachability_treet::dfs_position::read_from_file(
     assert(state.num_threads < 65536);
     if(state.cur_thread >= state.num_threads)
     {
-      std::cerr << "Inconsistent checkpoint data" << std::endl;
+      std::cerr << "Inconsistent checkpoint data"
+                << "\n";
       fclose(f);
       return true;
     }
@@ -512,7 +516,8 @@ bool reachability_treet::dfs_position::read_from_file(
   return false;
 
 fail:
-  std::cerr << "Read error on checkpoint file" << std::endl;
+  std::cerr << "Read error on checkpoint file"
+            << "\n";
   fclose(f);
   return true;
 }
@@ -522,10 +527,11 @@ void reachability_treet::print_ileave_trace() const
   std::list<std::shared_ptr<execution_statet>>::const_iterator it;
   int i = 0;
 
-  std::cout << "Context switch trace for interleaving:" << std::endl;
+  std::cout << "Context switch trace for interleaving:"
+            << "\n";
   for(it = execution_states.begin(); it != execution_states.end(); it++, i++)
   {
-    std::cout << "Context switch point " << i << std::endl;
+    std::cout << "Context switch point " << i << "\n";
     (*it)->print_stack_traces(4);
   }
 }
@@ -537,7 +543,7 @@ int reachability_treet::get_ileave_direction_from_user() const
 
   if(get_cur_state().get_active_state().guard.is_false())
     std::cout << "This trace's guard is false; it will not be evaulated."
-              << std::endl;
+              << "\n";
 
   // First of all, are there actually any valid context switch targets?
   for(tid = 0; tid < get_cur_state().threads_state.size(); tid++)
@@ -551,15 +557,17 @@ int reachability_treet::get_ileave_direction_from_user() const
     return get_cur_state().threads_state.size();
 
   std::cout << "Context switch point encountered; please select a thread to run"
-            << std::endl;
-  std::cout << "Current thread states:" << std::endl;
+            << "\n";
+  std::cout << "Current thread states:"
+            << "\n";
   execution_states.back()->print_stack_traces(4);
 
   while(std::cout << "Input: ", std::getline(std::cin, input))
   {
     if(input == "b")
     {
-      std::cout << "Back unimplemented" << std::endl;
+      std::cout << "Back unimplemented"
+                << "\n";
     }
     else if(input == "q")
     {
@@ -577,7 +585,8 @@ int reachability_treet::get_ileave_direction_from_user() const
       tid = strtol(start, &end, 10);
       if(start == end)
       {
-        std::cout << "Not a valid input" << std::endl;
+        std::cout << "Not a valid input"
+                  << "\n";
       }
       else if(tid >= get_cur_state().threads_state.size())
       {
@@ -593,7 +602,7 @@ int reachability_treet::get_ileave_direction_from_user() const
 
   if(std::cin.eof())
   {
-    std::cout << std::endl;
+    std::cout << "\n";
     exit(1);
   }
 
@@ -611,7 +620,7 @@ int reachability_treet::get_ileave_direction_from_scheduling() const
   if(get_cur_state().get_active_state().guard.is_false())
   {
     std::cout << "This trace's guard is false; it will not be evaulated."
-              << std::endl;
+              << "\n";
     exit(1);
   }
 
@@ -653,28 +662,30 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
   {
     if(!quiet)
       std::cout << "Thread unschedulable as it's already been explored"
-                << std::endl;
+                << "\n";
     return false;
   }
 
   if(ex.threads_state.at(tid).call_stack.empty())
   {
     if(!quiet)
-      std::cout << "Thread unschedulable due to empty call stack" << std::endl;
+      std::cout << "Thread unschedulable due to empty call stack"
+                << "\n";
     return false;
   }
 
   if(ex.threads_state.at(tid).thread_ended)
   {
     if(!quiet)
-      std::cout << "That thread has ended" << std::endl;
+      std::cout << "That thread has ended"
+                << "\n";
     return false;
   }
 
 #if 0
   if (por && !ex.is_thread_mpor_schedulable(tid)) {
     if (!quiet)
-      std::cout << "Thread unschedulable due to POR" << std::endl;
+      std::cout << "Thread unschedulable due to POR" << "\n";
     return false;
   }
 #endif
@@ -682,7 +693,8 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
   if(ex.tid_is_set && ex.monitor_tid == tid)
   {
     if(!quiet)
-      std::cout << "Can't context switch to a monitor thread" << std::endl;
+      std::cout << "Can't context switch to a monitor thread"
+                << "\n";
     return false;
   }
 
@@ -815,7 +827,7 @@ bool reachability_treet::restore_from_dfs_state(void *)
 
     if (get_cur_state().threads_state.size() != it->num_threads) {
       std::cerr << "Unexpected number of threads when reexploring checkpoint"
-                << std::endl;
+                << "\n";
       abort();
     }
 
@@ -830,7 +842,7 @@ bool reachability_treet::restore_from_dfs_state(void *)
     if (get_cur_state().get_active_state().source.pc->location_number !=
         it->location_number) {
       std::cerr << "Interleave at unexpected location when restoring checkpoint"
-                << std::endl;
+                << "\n";
       abort();
     }
 #endif
@@ -844,7 +856,7 @@ void reachability_treet::save_checkpoint(const std::string &&) const
 #if 0
   reachability_treet::dfs_position pos(*this);
   if (pos.write_to_file(fname))
-    std::cerr << "Couldn't save checkpoint; continuing" << std::endl;
+    std::cerr << "Couldn't save checkpoint; continuing" << "\n";
 #endif
 
   abort();

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -527,8 +527,9 @@ void reachability_treet::print_ileave_trace() const
   std::list<std::shared_ptr<execution_statet>>::const_iterator it;
   int i = 0;
 
-  std::cout << "Context switch trace for interleaving:"
-            << "\n";
+  PRINT(
+    "Context switch trace for interleaving:"
+    << "\n");
   for(it = execution_states.begin(); it != execution_states.end(); it++, i++)
   {
     PRINT("Context switch point " << i << "\n");
@@ -565,12 +566,14 @@ int reachability_treet::get_ileave_direction_from_user() const
     << "\n");
   execution_states.back()->print_stack_traces(4);
 
-  while(std::cout << "Input: ", std::getline(std::cin, input))
+  while(std::getline(std::cin, input))
   {
+    PRINT("Input: ");
     if(input == "b")
     {
-      std::cout << "Back unimplemented"
-                << "\n";
+      PRINT(
+        "Back unimplemented"
+        << "\n");
     }
     else if(input == "q")
     {
@@ -588,8 +591,9 @@ int reachability_treet::get_ileave_direction_from_user() const
       tid = strtol(start, &end, 10);
       if(start == end)
       {
-        std::cout << "Not a valid input"
-                  << "\n";
+        PRINT(
+          "Not a valid input"
+          << "\n");
       }
       else if(tid >= get_cur_state().threads_state.size())
       {
@@ -665,24 +669,27 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
   if(ex.DFS_traversed.at(tid) == true)
   {
     if(!quiet)
-      std::cout << "Thread unschedulable as it's already been explored"
-                << "\n";
+      PRINT(
+        "Thread unschedulable as it's already been explored"
+        << "\n");
     return false;
   }
 
   if(ex.threads_state.at(tid).call_stack.empty())
   {
     if(!quiet)
-      std::cout << "Thread unschedulable due to empty call stack"
-                << "\n";
+      PRINT(
+        "Thread unschedulable due to empty call stack"
+        << "\n");
     return false;
   }
 
   if(ex.threads_state.at(tid).thread_ended)
   {
     if(!quiet)
-      std::cout << "That thread has ended"
-                << "\n";
+      PRINT(
+        "That thread has ended"
+        << "\n");
     return false;
   }
 
@@ -697,8 +704,9 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
   if(ex.tid_is_set && ex.monitor_tid == tid)
   {
     if(!quiet)
-      std::cout << "Can't context switch to a monitor thread"
-                << "\n";
+      PRINT(
+        "Can't context switch to a monitor thread"
+        << "\n");
     return false;
   }
 

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -284,7 +284,9 @@ void renaming::level2t::print(std::ostream &out) const
 
 void renaming::level2t::dump() const
 {
-  print(std::cout);
+  std::stringstream output;
+  print(output);
+  PRINT(output.str());
 }
 
 void renaming::level2t::make_assignment(

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -243,7 +243,7 @@ void renaming::renaming_levelt::get_original_name(
     return;
 
   default:
-    std::cerr << "get_original_nameing to invalid level " << lev << std::endl;
+    std::cerr << "get_original_nameing to invalid level " << lev << "\n";
     abort();
   }
 }
@@ -252,8 +252,7 @@ void renaming::level1t::print(std::ostream &out) const
 {
   for(const auto &current_name : current_names)
     out << current_name.first.base_name << " --> "
-        << "thread " << thread_id << " count " << current_name.second
-        << std::endl;
+        << "thread " << thread_id << " count " << current_name.second << "\n";
 }
 
 void renaming::level2t::print(std::ostream &out) const
@@ -272,13 +271,13 @@ void renaming::level2t::print(std::ostream &out) const
     {
       out << from_expr(
                *migrate_namespace_lookup, "", current_name.second.constant)
-          << std::endl;
+          << "\n";
     }
     else
     {
       out << "node " << current_name.second.node_id << " num "
           << current_name.second.count;
-      out << std::endl;
+      out << "\n";
     }
   }
 }

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -243,7 +243,7 @@ void renaming::renaming_levelt::get_original_name(
     return;
 
   default:
-    std::cerr << "get_original_nameing to invalid level " << lev << "\n";
+    ERROR("get_original_nameing to invalid level " << lev << "\n");
     abort();
   }
 }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -270,7 +270,7 @@ void goto_symext::symex_assign_rec(
   }
   else
   {
-    std::cerr << "assignment to " << get_expr_id(lhs) << " not handled\n";
+    ERROR("assignment to " << get_expr_id(lhs) << " not handled\n");
     abort();
   }
 }

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -73,10 +73,11 @@ bool goto_symext::symex_throw()
   last_throw = const_cast<goto_programt::instructiont *>(&instruction);
 
   // Log
-  std::cout << "*** Exception thrown of type "
-            << exceptions_thrown.begin()->as_string() << " at file "
-            << instruction.location.file() << " line "
-            << instruction.location.line() << "\n";
+  PRINT(
+    "*** Exception thrown of type "
+    << exceptions_thrown.begin()->as_string() << " at file "
+    << instruction.location.file() << " line " << instruction.location.line()
+    << "\n");
 
   // We check before iterate over the throw list to save time:
   // If there is no catch, we return an error
@@ -199,9 +200,10 @@ bool goto_symext::symex_throw()
   }
 
   // Log
-  std::cout << "*** Caught by catch(" << catch_name << ") at file "
-            << (*catch_insn)->location.file() << " line "
-            << (*catch_insn)->location.line() << "\n";
+  PRINT(
+    "*** Caught by catch(" << catch_name << ") at file "
+                           << (*catch_insn)->location.file() << " line "
+                           << (*catch_insn)->location.line() << "\n");
 
   return true;
 }

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -76,7 +76,7 @@ bool goto_symext::symex_throw()
   std::cout << "*** Exception thrown of type "
             << exceptions_thrown.begin()->as_string() << " at file "
             << instruction.location.file() << " line "
-            << instruction.location.line() << std::endl;
+            << instruction.location.line() << "\n";
 
   // We check before iterate over the throw list to save time:
   // If there is no catch, we return an error
@@ -201,7 +201,7 @@ bool goto_symext::symex_throw()
   // Log
   std::cout << "*** Caught by catch(" << catch_name << ") at file "
             << (*catch_insn)->location.file() << " line "
-            << (*catch_insn)->location.line() << std::endl;
+            << (*catch_insn)->location.line() << "\n";
 
   return true;
 }

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -52,7 +52,7 @@ bool goto_symext::get_unwind_recursion(
     if(this_loop_max_unwind != 0)
       msg += " (" + integer2string(this_loop_max_unwind) + " max)";
 
-    std::cout << msg << "\n";
+    PRINT(msg << "\n");
   }
 
   return this_loop_max_unwind != 0 && unwind >= this_loop_max_unwind;
@@ -198,7 +198,7 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   {
     if(has_prefix(identifier.as_string(), "symex::invalid_object"))
     {
-      std::cout << "WARNING: function ptr call with no target, ";
+      PRINT("WARNING: function ptr call with no target, ");
       cur_state->source.pc++;
       return;
     }

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -362,8 +362,8 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
   // merge.
   if(is_nil_expr(call.function))
   {
-    std::cerr << "Function pointer call with no targets; irep: ";
-    std::cerr << call.pretty(0) << "\n";
+    ERROR("Function pointer call with no targets; irep: ");
+    ERROR(call.pretty(0) << "\n");
     abort();
   }
 
@@ -419,7 +419,7 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
 
     if(fit == goto_functions.function_map.end() || !fit->second.body_available)
     {
-      std::cerr << "**** WARNING: no body for function " << pretty_name << '\n';
+      ERROR("**** WARNING: no body for function " << pretty_name << '\n');
 
       continue; // XXX, find out why this fires on SV-COMP 14 benchmark
       // 32_7a_cilled_true_linux-3.8-rc1-drivers--ata--pata_legacy.ko-main.cil.out.c

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -52,7 +52,7 @@ bool goto_symext::get_unwind_recursion(
     if(this_loop_max_unwind != 0)
       msg += " (" + integer2string(this_loop_max_unwind) + " max)";
 
-    std::cout << msg << std::endl;
+    std::cout << msg << "\n";
   }
 
   return this_loop_max_unwind != 0 && unwind >= this_loop_max_unwind;
@@ -73,7 +73,8 @@ unsigned goto_symext::argument_assignments(
     // if you run out of actual arguments there was a mismatch
     if(it1 == arguments.end())
     {
-      std::cerr << "function call: not enough arguments" << std::endl;
+      std::cerr << "function call: not enough arguments"
+                << "\n";
       abort();
     }
 
@@ -150,7 +151,8 @@ unsigned goto_symext::argument_assignments(
 
       if(new_context.move(symbol))
       {
-        std::cerr << "Couldn't add new va_arg symbol" << std::endl;
+        std::cerr << "Couldn't add new va_arg symbol"
+                  << "\n";
         abort();
       }
 
@@ -285,7 +287,8 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   {
     std::cerr << "Function call to \"" << identifier << "\": number of "
               << "arguments doesn't match type definition; some inconsistent "
-              << "rewriting occured" << std::endl;
+              << "rewriting occured"
+              << "\n";
     abort();
   }
 
@@ -340,7 +343,8 @@ get_function_list(const expr2tc &expr)
     return get_function_list(to_typecast2t(expr).from);
 
   std::cerr << "Unexpected irep id " << get_expr_id(expr)
-            << " in function ptr dereference" << std::endl;
+            << " in function ptr dereference"
+            << "\n";
   // So, the function may point at something invalid. If that's the case,
   // wait for a solve-time pointer validity assertion to detect that. Return
   // nothing to call right now.
@@ -359,7 +363,7 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
   if(is_nil_expr(call.function))
   {
     std::cerr << "Function pointer call with no targets; irep: ";
-    std::cerr << call.pretty(0) << std::endl;
+    std::cerr << call.pretty(0) << "\n";
     abort();
   }
 
@@ -379,7 +383,7 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
     // Emit warning; perform no function call behaviour. Increment PC
     // XXX jmorse - no location information any more.
     std::cout << "No target candidate for function call "
-              << from_expr(ns, "", call.function) << std::endl;
+              << from_expr(ns, "", call.function) << "\n";
     cur_state->source.pc++;
     return;
   }
@@ -574,7 +578,8 @@ bool goto_symext::make_return_assignment(expr2tc &assign, const expr2tc &code)
   }
   else if(!is_nil_expr(frame.return_value))
   {
-    std::cerr << "return with unexpected value" << std::endl;
+    std::cerr << "return with unexpected value"
+              << "\n";
     abort();
   }
 

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -37,8 +37,9 @@ bool goto_symext::get_unwind_recursion(
       (k_induction || inductive_step) &&
       !options.get_bool_option("disable-inductive-step"))
     {
-      std::cout << "**** WARNING: k-induction does not support recursion yet. "
-                << "Disabling inductive step\n";
+      PRINT(
+        "**** WARNING: k-induction does not support recursion yet. "
+        << "Disabling inductive step\n");
 
       // Disable inductive step on recursion
       options.set_option("disable-inductive-step", true);
@@ -382,8 +383,9 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
   {
     // Emit warning; perform no function call behaviour. Increment PC
     // XXX jmorse - no location information any more.
-    std::cout << "No target candidate for function call "
-              << from_expr(ns, "", call.function) << "\n";
+    PRINT(
+      "No target candidate for function call "
+      << from_expr(ns, "", call.function) << "\n");
     cur_state->source.pc++;
     return;
   }

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -74,8 +74,9 @@ unsigned goto_symext::argument_assignments(
     // if you run out of actual arguments there was a mismatch
     if(it1 == arguments.end())
     {
-      std::cerr << "function call: not enough arguments"
-                << "\n";
+      ERROR(
+        "function call: not enough arguments"
+        << "\n");
       abort();
     }
 
@@ -109,9 +110,11 @@ unsigned goto_symext::argument_assignments(
         }
         else
         {
-          std::cerr << "function call: argument \"" << id2string(identifier)
-                    << "\" type mismatch: got " << get_type_id((*it1)->type)
-                    << ", expected " << get_type_id(arg_type) << '\n';
+          ERROR(
+            "function call: argument \""
+            << id2string(identifier) << "\" type mismatch: got "
+            << get_type_id((*it1)->type) << ", expected "
+            << get_type_id(arg_type) << '\n');
           abort();
         }
       }
@@ -152,8 +155,9 @@ unsigned goto_symext::argument_assignments(
 
       if(new_context.move(symbol))
       {
-        std::cerr << "Couldn't add new va_arg symbol"
-                  << "\n";
+        ERROR(
+          "Couldn't add new va_arg symbol"
+          << "\n");
         abort();
       }
 
@@ -204,8 +208,9 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
       return;
     }
 
-    std::cerr << "failed to find `" + get_pretty_name(identifier.as_string()) +
-                   "' in function_map";
+    ERROR(
+      "failed to find `" + get_pretty_name(identifier.as_string()) +
+      "' in function_map");
     abort();
   }
 
@@ -234,8 +239,9 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
 
   if(!goto_function.body_available)
   {
-    std::cerr << "**** WARNING: no body for function "
-              << get_pretty_name(identifier.as_string()) << '\n';
+    ERROR(
+      "**** WARNING: no body for function "
+      << get_pretty_name(identifier.as_string()) << '\n');
 
     if(!is_nil_expr(call.ret))
     {
@@ -286,10 +292,12 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
     to_code_type(tmp_type).arguments.size() != arguments.size() &&
     !to_code_type(tmp_type).ellipsis)
   {
-    std::cerr << "Function call to \"" << identifier << "\": number of "
-              << "arguments doesn't match type definition; some inconsistent "
-              << "rewriting occured"
-              << "\n";
+    ERROR(
+      "Function call to \""
+      << identifier << "\": number of "
+      << "arguments doesn't match type definition; some inconsistent "
+      << "rewriting occured"
+      << "\n");
     abort();
   }
 
@@ -343,9 +351,9 @@ get_function_list(const expr2tc &expr)
   if(is_typecast2t(expr))
     return get_function_list(to_typecast2t(expr).from);
 
-  std::cerr << "Unexpected irep id " << get_expr_id(expr)
-            << " in function ptr dereference"
-            << "\n";
+  ERROR(
+    "Unexpected irep id " << get_expr_id(expr) << " in function ptr dereference"
+                          << "\n");
   // So, the function may point at something invalid. If that's the case,
   // wait for a solve-time pointer validity assertion to detect that. Return
   // nothing to call right now.
@@ -580,8 +588,9 @@ bool goto_symext::make_return_assignment(expr2tc &assign, const expr2tc &code)
   }
   else if(!is_nil_expr(frame.return_value))
   {
-    std::cerr << "return with unexpected value"
-              << "\n";
+    ERROR(
+      "return with unexpected value"
+      << "\n");
     abort();
   }
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -455,10 +455,11 @@ bool goto_symext::get_unwind(
     this_loop_max_unwind != 0 && unwind >= this_loop_max_unwind;
   if(!options.get_bool_option("quiet"))
   {
-    std::cout << (stop_unwind ? "Not unwinding " : "Unwinding ")
-              << "loop " + i2string(cur_state->source.pc->loop_number)
-              << " iteration " + integer2string(unwind) + " "
-              << cur_state->source.pc->location.as_string() << '\n';
+    PRINT(
+      (stop_unwind ? "Not unwinding " : "Unwinding ")
+      << "loop " + i2string(cur_state->source.pc->loop_number)
+      << " iteration " + integer2string(unwind) + " "
+      << cur_state->source.pc->location.as_string() << '\n');
   }
 
   return stop_unwind;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -294,8 +294,9 @@ void goto_symext::symex_step(reachability_treet &art)
 
   default:
     ERROR("GOTO instruction type " << instruction.type);
-    std::cerr << " not handled in goto_symext::symex_step"
-              << "\n";
+    ERROR(
+      " not handled in goto_symext::symex_step"
+      << "\n");
     abort();
   }
 }
@@ -495,8 +496,9 @@ void goto_symext::run_intrinsic(
   {
     ERROR("Function call to non-intrinsic prefixed with __ESBMC");
     ERROR(" (fatal)\nThe name in question: " << symname);
-    std::cerr << "\n(NB: the C spec reserves the __ prefix for the compiler"
-                 " and environment)\n";
+    ERROR(
+      "\n(NB: the C spec reserves the __ prefix for the compiler"
+      " and environment)\n");
     abort();
   }
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -294,7 +294,8 @@ void goto_symext::symex_step(reachability_treet &art)
 
   default:
     std::cerr << "GOTO instruction type " << instruction.type;
-    std::cerr << " not handled in goto_symext::symex_step" << std::endl;
+    std::cerr << " not handled in goto_symext::symex_step"
+              << "\n";
     abort();
   }
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -293,7 +293,7 @@ void goto_symext::symex_step(reachability_treet &art)
     break;
 
   default:
-    std::cerr << "GOTO instruction type " << instruction.type;
+    ERROR("GOTO instruction type " << instruction.type);
     std::cerr << " not handled in goto_symext::symex_step"
               << "\n";
     abort();
@@ -493,8 +493,8 @@ void goto_symext::run_intrinsic(
   }
   else
   {
-    std::cerr << "Function call to non-intrinsic prefixed with __ESBMC";
-    std::cerr << " (fatal)\nThe name in question: " << symname;
+    ERROR("Function call to non-intrinsic prefixed with __ESBMC");
+    ERROR(" (fatal)\nThe name in question: " << symname);
     std::cerr << "\n(NB: the C spec reserves the __ prefix for the compiler"
                  " and environment)\n";
     abort();

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -164,7 +164,7 @@ void symex_target_equationt::convert_internal_step(
   if(ssa_trace)
   {
     step.output(ns, std::cout);
-    std::cout << std::endl;
+    std::cout << "\n";
   }
 
   step.guard_ast = smt_conv.convert_ast(step.guard);
@@ -177,7 +177,7 @@ void symex_target_equationt::convert_internal_step(
     if(ssa_smt_trace)
     {
       step.cond_ast->dump();
-      std::cout << std::endl;
+      std::cout << "\n";
     }
   }
   else if(step.is_assignment())
@@ -186,7 +186,7 @@ void symex_target_equationt::convert_internal_step(
     if(ssa_smt_trace)
     {
       assign->dump();
-      std::cout << std::endl;
+      std::cout << "\n";
     }
   }
   else if(step.is_output())
@@ -235,7 +235,8 @@ void symex_target_equationt::output(std::ostream &out) const
   for(const auto &SSA_step : SSA_steps)
   {
     SSA_step.output(ns, out);
-    out << "--------------" << std::endl;
+    out << "--------------"
+        << "\n";
   }
 }
 
@@ -262,21 +263,24 @@ void symex_target_equationt::SSA_stept::output(
     out << "Thread " << source.thread_nr;
 
     if(source.pc->location.is_not_nil())
-      out << " " << source.pc->location << std::endl;
+      out << " " << source.pc->location << "\n";
     else
-      out << std::endl;
+      out << "\n";
   }
 
   switch(type)
   {
   case goto_trace_stept::ASSERT:
-    out << "ASSERT" << std::endl;
+    out << "ASSERT"
+        << "\n";
     break;
   case goto_trace_stept::ASSUME:
-    out << "ASSUME" << std::endl;
+    out << "ASSUME"
+        << "\n";
     break;
   case goto_trace_stept::OUTPUT:
-    out << "OUTPUT" << std::endl;
+    out << "OUTPUT"
+        << "\n";
     break;
 
   case goto_trace_stept::ASSIGNMENT:
@@ -289,14 +293,13 @@ void symex_target_equationt::SSA_stept::output(
   }
 
   if(is_assert() || is_assume() || is_assignment())
-    out << from_expr(ns, "", migrate_expr_back(cond)) << std::endl;
+    out << from_expr(ns, "", migrate_expr_back(cond)) << "\n";
 
   if(is_assert())
-    out << comment << std::endl;
+    out << comment << "\n";
 
   if(config.options.get_bool_option("ssa-guards"))
-    out << "Guard: " << from_expr(ns, "", migrate_expr_back(guard))
-        << std::endl;
+    out << "Guard: " << from_expr(ns, "", migrate_expr_back(guard)) << "\n";
 }
 
 void symex_target_equationt::SSA_stept::short_output(
@@ -306,11 +309,11 @@ void symex_target_equationt::SSA_stept::short_output(
 {
   if((is_assignment() || is_assert() || is_assume()) && show_ignored == ignore)
   {
-    out << from_expr(ns, "", cond) << std::endl;
+    out << from_expr(ns, "", cond) << "\n";
   }
   else if(is_renumber())
   {
-    out << "renumber: " << from_expr(ns, "", lhs) << std::endl;
+    out << "renumber: " << from_expr(ns, "", lhs) << "\n";
   }
 }
 
@@ -352,11 +355,13 @@ void symex_target_equationt::check_for_duplicate_assigns() const
     if(it->second != 1)
     {
       std::cerr << "Symbol \"" << it->first << "\" appears " << it->second
-                << " times" << std::endl;
+                << " times"
+                << "\n";
     }
   }
 
-  std::cerr << "Checked " << i << " insns" << std::endl;
+  std::cerr << "Checked " << i << " insns"
+            << "\n";
 }
 
 unsigned int symex_target_equationt::clear_assertions()
@@ -516,7 +521,8 @@ tvt runtime_encoded_equationt::ask_solver_question(const expr2tc &question)
     res1 == smt_convt::P_ERROR || res1 == smt_convt::P_SMTLIB ||
     res2 == smt_convt::P_ERROR || res2 == smt_convt::P_SMTLIB)
   {
-    std::cerr << "Solver returned error while asking question" << std::endl;
+    std::cerr << "Solver returned error while asking question"
+              << "\n";
     abort();
   }
   else if(res1 == smt_convt::P_SATISFIABLE && res2 == smt_convt::P_SATISFIABLE)

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -46,7 +46,11 @@ void symex_target_equationt::assignment(
   SSA_step.loop_number = loop_number;
 
   if(debug_print)
-    SSA_step.output(ns, std::cout);
+  {
+    std::stringstream output;
+    SSA_step.output(ns, output);
+    PRINT(output.str());
+  }
 }
 
 void symex_target_equationt::output(
@@ -65,7 +69,11 @@ void symex_target_equationt::output(
   SSA_step.format_string = fmt;
 
   if(debug_print)
-    SSA_step.output(ns, std::cout);
+  {
+    std::stringstream output;
+    SSA_step.output(ns, output);
+    PRINT(output.str());
+  }
 }
 
 void symex_target_equationt::assumption(
@@ -84,7 +92,11 @@ void symex_target_equationt::assumption(
   SSA_step.loop_number = loop_number;
 
   if(debug_print)
-    SSA_step.output(ns, std::cout);
+  {
+    std::stringstream output;
+    SSA_step.output(ns, output);
+    PRINT(output.str());
+  }
 }
 
 void symex_target_equationt::assertion(
@@ -107,7 +119,11 @@ void symex_target_equationt::assertion(
   SSA_step.loop_number = loop_number;
 
   if(debug_print)
-    SSA_step.output(ns, std::cout);
+  {
+    std::stringstream output;
+    SSA_step.output(ns, output);
+    PRINT(output.str());
+  }
 }
 
 void symex_target_equationt::renumber(
@@ -128,7 +144,11 @@ void symex_target_equationt::renumber(
   SSA_step.source = source;
 
   if(debug_print)
-    SSA_step.output(ns, std::cout);
+  {
+    std::stringstream output;
+    SSA_step.output(ns, output);
+    PRINT(output.str());
+  }
 }
 
 void symex_target_equationt::convert(smt_convt &smt_conv)
@@ -163,7 +183,9 @@ void symex_target_equationt::convert_internal_step(
 
   if(ssa_trace)
   {
-    step.output(ns, std::cout);
+    std::stringstream output;
+    step.output(ns, output);
+    PRINT(output.str());
     PRINT("\n");
   }
 
@@ -251,7 +273,9 @@ void symex_target_equationt::short_output(std::ostream &out, bool show_ignored)
 
 void symex_target_equationt::SSA_stept::dump() const
 {
-  output(*migrate_namespace_lookup, std::cout);
+  std::stringstream out;
+  output(*migrate_namespace_lookup, out);
+  PRINT(out.str());
 }
 
 void symex_target_equationt::SSA_stept::output(

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -378,14 +378,15 @@ void symex_target_equationt::check_for_duplicate_assigns() const
   {
     if(it->second != 1)
     {
-      std::cerr << "Symbol \"" << it->first << "\" appears " << it->second
-                << " times"
-                << "\n";
+      ERROR(
+        "Symbol \"" << it->first << "\" appears " << it->second << " times"
+                    << "\n");
     }
   }
 
-  std::cerr << "Checked " << i << " insns"
-            << "\n";
+  ERROR(
+    "Checked " << i << " insns"
+               << "\n");
 }
 
 unsigned int symex_target_equationt::clear_assertions()
@@ -545,8 +546,9 @@ tvt runtime_encoded_equationt::ask_solver_question(const expr2tc &question)
     res1 == smt_convt::P_ERROR || res1 == smt_convt::P_SMTLIB ||
     res2 == smt_convt::P_ERROR || res2 == smt_convt::P_SMTLIB)
   {
-    std::cerr << "Solver returned error while asking question"
-              << "\n";
+    ERROR(
+      "Solver returned error while asking question"
+      << "\n");
     abort();
   }
   else if(res1 == smt_convt::P_SATISFIABLE && res2 == smt_convt::P_SATISFIABLE)

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -164,7 +164,7 @@ void symex_target_equationt::convert_internal_step(
   if(ssa_trace)
   {
     step.output(ns, std::cout);
-    std::cout << "\n";
+    PRINT("\n");
   }
 
   step.guard_ast = smt_conv.convert_ast(step.guard);
@@ -177,7 +177,7 @@ void symex_target_equationt::convert_internal_step(
     if(ssa_smt_trace)
     {
       step.cond_ast->dump();
-      std::cout << "\n";
+      PRINT("\n");
     }
   }
   else if(step.is_assignment())
@@ -186,7 +186,7 @@ void symex_target_equationt::convert_internal_step(
     if(ssa_smt_trace)
     {
       assign->dump();
-      std::cout << "\n";
+      PRINT("\n");
     }
   }
   else if(step.is_output())

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -79,7 +79,8 @@ bool language_uit::parse(const std::string &filename)
   if(language.parse(filename, *get_message_handler()))
   {
     if(get_ui() == ui_message_handlert::PLAIN)
-      std::cerr << "PARSING ERROR" << std::endl;
+      std::cerr << "PARSING ERROR"
+                << "\n";
 
     return true;
   }
@@ -99,7 +100,8 @@ bool language_uit::typecheck()
   if(language_files.typecheck(context))
   {
     if(get_ui() == ui_message_handlert::PLAIN)
-      std::cerr << "CONVERSION ERROR" << std::endl;
+      std::cerr << "CONVERSION ERROR"
+                << "\n";
 
     return true;
   }
@@ -115,7 +117,8 @@ bool language_uit::final()
   if(language_files.final(context))
   {
     if(get_ui() == ui_message_handlert::PLAIN)
-      std::cerr << "CONVERSION ERROR" << std::endl;
+      std::cerr << "CONVERSION ERROR"
+                << "\n";
 
     return true;
   }

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -79,8 +79,9 @@ bool language_uit::parse(const std::string &filename)
   if(language.parse(filename, *get_message_handler()))
   {
     if(get_ui() == ui_message_handlert::PLAIN)
-      std::cerr << "PARSING ERROR"
-                << "\n";
+      ERROR(
+        "PARSING ERROR"
+        << "\n");
 
     return true;
   }
@@ -100,8 +101,9 @@ bool language_uit::typecheck()
   if(language_files.typecheck(context))
   {
     if(get_ui() == ui_message_handlert::PLAIN)
-      std::cerr << "CONVERSION ERROR"
-                << "\n";
+      ERROR(
+        "CONVERSION ERROR"
+        << "\n");
 
     return true;
   }
@@ -117,8 +119,9 @@ bool language_uit::final()
   if(language_files.final(context))
   {
     if(get_ui() == ui_message_handlert::PLAIN)
-      std::cerr << "CONVERSION ERROR"
-                << "\n";
+      ERROR(
+        "CONVERSION ERROR"
+        << "\n");
 
     return true;
   }

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -131,8 +131,12 @@ void language_uit::show_symbol_table()
   switch(get_ui())
   {
   case ui_message_handlert::PLAIN:
-    show_symbol_table_plain(std::cout);
-    break;
+  {
+    std::stringstream out;
+    show_symbol_table_plain(out);
+    PRINT(out.str());
+  }
+  break;
 
   case ui_message_handlert::XML_UI:
     show_symbol_table_xml_ui();

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -417,7 +417,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     else
     {
       std::cerr << "Unexpected expression in dereference_expr_nonscalar"
-                << std::endl;
+                << "\n";
       expr->dump();
       abort();
     }
@@ -818,14 +818,15 @@ void dereferencet::build_reference_rec(
   {
     std::cerr
       << "Can't construct rvalue reference to array type during dereference";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     std::cerr << "(It isn't allowed by C anyway)";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
   else
   {
-    std::cerr << "Unrecognized dest type during dereference" << std::endl;
+    std::cerr << "Unrecognized dest type during dereference"
+              << "\n";
     type->dump();
     abort();
   }
@@ -834,7 +835,8 @@ void dereferencet::build_reference_rec(
     flags |= flag_src_struct;
   else if(is_union_type(value))
   {
-    std::cerr << "Dereference target of type union is now illegal" << std::endl;
+    std::cerr << "Dereference target of type union is now illegal"
+              << "\n";
     abort();
   }
   else if(is_scalar_type(value))
@@ -843,7 +845,8 @@ void dereferencet::build_reference_rec(
     flags |= flag_src_array;
   else
   {
-    std::cerr << "Unrecognized src type during dereference" << std::endl;
+    std::cerr << "Unrecognized src type during dereference"
+              << "\n";
     value->type->dump();
     abort();
   }
@@ -938,7 +941,8 @@ void dereferencet::build_reference_rec(
 
   // No scope for constructing references to arrays
   default:
-    std::cerr << "Unrecognized input to build_reference_rec" << std::endl;
+    std::cerr << "Unrecognized input to build_reference_rec"
+              << "\n";
     abort();
   }
 }
@@ -1483,7 +1487,8 @@ void dereferencet::construct_struct_ref_from_const_offset(
   }
 
   std::cerr << "Unexpectedly " << get_type_id(value->type) << " type'd";
-  std::cerr << " argument to construct_struct_ref" << std::endl;
+  std::cerr << " argument to construct_struct_ref"
+            << "\n";
   abort();
 }
 

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -416,8 +416,9 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     }
     else
     {
-      std::cerr << "Unexpected expression in dereference_expr_nonscalar"
-                << "\n";
+      ERROR(
+        "Unexpected expression in dereference_expr_nonscalar"
+        << "\n");
       expr->dump();
       abort();
     }
@@ -816,8 +817,7 @@ void dereferencet::build_reference_rec(
     flags |= flag_dst_scalar;
   else if(is_array_type(type) || is_string_type(type))
   {
-    std::cerr
-      << "Can't construct rvalue reference to array type during dereference";
+    ERROR("Can't construct rvalue reference to array type during dereference");
     ERROR("\n");
     ERROR("(It isn't allowed by C anyway)");
     ERROR("\n");
@@ -825,8 +825,9 @@ void dereferencet::build_reference_rec(
   }
   else
   {
-    std::cerr << "Unrecognized dest type during dereference"
-              << "\n";
+    ERROR(
+      "Unrecognized dest type during dereference"
+      << "\n");
     type->dump();
     abort();
   }
@@ -835,8 +836,9 @@ void dereferencet::build_reference_rec(
     flags |= flag_src_struct;
   else if(is_union_type(value))
   {
-    std::cerr << "Dereference target of type union is now illegal"
-              << "\n";
+    ERROR(
+      "Dereference target of type union is now illegal"
+      << "\n");
     abort();
   }
   else if(is_scalar_type(value))
@@ -845,8 +847,9 @@ void dereferencet::build_reference_rec(
     flags |= flag_src_array;
   else
   {
-    std::cerr << "Unrecognized src type during dereference"
-              << "\n";
+    ERROR(
+      "Unrecognized src type during dereference"
+      << "\n");
     value->type->dump();
     abort();
   }
@@ -941,8 +944,9 @@ void dereferencet::build_reference_rec(
 
   // No scope for constructing references to arrays
   default:
-    std::cerr << "Unrecognized input to build_reference_rec"
-              << "\n";
+    ERROR(
+      "Unrecognized input to build_reference_rec"
+      << "\n");
     abort();
   }
 }
@@ -1487,8 +1491,9 @@ void dereferencet::construct_struct_ref_from_const_offset(
   }
 
   ERROR("Unexpectedly " << get_type_id(value->type) << " type'd");
-  std::cerr << " argument to construct_struct_ref"
-            << "\n";
+  ERROR(
+    " argument to construct_struct_ref"
+    << "\n");
   abort();
 }
 

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -614,7 +614,7 @@ expr2tc dereferencet::build_reference_to(
 
   if(!is_object_descriptor2t(what))
   {
-    std::cerr << "unknown points-to: " << get_expr_id(what);
+    ERROR("unknown points-to: " << get_expr_id(what));
     abort();
   }
 
@@ -818,9 +818,9 @@ void dereferencet::build_reference_rec(
   {
     std::cerr
       << "Can't construct rvalue reference to array type during dereference";
-    std::cerr << "\n";
-    std::cerr << "(It isn't allowed by C anyway)";
-    std::cerr << "\n";
+    ERROR("\n");
+    ERROR("(It isn't allowed by C anyway)");
+    ERROR("\n");
     abort();
   }
   else
@@ -1486,7 +1486,7 @@ void dereferencet::construct_struct_ref_from_const_offset(
     return;
   }
 
-  std::cerr << "Unexpectedly " << get_type_id(value->type) << " type'd";
+  ERROR("Unexpectedly " << get_type_id(value->type) << " type'd");
   std::cerr << " argument to construct_struct_ref"
             << "\n";
   abort();

--- a/src/pointer-analysis/show_value_sets.cpp
+++ b/src/pointer-analysis/show_value_sets.cpp
@@ -19,7 +19,7 @@ void show_value_sets(
   {
     xmlt xml;
     convert(goto_functions, value_set_analysis, xml);
-    std::cout << xml << std::endl;
+    std::cout << xml << "\n";
   }
   break;
 
@@ -42,7 +42,7 @@ void show_value_sets(
   {
     xmlt xml;
     convert(goto_program, value_set_analysis, xml);
-    std::cout << xml << std::endl;
+    std::cout << xml << "\n";
   }
   break;
 

--- a/src/pointer-analysis/show_value_sets.cpp
+++ b/src/pointer-analysis/show_value_sets.cpp
@@ -19,7 +19,7 @@ void show_value_sets(
   {
     xmlt xml;
     convert(goto_functions, value_set_analysis, xml);
-    std::cout << xml << "\n";
+    PRINT(xml << "\n");
   }
   break;
 
@@ -42,7 +42,7 @@ void show_value_sets(
   {
     xmlt xml;
     convert(goto_program, value_set_analysis, xml);
-    std::cout << xml << "\n";
+    PRINT(xml << "\n");
   }
   break;
 

--- a/src/pointer-analysis/show_value_sets.cpp
+++ b/src/pointer-analysis/show_value_sets.cpp
@@ -24,8 +24,12 @@ void show_value_sets(
   break;
 
   case ui_message_handlert::PLAIN:
-    value_set_analysis.output(goto_functions, std::cout);
-    break;
+  {
+    std::stringstream out;
+    value_set_analysis.output(goto_functions, out);
+    PRINT(out.str());
+  }
+  break;
 
   default:;
   }
@@ -47,8 +51,12 @@ void show_value_sets(
   break;
 
   case ui_message_handlert::PLAIN:
-    value_set_analysis.output(goto_program, std::cout);
-    break;
+  {
+    std::stringstream out;
+    value_set_analysis.output(goto_program, out);
+    PRINT(out.str());
+  }
+  break;
 
   default:;
   }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -580,8 +580,9 @@ void value_sett::get_value_set_rec(
         else
         {
           ERROR("Pointer arithmetic on type where we can't determine ");
-          std::cerr << "size:"
-                    << "\n";
+          ERROR(
+            "size:"
+            << "\n");
           ERROR(subtype->pretty(0) << "\n");
           abort();
         }
@@ -1354,8 +1355,9 @@ void value_sett::apply_code(const expr2tc &code)
   else
   {
     ERROR(code->pretty() << "\n");
-    std::cerr << "value_sett: unexpected statement"
-              << "\n";
+    ERROR(
+      "value_sett: unexpected statement"
+      << "\n");
     abort();
   }
 }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -107,7 +107,8 @@ void value_sett::output(std::ostream &out) const
       }
     }
 
-    out << " } " << std::endl;
+    out << " } "
+        << "\n";
   }
 }
 
@@ -374,7 +375,7 @@ void value_sett::get_value_set_rec(
       return;
 
     default:
-      std::cerr << "Unexpected side-effect: " << expr->pretty(0) << std::endl;
+      std::cerr << "Unexpected side-effect: " << expr->pretty(0) << "\n";
       abort();
     }
   }
@@ -579,8 +580,9 @@ void value_sett::get_value_set_rec(
         else
         {
           std::cerr << "Pointer arithmetic on type where we can't determine ";
-          std::cerr << "size:" << std::endl;
-          std::cerr << subtype->pretty(0) << std::endl;
+          std::cerr << "size:"
+                    << "\n";
+          std::cerr << subtype->pretty(0) << "\n";
           abort();
         }
       }
@@ -1351,8 +1353,9 @@ void value_sett::apply_code(const expr2tc &code)
   }
   else
   {
-    std::cerr << code->pretty() << std::endl;
-    std::cerr << "value_sett: unexpected statement" << std::endl;
+    std::cerr << code->pretty() << "\n";
+    std::cerr << "value_sett: unexpected statement"
+              << "\n";
     abort();
   }
 }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -375,7 +375,7 @@ void value_sett::get_value_set_rec(
       return;
 
     default:
-      std::cerr << "Unexpected side-effect: " << expr->pretty(0) << "\n";
+      ERROR("Unexpected side-effect: " << expr->pretty(0) << "\n");
       abort();
     }
   }
@@ -579,10 +579,10 @@ void value_sett::get_value_set_rec(
         }
         else
         {
-          std::cerr << "Pointer arithmetic on type where we can't determine ";
+          ERROR("Pointer arithmetic on type where we can't determine ");
           std::cerr << "size:"
                     << "\n";
-          std::cerr << subtype->pretty(0) << "\n";
+          ERROR(subtype->pretty(0) << "\n");
           abort();
         }
       }
@@ -1206,7 +1206,7 @@ void value_sett::assign_rec(
   }
   else
   {
-    std::cerr << "assign NYI: `" + get_expr_id(lhs) + "'\n";
+    ERROR("assign NYI: `" + get_expr_id(lhs) + "'\n");
     abort();
   }
 }
@@ -1353,7 +1353,7 @@ void value_sett::apply_code(const expr2tc &code)
   }
   else
   {
-    std::cerr << code->pretty() << "\n";
+    ERROR(code->pretty() << "\n");
     std::cerr << "value_sett: unexpected statement"
               << "\n";
     abort();

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1406,7 +1406,9 @@ value_sett::make_member(const expr2tc &src, const irep_idt &component_name)
 
 void value_sett::dump() const
 {
-  output(std::cout);
+  std::stringstream out;
+  output(out);
+  PRINT(out.str());
 }
 
 void value_sett::obj_numbering_ref(unsigned int num)

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -813,7 +813,7 @@ void bitwuzla_convt::dump_smt()
 void bitw_smt_ast::dump() const
 {
   bitwuzla_term_dump(a, "smt2", stdout);
-  std::cout << std::flush;
+  PRINT(std::flush);
 }
 
 void bitwuzla_convt::print_model()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -529,15 +529,17 @@ smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
 
 smt_astt bitwuzla_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
-  std::cerr << "ESBMC can't create integer sorts with Bitwuzla yet"
-            << "\n";
+  ERROR(
+    "ESBMC can't create integer sorts with Bitwuzla yet"
+    << "\n");
   abort();
 }
 
 smt_astt bitwuzla_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
-  std::cerr << "ESBMC can't create real sorts with Bitwuzla yet"
-            << "\n";
+  ERROR(
+    "ESBMC can't create real sorts with Bitwuzla yet"
+    << "\n");
   abort();
 }
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -5,8 +5,8 @@
 
 void bitwuzla_error_handler(const char *msg)
 {
-  std::cerr << "Bitwuzla error encountered\n";
-  std::cerr << msg << '\n';
+  ERROR("Bitwuzla error encountered\n");
+  ERROR(msg << '\n');
   abort();
 }
 
@@ -589,7 +589,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
     break;
 
   default:
-    std::cerr << "Unknown type for symbol\n";
+    ERROR("Unknown type for symbol\n");
     abort();
   }
 
@@ -674,7 +674,7 @@ bool bitwuzla_convt::get_bool(smt_astt a)
     res = false;
     break;
   default:
-    std::cerr << "Can't get boolean value from Bitwuzla\n";
+    ERROR("Can't get boolean value from Bitwuzla\n");
     abort();
   }
   return res;

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -530,13 +530,14 @@ smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
 smt_astt bitwuzla_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
   std::cerr << "ESBMC can't create integer sorts with Bitwuzla yet"
-            << std::endl;
+            << "\n";
   abort();
 }
 
 smt_astt bitwuzla_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
-  std::cerr << "ESBMC can't create real sorts with Bitwuzla yet" << std::endl;
+  std::cerr << "ESBMC can't create real sorts with Bitwuzla yet"
+            << "\n";
   abort();
 }
 

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -5,8 +5,8 @@
 
 void error_handler(const char *msg)
 {
-  std::cerr << "Boolector error encountered\n";
-  std::cerr << msg << '\n';
+  ERROR("Boolector error encountered\n");
+  ERROR(msg << '\n');
   abort();
 }
 
@@ -563,7 +563,7 @@ boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
     break;
 
   default:
-    std::cerr << "Unknown type for symbol\n";
+    ERROR("Unknown type for symbol\n");
     abort();
   }
 
@@ -642,7 +642,7 @@ bool boolector_convt::get_bool(smt_astt a)
     res = false;
     break;
   default:
-    std::cerr << "Can't get boolean value from Boolector\n";
+    ERROR("Can't get boolean value from Boolector\n");
     abort();
   }
 

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -29,7 +29,7 @@ boolector_convt::boolector_convt(bool int_encoding, const namespacet &ns)
   if(int_encoding)
   {
     std::cerr << "Boolector does not support integer encoding mode"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -499,13 +499,15 @@ smt_astt boolector_convt::mk_select(smt_astt a, smt_astt b)
 
 smt_astt boolector_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
-  std::cerr << "Boolector can't create integer sorts" << std::endl;
+  std::cerr << "Boolector can't create integer sorts"
+            << "\n";
   abort();
 }
 
 smt_astt boolector_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
-  std::cerr << "Boolector can't create Real sorts" << std::endl;
+  std::cerr << "Boolector can't create Real sorts"
+            << "\n";
   abort();
 }
 

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -28,8 +28,9 @@ boolector_convt::boolector_convt(bool int_encoding, const namespacet &ns)
 {
   if(int_encoding)
   {
-    std::cerr << "Boolector does not support integer encoding mode"
-              << "\n";
+    ERROR(
+      "Boolector does not support integer encoding mode"
+      << "\n");
     abort();
   }
 
@@ -499,15 +500,17 @@ smt_astt boolector_convt::mk_select(smt_astt a, smt_astt b)
 
 smt_astt boolector_convt::mk_smt_int(const BigInt &theint [[gnu::unused]])
 {
-  std::cerr << "Boolector can't create integer sorts"
-            << "\n";
+  ERROR(
+    "Boolector can't create integer sorts"
+    << "\n");
   abort();
 }
 
 smt_astt boolector_convt::mk_smt_real(const std::string &str [[gnu::unused]])
 {
-  std::cerr << "Boolector can't create Real sorts"
-            << "\n";
+  ERROR(
+    "Boolector can't create Real sorts"
+    << "\n");
   abort();
 }
 

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -780,7 +780,7 @@ void boolector_convt::dump_smt()
 void btor_smt_ast::dump() const
 {
   boolector_dump_smt2_node(boolector_get_btor(a), stdout, a);
-  std::cout << std::flush;
+  PRINT(std::flush);
 }
 
 void boolector_convt::print_model()

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -1271,13 +1271,17 @@ void cvc_convt::dump_smt()
   auto const &assertions = smt.getAssertions();
   for(auto const &a : assertions)
   {
-    a.printAst(std::cout, 0);
+    std::stringstream out;
+    a.printAst(out, 0);
+    PRINT(out.str());
     PRINT(std::flush);
   }
 }
 
 void cvc_smt_ast::dump() const
 {
-  a.printAst(std::cout, 0);
+  std::stringstream out;
+  a.printAst(out, 0);
+  PRINT(out.str());
   PRINT(std::flush);
 }

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -1272,12 +1272,12 @@ void cvc_convt::dump_smt()
   for(auto const &a : assertions)
   {
     a.printAst(std::cout, 0);
-    std::cout << std::flush;
+    PRINT(std::flush);
   }
 }
 
 void cvc_smt_ast::dump() const
 {
   a.printAst(std::cout, 0);
-  std::cout << std::flush;
+  PRINT(std::flush);
 }

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -908,7 +908,7 @@ void mathsat_smt_ast::dump() const
   auto convt = dynamic_cast<const mathsat_convt *>(context);
   assert(convt != nullptr);
 
-  std::cout << msat_to_smtlib2(convt->env, a) << "\n";
+  PRINT(msat_to_smtlib2(convt->env, a) << "\n");
 }
 
 void mathsat_convt::dump_smt()
@@ -918,7 +918,7 @@ void mathsat_convt::dump_smt()
     msat_get_asserted_formulas(env, &num_of_asserted);
 
   for(unsigned i = 0; i < num_of_asserted; i++)
-    std::cout << msat_to_smtlib2(env, asserted_formulas[i]) << "\n";
+    PRINT(msat_to_smtlib2(env, asserted_formulas[i]) << "\n");
 
   msat_free(asserted_formulas);
 }

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -30,9 +30,10 @@ void mathsat_convt::check_msat_error(msat_term &r) const
 {
   if(MSAT_ERROR_TERM(r))
   {
-    std::cerr << "Error creating SMT " << std::endl;
+    std::cerr << "Error creating SMT "
+              << "\n";
     std::cerr << "Error text: \"" << msat_last_error_message(env) << "\""
-              << std::endl;
+              << "\n";
     abort();
   }
 }
@@ -111,7 +112,8 @@ bool mathsat_convt::get_bool(smt_astt a)
     res = false;
   else
   {
-    std::cerr << "Boolean model value is neither true or false" << std::endl;
+    std::cerr << "Boolean model value is neither true or false"
+              << "\n";
     abort();
   }
 
@@ -168,7 +170,7 @@ ieee_floatt mathsat_convt::get_fpbv(smt_astt a)
   if(!msat_is_fp_type(env, to_solver_smt_sort<msat_type>(a->sort)->s, &ew, &sw))
   {
     std::cerr << "Non FP type passed to mathsat_convt::get_exp_width"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -906,7 +908,7 @@ void mathsat_smt_ast::dump() const
   auto convt = dynamic_cast<const mathsat_convt *>(context);
   assert(convt != nullptr);
 
-  std::cout << msat_to_smtlib2(convt->env, a) << std::endl;
+  std::cout << msat_to_smtlib2(convt->env, a) << "\n";
 }
 
 void mathsat_convt::dump_smt()

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -30,10 +30,12 @@ void mathsat_convt::check_msat_error(msat_term &r) const
 {
   if(MSAT_ERROR_TERM(r))
   {
-    std::cerr << "Error creating SMT "
-              << "\n";
-    std::cerr << "Error text: \"" << msat_last_error_message(env) << "\""
-              << "\n";
+    ERROR(
+      "Error creating SMT "
+      << "\n");
+    ERROR(
+      "Error text: \"" << msat_last_error_message(env) << "\""
+                       << "\n");
     abort();
   }
 }
@@ -112,8 +114,9 @@ bool mathsat_convt::get_bool(smt_astt a)
     res = false;
   else
   {
-    std::cerr << "Boolean model value is neither true or false"
-              << "\n";
+    ERROR(
+      "Boolean model value is neither true or false"
+      << "\n");
     abort();
   }
 
@@ -169,8 +172,9 @@ ieee_floatt mathsat_convt::get_fpbv(smt_astt a)
   size_t ew, sw;
   if(!msat_is_fp_type(env, to_solver_smt_sort<msat_type>(a->sort)->s, &ew, &sw))
   {
-    std::cerr << "Non FP type passed to mathsat_convt::get_exp_width"
-              << "\n";
+    ERROR(
+      "Non FP type passed to mathsat_convt::get_exp_width"
+      << "\n");
     abort();
   }
 

--- a/src/solvers/minisat/minisat_conv.cpp
+++ b/src/solvers/minisat/minisat_conv.cpp
@@ -109,7 +109,7 @@ void minisat_convt::dump_bv(const bvt &bv) const
       std::cerr << "?";
   }
 
-  std::cerr << " " << bv.size() << std::endl;
+  std::cerr << " " << bv.size() << "\n";
   return;
 }
 

--- a/src/solvers/minisat/minisat_conv.cpp
+++ b/src/solvers/minisat/minisat_conv.cpp
@@ -102,14 +102,14 @@ void minisat_convt::dump_bv(const bvt &bv) const
   for(unsigned int i = 0; i < bv.size(); i++)
   {
     if(bv[i] == const_literal(false))
-      std::cerr << "0";
+      ERROR("0");
     else if(bv[i] == const_literal(true))
-      std::cerr << "1";
+      ERROR("1");
     else
-      std::cerr << "?";
+      ERROR("?");
   }
 
-  std::cerr << " " << bv.size() << "\n";
+  ERROR(" " << bv.size() << "\n");
   return;
 }
 

--- a/src/solvers/sat/bitblast_conv.cpp
+++ b/src/solvers/sat/bitblast_conv.cpp
@@ -274,7 +274,8 @@ smt_astt bitblast_convt::mk_func_app(
   }
   default:
     std::cerr << "Unimplemented SMT function \"" << smt_func_name_table[f]
-              << "\" in bitblast convt" << std::endl;
+              << "\" in bitblast convt"
+              << "\n";
     abort();
   }
 
@@ -292,10 +293,12 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
   switch(k)
   {
   case SMT_SORT_INT:
-    std::cerr << "Can't make Int sorts in bitblaster" << std::endl;
+    std::cerr << "Can't make Int sorts in bitblaster"
+              << "\n";
     abort();
   case SMT_SORT_REAL:
-    std::cerr << "Can't make Real sorts in bitblaster" << std::endl;
+    std::cerr << "Can't make Real sorts in bitblaster"
+              << "\n";
     abort();
   case SMT_SORT_BV:
     uint = va_arg(ap, unsigned long);
@@ -312,7 +315,7 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
     break;
   default:
     std::cerr << "Unimplemented SMT sort " << k << " in bitblaster conversion"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -321,13 +324,15 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
 
 smt_ast *bitblast_convt::mk_smt_int(const BigInt &intval [[gnu::unused]])
 {
-  std::cerr << "Can't create integers in bitblast solver" << std::endl;
+  std::cerr << "Can't create integers in bitblast solver"
+            << "\n";
   abort();
 }
 
 smt_ast *bitblast_convt::mk_smt_real(const std::string &value [[gnu::unused]])
 {
-  std::cerr << "Can't create reals in bitblast solver" << std::endl;
+  std::cerr << "Can't create reals in bitblast solver"
+            << "\n";
   abort();
 }
 
@@ -381,7 +386,8 @@ smt_astt bitblast_convt::mk_smt_symbol(const std::string &name, smt_sortt sort)
   }
   default:
     std::cerr << "Unimplemented symbol type " << sort->id
-              << " in bitblast symbol creation" << std::endl;
+              << " in bitblast symbol creation"
+              << "\n";
     abort();
   }
 
@@ -433,12 +439,12 @@ bitblast_convt::mk_ast_equality(smt_astt _a, smt_astt _b, smt_sortt ressort)
     // XXX - so, if we have different array encodings in the future then this
     // might get quite funky. Leave it until then, though.
     std::cerr << "No direct array equality support in bitblast converter"
-              << std::endl;
+              << "\n";
     abort();
   }
   default:
     std::cerr << "Invalid sort " << a->sort->id << " for equality in bitblast"
-              << std::endl;
+              << "\n";
     abort();
   }
 }

--- a/src/solvers/sat/bitblast_conv.cpp
+++ b/src/solvers/sat/bitblast_conv.cpp
@@ -273,9 +273,10 @@ smt_astt bitblast_convt::mk_func_app(
     break;
   }
   default:
-    std::cerr << "Unimplemented SMT function \"" << smt_func_name_table[f]
-              << "\" in bitblast convt"
-              << "\n";
+    ERROR(
+      "Unimplemented SMT function \"" << smt_func_name_table[f]
+                                      << "\" in bitblast convt"
+                                      << "\n");
     abort();
   }
 
@@ -293,12 +294,14 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
   switch(k)
   {
   case SMT_SORT_INT:
-    std::cerr << "Can't make Int sorts in bitblaster"
-              << "\n";
+    ERROR(
+      "Can't make Int sorts in bitblaster"
+      << "\n");
     abort();
   case SMT_SORT_REAL:
-    std::cerr << "Can't make Real sorts in bitblaster"
-              << "\n";
+    ERROR(
+      "Can't make Real sorts in bitblaster"
+      << "\n");
     abort();
   case SMT_SORT_BV:
     uint = va_arg(ap, unsigned long);
@@ -314,8 +317,9 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
     s = new bitblast_smt_sort(k);
     break;
   default:
-    std::cerr << "Unimplemented SMT sort " << k << " in bitblaster conversion"
-              << "\n";
+    ERROR(
+      "Unimplemented SMT sort " << k << " in bitblaster conversion"
+                                << "\n");
     abort();
   }
 
@@ -324,15 +328,17 @@ smt_sort *bitblast_convt::mk_sort(smt_sort_kind k, ...)
 
 smt_ast *bitblast_convt::mk_smt_int(const BigInt &intval [[gnu::unused]])
 {
-  std::cerr << "Can't create integers in bitblast solver"
-            << "\n";
+  ERROR(
+    "Can't create integers in bitblast solver"
+    << "\n");
   abort();
 }
 
 smt_ast *bitblast_convt::mk_smt_real(const std::string &value [[gnu::unused]])
 {
-  std::cerr << "Can't create reals in bitblast solver"
-            << "\n";
+  ERROR(
+    "Can't create reals in bitblast solver"
+    << "\n");
   abort();
 }
 
@@ -385,9 +391,9 @@ smt_astt bitblast_convt::mk_smt_symbol(const std::string &name, smt_sortt sort)
     break;
   }
   default:
-    std::cerr << "Unimplemented symbol type " << sort->id
-              << " in bitblast symbol creation"
-              << "\n";
+    ERROR(
+      "Unimplemented symbol type " << sort->id << " in bitblast symbol creation"
+                                   << "\n");
     abort();
   }
 
@@ -438,13 +444,15 @@ bitblast_convt::mk_ast_equality(smt_astt _a, smt_astt _b, smt_sortt ressort)
   {
     // XXX - so, if we have different array encodings in the future then this
     // might get quite funky. Leave it until then, though.
-    std::cerr << "No direct array equality support in bitblast converter"
-              << "\n";
+    ERROR(
+      "No direct array equality support in bitblast converter"
+      << "\n");
     abort();
   }
   default:
-    std::cerr << "Invalid sort " << a->sort->id << " for equality in bitblast"
-              << "\n";
+    ERROR(
+      "Invalid sort " << a->sort->id << " for equality in bitblast"
+                      << "\n");
     abort();
   }
 }

--- a/src/solvers/smt/array_conv.h
+++ b/src/solvers/smt/array_conv.h
@@ -73,7 +73,7 @@ public:
 
   void dump() const override
   {
-    std::cout << "name: " << symname << '\n';
+    PRINT("name: " << symname << '\n');
     for(auto const &e : array_fields)
       e->dump();
   }

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -2133,7 +2133,7 @@ smt_astt fp_convt::mk_is_rm(smt_astt &rme, ieee_floatt::rounding_modet rm)
     break;
   }
 
-  std::cerr << "Unknown rounding mode\n";
+  ERROR("Unknown rounding mode\n");
   abort();
 }
 

--- a/src/solvers/smt/smt_ast.h
+++ b/src/solvers/smt/smt_ast.h
@@ -83,7 +83,7 @@ public:
 
   virtual void dump() const
   {
-    std::cout << "Chosen solver doesn't support printing the AST\n";
+    PRINT("Chosen solver doesn't support printing the AST\n");
   }
 };
 

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -73,8 +73,9 @@ static expr2tc flatten_to_bitvector_rec(const expr2tc &new_expr)
   }
 
   ERROR("Unrecognized type " << get_type_id(*new_expr->type));
-  std::cerr << " when flattening to bytes"
-            << "\n";
+  ERROR(
+    " when flattening to bytes"
+    << "\n");
   abort();
 }
 

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -73,7 +73,8 @@ static expr2tc flatten_to_bitvector_rec(const expr2tc &new_expr)
   }
 
   std::cerr << "Unrecognized type " << get_type_id(*new_expr->type);
-  std::cerr << " when flattening to bytes" << std::endl;
+  std::cerr << " when flattening to bytes"
+            << "\n";
   abort();
 }
 

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -72,7 +72,7 @@ static expr2tc flatten_to_bitvector_rec(const expr2tc &new_expr)
     return expr;
   }
 
-  std::cerr << "Unrecognized type " << get_type_id(*new_expr->type);
+  ERROR("Unrecognized type " << get_type_id(*new_expr->type));
   std::cerr << " when flattening to bytes"
             << "\n";
   abort();
@@ -108,7 +108,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
 
     if(is_union_type(new_from))
     {
-      std::cerr << "Unions not supported when bitcasting to fp for now\n";
+      ERROR("Unions not supported when bitcasting to fp for now\n");
       expr->dump();
       abort();
     }
@@ -123,7 +123,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
 
     if(is_union_type(from))
     {
-      std::cerr << "Unions not supported when bitcasting to bv for now\n";
+      ERROR("Unions not supported when bitcasting to bv for now\n");
       expr->dump();
       abort();
     }
@@ -166,7 +166,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
 
     if(is_union_type(new_from))
     {
-      std::cerr << "Unions not supported when bitcasting to struct for now\n";
+      ERROR("Unions not supported when bitcasting to struct for now\n");
       expr->dump();
       abort();
     }
@@ -216,7 +216,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
 
     if(is_union_type(new_from))
     {
-      std::cerr << "Unions not supported when bitcasting to struct for now\n";
+      ERROR("Unions not supported when bitcasting to struct for now\n");
       expr->dump();
       abort();
     }

--- a/src/solvers/smt/smt_byteops.cpp
+++ b/src/solvers/smt/smt_byteops.cpp
@@ -5,9 +5,10 @@ smt_astt smt_convt::convert_byte_extract(const expr2tc &expr)
 {
   if(int_encoding)
   {
-    std::cerr << "Refusing to byte extract in integer mode; re-run in "
-                 "bitvector mode"
-              << "\n";
+    ERROR(
+      "Refusing to byte extract in integer mode; re-run in "
+      "bitvector mode"
+      << "\n");
     abort();
   }
 
@@ -79,8 +80,8 @@ smt_astt smt_convt::convert_byte_update(const expr2tc &expr)
 {
   if(int_encoding)
   {
-    std::cerr << "Can't byte update in integer mode; rerun in bitvector mode"
-              << "\n";
+    ERROR("Can't byte update in integer mode; rerun in bitvector mode"
+            << "\n";)
     abort();
   }
 

--- a/src/solvers/smt/smt_byteops.cpp
+++ b/src/solvers/smt/smt_byteops.cpp
@@ -7,7 +7,7 @@ smt_astt smt_convt::convert_byte_extract(const expr2tc &expr)
   {
     std::cerr << "Refusing to byte extract in integer mode; re-run in "
                  "bitvector mode"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -80,7 +80,7 @@ smt_astt smt_convt::convert_byte_update(const expr2tc &expr)
   if(int_encoding)
   {
     std::cerr << "Can't byte update in integer mode; rerun in bitvector mode"
-              << std::endl;
+              << "\n";
     abort();
   }
 

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -183,7 +183,7 @@ smt_astt smt_convt::convert_typecast_to_fpbv(const typecast2t &cast)
       convert_sort(cast.type),
       convert_rounding_mode(cast.rounding_mode));
 
-  std::cerr << "Unexpected type in typecast to fpbv\n";
+  ERROR("Unexpected type in typecast to fpbv\n");
   abort();
 }
 
@@ -203,7 +203,7 @@ smt_astt smt_convt::convert_typecast_from_fpbv(const typecast2t &cast)
       convert_sort(cast.type),
       convert_rounding_mode(cast.rounding_mode));
 
-  std::cerr << "Unexpected type in typecast from fpbv\n";
+  ERROR("Unexpected type in typecast from fpbv\n");
   abort();
 }
 

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -23,8 +23,9 @@ smt_astt smt_convt::convert_typecast_to_fixedbv_nonint(const expr2tc &expr)
 
   if(is_pointer_type(cast.from))
   {
-    std::cerr << "Converting pointer to a float is unsupported"
-              << "\n";
+    ERROR(
+      "Converting pointer to a float is unsupported"
+      << "\n");
     abort();
   }
 
@@ -35,8 +36,9 @@ smt_astt smt_convt::convert_typecast_to_fixedbv_nonint(const expr2tc &expr)
   else if(is_fixedbv_type(cast.from))
     return convert_typecast_to_fixedbv_nonint_from_fixedbv(expr);
 
-  std::cerr << "unexpected typecast to fixedbv"
-            << "\n";
+  ERROR(
+    "unexpected typecast to fixedbv"
+    << "\n");
   abort();
 }
 
@@ -224,8 +226,9 @@ smt_astt smt_convt::convert_typecast_to_ints(const typecast2t &cast)
   if(is_bool_type(cast.from))
     return convert_typecast_to_ints_from_bool(cast);
 
-  std::cerr << "Unexpected type in int/ptr typecast"
-            << "\n";
+  ERROR(
+    "Unexpected type in int/ptr typecast"
+    << "\n");
   abort();
 }
 
@@ -299,8 +302,9 @@ smt_convt::convert_typecast_to_ints_from_fbv_sint(const typecast2t &cast)
       // Operands have differing signs (and same width). Just return.
       return convert_ast(cast.from);
 
-    std::cerr << "Unrecognized equal-width int typecast format"
-              << "\n";
+    ERROR(
+      "Unrecognized equal-width int typecast format"
+      << "\n");
     abort();
   }
 
@@ -310,8 +314,9 @@ smt_convt::convert_typecast_to_ints_from_fbv_sint(const typecast2t &cast)
   if(from_width > to_width)
     return mk_extract(a, to_width - 1, 0);
 
-  std::cerr << "Malformed cast from signedbv/fixedbv"
-            << "\n";
+  ERROR(
+    "Malformed cast from signedbv/fixedbv"
+    << "\n");
   abort();
 }
 
@@ -514,8 +519,9 @@ smt_astt smt_convt::convert_typecast_to_struct(const typecast2t &cast)
     {
       if(!base_type_eq(struct_type_from.members[i], it, ns))
       {
-        std::cerr << "Incompatible struct in cast-to-struct"
-                  << "\n";
+        ERROR(
+          "Incompatible struct in cast-to-struct"
+          << "\n");
         abort();
       }
 
@@ -610,13 +616,15 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
     if(base_type_eq(cast.type, cast.from->type, ns))
       return convert_ast(cast.from); // No additional conversion required
 
-    std::cerr << "Can't typecast between unions"
-              << "\n";
+    ERROR(
+      "Can't typecast between unions"
+      << "\n");
     abort();
   }
 
-  std::cerr << "Typecast for unexpected type"
-            << "\n";
+  ERROR(
+    "Typecast for unexpected type"
+    << "\n");
   expr->dump();
   abort();
 }

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -23,7 +23,8 @@ smt_astt smt_convt::convert_typecast_to_fixedbv_nonint(const expr2tc &expr)
 
   if(is_pointer_type(cast.from))
   {
-    std::cerr << "Converting pointer to a float is unsupported" << std::endl;
+    std::cerr << "Converting pointer to a float is unsupported"
+              << "\n";
     abort();
   }
 
@@ -34,7 +35,8 @@ smt_astt smt_convt::convert_typecast_to_fixedbv_nonint(const expr2tc &expr)
   else if(is_fixedbv_type(cast.from))
     return convert_typecast_to_fixedbv_nonint_from_fixedbv(expr);
 
-  std::cerr << "unexpected typecast to fixedbv" << std::endl;
+  std::cerr << "unexpected typecast to fixedbv"
+            << "\n";
   abort();
 }
 
@@ -222,7 +224,8 @@ smt_astt smt_convt::convert_typecast_to_ints(const typecast2t &cast)
   if(is_bool_type(cast.from))
     return convert_typecast_to_ints_from_bool(cast);
 
-  std::cerr << "Unexpected type in int/ptr typecast" << std::endl;
+  std::cerr << "Unexpected type in int/ptr typecast"
+            << "\n";
   abort();
 }
 
@@ -296,7 +299,8 @@ smt_convt::convert_typecast_to_ints_from_fbv_sint(const typecast2t &cast)
       // Operands have differing signs (and same width). Just return.
       return convert_ast(cast.from);
 
-    std::cerr << "Unrecognized equal-width int typecast format" << std::endl;
+    std::cerr << "Unrecognized equal-width int typecast format"
+              << "\n";
     abort();
   }
 
@@ -306,7 +310,8 @@ smt_convt::convert_typecast_to_ints_from_fbv_sint(const typecast2t &cast)
   if(from_width > to_width)
     return mk_extract(a, to_width - 1, 0);
 
-  std::cerr << "Malformed cast from signedbv/fixedbv" << std::endl;
+  std::cerr << "Malformed cast from signedbv/fixedbv"
+            << "\n";
   abort();
 }
 
@@ -509,7 +514,8 @@ smt_astt smt_convt::convert_typecast_to_struct(const typecast2t &cast)
     {
       if(!base_type_eq(struct_type_from.members[i], it, ns))
       {
-        std::cerr << "Incompatible struct in cast-to-struct" << std::endl;
+        std::cerr << "Incompatible struct in cast-to-struct"
+                  << "\n";
         abort();
       }
 
@@ -604,11 +610,13 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
     if(base_type_eq(cast.type, cast.from->type, ns))
       return convert_ast(cast.from); // No additional conversion required
 
-    std::cerr << "Can't typecast between unions" << std::endl;
+    std::cerr << "Can't typecast between unions"
+              << "\n";
     abort();
   }
 
-  std::cerr << "Typecast for unexpected type" << std::endl;
+  std::cerr << "Typecast for unexpected type"
+            << "\n";
   expr->dump();
   abort();
 }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2098,9 +2098,10 @@ expr2tc smt_convt::get(const expr2tc &expr)
   {
     if(is_array_type(expr))
     {
-      std::cerr << "Fetching array elements inside tuples currently "
-                   "unimplemented, sorry"
-                << "\n";
+      ERROR(
+        "Fetching array elements inside tuples currently "
+        "unimplemented, sorry"
+        << "\n");
       return expr2tc();
     }
     simplify(res);
@@ -2178,8 +2179,8 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
     return constant_floatbv2tc(fp_api->get_fpbv(a));
 
   default:
-    std::cerr << "Unimplemented type'd expression (" << type->type_id
-              << ") in smt get\n";
+    ERROR(
+      "Unimplemented type'd expression (" << type->type_id << ") in smt get\n");
     abort();
   }
 }
@@ -2203,8 +2204,9 @@ expr2tc smt_convt::get_by_type(const expr2tc &expr)
     return tuple_api->tuple_get(expr);
 
   default:
-    std::cerr << "Unimplemented type'd expression (" << expr->type->type_id
-              << ") in smt get\n";
+    ERROR(
+      "Unimplemented type'd expression (" << expr->type->type_id
+                                          << ") in smt get\n");
     abort();
   }
 }
@@ -2552,8 +2554,7 @@ void smt_convt::dump_smt()
 
 void smt_convt::print_model()
 {
-  std::cerr << "SMT model printing not implemented for " << solver_text()
-            << "\n";
+  ERROR("SMT model printing not implemented for " << solver_text() << "\n");
 }
 
 tvt smt_convt::l_get(smt_astt a)

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2100,7 +2100,7 @@ expr2tc smt_convt::get(const expr2tc &expr)
     {
       std::cerr << "Fetching array elements inside tuples currently "
                    "unimplemented, sorry"
-                << std::endl;
+                << "\n";
       return expr2tc();
     }
     simplify(res);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -302,7 +302,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     break;
   }
   case expr2t::constant_union_id:
-    std::cerr << "Post-parse union literals are deprecated and broken, sorry\n";
+    ERROR("Post-parse union literals are deprecated and broken, sorry\n");
     abort();
   case expr2t::constant_array_id:
   case expr2t::constant_array_of_id:
@@ -1084,7 +1084,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     break;
   }
   default:
-    std::cerr << "Couldn't convert expression in unrecognised format\n";
+    ERROR("Couldn't convert expression in unrecognised format\n");
     expr->dump();
     abort();
   }
@@ -1192,8 +1192,8 @@ smt_sortt smt_convt::convert_sort(const type2tc &type)
     break;
   }
   default:
-    std::cerr << "Unexpected type ID " << get_type_id(type);
-    std::cerr << " reached SMT conversion\n";
+    ERROR("Unexpected type ID " << get_type_id(type));
+    ERROR(" reached SMT conversion\n");
     abort();
   }
 
@@ -1339,7 +1339,7 @@ smt_astt smt_convt::convert_terminal(const expr2tc &expr)
   }
 
   default:
-    std::cerr << "Converting unrecognized terminal expr to SMT\n";
+    ERROR("Converting unrecognized terminal expr to SMT\n");
     expr->dump();
     abort();
   }
@@ -2262,7 +2262,7 @@ smt_astt smt_convt::array_create(const expr2tc &expr)
 
   if(!is_constant_int2t(arr_type.array_size))
   {
-    std::cerr << "Non-constant sized array of type constant_array_of2t\n";
+    ERROR("Non-constant sized array of type constant_array_of2t\n");
     abort();
   }
 
@@ -2541,13 +2541,13 @@ smt_astt smt_ast::project(
   smt_convt *ctx [[gnu::unused]],
   unsigned int idx [[gnu::unused]]) const
 {
-  std::cerr << "Projecting from non-tuple based AST\n";
+  ERROR("Projecting from non-tuple based AST\n");
   abort();
 }
 
 void smt_convt::dump_smt()
 {
-  std::cerr << "SMT dump not implemented for " << solver_text() << "\n";
+  ERROR("SMT dump not implemented for " << solver_text() << "\n");
 }
 
 void smt_convt::print_model()
@@ -2593,45 +2593,45 @@ expr2tc smt_convt::get_by_value(const type2tc &type, BigInt value)
   default:;
   }
 
-  std::cerr << "Can't generate one for type " << get_type_id(type) << '\n';
+  ERROR("Can't generate one for type " << get_type_id(type) << '\n');
   abort();
 }
 
 smt_sortt smt_convt::mk_bool_sort()
 {
-  std::cerr << "Chosen solver doesn't support boolean sorts\n";
+  ERROR("Chosen solver doesn't support boolean sorts\n");
   abort();
 }
 
 smt_sortt smt_convt::mk_real_sort()
 {
-  std::cerr << "Chosen solver doesn't support real sorts\n";
+  ERROR("Chosen solver doesn't support real sorts\n");
   abort();
 }
 
 smt_sortt smt_convt::mk_int_sort()
 {
-  std::cerr << "Chosen solver doesn't support integer sorts\n";
+  ERROR("Chosen solver doesn't support integer sorts\n");
   abort();
 }
 
 smt_sortt smt_convt::mk_bv_sort(std::size_t width)
 {
-  std::cerr << "Chosen solver doesn't support bit vector sorts\n";
+  ERROR("Chosen solver doesn't support bit vector sorts\n");
   (void)width;
   abort();
 }
 
 smt_sortt smt_convt::mk_fbv_sort(std::size_t width)
 {
-  std::cerr << "Chosen solver doesn't support bit vector sorts\n";
+  ERROR("Chosen solver doesn't support bit vector sorts\n");
   (void)width;
   abort();
 }
 
 smt_sortt smt_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 {
-  std::cerr << "Chosen solver doesn't support array sorts\n";
+  ERROR("Chosen solver doesn't support array sorts\n");
   (void)domain;
   (void)range;
   abort();
@@ -2639,7 +2639,7 @@ smt_sortt smt_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 
 smt_sortt smt_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
-  std::cerr << "Chosen solver doesn't support bit vector sorts\n";
+  ERROR("Chosen solver doesn't support bit vector sorts\n");
   (void)ew;
   (void)sw;
   abort();
@@ -2647,7 +2647,7 @@ smt_sortt smt_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 
 smt_sortt smt_convt::mk_bvfp_rm_sort()
 {
-  std::cerr << "Chosen solver doesn't support bit vector sorts\n";
+  ERROR("Chosen solver doesn't support bit vector sorts\n");
   abort();
 }
 

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -123,16 +123,18 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
     }
     else
     {
-      std::cerr << "Pointer arithmetic with two pointer operands"
-                << "\n";
+      ERROR(
+        "Pointer arithmetic with two pointer operands"
+        << "\n");
       abort();
     }
     break;
   case 4:
     // Artithmetic operation that has the result type of ptr.
     // Should have been handled at a higher level
-    std::cerr << "Non-pointer op being interpreted as pointer without cast"
-              << "\n";
+    ERROR(
+      "Non-pointer op being interpreted as pointer without cast"
+      << "\n");
     abort();
     break;
   case 1:
@@ -194,8 +196,9 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
   }
   }
 
-  std::cerr << "Fell through convert_pointer_logic"
-            << "\n";
+  ERROR(
+    "Fell through convert_pointer_logic"
+    << "\n");
   abort();
 }
 
@@ -245,9 +248,10 @@ smt_astt smt_convt::convert_identifier_pointer(
 
   if(!ptr_foo_inited)
   {
-    std::cerr << "SMT solver must call smt_post_init immediately after "
-              << "construction"
-              << "\n";
+    ERROR(
+      "SMT solver must call smt_post_init immediately after "
+      << "construction"
+      << "\n");
     abort();
   }
 
@@ -530,8 +534,9 @@ smt_astt smt_convt::convert_addr_of(const expr2tc &expr)
     return convert_ast(tmp);
   }
 
-  std::cerr << "Unrecognized address_of operand:"
-            << "\n";
+  ERROR(
+    "Unrecognized address_of operand:"
+    << "\n");
   expr->dump();
   abort();
 }

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -123,7 +123,8 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
     }
     else
     {
-      std::cerr << "Pointer arithmetic with two pointer operands" << std::endl;
+      std::cerr << "Pointer arithmetic with two pointer operands"
+                << "\n";
       abort();
     }
     break;
@@ -131,7 +132,7 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
     // Artithmetic operation that has the result type of ptr.
     // Should have been handled at a higher level
     std::cerr << "Non-pointer op being interpreted as pointer without cast"
-              << std::endl;
+              << "\n";
     abort();
     break;
   case 1:
@@ -193,7 +194,8 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
   }
   }
 
-  std::cerr << "Fell through convert_pointer_logic" << std::endl;
+  std::cerr << "Fell through convert_pointer_logic"
+            << "\n";
   abort();
 }
 
@@ -244,7 +246,8 @@ smt_astt smt_convt::convert_identifier_pointer(
   if(!ptr_foo_inited)
   {
     std::cerr << "SMT solver must call smt_post_init immediately after "
-              << "construction" << std::endl;
+              << "construction"
+              << "\n";
     abort();
   }
 
@@ -527,7 +530,8 @@ smt_astt smt_convt::convert_addr_of(const expr2tc &expr)
     return convert_ast(tmp);
   }
 
-  std::cerr << "Unrecognized address_of operand:" << std::endl;
+  std::cerr << "Unrecognized address_of operand:"
+            << "\n";
   expr->dump();
   abort();
 }

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -165,8 +165,9 @@ smt_astt smt_convt::overflow_cast(const expr2tc &expr)
 
   if(ocast.bits >= width || ocast.bits == 0)
   {
-    std::cerr << "SMT conversion: overflow-typecast got wrong number of bits"
-              << "\n";
+    ERROR(
+      "SMT conversion: overflow-typecast got wrong number of bits"
+      << "\n");
     abort();
   }
 

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -166,7 +166,7 @@ smt_astt smt_convt::overflow_cast(const expr2tc &expr)
   if(ocast.bits >= width || ocast.bits == 0)
   {
     std::cerr << "SMT conversion: overflow-typecast got wrong number of bits"
-              << std::endl;
+              << "\n";
     abort();
   }
 

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -146,7 +146,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
   }
 
   default:
-    std::cerr << "unexpected overflow_arith operand\n";
+    ERROR("unexpected overflow_arith operand\n");
     abort();
   }
 

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -108,8 +108,9 @@ smt_astt smt_tuple_node_flattener::tuple_array_create(
   }
   if(!is_constant_int2t(arr_type.array_size))
   {
-    std::cerr << "Non-constant sized array of type constant_array_of2t"
-              << "\n";
+    ERROR(
+      "Non-constant sized array of type constant_array_of2t"
+      << "\n");
     abort();
   }
 
@@ -177,15 +178,17 @@ expr2tc smt_tuple_node_flattener::tuple_get_rec(tuple_node_smt_astt tuple)
     }
     else if(is_array_type(it))
     {
-      std::cerr << "Fetching array elements inside tuples currently "
-                   "unimplemented, sorry"
-                << "\n";
+      ERROR(
+        "Fetching array elements inside tuples currently "
+        "unimplemented, sorry"
+        << "\n");
       res = expr2tc();
     }
     else
     {
-      std::cerr << "Unexpected type in tuple_get_rec"
-                << "\n";
+      ERROR(
+        "Unexpected type in tuple_get_rec"
+        << "\n");
       abort();
     }
 

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -109,7 +109,7 @@ smt_astt smt_tuple_node_flattener::tuple_array_create(
   if(!is_constant_int2t(arr_type.array_size))
   {
     std::cerr << "Non-constant sized array of type constant_array_of2t"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -179,12 +179,13 @@ expr2tc smt_tuple_node_flattener::tuple_get_rec(tuple_node_smt_astt tuple)
     {
       std::cerr << "Fetching array elements inside tuples currently "
                    "unimplemented, sorry"
-                << std::endl;
+                << "\n";
       res = expr2tc();
     }
     else
     {
-      std::cerr << "Unexpected type in tuple_get_rec" << std::endl;
+      std::cerr << "Unexpected type in tuple_get_rec"
+                << "\n";
       abort();
     }
 

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -154,8 +154,9 @@ smt_astt tuple_node_smt_ast::select(
   smt_convt *ctx [[gnu::unused]],
   const expr2tc &idx [[gnu::unused]]) const
 {
-  std::cerr << "Select operation applied to tuple"
-            << "\n";
+  ERROR(
+    "Select operation applied to tuple"
+    << "\n");
   abort();
 }
 

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -154,7 +154,8 @@ smt_astt tuple_node_smt_ast::select(
   smt_convt *ctx [[gnu::unused]],
   const expr2tc &idx [[gnu::unused]]) const
 {
-  std::cerr << "Select operation applied to tuple" << std::endl;
+  std::cerr << "Select operation applied to tuple"
+            << "\n";
   abort();
 }
 

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.h
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.h
@@ -57,7 +57,7 @@ public:
 
   void dump() const override
   {
-    std::cout << "name: " << name << '\n';
+    PRINT("name: " << name << '\n');
     for(auto const &e : elements)
       e->dump();
   }

--- a/src/solvers/smt/tuple/smt_tuple_sym.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym.cpp
@@ -86,8 +86,9 @@ smt_astt smt_tuple_sym_flattener::tuple_array_create(
   }
   if(!is_constant_int2t(arr_type.array_size))
   {
-    std::cerr << "Non-constant sized array of type constant_array_of2t"
-              << "\n";
+    ERROR(
+      "Non-constant sized array of type constant_array_of2t"
+      << "\n");
     abort();
   }
 

--- a/src/solvers/smt/tuple/smt_tuple_sym.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym.cpp
@@ -87,7 +87,7 @@ smt_astt smt_tuple_sym_flattener::tuple_array_create(
   if(!is_constant_int2t(arr_type.array_size))
   {
     std::cerr << "Non-constant sized array of type constant_array_of2t"
-              << std::endl;
+              << "\n";
     abort();
   }
 

--- a/src/solvers/smt/tuple/smt_tuple_sym_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym_ast.cpp
@@ -161,7 +161,8 @@ smt_astt tuple_sym_smt_ast::select(
   smt_convt *ctx [[gnu::unused]],
   const expr2tc &idx [[gnu::unused]]) const
 {
-  std::cerr << "Select operation applied to tuple" << std::endl;
+  std::cerr << "Select operation applied to tuple"
+            << "\n";
   abort();
 }
 

--- a/src/solvers/smt/tuple/smt_tuple_sym_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym_ast.cpp
@@ -161,8 +161,9 @@ smt_astt tuple_sym_smt_ast::select(
   smt_convt *ctx [[gnu::unused]],
   const expr2tc &idx [[gnu::unused]]) const
 {
-  std::cerr << "Select operation applied to tuple"
-            << "\n";
+  ERROR(
+    "Select operation applied to tuple"
+    << "\n");
   abort();
 }
 

--- a/src/solvers/smtlib/smtlib.ypp
+++ b/src/solvers/smtlib/smtlib.ypp
@@ -364,17 +364,17 @@ term: spec_constant
          }
        | TOK_LPAREN TOK_KW_FORALL TOK_LPAREN sortvar_list TOK_RPAREN term TOK_RPAREN
          {
-           std::cerr << "Not handling forall in smtlib output" << "\n";
+           ERROR("Not handling forall in smtlib output" << "\n");
            abort();
          }
        | TOK_LPAREN TOK_KW_EXISTS TOK_LPAREN sortvar_list TOK_RPAREN term TOK_RPAREN
          {
-           std::cerr << "Not handling exists in smtlib output" << "\n";
+           ERROR("Not handling exists in smtlib output" << "\n");
            abort();
          }
        | TOK_LPAREN TOK_KW_EXCL term attr_list TOK_RPAREN
          {
-           std::cerr << "Not handling '!' in smtlib output" << "\n";
+           ERROR("Not handling '!' in smtlib output" << "\n");
            abort();
          }
 

--- a/src/solvers/smtlib/smtlib.ypp
+++ b/src/solvers/smtlib/smtlib.ypp
@@ -364,17 +364,17 @@ term: spec_constant
          }
        | TOK_LPAREN TOK_KW_FORALL TOK_LPAREN sortvar_list TOK_RPAREN term TOK_RPAREN
          {
-           std::cerr << "Not handling forall in smtlib output" << std::endl;
+           std::cerr << "Not handling forall in smtlib output" << "\n";
            abort();
          }
        | TOK_LPAREN TOK_KW_EXISTS TOK_LPAREN sortvar_list TOK_RPAREN term TOK_RPAREN
          {
-           std::cerr << "Not handling exists in smtlib output" << std::endl;
+           std::cerr << "Not handling exists in smtlib output" << "\n";
            abort();
          }
        | TOK_LPAREN TOK_KW_EXCL term attr_list TOK_RPAREN
          {
-           std::cerr << "Not handling '!' in smtlib output" << std::endl;
+           std::cerr << "Not handling '!' in smtlib output" << "\n";
            abort();
          }
 

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -124,8 +124,9 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
   {
     if(config.options.get_option("smtlib-solver-prog") != "")
     {
-      std::cerr << "Can't solve SMTLIB output and write to a file, sorry"
-                << "\n";
+      ERROR(
+        "Can't solve SMTLIB output and write to a file, sorry"
+        << "\n");
       abort();
     }
 
@@ -133,8 +134,9 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
     out_stream = fopen(cmd.c_str(), "w");
     if(!out_stream)
     {
-      std::cerr << "Failed to open \"" << cmd << "\""
-                << "\n";
+      ERROR(
+        "Failed to open \"" << cmd << "\""
+                            << "\n");
       abort();
     }
 
@@ -157,8 +159,9 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
   cmd = config.options.get_option("smtlib-solver-prog");
   if(cmd == "")
   {
-    std::cerr << "Must specify an smtlib solver program in smtlib mode"
-              << "\n";
+    ERROR(
+      "Must specify an smtlib solver program in smtlib mode"
+      << "\n");
     abort();
   }
 #ifdef _WIN32
@@ -168,15 +171,17 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
 #else
   if(pipe(inpipe) != 0)
   {
-    std::cerr << "Couldn't open a pipe for smtlib solver"
-              << "\n";
+    ERROR(
+      "Couldn't open a pipe for smtlib solver"
+      << "\n");
     abort();
   }
 
   if(pipe(outpipe) != 0)
   {
-    std::cerr << "Couldn't open a pipe for smtlib solver"
-              << "\n";
+    ERROR(
+      "Couldn't open a pipe for smtlib solver"
+      << "\n");
     abort();
   }
 
@@ -194,8 +199,9 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
 
     // Voila
     execlp(cmd.c_str(), cmd.c_str(), NULL);
-    std::cerr << "Exec of smtlib solver failed"
-              << "\n";
+    ERROR(
+      "Exec of smtlib solver failed"
+      << "\n");
     abort();
   }
   else
@@ -296,8 +302,9 @@ std::string smtlib_convt::sort_to_string(const smt_sort *s) const
   case SMT_SORT_BOOL:
     return "Bool";
   default:
-    std::cerr << "Unexpected sort in smtlib_convt"
-              << "\n";
+    ERROR(
+      "Unexpected sort in smtlib_convt"
+      << "\n");
     abort();
   }
 }
@@ -351,8 +358,9 @@ smtlib_convt::emit_terminal_ast(const smtlib_smt_ast *ast, std::string &output)
     output = ss.str();
     return 0;
   default:
-    std::cerr << "Invalid terminal AST kind"
-              << "\n";
+    ERROR(
+      "Invalid terminal AST kind"
+      << "\n");
     abort();
   }
 }
@@ -448,15 +456,16 @@ smt_convt::resultt smtlib_convt::dec_solve()
   }
   else if(smtlib_output->token == TOK_KW_ERROR)
   {
-    std::cerr << "SMTLIB solver returned error: \"" << smtlib_output->data
-              << "\""
-              << "\n";
+    ERROR(
+      "SMTLIB solver returned error: \"" << smtlib_output->data << "\""
+                                         << "\n");
     return smt_convt::P_ERROR;
   }
   else
   {
-    std::cerr << "Unrecognized check-sat output from smtlib solver"
-              << "\n";
+    ERROR(
+      "Unrecognized check-sat output from smtlib solver"
+      << "\n");
     abort();
   }
 }
@@ -475,15 +484,17 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
 
   if(smtlib_output->token == TOK_KW_ERROR)
   {
-    std::cerr << "Error from smtlib solver when fetching literal value: \""
-              << smtlib_output->data << "\""
-              << "\n";
+    ERROR(
+      "Error from smtlib solver when fetching literal value: \""
+      << smtlib_output->data << "\""
+      << "\n");
     abort();
   }
   else if(smtlib_output->token != 0)
   {
-    std::cerr << "Unrecognized response to get-value from smtlib solver"
-              << "\n";
+    ERROR(
+      "Unrecognized response to get-value from smtlib solver"
+      << "\n");
   }
 
   // Unpack our value from response list.
@@ -514,8 +525,9 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
   }
   else if(respval.token == TOK_NUMERAL)
   {
-    std::cerr << "Numeral value for integer symbol from smtlib solver"
-              << "\n";
+    ERROR(
+      "Numeral value for integer symbol from smtlib solver"
+      << "\n");
     abort();
   }
   else if(respval.token == TOK_HEXNUM)
@@ -555,15 +567,17 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
 
   if(smtlib_output->token == TOK_KW_ERROR)
   {
-    std::cerr << "Error from smtlib solver when fetching literal value: \""
-              << smtlib_output->data << "\""
-              << "\n";
+    ERROR(
+      "Error from smtlib solver when fetching literal value: \""
+      << smtlib_output->data << "\""
+      << "\n");
     abort();
   }
   else if(smtlib_output->token != 0)
   {
-    std::cerr << "Unrecognized response to get-value from smtlib solver"
-              << "\n";
+    ERROR(
+      "Unrecognized response to get-value from smtlib solver"
+      << "\n");
   }
 
   // Unpack our value from response list.
@@ -590,8 +604,9 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
   }
   else if(respval.token == TOK_NUMERAL)
   {
-    std::cerr << "Numeral value for integer symbol from smtlib solver"
-              << "\n";
+    ERROR(
+      "Numeral value for integer symbol from smtlib solver"
+      << "\n");
     abort();
   }
   else if(respval.token == TOK_HEXNUM)
@@ -615,8 +630,8 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
   {
     if(!was_integer)
     {
-      std::cerr
-        << "smtlib solver didn't provide integer response to integer get-value";
+      ERROR(
+        "smtlib solver didn't provide integer response to integer get-value");
       abort();
     }
     result = constant_int2tc(t, m);
@@ -669,9 +684,10 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
     }
     else
     {
-      std::cerr << "Unexpected token reading value of boolean symbol from "
-                   "smtlib solver"
-                << "\n";
+      ERROR(
+        "Unexpected token reading value of boolean symbol from "
+        "smtlib solver"
+        << "\n");
     }
   }
   else
@@ -704,15 +720,17 @@ bool smtlib_convt::get_bool(smt_astt a)
 
   if(smtlib_output->token == TOK_KW_ERROR)
   {
-    std::cerr << "Error from smtlib solver when fetching literal value: \""
-              << smtlib_output->data << "\""
-              << "\n";
+    ERROR(
+      "Error from smtlib solver when fetching literal value: \""
+      << smtlib_output->data << "\""
+      << "\n");
     abort();
   }
   else if(smtlib_output->token != 0)
   {
-    std::cerr << "Unrecognized response to get-value from smtlib solver"
-              << "\n";
+    ERROR(
+      "Unrecognized response to get-value from smtlib solver"
+      << "\n");
   }
 
   // First layer: valuation pair list. Should have one item.
@@ -850,8 +868,9 @@ smt_astt smtlib_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 
 smt_sort *smtlib_convt::mk_struct_sort(const type2tc &type [[gnu::unused]])
 {
-  std::cerr << "Attempted to make struct type in smtlib conversion"
-            << "\n";
+  ERROR(
+    "Attempted to make struct type in smtlib conversion"
+    << "\n");
   abort();
 }
 
@@ -915,8 +934,9 @@ smt_astt smtlib_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 
 int smtliberror(int startsym [[gnu::unused]], const std::string &error)
 {
-  std::cerr << "SMTLIB response parsing error: \"" << error << "\""
-            << "\n";
+  ERROR(
+    "SMTLIB response parsing error: \"" << error << "\""
+                                        << "\n");
   abort();
 }
 

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -125,7 +125,7 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
     if(config.options.get_option("smtlib-solver-prog") != "")
     {
       std::cerr << "Can't solve SMTLIB output and write to a file, sorry"
-                << std::endl;
+                << "\n";
       abort();
     }
 
@@ -133,7 +133,8 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
     out_stream = fopen(cmd.c_str(), "w");
     if(!out_stream)
     {
-      std::cerr << "Failed to open \"" << cmd << "\"" << std::endl;
+      std::cerr << "Failed to open \"" << cmd << "\""
+                << "\n";
       abort();
     }
 
@@ -157,7 +158,7 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
   if(cmd == "")
   {
     std::cerr << "Must specify an smtlib solver program in smtlib mode"
-              << std::endl;
+              << "\n";
     abort();
   }
 #ifdef _WIN32
@@ -167,13 +168,15 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
 #else
   if(pipe(inpipe) != 0)
   {
-    std::cerr << "Couldn't open a pipe for smtlib solver" << std::endl;
+    std::cerr << "Couldn't open a pipe for smtlib solver"
+              << "\n";
     abort();
   }
 
   if(pipe(outpipe) != 0)
   {
-    std::cerr << "Couldn't open a pipe for smtlib solver" << std::endl;
+    std::cerr << "Couldn't open a pipe for smtlib solver"
+              << "\n";
     abort();
   }
 
@@ -191,7 +194,8 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
 
     // Voila
     execlp(cmd.c_str(), cmd.c_str(), NULL);
-    std::cerr << "Exec of smtlib solver failed" << std::endl;
+    std::cerr << "Exec of smtlib solver failed"
+              << "\n";
     abort();
   }
   else
@@ -292,7 +296,8 @@ std::string smtlib_convt::sort_to_string(const smt_sort *s) const
   case SMT_SORT_BOOL:
     return "Bool";
   default:
-    std::cerr << "Unexpected sort in smtlib_convt" << std::endl;
+    std::cerr << "Unexpected sort in smtlib_convt"
+              << "\n";
     abort();
   }
 }
@@ -346,7 +351,8 @@ smtlib_convt::emit_terminal_ast(const smtlib_smt_ast *ast, std::string &output)
     output = ss.str();
     return 0;
   default:
-    std::cerr << "Invalid terminal AST kind" << std::endl;
+    std::cerr << "Invalid terminal AST kind"
+              << "\n";
     abort();
   }
 }
@@ -443,13 +449,14 @@ smt_convt::resultt smtlib_convt::dec_solve()
   else if(smtlib_output->token == TOK_KW_ERROR)
   {
     std::cerr << "SMTLIB solver returned error: \"" << smtlib_output->data
-              << "\"" << std::endl;
+              << "\""
+              << "\n";
     return smt_convt::P_ERROR;
   }
   else
   {
     std::cerr << "Unrecognized check-sat output from smtlib solver"
-              << std::endl;
+              << "\n";
     abort();
   }
 }
@@ -469,13 +476,14 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
   if(smtlib_output->token == TOK_KW_ERROR)
   {
     std::cerr << "Error from smtlib solver when fetching literal value: \""
-              << smtlib_output->data << "\"" << std::endl;
+              << smtlib_output->data << "\""
+              << "\n";
     abort();
   }
   else if(smtlib_output->token != 0)
   {
     std::cerr << "Unrecognized response to get-value from smtlib solver"
-              << std::endl;
+              << "\n";
   }
 
   // Unpack our value from response list.
@@ -507,7 +515,7 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
   else if(respval.token == TOK_NUMERAL)
   {
     std::cerr << "Numeral value for integer symbol from smtlib solver"
-              << std::endl;
+              << "\n";
     abort();
   }
   else if(respval.token == TOK_HEXNUM)
@@ -548,13 +556,14 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
   if(smtlib_output->token == TOK_KW_ERROR)
   {
     std::cerr << "Error from smtlib solver when fetching literal value: \""
-              << smtlib_output->data << "\"" << std::endl;
+              << smtlib_output->data << "\""
+              << "\n";
     abort();
   }
   else if(smtlib_output->token != 0)
   {
     std::cerr << "Unrecognized response to get-value from smtlib solver"
-              << std::endl;
+              << "\n";
   }
 
   // Unpack our value from response list.
@@ -582,7 +591,7 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
   else if(respval.token == TOK_NUMERAL)
   {
     std::cerr << "Numeral value for integer symbol from smtlib solver"
-              << std::endl;
+              << "\n";
     abort();
   }
   else if(respval.token == TOK_HEXNUM)
@@ -654,7 +663,7 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
       else
       {
         std::cerr << "Unrecognized boolean-typed binary number format";
-        std::cerr << std::endl;
+        std::cerr << "\n";
         abort();
       }
     }
@@ -662,7 +671,7 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
     {
       std::cerr << "Unexpected token reading value of boolean symbol from "
                    "smtlib solver"
-                << std::endl;
+                << "\n";
     }
   }
   else
@@ -696,13 +705,14 @@ bool smtlib_convt::get_bool(smt_astt a)
   if(smtlib_output->token == TOK_KW_ERROR)
   {
     std::cerr << "Error from smtlib solver when fetching literal value: \""
-              << smtlib_output->data << "\"" << std::endl;
+              << smtlib_output->data << "\""
+              << "\n";
     abort();
   }
   else if(smtlib_output->token != 0)
   {
     std::cerr << "Unrecognized response to get-value from smtlib solver"
-              << std::endl;
+              << "\n";
   }
 
   // First layer: valuation pair list. Should have one item.
@@ -841,7 +851,7 @@ smt_astt smtlib_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 smt_sort *smtlib_convt::mk_struct_sort(const type2tc &type [[gnu::unused]])
 {
   std::cerr << "Attempted to make struct type in smtlib conversion"
-            << std::endl;
+            << "\n";
   abort();
 }
 
@@ -906,7 +916,7 @@ smt_astt smtlib_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 int smtliberror(int startsym [[gnu::unused]], const std::string &error)
 {
   std::cerr << "SMTLIB response parsing error: \"" << error << "\""
-            << std::endl;
+            << "\n";
   abort();
 }
 

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -163,7 +163,7 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
   }
 #ifdef _WIN32
   // TODO: The current implementation uses UNIX Process
-  std::cerr << "smtlib works only in unix systems\n";
+  ERROR("smtlib works only in unix systems\n");
   abort();
 #else
   if(pipe(inpipe) != 0)
@@ -236,7 +236,7 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
   class sexpr &value = s.sexpr_list.back();
   if(!(keyword.token == TOK_KEYWORD && keyword.data == ":name"))
   {
-    std::cerr << "Bad get-info :name response from solver";
+    ERROR("Bad get-info :name response from solver");
     abort();
   }
 
@@ -261,7 +261,7 @@ smtlib_convt::smtlib_convt(bool int_encoding, const namespacet &_ns)
   class sexpr &val = v.sexpr_list.back();
   if(!(kw.token == TOK_KEYWORD && kw.data == ":version"))
   {
-    std::cerr << "Bad get-info :version response from solver";
+    ERROR("Bad get-info :version response from solver");
     abort();
   }
   assert(val.token == TOK_STRINGLIT && "Non-string solver version response");
@@ -502,7 +502,7 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
   sexpr &respval = *it++;
   if(!(symname.token == TOK_SIMPLESYM && symname.data == name))
   {
-    std::cerr << "smtlib solver returned different symbol from get-value";
+    ERROR("smtlib solver returned different symbol from get-value");
     abort();
   }
 
@@ -662,8 +662,8 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
         result = gen_true_expr();
       else
       {
-        std::cerr << "Unrecognized boolean-typed binary number format";
-        std::cerr << "\n";
+        ERROR("Unrecognized boolean-typed binary number format");
+        ERROR("\n");
         abort();
       }
     }

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -73,9 +73,10 @@ static smt_convt *create_solver(
     }
   }
 
-  std::cerr << "The " << the_solver
-            << " solver has not been built into this version of ESBMC, sorry"
-            << "\n";
+  ERROR(
+    "The " << the_solver
+           << " solver has not been built into this version of ESBMC, sorry"
+           << "\n");
   abort();
 }
 
@@ -121,8 +122,9 @@ static smt_convt *pick_solver(
     {
       if(the_solver != "")
       {
-        std::cerr << "Please only specify one solver"
-                  << "\n";
+        ERROR(
+          "Please only specify one solver"
+          << "\n");
         abort();
       }
 

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -75,14 +75,15 @@ static smt_convt *create_solver(
 
   std::cerr << "The " << the_solver
             << " solver has not been built into this version of ESBMC, sorry"
-            << std::endl;
+            << "\n";
   abort();
 }
 
 static const std::string pick_default_solver()
 {
 #ifdef BOOLECTOR
-  std::cerr << "No solver specified; defaulting to Boolector" << std::endl;
+  std::cerr << "No solver specified; defaulting to Boolector"
+            << "\n";
   return "boolector";
 #else
   // Pick whatever's first in the list.
@@ -90,13 +91,13 @@ static const std::string pick_default_solver()
   {
     std::cerr << "No solver backends built into ESBMC; please either build ";
     std::cerr << "some in, or explicitly configure the smtlib backend";
-    std::cerr << std::endl;
+    std::cerr << "\n";
     abort();
   }
   else
   {
     std::cerr << "No solver specified; defaulting to " << esbmc_solvers[1].name;
-    std::cerr << std::endl;
+    std::cerr << "\n";
     return esbmc_solvers[1].name;
   }
 #endif
@@ -119,7 +120,8 @@ static smt_convt *pick_solver(
     {
       if(the_solver != "")
       {
-        std::cerr << "Please only specify one solver" << std::endl;
+        std::cerr << "Please only specify one solver"
+                  << "\n";
         abort();
       }
 

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -82,22 +82,23 @@ static smt_convt *create_solver(
 static const std::string pick_default_solver()
 {
 #ifdef BOOLECTOR
-  std::cerr << "No solver specified; defaulting to Boolector"
-            << "\n";
+  ERROR(
+    "No solver specified; defaulting to Boolector"
+    << "\n");
   return "boolector";
 #else
   // Pick whatever's first in the list.
   if(esbmc_num_solvers == 1)
   {
-    std::cerr << "No solver backends built into ESBMC; please either build ";
-    std::cerr << "some in, or explicitly configure the smtlib backend";
-    std::cerr << "\n";
+    ERROR("No solver backends built into ESBMC; please either build ");
+    ERROR("some in, or explicitly configure the smtlib backend");
+    ERROR("\n");
     abort();
   }
   else
   {
-    std::cerr << "No solver specified; defaulting to " << esbmc_solvers[1].name;
-    std::cerr << "\n";
+    ERROR("No solver specified; defaulting to " << esbmc_solvers[1].name);
+    ERROR("\n");
     return esbmc_solvers[1].name;
   }
 #endif

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -63,8 +63,9 @@ void yices_convt::push_ctx()
 
   if(res != 0)
   {
-    std::cerr << "Error pushing yices context"
-              << "\n";
+    ERROR(
+      "Error pushing yices context"
+      << "\n");
     yices_print_error(stderr);
     abort();
   }
@@ -76,8 +77,9 @@ void yices_convt::pop_ctx()
 
   if(res != 0)
   {
-    std::cerr << "Error poping yices context"
-              << "\n";
+    ERROR(
+      "Error poping yices context"
+      << "\n");
     yices_print_error(stderr);
     abort();
   }
@@ -659,8 +661,9 @@ smt_astt yices_convt::mk_select(smt_astt a, smt_astt b)
 
 smt_astt yices_convt::mk_isint(smt_astt)
 {
-  std::cerr << "Yices does not support an is-integer operation on reals, "
-            << "therefore certain casts and operations don't work, sorry\n";
+  ERROR(
+    "Yices does not support an is-integer operation on reals, "
+    << "therefore certain casts and operations don't work, sorry\n");
   abort();
 }
 

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -63,7 +63,8 @@ void yices_convt::push_ctx()
 
   if(res != 0)
   {
-    std::cerr << "Error pushing yices context" << std::endl;
+    std::cerr << "Error pushing yices context"
+              << "\n";
     yices_print_error(stderr);
     abort();
   }
@@ -75,7 +76,8 @@ void yices_convt::pop_ctx()
 
   if(res != 0)
   {
-    std::cerr << "Error poping yices context" << std::endl;
+    std::cerr << "Error poping yices context"
+              << "\n";
     yices_print_error(stderr);
     abort();
   }

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -786,7 +786,7 @@ bool yices_convt::get_bool(smt_astt a)
   const yices_smt_ast *ast = to_solver_smt_ast<yices_smt_ast>(a);
   if(yices_get_bool_value(yices_get_model(yices_ctx, 1), ast->a, &val))
   {
-    std::cerr << "Can't get boolean value from Yices\n";
+    ERROR("Can't get boolean value from Yices\n");
     abort();
   }
   return val ? true : false;

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -13,8 +13,9 @@ public:
     // Detect term errors
     if(a == NULL_TERM)
     {
-      std::cerr << "Error creating yices term"
-                << "\n";
+      ERROR(
+        "Error creating yices term"
+        << "\n");
       yices_print_error(stderr);
       abort();
     }

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -13,7 +13,8 @@ public:
     // Detect term errors
     if(a == NULL_TERM)
     {
-      std::cerr << "Error creating yices term" << std::endl;
+      std::cerr << "Error creating yices term"
+                << "\n";
       yices_print_error(stderr);
       abort();
     }

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -12,8 +12,9 @@
 
 static void error_handler(Z3_context c, Z3_error_code e)
 {
-  std::cerr << "Z3 error " << e << " encountered" << std::endl;
-  std::cerr << Z3_get_error_msg(c, e) << std::endl;
+  std::cerr << "Z3 error " << e << " encountered"
+            << "\n";
+  std::cerr << Z3_get_error_msg(c, e) << "\n";
   abort();
 }
 
@@ -125,7 +126,8 @@ z3::expr z3_convt::mk_tuple_select(const z3::expr &t, unsigned i)
   z3::sort ty = t.get_sort();
   if(!ty.is_datatype())
   {
-    std::cerr << "Z3 conversion: argument must be a tuple" << std::endl;
+    std::cerr << "Z3 conversion: argument must be a tuple"
+              << "\n";
     abort();
   }
 
@@ -133,7 +135,7 @@ z3::expr z3_convt::mk_tuple_select(const z3::expr &t, unsigned i)
   if(i >= num_fields)
   {
     std::cerr << "Z3 conversion: invalid tuple select, index is too large"
-              << std::endl;
+              << "\n";
     abort();
   }
 
@@ -1215,14 +1217,14 @@ z3_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
 
 void z3_smt_ast::dump() const
 {
-  std::cout << Z3_ast_to_string(a.ctx(), a) << std::endl;
+  std::cout << Z3_ast_to_string(a.ctx(), a) << "\n";
   std::cout << "sort is " << Z3_sort_to_string(a.ctx(), Z3_get_sort(a.ctx(), a))
-            << std::endl;
+            << "\n";
 }
 
 void z3_convt::dump_smt()
 {
-  std::cout << solver << std::endl;
+  std::cout << solver << "\n";
 }
 
 smt_astt z3_convt::mk_smt_fpbv_gt(smt_astt lhs, smt_astt rhs)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1218,8 +1218,8 @@ z3_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
 void z3_smt_ast::dump() const
 {
   PRINT(Z3_ast_to_string(a.ctx(), a) << "\n");
-  std::cout << "sort is " << Z3_sort_to_string(a.ctx(), Z3_get_sort(a.ctx(), a))
-            << "\n";
+  PRINT(
+    "sort is " << Z3_sort_to_string(a.ctx(), Z3_get_sort(a.ctx(), a)) << "\n");
 }
 
 void z3_convt::dump_smt()

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1217,14 +1217,14 @@ z3_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
 
 void z3_smt_ast::dump() const
 {
-  std::cout << Z3_ast_to_string(a.ctx(), a) << "\n";
+  PRINT(Z3_ast_to_string(a.ctx(), a) << "\n");
   std::cout << "sort is " << Z3_sort_to_string(a.ctx(), Z3_get_sort(a.ctx(), a))
             << "\n";
 }
 
 void z3_convt::dump_smt()
 {
-  std::cout << solver << "\n";
+  PRINT(solver << "\n");
 }
 
 smt_astt z3_convt::mk_smt_fpbv_gt(smt_astt lhs, smt_astt rhs)
@@ -1282,7 +1282,7 @@ smt_astt z3_convt::mk_smt_fpbv_neg(smt_astt op)
 
 void z3_convt::print_model()
 {
-  std::cout << Z3_model_to_string(z3_ctx, solver.get_model());
+  PRINT(Z3_model_to_string(z3_ctx, solver.get_model()));
 }
 
 smt_sortt z3_convt::mk_fpbv_sort(const unsigned ew, const unsigned sw)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -12,8 +12,9 @@
 
 static void error_handler(Z3_context c, Z3_error_code e)
 {
-  std::cerr << "Z3 error " << e << " encountered"
-            << "\n";
+  ERROR(
+    "Z3 error " << e << " encountered"
+                << "\n");
   ERROR(Z3_get_error_msg(c, e) << "\n");
   abort();
 }
@@ -126,16 +127,18 @@ z3::expr z3_convt::mk_tuple_select(const z3::expr &t, unsigned i)
   z3::sort ty = t.get_sort();
   if(!ty.is_datatype())
   {
-    std::cerr << "Z3 conversion: argument must be a tuple"
-              << "\n";
+    ERROR(
+      "Z3 conversion: argument must be a tuple"
+      << "\n");
     abort();
   }
 
   size_t num_fields = Z3_get_tuple_sort_num_fields(z3_ctx, ty);
   if(i >= num_fields)
   {
-    std::cerr << "Z3 conversion: invalid tuple select, index is too large"
-              << "\n";
+    ERROR(
+      "Z3 conversion: invalid tuple select, index is too large"
+      << "\n");
     abort();
   }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -14,7 +14,7 @@ static void error_handler(Z3_context c, Z3_error_code e)
 {
   std::cerr << "Z3 error " << e << " encountered"
             << "\n";
-  std::cerr << Z3_get_error_msg(c, e) << "\n";
+  ERROR(Z3_get_error_msg(c, e) << "\n");
   abort();
 }
 
@@ -90,14 +90,14 @@ z3_convt::mk_tuple_update(const z3::expr &t, unsigned i, const z3::expr &newval)
   z3::sort ty = t.get_sort();
   if(!ty.is_datatype())
   {
-    std::cerr << "argument must be a tuple";
+    ERROR("argument must be a tuple");
     abort();
   }
 
   std::size_t num_fields = Z3_get_tuple_sort_num_fields(z3_ctx, ty);
   if(i >= num_fields)
   {
-    std::cerr << "invalid tuple update, index is too big";
+    ERROR("invalid tuple update, index is too big");
     abort();
   }
 
@@ -1144,7 +1144,7 @@ bool z3_convt::get_bool(smt_astt a)
     res = false;
     break;
   default:
-    std::cerr << "Can't get boolean value from Z3\n";
+    ERROR("Can't get boolean value from Z3\n");
     abort();
   }
 

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -245,8 +245,8 @@ bool base_type_eqt::base_type_eq_rec(const typet &type1, const typet &type2)
     return true;
 
 #if 0
-  std::cout << "T1: " << type1.pretty() << std::endl;
-  std::cout << "T2: " << type2.pretty() << std::endl;
+  std::cout << "T1: " << type1.pretty() << "\n";
+  std::cout << "T2: " << type2.pretty() << "\n";
 #endif
 
   // loop avoidance

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -245,8 +245,8 @@ bool base_type_eqt::base_type_eq_rec(const typet &type1, const typet &type2)
     return true;
 
 #if 0
-  std::cout << "T1: " << type1.pretty() << "\n";
-  std::cout << "T2: " << type2.pretty() << "\n";
+  PRINT("T1: " << type1.pretty() << "\n");
+  PRINT("T2: " << type2.pretty() << "\n");
 #endif
 
   // loop avoidance

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -150,10 +150,11 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
   {
     err_location(new_symbol.location);
     str << "error: conflicting definition for symbol \"" << in_context.name
-        << "\"" << std::endl;
-    str << "old definition: " << to_string(in_context.type) << std::endl;
-    str << "Module: " << in_context.module << std::endl;
-    str << "new definition: " << to_string(new_symbol.type) << std::endl;
+        << "\""
+        << "\n";
+    str << "old definition: " << to_string(in_context.type) << "\n";
+    str << "Module: " << in_context.module << "\n";
+    str << "new definition: " << to_string(new_symbol.type) << "\n";
     str << "Module: " << new_symbol.module;
     throw 0;
   }
@@ -190,7 +191,8 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       {
         err_location(new_symbol.value);
         str << "error: duplicate definition of function `" << in_context.name
-            << "'" << std::endl;
+            << "'"
+            << "\n";
         str << "In module `" << in_context.module << "' and module `"
             << new_symbol.module << "'";
         throw 0;
@@ -248,10 +250,11 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       {
         err_location(new_symbol.location);
         str << "error: conflicting definition for variable `" << in_context.name
-            << "'" << std::endl;
-        str << "old definition: " << to_string(in_context.type) << std::endl;
-        str << "Module: " << in_context.module << std::endl;
-        str << "new definition: " << to_string(new_symbol.type) << std::endl;
+            << "'"
+            << "\n";
+        str << "old definition: " << to_string(in_context.type) << "\n";
+        str << "Module: " << in_context.module << "\n";
+        str << "new definition: " << to_string(new_symbol.type) << "\n";
         str << "Module: " << new_symbol.module;
         throw 0;
       }
@@ -269,10 +272,11 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       {
         err_location(new_symbol.value);
         str << "error: conflicting initializers for variable `"
-            << in_context.name << "'" << std::endl;
-        str << "old value: " << to_string(in_context.value) << std::endl;
-        str << "Module: " << in_context.module << std::endl;
-        str << "new value: " << to_string(new_symbol.value) << std::endl;
+            << in_context.name << "'"
+            << "\n";
+        str << "old value: " << to_string(in_context.value) << "\n";
+        str << "Module: " << in_context.module << "\n";
+        str << "new value: " << to_string(new_symbol.value) << "\n";
         str << "Module: " << new_symbol.module;
         throw 0;
       }

--- a/src/util/c_sizeof.cpp
+++ b/src/util/c_sizeof.cpp
@@ -30,20 +30,23 @@ exprt c_sizeof(const typet &src, const namespacet &ns)
   }
   catch(array_type2t::dyn_sized_array_excp *e)
   { // Nondet'ly sized.
-    std::cerr << "Sizeof nondeterministically sized array encountered"
-              << "\n";
+    ERROR(
+      "Sizeof nondeterministically sized array encountered"
+      << "\n");
     abort();
   }
   catch(array_type2t::inf_sized_array_excp *e)
   {
-    std::cerr << "Sizeof infinite sized array encountered"
-              << "\n";
+    ERROR(
+      "Sizeof infinite sized array encountered"
+      << "\n");
     abort();
   }
   catch(type2t::symbolic_type_excp *e)
   {
-    std::cerr << "Sizeof symbolic type encountered"
-              << "\n";
+    ERROR(
+      "Sizeof symbolic type encountered"
+      << "\n");
     abort();
   }
 

--- a/src/util/c_sizeof.cpp
+++ b/src/util/c_sizeof.cpp
@@ -31,17 +31,19 @@ exprt c_sizeof(const typet &src, const namespacet &ns)
   catch(array_type2t::dyn_sized_array_excp *e)
   { // Nondet'ly sized.
     std::cerr << "Sizeof nondeterministically sized array encountered"
-              << std::endl;
+              << "\n";
     abort();
   }
   catch(array_type2t::inf_sized_array_excp *e)
   {
-    std::cerr << "Sizeof infinite sized array encountered" << std::endl;
+    std::cerr << "Sizeof infinite sized array encountered"
+              << "\n";
     abort();
   }
   catch(type2t::symbolic_type_excp *e)
   {
-    std::cerr << "Sizeof symbolic type encountered" << std::endl;
+    std::cerr << "Sizeof symbolic type encountered"
+              << "\n";
     abort();
   }
 

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstdlib>
 #include <iostream>
 #include <util/cmdline.h>
+#include <util/message.h>
 #include <sstream>
 
 std::string verification_file;
@@ -111,7 +112,7 @@ bool cmdlinet::parse(
   }
   catch(std::exception &e)
   {
-    std::cerr << "ESBMC error: " << e.what() << "\n";
+    ERROR("ESBMC error: " << e.what() << "\n");
     return true;
   }
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -105,8 +105,9 @@ bool configt::set(const cmdlinet &cmdline)
 
   if(cmdline.isset("floatbv") && cmdline.isset("fixedbv"))
   {
-    ERROR("Can't set both floatbv and fixedbv modes"
-              << "\n");
+    ERROR(
+      "Can't set both floatbv and fixedbv modes"
+      << "\n");
     return true;
   }
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -104,7 +104,8 @@ bool configt::set(const cmdlinet &cmdline)
 
   if(cmdline.isset("floatbv") && cmdline.isset("fixedbv"))
   {
-    std::cerr << "Can't set both floatbv and fixedbv modes" << std::endl;
+    std::cerr << "Can't set both floatbv and fixedbv modes"
+              << "\n";
     return true;
   }
 
@@ -179,7 +180,8 @@ bool configt::set(const cmdlinet &cmdline)
 
   if(cmdline.isset("little-endian") && cmdline.isset("big-endian"))
   {
-    std::cerr << "Can't set both little and big endian modes" << std::endl;
+    std::cerr << "Can't set both little and big endian modes"
+              << "\n";
     return true;
   }
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <algorithm>
 #include <iostream>
 #include <util/config.h>
+#include <util/message.h>
 
 configt config;
 
@@ -104,8 +105,8 @@ bool configt::set(const cmdlinet &cmdline)
 
   if(cmdline.isset("floatbv") && cmdline.isset("fixedbv"))
   {
-    std::cerr << "Can't set both floatbv and fixedbv modes"
-              << "\n";
+    ERROR("Can't set both floatbv and fixedbv modes"
+              << "\n");
     return true;
   }
 
@@ -180,8 +181,9 @@ bool configt::set(const cmdlinet &cmdline)
 
   if(cmdline.isset("little-endian") && cmdline.isset("big-endian"))
   {
-    std::cerr << "Can't set both little and big endian modes"
-              << "\n";
+    ERROR(
+      "Can't set both little and big endian modes"
+      << "\n");
     return true;
   }
 

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -76,8 +76,9 @@ void contextt::erase_symbol(irep_idt name)
   symbolst::iterator it = symbols.find(name);
   if(it == symbols.end())
   {
-    std::cerr << "Couldn't find symbol to erase"
-              << "\n";
+    ERROR(
+      "Couldn't find symbol to erase"
+      << "\n");
     abort();
   }
 

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -7,6 +7,7 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include <util/context.h>
+#include <util/message.h>
 
 bool contextt::add(const symbolt &symbol)
 {
@@ -45,9 +46,10 @@ bool contextt::move(symbolt &symbol, symbolt *&new_symbol)
 
 void contextt::dump() const
 {
-  std::cout << "\n"
-            << "Symbols:"
-            << "\n";
+  PRINT(
+    "\n"
+    << "Symbols:"
+    << "\n");
 
   // Do assignments based on "value".
   foreach_operand([](const symbolt &s) { s.dump(); });

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -45,7 +45,9 @@ bool contextt::move(symbolt &symbol, symbolt *&new_symbol)
 
 void contextt::dump() const
 {
-  std::cout << std::endl << "Symbols:" << std::endl;
+  std::cout << "\n"
+            << "Symbols:"
+            << "\n";
 
   // Do assignments based on "value".
   foreach_operand([](const symbolt &s) { s.dump(); });
@@ -72,7 +74,8 @@ void contextt::erase_symbol(irep_idt name)
   symbolst::iterator it = symbols.find(name);
   if(it == symbols.end())
   {
-    std::cerr << "Couldn't find symbol to erase" << std::endl;
+    std::cerr << "Couldn't find symbol to erase"
+              << "\n";
     abort();
   }
 

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <cstdlib>
 #include <util/i2string.h>
 #include <util/irep.h>
+#include <util/message.h>
 
 irept nil_rep_storage;
 
@@ -19,7 +20,7 @@ const irept::dt empty_d;
 
 void irept::dump() const
 {
-  std::cout << pretty(0) << "\n";
+  PRINT(pretty(0) << "\n");
 }
 
 const irept &get_nil_irep()
@@ -35,7 +36,7 @@ irept::irept(const irep_idt &_id) : data(new dt)
   id(_id);
 
 #ifdef IREP_DEBUG
-  std::cout << "CREATED " << data << " " << _id << "\n";
+  PRINT("CREATED " << data << " " << _id << "\n");
 #endif
 }
 #else
@@ -49,7 +50,7 @@ irept::irept(const irep_idt &_id)
 void irept::detatch()
 {
 #ifdef IREP_DEBUG
-  std::cout << "DETATCH1: " << data << "\n";
+  PRINT("DETATCH1: " << data << "\n");
 #endif
 
   if(data == nullptr)
@@ -57,7 +58,7 @@ void irept::detatch()
     data = new dt;
 
 #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << "\n";
+    PRINT("ALLOCATED " << data << "\n");
 #endif
   }
   else if(data->ref_count > 1)
@@ -66,7 +67,7 @@ void irept::detatch()
     data = new dt(*old_data);
 
 #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << "\n";
+    PRINT("ALLOCATED " << data << "\n");
 #endif
 
     data->ref_count = 1;
@@ -76,7 +77,7 @@ void irept::detatch()
   assert(data->ref_count == 1);
 
 #ifdef IREP_DEBUG
-  std::cout << "DETATCH2: " << data << "\n";
+  PRINT("DETATCH2: " << data << "\n");
 #endif
 }
 #endif
@@ -85,7 +86,7 @@ void irept::detatch()
 const irept::dt &irept::read() const
 {
 #ifdef IREP_DEBUG
-  std::cout << "READ: " << data << "\n";
+  PRINT("READ: " << data << "\n");
 #endif
 
   if(data == nullptr)
@@ -106,23 +107,23 @@ void irept::remove_ref(dt *old_data)
   assert(old_data->ref_count != 0);
 
 #ifdef IREP_DEBUG
-  std::cout << "R: " << old_data << " " << old_data->ref_count << "\n";
+  PRINT("R: " << old_data << " " << old_data->ref_count << "\n");
 #endif
 
   old_data->ref_count--;
   if(old_data->ref_count == 0)
   {
 #ifdef IREP_DEBUG
-    std::cout << "D: " << pretty() << "\n";
-    std::cout << "DELETING " << old_data->data << " " << old_data << "\n";
+    PRINT("D: " << pretty() << "\n");
+    PRINT("DELETING " << old_data->data << " " << old_data << "\n");
     old_data->clear();
-    std::cout << "DEALLOCATING " << old_data << "\n";
+    PRINT("DEALLOCATING " << old_data << "\n");
 #endif
 
     delete old_data;
 
 #ifdef IREP_DEBUG
-    std::cout << "DONE\n";
+    PRINT("DONE\n");
 #endif
   }
 }

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -19,7 +19,7 @@ const irept::dt empty_d;
 
 void irept::dump() const
 {
-  std::cout << pretty(0) << std::endl;
+  std::cout << pretty(0) << "\n";
 }
 
 const irept &get_nil_irep()
@@ -35,7 +35,7 @@ irept::irept(const irep_idt &_id) : data(new dt)
   id(_id);
 
 #ifdef IREP_DEBUG
-  std::cout << "CREATED " << data << " " << _id << std::endl;
+  std::cout << "CREATED " << data << " " << _id << "\n";
 #endif
 }
 #else
@@ -49,7 +49,7 @@ irept::irept(const irep_idt &_id)
 void irept::detatch()
 {
 #ifdef IREP_DEBUG
-  std::cout << "DETATCH1: " << data << std::endl;
+  std::cout << "DETATCH1: " << data << "\n";
 #endif
 
   if(data == nullptr)
@@ -57,7 +57,7 @@ void irept::detatch()
     data = new dt;
 
 #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << std::endl;
+    std::cout << "ALLOCATED " << data << "\n";
 #endif
   }
   else if(data->ref_count > 1)
@@ -66,7 +66,7 @@ void irept::detatch()
     data = new dt(*old_data);
 
 #ifdef IREP_DEBUG
-    std::cout << "ALLOCATED " << data << std::endl;
+    std::cout << "ALLOCATED " << data << "\n";
 #endif
 
     data->ref_count = 1;
@@ -76,7 +76,7 @@ void irept::detatch()
   assert(data->ref_count == 1);
 
 #ifdef IREP_DEBUG
-  std::cout << "DETATCH2: " << data << std::endl;
+  std::cout << "DETATCH2: " << data << "\n";
 #endif
 }
 #endif
@@ -85,7 +85,7 @@ void irept::detatch()
 const irept::dt &irept::read() const
 {
 #ifdef IREP_DEBUG
-  std::cout << "READ: " << data << std::endl;
+  std::cout << "READ: " << data << "\n";
 #endif
 
   if(data == nullptr)
@@ -106,15 +106,15 @@ void irept::remove_ref(dt *old_data)
   assert(old_data->ref_count != 0);
 
 #ifdef IREP_DEBUG
-  std::cout << "R: " << old_data << " " << old_data->ref_count << std::endl;
+  std::cout << "R: " << old_data << " " << old_data->ref_count << "\n";
 #endif
 
   old_data->ref_count--;
   if(old_data->ref_count == 0)
   {
 #ifdef IREP_DEBUG
-    std::cout << "D: " << pretty() << std::endl;
-    std::cout << "DELETING " << old_data->data << " " << old_data << std::endl;
+    std::cout << "D: " << pretty() << "\n";
+    std::cout << "DELETING " << old_data->data << " " << old_data << "\n";
     old_data->clear();
     std::cout << "DEALLOCATING " << old_data << "\n";
 #endif

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -76,7 +76,7 @@ public:
       assert(data->ref_count != 0);
       data->ref_count++;
 #ifdef IREP_DEBUG
-      std::cout << "COPY " << data << " " << data->ref_count << "\n";
+      PRINT("COPY " << data << " " << data->ref_count << "\n");
 #endif
     }
   }
@@ -87,7 +87,7 @@ public:
     assert(&irep != this); // check if we assign to ourselves
 
 #ifdef IREP_DEBUG
-    std::cout << "ASSIGN\n";
+    PRINT("ASSIGN\n");
 #endif
 
     tmp = data;

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -76,7 +76,7 @@ public:
       assert(data->ref_count != 0);
       data->ref_count++;
 #ifdef IREP_DEBUG
-      std::cout << "COPY " << data << " " << data->ref_count << std::endl;
+      std::cout << "COPY " << data << " " << data->ref_count << "\n";
 #endif
     }
   }

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -189,15 +189,17 @@ unsigned int empty_type2t::get_width() const
 
 unsigned int symbol_type2t::get_width() const
 {
-  std::cerr << "Fetching width of symbol type - invalid operation"
-            << "\n";
+  ERROR(
+    "Fetching width of symbol type - invalid operation"
+    << "\n");
   abort();
 }
 
 unsigned int cpp_name_type2t::get_width() const
 {
-  std::cerr << "Fetching width of cpp_name type - invalid operation"
-            << "\n";
+  ERROR(
+    "Fetching width of cpp_name type - invalid operation"
+    << "\n");
   abort();
 }
 
@@ -282,15 +284,17 @@ unsigned int struct_union_data::get_component_number(const irep_idt &comp) const
 
   if(!count)
   {
-    std::cerr << "Looking up index of nonexistant member \"" << comp
-              << "\" in struct/union \"" << name << "\""
-              << "\n";
+    ERROR(
+      "Looking up index of nonexistant member \""
+      << comp << "\" in struct/union \"" << name << "\""
+      << "\n");
   }
   else if(count > 1)
   {
-    std::cerr << "Name \"" << comp << "\" matches more than one member"
-              << "\" in struct/union \"" << name << "\""
-              << "\n";
+    ERROR(
+      "Name \"" << comp << "\" matches more than one member"
+                << "\" in struct/union \"" << name << "\""
+                << "\n");
   }
 
   abort();
@@ -650,8 +654,9 @@ std::string symbol_data::get_symbol_name() const
     return thename.as_string() + "&" + i2string(node_num) + "#" +
            i2string(level2_num);
   default:
-    std::cerr << "Unrecognized renaming level enum"
-              << "\n";
+    ERROR(
+      "Unrecognized renaming level enum"
+      << "\n");
     abort();
   }
 }
@@ -926,8 +931,9 @@ type_to_string(const symbol_data::renaming_level &theval, int)
   case symbol_data::level2_global:
     return "Level 2 (global)";
   default:
-    std::cerr << "Unrecognized renaming level enum"
-              << "\n";
+    ERROR(
+      "Unrecognized renaming level enum"
+      << "\n");
     abort();
   }
 }

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -9,6 +9,7 @@
 #include <util/irep2_utils.h>
 #include <util/migrate.h>
 #include <util/std_types.h>
+#include <util/message.h>
 
 template <typename T>
 class register_irep_methods;
@@ -122,7 +123,7 @@ std::string type2t::pretty(unsigned int indent) const
 
 void type2t::dump() const
 {
-  std::cout << pretty(0) << "\n";
+  PRINT(pretty(0) << "\n");
 }
 
 size_t type2t::crc() const
@@ -553,7 +554,7 @@ std::string expr2t::pretty(unsigned int indent) const
 
 void expr2t::dump() const
 {
-  std::cout << pretty(0) << "\n";
+  PRINT(pretty(0) << "\n");
 }
 
 // Map a base type to it's list of names

--- a/src/util/irep2.cpp
+++ b/src/util/irep2.cpp
@@ -122,7 +122,7 @@ std::string type2t::pretty(unsigned int indent) const
 
 void type2t::dump() const
 {
-  std::cout << pretty(0) << std::endl;
+  std::cout << pretty(0) << "\n";
 }
 
 size_t type2t::crc() const
@@ -188,14 +188,15 @@ unsigned int empty_type2t::get_width() const
 
 unsigned int symbol_type2t::get_width() const
 {
-  std::cerr << "Fetching width of symbol type - invalid operation" << std::endl;
+  std::cerr << "Fetching width of symbol type - invalid operation"
+            << "\n";
   abort();
 }
 
 unsigned int cpp_name_type2t::get_width() const
 {
   std::cerr << "Fetching width of cpp_name type - invalid operation"
-            << std::endl;
+            << "\n";
   abort();
 }
 
@@ -281,12 +282,14 @@ unsigned int struct_union_data::get_component_number(const irep_idt &comp) const
   if(!count)
   {
     std::cerr << "Looking up index of nonexistant member \"" << comp
-              << "\" in struct/union \"" << name << "\"" << std::endl;
+              << "\" in struct/union \"" << name << "\""
+              << "\n";
   }
   else if(count > 1)
   {
     std::cerr << "Name \"" << comp << "\" matches more than one member"
-              << "\" in struct/union \"" << name << "\"" << std::endl;
+              << "\" in struct/union \"" << name << "\""
+              << "\n";
   }
 
   abort();
@@ -550,7 +553,7 @@ std::string expr2t::pretty(unsigned int indent) const
 
 void expr2t::dump() const
 {
-  std::cout << pretty(0) << std::endl;
+  std::cout << pretty(0) << "\n";
 }
 
 // Map a base type to it's list of names
@@ -646,7 +649,8 @@ std::string symbol_data::get_symbol_name() const
     return thename.as_string() + "&" + i2string(node_num) + "#" +
            i2string(level2_num);
   default:
-    std::cerr << "Unrecognized renaming level enum" << std::endl;
+    std::cerr << "Unrecognized renaming level enum"
+              << "\n";
     abort();
   }
 }
@@ -921,7 +925,8 @@ type_to_string(const symbol_data::renaming_level &theval, int)
   case symbol_data::level2_global:
     return "Level 2 (global)";
   default:
-    std::cerr << "Unrecognized renaming level enum" << std::endl;
+    std::cerr << "Unrecognized renaming level enum"
+              << "\n";
     abort();
   }
 }

--- a/src/util/irep2_utils.h
+++ b/src/util/irep2_utils.h
@@ -3,6 +3,7 @@
 
 #include <util/irep2_expr.h>
 #include <util/c_types.h>
+#include <util/message.h>
 
 /** Test whether type is an integer. */
 inline bool is_bv_type(const type2tc &t)
@@ -403,7 +404,7 @@ inline expr2tc gen_one(const type2tc &type)
     break;
   }
 
-  std::cerr << "Can't generate one for type " << get_type_id(type) << '\n';
+  ERROR("Can't generate one for type " << get_type_id(type) << '\n');
   abort();
 }
 

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -82,7 +82,8 @@ void irep_serializationt::read_irep(std::istream &in, irept &irep)
 
   if(in.get() != 0)
   {
-    std::cerr << "irep not terminated. " << std::endl;
+    std::cerr << "irep not terminated. "
+              << "\n";
     throw 0;
   }
 }

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -10,6 +10,7 @@ Date: May 2007
 
 #include <sstream>
 #include <util/irep_serialization.h>
+#include <util/message.h>
 
 void irep_serializationt::write_irep(std::ostream &out, const irept &irep)
 {
@@ -82,8 +83,9 @@ void irep_serializationt::read_irep(std::istream &in, irept &irep)
 
   if(in.get() != 0)
   {
-    std::cerr << "irep not terminated. "
-              << "\n";
+    ERROR(
+      "irep not terminated. "
+      << "\n");
     throw 0;
   }
 }

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -230,7 +230,8 @@ void language_filest::typecheck_virtual_methods(contextt &context)
               member_function.location.as_string() +
               ": The virtual method isn't pure virtual and hasn't a "
               "method implementation ");
-            std::cerr << "CONVERSION ERROR" << std::endl;
+            std::cerr << "CONVERSION ERROR"
+                      << "\n";
             throw 0;
           }
         }

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -230,8 +230,9 @@ void language_filest::typecheck_virtual_methods(contextt &context)
               member_function.location.as_string() +
               ": The virtual method isn't pure virtual and hasn't a "
               "method implementation ");
-            std::cerr << "CONVERSION ERROR"
-                      << "\n";
+            ERROR(
+              "CONVERSION ERROR"
+              << "\n");
             throw 0;
           }
         }

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -73,4 +73,17 @@ void messaget::set_message_handler(message_handlert *_message_handler)
   message_handler = _message_handler;
 }
 
-messaget esbmc::global::_msg;
+void stream_message_handlert::print(unsigned level, const std::string &message)
+{
+  if(level == VERBOSITY_ERRORS)
+    error_output << message;
+  else
+    default_output << message;
+}
+
+namespace
+{
+stream_message_handlert default_handler(std::cout, std::cerr);
+}
+
+messaget esbmc::global::_msg(default_handler);

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -72,3 +72,5 @@ void messaget::set_message_handler(message_handlert *_message_handler)
 {
   message_handler = _message_handler;
 }
+
+messaget esbmc::global::_msg;

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -118,12 +118,17 @@ protected:
   message_handlert *message_handler;
 };
 
-namespace esbmc::global {
-  extern messaget _msg; // use this if you know what you are doing
+namespace esbmc::global
+{
+extern messaget _msg; // use this if you know what you are doing
 }
 // Magic definitions to help the use of messages during the program
-#define _TO_MSG(X) std::stringstream _convert_ss_to_str; _convert_ss_to_str << X;
-#define _CALL_MSG(MODE,X) _TO_MSG(X); esbmc::global::_msg.##MODE(_convert_ss_to_str.str());
+#define _TO_MSG(X)                                                             \
+  std::stringstream _convert_ss_to_str;                                        \
+  _convert_ss_to_str << X;
+#define _CALL_MSG(MODE, X)                                                     \
+  _TO_MSG(X);                                                                  \
+  esbmc::global::_msg.##MODE(_convert_ss_to_str.str());
 #define DEBUG(X) _CALL_MSG(debug, X)
 #define WARNING(X) _CALL_MSG(warning, X)
 #define ERROR(X) _CALL_MSG(error, X)

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -150,10 +150,14 @@ protected:
   message_handlert *message_handler;
 };
 
-namespace esbmc::global
+namespace esbmc
+{
+namespace global
 {
 extern messaget _msg; // use this if you know what you are doing
-}
+} // namespace esbmc::global
+
+} // namespace esbmc
 // Magic definitions to help the use of messages during the program
 
 /* in time the implementation can be replaced with <format> */

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -123,9 +123,11 @@ namespace esbmc::global {
 }
 // Magic definitions to help the use of messages during the program
 #define _TO_MSG(X) std::stringstream _convert_ss_to_str; _convert_ss_to_str << X;
-#define _CALL_MSG(MODE,X) _TO_MSG(X); msg.##MODE(_convert_ss_to_str.str());
+#define _CALL_MSG(MODE,X) _TO_MSG(X); esbmc::global::_msg.##MODE(_convert_ss_to_str.str());
 #define DEBUG(X) _CALL_MSG(debug, X)
 #define WARNING(X) _CALL_MSG(warning, X)
 #define ERROR(X) _CALL_MSG(error, X)
+#define STATUS(X) _CALL_MSG(status, X)
+#define PRINT(X) _CALL_MSG(print, X)
 
 #endif

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -118,4 +118,14 @@ protected:
   message_handlert *message_handler;
 };
 
+namespace esbmc::global {
+  extern messaget _msg; // use this if you know what you are doing
+}
+// Magic definitions to help the use of messages during the program
+#define _TO_MSG(X) std::stringstream _convert_ss_to_str; _convert_ss_to_str << X;
+#define _CALL_MSG(MODE,X) _TO_MSG(X); msg.##MODE(_convert_ss_to_str.str());
+#define DEBUG(X) _CALL_MSG(debug, X)
+#define WARNING(X) _CALL_MSG(warning, X)
+#define ERROR(X) _CALL_MSG(error, X)
+
 #endif

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -138,7 +138,8 @@ extern messaget _msg; // use this if you know what you are doing
   }
 #define ERROR(X)                                                               \
   {                                                                            \
-    _CALL_MSG(error, X)                                                        \
+    _TO_MSG(X);                                                                \
+    esbmc::global::_msg.error(_convert_ss_to_str.str());                       \
   }
 #define STATUS(X)                                                              \
   {                                                                            \

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iostream>
 #include <string>
+#include <sstream>
 #include <util/location.h>
 
 class message_handlert
@@ -126,13 +127,27 @@ extern messaget _msg; // use this if you know what you are doing
 #define _TO_MSG(X)                                                             \
   std::stringstream _convert_ss_to_str;                                        \
   _convert_ss_to_str << X;
-#define _CALL_MSG(MODE, X)                                                     \
-  _TO_MSG(X);                                                                  \
-  esbmc::global::_msg.##MODE(_convert_ss_to_str.str());
-#define DEBUG(X) _CALL_MSG(debug, X)
-#define WARNING(X) _CALL_MSG(warning, X)
-#define ERROR(X) _CALL_MSG(error, X)
-#define STATUS(X) _CALL_MSG(status, X)
-#define PRINT(X) _CALL_MSG(print, X)
+
+#define DEBUG(X)                                                               \
+  {                                                                            \
+    _CALL_MSG(debug, X)                                                        \
+  }
+#define WARNING(X)                                                             \
+  {                                                                            \
+    _CALL_MSG(warning, X)                                                      \
+  }
+#define ERROR(X)                                                               \
+  {                                                                            \
+    _CALL_MSG(error, X)                                                        \
+  }
+#define STATUS(X)                                                              \
+  {                                                                            \
+    _CALL_MSG(status, X)                                                       \
+  }
+#define PRINT(X)                                                               \
+  {                                                                            \
+    _TO_MSG(X);                                                                \
+    esbmc::global::_msg.print(_convert_ss_to_str.str());                       \
+  }
 
 #endif

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -743,7 +743,8 @@ static void flatten_to_bytes(const exprt &expr, std::vector<expr2tc> &bytes)
   else
   {
     std::cerr << "Unrecognized type " << get_type_id(*new_expr->type);
-    std::cerr << " when flattening union literal" << std::endl;
+    std::cerr << " when flattening union literal"
+              << "\n";
     abort();
   }
 }
@@ -1842,7 +1843,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     else
     {
       std::cerr << "Unexpected side-effect statement: " << expr.statement()
-                << std::endl;
+                << "\n";
       abort();
     }
 
@@ -2254,7 +2255,8 @@ typet migrate_type_back(const type2tc &ref)
     return ret;
   }
   default:
-    std::cerr << "Unrecognized type in migrate_type_back" << std::endl;
+    std::cerr << "Unrecognized type in migrate_type_back"
+              << "\n";
     abort();
   }
 }
@@ -3268,7 +3270,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     return back;
   }
   default:
-    std::cerr << "Unrecognized expr in migrate_expr_back" << std::endl;
+    std::cerr << "Unrecognized expr in migrate_expr_back"
+              << "\n";
     abort();
   }
 }

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -743,8 +743,9 @@ static void flatten_to_bytes(const exprt &expr, std::vector<expr2tc> &bytes)
   else
   {
     ERROR("Unrecognized type " << get_type_id(*new_expr->type));
-    std::cerr << " when flattening union literal"
-              << "\n";
+    ERROR(
+      " when flattening union literal"
+      << "\n");
     abort();
   }
 }
@@ -1842,8 +1843,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     }
     else
     {
-      std::cerr << "Unexpected side-effect statement: " << expr.statement()
-                << "\n";
+      ERROR("Unexpected side-effect statement: " << expr.statement() << "\n");
       abort();
     }
 
@@ -2255,8 +2255,9 @@ typet migrate_type_back(const type2tc &ref)
     return ret;
   }
   default:
-    std::cerr << "Unrecognized type in migrate_type_back"
-              << "\n";
+    ERROR(
+      "Unrecognized type in migrate_type_back"
+      << "\n");
     abort();
   }
 }
@@ -3270,8 +3271,9 @@ exprt migrate_expr_back(const expr2tc &ref)
     return back;
   }
   default:
-    std::cerr << "Unrecognized expr in migrate_expr_back"
-              << "\n";
+    ERROR(
+      "Unrecognized expr in migrate_expr_back"
+      << "\n");
     abort();
   }
 }

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -742,7 +742,7 @@ static void flatten_to_bytes(const exprt &expr, std::vector<expr2tc> &bytes)
   }
   else
   {
-    std::cerr << "Unrecognized type " << get_type_id(*new_expr->type);
+    ERROR("Unrecognized type " << get_type_id(*new_expr->type));
     std::cerr << " when flattening union literal"
               << "\n";
     abort();

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/context.h>
 #include <util/irep2.h>
 #include <util/migrate.h>
+#include <util/message.h>
 
 // second: true <=> not found
 
@@ -23,8 +24,9 @@ public:
     const symbolt *symbol;
     if(lookup(name, symbol))
     {
-      std::cerr << "Failed to find symbol " + id2string(name) + " not found"
-                << "\n";
+      ERROR(
+        "Failed to find symbol " + id2string(name) + " not found"
+        << "\n");
       abort();
     }
     return *symbol;

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -24,7 +24,7 @@ public:
     if(lookup(name, symbol))
     {
       std::cerr << "Failed to find symbol " + id2string(name) + " not found"
-                << std::endl;
+                << "\n";
       abort();
     }
     return *symbol;

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -20,9 +20,11 @@ void show_symbol_table_xml_ui()
 
 void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
 {
-  out << std::endl << "Symbols:" << std::endl;
-  out << "Number of symbols: " << ns.get_context().size() << std::endl;
-  out << std::endl;
+  out << "\n"
+      << "Symbols:"
+      << "\n";
+  out << "Number of symbols: " << ns.get_context().size() << "\n";
+  out << "\n";
 
   ns.get_context().foreach_operand_in_order([&out, &ns](const symbolt &s) {
     int mode;
@@ -45,12 +47,13 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     if(s.value.is_not_nil())
       p->from_expr(s.value, value_str, ns);
 
-    out << "Symbol......: " << s.id << std::endl;
-    out << "Module......: " << s.module << std::endl;
-    out << "Base name...: " << s.name << std::endl;
-    out << "Mode........: " << s.mode << " (" << mode << ")" << std::endl;
-    out << "Type........: " << type_str << std::endl;
-    out << "Value.......: " << value_str << std::endl;
+    out << "Symbol......: " << s.id << "\n";
+    out << "Module......: " << s.module << "\n";
+    out << "Base name...: " << s.name << "\n";
+    out << "Mode........: " << s.mode << " (" << mode << ")"
+        << "\n";
+    out << "Type........: " << type_str << "\n";
+    out << "Value.......: " << value_str << "\n";
     out << "Flags.......:";
 
     if(s.lvalue)
@@ -66,9 +69,9 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     if(s.is_macro)
       out << " macro";
 
-    out << std::endl;
-    out << "Location....: " << s.location << std::endl;
+    out << "\n";
+    out << "Location....: " << s.location << "\n";
 
-    out << std::endl;
+    out << "\n";
   });
 }

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -56,8 +56,8 @@ struct_union_typet::get_component(const irep_idt &component_name) const
 
   for(const auto &it : c)
   {
-    //std::cout << "it->get_name(): " << it->get_name() << std::endl;
-    //std::cout << "component_name: " << component_name << std::endl;
+    //std::cout << "it->get_name(): " << it->get_name() << "\n";
+    //std::cout << "component_name: " << component_name << "\n";
     if(it.get_name() == component_name)
       return it;
   }

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -56,8 +56,8 @@ struct_union_typet::get_component(const irep_idt &component_name) const
 
   for(const auto &it : c)
   {
-    //std::cout << "it->get_name(): " << it->get_name() << "\n";
-    //std::cout << "component_name: " << component_name << "\n";
+    //PRINT("it->get_name(): " << it->get_name() << "\n");
+    //PRINT("component_name: " << component_name << "\n");
     if(it.get_name() == component_name)
       return it;
   }

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/location.h>
 #include <util/symbol.h>
+#include <util/message.h>
 
 symbolt::symbolt()
 {
@@ -48,7 +49,9 @@ void symbolt::swap(symbolt &b)
 
 void symbolt::dump() const
 {
-  show(std::cout);
+  std::stringstream out;
+  show(out);
+  PRINT(out.str());
 }
 
 void symbolt::show(std::ostream &out) const

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -53,14 +53,15 @@ void symbolt::dump() const
 
 void symbolt::show(std::ostream &out) const
 {
-  out << "Symbol......: " << id << std::endl;
-  out << "Base name...: " << name << std::endl;
-  out << "Module......: " << module << std::endl;
-  out << "Mode........: " << mode << " (" << mode << ")" << std::endl;
+  out << "Symbol......: " << id << "\n";
+  out << "Base name...: " << name << "\n";
+  out << "Module......: " << module << "\n";
+  out << "Mode........: " << mode << " (" << mode << ")"
+      << "\n";
   if(type.is_not_nil())
-    out << "Type........: " << type.pretty(4) << std::endl;
+    out << "Type........: " << type.pretty(4) << "\n";
   if(value.is_not_nil())
-    out << "Value.......: " << value.pretty(4) << std::endl;
+    out << "Value.......: " << value.pretty(4) << "\n";
 
   out << "Flags.......:";
 
@@ -77,10 +78,10 @@ void symbolt::show(std::ostream &out) const
   if(is_macro)
     out << " macro";
 
-  out << std::endl;
-  out << "Location....: " << location << std::endl;
+  out << "\n";
+  out << "Location....: " << location << "\n";
 
-  out << std::endl;
+  out << "\n";
 }
 
 std::ostream &operator<<(std::ostream &out, const symbolt &symbol)

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -39,7 +39,7 @@ public:
 
   void swap(symbolt &b);
 
-  void show(std::ostream &out = std::cout) const;
+  void show(std::ostream &out) const;
   DUMP_METHOD void dump() const;
 
   void to_irep(irept &dest) const;

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -71,12 +71,14 @@ BigInt type_byte_size_bits(const type2tc &type)
     return 0;
 
   case type2t::symbol_id:
-    std::cerr << "Symbolic type id in type_byte_size" << std::endl;
+    std::cerr << "Symbolic type id in type_byte_size"
+              << "\n";
     type->dump();
     abort();
 
   case type2t::cpp_name_id:
-    std::cerr << "C++ symbolic type id in type_byte_size" << std::endl;
+    std::cerr << "C++ symbolic type id in type_byte_size"
+              << "\n";
     type->dump();
     abort();
 
@@ -138,7 +140,8 @@ BigInt type_byte_size_bits(const type2tc &type)
   }
 
   default:
-    std::cerr << "Unrecognised type in type_byte_size_bits:" << std::endl;
+    std::cerr << "Unrecognised type in type_byte_size_bits:"
+              << "\n";
     type->dump();
     abort();
   }
@@ -166,7 +169,7 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
     else
     {
       std::cerr << "Unexpected index type in computer_pointer_offset";
-      std::cerr << std::endl;
+      std::cerr << "\n";
       abort();
     }
 
@@ -247,8 +250,9 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
     return gen_ulong(0);
   }
 
-  std::cerr << "compute_pointer_offset, unexpected irep:" << std::endl;
-  std::cerr << expr->pretty() << std::endl;
+  std::cerr << "compute_pointer_offset, unexpected irep:"
+            << "\n";
+  std::cerr << expr->pretty() << "\n";
   abort();
 }
 

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -168,8 +168,8 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
     }
     else
     {
-      std::cerr << "Unexpected index type in computer_pointer_offset";
-      std::cerr << "\n";
+      ERROR("Unexpected index type in computer_pointer_offset");
+      ERROR("\n");
       abort();
     }
 
@@ -252,7 +252,7 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
 
   std::cerr << "compute_pointer_offset, unexpected irep:"
             << "\n";
-  std::cerr << expr->pretty() << "\n";
+  ERROR(expr->pretty() << "\n");
   abort();
 }
 

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -71,14 +71,16 @@ BigInt type_byte_size_bits(const type2tc &type)
     return 0;
 
   case type2t::symbol_id:
-    std::cerr << "Symbolic type id in type_byte_size"
-              << "\n";
+    ERROR(
+      "Symbolic type id in type_byte_size"
+      << "\n");
     type->dump();
     abort();
 
   case type2t::cpp_name_id:
-    std::cerr << "C++ symbolic type id in type_byte_size"
-              << "\n";
+    ERROR(
+      "C++ symbolic type id in type_byte_size"
+      << "\n");
     type->dump();
     abort();
 
@@ -140,8 +142,9 @@ BigInt type_byte_size_bits(const type2tc &type)
   }
 
   default:
-    std::cerr << "Unrecognised type in type_byte_size_bits:"
-              << "\n";
+    ERROR(
+      "Unrecognised type in type_byte_size_bits:"
+      << "\n");
     type->dump();
     abort();
   }
@@ -250,8 +253,9 @@ expr2tc compute_pointer_offset(const expr2tc &expr)
     return gen_ulong(0);
   }
 
-  std::cerr << "compute_pointer_offset, unexpected irep:"
-            << "\n";
+  ERROR(
+    "compute_pointer_offset, unexpected irep:"
+    << "\n");
   ERROR(expr->pretty() << "\n");
   abort();
 }

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -33,7 +33,7 @@ void ui_message_handlert::print(unsigned level, const std::string &message)
   else
   {
     if(level == 1)
-      std::cerr << message << "\n";
+      ERROR(message << "\n")
     else
       std::cout << message << "\n";
   }

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -33,9 +33,9 @@ void ui_message_handlert::print(unsigned level, const std::string &message)
   else
   {
     if(level == 1)
-      std::cerr << message << std::endl;
+      std::cerr << message << "\n";
     else
-      std::cout << message << std::endl;
+      std::cout << message << "\n";
   }
 }
 
@@ -66,11 +66,11 @@ void ui_message_handlert::old_gui_msg(
   const std::string &msg1,
   const locationt &location)
 {
-  std::cout << type << std::endl
-            << msg1 << std::endl
-            << location.get_file() << std::endl
-            << location.get_line() << std::endl
-            << location.get_column() << std::endl;
+  std::cout << type << "\n"
+            << msg1 << "\n"
+            << location.get_file() << "\n"
+            << location.get_line() << "\n"
+            << location.get_column() << "\n";
 }
 
 void ui_message_handlert::ui_msg(
@@ -103,5 +103,5 @@ void ui_message_handlert::xml_ui_msg(
   xml.set_attribute("type", xmlt::escape_attribute(type));
 
   std::cout << xml;
-  std::cout << std::endl;
+  std::cout << "\n";
 }

--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -35,7 +35,7 @@ void ui_message_handlert::print(unsigned level, const std::string &message)
     if(level == 1)
       ERROR(message << "\n")
     else
-      std::cout << message << "\n";
+      PRINT(message << "\n");
   }
 }
 
@@ -66,11 +66,12 @@ void ui_message_handlert::old_gui_msg(
   const std::string &msg1,
   const locationt &location)
 {
-  std::cout << type << "\n"
-            << msg1 << "\n"
-            << location.get_file() << "\n"
-            << location.get_line() << "\n"
-            << location.get_column() << "\n";
+  PRINT(
+    type << "\n"
+         << msg1 << "\n"
+         << location.get_file() << "\n"
+         << location.get_line() << "\n"
+         << location.get_column() << "\n");
 }
 
 void ui_message_handlert::ui_msg(
@@ -102,6 +103,6 @@ void ui_message_handlert::xml_ui_msg(
   xml.new_element("text").data = xmlt::escape(msg1);
   xml.set_attribute("type", xmlt::escape_attribute(type));
 
-  std::cout << xml;
-  std::cout << "\n";
+  PRINT(xml);
+  PRINT("\n");
 }

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -31,7 +31,9 @@ public:
       break;
 
     case XML_UI:
-      std::cout << "<cprover>" << std::endl << std::endl;
+      std::cout << "<cprover>"
+                << "\n"
+                << "\n";
       break;
 
     case PLAIN:
@@ -44,7 +46,8 @@ public:
   ~ui_message_handlert() override
   {
     if(get_ui() == XML_UI)
-      std::cout << "</cprover>" << std::endl;
+      std::cout << "</cprover>"
+                << "\n";
   }
 
   uit get_ui() const

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -31,9 +31,10 @@ public:
       break;
 
     case XML_UI:
-      std::cout << "<cprover>"
-                << "\n"
-                << "\n";
+      PRINT(
+        "<cprover>"
+        << "\n"
+        << "\n");
       break;
 
     case PLAIN:
@@ -46,8 +47,9 @@ public:
   ~ui_message_handlert() override
   {
     if(get_ui() == XML_UI)
-      std::cout << "</cprover>"
-                << "\n";
+      PRINT(
+        "</cprover>"
+        << "\n");
   }
 
   uit get_ui() const

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -41,7 +41,7 @@ void xmlt::output(std::ostream &out, unsigned indent) const
     out << data;
   else
   {
-    out << std::endl;
+    out << "\n";
 
     for(const auto &element : elements)
       element.output(out, indent + 2);
@@ -49,7 +49,7 @@ void xmlt::output(std::ostream &out, unsigned indent) const
     do_indent(out, indent);
   }
 
-  out << '<' << '/' << name << '>' << std::endl;
+  out << '<' << '/' << name << '>' << "\n";
 }
 
 std::string xmlt::escape(const std::string &s)

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening
 \*******************************************************************/
 
 #include <util/xml_irep.h>
+#include <util/message.h>
 
 void convert(const irept &irep, xmlt &xml)
 {

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -70,7 +70,7 @@ void convert(const xmlt &xml, irept &irep)
     {
       // Should not happen
       std::cout << "Unknown sub found (" << it->name << "); malformed xml?";
-      std::cout << std::endl;
+      std::cout << "\n";
     }
   }
 }

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -70,8 +70,7 @@ void convert(const xmlt &xml, irept &irep)
     else
     {
       // Should not happen
-      std::cout << "Unknown sub found (" << it->name << "); malformed xml?";
-      std::cout << "\n";
+      PRINT("Unknown sub found (" << it->name << "); malformed xml?\n");
     }
   }
 }


### PR DESCRIPTION
This should close https://github.com/esbmc/esbmc/issues/450

The PR does the following:
1. Created the PRINT and ERROR definitions into the `util/message.h`. Also added one global `messaget` named `_msg`
2. Created the `stream_message_handler` with a global object `default_handler` using std::cout and std::cerr.
2. Every std::endl is replaced with `\n`
3. Every std::cout is replaced with PRINT
4. Every std::cerr is replaced with ERROR

**Note: I've ignored everything that only works on the old-frontend.**

TODO:
- [ ] Test cases
