### PR TITLE
Rework temp file/dir usage and cleanup

### DIFF
--- a/regression/esbmc/github_536_bitwuzla/main.c
+++ b/regression/esbmc/github_536_bitwuzla/main.c
@@ -1,0 +1,8 @@
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  assert(x==x);
+  return 0;
+}

--- a/regression/esbmc/github_536_bitwuzla/test.desc
+++ b/regression/esbmc/github_536_bitwuzla/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-model --bitwuzla
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_536_bitwuzla/test.desc
+++ b/regression/esbmc/github_536_bitwuzla/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --smt-model --bitwuzla
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_536_boolector/main.c
+++ b/regression/esbmc/github_536_boolector/main.c
@@ -1,0 +1,8 @@
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  assert(x==x);
+  return 0;
+}

--- a/regression/esbmc/github_536_boolector/test.desc
+++ b/regression/esbmc/github_536_boolector/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --smt-model --boolector
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_536_boolector/test.desc
+++ b/regression/esbmc/github_536_boolector/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-model --boolector
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_536_yices/main.c
+++ b/regression/esbmc/github_536_yices/main.c
@@ -1,0 +1,8 @@
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  assert(x==x);
+  return 0;
+}

--- a/regression/esbmc/github_536_yices/test.desc
+++ b/regression/esbmc/github_536_yices/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --smt-model --yices
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_536_yices/test.desc
+++ b/regression/esbmc/github_536_yices/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-model --yices
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -38,14 +38,14 @@ clang_c_languaget::clang_c_languaget(const messaget &msg) : languaget(msg)
    * ever extracted before. This will guarantee that the same path will be used
    * during a run. And no more than one is required anyway */
   static auto p =
-    file_operations::get_unique_tmp_path("esbmc-headers-%%%%-%%%%-%%%%");
+    file_operations::create_tmp_dir("esbmc-headers-%%%%-%%%%-%%%%");
   // Build the compile arguments
-  build_compiler_args(std::move(p));
+  build_compiler_args(p.path());
   // Dump clang headers on the temporary folder
-  dump_clang_headers(p);
+  dump_clang_headers(p.path());
 }
 
-void clang_c_languaget::build_compiler_args(const std::string &&tmp_dir)
+void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
 {
   compiler_args.emplace_back("clang-tool");
 

--- a/src/clang-c-frontend/clang_c_language.h
+++ b/src/clang-c-frontend/clang_c_language.h
@@ -66,7 +66,7 @@ protected:
   virtual void force_file_type();
 
   void dump_clang_headers(const std::string &tmp_dir);
-  void build_compiler_args(const std::string &&tmp_dir);
+  void build_compiler_args(const std::string &tmp_dir);
 
   std::vector<std::string> compiler_args;
   std::vector<std::unique_ptr<clang::ASTUnit>> ASTs;

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -823,24 +823,24 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
 void bitwuzla_convt::dump_smt()
 {
-  FILE *f = msg.get_temp_file();
-  bitwuzla_dump_formula(bitw, "smt2", f);
-  msg.insert_and_close_file_contents(VerbosityLevel::Debug, f);
+  auto f = msg.get_temp_file();
+  bitwuzla_dump_formula(bitw, "smt2", f.file());
+  msg.insert_file_contents(VerbosityLevel::Debug, f.file());
 }
 
 void bitw_smt_ast::dump() const
 {
   default_message msg;
-  FILE *f = msg.get_temp_file();
-  bitwuzla_term_dump(a, "smt2", f);
-  msg.insert_and_close_file_contents(VerbosityLevel::Debug, f);
+  auto f = msg.get_temp_file();
+  bitwuzla_term_dump(a, "smt2", f.file());
+  msg.insert_file_contents(VerbosityLevel::Debug, f.file());
 }
 
 void bitwuzla_convt::print_model()
 {
-  FILE *f = msg.get_temp_file();
-  bitwuzla_print_model(bitw, "smt2", f);
-  msg.insert_and_close_file_contents(VerbosityLevel::Status, f);
+  auto f = msg.get_temp_file();
+  bitwuzla_print_model(bitw, "smt2", f.file());
+  msg.insert_file_contents(VerbosityLevel::Status, f.file());
 }
 
 smt_sortt bitwuzla_convt::mk_bool_sort()

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -790,24 +790,24 @@ boolector_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
 void boolector_convt::dump_smt()
 {
-  FILE *f = msg.get_temp_file();
-  boolector_dump_smt2(btor, f);
-  msg.insert_and_close_file_contents(VerbosityLevel::Debug, f);
+  auto f = msg.get_temp_file();
+  boolector_dump_smt2(btor, f.file());
+  msg.insert_file_contents(VerbosityLevel::Debug, f.file());
 }
 
 void btor_smt_ast::dump() const
 {
   default_message msg;
-  FILE *f = msg.get_temp_file();
-  boolector_dump_smt2_node(boolector_get_btor(a), f, a);
-  msg.insert_and_close_file_contents(VerbosityLevel::Debug, f);
+  auto f = msg.get_temp_file();
+  boolector_dump_smt2_node(boolector_get_btor(a), f.file(), a);
+  msg.insert_file_contents(VerbosityLevel::Debug, f.file());
 }
 
 void boolector_convt::print_model()
 {
-  FILE *f = msg.get_temp_file();
-  boolector_print_model(btor, const_cast<char *>("smt2"), f);
-  msg.insert_and_close_file_contents(VerbosityLevel::Status, f);
+  auto f = msg.get_temp_file();
+  boolector_print_model(btor, const_cast<char *>("smt2"), f.file());
+  msg.insert_file_contents(VerbosityLevel::Status, f.file());
 }
 
 smt_sortt boolector_convt::mk_bool_sort()

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -68,9 +68,11 @@ void yices_convt::push_ctx()
 
   if(res != 0)
   {
-    FILE *f = msg.get_temp_file();
-    yices_print_error(f);
-    msg.insert_and_close_file_contents(VerbosityLevel::Error, f);
+    {
+      auto f = msg.get_temp_file();
+      yices_print_error(f.file());
+      msg.insert_file_contents(VerbosityLevel::Error, f.file());
+    }
     msg.error("Error pushing yices context");
     abort();
   }
@@ -82,9 +84,11 @@ void yices_convt::pop_ctx()
 
   if(res != 0)
   {
-    FILE *f = msg.get_temp_file();
-    yices_print_error(f);
-    msg.insert_and_close_file_contents(VerbosityLevel::Error, f);
+    {
+      auto f = msg.get_temp_file();
+      yices_print_error(f.file());
+      msg.insert_file_contents(VerbosityLevel::Error, f.file());
+    }
     msg.error("Error poping yices context");
     abort();
   }
@@ -1066,9 +1070,9 @@ expr2tc yices_convt::tuple_get(const expr2tc &expr)
 
 void yices_convt::print_model()
 {
-  FILE *f = msg.get_temp_file();
-  yices_print_model(f, yices_get_model(yices_ctx, 1));
-  msg.insert_and_close_file_contents(VerbosityLevel::Status, f);
+  auto f = msg.get_temp_file();
+  yices_print_model(f.file(), yices_get_model(yices_ctx, 1));
+  msg.insert_file_contents(VerbosityLevel::Status, f.file());
 }
 
 smt_sortt yices_convt::mk_bool_sort()
@@ -1121,8 +1125,8 @@ smt_sortt yices_convt::mk_bvfp_rm_sort()
 void yices_smt_ast::dump() const
 {
   default_message msg;
-  FILE *f = msg.get_temp_file();
-  yices_pp_term(f, a, 80, 10, 0);
-  yices_pp_type(f, to_solver_smt_sort<type_t>(sort)->s, 80, 10, 0);
-  msg.insert_and_close_file_contents(VerbosityLevel::Debug, f);
+  auto f = msg.get_temp_file();
+  yices_pp_term(f.file(), a, 80, 10, 0);
+  yices_pp_type(f.file(), to_solver_smt_sort<type_t>(sort)->s, 80, 10, 0);
+  msg.insert_file_contents(VerbosityLevel::Debug, f.file());
 }

--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -3,18 +3,103 @@
 
 using namespace file_operations;
 
-tmp_dir::tmp_dir(std::string path, bool keep)
+tmp_path::tmp_path(std::string path, bool keep)
   : _path(std::move(path)), _keep(keep)
 {
-  assert(boost::filesystem::is_directory(_path));
+  assert(boost::filesystem::exists(_path));
 }
 
-tmp_dir::~tmp_dir()
+tmp_path::tmp_path(tmp_path &&o) : tmp_path(std::move(o._path), o._keep)
+{
+  o._keep = true;
+}
+
+tmp_path::~tmp_path()
 {
   if(_keep)
     return;
-  [[maybe_unused]] uintmax_t removed = boost::filesystem::remove_all({_path});
-  assert(removed >= 1 && "expected to remove temp dir");
+  uintmax_t removed [[gnu::unused]] = boost::filesystem::remove_all(_path);
+  assert(removed >= 1 && "expected to remove temp path");
+}
+
+tmp_path &tmp_path::operator=(tmp_path o)
+{
+  swap(*this, o);
+  return *this;
+}
+
+const std::string &tmp_path::path() const noexcept
+{
+  return _path;
+}
+
+tmp_path &tmp_path::keep(bool yes) &noexcept
+{
+  _keep = yes;
+  return *this;
+}
+
+tmp_path &&tmp_path::keep(bool yes) &&noexcept
+{
+  _keep = yes;
+  return std::move(*this);
+}
+
+tmp_file::tmp_file(FILE *f, tmp_path path) : tmp_path(std::move(path)), _file(f)
+{
+  assert(f);
+}
+
+tmp_file::~tmp_file()
+{
+  if(_keep)
+    return;
+  if(fclose(_file))
+    fprintf(
+      stderr, "ERROR: temp-file %s: %s\n", path().c_str(), strerror(errno));
+}
+
+tmp_file &tmp_file::operator=(tmp_file o)
+{
+  swap(*this, o);
+  return *this;
+}
+
+FILE *tmp_file::file() noexcept
+{
+  return _file;
+}
+
+template <typename F>
+static inline std::string with_unique_tmp_path(F &&f, const std::string &format)
+{
+  using namespace boost::filesystem;
+  for(path pattern = temp_directory_path() / format;;)
+  {
+    path p = unique_path(pattern);
+    if(f(p))
+      return p.string();
+  }
+}
+
+tmp_file
+file_operations::create_tmp_file(const std::string &format, const char *mode)
+{
+  FILE *r = NULL;
+  std::string path = with_unique_tmp_path(
+    [&r, mode](auto path) {
+      r = fopen(path.string().c_str(), mode);
+      return r;
+    },
+    format);
+  return {r, {std::move(path)}};
+}
+
+tmp_path file_operations::create_tmp_dir(const std::string &format)
+{
+  return {with_unique_tmp_path(
+    [](auto path) { return boost::filesystem::create_directory(path); },
+    format)};
 }
 
 const std::string

--- a/src/util/filesystem.cpp
+++ b/src/util/filesystem.cpp
@@ -1,6 +1,22 @@
 #include <util/filesystem.h>
 #include <boost/filesystem.hpp>
 
+using namespace file_operations;
+
+tmp_dir::tmp_dir(std::string path, bool keep)
+  : _path(std::move(path)), _keep(keep)
+{
+  assert(boost::filesystem::is_directory(_path));
+}
+
+tmp_dir::~tmp_dir()
+{
+  if(_keep)
+    return;
+  [[maybe_unused]] uintmax_t removed = boost::filesystem::remove_all({_path});
+  assert(removed >= 1 && "expected to remove temp dir");
+}
+
 const std::string
 file_operations::get_unique_tmp_path(const std::string &format)
 {

--- a/src/util/filesystem.h
+++ b/src/util/filesystem.h
@@ -14,19 +14,53 @@ Author: Rafael Menezes, rafael.sa.menezes@outlook.com
           files
  */
 
-class file_operations
+namespace file_operations {
+
+/**
+ * @brief Represents a temporary directory, which is removed by the destructor.
+ */
+class tmp_dir
 {
+  std::string _path;
+  bool _keep;
+
 public:
-  /**
-   * @brief Generates a unique path based on the format
-   *
-   * In Linux, running this function with "esbmc-%%%%" will
-   * return a string such as "/tmp/esbmc-0001" or "/tmp/esbmc-8787".
-   *
-   * This function does not have guarantee that will finish
-   * and can be run forever until it sees an available spot.
-   *
-   * @param format A string in the file specification
-   */
-  static const std::string get_unique_tmp_path(const std::string &format);
+  tmp_dir(std::string path, bool keep = false);
+  ~tmp_dir();
+
+  tmp_dir(const tmp_dir &) = delete;
+
+  tmp_dir & operator=(const tmp_dir &) = delete;
+
+  const std::string &path() const noexcept
+  {
+    return _path;
+  }
+
+  tmp_dir &keep(bool yes) &noexcept
+  {
+    _keep = yes;
+    return *this;
+  }
+
+  tmp_dir &&keep(bool yes) &&noexcept
+  {
+    _keep = yes;
+    return std::move(*this);
+  }
 };
+
+/**
+ * @brief Generates a unique path based on the format
+ *
+ * In Linux, running this function with "esbmc-%%%%" will
+ * return a string such as "/tmp/esbmc-0001" or "/tmp/esbmc-8787".
+ *
+ * This function does not have guarantee that will finish
+ * and can be run forever until it sees an available spot.
+ *
+ * @param format A string in the file specification
+ */
+const std::string get_unique_tmp_path(const std::string &format);
+
+}

--- a/src/util/filesystem.h
+++ b/src/util/filesystem.h
@@ -8,46 +8,86 @@ Author: Rafael Menezes, rafael.sa.menezes@outlook.com
 
 #pragma once
 
+#include <cstdio> /* FILE */
 #include <string>
+
 /**
  * @brief this file will contains helper functions for manipulating
-          files
+ *        files
  */
 
-namespace file_operations {
-
+namespace file_operations
+{
 /**
- * @brief Represents a temporary directory, which is removed by the destructor.
+ * @brief Represents a temporary path, which is (optionally) removed by the
+ *        destructor.
+ *
+ * On destruction, optionally (default: yes), the path removed along with all
+ * contained paths if it points to a directory. The default ctor is provided
+ * only to ease array allocation; it does not construct valid temporary paths.
+ * As an instance of this class represents a bound resource, it cannot be
+ * copied, only moved.
  */
-class tmp_dir
+class tmp_path
 {
   std::string _path;
-  bool _keep;
+
+protected:
+  bool _keep = true;
 
 public:
-  tmp_dir(std::string path, bool keep = false);
-  ~tmp_dir();
+  tmp_path() = default;
+  tmp_path(std::string path, bool keep = false);
+  tmp_path(const tmp_path &) = delete;
+  tmp_path(tmp_path &&o);
 
-  tmp_dir(const tmp_dir &) = delete;
+  ~tmp_path();
 
-  tmp_dir & operator=(const tmp_dir &) = delete;
+  tmp_path &operator=(tmp_path o);
 
-  const std::string &path() const noexcept
+  friend void swap(tmp_path &a, tmp_path &b)
   {
-    return _path;
+    using std::swap;
+    swap(a._path, b._path);
+    swap(a._keep, b._keep);
   }
 
-  tmp_dir &keep(bool yes) &noexcept
+  const std::string &path() const noexcept;
+
+  tmp_path &keep(bool yes) &noexcept;
+  tmp_path &&keep(bool yes) &&noexcept;
+};
+
+/**
+ * @brief Temporary path to an open file with an associated `FILE` handle.
+ *
+ * On destruction, optionally (default: yes), the file is closed and the path
+ * removed. The default ctor is provided only to ease array allocation; it
+ * does not construct valid temporary files. As an instance of this class
+ * represents a bound resource, it cannot be copied, only moved.
+ */
+class tmp_file : public tmp_path
+{
+  FILE *_file;
+
+public:
+  tmp_file() = default;
+  tmp_file(FILE *f, tmp_path path);
+  tmp_file(const tmp_file &) = delete;
+  tmp_file(tmp_file &&o) = default;
+
+  ~tmp_file();
+
+  tmp_file &operator=(tmp_file o);
+
+  friend void swap(tmp_file &a, tmp_file &b)
   {
-    _keep = yes;
-    return *this;
+    using std::swap;
+    swap(static_cast<tmp_path &>(a), static_cast<tmp_path &>(b));
+    swap(a._file, b._file);
   }
 
-  tmp_dir &&keep(bool yes) &&noexcept
-  {
-    _keep = yes;
-    return std::move(*this);
-  }
+  FILE *file() noexcept;
 };
 
 /**
@@ -63,4 +103,10 @@ public:
  */
 const std::string get_unique_tmp_path(const std::string &format);
 
-}
+tmp_file create_tmp_file(
+  const std::string &format = "esbmc.%%%%-%%%%-%%%%",
+  const char *mode = "w+");
+
+tmp_path create_tmp_dir(const std::string &format = "esbmc.%%%%-%%%%-%%%%");
+
+} // namespace file_operations

--- a/src/util/message/message.cpp
+++ b/src/util/message/message.cpp
@@ -10,14 +10,12 @@ Maintainers:
 #include <util/message/message.h>
 #include <util/filesystem.h>
 
-FILE *messaget::get_temp_file()
+file_operations::tmp_file messaget::get_temp_file()
 {
-  FILE *f = fopen(
-    file_operations::get_unique_tmp_path("esbmc-%%%%-%%%%").c_str(), "w+");
-  return f;
+  return file_operations::create_tmp_file("esbmc-%%%%-%%%%");
 }
 
-void messaget::insert_and_close_file_contents(VerbosityLevel l, FILE *f) const
+void messaget::insert_file_contents(VerbosityLevel l, FILE *f) const
 {
   const int MAX_LINE_LENGTH = 1024;
   // Go to the beginning of the file
@@ -28,7 +26,4 @@ void messaget::insert_and_close_file_contents(VerbosityLevel l, FILE *f) const
   while(fgets(line, MAX_LINE_LENGTH, f))
     // Send to message print method
     print(l, line);
-
-  // Close the file
-  fclose(f);
 }

--- a/src/util/message/message.h
+++ b/src/util/message/message.h
@@ -13,6 +13,7 @@ Maintainers:
 #include <memory>
 #include <util/message/message_handler.h>
 #include <util/location.h>
+#include <util/filesystem.h>
 
 /**
  * @brief messaget is used to send messages that
@@ -183,7 +184,7 @@ public:
    *
    * @return
    */
-  static FILE *get_temp_file();
+  static file_operations::tmp_file get_temp_file();
 
   /**
    * @brief Insert all contents of the file into all message handlers
@@ -192,7 +193,7 @@ public:
    * @param l verbosity level of the file
    * @param f file pointer with the file contents.
    */
-  void insert_and_close_file_contents(VerbosityLevel l, FILE *f) const;
+  void insert_file_contents(VerbosityLevel l, FILE *f) const;
 
 protected:
   // Current verbosity level

--- a/unit/util/filesystem.test.cpp
+++ b/unit/util/filesystem.test.cpp
@@ -7,13 +7,58 @@ Author: Rafael Sá Menezes
 #define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
 #include <catch2/catch.hpp>
 #include <util/filesystem.h>
+#include <boost/filesystem.hpp>
 
 TEST_CASE(
-  "tmp folder should be unique between two runs",
+  "tmp path should be unique between two runs",
   "[core][util][filesystem]")
 {
   const char *format = "esbmc-test-%%%%";
   auto first = file_operations::get_unique_tmp_path(format);
   auto second = file_operations::get_unique_tmp_path(format);
   REQUIRE(first != second);
+}
+
+TEST_CASE(
+  "tmp folder should be unique between two runs",
+  "[core][util][filesystem]")
+{
+  const char *format = "esbmc-test-%%%%";
+  auto first = file_operations::create_tmp_dir(format);
+  auto second = file_operations::create_tmp_dir(format);
+  REQUIRE(first.path() != second.path());
+}
+
+TEST_CASE(
+  "tmp file should be unique between two runs",
+  "[core][util][filesystem]")
+{
+  const char *format = "esbmc-test-%%%%";
+  auto first = file_operations::create_tmp_file(format);
+  auto second = file_operations::create_tmp_file(format);
+  REQUIRE(first.path() != second.path());
+}
+
+TEST_CASE("tmp dir is dir and should be removed", "[core][util][filesystem]")
+{
+  const char *format = "esbmc-test-%%%%";
+  std::string path;
+  {
+    auto dir = file_operations::create_tmp_dir(format);
+    path = dir.path();
+    REQUIRE(boost::filesystem::is_directory(path));
+  }
+  REQUIRE(!boost::filesystem::exists(path));
+}
+
+TEST_CASE("tmp file is file and should be removed", "[core][util][filesystem]")
+{
+  const char *format = "esbmc-test-%%%%";
+  std::string path;
+  {
+    auto file = file_operations::create_tmp_file(format);
+    path = file.path();
+    REQUIRE(boost::filesystem::is_regular_file(path));
+  }
+  REQUIRE(!boost::filesystem::exists(path));
 }


### PR DESCRIPTION
This patch series fixes #536 along with
- introducing abstractions `tmp_path` and `tmp_file` to avoid the file/directory confusion that caused #536 through the type system,
- avoiding to `abort()` when the race condition during the search for an unused tmp path triggers, and
- cleaning up the tmp header directory created by the `clang_c_frontend` on normal termination, which lead to ENOSPC when running esbmc `n` times and /tmp is not big enough to hold `n*10` MiB (e.g. a tmpfs).

I've grouped these into one PR since they all build on top of each other.