### PR TITLE
throw only statically allocated exception objects & catch by const-ref

### DIFF
--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -96,7 +96,7 @@ void build_goto_trace(
           goto_trace_step.value =
             build_rhs(smt_conv, SSA_step.original_rhs, msg);
       }
-      catch(type2t::symbolic_type_excp *e)
+      catch(const type2t::symbolic_type_excp &e)
       {
         // Don't add this assignment to the cex if we couldn't build the rhs value
         continue;

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -260,9 +260,9 @@ void goto_symext::track_new_pointer(
       BigInt object_size = type_byte_size(new_type);
       object_size_exp = constant_int2tc(uint_type2(), object_size.to_uint64());
     }
-    catch(array_type2t::dyn_sized_array_excp *e)
+    catch(const array_type2t::dyn_sized_array_excp &e)
     {
-      object_size_exp = typecast2tc(uint_type2(), e->size);
+      object_size_exp = typecast2tc(uint_type2(), e.size);
     }
   }
   else
@@ -807,11 +807,11 @@ void goto_symext::intrinsic_memset(
     {
       tmpsize = type_byte_size(item.object->type).to_int64();
     }
-    catch(array_type2t::dyn_sized_array_excp *e)
+    catch(const array_type2t::dyn_sized_array_excp &e)
     {
       tmpsize = -1;
     }
-    catch(array_type2t::inf_sized_array_excp *e)
+    catch(const array_type2t::inf_sized_array_excp &e)
     {
       tmpsize = -1;
     }
@@ -895,11 +895,11 @@ void goto_symext::intrinsic_memset(
       {
         tmpsize = type_byte_size(item.object->type).to_int64();
       }
-      catch(array_type2t::dyn_sized_array_excp *e)
+      catch(const array_type2t::dyn_sized_array_excp &e)
       {
         tmpsize = -1;
       }
-      catch(array_type2t::inf_sized_array_excp *e)
+      catch(const array_type2t::inf_sized_array_excp &e)
       {
         tmpsize = -1;
       }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -161,9 +161,8 @@ void goto_symext::symex_assign(
         return;
     }
   }
-  catch(array_type2t::dyn_sized_array_excp *foo)
+  catch(const array_type2t::dyn_sized_array_excp &)
   {
-    delete foo;
   }
 
   expr2tc original_lhs = code.target;

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -143,10 +143,10 @@ unsigned int array_type2t::get_width() const
   // Two edge cases: the array can have infinite size, or it can have a dynamic
   // size that's determined by the solver.
   if(size_is_infinite)
-    throw new inf_sized_array_excp();
+    throw inf_sized_array_excp();
 
   if(array_size->expr_id != expr2t::constant_int_id)
-    throw new dyn_sized_array_excp(array_size);
+    throw dyn_sized_array_excp(array_size);
 
   // Otherwise, we can multiply the size of the subtype by the number of elements.
   unsigned int sub_width = subtype->get_width();
@@ -167,7 +167,7 @@ unsigned int pointer_type2t::get_width() const
 
 unsigned int empty_type2t::get_width() const
 {
-  throw new symbolic_type_excp();
+  throw symbolic_type_excp();
 }
 
 unsigned int symbol_type2t::get_width() const
@@ -216,7 +216,7 @@ unsigned int floatbv_type2t::get_width() const
 
 unsigned int code_data::get_width() const
 {
-  throw new symbolic_type_excp();
+  throw symbolic_type_excp();
 }
 
 unsigned int string_type2t::get_width() const

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -610,7 +610,7 @@ void value_sett::get_value_set_rec(
             if(!is_nil_type(subtype))
             {
               if(is_empty_type(subtype))
-                throw new type2t::symbolic_type_excp();
+                throw type2t::symbolic_type_excp();
 
               // Potentially rename,
               const type2tc renamed = ns.follow(subtype);
@@ -628,13 +628,13 @@ void value_sett::get_value_set_rec(
           is_const = false;
         }
       }
-      catch(array_type2t::dyn_sized_array_excp *e)
+      catch(const array_type2t::dyn_sized_array_excp &e)
       { // Nondet'ly sized.
       }
-      catch(array_type2t::inf_sized_array_excp *e)
+      catch(const array_type2t::inf_sized_array_excp &e)
       {
       }
-      catch(type2t::symbolic_type_excp *e)
+      catch(const type2t::symbolic_type_excp &e)
       {
         // This vastly annoying piece of code is making operations on void
         // pointers, or worse. If a void pointer, treat the multiplier of the
@@ -820,7 +820,7 @@ void value_sett::get_reference_set_rec(const expr2tc &expr, object_mapt &dest)
         has_const_index_offset = true;
       }
     }
-    catch(array_type2t::dyn_sized_array_excp *e)
+    catch(const array_type2t::dyn_sized_array_excp &e)
     {
       // Not a constant index offset then.
     }

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -711,7 +711,7 @@ expr2tc bitwuzla_convt::get_array_elem(
 {
   const bitw_smt_ast *ast = dynamic_cast<const bitw_smt_ast *>(array);
   if(ast == nullptr)
-    throw new type2t::symbolic_type_excp();
+    throw type2t::symbolic_type_excp();
 
   size_t size;
   BitwuzlaTerm **indicies, **values, *default_value;

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -687,7 +687,7 @@ expr2tc boolector_convt::get_array_elem(
   // want to catch if the conversion fails
   const btor_smt_ast *ast = dynamic_cast<const btor_smt_ast *>(array);
   if(ast == nullptr)
-    throw new type2t::symbolic_type_excp();
+    throw type2t::symbolic_type_excp();
 
   uint32_t size;
   char **indicies, **values;

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -297,18 +297,18 @@ smt_astt smt_convt::convert_identifier_pointer(
       uint64_t type_size = expr->type->get_width() / 8;
       size = constant_int2tc(ptr_loc_type, BigInt(type_size));
     }
-    catch(array_type2t::dyn_sized_array_excp *e)
+    catch(const array_type2t::dyn_sized_array_excp &e)
     {
-      size = e->size;
+      size = e.size;
     }
-    catch(array_type2t::inf_sized_array_excp *e)
+    catch(const array_type2t::inf_sized_array_excp &e)
     {
       // This can occur when external symbols with no known size are used.
       // in that case, make a reasonable assumption on how large they might be,
       // say, 64k.
       size = constant_int2tc(ptr_loc_type, BigInt(0x10000));
     }
-    catch(type2t::symbolic_type_excp *e)
+    catch(const type2t::symbolic_type_excp &e)
     {
       // Type is empty or code -- something that we can never have a real size
       // for. In that case, create an object of size 1: this means we have a

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -89,7 +89,7 @@ expr2tc expr2t::simplify() const
     else
       return tmp;
   }
-  catch(array_type2t::dyn_sized_array_excp *e)
+  catch(const array_type2t::dyn_sized_array_excp &e)
   {
     // Pretty much anything in any expression could be fouled up by there
     // being a dynamically sized array somewhere in there. In this circumstance,
@@ -1588,7 +1588,7 @@ expr2tc typecast2t::do_simplify() const
 
       return expr2tc();
     }
-    catch(array_type2t::dyn_sized_array_excp *e)
+    catch(const array_type2t::dyn_sized_array_excp &e)
     {
       // Something crazy, and probably C++ based, occurred. Don't attempt to
       // simplify.

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -47,7 +47,7 @@ BigInt type_byte_size_default(const type2tc &type, const BigInt &defaultval)
   {
     return type_byte_size(type);
   }
-  catch(array_type2t::dyn_sized_array_excp *e)
+  catch(const array_type2t::dyn_sized_array_excp &e)
   {
     return defaultval;
   }
@@ -100,12 +100,12 @@ BigInt type_byte_size_bits(const type2tc &type)
     // reasonably return anything anyway, so throw.
     const array_type2t &t2 = to_array_type(type);
     if(t2.size_is_infinite)
-      throw new array_type2t::inf_sized_array_excp();
+      throw array_type2t::inf_sized_array_excp();
 
     expr2tc arrsize = t2.array_size;
     simplify(arrsize);
     if(!is_constant_int2t(arrsize))
-      throw new array_type2t::dyn_sized_array_excp(arrsize);
+      throw array_type2t::dyn_sized_array_excp(arrsize);
 
     BigInt subsize = type_byte_size_bits(t2.subtype);
     const constant_int2t &arrsize_int = to_constant_int2t(arrsize);


### PR DESCRIPTION
The reasons for this non-functional change are discussed at <https://github.com/esbmc/esbmc/discussions/702>.