### PR TITLE
[Solidity] Add line number decoding for counterexample trace

### DIFF
--- a/regression/esbmc-solidity/github_497_1/test.desc
+++ b/regression/esbmc-solidity/github_497_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_TxOrigin.solast
---function transferTo
+--function transferTo --contract MyContract_TxOrigin.sol
 .*Found vulnerability SWC-115.*

--- a/regression/esbmc-solidity/github_497_2/test.desc
+++ b/regression/esbmc-solidity/github_497_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_overflow_nested.solast
---function func_overflow
+--function func_overflow --contract MyContract_overflow_nested.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_2/test.desc
+++ b/regression/esbmc-solidity/github_497_2/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_overflow_nested.solast
 --function func_overflow --contract MyContract_overflow_nested.sol
+.*line 16 function func_overflow$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_3/test.desc
+++ b/regression/esbmc-solidity/github_497_3/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_underflow_UnaryOp.solast
 --function func_underflow --contract MyContract_underflow_UnaryOp.sol
+.*line 11 function func_underflow$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_3/test.desc
+++ b/regression/esbmc-solidity/github_497_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_underflow_UnaryOp.solast
---function func_underflow
+--function func_underflow --contract MyContract_underflow_UnaryOp.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_4/test.desc
+++ b/regression/esbmc-solidity/github_497_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_underflow_loop.solast
---function func_loop --incremental-bmc
+--function func_loop --incremental-bmc --contract MyContract_underflow_loop.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_4/test.desc
+++ b/regression/esbmc-solidity/github_497_4/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_underflow_loop.solast
 --function func_loop --incremental-bmc --contract MyContract_underflow_loop.sol
+.*line 12 function func_loop$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_5/test.desc
+++ b/regression/esbmc-solidity/github_497_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_array.solast
---function func_array --falsification
+--function func_array --falsification --contract MyContract_array.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_5/test.desc
+++ b/regression/esbmc-solidity/github_497_5/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_array.solast
 --function func_array --falsification --contract MyContract_array.sol
+.*line 13 function func_array$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_1/test.desc
+++ b/regression/esbmc-solidity/github_497_6_1/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_satisfiability_1.solast
 --function func_sat --contract MyContract_satisfiability_1.sol
+.*line 24 function func_sat$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_1/test.desc
+++ b/regression/esbmc-solidity/github_497_6_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_satisfiability_1.solast
---function func_sat
+--function func_sat --contract MyContract_satisfiability_1.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_2/test.desc
+++ b/regression/esbmc-solidity/github_497_6_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_satisfiability_2.solast
---function func_sat
+--function func_sat --contract MyContract_satisfiability_2.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_2/test.desc
+++ b/regression/esbmc-solidity/github_497_6_2/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_satisfiability_2.solast
 --function func_sat --contract MyContract_satisfiability_2.sol
+.*line 26 function func_sat$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_3/test.desc
+++ b/regression/esbmc-solidity/github_497_6_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_satisfiability_3.solast
---function func_sat
+--function func_sat --contract MyContract_satisfiability_3.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_3/test.desc
+++ b/regression/esbmc-solidity/github_497_6_3/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_satisfiability_3.solast
 --function func_sat --contract MyContract_satisfiability_3.sol
+.*line 27 function func_sat$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_6_4/test.desc
+++ b/regression/esbmc-solidity/github_497_6_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_satisfiability_4.solast
---function func_sat
+--function func_sat --contract MyContract_satisfiability_4.sol
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/github_497_7/test.desc
+++ b/regression/esbmc-solidity/github_497_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 MyContract_satisfiability_VERIFIER.solast
---function func_sat
+--function func_sat --contract MyContract_satisfiability_VERIFIER.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_497_7/test.desc
+++ b/regression/esbmc-solidity/github_497_7/test.desc
@@ -1,4 +1,5 @@
 CORE
 MyContract_satisfiability_VERIFIER.solast
 --function func_sat --contract MyContract_satisfiability_VERIFIER.sol
+.*line 28 function func_sat$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_dynamic_loop/dynamic_array_oob_loop.sol
+++ b/regression/esbmc-solidity/github_dynamic_loop/dynamic_array_oob_loop.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.4.26;
+
+contract MyContract {
+  uint8 i;
+  function dyn_array_oob_loop(uint8 n) public {
+    uint8[] memory a = new uint8[](n);
+    for (i = 0; i < n; ++i){
+      a[i] = 100;
+    }
+    assert(a[0] == 100);
+  }
+}

--- a/regression/esbmc-solidity/github_dynamic_loop/dynamic_array_oob_loop.solast
+++ b/regression/esbmc-solidity/github_dynamic_loop/dynamic_array_oob_loop.solast
@@ -1,0 +1,654 @@
+JSON AST (compact format):
+
+
+======= dynamic_array_oob_loop.sol =======
+{
+  "absolutePath": "dynamic_array_oob_loop.sol",
+  "exportedSymbols":
+  {
+    "MyContract":
+    [
+      47
+    ]
+  },
+  "id": 48,
+  "license": "GPL-3.0",
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 1,
+      "literals":
+      [
+        "solidity",
+        ">=",
+        "0.4",
+        ".26"
+      ],
+      "nodeType": "PragmaDirective",
+      "src": "36:25:0"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 47,
+      "linearizedBaseContracts":
+      [
+        47
+      ],
+      "name": "MyContract",
+      "nameLocation": "72:10:0",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 3,
+          "mutability": "mutable",
+          "name": "i",
+          "nameLocation": "93:1:0",
+          "nodeType": "VariableDeclaration",
+          "scope": 47,
+          "src": "87:7:0",
+          "stateVariable": true,
+          "storageLocation": "default",
+          "typeDescriptions":
+          {
+            "typeIdentifier": "t_uint8",
+            "typeString": "uint8"
+          },
+          "typeName":
+          {
+            "id": 2,
+            "name": "uint8",
+            "nodeType": "ElementaryTypeName",
+            "src": "87:5:0",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_uint8",
+              "typeString": "uint8"
+            }
+          },
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 45,
+            "nodeType": "Block",
+            "src": "142:122:0",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  12
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 12,
+                    "mutability": "mutable",
+                    "name": "a",
+                    "nameLocation": "163:1:0",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 45,
+                    "src": "148:16:0",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                      "typeString": "uint8[]"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 10,
+                        "name": "uint8",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "148:5:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "id": 11,
+                      "nodeType": "ArrayTypeName",
+                      "src": "148:7:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint8_$dyn_storage_ptr",
+                        "typeString": "uint8[]"
+                      }
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 18,
+                "initialValue":
+                {
+                  "arguments":
+                  [
+                    {
+                      "id": 16,
+                      "name": "n",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 5,
+                      "src": "179:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    }
+                  ],
+                  "expression":
+                  {
+                    "argumentTypes":
+                    [
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    ],
+                    "id": 15,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "nodeType": "NewExpression",
+                    "src": "167:11:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_function_objectcreation_pure$_t_uint256_$returns$_t_array$_t_uint8_$dyn_memory_ptr_$",
+                      "typeString": "function (uint256) pure returns (uint8[] memory)"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 13,
+                        "name": "uint8",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "171:5:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "id": 14,
+                      "nodeType": "ArrayTypeName",
+                      "src": "171:7:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint8_$dyn_storage_ptr",
+                        "typeString": "uint8[]"
+                      }
+                    }
+                  },
+                  "id": 17,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "167:14:0",
+                  "tryCall": false,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                    "typeString": "uint8[] memory"
+                  }
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "148:33:0"
+              },
+              {
+                "body":
+                {
+                  "id": 35,
+                  "nodeType": "Block",
+                  "src": "210:25:0",
+                  "statements":
+                  [
+                    {
+                      "expression":
+                      {
+                        "id": 33,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftHandSide":
+                        {
+                          "baseExpression":
+                          {
+                            "id": 29,
+                            "name": "a",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 12,
+                            "src": "218:1:0",
+                            "typeDescriptions":
+                            {
+                              "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                              "typeString": "uint8[] memory"
+                            }
+                          },
+                          "id": 31,
+                          "indexExpression":
+                          {
+                            "id": 30,
+                            "name": "i",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 3,
+                            "src": "220:1:0",
+                            "typeDescriptions":
+                            {
+                              "typeIdentifier": "t_uint8",
+                              "typeString": "uint8"
+                            }
+                          },
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": true,
+                          "nodeType": "IndexAccess",
+                          "src": "218:4:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_uint8",
+                            "typeString": "uint8"
+                          }
+                        },
+                        "nodeType": "Assignment",
+                        "operator": "=",
+                        "rightHandSide":
+                        {
+                          "hexValue": "313030",
+                          "id": 32,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "225:3:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_rational_100_by_1",
+                            "typeString": "int_const 100"
+                          },
+                          "value": "100"
+                        },
+                        "src": "218:10:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "id": 34,
+                      "nodeType": "ExpressionStatement",
+                      "src": "218:10:0"
+                    }
+                  ]
+                },
+                "condition":
+                {
+                  "commonType":
+                  {
+                    "typeIdentifier": "t_uint8",
+                    "typeString": "uint8"
+                  },
+                  "id": 25,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "leftExpression":
+                  {
+                    "id": 23,
+                    "name": "i",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 3,
+                    "src": "199:1:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    }
+                  },
+                  "nodeType": "BinaryOperation",
+                  "operator": "<",
+                  "rightExpression":
+                  {
+                    "id": 24,
+                    "name": "n",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 5,
+                    "src": "203:1:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    }
+                  },
+                  "src": "199:5:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "id": 36,
+                "initializationExpression":
+                {
+                  "expression":
+                  {
+                    "id": 21,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide":
+                    {
+                      "id": 19,
+                      "name": "i",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 3,
+                      "src": "192:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide":
+                    {
+                      "hexValue": "30",
+                      "id": 20,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "number",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "196:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_rational_0_by_1",
+                        "typeString": "int_const 0"
+                      },
+                      "value": "0"
+                    },
+                    "src": "192:5:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    }
+                  },
+                  "id": 22,
+                  "nodeType": "ExpressionStatement",
+                  "src": "192:5:0"
+                },
+                "loopExpression":
+                {
+                  "expression":
+                  {
+                    "id": 27,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "++",
+                    "prefix": true,
+                    "src": "206:3:0",
+                    "subExpression":
+                    {
+                      "id": 26,
+                      "name": "i",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 3,
+                      "src": "208:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    },
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    }
+                  },
+                  "id": 28,
+                  "nodeType": "ExpressionStatement",
+                  "src": "206:3:0"
+                },
+                "nodeType": "ForStatement",
+                "src": "187:48:0"
+              },
+              {
+                "expression":
+                {
+                  "arguments":
+                  [
+                    {
+                      "commonType":
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      },
+                      "id": 42,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "leftExpression":
+                      {
+                        "baseExpression":
+                        {
+                          "id": 38,
+                          "name": "a",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 12,
+                          "src": "247:1:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                            "typeString": "uint8[] memory"
+                          }
+                        },
+                        "id": 40,
+                        "indexExpression":
+                        {
+                          "hexValue": "30",
+                          "id": 39,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "249:1:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "247:4:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "nodeType": "BinaryOperation",
+                      "operator": "==",
+                      "rightExpression":
+                      {
+                        "hexValue": "313030",
+                        "id": 41,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "255:3:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_rational_100_by_1",
+                          "typeString": "int_const 100"
+                        },
+                        "value": "100"
+                      },
+                      "src": "247:11:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    }
+                  ],
+                  "expression":
+                  {
+                    "argumentTypes":
+                    [
+                      {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    ],
+                    "id": 37,
+                    "name": "assert",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": -3,
+                    "src": "240:6:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_function_assert_pure$_t_bool_$returns$__$",
+                      "typeString": "function (bool) pure"
+                    }
+                  },
+                  "id": 43,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "240:19:0",
+                  "tryCall": false,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_tuple$__$",
+                    "typeString": "tuple()"
+                  }
+                },
+                "id": 44,
+                "nodeType": "ExpressionStatement",
+                "src": "240:19:0"
+              }
+            ]
+          },
+          "functionSelector": "83986803",
+          "id": 46,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "dyn_array_oob_loop",
+          "nameLocation": "107:18:0",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 6,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 5,
+                "mutability": "mutable",
+                "name": "n",
+                "nameLocation": "132:1:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 46,
+                "src": "126:7:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint8",
+                  "typeString": "uint8"
+                },
+                "typeName":
+                {
+                  "id": 4,
+                  "name": "uint8",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "126:5:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint8",
+                    "typeString": "uint8"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "125:9:0"
+          },
+          "returnParameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "142:0:0"
+          },
+          "scope": 47,
+          "src": "98:166:0",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "scope": 48,
+      "src": "63:203:0",
+      "usedErrors": []
+    }
+  ],
+  "src": "36:231:0"
+}

--- a/regression/esbmc-solidity/github_dynamic_loop/test.desc
+++ b/regression/esbmc-solidity/github_dynamic_loop/test.desc
@@ -1,0 +1,4 @@
+CORE
+dynamic_array_oob_loop.solast
+--function dyn_array_oob_loop --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_dynamic_loop/test.desc
+++ b/regression/esbmc-solidity/github_dynamic_loop/test.desc
@@ -1,4 +1,5 @@
 CORE
 dynamic_array_oob_loop.solast
 --function dyn_array_oob_loop --incremental-bmc --contract dynamic_array_oob_loop.sol
+.*line 11 function dyn_array_oob_loop$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_dynamic_loop/test.desc
+++ b/regression/esbmc-solidity/github_dynamic_loop/test.desc
@@ -1,4 +1,4 @@
 CORE
 dynamic_array_oob_loop.solast
---function dyn_array_oob_loop --incremental-bmc
+--function dyn_array_oob_loop --incremental-bmc --contract dynamic_array_oob_loop.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_dynamic_simple/dynamic_array_oob_simple.sol
+++ b/regression/esbmc-solidity/github_dynamic_simple/dynamic_array_oob_simple.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.4.26;
+
+contract MyContract {
+  function dyn_array_oob_simple(uint8 n) public pure {
+    uint8[] memory a = new uint8[](n);
+    a[0] = 100;
+    assert(a[0] == 100);
+  }
+}

--- a/regression/esbmc-solidity/github_dynamic_simple/dynamic_array_oob_simple.solast
+++ b/regression/esbmc-solidity/github_dynamic_simple/dynamic_array_oob_simple.solast
@@ -1,0 +1,474 @@
+JSON AST (compact format):
+
+
+======= dynamic_array_oob_simple.sol =======
+{
+  "absolutePath": "dynamic_array_oob_simple.sol",
+  "exportedSymbols":
+  {
+    "MyContract":
+    [
+      33
+    ]
+  },
+  "id": 34,
+  "license": "GPL-3.0",
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 1,
+      "literals":
+      [
+        "solidity",
+        ">=",
+        "0.4",
+        ".26"
+      ],
+      "nodeType": "PragmaDirective",
+      "src": "36:25:0"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 33,
+      "linearizedBaseContracts":
+      [
+        33
+      ],
+      "name": "MyContract",
+      "nameLocation": "72:10:0",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 31,
+            "nodeType": "Block",
+            "src": "138:85:0",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  10
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 10,
+                    "mutability": "mutable",
+                    "name": "a",
+                    "nameLocation": "159:1:0",
+                    "nodeType": "VariableDeclaration",
+                    "scope": 31,
+                    "src": "144:16:0",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                      "typeString": "uint8[]"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 8,
+                        "name": "uint8",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "144:5:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "id": 9,
+                      "nodeType": "ArrayTypeName",
+                      "src": "144:7:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint8_$dyn_storage_ptr",
+                        "typeString": "uint8[]"
+                      }
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 16,
+                "initialValue":
+                {
+                  "arguments":
+                  [
+                    {
+                      "id": 14,
+                      "name": "n",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 3,
+                      "src": "175:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    }
+                  ],
+                  "expression":
+                  {
+                    "argumentTypes":
+                    [
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      }
+                    ],
+                    "id": 13,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "nodeType": "NewExpression",
+                    "src": "163:11:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_function_objectcreation_pure$_t_uint256_$returns$_t_array$_t_uint8_$dyn_memory_ptr_$",
+                      "typeString": "function (uint256) pure returns (uint8[] memory)"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 11,
+                        "name": "uint8",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "167:5:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "id": 12,
+                      "nodeType": "ArrayTypeName",
+                      "src": "167:7:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint8_$dyn_storage_ptr",
+                        "typeString": "uint8[]"
+                      }
+                    }
+                  },
+                  "id": 15,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "163:14:0",
+                  "tryCall": false,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                    "typeString": "uint8[] memory"
+                  }
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "144:33:0"
+              },
+              {
+                "expression":
+                {
+                  "id": 21,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "leftHandSide":
+                  {
+                    "baseExpression":
+                    {
+                      "id": 17,
+                      "name": "a",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 10,
+                      "src": "183:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                        "typeString": "uint8[] memory"
+                      }
+                    },
+                    "id": 19,
+                    "indexExpression":
+                    {
+                      "hexValue": "30",
+                      "id": 18,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "number",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "185:1:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_rational_0_by_1",
+                        "typeString": "int_const 0"
+                      },
+                      "value": "0"
+                    },
+                    "isConstant": false,
+                    "isLValue": true,
+                    "isPure": false,
+                    "lValueRequested": true,
+                    "nodeType": "IndexAccess",
+                    "src": "183:4:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    }
+                  },
+                  "nodeType": "Assignment",
+                  "operator": "=",
+                  "rightHandSide":
+                  {
+                    "hexValue": "313030",
+                    "id": 20,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "kind": "number",
+                    "lValueRequested": false,
+                    "nodeType": "Literal",
+                    "src": "190:3:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_rational_100_by_1",
+                      "typeString": "int_const 100"
+                    },
+                    "value": "100"
+                  },
+                  "src": "183:10:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint8",
+                    "typeString": "uint8"
+                  }
+                },
+                "id": 22,
+                "nodeType": "ExpressionStatement",
+                "src": "183:10:0"
+              },
+              {
+                "expression":
+                {
+                  "arguments":
+                  [
+                    {
+                      "commonType":
+                      {
+                        "typeIdentifier": "t_uint8",
+                        "typeString": "uint8"
+                      },
+                      "id": 28,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "leftExpression":
+                      {
+                        "baseExpression":
+                        {
+                          "id": 24,
+                          "name": "a",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 10,
+                          "src": "206:1:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_array$_t_uint8_$dyn_memory_ptr",
+                            "typeString": "uint8[] memory"
+                          }
+                        },
+                        "id": 26,
+                        "indexExpression":
+                        {
+                          "hexValue": "30",
+                          "id": 25,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "208:1:0",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "206:4:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint8",
+                          "typeString": "uint8"
+                        }
+                      },
+                      "nodeType": "BinaryOperation",
+                      "operator": "==",
+                      "rightExpression":
+                      {
+                        "hexValue": "313030",
+                        "id": 27,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "214:3:0",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_rational_100_by_1",
+                          "typeString": "int_const 100"
+                        },
+                        "value": "100"
+                      },
+                      "src": "206:11:0",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    }
+                  ],
+                  "expression":
+                  {
+                    "argumentTypes":
+                    [
+                      {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    ],
+                    "id": 23,
+                    "name": "assert",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": -3,
+                    "src": "199:6:0",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_function_assert_pure$_t_bool_$returns$__$",
+                      "typeString": "function (bool) pure"
+                    }
+                  },
+                  "id": 29,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "199:19:0",
+                  "tryCall": false,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_tuple$__$",
+                    "typeString": "tuple()"
+                  }
+                },
+                "id": 30,
+                "nodeType": "ExpressionStatement",
+                "src": "199:19:0"
+              }
+            ]
+          },
+          "functionSelector": "2cdd6922",
+          "id": 32,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "dyn_array_oob_simple",
+          "nameLocation": "96:20:0",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 4,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 3,
+                "mutability": "mutable",
+                "name": "n",
+                "nameLocation": "123:1:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 32,
+                "src": "117:7:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint8",
+                  "typeString": "uint8"
+                },
+                "typeName":
+                {
+                  "id": 2,
+                  "name": "uint8",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "117:5:0",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint8",
+                    "typeString": "uint8"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "116:9:0"
+          },
+          "returnParameters":
+          {
+            "id": 5,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "138:0:0"
+          },
+          "scope": 33,
+          "src": "87:136:0",
+          "stateMutability": "pure",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "scope": 34,
+      "src": "63:162:0",
+      "usedErrors": []
+    }
+  ],
+  "src": "36:190:0"
+}

--- a/regression/esbmc-solidity/github_dynamic_simple/test.desc
+++ b/regression/esbmc-solidity/github_dynamic_simple/test.desc
@@ -1,4 +1,4 @@
 CORE
 dynamic_array_oob_simple.solast
---function dyn_array_oob_simple
+--function dyn_array_oob_simple --contract dynamic_array_oob_simple.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_dynamic_simple/test.desc
+++ b/regression/esbmc-solidity/github_dynamic_simple/test.desc
@@ -1,4 +1,5 @@
 CORE
 dynamic_array_oob_simple.solast
 --function dyn_array_oob_simple --contract dynamic_array_oob_simple.sol
+.*line 7 function dyn_array_oob_simple$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/github_dynamic_simple/test.desc
+++ b/regression/esbmc-solidity/github_dynamic_simple/test.desc
@@ -1,0 +1,4 @@
+CORE
+dynamic_array_oob_simple.solast
+--function dyn_array_oob_simple
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -48,11 +48,11 @@ const struct group_opt_templ all_cmd_options[] = {
      "show value-set analysis during symbolic execution"}}},
 #ifdef ENABLE_SOLIDITY_FRONTEND
   {"Solidity frontend",
-  {
-    {"contract",
+   {
+     {"contract",
       boost::program_options::value<std::string>()->value_name("path"),
       "set smart contract source"},
-  }},
+   }},
 #endif
   {"Frontend",
    {{"include,I",

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -46,6 +46,14 @@ const struct group_opt_templ all_cmd_options[] = {
     {"show-symex-value-sets",
      NULL,
      "show value-set analysis during symbolic execution"}}},
+#ifdef ENABLE_SOLIDITY_FRONTEND
+  {"Solidity frontend",
+  {
+    {"contract",
+      boost::program_options::value<std::string>()->value_name("path"),
+      "set smart contract source"},
+  }},
+#endif
   {"Frontend",
    {{"include,I",
      boost::program_options::value<std::vector<std::string>>()->value_name(

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -83,7 +83,6 @@ bool language_uit::parse(const std::string &filename)
     }
     else
     {
-      //language.set_smart_contract_source(_cmdline.vm["contract"].as<std::string>());
       language.set_smart_contract_source(config.options.get_option("contract"));
     }
   }

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -73,7 +73,20 @@ bool language_uit::parse(const std::string &filename)
 
 #ifdef ENABLE_SOLIDITY_FRONTEND
   if(mode == get_mode("Solidity AST"))
+  {
     language.set_func_name(_cmdline.vm["function"].as<std::string>());
+
+    if(config.options.get_option("contract") == "")
+    {
+      msg.error("Please set the smart contract source file.");
+      return true;
+    }
+    else
+    {
+      //language.set_smart_contract_source(_cmdline.vm["contract"].as<std::string>());
+      language.set_smart_contract_source(config.options.get_option("contract"));
+    }
+  }
 #endif
 
   if(language.parse(filename, msg))

--- a/src/solidity-frontend/pattern_check.cpp
+++ b/src/solidity-frontend/pattern_check.cpp
@@ -45,7 +45,6 @@ bool pattern_checker::start_pattern_based_check(const nlohmann::json &func)
 void pattern_checker::check_authorization_through_tx_origin(
   const nlohmann::json &func)
 {
-  printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin\n");
   // looking for the pattern require(tx.origin == <VarDeclReference>)
   const nlohmann::json &body_stmt = func["body"]["statements"];
   msg.progress(
@@ -63,20 +62,11 @@ void pattern_checker::check_authorization_through_tx_origin(
     {
       if((*itr)["nodeType"].get<std::string>() == "ExpressionStatement")
       {
-        printf(
-          "DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - "
-          "ExpressionStatement\n");
         const nlohmann::json &expr = (*itr)["expression"];
         if(expr["nodeType"] == "FunctionCall")
         {
-          printf(
-            "DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - "
-            "FunctionCall\n");
           if(expr["kind"] == "functionCall")
           {
-            printf(
-              "DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - "
-              "functionCall\n");
             check_require_call(expr);
           }
         }
@@ -87,23 +77,17 @@ void pattern_checker::check_authorization_through_tx_origin(
 
 void pattern_checker::check_require_call(const nlohmann::json &expr)
 {
-  printf("DEBUG_TX_ORIGIN: in check_require_call\n");
   // Checking the authorization argument of require() function
   if(expr["expression"]["nodeType"].get<std::string>() == "Identifier")
   {
-    printf("DEBUG_TX_ORIGIN: in check_require_call - Identifier\n");
     if(expr["expression"]["name"].get<std::string>() == "require")
     {
-      printf("DEBUG_TX_ORIGIN: in check_require_call - require\n");
       const nlohmann::json &call_args = expr["arguments"];
       // Search for tx.origin in BinaryOperation (==) as used in require(tx.origin == <VarDeclReference>)
       // There should be just one argument, the BinaryOpration expression.
       // Checking 1 argument as in require(<leftExpr> == <rightExpr>)
       if(call_args.size() == 1)
       {
-        printf(
-          "DEBUG_TX_ORIGIN: in check_require_call - confirmed call_args.size() "
-          "== 1\n");
         check_require_argument(call_args);
       }
     }
@@ -112,17 +96,14 @@ void pattern_checker::check_require_call(const nlohmann::json &expr)
 
 void pattern_checker::check_require_argument(const nlohmann::json &call_args)
 {
-  printf("DEBUG_TX_ORIGIN: in check_require_argument\n");
   // This function is used to check the authorization argument of require() funciton
   const nlohmann::json &arg_expr = call_args[0];
 
   // look for BinaryOperation "=="
   if(arg_expr["nodeType"].get<std::string>() == "BinaryOperation")
   {
-    printf("DEBUG_TX_ORIGIN: in check_require_argument - BinaryOperation\n");
     if(arg_expr["operator"].get<std::string>() == "==")
     {
-      printf("DEBUG_TX_ORIGIN: in check_require_argument - operator\n");
       const nlohmann::json &left_expr = arg_expr["leftExpression"];
       // Search for "tx", "." and "origin". First, confirm the nodeType is MemeberAccess
       // If the nodeType was NOT MemberAccess, accessing "memberName" would throw an exception !
@@ -130,7 +111,6 @@ void pattern_checker::check_require_argument(const nlohmann::json &call_args)
         left_expr["nodeType"].get<std::string>() ==
         "MemberAccess") // tx.origin is of the type MemberAccess expression
       {
-        printf("DEBUG_TX_ORIGIN: in check_require_argument - MemberAccess\n");
         check_tx_origin(left_expr);
       }
     } // end of "=="
@@ -142,13 +122,10 @@ void pattern_checker::check_tx_origin(const nlohmann::json &left_expr)
   // This function is used to check the Tx.origin pattern used in BinOp expr
   if(left_expr["memberName"].get<std::string>() == "origin")
   {
-    printf("DEBUG_TX_ORIGIN: in check_tx_origin\n");
     if(left_expr["expression"]["nodeType"].get<std::string>() == "Identifier")
     {
-      printf("DEBUG_TX_ORIGIN: in check_tx_origin - Identifier\n");
       if(left_expr["expression"]["name"].get<std::string>() == "tx")
       {
-        printf("DEBUG_TX_ORIGIN: in check_tx_origin - tx\n");
         //assert(!"Found vulnerability SWC-115 Authorization through tx.origin");
         msg.error(
           "Found vulnerability SWC-115 Authorization through tx.origin");

--- a/src/solidity-frontend/pattern_check.cpp
+++ b/src/solidity-frontend/pattern_check.cpp
@@ -1,4 +1,5 @@
 #include <solidity-frontend/pattern_check.h>
+#include <stdlib.h>
 
 pattern_checker::pattern_checker(
   const nlohmann::json &_ast_nodes,
@@ -44,6 +45,7 @@ bool pattern_checker::start_pattern_based_check(const nlohmann::json &func)
 void pattern_checker::check_authorization_through_tx_origin(
   const nlohmann::json &func)
 {
+  printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin\n");
   // looking for the pattern require(tx.origin == <VarDeclReference>)
   const nlohmann::json &body_stmt = func["body"]["statements"];
   msg.progress(
@@ -61,11 +63,16 @@ void pattern_checker::check_authorization_through_tx_origin(
     {
       if((*itr)["nodeType"].get<std::string>() == "ExpressionStatement")
       {
+        printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - ExpressionStatement\n");
         const nlohmann::json &expr = (*itr)["expression"];
         if(expr["nodeType"] == "FunctionCall")
         {
+          printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - FunctionCall\n");
           if(expr["kind"] == "functionCall")
+          {
+            printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - functionCall\n");
             check_require_call(expr);
+          }
         }
       }
     }
@@ -74,38 +81,50 @@ void pattern_checker::check_authorization_through_tx_origin(
 
 void pattern_checker::check_require_call(const nlohmann::json &expr)
 {
+  printf("DEBUG_TX_ORIGIN: in check_require_call\n");
   // Checking the authorization argument of require() function
   if(expr["expression"]["nodeType"].get<std::string>() == "Identifier")
   {
+    printf("DEBUG_TX_ORIGIN: in check_require_call - Identifier\n");
     if(expr["expression"]["name"].get<std::string>() == "require")
     {
+      printf("DEBUG_TX_ORIGIN: in check_require_call - require\n");
       const nlohmann::json &call_args = expr["arguments"];
       // Search for tx.origin in BinaryOperation (==) as used in require(tx.origin == <VarDeclReference>)
       // There should be just one argument, the BinaryOpration expression.
       // Checking 1 argument as in require(<leftExpr> == <rightExpr>)
       if(call_args.size() == 1)
+      {
+        printf("DEBUG_TX_ORIGIN: in check_require_call - confirmed call_args.size() == 1\n");
         check_require_argument(call_args);
+      }
     }
   }
 }
 
 void pattern_checker::check_require_argument(const nlohmann::json &call_args)
 {
+  printf("DEBUG_TX_ORIGIN: in check_require_argument\n");
   // This function is used to check the authorization argument of require() funciton
   const nlohmann::json &arg_expr = call_args[0];
 
   // look for BinaryOperation "=="
   if(arg_expr["nodeType"].get<std::string>() == "BinaryOperation")
   {
+    printf("DEBUG_TX_ORIGIN: in check_require_argument - BinaryOperation\n");
     if(arg_expr["operator"].get<std::string>() == "==")
     {
+      printf("DEBUG_TX_ORIGIN: in check_require_argument - operator\n");
       const nlohmann::json &left_expr = arg_expr["leftExpression"];
       // Search for "tx", "." and "origin". First, confirm the nodeType is MemeberAccess
       // If the nodeType was NOT MemberAccess, accessing "memberName" would throw an exception !
       if(
         left_expr["nodeType"].get<std::string>() ==
         "MemberAccess") // tx.origin is of the type MemberAccess expression
+      {
+        printf("DEBUG_TX_ORIGIN: in check_require_argument - MemberAccess\n");
         check_tx_origin(left_expr);
+      }
     } // end of "=="
   }   // end of "BinaryOperation"
 }
@@ -115,10 +134,18 @@ void pattern_checker::check_tx_origin(const nlohmann::json &left_expr)
   // This function is used to check the Tx.origin pattern used in BinOp expr
   if(left_expr["memberName"].get<std::string>() == "origin")
   {
+    printf("DEBUG_TX_ORIGIN: in check_tx_origin\n");
     if(left_expr["expression"]["nodeType"].get<std::string>() == "Identifier")
     {
+      printf("DEBUG_TX_ORIGIN: in check_tx_origin - Identifier\n");
       if(left_expr["expression"]["name"].get<std::string>() == "tx")
-        assert(!"Found vulnerability SWC-115 Authorization through tx.origin");
+      {
+        printf("DEBUG_TX_ORIGIN: in check_tx_origin - tx\n");
+        //assert(!"Found vulnerability SWC-115 Authorization through tx.origin");
+        msg.error("Found vulnerability SWC-115 Authorization through tx.origin");
+        msg.error("VERIFICATION FAILED");
+        exit(EXIT_SUCCESS);
+      }
     }
   }
 }

--- a/src/solidity-frontend/pattern_check.cpp
+++ b/src/solidity-frontend/pattern_check.cpp
@@ -63,14 +63,20 @@ void pattern_checker::check_authorization_through_tx_origin(
     {
       if((*itr)["nodeType"].get<std::string>() == "ExpressionStatement")
       {
-        printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - ExpressionStatement\n");
+        printf(
+          "DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - "
+          "ExpressionStatement\n");
         const nlohmann::json &expr = (*itr)["expression"];
         if(expr["nodeType"] == "FunctionCall")
         {
-          printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - FunctionCall\n");
+          printf(
+            "DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - "
+            "FunctionCall\n");
           if(expr["kind"] == "functionCall")
           {
-            printf("DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - functionCall\n");
+            printf(
+              "DEBUG_TX_ORIGIN: in check_authorization_through_tx_origin - "
+              "functionCall\n");
             check_require_call(expr);
           }
         }
@@ -95,7 +101,9 @@ void pattern_checker::check_require_call(const nlohmann::json &expr)
       // Checking 1 argument as in require(<leftExpr> == <rightExpr>)
       if(call_args.size() == 1)
       {
-        printf("DEBUG_TX_ORIGIN: in check_require_call - confirmed call_args.size() == 1\n");
+        printf(
+          "DEBUG_TX_ORIGIN: in check_require_call - confirmed call_args.size() "
+          "== 1\n");
         check_require_argument(call_args);
       }
     }
@@ -142,7 +150,8 @@ void pattern_checker::check_tx_origin(const nlohmann::json &left_expr)
       {
         printf("DEBUG_TX_ORIGIN: in check_tx_origin - tx\n");
         //assert(!"Found vulnerability SWC-115 Authorization through tx.origin");
-        msg.error("Found vulnerability SWC-115 Authorization through tx.origin");
+        msg.error(
+          "Found vulnerability SWC-115 Authorization through tx.origin");
         msg.error("VERIFICATION FAILED");
         exit(EXIT_SUCCESS);
       }

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -31,8 +31,8 @@ solidity_convertert::solidity_convertert(
     current_functionName("")
 {
   std::ifstream in(_contract_path);
-  contract_contents.assign((std::istreambuf_iterator<char>(in)),
-      std::istreambuf_iterator<char>());
+  contract_contents.assign(
+    (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
 }
 
 bool solidity_convertert::convert()
@@ -199,11 +199,11 @@ bool solidity_convertert::get_var_decl(
   // For array, do NOT use ["typeName"]. Otherwise, it will cause problem
   // when populating typet in get_cast
   bool dyn_array = is_dyn_array(ast_node["typeDescriptions"]);
-  if (dyn_array)
+  if(dyn_array)
   {
     // append size expr in typeDescription JSON object
     const nlohmann::json &type_descriptor = add_dyn_array_size_expr(
-        ast_node["typeName"]["typeDescriptions"], ast_node);
+      ast_node["typeName"]["typeDescriptions"], ast_node);
     if(get_type_description(type_descriptor, t))
       return true;
   }
@@ -261,7 +261,8 @@ bool solidity_convertert::get_var_decl(
   // For state var decl, we look for "value".
   // For local var decl, we look for "initialValue"
   bool has_init =
-    (ast_node.contains("value") || ast_node.contains("initialValue")) && !dyn_array;
+    (ast_node.contains("value") || ast_node.contains("initialValue")) &&
+    !dyn_array;
   if(symbol.static_lifetime && !symbol.is_extern && !has_init)
   {
     symbol.value = gen_zero(t, true);
@@ -334,7 +335,7 @@ bool solidity_convertert::get_function_definition(
   get_function_definition_name(ast_node, name, id);
 
   // TODO: debug remove before commit
-  if (name == "func_dynamic")
+  if(name == "func_dynamic")
     printf("@@ found func_dynamic\n");
 
   // 8. populate "std::string debug_modulename"
@@ -1256,7 +1257,7 @@ bool solidity_convertert::get_type_description(
   {
     // Deal with dynamic array
     exprt size_expr;
-    if (type_name.contains("sizeExpr"))
+    if(type_name.contains("sizeExpr"))
     {
       const nlohmann::json &rtn_expr = type_name["sizeExpr"];
       // wrap it in an ImplicitCastExpr to convert LValue to RValue
@@ -1499,7 +1500,9 @@ void solidity_convertert::get_function_definition_name(
   id = name;
 }
 
-unsigned int solidity_convertert::add_offset(const std::string& src, unsigned int start_position)
+unsigned int solidity_convertert::add_offset(
+  const std::string &src,
+  unsigned int start_position)
 {
   // extract the length from "start:length:index"
   std::string offset = src.substr(1, src.find(":"));
@@ -1508,44 +1511,50 @@ unsigned int solidity_convertert::add_offset(const std::string& src, unsigned in
   return end_position;
 }
 
-std::string solidity_convertert::get_src_from_json(const nlohmann::json &ast_node)
+std::string
+solidity_convertert::get_src_from_json(const nlohmann::json &ast_node)
 {
   // some nodes may have "src" inside a member json object
   // we need to deal with them case by case based on the node type
-  SolidityGrammar::ExpressionT type = SolidityGrammar::get_expression_t(ast_node);
+  SolidityGrammar::ExpressionT type =
+    SolidityGrammar::get_expression_t(ast_node);
   switch(type)
   {
-    case SolidityGrammar::ExpressionT::ImplicitCastExprClass:
-    {
-      assert(ast_node.contains("subExpr"));
-      assert(ast_node["subExpr"].contains("src"));
-      return ast_node["subExpr"]["src"].get<std::string>();
-      break;
-    }
-    default:
-    {
-      assert(!"Unsupported node type when getting src from JSON");
-      return "";
-    }
+  case SolidityGrammar::ExpressionT::ImplicitCastExprClass:
+  {
+    assert(ast_node.contains("subExpr"));
+    assert(ast_node["subExpr"].contains("src"));
+    return ast_node["subExpr"]["src"].get<std::string>();
+    break;
+  }
+  default:
+  {
+    assert(!"Unsupported node type when getting src from JSON");
+    return "";
+  }
   }
 }
 
 unsigned int solidity_convertert::get_line_number(
-  const nlohmann::json &ast_node, bool final_position)
+  const nlohmann::json &ast_node,
+  bool final_position)
 {
   // Solidity src means "start:length:index", where "start" represents the position of the first char byte of the identifier.
-  std::string src = ast_node.contains("src") ?
-    ast_node["src"].get<std::string>() : get_src_from_json(ast_node);
+  std::string src = ast_node.contains("src")
+                      ? ast_node["src"].get<std::string>()
+                      : get_src_from_json(ast_node);
 
   std::string position = src.substr(0, src.find(":"));
   unsigned int byte_position = std::stoul(position) + 1;
 
-  if (final_position)
+  if(final_position)
     byte_position = add_offset(src, byte_position);
 
   // the line number can be calculated by counting the number of line breaks prior to the identifier.
-  unsigned int loc = std::count(contract_contents.begin(),
-      (contract_contents.begin()+byte_position), '\n');
+  unsigned int loc = std::count(
+    contract_contents.begin(),
+    (contract_contents.begin() + byte_position),
+    '\n');
   return loc;
 }
 
@@ -1570,7 +1579,8 @@ void solidity_convertert::get_location_from_decl(
 }
 
 void solidity_convertert::get_start_location_from_stmt(
-    const nlohmann::json &ast_node,locationt &location)
+  const nlohmann::json &ast_node,
+  locationt &location)
 {
   std::string function_name;
 
@@ -1588,7 +1598,8 @@ void solidity_convertert::get_start_location_from_stmt(
 }
 
 void solidity_convertert::get_final_location_from_stmt(
-    const nlohmann::json &ast_node,locationt &location)
+  const nlohmann::json &ast_node,
+  locationt &location)
 {
   std::string function_name;
 
@@ -1674,12 +1685,13 @@ const nlohmann::json &solidity_convertert::find_decl_ref(int ref_decl_id)
     assert(!"Unable to find the corresponding local variable decl. Current function does not have a function body.");
 
   // Search function parameter
-  if (current_func.contains("parameters"))
+  if(current_func.contains("parameters"))
   {
-    if (current_func["parameters"]["parameters"].size())
+    if(current_func["parameters"]["parameters"].size())
     {
       // var decl in function parameter array
-      for(const auto &param_decl : current_func["parameters"]["parameters"].items())
+      for(const auto &param_decl :
+          current_func["parameters"]["parameters"].items())
       {
         const nlohmann::json &param = param_decl.value();
         assert(param["nodeType"] == "VariableDeclaration");
@@ -1973,16 +1985,16 @@ nlohmann::json solidity_convertert::make_array_to_pointer_type(
   return adjusted_type;
 }
 
-nlohmann::json
-solidity_convertert::add_dyn_array_size_expr(
-    const nlohmann::json &type_descriptor, const nlohmann::json &dyn_array_node)
+nlohmann::json solidity_convertert::add_dyn_array_size_expr(
+  const nlohmann::json &type_descriptor,
+  const nlohmann::json &dyn_array_node)
 {
   nlohmann::json adjusted_descriptor;
   adjusted_descriptor = type_descriptor;
   // get the JSON object for size expr and merge it with the original type descriptor
   assert(dyn_array_node.contains("initialValue"));
-  adjusted_descriptor.push_back(
-      nlohmann::json::object_t::value_type("sizeExpr", dyn_array_node["initialValue"]["arguments"][0]));
+  adjusted_descriptor.push_back(nlohmann::json::object_t::value_type(
+    "sizeExpr", dyn_array_node["initialValue"]["arguments"][0]));
   return adjusted_descriptor;
 }
 
@@ -2007,9 +2019,11 @@ solidity_convertert::get_array_size(const nlohmann::json &type_descrpt)
 
 bool solidity_convertert::is_dyn_array(const nlohmann::json &json_in)
 {
-  if (json_in.contains("typeIdentifier"))
+  if(json_in.contains("typeIdentifier"))
   {
-    if(json_in["typeIdentifier"].get<std::string>().find("dyn") != std::string::npos)
+    if(
+      json_in["typeIdentifier"].get<std::string>().find("dyn") !=
+      std::string::npos)
     {
       return true;
     }
@@ -2021,6 +2035,7 @@ bool solidity_convertert::is_dyn_array(const nlohmann::json &json_in)
 void solidity_convertert::print_json(const nlohmann::json &json_in)
 {
   printf("### JSON: ###\n");
-  std::cout << std::setw(2) << json_in << '\n'; // '2' means 2x indentations in front of each line
+  std::cout << std::setw(2) << json_in
+            << '\n'; // '2' means 2x indentations in front of each line
   printf("\n");
 }

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -1552,9 +1552,10 @@ unsigned int solidity_convertert::get_line_number(
 
   // the line number can be calculated by counting the number of line breaks prior to the identifier.
   unsigned int loc = std::count(
-    contract_contents.begin(),
-    (contract_contents.begin() + byte_position),
-    '\n');
+                       contract_contents.begin(),
+                       (contract_contents.begin() + byte_position),
+                       '\n') +
+                     1;
   return loc;
 }
 

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -10,16 +10,19 @@
 #include <util/std_expr.h>
 #include <regex>
 #include <util/message/format.h>
+#include <fstream>
 
 solidity_convertert::solidity_convertert(
   contextt &_context,
   nlohmann::json &_ast_json,
   const std::string &_sol_func,
+  const std::string &_contract_path,
   const messaget &msg)
   : context(_context),
     ns(context),
     ast_json(_ast_json),
     sol_func(_sol_func),
+    contract_path(_contract_path),
     msg(msg),
     global_scope_id(0),
     current_scope_var_num(1),
@@ -27,6 +30,10 @@ solidity_convertert::solidity_convertert(
     current_forStmt(nullptr),
     current_functionName("")
 {
+  std::ifstream in(_contract_path);
+  contract_contents.assign((std::istreambuf_iterator<char>(in)),
+      std::istreambuf_iterator<char>());
+  std::cout << contract_contents << std::endl;
 }
 
 bool solidity_convertert::convert()

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -334,7 +334,6 @@ bool solidity_convertert::get_function_definition(
   std::string name, id;
   get_function_definition_name(ast_node, name, id);
 
-  // TODO: debug remove before commit
   if(name == "func_dynamic")
     printf("@@ found func_dynamic\n");
 
@@ -2030,13 +2029,4 @@ bool solidity_convertert::is_dyn_array(const nlohmann::json &json_in)
     }
   }
   return false;
-}
-
-// @@ DEBUG: remove before commit
-void solidity_convertert::print_json(const nlohmann::json &json_in)
-{
-  printf("### JSON: ###\n");
-  std::cout << std::setw(2) << json_in
-            << '\n'; // '2' means 2x indentations in front of each line
-  printf("\n");
 }

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -11,6 +11,8 @@
 #include <solidity-frontend/solidity_grammar.h>
 #include <solidity-frontend/pattern_check.h>
 
+#include <iostream> // @@ DEBUG: remove before commit
+
 class solidity_convertert
 {
 public:
@@ -22,6 +24,8 @@ public:
   virtual ~solidity_convertert() = default;
 
   bool convert();
+
+  void print_json(const nlohmann::json &json_in);
 
 protected:
   contextt &context;
@@ -102,6 +106,8 @@ protected:
   nlohmann::json make_array_elementary_type(const nlohmann::json &type_descrpt);
   nlohmann::json make_array_to_pointer_type(const nlohmann::json &type_descrpt);
   std::string get_array_size(const nlohmann::json &type_descrpt);
+  bool is_dyn_array(const nlohmann::json &json_in);
+  nlohmann::json add_dyn_array_size_expr(const nlohmann::json &type_descriptor, const nlohmann::json &dyn_array_node);
 
   void get_default_symbol(
     symbolt &symbol,

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -20,6 +20,7 @@ public:
     contextt &_context,
     nlohmann::json &_ast_json,
     const std::string &_sol_func,
+    const std::string &_contract_path,
     const messaget &msg);
   virtual ~solidity_convertert() = default;
 
@@ -33,8 +34,10 @@ protected:
   nlohmann::json
     &ast_json; // json for Solidity AST. Use vector for multiple contracts
   const std::string &sol_func; // Solidity function to be verified
+  const std::string &contract_path; //smart contract source file
   const messaget &msg;
   std::string absolute_path;
+  std::string contract_contents = "";
   int global_scope_id; // scope id of "ContractDefinition"
 
   unsigned int current_scope_var_num;

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -93,6 +93,7 @@ protected:
   void
   get_location_from_decl(const nlohmann::json &ast_node, locationt &location);
   void get_start_location_from_stmt(locationt &location);
+  unsigned int get_line_number(const nlohmann::json &ast_node);
   symbolt *move_symbol_to_context(symbolt &symbol);
 
   // auxiliary functions

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -90,10 +90,15 @@ protected:
     const nlohmann::json &ast_node,
     std::string &name,
     std::string &id);
-  void
-  get_location_from_decl(const nlohmann::json &ast_node, locationt &location);
-  void get_start_location_from_stmt(locationt &location);
-  unsigned int get_line_number(const nlohmann::json &ast_node);
+
+  // line number and locations
+  void get_location_from_decl(const nlohmann::json &ast_node, locationt &location);
+  void get_start_location_from_stmt(const nlohmann::json &ast_node, locationt &location);
+  void get_final_location_from_stmt(const nlohmann::json &ast_node, locationt &location);
+  unsigned int get_line_number(const nlohmann::json &ast_node, bool final_position=false);
+  unsigned int add_offset(const std::string& src, unsigned int start_position);
+  std::string get_src_from_json(const nlohmann::json &ast_node);
+
   symbolt *move_symbol_to_context(symbolt &symbol);
 
   // auxiliary functions

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -11,8 +11,6 @@
 #include <solidity-frontend/solidity_grammar.h>
 #include <solidity-frontend/pattern_check.h>
 
-#include <iostream> // @@ DEBUG: remove before commit
-
 class solidity_convertert
 {
 public:
@@ -25,8 +23,6 @@ public:
   virtual ~solidity_convertert() = default;
 
   bool convert();
-
-  void print_json(const nlohmann::json &json_in);
 
 protected:
   contextt &context;

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -33,7 +33,7 @@ protected:
   namespacet ns;
   nlohmann::json
     &ast_json; // json for Solidity AST. Use vector for multiple contracts
-  const std::string &sol_func; // Solidity function to be verified
+  const std::string &sol_func;      // Solidity function to be verified
   const std::string &contract_path; //smart contract source file
   const messaget &msg;
   std::string absolute_path;
@@ -92,11 +92,17 @@ protected:
     std::string &id);
 
   // line number and locations
-  void get_location_from_decl(const nlohmann::json &ast_node, locationt &location);
-  void get_start_location_from_stmt(const nlohmann::json &ast_node, locationt &location);
-  void get_final_location_from_stmt(const nlohmann::json &ast_node, locationt &location);
-  unsigned int get_line_number(const nlohmann::json &ast_node, bool final_position=false);
-  unsigned int add_offset(const std::string& src, unsigned int start_position);
+  void
+  get_location_from_decl(const nlohmann::json &ast_node, locationt &location);
+  void get_start_location_from_stmt(
+    const nlohmann::json &ast_node,
+    locationt &location);
+  void get_final_location_from_stmt(
+    const nlohmann::json &ast_node,
+    locationt &location);
+  unsigned int
+  get_line_number(const nlohmann::json &ast_node, bool final_position = false);
+  unsigned int add_offset(const std::string &src, unsigned int start_position);
   std::string get_src_from_json(const nlohmann::json &ast_node);
 
   symbolt *move_symbol_to_context(symbolt &symbol);
@@ -116,7 +122,9 @@ protected:
   nlohmann::json make_array_to_pointer_type(const nlohmann::json &type_descrpt);
   std::string get_array_size(const nlohmann::json &type_descrpt);
   bool is_dyn_array(const nlohmann::json &json_in);
-  nlohmann::json add_dyn_array_size_expr(const nlohmann::json &type_descriptor, const nlohmann::json &dyn_array_node);
+  nlohmann::json add_dyn_array_size_expr(
+    const nlohmann::json &type_descriptor,
+    const nlohmann::json &dyn_array_node);
 
   void get_default_symbol(
     symbolt &symbol,

--- a/src/solidity-frontend/solidity_grammar.cpp
+++ b/src/solidity-frontend/solidity_grammar.cpp
@@ -99,6 +99,9 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
       //  "typeIdentifier": "t_array$_t_uint8_$2_memory_ptr",
       //  "typeString": "uint8[2] memory"
       // Need to search for the substring "array" as in "typeIdentifier"
+      if(type_name["typeIdentifier"].get<std::string>().find("dyn") != std::string::npos)
+        return DynArrayTypeName;
+
       return ArrayTypeName;
     }
     else
@@ -137,6 +140,7 @@ const char *type_name_to_str(TypeNameT type)
     ENUM_TO_STR(Pointer)
     ENUM_TO_STR(PointerArrayToPtr)
     ENUM_TO_STR(ArrayTypeName)
+    ENUM_TO_STR(DynArrayTypeName)
     ENUM_TO_STR(TypeNameTError)
   default:
   {

--- a/src/solidity-frontend/solidity_grammar.cpp
+++ b/src/solidity-frontend/solidity_grammar.cpp
@@ -99,7 +99,9 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
       //  "typeIdentifier": "t_array$_t_uint8_$2_memory_ptr",
       //  "typeString": "uint8[2] memory"
       // Need to search for the substring "array" as in "typeIdentifier"
-      if(type_name["typeIdentifier"].get<std::string>().find("dyn") != std::string::npos)
+      if(
+        type_name["typeIdentifier"].get<std::string>().find("dyn") !=
+        std::string::npos)
         return DynArrayTypeName;
 
       return ArrayTypeName;

--- a/src/solidity-frontend/solidity_grammar.h
+++ b/src/solidity-frontend/solidity_grammar.h
@@ -34,8 +34,11 @@ enum TypeNameT
   // auxiliary type for ArrayToPointer when dereferencing array, e.g. a[0]
   PointerArrayToPtr,
 
-  // array type
+  // static array type
   ArrayTypeName,
+
+  // dynamic array type
+  DynArrayTypeName,
 
   TypeNameTError
 };

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -120,9 +120,7 @@ bool solidity_languaget::typecheck(
     new_context, msg); // Add ESBMC and TACAS intrinsic symbols to the context
   msg.progress("Done conversion of intrinsics...");
 
-  solidity_convertert converter(new_context, ast_json, func_name, msg);
-  printf("This is smart contract source: %s\n", smart_contract.c_str());
-  assert(!"cool");
+  solidity_convertert converter(new_context, ast_json, func_name, smart_contract, msg);
   if(converter.convert()) // Add Solidity symbols to the context
     return true;
 

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -121,6 +121,8 @@ bool solidity_languaget::typecheck(
   msg.progress("Done conversion of intrinsics...");
 
   solidity_convertert converter(new_context, ast_json, func_name, msg);
+  printf("This is smart contract source: %s\n", smart_contract.c_str());
+  assert(!"cool");
   if(converter.convert()) // Add Solidity symbols to the context
     return true;
 

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -120,7 +120,8 @@ bool solidity_languaget::typecheck(
     new_context, msg); // Add ESBMC and TACAS intrinsic symbols to the context
   msg.progress("Done conversion of intrinsics...");
 
-  solidity_convertert converter(new_context, ast_json, func_name, smart_contract, msg);
+  solidity_convertert converter(
+    new_context, ast_json, func_name, smart_contract, msg);
   if(converter.convert()) // Add Solidity symbols to the context
     return true;
 

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -87,9 +87,20 @@ public:
     func_name = _path;
   };
 
+#ifdef ENABLE_SOLIDITY_FRONTEND
+  inline void set_smart_contract_source(const std::string _path)
+  {
+    smart_contract = _path;
+  };
+#endif
+
 protected:
   const messaget &msg;
   // function name for verification that requires this information before GOTO conversion phase.
   std::string func_name = "";
+#ifdef ENABLE_SOLIDITY_FRONTEND
+  // smart contract source
+  std::string smart_contract = "";
+#endif
 };
 #endif


### PR DESCRIPTION
1. Added line number support. 
2. Dynamic array fixes and merge.

ESBMC-Solidity is now able to give exact line number in the couterexample. 