### PR TITLE
Enable build and test in all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,7 @@
 name: Build All Solvers
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
+
 jobs:
 
   build-arm:
@@ -37,7 +32,7 @@ jobs:
          path: ./release
      - name: Run tests
        continue-on-error: true
-       run: cd build/ && ctest -j3 --output-on-failure --progress . 
+       run: cd build/ && ctest -j3 --output-on-failure --progress .
 
   build-linux:
     name: Build ESBMC with all Solvers (Linux)

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ release
 .vs
 out
 .vscode
+
+tags


### PR DESCRIPTION
The purpose of this patch is to enable the full set of builds and tests when pushing to any branch of ESBMC so that developers can get regression feedback as early as possible in software development life cycle. The earlier a developer gets regression feedback, the easier and quicker the person can fix it, which will save time to get a PR merged. 

