### PR TITLE
updated boost for 1.76 (windows)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake.exe .. -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DENABLE_REGRESSION=On -DBUILD_TESTING=On -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_DIR=C:/deps/clang/clang -DClang_DIR=C:/deps/clang/clang -DZ3_DIR=C:/deps/z3-4.8.9-x64-win -DBOOST_DLL_FILE="C:/deps/boost_filesystem-vc142-mt-x64-1_75.dll;C:/deps/boost_program_options-vc142-mt-x64-1_75.dll"
+        cmake.exe .. -A x64 -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -DENABLE_REGRESSION=On -DBUILD_TESTING=On -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_DIR=C:/deps/clang/clang -DClang_DIR=C:/deps/clang/clang -DZ3_DIR=C:/deps/z3-4.8.9-x64-win -DBOOST_DLL_FILE="C:/deps/boost_filesystem-vc142-mt-x64-1_76.dll;C:/deps/boost_program_options-vc142-mt-x64-1_76.dll"
     - name: Build ESBMC
       run: |
         cd build

--- a/scripts/configure_environment.ps1
+++ b/scripts/configure_environment.ps1
@@ -14,5 +14,5 @@ $Z3_DEST = "C:\deps"
 Invoke-WebRequest $Z3 -OutFile $Z3_ZIP
 Expand-Archive -LiteralPath $Z3_ZIP -DestinationPath $Z3_DEST
 
-Copy-Item C:\vcpkg\installed\x64-windows\bin\boost_filesystem-vc142-mt-x64-1_75.dll C:\Deps
-Copy-Item C:\vcpkg\installed\x64-windows\bin\boost_program_options-vc142-mt-x64-1_75.dll C:\Deps
+Copy-Item C:\vcpkg\installed\x64-windows\bin\boost_filesystem-vc142-mt-x64-1_76.dll C:\Deps
+Copy-Item C:\vcpkg\installed\x64-windows\bin\boost_program_options-vc142-mt-x64-1_76.dll C:\Deps


### PR DESCRIPTION
Latest version of vcpkg is using Boost 1.76. This PR will update the CI scripts