### PR TITLE
[util/config] distinguish between target and host

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -104,6 +104,9 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
   for(auto const &def : config.ansi_c.defines)
     compiler_args.push_back("-D" + def);
 
+  compiler_args.emplace_back("-target");
+  compiler_args.emplace_back(config.ansi_c.target.to_string());
+
   for(auto const &inc : config.ansi_c.include_paths)
     compiler_args.push_back("-I" + inc);
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -156,19 +156,21 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
   // Ignore ctype defined by the system
   compiler_args.emplace_back("-D__NO_CTYPE");
 
-#ifdef __APPLE__
-  compiler_args.push_back("-D_EXTERNALIZE_CTYPE_INLINES_");
-  compiler_args.push_back("-D_SECURE__STRING_H_");
-  compiler_args.push_back("-U__BLOCKS__");
-  compiler_args.push_back("-Wno-nullability-completeness");
-  compiler_args.push_back("-Wno-deprecated-register");
-#endif
+  if(config.ansi_c.target.is_macos())
+  {
+    compiler_args.push_back("-D_EXTERNALIZE_CTYPE_INLINES_");
+    compiler_args.push_back("-D_SECURE__STRING_H_");
+    compiler_args.push_back("-U__BLOCKS__");
+    compiler_args.push_back("-Wno-nullability-completeness");
+    compiler_args.push_back("-Wno-deprecated-register");
+  }
 
-#ifdef _WIN32
-  compiler_args.push_back("-D_INC_TIME_INL");
-  compiler_args.push_back("-D__CRT__NO_INLINE");
-  compiler_args.push_back("-D_USE_MATH_DEFINES");
-#endif
+  if(config.ansi_c.target.is_windows_abi())
+  {
+    compiler_args.push_back("-D_INC_TIME_INL");
+    compiler_args.push_back("-D__CRT__NO_INLINE");
+    compiler_args.push_back("-D_USE_MATH_DEFINES");
+  }
 
   // Increase maximum bracket depth
   compiler_args.push_back("-fbracket-depth=1024");

--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -177,9 +177,6 @@ void add_padding(struct_typet &type, const namespacet &ns)
     const typet it_type = it->type();
     BigInt a = 1;
 
-    const bool packed =
-      it_type.get_bool("packed") || ns.follow(it_type).get_bool("packed");
-
     if(it_type.get_bool("#bitfield"))
     {
       a = alignment(it_type, ns);

--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -207,10 +207,7 @@ void add_padding(struct_typet &type, const namespacet &ns)
       a = alignment(it_type, ns);
 
     assert(bit_field_bits == 0);
-
-    // check minimum alignment
-    if(a < config.ansi_c.alignment && !packed)
-      a = config.ansi_c.alignment;
+    assert(a > 0);
 
     if(max_alignment < a)
       max_alignment = a;

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -182,12 +182,48 @@ uint64_t esbmc_parseoptionst::read_mem_spec(const char *str)
   return size;
 }
 
+static std::string format_target()
+{
+  const char *endian = nullptr;
+  switch(config.ansi_c.endianess)
+  {
+  case configt::ansi_ct::IS_LITTLE_ENDIAN:
+    endian = "little";
+    break;
+  case configt::ansi_ct::IS_BIG_ENDIAN:
+    endian = "big";
+    break;
+  case configt::ansi_ct::NO_ENDIANESS:
+    endian = "no";
+    break;
+  }
+  assert(endian);
+  const char *lib = nullptr;
+  switch(config.ansi_c.lib)
+  {
+  case configt::ansi_ct::LIB_NONE:
+    lib = "system";
+    break;
+  case configt::ansi_ct::LIB_FULL:
+    lib = "esbmc";
+    break;
+  }
+  assert(lib);
+  return fmt::format(
+    "{}-bit {}-endian {} with {} libc",
+    config.ansi_c.word_size,
+    endian,
+    config.ansi_c.target.to_string(),
+    lib);
+}
+
 void esbmc_parseoptionst::get_command_line_options(optionst &options)
 {
   if(config.set(cmdline, msg))
   {
     exit(1);
   }
+  msg.status(fmt::format("Target: {}", format_target()));
 
   options.cmdline(cmdline);
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -54,9 +54,9 @@ static const eregex POWERPC("(ppc|powerpc)(64)?(le)?");
 static configt::ansi_ct::endianesst
 arch_endianness(const std::string &arch, const messaget &msg)
 {
-  std::smatch r;
-  if(std::regex_match(arch, r, X86) || arch == "riscv32" || arch == "riscv64")
+  if(std::regex_match(arch, X86) || arch == "riscv32" || arch == "riscv64")
     return configt::ansi_ct::IS_LITTLE_ENDIAN;
+  std::smatch r;
   if(std::regex_match(arch, r, MIPS))
     return r.length(3) > 0 ? configt::ansi_ct::IS_LITTLE_ENDIAN
                            : configt::ansi_ct::IS_BIG_ENDIAN;
@@ -71,20 +71,17 @@ arch_endianness(const std::string &arch, const messaget &msg)
 
 bool configt::triple::is_windows_abi() const
 {
-  std::smatch r;
-  return std::regex_match(os, r, WINDOWS_ABI);
+  return std::regex_match(os, WINDOWS_ABI);
 }
 
 bool configt::triple::is_freebsd() const
 {
-  std::smatch r;
-  return std::regex_match(os, r, FREEBSD);
+  return std::regex_match(os, FREEBSD);
 }
 
 bool configt::triple::is_macos() const
 {
-  std::smatch r;
-  return std::regex_match(os, r, MACOS);
+  return std::regex_match(os, MACOS);
 }
 
 std::string configt::triple::to_string() const

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -91,11 +91,6 @@ std::string configt::triple::to_string() const
 
 bool configt::set(const cmdlinet &cmdline, const messaget &msg)
 {
-  // defaults
-  ansi_c.use_fixed_for_float = false;
-  ansi_c.endianess = ansi_ct::NO_ENDIANESS;
-  ansi_c.lib = configt::ansi_ct::LIB_NONE;
-
   if(cmdline.isset("function"))
     main = cmdline.getval("function");
 
@@ -117,11 +112,7 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
     return true;
   }
 
-  if(cmdline.isset("floatbv"))
-    ansi_c.use_fixed_for_float = false;
-
-  if(cmdline.isset("fixedbv"))
-    ansi_c.use_fixed_for_float = true;
+  ansi_c.use_fixed_for_float = cmdline.isset("fixedbv");
 
   // this is the default
   std::string arch = this_architecture(), os = this_operating_system();

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -75,7 +75,6 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
   ansi_c.set_64();
   ansi_c.use_fixed_for_float = false;
   ansi_c.endianess = ansi_ct::NO_ENDIANESS;
-  ansi_c.os = ansi_ct::NO_OS;
   ansi_c.lib = configt::ansi_ct::LIB_NONE;
 
   if(cmdline.isset("16"))
@@ -116,56 +115,38 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
 
   if(cmdline.isset("i386-linux"))
   {
-    ansi_c.os = configt::ansi_ct::OS_I386_LINUX;
     ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
     ansi_c.lib = configt::ansi_ct::LIB_FULL;
   }
 
   if(cmdline.isset("i386-win32"))
   {
-    ansi_c.os = configt::ansi_ct::OS_WIN32;
     ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
     ansi_c.lib = configt::ansi_ct::LIB_FULL;
   }
 
   if(cmdline.isset("i386-macos"))
   {
-    ansi_c.os = configt::ansi_ct::OS_I386_MACOS;
     ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
     ansi_c.lib = configt::ansi_ct::LIB_FULL;
   }
 
   if(cmdline.isset("ppc-macos"))
   {
-    ansi_c.os = configt::ansi_ct::OS_PPC_MACOS;
     ansi_c.endianess = configt::ansi_ct::IS_BIG_ENDIAN;
     ansi_c.lib = configt::ansi_ct::LIB_FULL;
   }
 
   if(cmdline.isset("no-arch"))
   {
-    ansi_c.os = configt::ansi_ct::NO_OS;
     ansi_c.endianess = configt::ansi_ct::NO_ENDIANESS;
     ansi_c.lib = configt::ansi_ct::LIB_NONE;
   }
-  else if(ansi_c.os == configt::ansi_ct::NO_OS)
+  else
   {
-// this is the default
-#ifdef _WIN32
-    ansi_c.os = configt::ansi_ct::OS_WIN32;
+    // this is the default
     ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
     ansi_c.lib = configt::ansi_ct::LIB_FULL;
-#else
-#ifdef __APPLE__
-    ansi_c.os = configt::ansi_ct::OS_I386_MACOS;
-    ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
-    ansi_c.lib = configt::ansi_ct::LIB_FULL;
-#else
-    ansi_c.os = configt::ansi_ct::OS_I386_LINUX;
-    ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
-    ansi_c.lib = configt::ansi_ct::LIB_FULL;
-#endif
-#endif
   }
 
   if(cmdline.isset("no-library"))

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -45,6 +45,7 @@ struct eregex : std::regex
 } // namespace
 
 static const eregex WINDOWS_ABI("mingw.*|win[0-9]{2}|windows|msys");
+static const eregex FREEBSD("k?freebsd.*");
 static const eregex MACOS("macos|osx.*");
 static const eregex X86("i[3456]86|x86_64|x64");
 static const eregex MIPS("mips(64|isa64|isa64sb1)?(r[0-9]+)?(el|le)?.*");
@@ -72,6 +73,12 @@ bool configt::triple::is_windows_abi() const
 {
   std::smatch r;
   return std::regex_match(os, r, WINDOWS_ABI);
+}
+
+bool configt::triple::is_freebsd() const
+{
+  std::smatch r;
+  return std::regex_match(os, r, FREEBSD);
 }
 
 bool configt::triple::is_macos() const

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -124,7 +124,7 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
     ansi_c.use_fixed_for_float = true;
 
   // this is the default
-  const char *arch = "x86_64", *os = this_operating_system();
+  std::string arch = "x86_64", os = this_operating_system();
   int req_target = 0;
 
   if(cmdline.isset("i386-linux"))
@@ -199,8 +199,9 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
   }
 
   ansi_c.endianess = cmdline.isset("little-endian") ? ansi_ct::IS_LITTLE_ENDIAN
-                     : cmdline.isset("big-endian")  ? ansi_ct::IS_BIG_ENDIAN
-                                                   : arch_endianness(arch, msg);
+                     : cmdline.isset("big-endian")
+                       ? ansi_ct::IS_BIG_ENDIAN
+                       : arch_endianness(ansi_c.target.arch, msg);
 
   ansi_c.lib = ansi_c.target.arch == "none" || cmdline.isset("no-library")
                  ? ansi_ct::LIB_NONE
@@ -295,9 +296,9 @@ std::string configt::this_architecture()
   return this_arch;
 }
 
-const char *configt::this_operating_system()
+std::string configt::this_operating_system()
 {
-  const char *this_os = nullptr;
+  std::string this_os;
 
 #ifdef _WIN32
   this_os = "windows";

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -15,15 +15,19 @@ configt config;
 
 void configt::ansi_ct::set_data_model(enum data_model dm)
 {
-  uint64_t m = dm;
+  auto next = [m = static_cast<uint64_t>(dm)]() mutable {
+    unsigned r = m & 0xff;
+    m >>= 8;
+    return r;
+  };
 
-  char_width = m & 0xff, m >>= 8;
-  short_int_width = m & 0xff, m >>= 8;
-  int_width = m & 0xff, m >>= 8;
-  long_int_width = m & 0xff, m >>= 8;
-  pointer_width = m & 0xff, m >>= 8;
-  word_size = m & 0xff, m >>= 8;
-  long_double_width = m & 0xff, m >>= 8;
+  char_width = next();
+  short_int_width = next();
+  int_width = next();
+  long_int_width = next();
+  pointer_width = next();
+  word_size = next();
+  long_double_width = next();
 
   long_long_int_width = 64;
   bool_width = char_width;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -223,17 +223,30 @@ std::string configt::this_architecture()
 {
   std::string this_arch;
 
-  // following http://wiki.debian.org/ArchitectureSpecificsMemo
+  /* We're passing this down to clang via -target */
+
+  /* References:
+   * http://wiki.debian.org/ArchitectureSpecificsMemo
+   * https://sourceforge.net/p/predef/wiki/Architectures/
+   */
 
 #ifdef __alpha__
   this_arch = "alpha";
-#elif __armel__
-  this_arch = "armel";
+#elif __thumb__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  this_arch = "thumbeb"
+#else
+  this_arch = "thumb";
+#endif
 #elif __aarch64__
-  this_arch = "arm64";
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  this_arch = "aarch64_be"
+#else
+  this_arch = "aarch64";
+#endif
 #elif __arm__
-#ifdef __ARM_PCS_VFP
-  this_arch = "armhf"; // variant of arm with hard float
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  this_arch = "armeb";
 #else
   this_arch = "arm";
 #endif

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -96,25 +96,6 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
   ansi_c.endianess = ansi_ct::NO_ENDIANESS;
   ansi_c.lib = configt::ansi_ct::LIB_NONE;
 
-  bool have_16 = cmdline.isset("16");
-  bool have_32 = cmdline.isset("32");
-  bool have_64 = cmdline.isset("64");
-
-  if(have_16 + have_32 + have_64 > 1)
-  {
-    msg.error("Only one of --16, --32 and --64 is supported");
-    return true;
-  }
-
-  enum data_model dm;
-  if(have_16)
-    dm = LP32;
-  else if(have_32)
-    dm = ILP32;
-  else
-    dm = LP64;
-  ansi_c.set_data_model(dm);
-
   if(cmdline.isset("function"))
     main = cmdline.getval("function");
 
@@ -191,6 +172,25 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
 
   ansi_c.target.arch = arch;
   ansi_c.target.os = os;
+
+  bool have_16 = cmdline.isset("16");
+  bool have_32 = cmdline.isset("32");
+  bool have_64 = cmdline.isset("64");
+
+  if(have_16 + have_32 + have_64 > 1)
+  {
+    msg.error("Only one of --16, --32 and --64 is supported");
+    return true;
+  }
+
+  enum data_model dm;
+  if(have_16)
+    dm = LP32;
+  else if(have_32)
+    dm = ILP32;
+  else
+    dm = ansi_c.target.is_windows_abi() ? LLP64 : LP64;
+  ansi_c.set_data_model(dm);
 
   if(cmdline.isset("little-endian") && cmdline.isset("big-endian"))
   {

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -124,7 +124,7 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
     ansi_c.use_fixed_for_float = true;
 
   // this is the default
-  std::string arch = "x86_64", os = this_operating_system();
+  std::string arch = this_architecture(), os = this_operating_system();
   int req_target = 0;
 
   if(cmdline.isset("i386-linux"))

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -31,7 +31,6 @@ void configt::ansi_ct::set_data_model(enum data_model dm)
   single_width = 32;
   double_width = 64;
   char_is_unsigned = false;
-  alignment = 1;
 }
 
 static const std::regex

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -99,7 +99,6 @@ bool configt::set(const cmdlinet &cmdline, const messaget &msg)
   ansi_c.endianess = ansi_ct::NO_ENDIANESS;
   ansi_c.lib = configt::ansi_ct::LIB_NONE;
 
-
   bool have_16 = cmdline.isset("16");
   bool have_32 = cmdline.isset("32");
   bool have_64 = cmdline.isset("64");
@@ -322,5 +321,5 @@ const char *configt::this_operating_system()
 
 configt::triple configt::host()
 {
-  return { this_architecture(), "unknown", this_operating_system(), "" };
+  return {this_architecture(), "unknown", this_operating_system(), ""};
 }

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -56,6 +56,7 @@ public:
     std::string flavor;
 
     bool is_windows_abi() const;
+    bool is_freebsd() const;
     bool is_macos() const;
     std::string to_string() const;
   };

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -66,12 +66,13 @@ public:
    (uint64_t)(long) << 24 | (uint64_t)(addr) << 32 | (uint64_t)(word) << 40 |  \
    (uint64_t)(long_dbl) << 48)
 
-  enum data_model : uint64_t {
+  enum data_model : uint64_t
+  {
     /* 16-bit */
     IP16 = dm(8, 16, 16, 32, 16, 16, 64), /* unsegmented 16-bit */
     LP32 = dm(8, 16, 16, 32, 32, 16, 64), /* segmented 16-bit DOS, Win16 */
     /* 32-bit */
-    IP32 = dm(8, 16, 32, 64, 32, 32, 96), /* Ultrix '82-'95 */
+    IP32 = dm(8, 16, 32, 64, 32, 32, 96),  /* Ultrix '82-'95 */
     ILP32 = dm(8, 16, 32, 32, 32, 32, 96), /* Win32 || other 32-bit Unix */
     /* 64-bit */
     LLP64 = dm(8, 16, 32, 32, 64, 64, 128), /* Win64 */

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -56,6 +56,7 @@ public:
     std::string flavor;
 
     bool is_windows_abi() const;
+    bool is_macos() const;
     std::string to_string() const;
   };
 
@@ -131,7 +132,7 @@ public:
   optionst options;
 
   static std::string this_architecture();
-  static std::string this_operating_system();
+  static const char *this_operating_system();
 
   static triple host();
 };

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -48,6 +48,37 @@ Author: Daniel Kroening, kroening@kroening.com
 class configt
 {
 public:
+  struct triple
+  {
+    std::string arch = "none";
+    std::string vendor = "unknown";
+    std::string os = "elf";
+    std::string flavor;
+
+    bool is_windows_abi() const;
+    std::string to_string() const;
+  };
+
+#define dm(char, short, int, long, addr, word, long_dbl)                       \
+  ((uint64_t)(char) | (uint64_t)(short) << 8 | (uint64_t)(int) << 16 |         \
+   (uint64_t)(long) << 24 | (uint64_t)(addr) << 32 | (uint64_t)(word) << 40 |  \
+   (uint64_t)(long_dbl) << 48)
+
+  enum data_model : uint64_t {
+    /* 16-bit */
+    IP16 = dm(8, 16, 16, 32, 16, 16, 64), /* unsegmented 16-bit */
+    LP32 = dm(8, 16, 16, 32, 32, 16, 64), /* segmented 16-bit DOS, Win16 */
+    /* 32-bit */
+    IP32 = dm(8, 16, 32, 64, 32, 32, 96), /* Ultrix '82-'95 */
+    ILP32 = dm(8, 16, 32, 32, 32, 32, 96), /* Win32 || other 32-bit Unix */
+    /* 64-bit */
+    LLP64 = dm(8, 16, 32, 32, 64, 64, 128), /* Win64 */
+    ILP64 = dm(8, 16, 64, 64, 64, 64, 128), /* Unicos for Cray PVP systems */
+    LP64 = dm(8, 16, 32, 64, 64, 64, 128),  /* other 64-bit Unix */
+  };
+
+#undef dm
+
   struct ansi_ct
   {
     // for ANSI-C
@@ -68,10 +99,6 @@ public:
     bool char_is_unsigned;
     bool use_fixed_for_float;
 
-    void set_16();
-    void set_32();
-    void set_64();
-
     // alignment (in structs) measured in bytes
     unsigned alignment;
 
@@ -82,6 +109,8 @@ public:
       IS_BIG_ENDIAN
     } endianesst;
     endianesst endianess;
+
+    triple target;
 
     std::list<std::string> defines;
     std::list<std::string> include_paths;
@@ -94,6 +123,8 @@ public:
       LIB_FULL
     } libt;
     libt lib;
+
+    void set_data_model(enum data_model dm);
   } ansi_c;
 
   std::string main;
@@ -104,6 +135,8 @@ public:
 
   static std::string this_architecture();
   static std::string this_operating_system();
+
+  static triple host();
 };
 
 extern configt config;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -134,7 +134,7 @@ public:
   optionst options;
 
   static std::string this_architecture();
-  static const char *this_operating_system();
+  static std::string this_operating_system();
 
   static triple host();
 };

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -83,16 +83,6 @@ public:
     } endianesst;
     endianesst endianess;
 
-    typedef enum
-    {
-      NO_OS,
-      OS_I386_LINUX,
-      OS_I386_MACOS,
-      OS_PPC_MACOS,
-      OS_WIN32
-    } ost;
-    ost os;
-
     std::list<std::string> defines;
     std::list<std::string> include_paths;
     std::list<std::string> forces;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -99,9 +99,6 @@ public:
     bool char_is_unsigned;
     bool use_fixed_for_float;
 
-    // alignment (in structs) measured in bytes
-    unsigned alignment;
-
     typedef enum
     {
       NO_ENDIANESS,

--- a/unit/testing-utils/goto_factory.cpp
+++ b/unit/testing-utils/goto_factory.cpp
@@ -40,20 +40,24 @@ void goto_factory::create_file_from_istream(
 
 void goto_factory::config_environment(
   goto_factory::Architecture arch,
+  cmdlinet c,
   optionst o)
 {
+  messaget msg;
+  config.set(c, msg);
+
   switch(arch)
   {
   case goto_factory::Architecture::BIT_16:
-    config.ansi_c.set_16();
+    config.ansi_c.set_data_model(configt::LP32);
     break;
 
   case goto_factory::Architecture::BIT_32:
-    config.ansi_c.set_32();
+    config.ansi_c.set_data_model(configt::ILP32);
     break;
 
   case goto_factory::Architecture::BIT_64:
-    config.ansi_c.set_64();
+    config.ansi_c.set_data_model(configt::LP64);
     break;
   default:
     break;
@@ -80,7 +84,7 @@ goto_functionst goto_factory::get_goto_functions(
   cmdlinet cmd = goto_factory::get_default_cmdline(filename);
   optionst opts = goto_factory::get_default_options(cmd);
 
-  goto_factory::config_environment(arch, opts);
+  goto_factory::config_environment(arch, cmd, opts);
   return goto_factory::get_goto_functions(cmd, opts);
 }
 
@@ -100,7 +104,7 @@ goto_functionst goto_factory::get_goto_functions(
   std::string filename(
     "tmp.c"); // TODO: Make this unique and add support for CPP
   goto_factory::create_file_from_istream(c_file, filename);
-  goto_factory::config_environment(arch, opts);
+  goto_factory::config_environment(arch, cmd, opts);
   return goto_factory::get_goto_functions(cmd, opts);
 }
 

--- a/unit/testing-utils/goto_factory.h
+++ b/unit/testing-utils/goto_factory.h
@@ -42,7 +42,8 @@ private:
   static bool parse(language_uit &l);
   static void
   create_file_from_istream(std::istream &c_inputstream, std::string filename);
-  static void config_environment(goto_factory::Architecture arch, optionst o);
+  static void
+  config_environment(goto_factory::Architecture arch, cmdlinet c, optionst o);
 
   static goto_functionst get_goto_functions(cmdlinet &cmd, optionst &opts);
 };

--- a/unit/testing-utils/util_irep.cpp
+++ b/unit/testing-utils/util_irep.cpp
@@ -5,7 +5,7 @@
 
 void gen_builtin_type(typet &new_type, Builtin_Type bt)
 {
-  config.ansi_c.set_32();
+  config.ansi_c.set_data_model(configt::ILP32);
   std::string c_type;
   switch(bt)
   {


### PR DESCRIPTION
This PR makes the distinction between "host" and "target" platforms more explicit:
- the `clang-c-frontend` determines compiler args based on target, not host
- a target (autoconf-like) triple is computed based on `--{16,32,64}` and the various platform/OS-parameter combinations
- the target triple is passed to clang via `-target`
- sizeof(wchar_t) is computed based on whether the target is a win32-ABI (this was not done before)
- the size of the various implementation-defined types like `short`, `int`, etc. are determined based on a data model like LP64, ILP32, etc.

Additonally, `config.ansi_c.alignment` is removed (as it was unused) and removes `config.ansi_c.os` in favour of a `target` triple. Both removed members were unused, while the new target triple is not.

The effect of these changes is more control over how clang interprets the given source code and accordingly how libc-headers are interpreted and how esmbc assigns bv-widths. The defaults `x86_64-unknown-${host_os}` remain unchanged. Additionally, duplications between the replaced `set_{16,32,64}()` are removed.

This explicit control is required in order to accomodate the CHERI-enabled clang frontend, which determines the concrete hybrid or purecap mode based on its `-target` setting (in addition to `-mabi` and `-mcpu`, which will be addressed in another PR).