### PR TITLE
Macro ESBMC_AVAILABLE_SOLVERS affecting "esbmc --list-solvers" only set in src, not esbmc root

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,3 +24,5 @@ add_subdirectory (solvers)
 add_subdirectory (clang-cpp-frontend)
 add_subdirectory (goto-symex)
 add_subdirectory (esbmc)
+
+set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS}" PARENT_SCOPE)


### PR DESCRIPTION
Fixes #361. The value of the CMake macro in the title containing the list of solvers to be printed by `esbmc --list-solvers` is only propagated from `src/solvers` to `src`, but not to the top level, where it is used to generate the definitions: https://github.com/esbmc/esbmc/blob/b8b738f3f4cd0cd1fce1b437618d86429b78dab9/CMakeLists.txt#L102-L106

A fix is to duplicate the `set([...] PARENT_SCOPE)` statement in `src/CMakeLists.txt`.