### PR TITLE
[util] fix numbering<T> + protect it in union_find (due to erase())

### DIFF
--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -27,12 +27,13 @@ public:
 
   unsigned number(const T &a)
   {
-    unsigned int num = next_obj_num++;
+    unsigned int num = next_obj_num;
     std::pair<typename numberst::const_iterator, bool> result =
       numbers.insert(std::pair<T, unsigned>(a, num));
 
     if(result.second) // inserted?
     {
+      next_obj_num++;
       vec[num] = a;
       assert(vec.size() == numbers.size());
     }

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -102,7 +102,7 @@ protected:
 };
 
 template <typename T>
-class union_find : public numbering<T>
+class union_find : protected numbering<T>
 {
 public:
   // true == already in same set
@@ -149,6 +149,12 @@ public:
     assert(uuf.size() == this->size());
 
     return n;
+  }
+
+  void clear()
+  {
+    uuf.clear();
+    subt::clear();
   }
 
 protected:


### PR DESCRIPTION
This patch fixes the problem that a duplicate key in `numbering`'s map will still increment its counter. Additionally, the `erase()` method should not be exported by `union_find` if it is not implemented to update its `uuf` member.