### PR TITLE
Fixed parse errors in operational mode

### DIFF
--- a/src/cpp/library/cstdarg
+++ b/src/cpp/library/cstdarg
@@ -20,6 +20,4 @@ void va_end(va_list ap);
 
 void va_start(va_list ap, ...);
 
-int vsprintf(char * str, const char * format, va_list arg);
-
 #endif

--- a/src/cpp/library/cstdio
+++ b/src/cpp/library/cstdio
@@ -18,9 +18,9 @@
 #define EOF (-1)
 #endif
 
-typedef int& fpos_t;
+typedef int fpos_t;
 
-typedef void& FILE;
+typedef void FILE;
 
 typedef unsigned int TMP_MAX;
 
@@ -54,7 +54,7 @@ extern "C" {
 
   int vprintf(const char * format, va_list arg);
 
-  int vsprintf(char * str, const char * format, va_list arg);
+  //int vsprintf(char * str, const char * format, va_list arg); // removed as duplicate of vsprintf in cstdarg
 
   int fgetc(FILE * stream);
 

--- a/src/cpp/library/cstdio
+++ b/src/cpp/library/cstdio
@@ -20,7 +20,7 @@
 
 typedef int fpos_t;
 
-typedef void FILE;
+typedef void* FILE;
 
 typedef unsigned int TMP_MAX;
 
@@ -54,7 +54,7 @@ extern "C" {
 
   int vprintf(const char * format, va_list arg);
 
-  //int vsprintf(char * str, const char * format, va_list arg); // removed as duplicate of vsprintf in cstdarg
+  int vsprintf(char * str, const char * format, va_list arg);
 
   int fgetc(FILE * stream);
 

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -129,7 +129,7 @@ namespace std
 namespace std {
   //Output manipulators
   ostream& endl ( ostream& os ) { return os; }
-  ostream& ends ( ostream& os ) {  }
+  ostream& ends ( ostream& os );
 }
 
 #endif

--- a/src/cpp/library/streambuf
+++ b/src/cpp/library/streambuf
@@ -67,21 +67,21 @@ protected:
 	virtual void imbue ( const locale & loc ){}
 
 //	Buffer management and positioning:
-	virtual streambuf * setbuf ( char * s, streamsize n ){}
-	virtual streampos seekoff ( streamoff off, seekdir way, openmode which = in | out ){}
-	virtual streampos seekpos ( streampos sp, openmode which = in | out ){}
-	virtual int sync ( ){}
+	virtual streambuf * setbuf ( char * s, streamsize n );
+	virtual streampos seekoff ( streamoff off, seekdir way, openmode which = in | out );
+	virtual streampos seekpos ( streampos sp, openmode which = in | out );
+	virtual int sync ( );
 
 //	Input functions (get):
-	virtual streamsize showmanyc ( ){}
-	virtual streamsize xsgetn ( char * s, streamsize n ){}
-	virtual int underflow ( ){}
-	virtual int uflow ( ){}
-	virtual int pbackfail ( int c = EOF ){}
+	virtual streamsize showmanyc ( );
+	virtual streamsize xsgetn ( char * s, streamsize n );
+	virtual int underflow ( );
+	virtual int uflow ( );
+	virtual int pbackfail ( int c = EOF );
 
 //	Output functions (put):
-	virtual streamsize xsputn ( const char * s, streamsize n ){}
-	virtual int overflow ( int c = EOF ){}
+	virtual streamsize xsputn ( const char * s, streamsize n );
+	virtual int overflow ( int c = EOF );
 
 
 };


### PR DESCRIPTION
Fixed parse errors in operational mode to pass esbmc-cpp11/ch2_01.

### Before: 
```
/home/kunjian/ESBMC_Project/esbmc/src/cpp/library/cstdio:23:13: error: cannot form a reference to 'void'
typedef void& FILE;
            ^
/home/kunjian/ESBMC_Project/esbmc/src/cpp/library/cstdio:57:7: error: declaration of 'vsprintf' has a different language linkage
  int vsprintf(char * str, const char * format, va_list arg);
      ^
/home/kunjian/ESBMC_Project/esbmc/src/cpp/library/cstdarg:23:5: note: previous declaration is here
int vsprintf(char * str, const char * format, va_list arg);
...
...
/home/kunjian/ESBMC_Project/esbmc/src/cpp/library/cstdio:83:37: error: 'position' declared as a pointer to a reference of type 'fpos_t' (aka 'int &')
  int fgetpos(FILE * stream, fpos_t * position);
                                    ^
/home/kunjian/ESBMC_Project/esbmc/src/cpp/library/cstdio:87:30: warning: 'const' qualifier on reference type 'fpos_t' (aka 'int &') has no effect [-Wignored-qualifiers]
  int fsetpos(FILE * stream, const fpos_t * pos);
                             ^~~~~~
/home/kunjian/ESBMC_Project/esbmc/src/cpp/library/cstdio:87:43: error: 'pos' declared as a pointer to a reference of type 'fpos_t' (aka 'int &')
  int fsetpos(FILE * stream, const fpos_t * pos);
                                          ^
### ERROR:
PARSING ERROR
```


### After: 
```
### ERROR:
Conversion of unsupported clang expr: "CXXTemporaryObjectExpr" to expression
CXXTemporaryObjectExpr 0x80a95f8 </home/kunjian/ESBMC_Project/esbmc/src/cpp/library/ios:148:10, col:19> 'std::ios_base' 'void ()'
```