### PR TITLE
Slicer improvements

### DIFF
--- a/regression/esbmc/github_666/config.json
+++ b/regression/esbmc/github_666/config.json
@@ -1,0 +1,5 @@
+{
+        "no-slice-symbols": [
+                "c:no_slice.c@14@F@main@foo"
+        ]
+}

--- a/regression/esbmc/github_666/no_slice.c
+++ b/regression/esbmc/github_666/no_slice.c
@@ -1,0 +1,8 @@
+int main() {
+        int foo __attribute__ ((annotate("__ESBMC_no_slice")));
+        foo = 42;
+        int asd = foo + 10;
+        foo = 15;
+        __ESBMC_assert(0, "bar");
+        return 0;
+}

--- a/regression/esbmc/github_666/test.desc
+++ b/regression/esbmc/github_666/test.desc
@@ -1,0 +1,4 @@
+CORE
+no_slice.c
+--json-options-input config.json
+^VERIFICATION FAILED$

--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -30,6 +30,6 @@ target_include_directories(esbmc
 
 target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} clangcfrontend
   clangcppfrontend symex pointeranalysis langapi util_esbmc bigint
-  solvers clibs default_message gotoalgorithms nlohmann_json::nlohmann_json  ${Boost_LIBRARIES})
+  solvers clibs default_message gotoalgorithms nlohmann_json::nlohmann_json ${Boost_LIBRARIES})
 
 install(TARGETS esbmc DESTINATION bin)

--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -30,6 +30,6 @@ target_include_directories(esbmc
 
 target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} clangcfrontend
   clangcppfrontend symex pointeranalysis langapi util_esbmc bigint
-  solvers clibs default_message gotoalgorithms ${Boost_LIBRARIES})
+  solvers clibs default_message gotoalgorithms nlohmann_json::nlohmann_json  ${Boost_LIBRARIES})
 
 install(TARGETS esbmc DESTINATION bin)

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -615,7 +615,8 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
         i >> j;
         j.at("no-slice-symbols").get_to(ignored_symbols);
       }
-      ignored = slicer::slice(eq, options.get_bool_option("slice-assumes"), ignored_symbols);
+      ignored = slicer::slice(
+        eq, options.get_bool_option("slice-assumes"), ignored_symbols);
     }
     else
       ignored = slicer::simple_slice(eq);

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -44,9 +44,6 @@ Authors: Daniel Kroening, kroening@kroening.com
 #include <util/time_stopping.h>
 #include <nlohmann/json.hpp>
 
-// For json parsing
-using json = nlohmann::json;
-
 bmct::bmct(
   goto_functionst &funcs,
   optionst &opts,
@@ -606,12 +603,11 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if(!options.get_bool_option("no-slice"))
     {
       std::unordered_set<std::string> ignored_symbols;
-      // TODO: This could be expanded to the whole ESBMC options and configuration system (#477)
       auto ignored_symbols_file = options.get_option("json-options-input");
       if(ignored_symbols_file != "")
       {
         std::ifstream i(ignored_symbols_file);
-        json j;
+        nlohmann::json j;
         i >> j;
         j.at("no-slice-symbols").get_to(ignored_symbols);
       }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -600,9 +600,9 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     fine_timet slice_start = current_time();
     BigInt ignored;
     if(!options.get_bool_option("no-slice"))
-      ignored = slice(eq, options.get_bool_option("slice-assumes"));
+      ignored = slicer::slice(eq, options.get_bool_option("slice-assumes"));
     else
-      ignored = simple_slice(eq);
+      ignored = slicer::simple_slice(eq);
     fine_timet slice_stop = current_time();
 
     {

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -42,6 +42,10 @@ Authors: Daniel Kroening, kroening@kroening.com
 #include <util/migrate.h>
 #include <util/show_symbol_table.h>
 #include <util/time_stopping.h>
+#include <nlohmann/json.hpp>
+
+// For json parsing
+using json = nlohmann::json;
 
 bmct::bmct(
   goto_functionst &funcs,
@@ -600,7 +604,19 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     fine_timet slice_start = current_time();
     BigInt ignored;
     if(!options.get_bool_option("no-slice"))
-      ignored = slicer::slice(eq, options.get_bool_option("slice-assumes"));
+    {
+      std::unordered_set<std::string> ignored_symbols;
+      // TODO: This could be expanded to the whole ESBMC options and configuration system (#477)
+      auto ignored_symbols_file = options.get_option("json-options-input");
+      if(ignored_symbols_file != "")
+      {
+        std::ifstream i(ignored_symbols_file);
+        json j;
+        i >> j;
+        j.at("no-slice-symbols").get_to(ignored_symbols);
+      }
+      ignored = slicer::slice(eq, options.get_bool_option("slice-assumes"), ignored_symbols);
+    }
     else
       ignored = slicer::simple_slice(eq);
     fine_timet slice_stop = current_time();

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -100,6 +100,7 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "parse source files using our old frontend {deprecated},"},
     {"result-only", NULL, "do not print the counter-example"},
+    {"json-options-input", boost::program_options::value<std::string>(), "use a JSON file as the configuration input"},
 #ifdef _WIN32
     {"i386-macos", NULL, "set MACOS/I386 architecture"},
     {"ppc-macos", NULL, "set PPC/I386 architecture"},

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -100,7 +100,9 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "parse source files using our old frontend {deprecated},"},
     {"result-only", NULL, "do not print the counter-example"},
-    {"json-options-input", boost::program_options::value<std::string>(), "use a JSON file as the configuration input"},
+    {"json-options-input",
+     boost::program_options::value<std::string>(),
+     "use a JSON file as the configuration input"},
 #ifdef _WIN32
     {"i386-macos", NULL, "set MACOS/I386 architecture"},
     {"ppc-macos", NULL, "set PPC/I386 architecture"},

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -22,6 +22,8 @@ bool symex_slicet::get_symbols(
   std::function<bool(const symbol2t &)> fn)
 {
   bool res = false;
+
+  // Recursively look if any of the operands has a inner symbol
   expr->foreach_operand([this, &fn, &res](const expr2tc &e) {
     if(!is_nil_expr(e))
       res = get_symbols(e, fn) || res;
@@ -32,6 +34,7 @@ bool symex_slicet::get_symbols(
     return res;
 
   const symbol2t &tmp = to_symbol2t(expr);
+  // Add the symbol into de dependency list
   return fn(tmp) || res;
 }
 
@@ -83,6 +86,7 @@ void symex_slicet::slice(symex_target_equationt::SSA_stept &SSA_step)
 
 void symex_slicet::slice_assume(symex_target_equationt::SSA_stept &SSA_step)
 {
+  // TODO: add an assert here
   auto check_in_deps = [this](const symbol2t &s) -> bool {
     return depends.find(s.get_symbol_name()) != depends.end();
   };
@@ -105,7 +109,10 @@ void symex_slicet::slice_assignment(symex_target_equationt::SSA_stept &SSA_step)
 {
   assert(is_symbol2t(SSA_step.lhs));
 
+  // TODO: create an option to ignore nondet symbols (test case generation)
+
   auto check_in_deps = [this](const symbol2t &s) -> bool {
+
     return depends.find(s.get_symbol_name()) != depends.end();
   };
 
@@ -144,14 +151,15 @@ void symex_slicet::slice_renumber(symex_target_equationt::SSA_stept &SSA_step)
   // Don't collect the symbol; this insn has no effect on dependencies.
 }
 
-BigInt slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assumes)
+BigInt
+slicer::slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assumes)
 {
   symex_slicet symex_slice(slice_assumes);
   symex_slice.slice(eq);
   return symex_slice.ignored;
 }
 
-BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq)
+BigInt slicer::simple_slice(std::shared_ptr<symex_target_equationt> &eq)
 {
   BigInt ignored = 0;
 

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -8,7 +8,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-symex/slice.h>
 
-symex_slicet::symex_slicet(bool assume, std::unordered_set<std::string> ignored_symbols)
+symex_slicet::symex_slicet(
+  bool assume,
+  std::unordered_set<std::string> ignored_symbols)
   : ignored(0),
     slice_assumes(assume),
     ignored_symbols(ignored_symbols),
@@ -106,7 +108,6 @@ void symex_slicet::slice_assume(symex_target_equationt::SSA_stept &SSA_step)
   }
 }
 
-#include <iostream>
 void symex_slicet::slice_assignment(symex_target_equationt::SSA_stept &SSA_step)
 {
   assert(is_symbol2t(SSA_step.lhs));
@@ -115,7 +116,8 @@ void symex_slicet::slice_assignment(symex_target_equationt::SSA_stept &SSA_step)
 
   auto check_in_deps = [this](const symbol2t &s) -> bool {
     return (depends.find(s.get_symbol_name()) != depends.end()) ||
-           (ignored_symbols.find(s.thename.as_string()) != ignored_symbols.end());
+           (ignored_symbols.find(s.thename.as_string()) !=
+            ignored_symbols.end());
   };
 
   if(!get_symbols(SSA_step.lhs, check_in_deps))
@@ -153,8 +155,10 @@ void symex_slicet::slice_renumber(symex_target_equationt::SSA_stept &SSA_step)
   // Don't collect the symbol; this insn has no effect on dependencies.
 }
 
-BigInt
-slicer::slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assumes, std::unordered_set<std::string> ignored_symbols)
+BigInt slicer::slice(
+  std::shared_ptr<symex_target_equationt> &eq,
+  bool slice_assumes,
+  std::unordered_set<std::string> ignored_symbols)
 {
   symex_slicet symex_slice(slice_assumes, ignored_symbols);
   symex_slice.slice(eq);

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -4,6 +4,9 @@ Module: Slicer for symex traces
 
 Author: Daniel Kroening, kroening@kroening.com
 
+Contributors:
+ - Rafael Sá Menezes, 2022
+
 \*******************************************************************/
 
 #ifndef CPROVER_GOTO_SYMEX_SLICE_H
@@ -13,29 +16,136 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-symex/symex_target_equation.h>
 #include <unordered_set>
 
+namespace slicer
+{
+/**
+ * Helper function to call the slicer
+ * @param eq symex formula to be sliced
+ * @param slice_assume whether assumes should be sliced
+ * @return number of steps that were ignored
+ */
 BigInt slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assume);
-BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq);
 
+/**
+ * Naive slicer: slice every step after the last assertion
+ * @param eq symex formula to be sliced
+ * @return number of steps that were ignored
+ */
+BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq);
+} // namespace slicer
+/**
+ * @brief Class for the symex-slicer, this slicer is to be executed
+ * on SSA formula in order to remove every symbol that does not depends
+ * on it
+ *
+ * It works by constructing a symbol dependency list by transversing
+ * the SSA formula in reverse order. If any assume, assignment, or renumber
+ * step does not belong into this dependency, then it will be ignored.
+ */
 class symex_slicet
 {
 public:
   symex_slicet(bool assume);
+  /**
+   * Iterate over all steps of the \eq in REVERSE order,
+   * getting symbol dependencies. If an
+   * assignment, renumber or assume does not contain one
+   * of the dependency symbols, then it will be ignored.
+   *
+   * @param eq symex formula to be sliced
+   */
   void slice(std::shared_ptr<symex_target_equationt> &eq);
-
-  typedef std::unordered_set<std::string> symbol_sett;
-  symbol_sett depends;
+  // To show how many assignments were sliced
   BigInt ignored;
 
 protected:
+  // Option to enable slicing of assumes
   bool slice_assumes;
+  /**
+   * This type will be the one used to hold every symbol
+   * that the current equation depends on.
+   */
+  typedef std::unordered_set<std::string> symbol_sett;
+  symbol_sett depends;
+  // Anonymous function to add elements into #depends
   std::function<bool(const symbol2t &)> add_to_deps;
+  // TODO: we probably don't need #add_to_deps
+  // TODO: In the implementation, there is also the #check_in_deps which we could remove
 
+  /**
+   * Recursively explores the operands of an expression \expr
+   * If a symbol is found, then it is added into the #depends
+   * member.
+   *
+   * TODO: We probably don't need to pass the \param
+   *
+   * @param expr expression to extract every symbol
+   * @param fn `add_to_depends` kind of function.
+   * @return true if at least one symbol was found
+   */
   bool
   get_symbols(const expr2tc &expr, std::function<bool(const symbol2t &)> fn);
 
+  /**
+   * Helper function, it is used to select specialization will
+   * be used, i.e. assume, assignment or renumber
+   *
+   * Note 1: ASSERTS are not sliced, only their symbols are added
+   * into the #depends
+   *
+   * Note 2: Similar to ASSERTS, if 'slice-assumes' option is
+   * is not enabled. Then only its symbols are added into the
+   * #depends
+   *
+   * TODO: All slice specialization can be converted into a lambda
+   *
+   * @param SSA_step any kind of SSA expression
+   */
   void slice(symex_target_equationt::SSA_stept &SSA_step);
+
+  /**
+   * Remove unneeded assumes from the formula
+   *
+   * Check if the Assume cond symbol is in the #depends, if
+   * it is not then mark the \SSA_Step as ignored.
+   *
+   * If the assume cond is in the #depends, then add its guards
+   * and cond into the #depends
+   *
+   * Note 1: All the conditions operands are going to be added
+   * into the #depends. This makes that the condition itself as
+   * a "reverse taint"
+   *
+   * TODO: What happens if the ASSUME would result in false?
+   *
+   * @param SSA_step an assume step
+   */
   void slice_assume(symex_target_equationt::SSA_stept &SSA_step);
+
+  /**
+   * Remove unneeded assignments from the formula
+   *
+   * Check if the LHS symbol is in the #depends, if
+   * it is not then mark the \SSA_Step as ignored.
+   *
+   * If the assume cond is in the #depends, then add its guards
+   * and cond into the #depends
+   *
+   * @param SSA_step an assignment step
+   */
   void slice_assignment(symex_target_equationt::SSA_stept &SSA_step);
+
+  /**
+   * Remove unneeded renumbers from the formula
+   *
+   * Check if the LHS symbol is in the #depends, if
+   * it is not then mark the \SSA_Step as ignored.
+   *
+   * If the assume cond is in the #depends, then add its guards
+   * and cond into the #depends
+   *
+   * @param SSA_step an renumber step
+   */
   void slice_renumber(symex_target_equationt::SSA_stept &SSA_step);
 };
 

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -25,7 +25,10 @@ namespace slicer
  * @param ignored_symbols list of symbols that cannot be sliced
  * @return number of steps that were ignored
  */
-BigInt slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assume, std::unordered_set<std::string> ignored_symbols);
+BigInt slice(
+  std::shared_ptr<symex_target_equationt> &eq,
+  bool slice_assume,
+  std::unordered_set<std::string> ignored_symbols);
 
 /**
  * Naive slicer: slice every step after the last assertion

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -22,9 +22,10 @@ namespace slicer
  * Helper function to call the slicer
  * @param eq symex formula to be sliced
  * @param slice_assume whether assumes should be sliced
+ * @param ignored_symbols list of symbols that cannot be sliced
  * @return number of steps that were ignored
  */
-BigInt slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assume);
+BigInt slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assume, std::unordered_set<std::string> ignored_symbols);
 
 /**
  * Naive slicer: slice every step after the last assertion
@@ -45,7 +46,7 @@ BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq);
 class symex_slicet
 {
 public:
-  symex_slicet(bool assume);
+  symex_slicet(bool assume, std::unordered_set<std::string> ignored_symbols);
   /**
    * Iterate over all steps of the \eq in REVERSE order,
    * getting symbol dependencies. If an
@@ -67,6 +68,7 @@ protected:
    */
   typedef std::unordered_set<std::string> symbol_sett;
   symbol_sett depends;
+  const symbol_sett ignored_symbols;
   // Anonymous function to add elements into #depends
   std::function<bool(const symbol2t &)> add_to_deps;
   // TODO: we probably don't need #add_to_deps


### PR DESCRIPTION
This PR:

- Adds documentation over the symex-slicer.
- Adds a couple of todos to the slicer
- Adds support to ignoring some symbols during the slicing.

Originally, the idea was to add an attribute for symbols that we'd like to be ignored. However, it was more practical to pass a list of variables that should be ignored. I think we should still add the attribute on a later patch.

To get the list of symbols, I added support to a JSON file. For now, it is only used for ignored symbols, but I'd think that it can expanded further as suggested in #477 