### PR TITLE
[smt] guard tuple API usage by is_tuple_ast_type()

### DIFF
--- a/regression/esbmc/github_691/main.c
+++ b/regression/esbmc/github_691/main.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+
+#define ARR_SIZE 1
+
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+
+typedef union {
+  uint32_t dwords[2];
+  uint8_t bytes[8];
+} qword_t;
+
+uint32_t nondet_uint32_t() {
+  uint32_t val;
+  return val;
+}
+
+int main() {
+
+  qword_t a[ARR_SIZE];
+  qword_t b[ARR_SIZE];
+  
+  for (int i = 0; i < ARR_SIZE; i++) { 
+    for (int j = 0; j < 2; j++) {
+      a[i].dwords[j] = nondet_uint32_t();
+    }
+    b[i] = a[i];
+  }
+
+  assert(b[0].bytes[0] == 0);
+
+  return 0;
+}

--- a/regression/esbmc/github_691/test.desc
+++ b/regression/esbmc/github_691/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -718,23 +718,14 @@ expr2tc bitwuzla_convt::get_array_elem(
   bitwuzla_get_array_value(
     bitw, ast->a, &indicies, &values, &size, &default_value);
 
-  BigInt val = 0;
   if(size > 0)
-  {
     for(size_t i = 0; i < size; i++)
     {
       const char *index_str = bitwuzla_get_bv_value(bitw, indicies[i]);
       auto idx = string2integer(index_str, 2);
       if(idx == index)
-      {
-        const char *value_str = bitwuzla_get_bv_value(bitw, values[i]);
-        val = binary2integer(value_str, is_signedbv_type(subtype));
-        break;
-      }
+        return get_by_ast(subtype, new_ast(values[i], convert_sort(subtype)));
     }
-
-    return get_by_value(subtype, val);
-  }
 
   return gen_zero(subtype);
 }

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -693,24 +693,29 @@ expr2tc boolector_convt::get_array_elem(
   char **indicies, **values;
   boolector_array_assignment(btor, ast->a, &indicies, &values, &size);
 
-  BigInt val = 0;
-  if(size > 0)
-  {
-    for(uint32_t i = 0; i < size; i++)
-    {
-      auto idx = string2integer(indicies[i], 2);
-      if(idx == index)
-      {
-        val = binary2integer(values[i], is_signedbv_type(subtype));
-        break;
-      }
-    }
+  expr2tc ret = gen_zero(subtype);
 
-    boolector_free_array_assignment(btor, indicies, values, size);
-    return get_by_value(subtype, val);
+  for(uint32_t i = 0; i < size; i++)
+  {
+    auto idx = string2integer(indicies[i], 2);
+    if(idx == index)
+    {
+      BigInt val = binary2integer(values[i], is_signedbv_type(subtype));
+      /* Boolector only supports BVs in arrays, but for instance unions also
+       * get encoded as BVs, so we need to distinguish whether it is a simple
+       * BV or a more complex type, which get_by_value() does not handle.
+       * In the simple type case we can avoid the overhead of constructing new
+       * SMT nodes and sort conversion. */
+      if(is_bv_type(subtype))
+        ret = get_by_value(subtype, val);
+      else
+        ret = get_by_ast(subtype, mk_smt_bv(val, convert_sort(subtype)));
+      break;
+    }
   }
 
-  return gen_zero(subtype);
+  boolector_free_array_assignment(btor, indicies, values, size);
+  return ret;
 }
 
 smt_astt boolector_convt::overflow_arith(const expr2tc &expr)

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1359,7 +1359,7 @@ smt_astt smt_convt::convert_terminal(const expr2tc &expr)
       type2tc range = get_flattened_array_subtype(expr->type);
 
       // If this is an array of structs, we have a tuple array sym.
-      if(is_structure_type(range) || is_pointer_type(range))
+      if(is_tuple_ast_type(range))
         return tuple_api->mk_tuple_array_symbol(expr);
     }
 


### PR DESCRIPTION
Fixes #691. The tuple API was incorrectly used for unions in `convert_terminal()` for symbols.