### PR TITLE
[z3] Fixed on-screen SMT formula printing

### DIFF
--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -7,8 +7,6 @@
 
 #include <cassert>
 #include <z3_conv.h>
-#include <fstream>
-#include <util/message/default_message.h>
 
 #define new_ast new_solver_ast<z3_smt_ast>
 
@@ -1285,29 +1283,37 @@ void z3_convt::dump_smt()
   const std::string &filename = options.get_option("output");
   if(!filename.empty())
   {
+    // print to output file
     std::ofstream out(filename.c_str());
-    if(out)
-    {
-      // Add whatever logic is needed.
-      // Add sovler specific declarations as well.
-      out << "(set-info :smt-lib-version 2.6)\n";
-      out << "(set-option :print-success true)\n";
-      out << "(set-option :produce-models true)\n";
-      out << "; Asserts from ESMBC starts\n";
-      out << solver; // All VCC conditions in SMTLIB format.
-      out << "; Asserts from ESMBC ends\n";
-      out << "(apply (then simplify solve-eqs))\n";
-      out << "(check-sat)\n";
-      out << "(get-model)\n";
-      out << "(exit)\n";
-    }
+    print_smt_formulae(out);
   }
+  else
+  {
+    // print to screen
+    default_message msg;
+    std::ostringstream oss;
+    print_smt_formulae(oss);
+    msg.debug(oss.str());
+  }
+}
 
+void z3_convt::print_smt_formulae(std::ostream &dest)
+{
   Z3_ast_vector __z3_assertions = Z3_solver_get_assertions(z3_ctx, solver);
-  default_message msg;
-  std::ostringstream oss;
-  oss << "Assertions Size : " << Z3_ast_vector_size(z3_ctx, __z3_assertions);
-  msg.debug(oss.str());
+  // Add whatever logic is needed.
+  // Add sovler specific declarations as well.
+  dest << "(set-info :smt-lib-version 2.6)\n";
+  dest << "(set-option :print-success true)\n";
+  dest << "(set-option :produce-models true)\n";
+  dest << "; Asserts from ESMBC starts\n";
+  dest << solver; // All VCC conditions in SMTLIB format.
+  dest << "; Asserts from ESMBC ends\n";
+  dest << "(apply (then simplify solve-eqs))\n";
+  dest << "(check-sat)\n";
+  dest << "(get-model)\n";
+  dest << "(exit)\n";
+  dest << "Total number of safety properties: "
+       << Z3_ast_vector_size(z3_ctx, __z3_assertions) << std::endl;
 }
 
 smt_astt z3_convt::mk_smt_fpbv_gt(smt_astt lhs, smt_astt rhs)

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -11,6 +11,8 @@ Author: Lucas Cordeiro, lcc08r@ecs.soton.ac.uk
 
 #include <solvers/smt/smt_conv.h>
 #include <z3++.h>
+#include <fstream>
+#include <util/message/default_message.h>
 
 class z3_smt_ast : public solver_smt_ast<z3::expr>
 {
@@ -203,6 +205,9 @@ public:
 
   void dump_smt() override;
   void print_model() override;
+
+private:
+  void print_smt_formulae(std::ostream &dest);
 
 public:
   //  Must be first member; that way it's the last to be destroyed.


### PR DESCRIPTION
This PR fixed the broken on-screen SMT formula printing as reported in PR https://github.com/esbmc/esbmc/pull/660. 

Now we can use `--smt-formula-too` (or `--smt-formula-only`) to print the SMT formula either to screen or another output file. 

Log evidence: 
```
Generated 1 VCC(s), 1 remaining after simplification (6 assignments)
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.000s
(set-info :smt-lib-version 2.6)
(set-option :print-success true)
(set-option :produce-models true)
; Asserts from ESMBC starts
(declare-datatypes ((struct_type_pointer_struct 0)) (((struct_type_pointer_struct (pointer_object (_ BitVec 64)) (pointer_offset (_ BitVec 64))))))
(declare-datatypes ((struct_type_addr_space_type 0)) (((struct_type_addr_space_type (start (_ BitVec 64)) (end (_ BitVec 64))))))
(declare-fun __ESBMC_ptr_obj_start_0 () (_ BitVec 64))
(declare-fun __ESBMC_ptr_obj_end_0 () (_ BitVec 64))
(declare-fun __ESBMC_ptr_obj_start_1 () (_ BitVec 64))
(declare-fun __ESBMC_ptr_obj_end_1 () (_ BitVec 64))
(declare-fun __ESBMC_ptr_addr_range_0 () struct_type_addr_space_type)
(declare-fun __ESBMC_ptr_addr_range_1 () struct_type_addr_space_type)
(declare-fun __ESBMC_addrspace_arr_2
             ()
             (Array (_ BitVec 64) struct_type_addr_space_type))
(declare-fun __ESBMC_addrspace_arr_1
             ()
             (Array (_ BitVec 64) struct_type_addr_space_type))
(declare-fun __ESBMC_addrspace_arr_3
             ()
             (Array (_ BitVec 64) struct_type_addr_space_type))
(declare-fun |0| () struct_type_pointer_struct)
(declare-fun NULL () struct_type_pointer_struct)
(declare-fun INVALID () struct_type_pointer_struct)
(declare-fun |c:@F@main::$tmp::return_value$_nondet_uchar$1?1!0&0#1|
             ()
             (_ BitVec 8))
(declare-fun |nondet$symex::nondet0| () (_ BitVec 8))
(declare-fun |c:main_test.c@15@F@main@a?1!0&0#1| () (_ BitVec 8))
(declare-fun |c:@F@main::$tmp::return_value$_nondet_int$2?1!0&0#1|
             ()
             (_ BitVec 32))
(declare-fun |nondet$symex::nondet1| () (_ BitVec 32))
(declare-fun |c:main_test.c@51@F@main@b?1!0&0#1| () (_ BitVec 32))
(declare-fun |execution_statet::\\guard_exec?0!0| () Bool)
(assert (= __ESBMC_ptr_obj_start_0 #x0000000000000000))
(assert (= __ESBMC_ptr_obj_end_0 #x0000000000000000))
(assert (= __ESBMC_ptr_obj_start_1 #x0000000000000001))
(assert (= __ESBMC_ptr_obj_end_1 #xffffffffffffffff))
(assert (= __ESBMC_ptr_addr_range_0
   (struct_type_addr_space_type __ESBMC_ptr_obj_start_0 __ESBMC_ptr_obj_end_0)))
(assert (= __ESBMC_ptr_addr_range_1
   (struct_type_addr_space_type __ESBMC_ptr_obj_start_1 __ESBMC_ptr_obj_end_1)))
(assert (= (store __ESBMC_addrspace_arr_1
          #x0000000000000000
          (struct_type_addr_space_type
            __ESBMC_ptr_obj_start_0
            __ESBMC_ptr_obj_end_0))
   __ESBMC_addrspace_arr_2))
(assert (= (store __ESBMC_addrspace_arr_2
          #x0000000000000001
          (struct_type_addr_space_type
            __ESBMC_ptr_obj_start_1
            __ESBMC_ptr_obj_end_1))
   __ESBMC_addrspace_arr_3))
(assert (= |0| (struct_type_pointer_struct #x0000000000000000 #x0000000000000000)))
(assert (= NULL (struct_type_pointer_struct #x0000000000000000 #x0000000000000000)))
(assert (= INVALID (struct_type_pointer_struct #x0000000000000001 #x0000000000000000)))
(assert (= |nondet$symex::nondet0|
   |c:@F@main::$tmp::return_value$_nondet_uchar$1?1!0&0#1|))
(assert (= |c:@F@main::$tmp::return_value$_nondet_uchar$1?1!0&0#1|
   |c:main_test.c@15@F@main@a?1!0&0#1|))
(assert (= |nondet$symex::nondet1|
   |c:@F@main::$tmp::return_value$_nondet_int$2?1!0&0#1|))
(assert (= |c:@F@main::$tmp::return_value$_nondet_int$2?1!0&0#1|
   |c:main_test.c@51@F@main@b?1!0&0#1|))
(assert (let ((a!1 (=> true
               (=> |execution_statet::\\guard_exec?0!0|
                   (= |c:main_test.c@51@F@main@b?1!0&0#1|
                      ((_ zero_extend 24) |c:main_test.c@15@F@main@a?1!0&0#1|))))))
  (not a!1)))
; Asserts from ESMBC ends
(apply (then simplify solve-eqs))
(check-sat)
(get-model)
(exit)
Total number of safety properties: 16

Solving with solver Z3 v4.8.9
Encoding to solver time: 0.000s
Runtime decision procedure: 0.001s
Building error trace

Counterexample:

State 1 file main_test.c line 3 function main thread 0
----------------------------------------------------
  a = 0 (00000000)

State 2 file main_test.c line 4 function main thread 0
----------------------------------------------------
  b = 1 (00000000 00000000 00000000 00000001)

State 3 file main_test.c line 5 function main thread 0
----------------------------------------------------
Violated property:
  file main_test.c line 5 function main
  assertion
  b == (signed int)a


VERIFICATION FAILED
```

