### PR TITLE
Fix Z3 build with the Ubuntu APT packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
        run: pwd && rm -rf ./*
      - uses: actions/checkout@v1
      - name: Install Dependencies
-       run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gperf libgmp-dev cmake bison flex linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev libtinfo5 git curl build-essential gcc wget
+       run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gperf libgmp-dev cmake bison flex linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev libtinfo5 git curl build-essential gcc wget libz3-dev
      - name: Configure Boolector
        run: git clone --depth=1 --branch=3.2.1 https://github.com/boolector/boolector && cd boolector && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh --prefix $PWD/../boolector-release && cd build && make -j4 && make install
      - name: Download Clang 11
@@ -28,7 +28,7 @@ jobs:
      - name: Get current folder and files
        run: pwd && ls
      - name: Configure CMake
-       run: mkdir build && cd build && cmake .. -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
+       run: mkdir build && cd build && cmake .. -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DENABLE_Z3=On -DBoolector_DIR=$PWD/../boolector-release -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
      - name: Build ESBMC
        run: cd build && make -j3 && cmake --install .
      - uses: actions/upload-artifact@v1
@@ -37,7 +37,7 @@ jobs:
          path: ./release
      - name: Run tests
        continue-on-error: true
-       run: cd build/ && ctest -j3 --output-on-failure --progress . 
+       run: cd build/ && ctest -j3 --output-on-failure --progress .
 
   build-linux:
     name: Build ESBMC with all Solvers (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,13 @@ jobs:
        run: pwd && rm -rf ./*
      - uses: actions/checkout@v1
      - name: Install Dependencies
-       run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gperf libgmp-dev cmake bison flex linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev libtinfo5 git curl build-essential gcc wget libz3-dev
+       run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y gperf libgmp-dev cmake bison flex linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev libtinfo5 git curl build-essential gcc wget libz3-dev llvm-11-dev clang-11 libclang-11-dev
      - name: Configure Boolector
        run: git clone --depth=1 --branch=3.2.1 https://github.com/boolector/boolector && cd boolector && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh --prefix $PWD/../boolector-release && cd build && make -j4 && make install
-     - name: Download Clang 11
-       run: wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-aarch64-linux-gnu.tar.xz
-     - name: Extract Clang 11
-       run: tar xf clang+llvm-11.0.0-aarch64-linux-gnu.tar.xz && mv clang+llvm-11.0.0-aarch64-linux-gnu clang
      - name: Get current folder and files
        run: pwd && ls
      - name: Configure CMake
-       run: mkdir build && cd build && cmake .. -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DENABLE_Z3=On -DBoolector_DIR=$PWD/../boolector-release -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
+       run: mkdir build && cd build && cmake ..  -DENABLE_Z3=On -DBoolector_DIR=$PWD/../boolector-release -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release
      - name: Build ESBMC
        run: cd build && make -j3 && cmake --install .
      - uses: actions/upload-artifact@v1

--- a/src/solvers/z3/CMakeLists.txt
+++ b/src/solvers/z3/CMakeLists.txt
@@ -32,13 +32,13 @@ if(ENABLE_Z3)
     endif()
 
     message(STATUS "Using Z3 at: ${Z3_LIB}")
-    string(REGEX MATCH "Z3 ([0-9]+.[0-9]+.[0-9]+.[0-9]+)"  REGEX_OUTPUT ${Z3_VERSION})
-    set(Z3_VERSION "${CMAKE_MATCH_1}")    
+    string(REGEX MATCH "(Z3 )?([0-9]+.[0-9]+.[0-9]+.[0-9]+)"  REGEX_OUTPUT ${Z3_VERSION})
+    set(Z3_VERSION "${CMAKE_MATCH_2}")
     message(STATUS "Z3 version: ${Z3_VERSION}")
     if(Z3_VERSION VERSION_LESS Z3_MIN_VERSION)
         message(FATAL_ERROR "Expected version ${Z3_MIN_VERSION} or greater")
     endif()
-    
+
 
     add_library(solverz3 z3_conv.cpp)
     target_include_directories(solverz3
@@ -60,7 +60,7 @@ if(ENABLE_Z3)
         message(STATUS "Windows will install ${Z3_DLL}")
         install(FILES ${Z3_DLL} DESTINATION bin)
     endif()
-    
+
     set(ESBMC_ENABLE_z3 1 PARENT_SCOPE)
     set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS} z3" PARENT_SCOPE)
 endif()

--- a/src/solvers/z3/CMakeLists.txt
+++ b/src/solvers/z3/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(Z3_MIN_VERSION "4.8.9")
+set(Z3_MIN_VERSION "4.8.7")
 
 if(DEFINED Z3_DIR)
     set(ENABLE_Z3 ON)


### PR DESCRIPTION
The String that comes from Z3_VERSION on apt is different from the pre-built packages.

This also sets the arm debug build to use the version from the system.