### PR TITLE
[z3 conv] fix #447: get_bv()

### DIFF
--- a/regression/esbmc/github_447-1/main.c
+++ b/regression/esbmc/github_447-1/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+	int tt = nondet_int();
+	int res = tt + 1;
+	int a = res > 1 ? res / 2 : res;
+	__ESBMC_assert(a == 2, "Failed as expected");
+}

--- a/regression/esbmc/github_447-1/test.desc
+++ b/regression/esbmc/github_447-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+\n\s*res = ([^ ]+) .*\n.*\n.*\n.*\s*a = \1 

--- a/regression/esbmc/github_447/main.c
+++ b/regression/esbmc/github_447/main.c
@@ -1,0 +1,23 @@
+#define UINT8  unsigned __int8
+unsigned arr[100];
+int tt;
+
+int foo() {
+	int x;
+    tt = nondet_int();
+	tt += 1;
+	int y = 25;
+	int res = tt + y;
+
+	return res;
+}
+
+int loop_init() {
+	//__ESBMC_init_var(&arr);
+	int a = foo();
+	while (a > 1)
+		a = a / 2;
+	__ESBMC_assert(a == 2, "Failed as expected");
+
+	return 0;
+}

--- a/regression/esbmc/github_447/test.desc
+++ b/regression/esbmc/github_447/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function loop_init --k-induction
+\n\s*res = ([^ ]+) .*\n.*\n.*\n.*\s*a = \1 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1165,7 +1165,14 @@ BigInt z3_convt::get_bv(smt_astt a, bool is_signed)
     return string2integer(Z3_get_numeral_string(z3_ctx, e));
 
   // Not a numeral? Let's not try to convert it
-  return binary2integer(Z3_get_numeral_binary_string(z3_ctx, e), is_signed);
+  std::string bin;
+  bool is_numeral [[gnu::unused]] = e.as_binary(bin);
+  assert(is_numeral);
+  /* 'bin' contains the ascii representation of the bit-vector, msb-first,
+   * no leading zeroes; zero-extend if possible */
+  if(bin.size() < e.get_sort().bv_size())
+    bin.insert(bin.begin(), '0');
+  return binary2integer(bin, is_signed);
 }
 
 ieee_floatt z3_convt::get_fpbv(smt_astt a)

--- a/unit/util/CMakeLists.txt
+++ b/unit/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 new_unit_test(xmltest "xml.test.cpp" "util_esbmc;bigint")
 new_unit_test(stdexprtest "std_expr.test.cpp" "util_esbmc;bigint")
 new_unit_test(symboltest "symbol.test.cpp" "util_esbmc;bigint")
+new_unit_test(bin2integertest "bin2integer.test.cpp" "util_esbmc;bigint")
 new_unit_test(string2integertest "string2integer.test.cpp" "util_esbmc;bigint")
 new_unit_test(replace_symboltest "replace_symbol.test.cpp" "util_esbmc;bigint")
 new_unit_test(ireptest "irep.test.cpp" "util_esbmc;bigint")

--- a/unit/util/bin2integer.test.cpp
+++ b/unit/util/bin2integer.test.cpp
@@ -1,0 +1,24 @@
+/*******************************************************************\
+Module: Unit tests for binary2integer
+Author: Franz Brauße
+
+\*******************************************************************/
+
+#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
+#include <catch2/catch.hpp>
+#include <util/mp_arith.h>
+
+TEST_CASE("signed binary2integer leading one matters", "[core][util][bin2int]")
+{
+  auto b2i = binary2integer;
+  auto i2b = integer2binary;
+  REQUIRE(b2i(/**/ "01111111111111111111111111101010", true) == 2147483626);
+  REQUIRE(b2i(/***/ "1111111111111111111111111101010", true) == -22);
+  REQUIRE(b2i(/**/ "10000000000000000000000000000100", true) == -2147483644);
+  REQUIRE(i2b(-2147483644, 32) == "10000000000000000000000000000100");
+}
+
+TEST_CASE("signed binary2integer leading zero is zero", "[core][util][bin2int]")
+{
+  REQUIRE(binary2integer("00", true) == 0);
+}


### PR DESCRIPTION
This patch fixes a wrong assumption made about `Z3_get_numeral_binary_string()`, namely that it returns a string of length equal to that of the constant bit-vector expression, and thus for the example now returns the same value for `res` and `a`.