### PR TITLE
[solvers] fix #513: fp_convt: do not treat bit-string as two's complement when constructing a float

### DIFF
--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -1159,7 +1159,7 @@ ieee_floatt fp_convt::get_fpbv(smt_astt a)
   std::size_t swidth = a->sort->get_significand_width();
 
   ieee_floatt number(ieee_float_spect(swidth - 1, width - swidth));
-  number.unpack(ctx->get_bv(a, true));
+  number.unpack(ctx->get_bv(a, false));
   return number;
 }
 

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -225,7 +225,15 @@ public:
   void from_integer(const BigInt &i);
   void from_base10(const BigInt &exp, const BigInt &frac);
   void build(const BigInt &exp, const BigInt &frac);
+
+  /* Given i non-negative, this method replaces the contents of this instance
+   * by interpreting it according to the IEEE-754 in-memory representation.
+   * In particular, the low-order spec.f bits are taken as the fraction, the
+   * following spec.e bits as the exponent and the sign_flag is determined
+   * based on the remaining bits being zero or not. Afterwards adjustments for
+   * bias, denormalized numbers and NaNs are performed. */
   void unpack(const BigInt &i);
+
   void from_double(const double d);
   void from_float(const float f);
   double to_double() const;


### PR DESCRIPTION
Fix #513:
> The Z3 frontend has a special implementation `get_fpbv` while the other solvers seem to rely on the default `fp_convt`. The latter constructs a floating-point number by obtaining an integer from the bitstring by treating it as "signed" (that is, two's complement). I believe it should not, i.e., replace `true` by `false` in
> 
> https://github.com/esbmc/esbmc/blob/493f459f1089317da78d81b81b95b01541f4aa52/src/solvers/smt/fp/fp_conv.cpp#L1162