### PR TITLE
Added operational model for __builtin_memcpy function

### DIFF
--- a/regression/esbmc-cpp/cpp/ch8_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_5/test.desc
@@ -9,4 +9,6 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
+  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_11_issue>ConvertionError</item_11_issue>
 </test-case>

--- a/regression/esbmc/github_569/main.c
+++ b/regression/esbmc/github_569/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+  const char src[9] = "testing!";
+  char dest[9];
+  strcpy(dest, "Heloooo!");
+  __builtin_memcpy(dest, src, strlen(src) + 1);
+  assert(dest[0] == 't');
+  return 0;
+}

--- a/regression/esbmc/github_569/test.desc
+++ b/regression/esbmc/github_569/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 10
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_569_fail/main.c
+++ b/regression/esbmc/github_569_fail/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+  const char src[9] = "testing!";
+  char dest[9];
+  strcpy(dest, "Heloooo!");
+  __builtin_memcpy(dest, src, strlen(src) + 1);
+  assert(dest[0] == 'e');
+  return 0;
+}

--- a/regression/esbmc/github_569_fail/test.desc
+++ b/regression/esbmc/github_569_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 10
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -148,6 +148,8 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
   compiler_args.emplace_back(
     "-D__sync_fetch_and_add=__ESBMC_sync_fetch_and_add");
 
+  compiler_args.emplace_back("-D__builtin_memcpy=memcpy");
+
   // Ignore ctype defined by the system
   compiler_args.emplace_back("-D__NO_CTYPE");
 


### PR DESCRIPTION
This PR should close https://github.com/esbmc/esbmc/issues/569.

Since both `__builtin_memcpy` and `memcpy` have the same operational model, the solution proposed by @rafaelsamenezes seems to be more efficient and clean. It consists of replacing in constant time `__builtin_memcpy` with `memcpy`.

For the second solution proposed by @mikhailramalho, we would need to add something like the following piece of code to a long chain of `if-then-else` in `do_special_function`:

```CPP
else if(identifier == "__builtin_memcpy")
{
      if(expr.arguments().size() != 3)
      {
        msg.error(
          fmt::format("__builtin_memcpy expects three operands\n{}", expr));
        abort();
      }
      exprt memcpy_expr("memcpy", expr.type());
      memcpy_expr.operands() = expr.arguments();
      expr.swap(memcpy_expr);
}
```

With this solution, ESBMC crashes in the GOTO program creation since we would need to handle the `memcpy` function in `builtin_functions.cpp`.

