### PR TITLE
Changes in incomplete_array behaviour

### DIFF
--- a/regression/esbmc/fam_false_0/main.c
+++ b/regression/esbmc/fam_false_0/main.c
@@ -5,5 +5,5 @@ typedef struct {
 
 int main() {
   FAM F = {1, {}};
-  F.arr[10] = 7; // out-of-bounds
+  F.arr[2000] = 7; // out-of-bounds
 }

--- a/regression/esbmc/fam_false_0/test.desc
+++ b/regression/esbmc/fam_false_0/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --compact-trace
+^\s*array bounds violated:
 ^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_1/main.c
+++ b/regression/esbmc/fam_false_1/main.c
@@ -4,7 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM) + sizeof(int)*3);
   ptr->arr[3] = 42; // out-of-bounds

--- a/regression/esbmc/fam_false_1/test.desc
+++ b/regression/esbmc/fam_false_1/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --compact-trace  --force-malloc-success
+^\s*dereference failure:
 ^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_10/main.c
+++ b/regression/esbmc/fam_false_10/main.c
@@ -1,0 +1,58 @@
+struct RANGE {
+  int value;
+  int lbl;
+};
+
+typedef struct {
+  struct RANGE *a[2];
+  struct RANGE *b[2];
+  struct RANGE *free[]; // int *free[1]
+} FAM;
+
+struct RANGE array1[2];
+struct RANGE array2[2];
+struct RANGE end = {-1, -1};
+struct RANGE other = {0, 0};
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+void FamInit()
+{
+  unsigned i;
+  struct RANGE **p = fam.a;
+
+  p[0] = &array1[0];
+  p[1] = &array1[1];
+
+  p = &fam.a[2]; // array2
+  p[0] = &array2[0];
+  p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  struct RANGE **pra = fam.a;
+  for(int i = 0; 1; i++)
+  {
+    //pra[i+1]->lbl;
+         if(pra[i+1]->lbl == -1)
+      break;
+  }
+  pra[50]->lbl;
+}

--- a/regression/esbmc/fam_false_10/test.desc
+++ b/regression/esbmc/fam_false_10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---compact-trace  --force-malloc-success
-^VERIFICATION SUCCESSFUL$
+--compact-trace  --force-malloc-success --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_10/test.desc
+++ b/regression/esbmc/fam_false_10/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --compact-trace  --force-malloc-success
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_false_11/main.c
+++ b/regression/esbmc/fam_false_11/main.c
@@ -1,0 +1,55 @@
+struct RANGE {
+  int value;
+  int lbl;
+};
+
+typedef struct {
+  struct RANGE *a[2];
+  struct RANGE *b[2];
+  struct RANGE *free[]; // int *free[1]
+} FAM;
+
+struct RANGE array1[2];
+struct RANGE array2[2];
+struct RANGE end = {-1, -1};
+struct RANGE other = {0, 0};
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+void FamInit()
+{
+  unsigned i;
+  struct RANGE **p = fam.a;
+
+  p[0] = &array1[0];
+  p[1] = &array1[1];
+
+  p = &fam.a[2]; // array2
+  p[0] = &array2[0];
+  p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  struct RANGE **pra = fam.a;
+  for(int i = 0; i < 100; i++)
+  {
+    pra[i+1]->lbl;
+  }
+}

--- a/regression/esbmc/fam_false_11/test.desc
+++ b/regression/esbmc/fam_false_11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --compact-trace  --force-malloc-success
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_11/test.desc
+++ b/regression/esbmc/fam_false_11/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --compact-trace  --force-malloc-success
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_false_2/main.c
+++ b/regression/esbmc/fam_false_2/main.c
@@ -1,12 +1,13 @@
 
 typedef struct {
   int v; // FAM needs at least one variable
-  int arr[]; // Array of size 0
+  int q;
+  double arr[]; // Array of size 0
 } FAM;
 
 
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM));
-  ptr->arr[0] = 42; // out-of-bounds (0 sized array)
+  ptr->arr[2] = 42; // out-of-bounds (0 sized array)
   free(ptr);
 }

--- a/regression/esbmc/fam_false_2/main.c
+++ b/regression/esbmc/fam_false_2/main.c
@@ -5,7 +5,7 @@ typedef struct {
   double arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM));
   ptr->arr[2] = 42; // out-of-bounds (0 sized array)

--- a/regression/esbmc/fam_false_2/test.desc
+++ b/regression/esbmc/fam_false_2/test.desc
@@ -1,4 +1,5 @@
-KNOWNBUG
+CORE
 main.c
 --compact-trace  --force-malloc-success
+^\s*dereference failure:
 ^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_3/main.c
+++ b/regression/esbmc/fam_false_3/main.c
@@ -4,7 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   int value = 42;
   FAM *ptr = (FAM*) malloc(sizeof(FAM));

--- a/regression/esbmc/fam_false_3/test.desc
+++ b/regression/esbmc/fam_false_3/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --compact-trace  --force-malloc-success
+^\s*assertion deref.v != value
 ^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_4/main.c
+++ b/regression/esbmc/fam_false_4/main.c
@@ -8,6 +8,6 @@ typedef struct {
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM) + sizeof(int)*3);
   FAM deref = *ptr;
-  deref.arr[3] = 42; // out-of-bounds
+  deref.arr[34] = 42; // out-of-bounds
   free(ptr);
 }

--- a/regression/esbmc/fam_false_4/main.c
+++ b/regression/esbmc/fam_false_4/main.c
@@ -4,7 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM) + sizeof(int)*3);
   FAM deref = *ptr;

--- a/regression/esbmc/fam_false_5/main.c
+++ b/regression/esbmc/fam_false_5/main.c
@@ -4,13 +4,14 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   // 10 positions with arr of size 5
   FAM **matrix = (FAM**) malloc(sizeof(FAM*) * 10);
   for(int i = 0; i < 10; i++) {
     matrix[i] = (FAM*) malloc(sizeof(FAM) + sizeof(int)*5);
   }
+  // Only address sanitizer detects this
   matrix[9]->arr[5] = 42;
   free(matrix);
 }

--- a/regression/esbmc/fam_false_6/main.c
+++ b/regression/esbmc/fam_false_6/main.c
@@ -1,0 +1,52 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[]; // int *free[1]
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+	{
+		&array1[0]
+	}
+	,
+	{
+		&array2[0]
+	}
+	,
+	{
+		&other,
+		&end
+	}
+};
+
+void FamInit()
+{
+	unsigned i;
+	int **p = fam.a;
+
+	p[0] = &array1[0];
+    p[1] = &array1[1];
+
+	p = &fam.a[2]; // array2
+	p[0] = &array2[0];
+	p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  int **pra = fam.a;
+  assert(pra[0] == &array1[0]);
+  assert(pra[1] == &array1[1]);
+  assert(pra[2] == &array2[0]);
+  assert(pra[3] == &array2[1]);
+  assert(pra[4] == &other);
+  assert(pra[5] == &end);
+  assert(pra[6] == &end);
+}

--- a/regression/esbmc/fam_false_6/main.c
+++ b/regression/esbmc/fam_false_6/main.c
@@ -1,7 +1,7 @@
 typedef struct {
   int *a[2];
   int *b[2];
-  int *free[]; // int *free[1]
+  int *free[];
 } FAM;
 
 int array1[2];

--- a/regression/esbmc/fam_false_6/test.desc
+++ b/regression/esbmc/fam_false_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_7/main.c
+++ b/regression/esbmc/fam_false_7/main.c
@@ -1,0 +1,48 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[]; // int *free[1]
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+void FamInit()
+{
+  unsigned i;
+  int **p = fam.a;
+
+  p[0] = &array1[0];
+  p[1] = &array1[1];
+
+  p = &fam.a[2]; // array2
+  p[0] = &array2[0];
+  p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  int **pra = fam.a;
+  int i = 4;
+  assert(pra[i] == &end);
+}

--- a/regression/esbmc/fam_false_7/test.desc
+++ b/regression/esbmc/fam_false_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_8/main.c
+++ b/regression/esbmc/fam_false_8/main.c
@@ -1,0 +1,32 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[];
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+#include <assert.h>
+int main() {
+  int **pra = fam.a;
+  pra[7]; // out-of-bounds
+}

--- a/regression/esbmc/fam_false_8/test.desc
+++ b/regression/esbmc/fam_false_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/fam_false_9/main.c
+++ b/regression/esbmc/fam_false_9/main.c
@@ -1,0 +1,48 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[]; // int *free[1]
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+void FamInit()
+{
+  unsigned i;
+  int **p = fam.a;
+
+  p[0] = &array1[0];
+  p[1] = &array1[1];
+
+  p = &fam.a[2]; // array2
+  p[0] = &array2[0];
+  p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  int **pra = fam.a;
+  int i = 6;
+  assert(pra[i] == &other);
+}

--- a/regression/esbmc/fam_false_9/main.c
+++ b/regression/esbmc/fam_false_9/main.c
@@ -6,43 +6,65 @@ typedef struct {
 
 int array1[2];
 int array2[2];
-int end;
-int other;
+int pos0;
+int pos1;
+int pos2;
+
 
 FAM fam = {
-  {
-    &array1[0]
-  }
-  ,
-  {
-    &array2[0]
-  }
-  ,
-  {
-    &other,
-    &end
-  }
+	{
+		&array1[0]
+	}
+	,
+	{
+		&array2[0]
+	}
+	,
+	{
+		&pos0,
+		&pos1,
+		&pos2
+	}
 };
-
 
 void FamInit()
 {
-  unsigned i;
-  int **p = fam.a;
+	unsigned i;
+	int **p = fam.a;
 
-  p[0] = &array1[0];
-  p[1] = &array1[1];
+	p[0] = &array1[0];
+        p[1] = &array1[1];
 
-  p = &fam.a[2]; // array2
-  p[0] = &array2[0];
-  p[1] = &array2[1];
+	p = &fam.a[2]; // array2
+	p[0] = &array2[0];
+	p[1] = &array2[1];
 }
 
 
 #include <assert.h>
 int main() {
+
+  assert(fam.a[0] == &array1[0]);
+  assert(fam.a[1] == 0);
+  assert(fam.b[0] == &array2[0]);
+  assert(fam.b[1] == 0);
+  assert(fam.free[0] == &pos0);
+  assert(fam.free[1] == &pos1);
+  assert(fam.free[2] == &pos2);
+
+
   FamInit();
-  int **pra = fam.a;
-  int i = 6;
-  assert(pra[i] == &other);
+  FAM *dst = (FAM*) malloc(sizeof(int*) * 7);
+  memcpy(dst->free, fam.free, 0);
+  /*
+  int **pra = dst->a;
+  //assert(pra[0] == &array1[0]);
+  //assert(pra[1] == &array1[1]);
+  //assert(pra[2] == &array2[0]);
+  //assert(pra[3] == &array2[1]);
+  assert(pra[4] == &pos0);
+  assert(pra[5] == &pos2);
+  */
+
+  free(dst);
 }

--- a/regression/esbmc/fam_false_9/main.c
+++ b/regression/esbmc/fam_false_9/main.c
@@ -42,6 +42,7 @@ void FamInit()
 
 
 #include <assert.h>
+#include <stdlib.h>
 int main() {
 
   assert(fam.a[0] == &array1[0]);
@@ -56,15 +57,15 @@ int main() {
   FamInit();
   FAM *dst = (FAM*) malloc(sizeof(int*) * 7);
   memcpy(dst->free, fam.free, 0);
-  /*
+
   int **pra = dst->a;
-  //assert(pra[0] == &array1[0]);
-  //assert(pra[1] == &array1[1]);
-  //assert(pra[2] == &array2[0]);
-  //assert(pra[3] == &array2[1]);
+  assert(pra[0] == &array1[0]);
+  assert(pra[1] == &array1[1]);
+  assert(pra[2] == &array2[0]);
+  assert(pra[3] == &array2[1]);
   assert(pra[4] == &pos0);
   assert(pra[5] == &pos2);
-  */
+
 
   free(dst);
 }

--- a/regression/esbmc/fam_false_9/test.desc
+++ b/regression/esbmc/fam_false_9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_false_9/test.desc
+++ b/regression/esbmc/fam_false_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --compact-trace  --force-malloc-success
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc/fam_true_0/main.c
+++ b/regression/esbmc/fam_true_0/main.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <assert.h>
 typedef struct {
   int v; // FAM needs at least one variable
   int arr[]; // Array of size 0
@@ -6,5 +7,5 @@ typedef struct {
 
 int main() {
   FAM F = {1, {}};
-  __ESBMC_assert(F.arr != NULL, "FAM should be initialized properly");
+  assert(F.arr != NULL);
 }

--- a/regression/esbmc/fam_true_1/main.c
+++ b/regression/esbmc/fam_true_1/main.c
@@ -4,6 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
+#include <stdlib.h>
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM) + sizeof(int)*3);
   ptr->arr[2] = 42; // out-of-bounds

--- a/regression/esbmc/fam_true_10/main.c
+++ b/regression/esbmc/fam_true_10/main.c
@@ -1,0 +1,58 @@
+struct RANGE {
+  int value;
+  int lbl;
+};
+
+typedef struct {
+  struct RANGE *a[2];
+  struct RANGE *b[2];
+  struct RANGE *free[]; // int *free[1]
+} FAM;
+
+struct RANGE array1[2];
+struct RANGE array2[2];
+struct RANGE end = {-1, -1};
+struct RANGE other = {0, 0};
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+void FamInit()
+{
+  unsigned i;
+  struct RANGE **p = fam.a;
+
+  p[0] = &array1[0];
+  p[1] = &array1[1];
+
+  p = &fam.a[2]; // array2
+  p[0] = &array2[0];
+  p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  struct RANGE **pra = fam.a;
+  for(int i = 0; 1; i++)
+  {
+    //pra[i+1]->lbl;
+         if(pra[i+1]->lbl == -1)
+      break;
+  }
+  pra[5]->lbl;
+}

--- a/regression/esbmc/fam_true_10/test.desc
+++ b/regression/esbmc/fam_true_10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---compact-trace  --force-malloc-success
+--compact-trace  --force-malloc-success --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_10/test.desc
+++ b/regression/esbmc/fam_true_10/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --compact-trace  --force-malloc-success
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_3/main.c
+++ b/regression/esbmc/fam_true_3/main.c
@@ -4,7 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   int value = 42;
   FAM *ptr = (FAM*) malloc(sizeof(FAM));

--- a/regression/esbmc/fam_true_4/main.c
+++ b/regression/esbmc/fam_true_4/main.c
@@ -7,7 +7,6 @@ typedef struct {
 
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM) + sizeof(int)*3);
-  FAM deref = *ptr;
-  deref.arr[2] = 42; // out-of-bounds
+  ptr->arr[2] = 42; // out-of-bounds
   free(ptr);
 }

--- a/regression/esbmc/fam_true_4/main.c
+++ b/regression/esbmc/fam_true_4/main.c
@@ -4,7 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   FAM *ptr = (FAM*) malloc(sizeof(FAM) + sizeof(int)*3);
   ptr->arr[2] = 42; // out-of-bounds

--- a/regression/esbmc/fam_true_4/test.desc
+++ b/regression/esbmc/fam_true_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --compact-trace --force-malloc-success
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_5/main.c
+++ b/regression/esbmc/fam_true_5/main.c
@@ -4,7 +4,7 @@ typedef struct {
   int arr[]; // Array of size 0
 } FAM;
 
-
+#include <stdlib.h>
 main() {
   // 10 positions with arr of size 5
   FAM **matrix = (FAM**) malloc(sizeof(FAM*) * 10);

--- a/regression/esbmc/fam_true_5/main.c
+++ b/regression/esbmc/fam_true_5/main.c
@@ -12,5 +12,8 @@ main() {
     matrix[i] = (FAM*) malloc(sizeof(FAM) + sizeof(int)*5);
   }
   matrix[9]->arr[4] = 42;
+  for(int i = 0; i < 10; i++) {
+    free(matrix[i]);
+  }
   free(matrix);
 }

--- a/regression/esbmc/fam_true_6/main.c
+++ b/regression/esbmc/fam_true_6/main.c
@@ -1,0 +1,51 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[]; // int *free[1]
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+	{
+		&array1[0]
+	}
+	,
+	{
+		&array2[0]
+	}
+	,
+	{
+		&other,
+		&end
+	}
+};
+
+void FamInit()
+{
+	unsigned i;
+	int **p = fam.a;
+
+	p[0] = &array1[0];
+    p[1] = &array1[1];
+
+	p = &fam.a[2]; // array2
+	p[0] = &array2[0];
+	p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  int **pra = fam.a;
+  assert(pra[0] == &array1[0]);
+  assert(pra[1] == &array1[1]);
+  assert(pra[2] == &array2[0]);
+  assert(pra[3] == &array2[1]);
+  assert(pra[4] == &other);
+  assert(pra[5] == &end);
+}

--- a/regression/esbmc/fam_true_6/test.desc
+++ b/regression/esbmc/fam_true_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_7/main.c
+++ b/regression/esbmc/fam_true_7/main.c
@@ -1,0 +1,48 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[]; // int *free[1]
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+  {
+    &array1[0]
+  }
+  ,
+  {
+    &array2[0]
+  }
+  ,
+  {
+    &other,
+    &end
+  }
+};
+
+
+void FamInit()
+{
+  unsigned i;
+  int **p = fam.a;
+
+  p[0] = &array1[0];
+  p[1] = &array1[1];
+
+  p = &fam.a[2]; // array2
+  p[0] = &array2[0];
+  p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  int **pra = fam.a;
+  int i = 4;
+  assert(pra[i] == &other);
+}

--- a/regression/esbmc/fam_true_7/test.desc
+++ b/regression/esbmc/fam_true_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_8/main.c
+++ b/regression/esbmc/fam_true_8/main.c
@@ -1,0 +1,60 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct S {
+  int x;
+  int y[];
+};
+
+void dynamic_fam_test_1(int x) {
+  // Allocate FAM
+  struct S *s = (struct S*) malloc(sizeof(int) + sizeof(int) * x);
+
+  // This is probably checked by clang itself!
+  assert(sizeof(s) == 8);
+  assert(sizeof(s->x) == 4);
+  assert(sizeof(*s) == 4);
+
+  s->x = x;
+
+  // Initialize FAM with i
+  for(int i = 0; i < s->x; i++)
+    s->y[i] = i;
+
+  // Check if FAM was actually initialized (Check #1)
+  for(int i = 0; i < s->x; i++)
+    assert(s->y[i] == i);
+
+  free(s);
+}
+
+void dynamic_fam_test_2()
+{
+  int y[] = {0, 1, 2, 3};
+  int x = sizeof(y)/sizeof(y[0]);
+  assert(x == 4);
+
+  // Allocate FAM
+  struct S *s = (struct S*) malloc(sizeof(int) * (x + 1));
+
+  // Initialize it with Y
+
+  // Wrong test
+  memcpy(s->y, y, sizeof(s->y[0]) * x);
+
+  // Check
+  for(int i = 0; i < x; i++)
+    assert(s->y[i] == i);
+
+  memset(s->y, 0, sizeof(s->y[0]) * x);
+  for(int i = 0; i < x; i++)
+    assert(!s->y[i]);
+
+  free(s);
+}
+
+int main() {
+  dynamic_fam_test_1(3);
+  dynamic_fam_test_2();
+}

--- a/regression/esbmc/fam_true_8/main.c
+++ b/regression/esbmc/fam_true_8/main.c
@@ -22,7 +22,7 @@ void dynamic_fam_test_1(int x) {
   for(int i = 0; i < s->x; i++)
     s->y[i] = i;
 
-  // Check if FAM was actually initialized (Check #1)
+  // Check if FAM was actually initialized
   for(int i = 0; i < s->x; i++)
     assert(s->y[i] == i);
 
@@ -39,14 +39,13 @@ void dynamic_fam_test_2()
   struct S *s = (struct S*) malloc(sizeof(int) * (x + 1));
 
   // Initialize it with Y
-
-  // Wrong test
   memcpy(s->y, y, sizeof(s->y[0]) * x);
 
-  // Check
+  // Check if 's->y' is initialized with 'y'
   for(int i = 0; i < x; i++)
     assert(s->y[i] == i);
 
+  // Resets 's->y'
   memset(s->y, 0, sizeof(s->y[0]) * x);
   for(int i = 0; i < x; i++)
     assert(!s->y[i]);

--- a/regression/esbmc/fam_true_8/test.desc
+++ b/regression/esbmc/fam_true_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_8/test.desc
+++ b/regression/esbmc/fam_true_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---compact-trace  --force-malloc-success
+--compact-trace  --force-malloc-success --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/fam_true_9/main.c
+++ b/regression/esbmc/fam_true_9/main.c
@@ -1,0 +1,53 @@
+typedef struct {
+  int *a[2];
+  int *b[2];
+  int *free[]; // int *free[1]
+} FAM;
+
+int array1[2];
+int array2[2];
+int end;
+int other;
+
+FAM fam = {
+	{
+		&array1[0]
+	}
+	,
+	{
+		&array2[0]
+	}
+	,
+	{
+		&other,
+		&end
+	}
+};
+
+void FamInit()
+{
+	unsigned i;
+	int **p = fam.a;
+
+	p[0] = &array1[0];
+        p[1] = &array1[1];
+
+	p = &fam.a[2]; // array2
+	p[0] = &array2[0];
+	p[1] = &array2[1];
+}
+
+
+#include <assert.h>
+int main() {
+  FamInit();
+  FAM *dst = (FAM*) malloc(sizeof(int*) * 6);
+  memcpy(dst->free, &fam.free, sizeof(int*) * 6);
+  int **pra = dst->a;
+  //assert(pra[0] == &array1[0]);
+  //assert(pra[1] == &array1[1]);
+  //assert(pra[2] == &array2[0]);
+  //assert(pra[3] == &array2[1]);
+  assert(pra[4] == &other);
+  assert(pra[5] == &end);
+}

--- a/regression/esbmc/fam_true_9/main.c
+++ b/regression/esbmc/fam_true_9/main.c
@@ -6,8 +6,10 @@ typedef struct {
 
 int array1[2];
 int array2[2];
-int end;
-int other;
+int pos0;
+int pos1;
+int pos2;
+
 
 FAM fam = {
 	{
@@ -19,8 +21,9 @@ FAM fam = {
 	}
 	,
 	{
-		&other,
-		&end
+		&pos0,
+		&pos1,
+		&pos2
 	}
 };
 
@@ -40,14 +43,24 @@ void FamInit()
 
 #include <assert.h>
 int main() {
+
+  assert(fam.a[0] == &array1[0]);
+  assert(fam.a[1] == 0);
+  assert(fam.b[0] == &array2[0]);
+  assert(fam.b[1] == 0);
+  assert(fam.free[0] == &pos0);
+  assert(fam.free[1] == &pos1);
+  assert(fam.free[2] == &pos2);
+
+
   FamInit();
-  FAM *dst = (FAM*) malloc(sizeof(int*) * 6);
-  memcpy(dst->free, &fam.free, sizeof(int*) * 6);
+  FAM *dst = (FAM*) malloc(sizeof(int*) * 7);
+  memcpy(dst->free, &fam.free, sizeof(int*) * 3);
+
   int **pra = dst->a;
-  //assert(pra[0] == &array1[0]);
-  //assert(pra[1] == &array1[1]);
-  //assert(pra[2] == &array2[0]);
-  //assert(pra[3] == &array2[1]);
-  assert(pra[4] == &other);
-  assert(pra[5] == &end);
+  assert(pra[4] == &pos0);
+  assert(pra[5] == &pos1);
+  assert(pra[6] == &pos2);
+
+  free(dst);
 }

--- a/regression/esbmc/fam_true_9/main.c
+++ b/regression/esbmc/fam_true_9/main.c
@@ -40,7 +40,8 @@ void FamInit()
 	p[1] = &array2[1];
 }
 
-
+#include <stdlib.h>
+#include <string.h>
 #include <assert.h>
 int main() {
 

--- a/regression/esbmc/fam_true_9/test.desc
+++ b/regression/esbmc/fam_true_9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--compact-trace  --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -873,7 +873,7 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
       return true;
 
     new_type = array_typet(sub_type, gen_zero(index_type()));
-    new_type.set("incomplete", "true");
+    new_type.set("incomplete", true);
     break;
   }
 
@@ -1891,16 +1891,16 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     // If this is a struct, we might be dealing with a fam!
     if(
-      t.is_struct() && to_struct_union_type(t).components().back().type().get(
-                         "incomplete") == "true")
+      t.is_struct() && to_struct_union_type(t).components().back().type().get_bool(
+                         "incomplete"))
     {
       // We should update the size of the incomplete array to the size of the last init!
-      typet fam_member;
+      typet fam_member_type;
       if(get_type(
            (*init_stmt.getInit(init_stmt.getNumInits() - 1)).getType(),
-           fam_member))
+           fam_member_type))
         return true;
-      to_struct_union_type(t).components().back().set("type", fam_member);
+      to_struct_union_type(t).components().back().type() = fam_member_type;
     }
 
     exprt inits;
@@ -1928,7 +1928,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
           return true;
 
         typet elem_type;
-        if(t.is_struct() || t.is_union())
+        if(t.is_struct())
           elem_type = to_struct_union_type(t).components()[i].type();
 
         else if(t.is_array())

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1915,19 +1915,17 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
           return true;
 
         typet elem_type;
-        bool do_typecast = true;
         if(t.is_struct() || t.is_union())
           elem_type = to_struct_union_type(t).components()[i].type();
+
         else if(t.is_array())
-        {
           elem_type = to_array_type(t).subtype();
-          do_typecast = t.get("incomplete") != "true";
-        }
+
         else
           elem_type = to_vector_type(t).subtype();
 
-        if(do_typecast)
-          gen_typecast(ns, init, elem_type);
+        gen_typecast(ns, init, elem_type);
+
         inits.operands().at(i) = init;
       }
     }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1889,8 +1889,17 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if(get_type(init_stmt.getType(), t))
       return true;
 
-    exprt inits;
+    // If this is a struct, we might be dealing with a fam!
+    if(t.is_struct() && to_struct_union_type(t).components().back().type().get("incomplete") == "true")
+      {
+        // We should update the size of the incomplete array to the size of the last init!
+        typet fam_member;
+        if(get_type((*init_stmt.getInit(init_stmt.getNumInits()-1)).getType(), fam_member))
+          return true;
+        to_struct_union_type(t).components().back().set("type", fam_member);
+      }
 
+    exprt inits;
     // Structs/unions/arrays put the initializer on operands
     if(t.is_struct() || t.is_array() || t.is_vector())
     {

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1890,14 +1890,18 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       return true;
 
     // If this is a struct, we might be dealing with a fam!
-    if(t.is_struct() && to_struct_union_type(t).components().back().type().get("incomplete") == "true")
-      {
-        // We should update the size of the incomplete array to the size of the last init!
-        typet fam_member;
-        if(get_type((*init_stmt.getInit(init_stmt.getNumInits()-1)).getType(), fam_member))
-          return true;
-        to_struct_union_type(t).components().back().set("type", fam_member);
-      }
+    if(
+      t.is_struct() && to_struct_union_type(t).components().back().type().get(
+                         "incomplete") == "true")
+    {
+      // We should update the size of the incomplete array to the size of the last init!
+      typet fam_member;
+      if(get_type(
+           (*init_stmt.getInit(init_stmt.getNumInits() - 1)).getType(),
+           fam_member))
+        return true;
+      to_struct_union_type(t).components().back().set("type", fam_member);
+    }
 
     exprt inits;
     // Structs/unions/arrays put the initializer on operands

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1921,7 +1921,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         else if(t.is_array())
         {
           elem_type = to_array_type(t).subtype();
-          do_typecast = to_array_type(t).get("incomplete") != "true";
+          do_typecast = t.get("incomplete") != "true";
         }
         else
           elem_type = to_vector_type(t).subtype();

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -555,13 +555,16 @@ void goto_checkt::bounds_check(
       : constant_int2tc(get_uint32_type(), to_string_type(t).get_length());
 
   // Are we dealing with infinity/incomplete arrays?
-  if(
-    is_array_type(t) &&
-    (to_array_type(t).size_is_infinite ||
-     (to_constant_int2t(to_array_type(t).array_size).value == 0)))
+  if(is_array_type(t))
   {
-    // Special case for FAMs, which might have an updated static size
-    if(is_member2t(ind.source_value))
+    // No bounds for infinity
+    if(to_array_type(t).size_is_infinite)
+      return;
+
+    // Are we dealing with an incomplete array?
+    if(
+      is_constant_int2t(array_size) &&
+      to_constant_int2t(array_size).value == 0 && is_member2t(ind.source_value))
     {
       auto member = to_member2t(ind.source_value);
       if(is_symbol2t(member.source_value))
@@ -576,9 +579,6 @@ void goto_checkt::bounds_check(
               .array_size;
       }
     }
-    // Upper bound of incomplete/infinity arrays should be handled at symex
-    else
-      return;
   }
 
   // Cast size to index type

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -487,8 +487,8 @@ static bool has_dereference(const expr2tc &expr)
   // Recurse through all subsequent source objects, which are always operand
   // zero.
   bool found = false;
-  expr->foreach_operand(
-    [&found](const expr2tc &e) { found |= has_dereference(e); });
+  expr->foreach_operand([&found](const expr2tc &e)
+                        { found |= has_dereference(e); });
 
   return found;
 }
@@ -555,7 +555,10 @@ void goto_checkt::bounds_check(
       : constant_int2tc(get_uint32_type(), to_string_type(t).get_length());
 
   // Are we dealing with infinity/incomplete arrays?
-  if(is_array_type(t) && (to_array_type(t).size_is_infinite ||  (to_constant_int2t(to_array_type(t).array_size).value == 0)))
+  if(
+    is_array_type(t) &&
+    (to_array_type(t).size_is_infinite ||
+     (to_constant_int2t(to_array_type(t).array_size).value == 0)))
   {
     // Special case for FAMs, which might have an updated static size
     if(is_member2t(ind.source_value))
@@ -568,7 +571,9 @@ void goto_checkt::bounds_check(
         assert(fam);
         // Static FAM: update array_size
         if(!fam->value.is_dereference())
-            array_size = to_array_type(migrate_type(fam->value.operands().back().type())).array_size;
+          array_size =
+            to_array_type(migrate_type(fam->value.operands().back().type()))
+              .array_size;
       }
     }
     // Upper bound of incomplete/infinity arrays should be handled at symex

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -551,7 +551,7 @@ void goto_checkt::bounds_check(
   // or of FAMs
   if(
     is_array_type(t) &&
-    (to_array_type(t).size_is_infinite || to_array_type(t).fam()))
+    (to_array_type(t).size_is_infinite || !to_array_type(t).get_width()))
     return;
 
   const expr2tc &array_size =

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -554,7 +554,8 @@ void goto_checkt::bounds_check(
   // TODO: Rewrite this in a proper way
   if(
     is_array_type(t) &&
-    (to_array_type(t).size_is_infinite || !to_array_type(t).get_width()))
+    (to_array_type(t).size_is_infinite ||
+     (to_constant_int2t(to_array_type(t).array_size).value == 0)))
   {
     // Is it a FAM?
     if(is_member2t(ind.source_value))
@@ -570,6 +571,8 @@ void goto_checkt::bounds_check(
           return;
 
         // We can add the bound check then!
+        // TODO: get the upper bound
+        return;
       }
       else
         return;

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -548,7 +548,10 @@ void goto_checkt::bounds_check(
   assert(is_array_type(t) || is_string_type(t) || is_vector_type(t));
 
   // We can't check the upper bound of an infinite sized array
-  if(is_array_type(t) && to_array_type(t).size_is_infinite)
+  // or of FAMs
+  if(
+    is_array_type(t) &&
+    (to_array_type(t).size_is_infinite || to_array_type(t).fam()))
     return;
 
   const expr2tc &array_size =

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -34,7 +34,6 @@ public:
 protected:
   const namespacet &ns;
   optionst &options;
-  const messaget &msg;
 
   void check(const expr2tc &expr, const locationt &location);
 
@@ -565,9 +564,9 @@ void goto_checkt::bounds_check(
       {
         // Lookup for FAM
         auto fam = ns.lookup(to_symbol2t(member.source_value).thename);
-
+        assert(fam);
         // If it is a dereference, lets check it later!
-        if(fam.value.is_dereference())
+        if(fam->value.is_dereference())
           return;
 
         // We can add the bound check then!

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -174,18 +174,6 @@ unsigned int vector_type2t::get_width() const
   return num_elems * sub_width;
 }
 
-bool array_type2t::fam() const
-{
-  try
-  {
-    return get_width() == 0;
-  }
-  catch(...)
-  {
-    return true;
-  }
-}
-
 unsigned int pointer_type2t::get_width() const
 {
   return config.ansi_c.pointer_width;

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -160,6 +160,7 @@ unsigned int array_type2t::get_width() const
   return num_elems * sub_width;
 }
 
+
 unsigned int vector_type2t::get_width() const
 {
   unsigned int sub_width = subtype->get_width();
@@ -171,6 +172,18 @@ unsigned int vector_type2t::get_width() const
   unsigned long num_elems = const_elem_size->as_ulong();
 
   return num_elems * sub_width;
+}
+
+bool array_type2t::fam() const
+{
+  try
+  {
+    return get_width() == 0;
+  }
+  catch(...)
+  {
+    return true;
+  }
 }
 
 unsigned int pointer_type2t::get_width() const

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -160,7 +160,6 @@ unsigned int array_type2t::get_width() const
   return num_elems * sub_width;
 }
 
-
 unsigned int vector_type2t::get_width() const
 {
   unsigned int sub_width = subtype->get_width();

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -548,6 +548,7 @@ public:
   virtual ~array_type2t() = default;
 
   unsigned int get_width() const override;
+  bool fam() const;
 
   /** Exception for invalid manipulations of an infinitely sized array. No
    *  actual data stored. */

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -548,7 +548,6 @@ public:
   virtual ~array_type2t() = default;
 
   unsigned int get_width() const override;
-  bool fam() const;
 
   /** Exception for invalid manipulations of an infinitely sized array. No
    *  actual data stored. */

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1191,41 +1191,9 @@ void dereferencet::construct_from_const_struct_offset(
       if(is_array_type(it))
       {
         // Array of size 0 in a struct, means FAM
-        log_debug("FAM in deref");
         // TODO: Check for allignment.
-        // GET THE VALUES
         expr2tc memb = member2tc(it, value, struct_type.member_names[i]);
         constant_int2tc new_offs(pointer_type2(), int_offset - m_offs);
-
-        /* CAN WE CHECK FOR OVER READS?
-         *
-         * Global initializations are not handled by the goto_check
-         * code, here we try to get the size of the value assigned for
-         * it
-        */
-        /*
-        if(is_symbol2t(value) && mode == READ)
-        {
-          auto fam = ns.lookup(to_symbol2t(value).thename);
-          //assert(fam.is_struct());
-          auto last_operand =
-            to_array_type(fam->value.operands().back().type()).size();
-          BigInt size(
-            to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
-          auto limit = size * type->get_width();
-          if((new_offs->value + type->get_width()) > limit)
-          {
-            dereference_failure(
-              "pointer dereference",
-              fmt::format(
-                "Invalid read from FAM with offset {}. FAM contains {} "
-                "elements",
-                new_offs->value / type->get_width(),
-                size),
-              guard);
-          }
-        }
-        */
 
         // Extract.
         build_reference_rec(memb, new_offs, type, guard, mode);
@@ -1357,7 +1325,6 @@ void dereferencet::construct_from_dyn_struct_offset(
     // Compute some kind of guard
     BigInt field_size = type_byte_size_bits(it);
 
-    // This breaks FAM
     // Lets compute field size manually for fam :)
     if(
       is_array_type(it) &&

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -487,11 +487,6 @@ expr2tc dereferencet::dereference(
   for(const expr2tc &target : points_to_set)
     known_exhaustive &= !(is_unknown2t(target) || is_invalid2t(target));
 
-  if(is_struct_type(type)) {
-    log_warning("FAM dereference!");
-
-  }
-
   expr2tc value;
   if(!known_exhaustive)
     value = make_failed_symbol(type);
@@ -1210,7 +1205,7 @@ void dereferencet::construct_from_const_struct_offset(
          * Global initializations are not handled by the goto_check
          * code, here we try to get the size of the value assigned for
          * it
-        *
+        */
         /*
         if(is_symbol2t(value) && mode == READ)
         {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1185,6 +1185,19 @@ void dereferencet::construct_from_const_struct_offset(
       // is supposed to point at.
       // If user is seeking a reference to this substruct, a different method
       // should have been called (construct_struct_ref_from_const_offset).
+      if(is_array_type(it))
+      {
+        // FAM
+        // This access is in the bounds of this member, but isn't at the start.
+        // XXX that might be an alignment error.
+        expr2tc memb = member2tc(it, value, struct_type.member_names[i]);
+        constant_int2tc new_offs(pointer_type2(), int_offset - m_offs);
+
+        // Extract.
+        build_reference_rec(memb, new_offs, type, guard, mode);
+        value = memb;
+        return;
+      }
       assert(is_struct_type(it));
       assert(!is_struct_type(type));
       i++;

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -469,14 +469,13 @@ expr2tc dereferencet::dereference(
     src = typecast2tc(type2tc(new pointer_type2t(get_empty_type())), src);
 
   type2tc type = to_type;
-
   // collect objects dest may point to
   value_setst::valuest points_to_set;
-
   dereference_callback.get_value_set(src, points_to_set);
 
   // now build big case split
   // only "good" objects
+
 
   /* If the value-set contains unknown or invalid, we cannot be sure it contains
    * all possible values and we have to add a fallback symbol in case all guards
@@ -488,6 +487,10 @@ expr2tc dereferencet::dereference(
   bool known_exhaustive = true;
   for(const expr2tc &target : points_to_set)
     known_exhaustive &= !(is_unknown2t(target) || is_invalid2t(target));
+
+  if(is_struct_type(type)) {
+    log_warning("FAM dereference!");
+  }
 
   expr2tc value;
   if(!known_exhaustive)
@@ -1078,6 +1081,13 @@ void dereferencet::construct_from_array(
     unsigned int num_bytes = compute_num_bytes_to_extract(
       replaced_dyn_offset, type_byte_size_bits(type).to_uint64());
 
+    if(!num_bytes)
+      {
+        msg.warning("FAM detected, extracting the entire array on deref");
+        // Are we handling a FAM? Extract everything
+        num_bytes = compute_num_bytes_to_extract(offset, type_byte_size_bits(value->type).to_uint64());
+      }
+
     // Converting offset to bytes for byte extracting
     expr2tc offset_bytes = div2tc(offset->type, offset, gen_ulong(8));
     simplify(offset_bytes);
@@ -1187,16 +1197,40 @@ void dereferencet::construct_from_const_struct_offset(
       // should have been called (construct_struct_ref_from_const_offset).
       if(is_array_type(it))
       {
-        msg.warning("Can't verify upper-bound of FAM!");
-        // FAM
-        // This access is in the bounds of this member, but isn't at the start.
-        // XXX that might be an alignment error.
+        // Array of size 0 in a struct, means FAM
+        msg.warning("FAM in deref");
+        // TODO: Check for allignment.
+        // GET THE VALUES
         expr2tc memb = member2tc(it, value, struct_type.member_names[i]);
         constant_int2tc new_offs(pointer_type2(), int_offset - m_offs);
+
+        /* CAN WE CHECK FOR OVER READS?
+         *
+         * Global initializations are not handled by the goto_check
+         * code, here we try to get the size of the value assigned for
+         * it
+        */
+        if(is_symbol2t(value) && mode == READ)
+          {
+          auto fam = ns.lookup(to_symbol2t(value).thename);
+          //assert(fam.is_struct());
+          auto last_operand = to_array_type(fam.value.operands().back().type()).size();
+          BigInt size(to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
+          auto limit = size * type->get_width();
+          if((new_offs->value + type->get_width()) > limit) {
+            dereference_failure(
+                                "pointer dereference",
+                                fmt::format("Invalid read from FAM with offset {}. FAM contains {} elements", new_offs->value / type->get_width(), size),
+                                guard);
+
+          }
+        }
+
 
         // Extract.
         build_reference_rec(memb, new_offs, type, guard, mode);
         value = memb;
+
         return;
       }
       assert(is_struct_type(it));
@@ -1333,16 +1367,27 @@ void dereferencet::construct_from_dyn_struct_offset(
     expr2tc new_offset = sub2tc(offset->type, offset, field_offset);
     simplify(new_offset);
     // This breaks FAM
+    // Lets compute field size manually for fam :)
     if(
       is_array_type(it) &&
       (to_array_type(it).array_size->expr_id != expr2t::constant_int_id ||
        !to_array_type(it).get_width()))
     {
-      msg.warning(
-        "Dynamic index for FAM member detected. Upper bound will not be "
-        "verified...");
-      field_guard = lower_bound;
+      auto fam = ns.lookup(to_symbol2t(value).thename);
+      auto last_operand = to_array_type(fam.value.operands().back().type()).size();
+      BigInt quantity(to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
+      auto base_type_width = type_byte_size_bits(to_array_type(it).subtype);
+      field_size = quantity * base_type_width;
+
+      msg.debug(fmt::format("Adding field size: {}, quantity: {}, base_type: {}, offs: {}", field_size, quantity, base_type_width, offs));
     }
+
+    // Round up to word size
+    expr2tc field_offs = constant_int2tc(offset->type, offs);
+    expr2tc field_top = constant_int2tc(offset->type, offs + field_size);
+    expr2tc lower_bound = greaterthanequal2tc(bits_offset, field_offs);
+    expr2tc upper_bound = lessthan2tc(bits_offset, field_top);
+    expr2tc field_guard = and2tc(lower_bound, upper_bound);
 
     if(is_struct_type(it))
     {
@@ -2222,15 +2267,6 @@ void dereferencet::check_data_obj_access(
 {
   assert(!is_array_type(value));
 
-  // Check for FAM struct
-  if(is_struct_type(value->type))
-  {
-    auto &v = to_struct_type(value->type);
-    auto last = v.members.back();
-    if(is_array_type(last) && !to_array_type(last).get_width())
-      return;
-  }
-
   expr2tc offset = typecast2tc(pointer_type2(), src_offset);
   unsigned int data_sz = type_byte_size_bits(value->type).to_uint64();
   unsigned int access_sz = type_byte_size_bits(type).to_uint64();
@@ -2244,6 +2280,32 @@ void dereferencet::check_data_obj_access(
   // which has the same effect.
   add2tc add(access_sz_e->type, offset, access_sz_e);
   greaterthan2tc gt(add, data_sz_e);
+
+   // Check for FAM struct
+  if(is_struct_type(value->type))
+  {
+    // Here we are checking for a dynamic index of a FAM!
+    auto &v = to_struct_type(value->type);
+    auto last = v.members.back();
+    if(is_array_type(last) && !to_array_type(last).get_width())
+      {
+        msg.debug("FAM in obj access");
+        if(is_symbol2t(value))
+          {
+          auto fam = ns.lookup(to_symbol2t(value).thename);
+           // Is FAM pointing to a static object?
+          if(!has_prefix(fam.id.as_string(), "symex_dynamic::"))
+            {
+              msg.debug("Skipping FAM check on obj access");
+              return;
+            }
+          else {
+            msg.debug("Dynamic memory for FAM");
+          }
+
+          }
+      }
+  }
 
   if(!options.get_bool_option("no-bounds-check"))
   {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1083,7 +1083,7 @@ void dereferencet::construct_from_array(
 
     if(!num_bytes)
     {
-      msg.debug("FAM detected, extracting the entire array on deref");
+      log_debug("FAM detected, extracting the entire array on deref");
       // Are we handling a FAM? Extract everything
       num_bytes = compute_num_bytes_to_extract(
         offset, type_byte_size_bits(value->type).to_uint64());
@@ -1199,7 +1199,7 @@ void dereferencet::construct_from_const_struct_offset(
       if(is_array_type(it))
       {
         // Array of size 0 in a struct, means FAM
-        msg.debug("FAM in deref");
+        log_debug("FAM in deref");
         // TODO: Check for allignment.
         // GET THE VALUES
         expr2tc memb = member2tc(it, value, struct_type.member_names[i]);
@@ -1210,13 +1210,14 @@ void dereferencet::construct_from_const_struct_offset(
          * Global initializations are not handled by the goto_check
          * code, here we try to get the size of the value assigned for
          * it
-        */
+        *
+        /*
         if(is_symbol2t(value) && mode == READ)
         {
           auto fam = ns.lookup(to_symbol2t(value).thename);
           //assert(fam.is_struct());
           auto last_operand =
-            to_array_type(fam.value.operands().back().type()).size();
+            to_array_type(fam->value.operands().back().type()).size();
           BigInt size(
             to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
           auto limit = size * type->get_width();
@@ -1232,6 +1233,7 @@ void dereferencet::construct_from_const_struct_offset(
               guard);
           }
         }
+        */
 
         // Extract.
         build_reference_rec(memb, new_offs, type, guard, mode);
@@ -1372,18 +1374,18 @@ void dereferencet::construct_from_dyn_struct_offset(
     {
       auto fam = ns.lookup(to_symbol2t(value).thename);
       auto last_operand =
-        to_array_type(fam.value.operands().back().type()).size();
+        to_array_type(fam->value.operands().back().type()).size();
       BigInt quantity(
         to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
       auto base_type_width = type_byte_size_bits(to_array_type(it).subtype);
       field_size = quantity * base_type_width;
 
-      msg.debug(fmt::format(
+      log_debug(
         "Adding field size: {}, quantity: {}, base_type: {}, offs: {}",
         field_size,
         quantity,
         base_type_width,
-        offs));
+        offs);
     }
 
     // Round up to word size
@@ -2057,7 +2059,7 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   {
     /* 0 could mean that we are dealing with a FAM
      * we have to extract the entire byte_array */
-    msg.debug("Size of type returned 0. Is this an incomplete array?");
+    log_debug("Size of type returned 0. Is this an incomplete array?");
     num_bits = type_byte_size_bits(byte_array->type);
   }
   assert(num_bits.is_uint64());
@@ -2069,7 +2071,7 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   offset_bits = modulus2tc(offset_bits->type, offset_bits, gen_ulong(8));
   simplify(offset_bits);
 
-  msg.debug(fmt::format("New num_bytes: {}", num_bytes));
+  log_debug("New num_bytes: {}", num_bytes);
   return bitcast2tc(
     type,
     extract_bits_from_byte_array(
@@ -2304,19 +2306,19 @@ void dereferencet::check_data_obj_access(
     auto last = v.members.back();
     if(is_array_type(last) && !to_array_type(last).get_width())
     {
-      msg.debug("FAM in obj access");
+      log_debug("FAM in obj access");
       if(is_symbol2t(value))
       {
         auto fam = ns.lookup(to_symbol2t(value).thename);
         // Is FAM pointing to a static object?
-        if(!has_prefix(fam.id.as_string(), "symex_dynamic::"))
+        if(!has_prefix(fam->id.as_string(), "symex_dynamic::"))
         {
-          msg.debug("Skipping FAM check on obj access");
+          log_debug("Skipping FAM check on obj access");
           return;
         }
         else
         {
-          msg.debug("Dynamic memory for FAM");
+          log_debug("Dynamic memory for FAM");
         }
       }
     }

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -2047,10 +2047,8 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   simplify(offset_bytes);
 
   BigInt num_bits = type_byte_size_bits(type);
-  /* If the destiny is a zero-sized array then we can just return it
-   * dereferencing should be catch from bounds-check or we just
-   * return a nondet anyway */
-  if(!num_bits.compare(0)_array)
+  // If the destiny is a zero-sized array then we can just return anything
+  if(!num_bits.compare(0))
     return gen_zero(type);
   assert(num_bits.is_uint64());
   uint64_t num_bits64 = num_bits.to_uint64();

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1076,10 +1076,6 @@ void dereferencet::construct_from_array(
     unsigned int num_bytes = compute_num_bytes_to_extract(
       replaced_dyn_offset, type_byte_size_bits(type).to_uint64());
 
-    if(!num_bytes)
-      num_bytes = compute_num_bytes_to_extract(
-        offset, type_byte_size_bits(value->type).to_uint64());
-
     // Converting offset to bytes for byte extracting
     expr2tc offset_bytes = div2tc(offset->type, offset, gen_ulong(8));
     simplify(offset_bytes);
@@ -2013,7 +2009,7 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   simplify(offset_bytes);
 
   BigInt num_bits = type_byte_size_bits(type);
-  // If the destiny is a zero-sized array then we can just return anything
+  // If the destination is a zero-sized array then we can just return anything
   if(!num_bits.compare(0))
     return gen_zero(type);
   assert(num_bits.is_uint64());

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1333,9 +1333,14 @@ void dereferencet::construct_from_dyn_struct_offset(
     expr2tc new_offset = sub2tc(offset->type, offset, field_offset);
     simplify(new_offset);
     // This breaks FAM
-    if(is_array_type(it) && to_array_type(it).fam())
+    if(
+      is_array_type(it) &&
+      (to_array_type(it).array_size->expr_id != expr2t::constant_int_id ||
+       !to_array_type(it).get_width()))
     {
-      msg.warning("Dynamic index for FAM member detected. Upper bound will not be verified...");
+      msg.warning(
+        "Dynamic index for FAM member detected. Upper bound will not be "
+        "verified...");
       field_guard = lower_bound;
     }
 
@@ -2220,10 +2225,10 @@ void dereferencet::check_data_obj_access(
   // Check for FAM struct
   if(is_struct_type(value->type))
   {
-     auto &v = to_struct_type(value->type);
-      auto last = v.members.back();
-      if (is_array_type(last) && to_array_type(last).fam())
-        return;
+    auto &v = to_struct_type(value->type);
+    auto last = v.members.back();
+    if(is_array_type(last) && !to_array_type(last).get_width())
+      return;
   }
 
   expr2tc offset = typecast2tc(pointer_type2(), src_offset);

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1187,6 +1187,7 @@ void dereferencet::construct_from_const_struct_offset(
       // should have been called (construct_struct_ref_from_const_offset).
       if(is_array_type(it))
       {
+        msg.warning("Can't verify upper-bound of FAM!");
         // FAM
         // This access is in the bounds of this member, but isn't at the start.
         // XXX that might be an alignment error.
@@ -1331,6 +1332,12 @@ void dereferencet::construct_from_dyn_struct_offset(
     expr2tc field = member2tc(it, value, struct_type.member_names[i]);
     expr2tc new_offset = sub2tc(offset->type, offset, field_offset);
     simplify(new_offset);
+    // This breaks FAM
+    if(is_array_type(it) && to_array_type(it).fam())
+    {
+      msg.warning("Dynamic index for FAM member detected. Upper bound will not be verified...");
+      field_guard = lower_bound;
+    }
 
     if(is_struct_type(it))
     {
@@ -2209,6 +2216,15 @@ void dereferencet::check_data_obj_access(
   modet mode)
 {
   assert(!is_array_type(value));
+
+  // Check for FAM struct
+  if(is_struct_type(value->type))
+  {
+     auto &v = to_struct_type(value->type);
+      auto last = v.members.back();
+      if (is_array_type(last) && to_array_type(last).fam())
+        return;
+  }
 
   expr2tc offset = typecast2tc(pointer_type2(), src_offset);
   unsigned int data_sz = type_byte_size_bits(value->type).to_uint64();

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1080,7 +1080,6 @@ void dereferencet::construct_from_array(
       num_bytes = compute_num_bytes_to_extract(
         offset, type_byte_size_bits(value->type).to_uint64());
 
-
     // Converting offset to bytes for byte extracting
     expr2tc offset_bytes = div2tc(offset->type, offset, gen_ulong(8));
     simplify(offset_bytes);
@@ -2241,18 +2240,21 @@ void dereferencet::check_data_obj_access(
   expr2tc offset = typecast2tc(pointer_type2(), src_offset);
   unsigned int data_sz = type_byte_size_bits(value->type).to_uint64();
   // Check for FAM struct
-  if(is_struct_type(value->type) && is_symbol2t(value)) {
+  if(is_struct_type(value->type) && is_symbol2t(value))
+  {
     auto fam = ns.lookup(to_symbol2t(value).thename);
-            // Is FAM pointing to a static object?
-    if(!has_prefix(fam->id.as_string(), "symex_dynamic::")) {
+    // Is FAM pointing to a static object?
+    if(!has_prefix(fam->id.as_string(), "symex_dynamic::"))
+    {
       // Here we are checking for a dynamic index of a FAM!
       auto &v = to_struct_type(value->type);
       auto last = v.members.back();
       if(is_array_type(last) && !to_array_type(last).get_width())
-        data_sz += type_byte_size_bits(migrate_type(fam->value.operands().back().type())).to_uint64();
+        data_sz +=
+          type_byte_size_bits(migrate_type(fam->value.operands().back().type()))
+            .to_uint64();
     }
   }
-
 
   unsigned int access_sz = type_byte_size_bits(type).to_uint64();
   expr2tc data_sz_e = gen_ulong(data_sz);
@@ -2265,8 +2267,6 @@ void dereferencet::check_data_obj_access(
   // which has the same effect.
   add2tc add(access_sz_e->type, offset, access_sz_e);
   greaterthan2tc gt(add, data_sz_e);
-
-
 
   if(!options.get_bool_option("no-bounds-check"))
   {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -476,7 +476,6 @@ expr2tc dereferencet::dereference(
   // now build big case split
   // only "good" objects
 
-
   /* If the value-set contains unknown or invalid, we cannot be sure it contains
    * all possible values and we have to add a fallback symbol in case all guards
    * evaluate to false. On the other hand when it is exhaustive, we only need to
@@ -490,6 +489,7 @@ expr2tc dereferencet::dereference(
 
   if(is_struct_type(type)) {
     log_warning("FAM dereference!");
+
   }
 
   expr2tc value;
@@ -1082,11 +1082,12 @@ void dereferencet::construct_from_array(
       replaced_dyn_offset, type_byte_size_bits(type).to_uint64());
 
     if(!num_bytes)
-      {
-        msg.warning("FAM detected, extracting the entire array on deref");
-        // Are we handling a FAM? Extract everything
-        num_bytes = compute_num_bytes_to_extract(offset, type_byte_size_bits(value->type).to_uint64());
-      }
+    {
+      msg.warning("FAM detected, extracting the entire array on deref");
+      // Are we handling a FAM? Extract everything
+      num_bytes = compute_num_bytes_to_extract(
+        offset, type_byte_size_bits(value->type).to_uint64());
+    }
 
     // Converting offset to bytes for byte extracting
     expr2tc offset_bytes = div2tc(offset->type, offset, gen_ulong(8));
@@ -1211,21 +1212,26 @@ void dereferencet::construct_from_const_struct_offset(
          * it
         */
         if(is_symbol2t(value) && mode == READ)
-          {
+        {
           auto fam = ns.lookup(to_symbol2t(value).thename);
           //assert(fam.is_struct());
-          auto last_operand = to_array_type(fam.value.operands().back().type()).size();
-          BigInt size(to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
+          auto last_operand =
+            to_array_type(fam.value.operands().back().type()).size();
+          BigInt size(
+            to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
           auto limit = size * type->get_width();
-          if((new_offs->value + type->get_width()) > limit) {
+          if((new_offs->value + type->get_width()) > limit)
+          {
             dereference_failure(
-                                "pointer dereference",
-                                fmt::format("Invalid read from FAM with offset {}. FAM contains {} elements", new_offs->value / type->get_width(), size),
-                                guard);
-
+              "pointer dereference",
+              fmt::format(
+                "Invalid read from FAM with offset {}. FAM contains {} "
+                "elements",
+                new_offs->value / type->get_width(),
+                size),
+              guard);
           }
         }
-
 
         // Extract.
         build_reference_rec(memb, new_offs, type, guard, mode);
@@ -1357,6 +1363,29 @@ void dereferencet::construct_from_dyn_struct_offset(
     // Compute some kind of guard
     BigInt field_size = type_byte_size_bits(it);
 
+    // This breaks FAM
+    // Lets compute field size manually for fam :)
+    if(
+      is_array_type(it) &&
+      (to_array_type(it).array_size->expr_id != expr2t::constant_int_id ||
+       !to_array_type(it).get_width()))
+    {
+      auto fam = ns.lookup(to_symbol2t(value).thename);
+      auto last_operand =
+        to_array_type(fam.value.operands().back().type()).size();
+      BigInt quantity(
+        to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
+      auto base_type_width = type_byte_size_bits(to_array_type(it).subtype);
+      field_size = quantity * base_type_width;
+
+      msg.debug(fmt::format(
+        "Adding field size: {}, quantity: {}, base_type: {}, offs: {}",
+        field_size,
+        quantity,
+        base_type_width,
+        offs));
+    }
+
     // Round up to word size
     expr2tc field_offset = constant_int2tc(offset->type, offs);
     expr2tc field_top = constant_int2tc(offset->type, offs + field_size);
@@ -1366,28 +1395,6 @@ void dereferencet::construct_from_dyn_struct_offset(
     expr2tc field = member2tc(it, value, struct_type.member_names[i]);
     expr2tc new_offset = sub2tc(offset->type, offset, field_offset);
     simplify(new_offset);
-    // This breaks FAM
-    // Lets compute field size manually for fam :)
-    if(
-      is_array_type(it) &&
-      (to_array_type(it).array_size->expr_id != expr2t::constant_int_id ||
-       !to_array_type(it).get_width()))
-    {
-      auto fam = ns.lookup(to_symbol2t(value).thename);
-      auto last_operand = to_array_type(fam.value.operands().back().type()).size();
-      BigInt quantity(to_constant_expr(last_operand).get_value().as_string().c_str(), 2);
-      auto base_type_width = type_byte_size_bits(to_array_type(it).subtype);
-      field_size = quantity * base_type_width;
-
-      msg.debug(fmt::format("Adding field size: {}, quantity: {}, base_type: {}, offs: {}", field_size, quantity, base_type_width, offs));
-    }
-
-    // Round up to word size
-    expr2tc field_offs = constant_int2tc(offset->type, offs);
-    expr2tc field_top = constant_int2tc(offset->type, offs + field_size);
-    expr2tc lower_bound = greaterthanequal2tc(bits_offset, field_offs);
-    expr2tc upper_bound = lessthan2tc(bits_offset, field_top);
-    expr2tc field_guard = and2tc(lower_bound, upper_bound);
 
     if(is_struct_type(it))
     {
@@ -2281,30 +2288,30 @@ void dereferencet::check_data_obj_access(
   add2tc add(access_sz_e->type, offset, access_sz_e);
   greaterthan2tc gt(add, data_sz_e);
 
-   // Check for FAM struct
+  // Check for FAM struct
   if(is_struct_type(value->type))
   {
     // Here we are checking for a dynamic index of a FAM!
     auto &v = to_struct_type(value->type);
     auto last = v.members.back();
     if(is_array_type(last) && !to_array_type(last).get_width())
+    {
+      msg.debug("FAM in obj access");
+      if(is_symbol2t(value))
       {
-        msg.debug("FAM in obj access");
-        if(is_symbol2t(value))
-          {
-          auto fam = ns.lookup(to_symbol2t(value).thename);
-           // Is FAM pointing to a static object?
-          if(!has_prefix(fam.id.as_string(), "symex_dynamic::"))
-            {
-              msg.debug("Skipping FAM check on obj access");
-              return;
-            }
-          else {
-            msg.debug("Dynamic memory for FAM");
-          }
-
-          }
+        auto fam = ns.lookup(to_symbol2t(value).thename);
+        // Is FAM pointing to a static object?
+        if(!has_prefix(fam.id.as_string(), "symex_dynamic::"))
+        {
+          msg.debug("Skipping FAM check on obj access");
+          return;
+        }
+        else
+        {
+          msg.debug("Dynamic memory for FAM");
+        }
       }
+    }
   }
 
   if(!options.get_bool_option("no-bounds-check"))

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -215,6 +215,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
       type2tc subtype = arr_type.subtype;
 
       // We shouldn't have any bit left behind
+      // This will not work for FAMs!
       //assert(new_from->type->get_width() % subtype->get_width() == 0);
       unsigned int num_el = new_from->type->get_width() / subtype->get_width();
 

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -216,8 +216,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
       type2tc subtype = arr_type.subtype;
 
       // We shouldn't have any bit left behind
-      // This will not work for FAMs!
-      //assert(new_from->type->get_width() % subtype->get_width() == 0);
+      assert(new_from->type->get_width() % subtype->get_width() == 0);
       unsigned int num_el = new_from->type->get_width() / subtype->get_width();
 
       std::vector<expr2tc> elems;

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -65,8 +65,9 @@ static expr2tc flatten_to_bitvector(const expr2tc &new_expr)
       is_constant_int2t(arraytype.array_size) &&
       "Can't flatten array with unbounded size");
 
+    auto array_for_ref = arraytype.array_size;
     // Iterate over each element and flatten them
-    const constant_int2t &intref = to_constant_int2t(arraytype.array_size);
+    const constant_int2t &intref = to_constant_int2t(array_for_ref);
     assert(intref.value > 0);
 
     size_t sz = intref.value.to_uint64();

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -215,7 +215,7 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
       type2tc subtype = arr_type.subtype;
 
       // We shouldn't have any bit left behind
-      assert(new_from->type->get_width() % subtype->get_width() == 0);
+      //assert(new_from->type->get_width() % subtype->get_width() == 0);
       unsigned int num_el = new_from->type->get_width() / subtype->get_width();
 
       std::vector<expr2tc> elems;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1765,12 +1765,12 @@ expr2tc smt_convt::fix_array_idx(const expr2tc &idx, const type2tc &arr_sort)
     if(index_value >= limit)
     {
       // TODO: Maybe we should propagate an invalid expression here?
-      msg.error(fmt::format(
+      log_error(
         "ESBMC encodes array domains by the nearest power of 2. "
         "Current array has a index limit of {}. \nArray: {}\nIndex: {}",
         limit,
         *arr_sort,
-        *idx));
+        *idx);
       abort();
     }
   }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1766,7 +1766,8 @@ expr2tc smt_convt::fix_array_idx(const expr2tc &idx, const type2tc &arr_sort)
     {
       // TODO: Maybe we should propagate an invalid expression here?
       log_warning(
-        "ESBMC relies on bounds check to guarantee that arrays are not overlaping!"
+        "ESBMC relies on bounds check to guarantee that arrays are not "
+        "overlaping!"
         "You have an array with an index limit of {}. \nArray: {}\nIndex: {}",
         limit,
         *arr_sort,

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1762,16 +1762,15 @@ expr2tc smt_convt::fix_array_idx(const expr2tc &idx, const type2tc &arr_sort)
   {
     auto index_value = to_constant_int2t(idx).value.to_uint64();
     auto limit = pow(2, domain_width);
-    if(index_value >= limit)
+    if(index_value >= limit && options.get_bool_option("no-bounds-check"))
     {
       // TODO: Maybe we should propagate an invalid expression here?
-      log_error(
-        "ESBMC encodes array domains by the nearest power of 2. "
-        "Current array has a index limit of {}. \nArray: {}\nIndex: {}",
+      log_warning(
+        "ESBMC relies on bounds check to guarantee that arrays are not overlaping!"
+        "You have an array with an index limit of {}. \nArray: {}\nIndex: {}",
         limit,
         *arr_sort,
         *idx);
-      abort();
     }
   }
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1807,9 +1807,10 @@ unsigned long smt_convt::calculate_array_domain_width(const array_type2t &arr)
   if(!is_nil_expr(arr.array_size) && is_constant_int2t(arr.array_size))
   {
     constant_int2tc thesize = arr.array_size;
-    return size_to_bit_width(thesize->value.to_uint64());
+    uint64_t width = thesize->value.to_uint64();
+    if(width)
+      return size_to_bit_width(width);
   }
-
   return config.ansi_c.word_size;
 }
 


### PR DESCRIPTION
I am opening this as a draft for more discussion.

@mikhailramalho has suggested me to look into the `incomplete_array` from CBMC. It seems that they actually removed it and use it as an zero-sized array.

Using this approach fixed most fam-related bugs that I was having, even using the fam as an array (`fam_false_6`). Now the only problem is:

- Bounds-check for dereference to fam (e.g. `fam_false_0`, `fam_false_4`).

I am still doing some cleanup on the code so its not ready for review.

@mikhailramalho, @lucasccordeiro and @fbrausse let me know what you think. If this is ok, then I will remove the incomplete_array type.  Also, I would love some testcases as it is hard to find good examples of FAM.
