### PR TITLE
[Concurrency] Remove unviable interleavings

### DIFF
--- a/regression/esbmc-unix/03_arithmetic_progression_04/test.desc
+++ b/regression/esbmc-unix/03_arithmetic_progression_04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
---no-unwinding-assertions --unwind 2
+--incremental-bmc --context-bound 2
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/03_reorder_01/test.desc
+++ b/regression/esbmc-unix/03_reorder_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
---control-flow-test --context-bound 3
+--context-bound 3
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/01_pthread32/test.desc
+++ b/regression/esbmc-unix2/01_pthread32/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---context-bound 4
+--context-bound 2
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/01_pthread71/test.desc
+++ b/regression/esbmc-unix2/01_pthread71/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
-
+--context-bound 2
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/11_lu-fig2/test.desc
+++ b/regression/esbmc-unix2/11_lu-fig2/test.desc
@@ -1,4 +1,4 @@
 CORE
 lu-fig2.c
---unwind 1 --no-unwinding-assertions
+ --incremental-bmc --context-bound 2
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/15_parallel-misc-3/main.c
+++ b/regression/esbmc-unix2/15_parallel-misc-3/main.c
@@ -1,0 +1,104 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "parallel-misc-3.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+extern int   __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
+extern void  __VERIFIER_atomic_begin();
+extern void  __VERIFIER_atomic_end();
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int pos;
+_Bool d1, d2, g1, g2;
+
+void* thread1() {
+  while (g1) {
+    if (d1) {
+      __VERIFIER_atomic_begin();
+      pos++;
+      __VERIFIER_atomic_end();
+    } else {
+      __VERIFIER_atomic_begin();
+      pos--;
+      __VERIFIER_atomic_end();
+    }
+    d1 = !d1;
+    if (d1) {
+      if (__VERIFIER_nondet_bool()) {
+        g1 = 0;
+      }
+    }
+  }
+
+  return 0;
+}
+
+void* thread2() {
+  while (g2) {
+    if (d2) {
+      __VERIFIER_atomic_begin();
+      pos = ( pos + 2 );
+      __VERIFIER_atomic_end();
+    } else {
+      __VERIFIER_atomic_begin();
+      pos = ( pos - 2 );
+      __VERIFIER_atomic_end();
+    }
+    d2 = !d2;
+    if (d2) {
+      if (__VERIFIER_nondet_bool()) {
+        g2 = 0;
+      }
+    }
+  }
+
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  d1 = 1;
+  d2 = 1;
+  g1 = 1;
+  g2 = 1;
+
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  assume_abort_if_not(pos != 0);
+  reach_error();
+
+  return 0;
+}

--- a/regression/esbmc-unix2/15_parallel-misc-3/test.desc
+++ b/regression/esbmc-unix2/15_parallel-misc-3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--context-bound 2 --unwind 4  --no-por --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix2/15_parallel-misc-3_fail/main.c
+++ b/regression/esbmc-unix2/15_parallel-misc-3_fail/main.c
@@ -1,0 +1,105 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "parallel-misc-3.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+extern int   __VERIFIER_nondet_int(void);
+extern _Bool __VERIFIER_nondet_bool(void);
+extern void  __VERIFIER_atomic_begin();
+extern void  __VERIFIER_atomic_end();
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int pos;
+_Bool d1, d2, g1, g2;
+
+void* thread1() {
+  while (g1) {
+    if (d1) {
+      __VERIFIER_atomic_begin();
+      pos++;
+      __VERIFIER_atomic_end();
+    } else {
+      __VERIFIER_atomic_begin();
+      pos--;
+      __VERIFIER_atomic_end();
+    }
+    d1 = !d1;
+    if (d1) {
+      if (__VERIFIER_nondet_bool()) {
+        g1 = 0;
+      }
+    }
+  }
+
+  return 0;
+}
+
+void* thread2() {
+  while (g2) {
+    if (d2) {
+      __VERIFIER_atomic_begin();
+      pos = ( pos + 2 );
+      __VERIFIER_atomic_end();
+    } else {
+      __VERIFIER_atomic_begin();
+      pos = ( pos - 2 );
+      __VERIFIER_atomic_end();
+    }
+    d2 = !d2;
+    if (d2) {
+      if (__VERIFIER_nondet_bool()) {
+        g2 = 0;
+      }
+    }
+  }
+
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  d1 = 1;
+  d2 = 1;
+  g1 = 1;
+  g2 = 1;
+
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  // this missing pthread_join will allow us to reach the error
+  //pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  assume_abort_if_not(pos != 0);
+  reach_error();
+
+  return 0;
+}

--- a/regression/esbmc-unix2/15_parallel-misc-3_fail/test.desc
+++ b/regression/esbmc-unix2/15_parallel-misc-3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--context-bound 2 --unwind 4  --no-por --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -277,7 +277,7 @@ __ESBMC_HIDE:;
   if(retval != NULL)
     *retval = __ESBMC_pthread_end_values[(int)thread];
 
-  __ESBMC_really_atomic_end();
+  __ESBMC_atomic_end();
 
   return 0;
 }

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -703,7 +703,10 @@ void execution_statet::execute_guard()
   // guards, not the symbolic guard name. This is the only way to bail out of
   // evaluating a particular interleaving early right now.
   if(is_false(parent_guard))
+  {
     cur_state->guard.make_false();
+    return;
+  }
 
   // Check to see whether or not the state guard is false, indicating we've
   // found an unviable interleaving. However don't do this if we didn't

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -706,7 +706,7 @@ void execution_statet::execute_guard()
   // guards, not the symbolic guard name. This is the only way to bail out of
   // evaulating a particular interleaving early right now.
   if(is_false(parent_guard))
-    guard_expr = parent_guard;
+    cur_state->guard.make_false();
 
   // Check to see whether or not the state guard is false, indicating we've
   // found an unviable interleaving. However don't do this if we didn't

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -964,7 +964,7 @@ void execution_statet::calculate_mpor_constraints()
   new_dep_chain[active_thread][active_thread] = 1;
 
   // Mark un-run threads as continuing to be un-run. Otherwise, look for a
-  // Dependency chain from each thread to the run thread.
+  // dependency chain from each thread to the run thread.
   for(unsigned int j = 0; j < new_dep_chain.size(); j++)
   {
     if(j == active_thread)

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -704,7 +704,7 @@ void execution_statet::execute_guard()
 
   // If we simplified the global guard expr to false, write that to thread
   // guards, not the symbolic guard name. This is the only way to bail out of
-  // evaulating a particular interleaving early right now.
+  // evaluating a particular interleaving early right now.
   if(is_false(parent_guard))
     cur_state->guard.make_false();
 
@@ -941,9 +941,9 @@ bool execution_statet::check_mpor_dependancy(unsigned int j, unsigned int l)
 void execution_statet::calculate_mpor_constraints()
 {
   // Primary bit of MPOR logic - to be executed at the end of a transition to
-  // update dependancy tracking and suchlike.
+  // update dependency tracking and such like.
 
-  // MPOR paper, page 12, create new dependancy chain record for this time step.
+  // MPOR paper, page 12, create new dependency chain record for this time step.
 
   // 2D Vector of relations, T x T, i.e. threads on each axis:
   //    -1 signifies that no relation exists.
@@ -955,7 +955,7 @@ void execution_statet::calculate_mpor_constraints()
   //  about progress later.
   std::vector<std::vector<int>> new_dep_chain = dependancy_chain;
 
-  // Start new dependancy chain for this thread. Default to there being no
+  // Start new dependency chain for this thread. Default to there being no
   // relation.
   for(unsigned int i = 0; i < new_dep_chain.size(); i++)
     new_dep_chain[active_thread][i] = -1;
@@ -964,7 +964,7 @@ void execution_statet::calculate_mpor_constraints()
   new_dep_chain[active_thread][active_thread] = 1;
 
   // Mark un-run threads as continuing to be un-run. Otherwise, look for a
-  // dependancy chain from each thread to the run thread.
+  // Dependency chain from each thread to the run thread.
   for(unsigned int j = 0; j < new_dep_chain.size(); j++)
   {
     if(j == active_thread)
@@ -979,17 +979,17 @@ void execution_statet::calculate_mpor_constraints()
     {
       // This is where the beef is. If there is any other thread (including
       // the active thread) that we depend on, that depends on the active
-      // thread, then record a dependancy.
-      // A direct dependancy occurs when l = j, as DCjj always = 1, and DEPji
+      // thread, then record a dependency.
+      // A direct dependency occurs when l = j, as DCjj always = 1, and DEPji
       // is true.
       int res = 0;
 
       for(unsigned int l = 0; l < new_dep_chain.size(); l++)
       {
         if(dependancy_chain[j][l] != 1)
-          continue; // No dependancy relation here
+          continue; // No dependency relation here
 
-        // Now check for variable dependancy.
+        // Now check for variable dependency.
         if(!check_mpor_dependancy(active_thread, l))
           continue;
 
@@ -1003,10 +1003,10 @@ void execution_statet::calculate_mpor_constraints()
     }
   }
 
-  // For /all other relations/, just propagate the dependancy it already has.
+  // For /all other relations/, just propagate the dependency it already has.
   // Achieved by initial duplication of dependancy_chain.
 
-  // Voila, new dependancy chain.
+  // Voila, new dependency chain.
 
   // Calculate whether or not the transition we just took, in active_thread,
   // was in fact schedulable. We can't tell whether or not a transition is
@@ -1017,11 +1017,11 @@ void execution_statet::calculate_mpor_constraints()
   for(unsigned int j = active_thread + 1; j < threads_state.size(); j++)
   {
     if(new_dep_chain[j][active_thread] != -1)
-      // Either no higher threads have been run, or a dependancy relation in
+      // Either no higher threads have been run, or a dependency relation in
       // a higher thread justifies our out-of-order execution.
       continue;
 
-    // Search for a dependancy chain in a lower thread that links us back to
+    // Search for a dependency chain in a lower thread that links us back to
     // a higher thread, justifying this order.
     bool dep_exists = false;
     for(unsigned int l = 0; l < active_thread; l++)

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -699,9 +699,6 @@ void execution_statet::execute_guard()
   target->assumption(
     guardt().as_expr(), assumpt, get_active_state().source, first_loop);
 
-  guardt old_guard;
-  old_guard.add(threads_state[last_active_thread].guard.as_expr());
-
   // If we simplified the global guard expr to false, write that to thread
   // guards, not the symbolic guard name. This is the only way to bail out of
   // evaluating a particular interleaving early right now.


### PR DESCRIPTION
This PR aims to fix this class of multi-threaded C programs from SV-COMP 2022, where ESBMC provides incorrect `VERIFICATION FAILED`:

https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/blob/main/c/weaver/parallel-misc-3.wvr.c

 ESBMC v6.8, which was released in October 2021, does not produce incorrect verification result for this class of programs. 

Here, we check whether the state guard is false and whether we are not actually switching between threads. If that's the case, we remove this unviable interleaving if the deadlock check is not enabled.

I'll run this PR over the SV-COMP 2022 benchmarks to see the results.
