### PR TITLE
[options] added an option to not crash on non supported models

### DIFF
--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -172,6 +172,7 @@ const struct group_opt_templ all_cmd_options[] = {
     {"bv", NULL, "use solver with bit-vector arithmetic"},
     {"ir", NULL, "use solver with integer/real arithmetic"},
     {"smtlib", NULL, "use SMT lib format"},
+    {"non-supported-models-as-zero", NULL, "if ESBMC does  as a zero"},
     {"smtlib-solver-prog",
 
      boost::program_options::value<std::string>(),

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -172,7 +172,10 @@ const struct group_opt_templ all_cmd_options[] = {
     {"bv", NULL, "use solver with bit-vector arithmetic"},
     {"ir", NULL, "use solver with integer/real arithmetic"},
     {"smtlib", NULL, "use SMT lib format"},
-    {"non-supported-models-as-zero", NULL, "if ESBMC does  as a zero"},
+    {"non-supported-models-as-zero",
+     NULL,
+     "if ESBMC can't extract a type/expression from the solver, then the value "
+     "will be set to zero"},
     {"smtlib-solver-prog",
 
      boost::program_options::value<std::string>(),

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2283,9 +2283,19 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
   }
 
   default:
-    msg.error(fmt::format(
-      "Unimplemented type'd expression ({}) in smt get", type->type_id));
-    abort();
+    if(options.get_bool_option("non-supported-models-as-zero"))
+    {
+      msg.error(fmt::format(
+        "Unimplemented type'd expression ({}) in smt get", type->type_id));
+      abort();
+    }
+    else
+    {
+      msg.warning(fmt::format(
+        "Unimplemented type'd expression ({}) in smt get. Returning zero!",
+        type->type_id));
+      return gen_zero(type);
+    }
   }
 }
 
@@ -2309,9 +2319,20 @@ expr2tc smt_convt::get_by_type(const expr2tc &expr)
     return tuple_api->tuple_get(expr);
 
   default:
-    msg.error(fmt::format(
-      "Unimplemented type'd expression ({}) in smt get", expr->type->type_id));
-    abort();
+    if(options.get_bool_option("non-supported-models-as-zero"))
+    {
+      msg.error(fmt::format(
+        "Unimplemented type'd expression ({}) in smt get",
+        expr->type->type_id));
+      abort();
+    }
+    else
+    {
+      msg.warning(fmt::format(
+        "Unimplemented type'd expression ({}) in smt get. Returning zero!",
+        expr->type->type_id));
+      return gen_zero(expr->type);
+    }
   }
 }
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2283,7 +2283,7 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
   }
 
   default:
-    if(options.get_bool_option("non-supported-models-as-zero"))
+    if(!options.get_bool_option("non-supported-models-as-zero"))
     {
       msg.error(fmt::format(
         "Unimplemented type'd expression ({}) in smt get", type->type_id));
@@ -2319,7 +2319,7 @@ expr2tc smt_convt::get_by_type(const expr2tc &expr)
     return tuple_api->tuple_get(expr);
 
   default:
-    if(options.get_bool_option("non-supported-models-as-zero"))
+    if(!options.get_bool_option("non-supported-models-as-zero"))
     {
       msg.error(fmt::format(
         "Unimplemented type'd expression ({}) in smt get",

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2724,6 +2724,13 @@ expr2tc smt_convt::get_by_value(const type2tc &type, BigInt value)
   default:;
   }
 
+  if(options.get_bool_option("non-supported-models-as-zero"))
+  {
+    msg.warning(fmt::format(
+      "Can't generate one for type {}. Returning zero", get_type_id(type)));
+    return gen_zero(type);
+  }
+
   msg.error(fmt::format("Can't generate one for type {}", get_type_id(type)));
   abort();
 }


### PR DESCRIPTION
Added an option to make every non supported model extraction return zero. Closes: #656 

This is a draft because I will still look for some test cases on sv-benchmarks