### PR TITLE
Skip assignment in value-set analysis for structure dereferences of incompatible types

### DIFF
--- a/regression/esbmc/github_669-empty-struct/main.c
+++ b/regression/esbmc/github_669-empty-struct/main.c
@@ -1,0 +1,5 @@
+// main.i
+typedef struct {
+} a;
+int b;
+void func1() { a c = *(a *)&b; }

--- a/regression/esbmc/github_669-empty-struct/test.desc
+++ b/regression/esbmc/github_669-empty-struct/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function func1
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_669-empty-union/main.c
+++ b/regression/esbmc/github_669-empty-union/main.c
@@ -1,0 +1,5 @@
+// main.i
+typedef union {
+} a;
+int b;
+void func1() { a c = *(a *)&b; }

--- a/regression/esbmc/github_669-empty-union/test.desc
+++ b/regression/esbmc/github_669-empty-union/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function func1
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_669-struct-union/main.c
+++ b/regression/esbmc/github_669-struct-union/main.c
@@ -1,0 +1,5 @@
+// main.i
+typedef struct { int x;
+} a;
+union { int x; } b;
+void func1() { a c = *(a *)&b; }

--- a/regression/esbmc/github_669-struct-union/test.desc
+++ b/regression/esbmc/github_669-struct-union/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function func1
+^\s*dereference failure:
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_669-struct/main.c
+++ b/regression/esbmc/github_669-struct/main.c
@@ -1,0 +1,5 @@
+// main.i
+typedef struct { float x;
+} a;
+int b;
+void func1() { a c = *(a *)&b; }

--- a/regression/esbmc/github_669-struct/test.desc
+++ b/regression/esbmc/github_669-struct/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function func1
+^\s*dereference failure:
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_669-union-struct/main.c
+++ b/regression/esbmc/github_669-union-struct/main.c
@@ -1,0 +1,5 @@
+// main.i
+typedef union { int x;
+} a;
+struct { int x; } b;
+void func1() { a c = *(a *)&b; }

--- a/regression/esbmc/github_669-union-struct/test.desc
+++ b/regression/esbmc/github_669-union-struct/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function func1
+^\s*dereference failure:
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_669-union/main.c
+++ b/regression/esbmc/github_669-union/main.c
@@ -1,0 +1,5 @@
+// main.i
+typedef union { float x;
+} a;
+int b;
+void func1() { a c = *(a *)&b; }

--- a/regression/esbmc/github_669-union/test.desc
+++ b/regression/esbmc/github_669-union/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function func1
+^\s*dereference failure:
+^VERIFICATION FAILED$

--- a/scripts/competitions/svcomp/stats-300s.txt
+++ b/scripts/competitions/svcomp/stats-300s.txt
@@ -1,9 +1,9 @@
 Statistics:          15648 Files
-  correct:            8448
-    correct true:     5130
-    correct false:    3318
+  correct:            8431
+    correct true:     5121
+    correct false:    3310
   incorrect:            53
     incorrect true:     24
     incorrect false:    29
-  unknown:            7147
-  Score:             12346 (max: 25567)
+  unknown:            7164
+  Score:             12320 (max: 25567)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -148,8 +148,10 @@ void goto_symext::symex_assign(
   const code_assign2t &code = to_code_assign2t(code_assign);
 
   // Sanity check: if the target has zero size, then we've ended up assigning
-  // to/from a C++ POD class with no fields. The rest of the model checker isn't
-  // rated for dealing with this concept; perform a NOP.
+  // to/from either a C++ POD class with no fields or an empty C struct or
+  // union. The rest of the model checker isn't rated for dealing with this
+  // concept; perform a NOP.
+  /* TODO: either we support empty classes/structs/unions, or we don't. */
   try
   {
     if(is_structure_type(code.target->type))

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -152,19 +152,13 @@ void goto_symext::symex_assign(
   // union. The rest of the model checker isn't rated for dealing with this
   // concept; perform a NOP.
   /* TODO: either we support empty classes/structs/unions, or we don't. */
-  try
+  if(is_structure_type(code.target->type))
   {
-    if(is_structure_type(code.target->type))
-    {
-      const struct_type2t &t2 =
-        static_cast<const struct_type2t &>(*code.target->type);
+    const struct_union_data &t2 =
+      static_cast<const struct_union_data &>(*code.target->type);
 
-      if(!t2.members.size())
-        return;
-    }
-  }
-  catch(const array_type2t::dyn_sized_array_excp &)
-  {
+    if(t2.members.empty())
+      return;
   }
 
   expr2tc original_lhs = code.target;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -152,7 +152,7 @@ void goto_symext::symex_assign(
   // rated for dealing with this concept; perform a NOP.
   try
   {
-    if(is_struct_type(code.target->type))
+    if(is_structure_type(code.target->type))
     {
       const struct_type2t &t2 =
         static_cast<const struct_type2t &>(*code.target->type);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1061,10 +1061,10 @@ void value_sett::assign(
     }
     else
     {
-      /* types do not agree, this can happen during for dereferences like this:
+      /* types do not agree, this can happen during dereferences like this:
        *   struct S { int x; } a;
        *   int b;
-       *   a = (struct S *)&b;
+       *   a = *(struct S *)&b;
        * and is caught as a dereference_failure by build_reference_to().
        *
        * Thus, we ignore this value-set assignment request here.


### PR DESCRIPTION
This PR fixes #669 by avoiding a crash during assignment in value-set analysis. In particular, if a pointer to a non-structure is type-casted to a structure type, dereferenced and assigned like this
```c
typedef struct { [...] } a;
int y;
a x = *(a *)&y;
```
value_sett::assign() would crash as it does expect lhs and rhs to be of the same structure type - an error which the derefence code already caught by guarding. This happens when the structure (struct or union) `a` is non-empty. For empty `a` there is a special case during symex avoiding the crashing assignment, see https://github.com/esbmc/esbmc/issues/669#issuecomment-1091543699.