### PR TITLE
[clang-cpp-frontend] Added symbol mode

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -28,11 +28,13 @@
 clang_c_convertert::clang_c_convertert(
   contextt &_context,
   std::vector<std::unique_ptr<clang::ASTUnit>> &_ASTs,
+  const std::string &_mode,
   const messaget &msg)
   : ASTContext(nullptr),
     context(_context),
     ns(context),
     ASTs(_ASTs),
+    symbol_mode(_mode),
     msg(msg),
     current_scope_var_num(1),
     sm(nullptr),
@@ -2745,7 +2747,7 @@ void clang_c_convertert::get_default_symbol(
   std::string id,
   locationt location)
 {
-  symbol.mode = "C";
+  symbol.mode = symbol_mode;
   symbol.module = module_name;
   symbol.location = std::move(location);
   symbol.type = std::move(type);

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -44,6 +44,7 @@ public:
   clang_c_convertert(
     contextt &_context,
     std::vector<std::unique_ptr<clang::ASTUnit>> &_ASTs,
+    const std::string &_mode,
     const messaget &msg);
   virtual ~clang_c_convertert() = default;
 
@@ -67,6 +68,7 @@ protected:
   contextt &context;
   namespacet ns;
   std::vector<std::unique_ptr<clang::ASTUnit>> &ASTs;
+  const std::string &symbol_mode;
   const messaget &msg;
 
   unsigned int current_scope_var_num;

--- a/src/clang-c-frontend/clang_c_language.h
+++ b/src/clang-c-frontend/clang_c_language.h
@@ -61,6 +61,10 @@ public:
   ~clang_c_languaget() override = default;
   explicit clang_c_languaget(const messaget &msg);
 
+  // language mode
+  std::string mode;
+  void set_mode(const std::string &path);
+
 protected:
   virtual std::string internal_additions();
   virtual void force_file_type();

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -22,8 +22,9 @@
 clang_cpp_convertert::clang_cpp_convertert(
   contextt &_context,
   std::vector<std::unique_ptr<clang::ASTUnit>> &_ASTs,
+  const std::string &_mode,
   const messaget &msg)
-  : clang_c_convertert(_context, _ASTs, msg)
+  : clang_c_convertert(_context, _ASTs, _mode, msg)
 {
 }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -12,6 +12,7 @@ public:
   clang_cpp_convertert(
     contextt &_context,
     std::vector<std::unique_ptr<clang::ASTUnit>> &_ASTs,
+    const std::string &_mode,
     const messaget &msg);
   virtual ~clang_cpp_convertert() = default;
 

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -57,9 +57,11 @@ bool clang_cpp_languaget::typecheck(
   const std::string &module,
   const messaget &message_handler)
 {
+  assert(mode == "C++");
+
   contextt new_context(message_handler);
 
-  clang_cpp_convertert converter(new_context, ASTs, message_handler);
+  clang_cpp_convertert converter(new_context, ASTs, mode, message_handler);
   if(converter.convert())
     return true;
 


### PR DESCRIPTION
This PR fixed the symbol mode in clang-c/cpp-frontend. When verifying C++ programs, the symbol mode should be "C++", not "C". 

### Symbol printing before the fix:
```
Symbol......: c:@S@Test@F@increment_x#I#
Module......: main
Base name...: increment_x
Mode........: C (0)
``` 
### Symbol printing after the fix:
```
Symbol......: c:@S@Test@F@increment_x#I#
Module......: main
Base name...: increment_x
Mode........: C++ (1)
```

