### PR TITLE
[smt] fp member typecast in real/int mode

### DIFF
--- a/regression/esbmc/github_690_z3_cast_fail/main.c
+++ b/regression/esbmc/github_690_z3_cast_fail/main.c
@@ -1,0 +1,22 @@
+typedef struct {
+	float x;
+} myStruct;
+
+int main(void) {
+  myStruct testObj;
+  testObj.x = 200.0;
+  double y = 10.0;
+  float z = 0.0;
+
+  if (testObj.x > y)
+  {
+    z = testObj.x;
+  }
+  else
+  {
+    z = y;
+  }
+
+  assert(z == y); // fail
+  return 0;
+}

--- a/regression/esbmc/github_690_z3_cast_fail/test.desc
+++ b/regression/esbmc/github_690_z3_cast_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --z3
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_690_z3_cast_success/main.c
+++ b/regression/esbmc/github_690_z3_cast_success/main.c
@@ -1,0 +1,22 @@
+typedef struct {
+	float x;
+} myStruct;
+
+int main(void) {
+  myStruct testObj;
+  testObj.x = 200.0;
+  double y = 10.0;
+  float z = 0.0;
+
+  if (testObj.x > y)
+  {
+    z = testObj.x;
+  }
+  else
+  {
+    z = y;
+  }
+
+  assert(z == testObj.x); // success
+  return 0;
+}

--- a/regression/esbmc/github_690_z3_cast_success/test.desc
+++ b/regression/esbmc/github_690_z3_cast_success/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--ir --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_690_z3_nocast_fail/main.c
+++ b/regression/esbmc/github_690_z3_nocast_fail/main.c
@@ -1,0 +1,17 @@
+typedef struct {
+	float x;
+} myStruct;
+
+int main(void) {
+  myStruct testObj;
+  testObj.x = 200.0;
+  float z = 0.0;
+
+  if (testObj.x > 10.0f)
+  {
+    z = testObj.x;
+  }
+
+  assert(z == 0.0); // fail
+  return 0;
+}

--- a/regression/esbmc/github_690_z3_nocast_fail/test.desc
+++ b/regression/esbmc/github_690_z3_nocast_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --z3
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_690_z3_nocast_success/main.c
+++ b/regression/esbmc/github_690_z3_nocast_success/main.c
@@ -1,0 +1,17 @@
+typedef struct {
+	float x;
+} myStruct;
+
+int main(void) {
+  myStruct testObj;
+  testObj.x = 200.0;
+  float z = 0.0;
+
+  if (testObj.x > 10.0f)
+  {
+    z = testObj.x;
+  }
+
+  assert(z == testObj.x); // success
+  return 0;
+}

--- a/regression/esbmc/github_690_z3_nocast_success/test.desc
+++ b/regression/esbmc/github_690_z3_nocast_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --z3
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -579,6 +579,8 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
   {
     // When using --ir mode and --floatbv, we ignore the fp-to-fp typecasting
     // and the just encode the original fp term using real mode
+    if(cast.from.get()->expr_id == expr2t::member_id)
+      return convert_member(cast.from);
     return convert_terminal(cast.from);
   }
 


### PR DESCRIPTION
Patch for fp member typecast in real/int mode mentioned in issue https://github.com/esbmc/esbmc/issues/687. 