### PR TITLE
[builtin] added an intrinsic function for stack allocation

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -162,6 +162,8 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
 
   compiler_args.emplace_back("-D__builtin_memcpy=memcpy");
 
+  compiler_args.emplace_back("-D__ESBMC_alloca=__builtin_alloca");
+
   // Ignore ctype defined by the system
   compiler_args.emplace_back("-D__NO_CTYPE");
 


### PR DESCRIPTION
This adds the intrinsic `__ESBMC_alloca`, it will have the same behaviour as the `__builtin_alloca`. This is part of the solution for #652 