### PR TITLE
Extern symbols linking

### DIFF
--- a/regression/esbmc/extern_false_0/extern.h
+++ b/regression/esbmc/extern_false_0/extern.h
@@ -1,0 +1,1 @@
+extern int value; 

--- a/regression/esbmc/extern_false_0/main.c
+++ b/regression/esbmc/extern_false_0/main.c
@@ -1,0 +1,5 @@
+#include "extern.h"
+int main() {
+  __ESBMC_assert(value != 42, "extern should be nondet");
+  return 0;
+} 

--- a/regression/esbmc/extern_false_0/test.desc
+++ b/regression/esbmc/extern_false_0/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/extern_false_1/extern.h
+++ b/regression/esbmc/extern_false_1/extern.h
@@ -1,0 +1,1 @@
+extern int arr[];

--- a/regression/esbmc/extern_false_1/main.c
+++ b/regression/esbmc/extern_false_1/main.c
@@ -1,0 +1,5 @@
+#include "extern.h"
+int main() {
+  int a  = arr[3]; // out-of-bounds
+  return 0;
+} 

--- a/regression/esbmc/extern_false_1/test.desc
+++ b/regression/esbmc/extern_false_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/extern_true_0/extern.c
+++ b/regression/esbmc/extern_true_0/extern.c
@@ -1,0 +1,3 @@
+#include "extern.h"
+
+int value = 42;

--- a/regression/esbmc/extern_true_0/extern.h
+++ b/regression/esbmc/extern_true_0/extern.h
@@ -1,0 +1,1 @@
+extern int value; 

--- a/regression/esbmc/extern_true_0/main.c
+++ b/regression/esbmc/extern_true_0/main.c
@@ -1,0 +1,5 @@
+#include "extern.h"
+int main() {
+  __ESBMC_assert(value == 42, "extern should be 42");
+  return 0;
+}

--- a/regression/esbmc/extern_true_0/test.desc
+++ b/regression/esbmc/extern_true_0/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+extern.c
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/extern_true_1/extern.c
+++ b/regression/esbmc/extern_true_1/extern.c
@@ -1,0 +1,3 @@
+#include "extern.h"
+
+int arr[4];

--- a/regression/esbmc/extern_true_1/extern.h
+++ b/regression/esbmc/extern_true_1/extern.h
@@ -1,0 +1,1 @@
+extern int arr[];

--- a/regression/esbmc/extern_true_1/main.c
+++ b/regression/esbmc/extern_true_1/main.c
@@ -1,0 +1,5 @@
+#include "extern.h"
+int main() {
+  int a  = arr[3]; // out-of-bounds
+  return 0;
+} 

--- a/regression/esbmc/extern_true_1/test.desc
+++ b/regression/esbmc/extern_true_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+extern.c
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -7,6 +7,7 @@
 #include <util/context.h>
 #include <util/namespace.h>
 #include <util/std_types.h>
+#include <unordered_map>
 
 // Forward dec, to avoid bringing in clang headers
 namespace clang
@@ -61,6 +62,14 @@ public:
  */
   static void
   gen_typecast_to_union(exprt &dest, const typet &type, const messaget &msg);
+  void set_symbols_to_add(std::vector<symbolt> &v)
+  {
+    symbols_to_add = v;
+  }
+  std::vector<symbolt> get_symbols_to_add()
+  {
+    return symbols_to_add;
+  }
 
 protected:
   clang::ASTContext *ASTContext;
@@ -176,6 +185,9 @@ protected:
   const clang::Decl *get_top_FunctionDecl_from_Stmt(const clang::Stmt &stmt);
 
   void gen_typecast_to_union(exprt &dest, const typet &type);
+  bool foo(const clang::VarDecl &vd, symbolt symbol, exprt &new_expr);
+  bool skip_extern_symbol(const symbolt symbol);
+  std::vector<symbolt> symbols_to_add;
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -242,9 +242,10 @@ bool clang_c_languaget::typecheck(
   contextt new_context(msg);
 
   clang_c_convertert converter(new_context, ASTs, msg);
+  converter.set_symbols_to_add(extern_symbols);
   if(converter.convert())
     return true;
-
+  extern_symbols = converter.get_symbols_to_add();
   clang_c_adjust adjuster(new_context, msg);
   if(adjuster.adjust())
     return true;
@@ -252,6 +253,33 @@ bool clang_c_languaget::typecheck(
   if(c_link(context, new_context, msg, module))
     return true;
 
+  return false;
+}
+
+#include <util/expr_util.h>
+bool clang_c_languaget::add_later(contextt &context, symbolt symbol)
+{
+  exprt dummy;
+  symbolt *s = context.find_symbol(symbol.id);
+  if(s == nullptr)
+  {
+    if(context.move(symbol, s))
+    {
+      msg.error(fmt::format(
+        "Couldn't add symbol {} to symbol table\n{}", symbol.name, symbol));
+      abort();
+    }
+  }
+  else
+  {
+    return true;
+  }
+  /*
+  symbolt &added_symbol = *s;
+  code_declt decl(symbol_expr(added_symbol));
+  decl.location() = symbol.location;
+  dummy = decl;
+  */
   return false;
 }
 
@@ -275,6 +303,9 @@ bool clang_c_languaget::preprocess(
 
 bool clang_c_languaget::final(contextt &context, const messaget &msg)
 {
+  for(auto x : extern_symbols)
+    add_later(context, x);
+
   add_cprover_library(context, msg, this);
   return clang_main(context, msg);
 }

--- a/src/clang-c-frontend/clang_c_language.h
+++ b/src/clang-c-frontend/clang_c_language.h
@@ -10,6 +10,7 @@ Author:
 #define CLANG_C_FRONTEND_CLANG_C_LANGUAGE_H_
 
 #include <util/language.h>
+#include <unordered_map>
 
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
@@ -70,6 +71,9 @@ protected:
 
   std::vector<std::string> compiler_args;
   std::vector<std::unique_ptr<clang::ASTUnit>> ASTs;
+
+  std::vector<symbolt> extern_symbols;
+  bool add_later(contextt &ctx, symbolt symbol);
 };
 
 languaget *new_clang_c_language(const messaget &msg);


### PR DESCRIPTION
Note: This is an incorrect approach for this! I am opening this as a PR so I can properly fix at ucode branch.  Right now the PR is adding external symbols later on the flow.

@mikhailramalho any suggestions on how to implement this correctly?

This intends to fix linking issues from external symbols.

```c
// extern.h
extern int arr[];

// extern.c
#include "extern.h"
int arr[4];

// main.c
#include "extern.h"
int main() {
  int a  = arr[3]; // ESBMC throws out-of-bounds
  return 0;
} 
```