### PR TITLE
[z3] Improved error message printing in Z3 error handler

### DIFF
--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -19,9 +19,7 @@ static void error_handler(Z3_context c, Z3_error_code e)
       << "\n";
   oss << Z3_get_error_msg(c, e);
   default_message msg;
-  // use msg.status + abort instead of msg.error
-  // In GDB, the latter does not show a backtrace of the exact failure line in this function
-  msg.status(oss.str());
+  msg.error(oss.str());
   abort();
 }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -12,13 +12,19 @@
 
 #define new_ast new_solver_ast<z3_smt_ast>
 
+#if !defined(Z3_THROW)
+#if __cpp_exceptions || _CPPUNWIND || __EXCEPTIONS
+#define Z3_THROW(x) throw x
+#else
+#define Z3_THROW(x)                                                            \
+  {                                                                            \
+  }
+#endif
+#endif // !defined(Z3_THROW)
+
 static void error_handler(Z3_context c, Z3_error_code e)
 {
-  std::ostringstream oss;
-  oss << "Z3 error " << e << " encountered"
-      << "\n";
-  oss << Z3_get_error_msg(c, e);
-  assert(0 && oss.str().c_str());
+  Z3_THROW(z3::exception(Z3_get_error_msg(c, e)));
 }
 
 smt_convt *create_new_z3_solver(

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -12,19 +12,17 @@
 
 #define new_ast new_solver_ast<z3_smt_ast>
 
-#if !defined(Z3_THROW)
-#if __cpp_exceptions || _CPPUNWIND || __EXCEPTIONS
-#define Z3_THROW(x) throw x
-#else
-#define Z3_THROW(x)                                                            \
-  {                                                                            \
-  }
-#endif
-#endif // !defined(Z3_THROW)
-
 static void error_handler(Z3_context c, Z3_error_code e)
 {
-  Z3_THROW(z3::exception(Z3_get_error_msg(c, e)));
+  std::ostringstream oss;
+  oss << "Z3 error " << e << " encountered"
+      << "\n";
+  oss << Z3_get_error_msg(c, e);
+  default_message msg;
+  // use msg.status + abort instead of msg.error
+  // In GDB, the latter does not show a backtrace of the exact failure line in this function
+  msg.status(oss.str());
+  abort();
 }
 
 smt_convt *create_new_z3_solver(


### PR DESCRIPTION
### Summary: 
This patch improved Z3 error handler to print out more informative error message. 

### Error message printing *Before* the change:
```
Thread 0 file main.c line 4 function main
ASSIGNMENT ()
f?1!0&0#1 == (float)d?1!0&0#1

esbmc: ../src/solvers/z3/z3_conv.cpp:21: void error_handler(Z3_context, Z3_error_code): Assertion `0 && oss.str().c_str()' failed.
```
### Error message printing *After* the change:
```
Thread 0 file main.c line 4 function main
ASSIGNMENT ()
f?1!0&0#1 == (float)d?1!0&0#1

terminate called after throwing an instance of 'z3::exception'
  what():  Sorts Real and (_ FloatingPoint 8 24) are incompatible
Aborted (core dumped)
```

Now we can see the root cause of Z3 equation conversion - incompatible sorts. 