### PR TITLE
[regression] Added new benchmarks extracted from C++11 book

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -26,10 +26,10 @@ endfunction()
 
 # NOTE: In order to make the best of the concurrency set sort the tests from the slowest to fastest.
 if(APPLE)
-    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc esbmc-solidity cbmc cstd llvm floats floats-regression k-induction k-induction-parallel nonz3 bitwuzla incremental-smt)
+    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc esbmc-solidity cbmc cstd llvm floats floats-regression k-induction k-induction-parallel nonz3 bitwuzla incremental-smt esbmc-cpp11)
 elseif(WIN32)
     # FUTURE: Add floats-regression esbmc-cpp/cpp
-    set(REGRESSIONS esbmc cbmc cstd llvm floats  k-induction )
+    set(REGRESSIONS esbmc cbmc cstd llvm floats  k-induction esbmc-cpp11)
 else()
     set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc esbmc-solidity esbmc-old cbmc cstd llvm floats floats-regression k-induction esbmc-cpp/cpp esbmc-cpp/cbmc csmith k-induction-parallel nonz3 bitwuzla incremental-smt esbmc-cpp11)
 endif()

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -31,7 +31,7 @@ elseif(WIN32)
     # FUTURE: Add floats-regression esbmc-cpp/cpp
     set(REGRESSIONS esbmc cbmc cstd llvm floats  k-induction )
 else()
-    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc esbmc-solidity esbmc-old cbmc cstd llvm floats floats-regression k-induction esbmc-cpp/cpp esbmc-cpp/cbmc csmith k-induction-parallel nonz3 bitwuzla incremental-smt)
+    set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc esbmc-solidity esbmc-old cbmc cstd llvm floats floats-regression k-induction esbmc-cpp/cpp esbmc-cpp/cbmc csmith k-induction-parallel nonz3 bitwuzla incremental-smt esbmc-cpp11)
 endif()
 
 foreach(regression IN LISTS REGRESSIONS)

--- a/regression/esbmc-cpp11/README.md
+++ b/regression/esbmc-cpp11/README.md
@@ -1,16 +1,22 @@
-Benchmark Description
+Benchmark Description:
 
-| Test Case| Main Features Tested |
-| :----:   | :---                 |
-| ch2_01   | COM <iostream>, string, standard output stream |
-| ch2_03   | same as above   |
-| ch2_04   | same as above   |
-| ch2_05   | COM <iostream>, standard input stream, variable decl, arithmetic operators, *+*, *=*|
-| ch2_13   | preceeding features plus *if* statement, relational operator *<*, *using* directive|
-| ch3_01   | class member function call without parameter, const member function|
-| ch3_03   | COM <string>, getline, member function call with parameter|
-| ch3_05   | private access specifier, setter, getter|
-| ch3_07   | explicit constructor, member-initializer list|
-| ch3_09   | separate implementation from interfaces (header)|
-| ch3_11   | scope resolution, function prototypes|
-| ch3_15   | preceeding features plus *substr* function of COM <string>, standard error stream|
+Test cases with asterisk(\*) are modified manually to verify a specific feature.
+
+| Test Case | Main Features Tested |
+| :----:    | :---                 |
+| ch2_01    | COM <iostream>, string, standard output stream |
+| ch2_03    | same as above   |
+| ch2_04    | same as above   |
+| ch2_05    | COM <iostream>, standard input stream, variable decl, arithmetic operators, *+*, *=*|
+| ch2_13    | preceeding features plus *if* statement, relational operator *<*, *using* directive|
+| ch3_01    | class member function call without parameter, const member function|
+| ch3_03    | COM <string>, getline, member function call with parameter|
+| ch3_05    | private access specifier, setter, getter|
+| ch3_07    | explicit constructor, member-initializer list|
+| ch3_09    | separate implementation from interfaces (header)|
+| ch3_11    | scope resolution, function prototypes|
+| ch3_15    | preceeding features plus *substr* function of COM <string>, standard error stream|
+| ch4_08    | counter-controlled *while* loop with definite repetition, int division|
+| ch4_12    | sentinel-controlled *while* loop w/o definite repetition, double, static_cast, COM <iomanip> setprecision, fixed|
+| ch4_16\*  | C++11 list initialisation (aka uniform initialisation)|
+| ch4_16_2\*| C++11 list initialisation (aka uniform initialisation), addition assignment operator|

--- a/regression/esbmc-cpp11/README.md
+++ b/regression/esbmc-cpp11/README.md
@@ -1,0 +1,16 @@
+Benchmark Description
+
+| Test Case| Main Features Tested |
+| :----:   | :---                 |
+| ch2_01   | COM <iostream>, string, standard output stream |
+| ch2_03   | same as above   |
+| ch2_04   | same as above   |
+| ch2_05   | COM <iostream>, standard input stream, variable decl, arithmetic operators, *+*, *=*|
+| ch2_13   | preceeding features plus *if* statement, relational operator *<*, *using* directive|
+| ch3_01   | class member function call without parameter, const member function|
+| ch3_03   | COM <string>, getline, member function call with parameter|
+| ch3_05   | private access specifier, setter, getter|
+| ch3_07   | explicit constructor, member-initializer list|
+| ch3_09   | separate implementation from interfaces (header)|
+| ch3_11   | scope resolution, function prototypes|
+| ch3_15   | preceeding features plus *substr* function of COM <string>, standard error stream|

--- a/regression/esbmc-cpp11/README.md
+++ b/regression/esbmc-cpp11/README.md
@@ -17,6 +17,15 @@ Test cases with asterisk(\*) are modified manually to verify a specific feature.
 | ch3_11    | scope resolution, function prototypes|
 | ch3_15    | preceeding features plus *substr* function of COM <string>, standard error stream|
 | ch4_08    | counter-controlled *while* loop with definite repetition, int division|
-| ch4_12    | sentinel-controlled *while* loop w/o definite repetition, double, static_cast, COM <iomanip> setprecision, fixed|
+| ch4_12    | sentinel-controlled *while* loop w/o definite repetition, double, static_cast, COM <iomanip> *setprecision* and *fixed* functions|
 | ch4_16\*  | C++11 list initialisation (aka uniform initialisation)|
 | ch4_16_2\*| C++11 list initialisation (aka uniform initialisation), addition assignment operator|
+| ch5_01    | COM <iostream>, *while* loop, pre-increment operator|
+| ch5_02    | COM <iostream>, *for* loop, pre-increment operator|
+| ch5_05    | same as above plus addition assignment operator|
+| ch5_06    | COM <cmath> *pow* function, COM <iostream>, *setw* function|
+| ch5_07    | *do...while* loop|
+| ch5_09\*  | C++11 in-class initialization, *switch* statement|
+| ch5_13    | *break* statement|
+| ch5_14    | *continue* statement|
+| ch5_18    | Logical operator *&&* *||* *!*, COM <iostream> *boolalpha* function|

--- a/regression/esbmc-cpp11/ch2_01/main.cpp
+++ b/regression/esbmc-cpp11/ch2_01/main.cpp
@@ -1,0 +1,29 @@
+// Fig. 2.1: fig02_01.cpp
+// Text-printing program.
+#include <iostream> // allows program to output data to the screen
+
+// function main begins program execution
+int main()
+{
+   std::cout << "Welcome to C++!\n"; // display message
+
+   return 0; // indicate that program ended successfully
+} // end function main
+
+
+                                                 
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch2_01/test.desc
+++ b/regression/esbmc-cpp11/ch2_01/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch2_03/main.cpp
+++ b/regression/esbmc-cpp11/ch2_03/main.cpp
@@ -1,0 +1,27 @@
+// Fig. 2.3: fig02_03.cpp
+// Printing a line of text with multiple statements.
+#include <iostream> // allows program to output data to the screen
+
+// function main begins program execution
+int main()
+{
+   std::cout << "Welcome ";
+   std::cout << "to C++!\n";
+} // end function main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch2_03/test.desc
+++ b/regression/esbmc-cpp11/ch2_03/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch2_04/main.cpp
+++ b/regression/esbmc-cpp11/ch2_04/main.cpp
@@ -1,0 +1,26 @@
+// Fig. 2.4: fig02_04.cpp
+// Printing multiple lines of text with a single statement.
+#include <iostream> // allows program to output data to the screen
+
+// function main begins program execution
+int main()
+{
+   std::cout << "Welcome\nto\n\nC++!\n";
+} // end function main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch2_04/test.desc
+++ b/regression/esbmc-cpp11/ch2_04/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch2_05/main.cpp
+++ b/regression/esbmc-cpp11/ch2_05/main.cpp
@@ -1,0 +1,39 @@
+// Fig. 2.5: fig02_05.cpp
+// Addition program that displays the sum of two integers.
+#include <iostream> // allows program to perform input and output
+
+// function main begins program execution
+int main()
+{
+   // variable declarations
+   int number1 = 0; // first integer to add (initialized to 0)
+   int number2 = 0; // second integer to add (initialized to 0)
+   int sum = 0; // sum of number1 and number2 (initialized to 0)
+
+   std::cout << "Enter first integer: "; // prompt user for data
+   std::cin >> number1; // read first integer from user into number1
+
+   std::cout << "Enter second integer: "; // prompt user for data
+   std::cin >> number2; // read second integer from user into number2
+
+   sum = number1 + number2; // add the numbers; store result in sum
+
+   std::cout << "Sum is " << sum << std::endl; // display sum; end line
+} // end function main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch2_05/test.desc
+++ b/regression/esbmc-cpp11/ch2_05/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch2_13/main.cpp
+++ b/regression/esbmc-cpp11/ch2_13/main.cpp
@@ -1,0 +1,52 @@
+// Fig. 2.13: fig02_13.cpp
+// Comparing integers using if statements, relational operators
+// and equality operators.
+#include <iostream> // allows program to perform input and output
+
+using std::cout; // program uses cout
+using std::cin; // program uses cin
+using std::endl; // program uses endl
+
+// function main begins program execution
+int main()
+{
+   int number1 = 0; // first integer to compare (initialized to 0)
+   int number2 = 0; // second integer to compare (initialized to 0)
+   
+   cout << "Enter two integers to compare: "; // prompt user for data
+   cin >> number1 >> number2; // read two integers from user
+
+   if ( number1 == number2 )
+      cout << number1 << " == " << number2 << endl;
+
+   if ( number1 != number2 )
+      cout << number1 << " != " << number2 << endl;
+
+   if ( number1 < number2 )
+      cout << number1 << " < " << number2 << endl;
+
+   if ( number1 > number2 )
+      cout << number1 << " > " << number2 << endl;
+
+   if ( number1 <= number2 )
+      cout << number1 << " <= " << number2 << endl;
+
+   if ( number1 >= number2 )
+      cout << number1 << " >= " << number2 << endl;
+} // end function main
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch2_13/test.desc
+++ b/regression/esbmc-cpp11/ch2_13/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_01/main.cpp
+++ b/regression/esbmc-cpp11/ch3_01/main.cpp
@@ -1,0 +1,39 @@
+// Fig. 3.1: fig03_01.cpp
+// Define class GradeBook with a member function displayMessage;
+// Create a GradeBook object and call its displayMessage function.
+#include <iostream>
+using namespace std;
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   // function that displays a welcome message to the GradeBook user
+   void displayMessage() const
+   {
+      cout << "Welcome to the Grade Book!" << endl;
+   } // end function displayMessage
+}; // end class GradeBook  
+
+// function main begins program execution
+int main()
+{
+   GradeBook myGradeBook; // create a GradeBook object named myGradeBook
+   myGradeBook.displayMessage(); // call object's displayMessage function	
+} // end main
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_01/test.desc
+++ b/regression/esbmc-cpp11/ch3_01/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_03/main.cpp
+++ b/regression/esbmc-cpp11/ch3_03/main.cpp
@@ -1,0 +1,51 @@
+// Fig. 3.3: fig03_03.cpp
+// Define class GradeBook with a member function that takes a parameter,
+// create a GradeBook object and call its displayMessage function.
+#include <iostream>
+#include <string> // program uses C++ standard string class
+using namespace std;
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   // function that displays a welcome message to the GradeBook user 
+   void displayMessage( string courseName ) const
+   {
+      cout << "Welcome to the grade book for\n" << courseName << "!" 
+         << endl;
+   } // end function displayMessage
+}; // end class GradeBook  
+
+// function main begins program execution
+int main()
+{
+   string nameOfCourse; // string of characters to store the course name
+   GradeBook myGradeBook; // create a GradeBook object named myGradeBook
+   
+   // prompt for and input course name
+   cout << "Please enter the course name:" << endl;
+   getline( cin, nameOfCourse ); // read a course name with blanks
+   cout << endl; // output a blank line
+
+   // call myGradeBook's displayMessage function
+   // and pass nameOfCourse as an argument
+   myGradeBook.displayMessage( nameOfCourse );
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_03/test.desc
+++ b/regression/esbmc-cpp11/ch3_03/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_05/main.cpp
+++ b/regression/esbmc-cpp11/ch3_05/main.cpp
@@ -1,0 +1,71 @@
+// Fig. 3.5: fig03_05.cpp
+// Define class GradeBook that contains a courseName data member
+// and member functions to set and get its value; 
+// Create and manipulate a GradeBook object with these functions.
+#include <iostream>
+#include <string> // program uses C++ standard string class
+using namespace std;
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   // function that sets the course name
+   void setCourseName( string name ) 
+   {      
+      courseName = name; // store the course name in the object
+   } // end function setCourseName
+   
+   // function that gets the course name
+   string getCourseName() const 
+   {
+      return courseName; // return the object's courseName
+   } // end function getCourseName
+
+   // function that displays a welcome message
+   void displayMessage() const
+   {
+      // this statement calls getCourseName to get the 
+      // name of the course this GradeBook represents
+      cout << "Welcome to the grade book for\n" << getCourseName() << "!" 
+         << endl;
+   } // end function displayMessage
+private:
+   string courseName; // course name for this GradeBook
+}; // end class GradeBook  
+
+// function main begins program execution
+int main()
+{
+   string nameOfCourse; // string of characters to store the course name
+   GradeBook myGradeBook; // create a GradeBook object named myGradeBook
+   
+   // display initial value of courseName
+   cout << "Initial course name is: " << myGradeBook.getCourseName() 
+      << endl;
+
+   // prompt for, input and set course name
+   cout << "\nPlease enter the course name:" << endl;
+   getline( cin, nameOfCourse ); // read a course name with blanks
+   myGradeBook.setCourseName( nameOfCourse ); // set the course name
+
+   cout << endl; // outputs a blank line
+   myGradeBook.displayMessage(); // display message with new course name
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_05/test.desc
+++ b/regression/esbmc-cpp11/ch3_05/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_07/main.cpp
+++ b/regression/esbmc-cpp11/ch3_07/main.cpp
@@ -1,0 +1,71 @@
+// Fig. 3.7: fig03_07.cpp
+// Instantiating multiple objects of the GradeBook class and using  
+// the GradeBook constructor to specify the course name 
+// when each GradeBook object is created.
+#include <iostream>
+#include <string> // program uses C++ standard string class
+using namespace std;
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   // constructor initializes courseName with string supplied as argument
+   explicit GradeBook( string name )
+      : courseName( name ) // member initializer to initialize courseName 
+   {
+      // empty body
+   } // end GradeBook constructor
+
+   // function to set the course name
+   void setCourseName( string name )
+   {
+      courseName = name; // store the course name in the object
+   } // end function setCourseName
+
+   // function to get the course name
+   string getCourseName() const
+   {
+      return courseName; // return object's courseName
+   } // end function getCourseName
+
+   // display a welcome message to the GradeBook user
+   void displayMessage() const
+   {
+      // call getCourseName to get the courseName
+      cout << "Welcome to the grade book for\n" << getCourseName()  
+         << "!" << endl;
+   } // end function displayMessage
+private:
+   string courseName; // course name for this GradeBook
+}; // end class GradeBook  
+
+// function main begins program execution
+int main()
+{
+   // create two GradeBook objects
+   GradeBook gradeBook1( "CS101 Introduction to C++ Programming" );
+   GradeBook gradeBook2( "CS102 Data Structures in C++" );
+
+   // display initial value of courseName for each GradeBook
+   cout << "gradeBook1 created for course: " << gradeBook1.getCourseName()
+      << "\ngradeBook2 created for course: " << gradeBook2.getCourseName() 
+      << endl;
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_07/test.desc
+++ b/regression/esbmc-cpp11/ch3_07/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_09/GradeBook.h
+++ b/regression/esbmc-cpp11/ch3_09/GradeBook.h
@@ -1,0 +1,53 @@
+// Fig. 3.9: GradeBook.h
+// GradeBook class definition in a separate file from main.
+#include <iostream> 
+#include <string> // class GradeBook uses C++ standard string class
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   // constructor initializes courseName with string supplied as argument
+   explicit GradeBook( std::string name )
+      : courseName( name ) // member initializer to initialize courseName 
+   {
+      // empty body
+   } // end GradeBook constructor
+
+   // function to set the course name
+   void setCourseName( std::string name )
+   {
+      courseName = name; // store the course name in the object
+   } // end function setCourseName
+
+   // function to get the course name
+   std::string getCourseName() const
+   {
+      return courseName; // return object's courseName
+   } // end function getCourseName
+
+   // display a welcome message to the GradeBook user
+   void displayMessage() const
+   {
+      // call getCourseName to get the courseName
+      std::cout << "Welcome to the grade book for\n" << getCourseName()  
+         << "!" << std::endl;
+   } // end function displayMessage
+private:
+   std::string courseName; // course name for this GradeBook
+}; // end class GradeBook  
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/   

--- a/regression/esbmc-cpp11/ch3_09/main.cpp
+++ b/regression/esbmc-cpp11/ch3_09/main.cpp
@@ -1,0 +1,34 @@
+// Fig. 3.10: fig03_10.cpp
+// Including class GradeBook from file GradeBook.h for use in main.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// function main begins program execution
+int main()
+{
+   // create two GradeBook objects
+   GradeBook gradeBook1( "CS101 Introduction to C++ Programming" );
+   GradeBook gradeBook2( "CS102 Data Structures in C++" );
+
+   // display initial value of courseName for each GradeBook
+   cout << "gradeBook1 created for course: " << gradeBook1.getCourseName()
+      << "\ngradeBook2 created for course: " << gradeBook2.getCourseName() 
+      << endl;
+} // end main
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_09/test.desc
+++ b/regression/esbmc-cpp11/ch3_09/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_11/GradeBook.cpp
+++ b/regression/esbmc-cpp11/ch3_11/GradeBook.cpp
@@ -1,0 +1,49 @@
+// Fig. 3.12: GradeBook.cpp
+// GradeBook member-function definitions. This file contains
+// implementations of the member functions prototyped in GradeBook.h.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// constructor initializes courseName with string supplied as argument
+GradeBook::GradeBook( string name )
+   : courseName( name ) // member initializer to initialize courseName 
+{                                                                      
+   // empty body
+} // end GradeBook constructor
+
+// function to set the course name
+void GradeBook::setCourseName( string name )
+{
+   courseName = name; // store the course name in the object
+} // end function setCourseName
+
+// function to get the course name
+string GradeBook::getCourseName() const
+{
+   return courseName; // return object's courseName
+} // end function getCourseName
+
+// display a welcome message to the GradeBook user
+void GradeBook::displayMessage() const
+{
+   // call getCourseName to get the courseName
+   cout << "Welcome to the grade book for\n" << getCourseName() 
+      << "!" << endl;
+} // end function displayMessage
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/   

--- a/regression/esbmc-cpp11/ch3_11/GradeBook.h
+++ b/regression/esbmc-cpp11/ch3_11/GradeBook.h
@@ -1,0 +1,34 @@
+// Fig. 3.11: GradeBook.h
+// GradeBook class definition. This file presents GradeBook's public 
+// interface without revealing the implementations of GradeBook's member
+// functions, which are defined in GradeBook.cpp.
+#include <string> // class GradeBook uses C++ standard string class
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   explicit GradeBook( std::string ); // constructor initialize courseName
+   void setCourseName( std::string ); // sets the course name
+   std::string getCourseName() const; // gets the course name
+   void displayMessage() const; // displays a welcome message
+private:
+   std::string courseName; // course name for this GradeBook
+}; // end class GradeBook  
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/
+

--- a/regression/esbmc-cpp11/ch3_11/main.cpp
+++ b/regression/esbmc-cpp11/ch3_11/main.cpp
@@ -1,0 +1,36 @@
+// Fig. 3.13: fig03_13.cpp
+// GradeBook class demonstration after separating 
+// its interface from its implementation.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// function main begins program execution
+int main()
+{
+   // create two GradeBook objects
+   GradeBook gradeBook1( "CS101 Introduction to C++ Programming" );
+   GradeBook gradeBook2( "CS102 Data Structures in C++" );
+
+   // display initial value of courseName for each GradeBook
+   cout << "gradeBook1 created for course: " << gradeBook1.getCourseName()
+      << "\ngradeBook2 created for course: " << gradeBook2.getCourseName() 
+      << endl;
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_11/test.desc
+++ b/regression/esbmc-cpp11/ch3_11/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+GradeBook.cpp --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch3_15/GradeBook.cpp
+++ b/regression/esbmc-cpp11/ch3_15/GradeBook.cpp
@@ -1,0 +1,59 @@
+// Fig. 3.16: GradeBook.cpp
+// Implementations of the GradeBook member-function definitions.
+// The setCourseName function performs validation.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// constructor initializes courseName with string supplied as argument
+GradeBook::GradeBook( string name )
+{
+   setCourseName( name ); // validate and store courseName
+} // end GradeBook constructor
+
+// function that sets the course name;
+// ensures that the course name has at most 25 characters
+void GradeBook::setCourseName( string name )
+{
+   if ( name.size() <= 25 ) // if name has 25 or fewer characters
+      courseName = name; // store the course name in the object
+
+   if ( name.size() > 25 ) // if name has more than 25 characters
+   { 
+      // set courseName to first 25 characters of parameter name
+      courseName = name.substr( 0, 25 ); // start at 0, length of 25
+
+      cerr << "Name \"" << name << "\" exceeds maximum length (25).\n"
+         << "Limiting courseName to first 25 characters.\n" << endl;
+   } // end if
+} // end function setCourseName
+
+// function to get the course name
+string GradeBook::getCourseName() const
+{
+   return courseName; // return object's courseName
+} // end function getCourseName
+
+// display a welcome message to the GradeBook user
+void GradeBook::displayMessage() const
+{
+   // call getCourseName to get the courseName
+   cout << "Welcome to the grade book for\n" << getCourseName()  
+      << "!" << endl;
+} // end function displayMessage
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/   

--- a/regression/esbmc-cpp11/ch3_15/GradeBook.h
+++ b/regression/esbmc-cpp11/ch3_15/GradeBook.h
@@ -1,0 +1,32 @@
+// Fig. 3.15: GradeBook.h
+// GradeBook class definition presents the public interface of  
+// the class. Member-function definitions appear in GradeBook.cpp.
+#include <string> // program uses C++ standard string class
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   explicit GradeBook( std::string ); // constructor initialize courseName
+   void setCourseName( std::string ); // sets the course name
+   std::string getCourseName() const; // gets the course name
+   void displayMessage() const; // displays a welcome message
+private:
+   std::string courseName; // course name for this GradeBook
+}; // end class GradeBook  
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/   

--- a/regression/esbmc-cpp11/ch3_15/main.cpp
+++ b/regression/esbmc-cpp11/ch3_15/main.cpp
@@ -1,0 +1,46 @@
+// Fig. 3.17: fig03_16.cpp
+// Create and manipulate a GradeBook object; illustrate validation.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// function main begins program execution
+int main()
+{
+   // create two GradeBook objects; 
+   // initial course name of gradeBook1 is too long
+   GradeBook gradeBook1( "CS101 Introduction to Programming in C++" );
+   GradeBook gradeBook2( "CS102 C++ Data Structures" );
+
+   // display each GradeBook's courseName 
+   cout << "gradeBook1's initial course name is: " 
+      << gradeBook1.getCourseName()
+      << "\ngradeBook2's initial course name is: " 
+      << gradeBook2.getCourseName() << endl;
+
+   // modify gradeBook1's courseName (with a valid-length string)
+   gradeBook1.setCourseName( "CS101 C++ Programming" );
+
+   // display each GradeBook's courseName 
+   cout << "\ngradeBook1's course name is: " 
+      << gradeBook1.getCourseName()
+      << "\ngradeBook2's course name is: " 
+      << gradeBook2.getCourseName() << endl;
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch3_15/test.desc
+++ b/regression/esbmc-cpp11/ch3_15/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+GradeBook.cpp --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch4_08/GradeBook.cpp
+++ b/regression/esbmc-cpp11/ch4_08/GradeBook.cpp
@@ -1,0 +1,81 @@
+// Fig. 4.9: GradeBook.cpp
+// Member-function definitions for class GradeBook that solves the 
+// class average program with counter-controlled repetition.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// constructor initializes courseName with string supplied as argument
+GradeBook::GradeBook( string name )
+{
+   setCourseName( name ); // validate and store courseName
+} // end GradeBook constructor
+
+// function to set the course name;
+// ensures that the course name has at most 25 characters
+void GradeBook::setCourseName( string name )
+{
+   if ( name.size() <= 25 ) // if name has 25 or fewer characters
+      courseName = name; // store the course name in the object
+   else // if name is longer than 25 characters
+   { // set courseName to first 25 characters of parameter name
+      courseName = name.substr( 0, 25 ); // select first 25 characters
+      cerr << "Name \"" << name << "\" exceeds maximum length (25).\n"
+         << "Limiting courseName to first 25 characters.\n" << endl;
+   } // end if...else
+} // end function setCourseName
+
+// function to retrieve the course name
+string GradeBook::getCourseName() const
+{
+   return courseName;
+} // end function getCourseName
+
+// display a welcome message to the GradeBook user
+void GradeBook::displayMessage() const
+{
+   cout << "Welcome to the grade book for\n" << getCourseName() << "!\n" 
+      << endl;
+} // end function displayMessage
+
+// determine class average based on 10 grades entered by user
+void GradeBook::determineClassAverage() const
+{
+   // initialization phase
+   int total = 0; // sum of grades entered by user
+   unsigned int gradeCounter = 1; // number of grade to be entered next
+
+   // processing phase
+   while ( gradeCounter <= 10 ) // loop 10 times
+   {
+      cout << "Enter grade: "; // prompt for input
+      int grade = 0; // grade value entered by user
+      cin >> grade; // input next grade
+      total = total + grade; // add grade to total
+      gradeCounter = gradeCounter + 1; // increment counter by 1
+   } // end while
+
+   // termination phase
+   int average = total / 10; // ok to mix declaration and calculation
+
+   // display total and average of grades
+   cout << "\nTotal of all 10 grades is " << total << endl;
+   cout << "Class average is " << average << endl; 
+} // end function determineClassAverage
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_08/GradeBook.h
+++ b/regression/esbmc-cpp11/ch4_08/GradeBook.h
@@ -1,0 +1,33 @@
+// Fig. 4.8: GradeBook.h
+// Definition of class GradeBook that determines a class average.
+// Member functions are defined in GradeBook.cpp
+#include <string> // program uses C++ standard string class
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   explicit GradeBook( std::string ); // initializes course name
+   void setCourseName( std::string ); // set the course name
+   std::string getCourseName() const; // retrieve the course name
+   void displayMessage() const; // display a welcome message
+   void determineClassAverage() const; // averages user-entered grades 
+private:
+   std::string courseName; // course name for this GradeBook
+}; // end class GradeBook 
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_08/main.cpp
+++ b/regression/esbmc-cpp11/ch4_08/main.cpp
@@ -1,0 +1,29 @@
+// Fig. 4.10: fig04_10.cpp
+// Create GradeBook object and invoke its determineClassAverage function.
+#include "GradeBook.h" // include definition of class GradeBook
+
+int main()
+{
+   // create GradeBook object myGradeBook and 
+   // pass course name to constructor
+   GradeBook myGradeBook( "CS101 C++ Programming" );
+
+   myGradeBook.displayMessage(); // display welcome message
+   myGradeBook.determineClassAverage(); // find average of 10 grades
+} // end main
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_08/test.desc
+++ b/regression/esbmc-cpp11/ch4_08/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+GradeBook.cpp --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch4_12/GradeBook.cpp
+++ b/regression/esbmc-cpp11/ch4_12/GradeBook.cpp
@@ -1,0 +1,95 @@
+// Fig. 4.13: GradeBook.cpp
+// Member-function definitions for class GradeBook that solves the 
+// class average program with sentinel-controlled repetition.
+#include <iostream>
+#include <iomanip> // parameterized stream manipulators  
+#include "GradeBook.h" // include definition of class GradeBook 
+using namespace std;
+
+// constructor initializes courseName with string supplied as argument
+GradeBook::GradeBook( string name )
+{
+   setCourseName( name ); // validate and store courseName
+} // end GradeBook constructor
+
+// function to set the course name;
+// ensures that the course name has at most 25 characters
+void GradeBook::setCourseName( string name )
+{
+   if ( name.size() <= 25 ) // if name has 25 or fewer characters
+      courseName = name; // store the course name in the object
+   else // if name is longer than 25 characters
+   { // set courseName to first 25 characters of parameter name
+      courseName = name.substr( 0, 25 ); // select first 25 characters
+      cerr << "Name \"" << name << "\" exceeds maximum length (25).\n"
+         << "Limiting courseName to first 25 characters.\n" << endl;
+   } // end if...else
+} // end function setCourseName
+
+// function to retrieve the course name
+string GradeBook::getCourseName() const
+{
+   return courseName;
+} // end function getCourseName
+
+// display a welcome message to the GradeBook user
+void GradeBook::displayMessage() const
+{
+   cout << "Welcome to the grade book for\n" << getCourseName() << "!\n" 
+      << endl;
+} // end function displayMessage
+
+// determine class average based on 10 grades entered by user
+void GradeBook::determineClassAverage() const
+{
+   // initialization phase
+   int total = 0; // sum of grades entered by user
+   unsigned int gradeCounter = 0; // number of grades entered
+
+   // processing phase
+   // prompt for input and read grade from user  
+   cout << "Enter grade or -1 to quit: ";        
+   int grade = 0; // grade value
+   cin >> grade; // input grade or sentinel value
+
+   // loop until sentinel value read from user   
+   while ( grade != -1 ) // while grade is not -1
+   {                  
+      total = total + grade; // add grade to total
+      gradeCounter = gradeCounter + 1; // increment counter
+      
+      // prompt for input and read next grade from user
+      cout << "Enter grade or -1 to quit: ";           
+      cin >> grade; // input grade or sentinel value   
+   } // end while
+
+   // termination phase
+   if ( gradeCounter != 0 ) // if user entered at least one grade...
+   {
+      // calculate average of all grades entered              
+      double average = static_cast< double >( total ) / gradeCounter;
+      
+      // display 7total and average (with two digits of precision)
+      cout << "\nTotal of all " << gradeCounter << " grades entered is " 
+         << total << endl;
+      cout << setprecision( 2 ) << fixed;
+      cout << "Class average is " << average << endl;
+   } // end if
+   else // no grades were entered, so output appropriate message
+      cout << "No grades were entered" << endl;
+} // end function determineClassAverage
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_12/GradeBook.h
+++ b/regression/esbmc-cpp11/ch4_12/GradeBook.h
@@ -1,0 +1,32 @@
+// Fig. 4.12: GradeBook.h
+// Definition of class GradeBook that determines a class average.
+// Member functions are defined in GradeBook.cpp
+#include <string> // program uses C++ standard string class
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   explicit GradeBook( std::string ); // initializes course name
+   void setCourseName( std::string ); // set the course name
+   std::string getCourseName() const; // retrieve the course name
+   void displayMessage() const; // display a welcome message
+   void determineClassAverage() const; // averages user-entered grades
+private:
+   std::string courseName; // course name for this GradeBook
+}; // end class GradeBook 
+
+/**************************************************************************
+ * (C) Copyright 1992-2012 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_12/main.cpp
+++ b/regression/esbmc-cpp11/ch4_12/main.cpp
@@ -1,0 +1,28 @@
+// Fig. 4.14: fig04_14.cpp
+// Create GradeBook object and invoke its determineClassAverage function.
+#include "GradeBook.h" // include definition of class GradeBook
+
+int main()
+{
+   // create GradeBook object myGradeBook and 
+   // pass course name to constructor
+   GradeBook myGradeBook( "CS101 C++ Programming" );
+
+   myGradeBook.displayMessage(); // display welcome message
+   myGradeBook.determineClassAverage(); // find average of 10 grades
+} // end main
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_12/test.desc
+++ b/regression/esbmc-cpp11/ch4_12/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+GradeBook.cpp --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch4_16/main.cpp
+++ b/regression/esbmc-cpp11/ch4_16/main.cpp
@@ -1,0 +1,53 @@
+// Fig. 4.16: fig04_16.cpp
+// Examination-results problem: Nested control statements.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   // initializing variables in declarations
+   unsigned int passes = 0; // number of passes
+   unsigned int failures = 0; // number of failures
+   //unsigned int studentCounter = 1; // student counter
+   unsigned int studentCounter{ 1 }; // student counter initialised using C++11 list initialisation
+
+   // process 10 students using counter-controlled loop
+   while ( studentCounter <= 10 )
+   {
+      // prompt user for input and obtain value from user
+      cout << "Enter result (1 = pass, 2 = fail): ";
+      int result = 0; // one exam result (1 = pass, 2 = fail)
+      cin >> result; // input result
+
+      // if...else nested in while
+      if ( result == 1 )          // if result is 1,
+         passes = passes + 1;     // increment passes;
+      else                        // else result is not 1, so
+         failures = failures + 1; // increment failures
+
+      // increment studentCounter so loop eventually terminates
+      studentCounter = studentCounter + 1;
+   } // end while
+
+   // termination phase; display number of passes and failures
+   cout << "Passed " << passes << "\nFailed " << failures << endl;
+
+   // determine whether more than eight students passed
+   if ( passes > 8 )
+      cout << "Bonus to instructor!" << endl;
+} // end main
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_16/test.desc
+++ b/regression/esbmc-cpp11/ch4_16/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch4_16_2/main.cpp
+++ b/regression/esbmc-cpp11/ch4_16_2/main.cpp
@@ -1,0 +1,53 @@
+// Fig. 4.16: fig04_16.cpp
+// Examination-results problem: Nested control statements.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   // initializing variables in declarations
+   unsigned int passes = 0; // number of passes
+   unsigned int failures = 0; // number of failures
+   //unsigned int studentCounter = 1; // student counter
+   unsigned int studentCounter = { 1 }; // student counter initialised using C++11 list initialisation
+
+   // process 10 students using counter-controlled loop
+   while ( studentCounter <= 10 )
+   {
+      // prompt user for input and obtain value from user
+      cout << "Enter result (1 = pass, 2 = fail): ";
+      int result = 0; // one exam result (1 = pass, 2 = fail)
+      cin >> result; // input result
+
+      // if...else nested in while
+      if ( result == 1 )          // if result is 1,
+         passes += 1;             // addition assignment operator;
+      else                        // else result is not 1, so
+         failures = failures + 1; // increment failures
+
+      // increment studentCounter so loop eventually terminates
+      studentCounter = studentCounter + 1;
+   } // end while
+
+   // termination phase; display number of passes and failures
+   cout << "Passed " << passes << "\nFailed " << failures << endl;
+
+   // determine whether more than eight students passed
+   if ( passes > 8 )
+      cout << "Bonus to instructor!" << endl;
+} // end main
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch4_16_2/test.desc
+++ b/regression/esbmc-cpp11/ch4_16_2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_01/main.cpp
+++ b/regression/esbmc-cpp11/ch5_01/main.cpp
@@ -1,0 +1,34 @@
+// Fig. 5.1: fig05_01.cpp
+// Counter-controlled repetition.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   unsigned int counter = 1; // declare and initialize control variable
+
+   while ( counter <= 10 ) // loop-continuation condition
+   {    
+      cout << counter << " ";
+      ++counter; // increment control variable by 1
+   } // end while 
+
+   cout << endl; // output a newline
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_01/test.desc
+++ b/regression/esbmc-cpp11/ch5_01/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_02/main.cpp
+++ b/regression/esbmc-cpp11/ch5_02/main.cpp
@@ -1,0 +1,31 @@
+// Fig. 5.2: fig05_02.cpp
+// Counter-controlled repetition with the for statement.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   // for statement header includes initialization, 
+   // loop-continuation condition and increment. 
+   for ( unsigned int counter = 1; counter <= 10; ++counter )
+      cout << counter << " ";
+
+   cout << endl; // output a newline
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_02/test.desc
+++ b/regression/esbmc-cpp11/ch5_02/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_05/main.cpp
+++ b/regression/esbmc-cpp11/ch5_05/main.cpp
@@ -1,0 +1,33 @@
+// Fig. 5.5: fig05_05.cpp
+// Summing integers with the for statement.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   unsigned int total = 0; // initialize total
+
+   // total even integers from 2 through 20
+   for ( unsigned int number = 2; number <= 20; number += 2 )
+      total += number; 
+
+   cout << "Sum is " << total << endl; // display results
+} // end main
+
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_05/test.desc
+++ b/regression/esbmc-cpp11/ch5_05/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_06/main.cpp
+++ b/regression/esbmc-cpp11/ch5_06/main.cpp
@@ -1,0 +1,45 @@
+// Fig. 5.6: fig05_06.cpp
+// Compound interest calculations with for.
+#include <iostream>
+#include <iomanip>
+#include <cmath> // standard math library
+using namespace std;
+
+int main()
+{
+   double amount; // amount on deposit at end of each year
+   double principal = 1000.0; // initial amount before interest
+   double rate = .05; // annual interest rate
+
+   // display headers
+   cout << "Year" << setw( 21 ) << "Amount on deposit" << endl;
+
+   // set floating-point number format
+   cout << fixed << setprecision( 2 );
+
+   // calculate amount on deposit for each of ten years
+   for ( unsigned int year = 1; year <= 10; ++year ) 
+   {
+      // calculate new amount for specified year
+      amount = principal * pow( 1.0 + rate, year );
+
+      // display the year and the amount
+      cout << setw( 4 ) << year << setw( 21 ) << amount << endl;
+   } // end for 
+} // end main
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_06/test.desc
+++ b/regression/esbmc-cpp11/ch5_06/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_07/main.cpp
+++ b/regression/esbmc-cpp11/ch5_07/main.cpp
@@ -1,0 +1,35 @@
+// Fig. 5.7: fig05_07.cpp
+// do...while repetition statement.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   unsigned int counter = 1; // initialize counter
+
+   do 
+   {
+      cout << counter << " "; // display counter
+      ++counter; // increment counter
+   } while ( counter <= 10 ); // end do...while 
+
+   cout << endl; // output a newline
+} // end main
+
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_07/test.desc
+++ b/regression/esbmc-cpp11/ch5_07/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_09/GradeBook.cpp
+++ b/regression/esbmc-cpp11/ch5_09/GradeBook.cpp
@@ -1,0 +1,128 @@
+// Fig. 5.10: GradeBook.cpp
+// Member-function definitions for class GradeBook that
+// uses a switch statement to count A, B, C, D and F grades.
+#include <iostream>
+#include "GradeBook.h" // include definition of class GradeBook
+using namespace std;
+
+// constructor initializes courseName with string supplied as argument;
+// initializes counter data members to 0
+GradeBook::GradeBook( string name )
+   : aCount( 0 ), // initialize count of A grades to 0 
+     bCount( 0 ), // initialize count of B grades to 0
+     cCount( 0 ), // initialize count of C grades to 0
+     dCount( 0 ), // initialize count of D grades to 0
+     fCount( 0 )  // initialize count of F grades to 0
+{
+   setCourseName( name );
+} // end GradeBook constructor
+
+// function to set the course name; limits name to 25 or fewer characters
+void GradeBook::setCourseName( string name )
+{
+   if ( name.size() <= 25 ) // if name has 25 or fewer characters
+      courseName = name; // store the course name in the object
+   else // if name is longer than 25 characters
+   { // set courseName to first 25 characters of parameter name
+      courseName = name.substr( 0, 25 ); // select first 25 characters
+      cerr << "Name \"" << name << "\" exceeds maximum length (25).\n"
+         << "Limiting courseName to first 25 characters.\n" << endl;
+   } // end if...else
+} // end function setCourseName
+
+// function to retrieve the course name
+string GradeBook::getCourseName() const
+{
+   return courseName;
+} // end function getCourseName
+
+// display a welcome message to the GradeBook user
+void GradeBook::displayMessage() const
+{
+   // this statement calls getCourseName to get the 
+   // name of the course this GradeBook represents
+   cout << "Welcome to the grade book for\n" << getCourseName() << "!\n" 
+      << endl;
+} // end function displayMessage
+
+// input arbitrary number of grades from user; update grade counter
+void GradeBook::inputGrades() 
+{
+   int grade; // grade entered by user
+
+   cout << "Enter the letter grades." << endl
+      << "Enter the EOF character to end input." << endl;
+
+   // loop until user types end-of-file key sequence
+   while ( ( grade = cin.get() ) != EOF )
+   {
+      // determine which grade was entered
+      switch ( grade ) // switch statement nested in while
+      {
+         case 'A': // grade was uppercase A
+         case 'a': // or lowercase a
+            ++aCount; // increment aCount
+            break; // necessary to exit switch
+
+         case 'B': // grade was uppercase B
+         case 'b': // or lowercase b
+            ++bCount; // increment bCount    
+            break; // exit switch
+
+         case 'C': // grade was uppercase C
+         case 'c': // or lowercase c
+            ++cCount; // increment cCount    
+            break; // exit switch
+
+         case 'D': // grade was uppercase D
+         case 'd': // or lowercase d
+            ++dCount; // increment dCount    
+            break; // exit switch
+
+         case 'F': // grade was uppercase F
+         case 'f': // or lowercase f
+            ++fCount; // increment fCount    
+            break; // exit switch
+
+         case '\n': // ignore newlines,  
+         case '\t': // tabs, 
+         case ' ': // and spaces in input
+            break; // exit switch
+
+         default: // catch all other characters
+            cout << "Incorrect letter grade entered."
+               << " Enter a new grade." << endl;
+            break; // optional; will exit switch anyway
+      } // end switch
+   } // end while
+} // end function inputGrades
+
+// display a report based on the grades entered by user
+void GradeBook::displayGradeReport() const
+{
+   // output summary of results
+   cout << "\n\nNumber of students who received each letter grade:" 
+      << "\nA: " << aCount // display number of A grades
+      << "\nB: " << bCount // display number of B grades
+      << "\nC: " << cCount // display number of C grades 
+      << "\nD: " << dCount // display number of D grades
+      << "\nF: " << fCount // display number of F grades
+      << endl;
+} // end function displayGradeReport
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_09/GradeBook.h
+++ b/regression/esbmc-cpp11/ch5_09/GradeBook.h
@@ -1,0 +1,39 @@
+// Fig. 5.9: GradeBook.h
+// GradeBook class definition that counts letter grades.
+// Member functions are defined in GradeBook.cpp
+#include <string> // program uses C++ standard string class
+
+// GradeBook class definition
+class GradeBook
+{
+public:
+   explicit GradeBook( std::string ); // initialize course name
+   void setCourseName( std::string ); // set the course name
+   std::string getCourseName() const; // retrieve the course name
+   void displayMessage() const; // display a welcome message
+   void inputGrades(); // input arbitrary number of grades from user
+   void displayGradeReport() const;  // display report based on user input
+private:
+   std::string courseName; // course name for this GradeBook
+   unsigned int aCount; // count of A grades
+   unsigned int bCount; // count of B grades
+   unsigned int cCount; // count of C grades
+   unsigned int dCount; // count of D grades
+   unsigned int fCount; // count of F grades
+   bool flag = false;   // C++11 in-class initializers
+}; // end class GradeBook
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_09/main.cpp
+++ b/regression/esbmc-cpp11/ch5_09/main.cpp
@@ -1,0 +1,29 @@
+// Fig. 5.11: fig05_11.cpp
+// Creating a GradeBook object and calling its member functions.
+#include "GradeBook.h" // include definition of class GradeBook
+
+int main()
+{
+   // create GradeBook object
+   GradeBook myGradeBook( "CS101 C++ Programming" );
+
+   myGradeBook.displayMessage(); // display welcome message
+   myGradeBook.inputGrades(); // read grades from user
+   myGradeBook.displayGradeReport(); // display report based on grades
+} // end main
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_09/test.desc
+++ b/regression/esbmc-cpp11/ch5_09/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+GradeBook.cpp --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_13/main.cpp
+++ b/regression/esbmc-cpp11/ch5_13/main.cpp
@@ -1,0 +1,36 @@
+// Fig. 5.13: fig05_13.cpp
+// break statement exiting a for statement.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   unsigned int count; // control variable also used after loop terminates
+
+   for ( count = 1; count <= 10; ++count ) // loop 10 times
+   {
+      if ( 5 == count ) // if count is 5,
+         break; // break loop only if x is 5
+
+      cout << count << " ";
+   } // end for 
+
+   cout << "\nBroke out of loop at count = " << count << endl;
+} // end main
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_13/test.desc
+++ b/regression/esbmc-cpp11/ch5_13/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_14/main.cpp
+++ b/regression/esbmc-cpp11/ch5_14/main.cpp
@@ -1,0 +1,35 @@
+// Fig. 5.14: fig05_14.cpp
+// continue statement terminating an iteration of a for statement.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   for ( unsigned int count = 1; count <= 10; ++count ) // loop 10 times
+   { 
+      if ( count == 5 ) // if count is 5,
+         continue;      // skip remaining code in loop
+
+      cout << count << " ";
+   } // end for
+
+   cout << "\nUsed continue to skip printing 5" << endl;
+} // end main
+
+
+
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_14/test.desc
+++ b/regression/esbmc-cpp11/ch5_14/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/ch5_18/main.cpp
+++ b/regression/esbmc-cpp11/ch5_18/main.cpp
@@ -1,0 +1,41 @@
+// Fig. 5.18: fig05_18.cpp
+// Logical operators.
+#include <iostream>
+using namespace std;
+
+int main()
+{
+   // create truth table for && (logical AND) operator
+   cout << boolalpha << "Logical AND (&&)"
+      << "\nfalse && false: " << ( false && false )
+      << "\nfalse && true: " << ( false && true )
+      << "\ntrue && false: " << ( true && false )
+      << "\ntrue && true: " << ( true && true ) << "\n\n";
+
+   // create truth table for || (logical OR) operator
+   cout << "Logical OR (||)"
+      << "\nfalse || false: " << ( false || false )
+      << "\nfalse || true: " << ( false || true )
+      << "\ntrue || false: " << ( true || false )
+      << "\ntrue || true: " << ( true || true ) << "\n\n";
+
+   // create truth table for ! (logical negation) operator
+   cout << "Logical NOT (!)"
+      << "\n!false: " << ( !false )
+      << "\n!true: " << ( !true ) << endl;
+} // end main
+
+/**************************************************************************
+ * (C) Copyright 1992-2014 by Deitel & Associates, Inc. and               *
+ * Pearson Education, Inc. All Rights Reserved.                           *
+ *                                                                        *
+ * DISCLAIMER: The authors and publisher of this book have used their     *
+ * best efforts in preparing the book. These efforts include the          *
+ * development, research, and testing of the theories and programs        *
+ * to determine their effectiveness. The authors and publisher make       *
+ * no warranty of any kind, expressed or implied, with regard to these    *
+ * programs or to the documentation contained in these books. The authors *
+ * and publisher shall not be liable in any event for incidental or       *
+ * consequential damages in connection with, or arising out of, the       *
+ * furnishing, performance, or use of these programs.                     *
+ **************************************************************************/

--- a/regression/esbmc-cpp11/ch5_18/test.desc
+++ b/regression/esbmc-cpp11/ch5_18/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Extracted benchmarks from _C++ How to Program 9th edition_ (C++11). The README file contains test case descriptions and the corresponding language features. 

The new benchmark will be used as part of the TDD process to bring up the clang-cpp-frontend for C++11 verification. 

Done ch1, ch2, ch3 for basic classes and member function calls. 

TODO: 
1. More control statements: ch4, ch5, ~ch6 (ignored, as function overloading and templates not covered in Milestone#2)~  (Done)
2. Pointers and arrays ch7, ch8 (in another PR)