### PR TITLE
Fixed symbol table printing

### DIFF
--- a/regression/esbmc/github_485/main.c
+++ b/regression/esbmc/github_485/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int resp, a, b;
+
+  resp=a+b;
+
+  assert(resp==a+b);
+}

--- a/regression/esbmc/github_485/test.desc
+++ b/regression/esbmc/github_485/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --symbol-table-too
+^VERIFICATION FAILED$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1395,7 +1395,9 @@ bool esbmc_parseoptionst::get_goto_program(
       if(
         cmdline.isset("symbol-table-too") || cmdline.isset("symbol-table-only"))
       {
-        show_symbol_table();
+        std::ostringstream oss;
+        show_symbol_table_plain(oss);
+        msg.status(oss.str());
         if(cmdline.isset("symbol-table-only"))
           return true;
       }


### PR DESCRIPTION
Signed-off-by: kunjsong01 <kunjian90@gmail.com>

This patch fixed symbol table printing. 
## Problem: Since "show_symbol_table()" is an empty function, ESBMC doesn't print the symbol table when giving "--symbol-table-only" or "--symbol-table-too" arguments. 

## Solution: Use "show_symbol_table_plain()" instead. 