### PR TITLE
implemented push/pop for Bitwuzla and Boolector

### DIFF
--- a/regression/incremental-smt/incremental-02/main.c
+++ b/regression/incremental-smt/incremental-02/main.c
@@ -1,0 +1,14 @@
+#include "assert.h"
+
+int main()
+{
+  int x = 1;
+  int y = 0;
+  while(y < 10 && __VERIFIER_nondet_int())
+  {
+    x = x + y;
+    y = y + 1;
+  }
+  assert(x >= y);
+  return 0;
+}

--- a/regression/incremental-smt/incremental-02/test.desc
+++ b/regression/incremental-smt/incremental-02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/incremental-smt/incremental-03/main.c
+++ b/regression/incremental-smt/incremental-03/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int main()
+{
+  int x = 1;
+  int y = 0;
+  while(y < 10 && __VERIFIER_nondet_int())
+  {
+    x = x + y;
+    y = y + 1;
+  }
+  assert(x == y);
+  return 0;
+}

--- a/regression/incremental-smt/incremental-03/test.desc
+++ b/regression/incremental-smt/incremental-03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION FAILED$

--- a/regression/incremental-smt/incremental-04/main.c
+++ b/regression/incremental-smt/incremental-04/main.c
@@ -15,6 +15,6 @@ int main()
   f = ((3 * x) + y);
   if(f < 0)
     f = 0;
-  assert(a <= 2 && b <= 5 && f <= 4);
+  assert(a <= 1 && b <= 5 && f <= 4);
   return 0;
 }

--- a/regression/incremental-smt/incremental-04/test.desc
+++ b/regression/incremental-smt/incremental-04/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -37,6 +37,18 @@ bitwuzla_convt::~bitwuzla_convt()
   bitw = nullptr;
 }
 
+void bitwuzla_convt::push_ctx()
+{
+  smt_convt::push_ctx();
+  bitwuzla_push(bitw, 1);
+}
+
+void bitwuzla_convt::pop_ctx()
+{
+  bitwuzla_pop(bitw, 1);
+  smt_convt::pop_ctx();
+}
+
 smt_convt::resultt bitwuzla_convt::dec_solve()
 {
   pre_solve();

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -29,6 +29,8 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
   bitw = bitwuzla_new();
   bitwuzla_set_option(bitw, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
+  if(options.get_bool_option("smt-during-symex"))
+    bitwuzla_set_option(bitw, BITWUZLA_OPT_INCREMENTAL, 1);
 }
 
 bitwuzla_convt::~bitwuzla_convt()

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -26,6 +26,8 @@ public:
   bitwuzla_convt(const namespacet &ns, const optionst &options);
   ~bitwuzla_convt() override;
 
+  void push_ctx() override;
+  void pop_ctx() override;
   resultt dec_solve() override;
   const std::string solver_text() override;
 

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -47,6 +47,18 @@ boolector_convt::~boolector_convt()
   btor = nullptr;
 }
 
+void boolector_convt::push_ctx()
+{
+  smt_convt::push_ctx();
+  boolector_push(btor, 1);
+}
+
+void boolector_convt::pop_ctx()
+{
+  boolector_pop(btor, 1);
+  smt_convt::pop_ctx();
+}
+
 smt_convt::resultt boolector_convt::dec_solve()
 {
   pre_solve();

--- a/src/solvers/boolector/boolector_conv.h
+++ b/src/solvers/boolector/boolector_conv.h
@@ -26,6 +26,8 @@ public:
   boolector_convt(const namespacet &ns, const optionst &options);
   ~boolector_convt() override;
 
+  void push_ctx() override;
+  void pop_ctx() override;
   resultt dec_solve() override;
   const std::string solver_text() override;
 


### PR DESCRIPTION
This PR implements the pus/pop methods for incremental solving with the SMT solvers Bitwuzla and Boolector.