### PR TITLE
[clang-cpp-frontend] Added support for -CXXConstructExpr

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates14/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates14/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates16/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates16/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates17/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates17/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates18/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates18/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates2/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates2/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates34/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates34/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates36/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates36/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates37/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates37/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates39/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates39/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates7/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates7/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>THOROUGH</item_10_mode>
 </test-case>

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -540,6 +540,43 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::CXXConstructExprClass:
+  {
+    const clang::CXXConstructExpr &ctr_call =
+      static_cast<const clang::CXXConstructExpr &>(stmt);
+
+    /*
+    // Do we really need the side_effect for default constructor?
+    const clang::Decl *callee = ctr_call.getExpr();
+
+    exprt callee_expr;
+    if(get_expr(*callee, callee_expr))
+      return true;
+    */
+
+    typet type;
+    if(get_type(ctr_call.getType(), type))
+      return true;
+
+    side_effect_expr_function_callt call;
+    //call.function() = callee_expr;
+    call.type() = type;
+
+    // Do args
+    for(const clang::Expr *arg : ctr_call.arguments())
+    {
+      exprt single_arg;
+      if(get_expr(*arg, single_arg))
+        return true;
+
+      call.arguments().push_back(single_arg);
+    }
+
+    new_expr = call;
+    assert(!"Continue from here");
+    break;
+  }
+
   default:
     return clang_c_convertert::get_expr(stmt, new_expr);
   }

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -548,6 +548,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     if(ctr_call.getNumArgs() != 0)
     {
+      // TODO: currently only supporting zero-argument implicit default constructors.
       assert(
         !"come back and continue - got user defined ctor, need side effect?");
     }

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -542,38 +542,24 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
   case clang::Stmt::CXXConstructExprClass:
   {
+    // Reference to a declared construstor
     const clang::CXXConstructExpr &ctr_call =
       static_cast<const clang::CXXConstructExpr &>(stmt);
 
-    /*
-    // Do we really need the side_effect for default constructor?
-    const clang::Decl *callee = ctr_call.getExpr();
-
-    exprt callee_expr;
-    if(get_expr(*callee, callee_expr))
-      return true;
-    */
-
-    typet type;
-    if(get_type(ctr_call.getType(), type))
-      return true;
-
-    side_effect_expr_function_callt call;
-    //call.function() = callee_expr;
-    call.type() = type;
-
-    // Do args
-    for(const clang::Expr *arg : ctr_call.arguments())
+    if(ctr_call.getNumArgs() != 0)
     {
-      exprt single_arg;
-      if(get_expr(*arg, single_arg))
+      assert(
+        !"come back and continue - got user defined ctor, need side effect?");
+    }
+    else
+    {
+      // no additional annotation for zero-arg constructor
+      typet t;
+      if(get_type(ctr_call.getType(), t))
         return true;
-
-      call.arguments().push_back(single_arg);
+      new_expr = gen_zero(t);
     }
 
-    new_expr = call;
-    assert(!"Continue from here");
     break;
   }
 


### PR DESCRIPTION
This PR added support for `CXXConstructExpr`.

### Test case: 
```cpp
#include <assert.h>
class Test {
public:
  int x;
  /*
  Test(int _x) {
    x = _x; // requires CXXThisExpr
  }
  */
  int increment_x(int a) {
    return a + 1;
  }
};

int main() {
  Test testObj;
  int y = 0;
  y = testObj.increment_x(y);
  assert(y != 1);
  return 0;
}
```

### TODOs: 
1. The `CXXMemberCallExpr` does not generate the correct symbol: 
```
Symbol......: c:@F@main#
Module......: main
Base name...: main
Mode........: C (0)
Type........: signed int ()
Value.......:
{
Test testObj={ .x=0 };

signed int y=0;

y = member
  * type: code
      * arguments:
  * operands:
    0: symbol
        * type: struct
            * tag: Test
            * components:
              0: component
                  * type: signedbv
                      * width: 32
                      * #cpp_type: signed_int
                  * name: x
                  * pretty_name: x
        * name: testObj
        * identifier: c:main.cpp@185@F@main#@testObj
        * #location:
          * file: main.cpp
          * line: 18
          * function: main
        * #lvalue: 1
  * component_name:
  * #location:
    * file: main.cpp
    * line: 18
    * function: main(testObj, y);

y != 1 ? 0 : __assert_fail(&"y != 1"[0], &"main.cpp"[0], 19, &"int main()"[0]);

return 0;

}
Flags.......: lvalue
Location....: file main.cpp line 15
```

Expected the memebr function call to be like `y=increment_x(&testObj, y)`. 
