### PR TITLE
[testing_tool] allow TOOL parameter to contain an arbitrary command

### DIFF
--- a/regression/esbmc/github_381/test.desc
+++ b/regression/esbmc/github_381/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --overflow-check
-file main.c line 7 function main$
+main.c line 7 function main$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -43,13 +43,14 @@ class BaseTest:
         """Reads test description and initialize this object"""
         raise NotImplementedError
 
-    def generate_run_argument_list(self, executable: str, *args):
+    def generate_run_argument_list(self, *tool):
         """Generates run command list to be used in Popen"""
-        result = [executable] + list(args)
-        result.append(self.test_file)
+        result = list(tool)
+        result.append(os.path.join(self.test_dir, self.test_file))
         for x in shlex.split(self.test_args):
             if x != "":
-                result.append(x)
+                p = os.path.join(self.test_dir, x)
+                result.append(p if os.path.exists(p) else x)
         return result
 
     def mark_test_as_knownbug(self, issue: str):
@@ -144,8 +145,8 @@ class XMLTestCase(BaseTest):
                 self.test_mode) + " is not supported"
         assert os.path.exists(os.path.join(self.test_dir, self.test_file))
 
-    def generate_run_argument_list(self, executable: str, *args):
-        result = super().generate_run_argument_list(executable, *args)
+    def generate_run_argument_list(self, *tool):
+        result = super().generate_run_argument_list(*tool)
         # Some sins were committed into test.desc hack them here
         try:
             index = result.index("~/libraries/")
@@ -194,15 +195,13 @@ class TestParser:
 
 class Executor:
     def __init__(self, tool="esbmc"):
-        split = shlex.split(tool)
-        self.tool = os.path.realpath(split[0])
-        self.args = split[1:]
+        self.tool = shlex.split(tool)
         self.timeout = RegressionBase.TIMEOUT
 
     def run(self, test_case: BaseTest):
         """Execute the test case with `executable`"""
-        process = Popen(test_case.generate_run_argument_list(self.tool, *self.args), stdout=PIPE, stderr=PIPE,
-                        cwd=test_case.test_dir)
+        process = Popen(test_case.generate_run_argument_list(*self.tool),
+                        stdout=PIPE, stderr=PIPE)
         try:
             stdout, stderr = process.communicate(timeout=self.timeout)
         except:
@@ -256,7 +255,7 @@ def _add_test(test_case, executor):
             str(test_case.test_dir) + "\nEXPECTED TO FIND: " + \
             str(test_case.test_regex) + "\n\nPROGRAM OUTPUT\n"
         error_message = output_to_validate + "\n\nARGUMENTS: " + \
-            str(test_case.generate_run_argument_list(executor.tool, *executor.args))
+            str(test_case.generate_run_argument_list(*executor.tool))
 
         matches_regex = True
         for regex in test_case.test_regex:
@@ -324,7 +323,10 @@ def _arg_parsing():
     if main_args.file:
         gen_one_test(main_args.regression, main_args.file, main_args.tool, main_args.modes)
     else:
-        create_tests(main_args.tool, main_args.regression, main_args.mode)
+        create_tests(main_args.tool,
+                     os.path.join(os.path.dirname(os.path.relpath(__file__)),
+                                  main_args.regression),
+                     main_args.mode)
 
 def main():
     _arg_parsing()

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -320,13 +320,13 @@ def _arg_parsing():
     XMLTestCase.CPP_INCLUDE_DIR = main_args.library
     RegressionBase.FAIL_WITH_WORD = main_args.mark_knownbug_with_word
 
+    regression_path = os.path.join(os.path.dirname(os.path.relpath(__file__)),
+                                   main_args.regression)
+
     if main_args.file:
-        gen_one_test(main_args.regression, main_args.file, main_args.tool, main_args.modes)
+        gen_one_test(regression_path, main_args.file, main_args.tool, main_args.modes)
     else:
-        create_tests(main_args.tool,
-                     os.path.join(os.path.dirname(os.path.relpath(__file__)),
-                                  main_args.regression),
-                     main_args.mode)
+        create_tests(main_args.tool, regression_path, main_args.mode)
 
 def main():
     _arg_parsing()

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import unittest
 from testing_tool import *
 

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -134,6 +134,30 @@ class CTest4(ParseTest):
         self.assertEqual(argument_list, expected, str(argument_list))
 
 
+class ToolTest1(CTest4):
+    """Added testcase with multiple white spaces in description"""
+
+    def _argument_list_checks(self, test_obj: BaseTest):
+        argument_list = self.test_case.generate_run_argument_list(
+            "__tool_contains_spaces__ --param 1 __test__")
+        expected = ['__tool_contains_spaces__ --param 1 __test__',
+                    './nonz3/29_exStbHwAcc/main.c', '--overflow-check',
+                    '--unwind', '3', '--32']
+        self.assertEqual(argument_list, expected, str(argument_list))
+
+
+class ToolTest2(CTest4):
+    """Added testcase with multiple white spaces in description"""
+
+    def _argument_list_checks(self, test_obj: BaseTest):
+        argument_list = self.test_case.generate_run_argument_list(
+            '__tool_contains_no_spaces__', '--param', '1', '__test__')
+        expected = ['__tool_contains_no_spaces__', '--param', '1', '__test__',
+                    './nonz3/29_exStbHwAcc/main.c', '--overflow-check',
+                    '--unwind', '3', '--32']
+        self.assertEqual(argument_list, expected, str(argument_list))
+
+
 class XMLTest1(ParseTest):
     """Added testcase with multiple white spaces in description"""
 

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -64,7 +64,7 @@ class CTest1(ParseTest):
     def _argument_list_checks(self, test_obj):
         argument_list = self.test_case.generate_run_argument_list("__test__")
         self.assertEqual(argument_list[0], "__test__")
-        self.assertEqual(argument_list[1], "main.c")
+        self.assertEqual(argument_list[1], "./esbmc-unix/00_bbuf_02/main.c")
         self.assertEqual(argument_list[2], "--unwind")
 
 
@@ -105,8 +105,9 @@ class CTest3(ParseTest):
 
     def _argument_list_checks(self, test_obj: BaseTest):
         argument_list = self.test_case.generate_run_argument_list("__test__")
-        expected = ['__test__', 'test.c', 'account.c', '--no-slice', '--context-bound',
-                    '1', '--depth', '150']
+        expected = ['__test__', './esbmc-unix/00_account_02/test.c',
+                    './esbmc-unix/00_account_02/account.c',
+                    '--no-slice', '--context-bound', '1', '--depth', '150']
         self.assertEqual(argument_list, expected, str(argument_list))
 
 
@@ -128,7 +129,7 @@ class CTest4(ParseTest):
 
     def _argument_list_checks(self, test_obj: BaseTest):
         argument_list = self.test_case.generate_run_argument_list("__test__")
-        expected = ['__test__', 'main.c',
+        expected = ['__test__', './nonz3/29_exStbHwAcc/main.c',
                     '--overflow-check', '--unwind', '3', '--32']
         self.assertEqual(argument_list, expected, str(argument_list))
 
@@ -151,7 +152,7 @@ class XMLTest1(ParseTest):
 
     def _argument_list_checks(self, test_obj: BaseTest):
         argument_list = self.test_case.generate_run_argument_list("__test__")
-        expected = ['__test__', 'main.cpp', '--unwind',
+        expected = ['__test__', './esbmc-cpp/cpp/ch1_0/main.cpp', '--unwind',
                     '10', '--no-unwinding-assertions']
         self.assertEqual(argument_list, expected, str(argument_list))
 


### PR DESCRIPTION
Currently, the `testing_tool.py` requires its TOOL parameter to be a an absolute path to the executable and nothing else, since it is used directly for `Pexec` **after** changing the current working directory. This patch relaxes these requirements and enables
- TOOL to be a string interpreted by the shell (via the `shlex` package in Python's stdlib), i.e., split at (non-escaped/non-quoted) spaces, etc. and the first element of it should be a path (relative or absolute) to the tool. This allows running esbmc for example with default parameters not part of the specific test: `./testing_tool.py --tool '../build/src/esbmc/esbmc --yices' [...]`
- shell-escaping also in the `test_args` string (i.e. the 3rd line in `test.desc`), whereas before it was split at any space character.