### PR TITLE
Fix issue with SMT File dumping when using Z3 solver.

### DIFF
--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -8,10 +8,7 @@
 #include <cassert>
 #include <esbmc/bmc.h>
 #include <z3_conv.h>
-#include <fmt/format.h>
 #include <fstream>
-#include <stdio.h>
-#include <stdlib.h>
 #include <util/message/default_message.h>
 
 #define new_ast new_solver_ast<z3_smt_ast>

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -10,6 +10,8 @@
 #include <z3_conv.h>
 #include <fmt/format.h>
 #include <fstream>
+#include <stdio.h>
+#include <stdlib.h>
 #include <util/message/default_message.h>
 
 #define new_ast new_solver_ast<z3_smt_ast>
@@ -1244,16 +1246,36 @@ void z3_convt::dump_smt()
     {
       // Add whatever logic is needed.
       // Add sovler specific declarations as well.
-      out << "(set-info :smt-lib-version 2.0) \n";
+      out << "(set-info :smt-lib-version 2.6) \n";
       out << "(set-option :print-success true) \n";
       out << "(set-option :produce-models true) \n";
+      out << "(set-option :opt.priority lex) \n";
+      out << "(set-option :pp-decimal true) \n";
+      out << "; Asserts from ESMBC starts \n";
       out << solver; // All VCC conditions in SMTLIB format.
-      out << "(check-sat) \n";
+      out << "\n\n;;\n\n";
+      out << "; put optimization expression here.\n";
+      out << "; Eg : (maximize (ite c 1 0))\n";
+      out << "; Eg : (minimize obj)\n";
+      out << "(apply (then simplify solve-eqs bit-blast sat)) \n";
+      out << "(check-sat)\n";
+      out << "(get-objectives)\n";
+      out << "(get-model)\n";
+      out << "(exit)\n\n";
     }
   }
+
+  // Z3_ast_vector __z3_assertions = Z3_solver_get_assertions(z3_ctx, solver);
+  // for(unsigned index = 0; index < Z3_ast_vector_size(z3_ctx, __z3_assertions);
+  //     index++)
+  // {
+  //   auto ast = Z3_ast_vector_get(z3_ctx, __z3_assertions, index);
+  //   fprintf(stdout, "Assert : %s\n", Z3_get_string(z3_ctx, ast));
+  // }
+
   // default_message msg;
   // std::ostringstream oss;
-  // oss << solver;
+  // oss << sovler;
   // msg.debug(oss.str());
 }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -6,7 +6,10 @@
  \*******************************************************************/
 
 #include <cassert>
+#include <esbmc/bmc.h>
 #include <z3_conv.h>
+#include <fmt/format.h>
+#include <fstream>
 #include <util/message/default_message.h>
 
 #define new_ast new_solver_ast<z3_smt_ast>
@@ -1231,10 +1234,27 @@ void z3_smt_ast::dump() const
 
 void z3_convt::dump_smt()
 {
-  default_message msg;
-  std::ostringstream oss;
-  oss << solver;
-  msg.debug(oss.str());
+  // #include <esbmc/bmc.h>
+  // #include <fstream>
+  const std::string &filename = options.get_option("output");
+  if(!filename.empty())
+  {
+    std::ofstream out(filename.c_str());
+    if(out)
+    {
+      // Add whatever logic is needed.
+      // Add sovler specific declarations as well.
+      out << "(set-info :smt-lib-version 2.0) \n";
+      out << "(set-option :print-success true) \n";
+      out << "(set-option :produce-models true) \n";
+      out << solver; // All VCC conditions in SMTLIB format.
+      out << "(check-sat) \n";
+    }
+  }
+  // default_message msg;
+  // std::ostringstream oss;
+  // oss << solver;
+  // msg.debug(oss.str());
 }
 
 smt_astt z3_convt::mk_smt_fpbv_gt(smt_astt lhs, smt_astt rhs)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1246,37 +1246,35 @@ void z3_convt::dump_smt()
     {
       // Add whatever logic is needed.
       // Add sovler specific declarations as well.
-      out << "(set-info :smt-lib-version 2.6) \n";
-      out << "(set-option :print-success true) \n";
-      out << "(set-option :produce-models true) \n";
-      out << "(set-option :opt.priority lex) \n";
-      out << "(set-option :pp-decimal true) \n";
-      out << "; Asserts from ESMBC starts \n";
+      out << "(set-info :smt-lib-version 2.6)\n";
+      out << "(set-option :print-success true)\n";
+      out << "(set-option :produce-models true)\n";
+      out << "(set-option :opt.priority pareto)\n";
+      out << "; Asserts from ESMBC starts\n";
       out << solver; // All VCC conditions in SMTLIB format.
-      out << "\n\n;;\n\n";
+      out << "; Asserts from ESMBC ends\n";
       out << "; put optimization expression here.\n";
       out << "; Eg : (maximize (ite c 1 0))\n";
       out << "; Eg : (minimize obj)\n";
-      out << "(apply (then simplify solve-eqs bit-blast sat)) \n";
+      out << "(apply (then simplify solve-eqs))\n";
       out << "(check-sat)\n";
       out << "(get-objectives)\n";
       out << "(get-model)\n";
-      out << "(exit)\n\n";
+      out << "(exit)\n";
     }
   }
 
-  // Z3_ast_vector __z3_assertions = Z3_solver_get_assertions(z3_ctx, solver);
+  Z3_ast_vector __z3_assertions = Z3_solver_get_assertions(z3_ctx, solver);
   // for(unsigned index = 0; index < Z3_ast_vector_size(z3_ctx, __z3_assertions);
   //     index++)
   // {
   //   auto ast = Z3_ast_vector_get(z3_ctx, __z3_assertions, index);
   //   fprintf(stdout, "Assert : %s\n", Z3_get_string(z3_ctx, ast));
   // }
-
-  // default_message msg;
-  // std::ostringstream oss;
-  // oss << sovler;
-  // msg.debug(oss.str());
+  default_message msg;
+  std::ostringstream oss;
+  oss << Z3_ast_vector_size(z3_ctx, __z3_assertions);
+  msg.debug(oss.str());
 }
 
 smt_astt z3_convt::mk_smt_fpbv_gt(smt_astt lhs, smt_astt rhs)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -6,7 +6,6 @@
  \*******************************************************************/
 
 #include <cassert>
-#include <esbmc/bmc.h>
 #include <z3_conv.h>
 #include <fstream>
 #include <util/message/default_message.h>

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1236,8 +1236,6 @@ void z3_smt_ast::dump() const
 
 void z3_convt::dump_smt()
 {
-  // #include <esbmc/bmc.h>
-  // #include <fstream>
   const std::string &filename = options.get_option("output");
   if(!filename.empty())
   {
@@ -1249,31 +1247,19 @@ void z3_convt::dump_smt()
       out << "(set-info :smt-lib-version 2.6)\n";
       out << "(set-option :print-success true)\n";
       out << "(set-option :produce-models true)\n";
-      out << "(set-option :opt.priority pareto)\n";
       out << "; Asserts from ESMBC starts\n";
       out << solver; // All VCC conditions in SMTLIB format.
       out << "; Asserts from ESMBC ends\n";
-      out << "; put optimization expression here.\n";
-      out << "; Eg : (maximize (ite c 1 0))\n";
-      out << "; Eg : (minimize obj)\n";
       out << "(apply (then simplify solve-eqs))\n";
       out << "(check-sat)\n";
-      out << "(get-objectives)\n";
       out << "(get-model)\n";
       out << "(exit)\n";
     }
   }
 
-  Z3_ast_vector __z3_assertions = Z3_solver_get_assertions(z3_ctx, solver);
-  // for(unsigned index = 0; index < Z3_ast_vector_size(z3_ctx, __z3_assertions);
-  //     index++)
-  // {
-  //   auto ast = Z3_ast_vector_get(z3_ctx, __z3_assertions, index);
-  //   fprintf(stdout, "Assert : %s\n", Z3_get_string(z3_ctx, ast));
-  // }
   default_message msg;
   std::ostringstream oss;
-  oss << Z3_ast_vector_size(z3_ctx, __z3_assertions);
+  oss << "Assertions Size : " << Z3_ast_vector_size(z3_ctx, __z3_assertions);
   msg.debug(oss.str());
 }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1257,6 +1257,7 @@ void z3_convt::dump_smt()
     }
   }
 
+  Z3_ast_vector __z3_assertions = Z3_solver_get_assertions(z3_ctx, solver);
   default_message msg;
   std::ostringstream oss;
   oss << "Assertions Size : " << Z3_ast_vector_size(z3_ctx, __z3_assertions);


### PR DESCRIPTION
The z3 smt dumping with `--output` option didn't seem to dump the smt formulas to a file. 
Added code as a workaround to print the `smt` formulas to a file specified by `--output` flag.