### PR TITLE
Atexit support

### DIFF
--- a/regression/esbmc/atexit-1/main.c
+++ b/regression/esbmc/atexit-1/main.c
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	if (__VERIFIER_nondet_bool()) _Exit(1); // memory leak, but still reachable
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g2);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+	atexit(free_g1);
+	if (__VERIFIER_nondet_bool()) exit(1);
+	f();
+	return 0;
+}

--- a/regression/esbmc/atexit-1/test.desc
+++ b/regression/esbmc/atexit-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-2/main.c
+++ b/regression/esbmc/atexit-2/main.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	if (__VERIFIER_nondet_bool()) exit(1); // memory leak
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g1);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+	atexit(free_g2);
+//	if (__VERIFIER_nondet_bool()) exit(1);
+	f();
+	free(*g);
+	free(g);
+	g = NULL;
+	return 0;
+}

--- a/regression/esbmc/atexit-2/test.desc
+++ b/regression/esbmc/atexit-2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-2/test.desc
+++ b/regression/esbmc/atexit-2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --memory-leak-check --force-malloc-success
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-2/test.desc
+++ b/regression/esbmc/atexit-2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --memory-leak-check --force-malloc-success
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/atexit-3/main.c
+++ b/regression/esbmc/atexit-3/main.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	exit(1); // memory leak, but still reachable
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g2);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+// 	atexit(free_g1);
+	f();
+	free(*g);
+	free(g);
+	g = NULL;
+	return 0;
+}

--- a/regression/esbmc/atexit-3/test.desc
+++ b/regression/esbmc/atexit-3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-4/main.c
+++ b/regression/esbmc/atexit-4/main.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	if (__VERIFIER_nondet_bool()) exit(1);
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g2);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+	atexit(free_g1);
+	if (__VERIFIER_nondet_bool()) exit(1);
+	f();
+	free(*g);
+	free(g);
+	return 0;
+}
+

--- a/regression/esbmc/atexit-4/test.desc
+++ b/regression/esbmc/atexit-4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -115,7 +115,7 @@ def parse_result(the_output, prop):
 
     if prop == Property.memory:
       if memory_leak in the_output:
-        return Result.fail_memtrack
+        return Result.unknown
 
       if invalid_pointer_free in the_output:
         return Result.fail_free

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -13,12 +13,14 @@ void (*atexit_func[32])();
 
 void __atexit_handler()
 {
+__ESBMC_HIDE:;
   for(short i = atexit_index - 1; i >= 0; --i)
     atexit_func[i]();
 }
 
 int atexit(void (*func)(void))
 {
+__ESBMC_HIDE:;
   // Max of 32 functions can be registered
   if(atexit_index == 32)
     return 1;

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -10,16 +10,12 @@
 
 unsigned short atexit_index = 0;
 void (*atexit_func[32])();
-_Bool atexit_enabled = 1;
 
 void __ESBMC_atexit()
 {
 __ESBMC_HIDE:;
-  if(!atexit_enabled)
-    return;
-
-  for(; atexit_index > 0; --atexit_index)
-    atexit_func[atexit_index - 1]();
+  for(unsigned short i = atexit_index; i > 0; --i)
+    atexit_func[i - 1]();
   __ESBMC_assume(0);
 }
 
@@ -40,18 +36,15 @@ __ESBMC_HIDE:;
 void exit(int status)
 {
   __ESBMC_atexit();
-  __ESBMC_assume(0);
 }
 
 void abort(void)
 {
   __ESBMC_atexit();
-  __ESBMC_assume(0);
 }
 
 void _Exit(int exit_code)
 {
-  atexit_enabled = 0;
   __ESBMC_assume(0);
 }
 #pragma clang diagnostic pop

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -9,23 +9,19 @@
 #undef getenv
 
 short atexit_index = 0;
-void (*atexit_func[32])();
+__attribute__((annotate("__ESBMC_inf_size"))) void (*__ESBMC_atexit_func[1])();
 
-void __atexit_handler()
+void __ESBMC_atexit_handler()
 {
 __ESBMC_HIDE:;
   for(short i = atexit_index - 1; i >= 0; --i)
-    atexit_func[i]();
+    __ESBMC_atexit_func[i]();
 }
 
 int atexit(void (*func)(void))
 {
 __ESBMC_HIDE:;
-  // Max of 32 functions can be registered
-  if(atexit_index == 32)
-    return 1;
-
-  atexit_func[atexit_index] = func;
+  __ESBMC_atexit_func[atexit_index] = func;
   ++atexit_index;
   return 0;
 }
@@ -34,13 +30,13 @@ __ESBMC_HIDE:;
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
 void exit(int status)
 {
-  __atexit_handler();
+  __ESBMC_atexit_handler();
   __ESBMC_assume(0);
 }
 
 void abort(void)
 {
-  __atexit_handler();
+  __ESBMC_atexit_handler();
   __ESBMC_assume(0);
 }
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -21,22 +21,23 @@ __ESBMC_HIDE:;
 
 #pragma clang diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
-void exit(int)
+void exit(int status)
 {
 __ESBMC_HIDE:;
+  (void)status;
   for(int i = atexit_index - 1; i >= 0; --i)
     __ESBMC_atexit_func[i]();
-  __ESBMC_assume(0);
+  __ESBMC_exit_program();
 }
 
 void abort(void)
 {
-  __ESBMC_assume(0);
+  __ESBMC_exit_program();
 }
 
 void _Exit(int exit_code)
 {
-  __ESBMC_assume(0);
+  __ESBMC_exit_program();
 }
 #pragma clang diagnostic pop
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -8,20 +8,17 @@
 #undef atol
 #undef getenv
 
-unsigned short atexit_index = 0;
+short atexit_index = 0;
 void (*atexit_func[32])();
 
-void __ESBMC_atexit()
+void __atexit_handler()
 {
-__ESBMC_HIDE:;
-  for(unsigned short i = atexit_index; i > 0; --i)
-    atexit_func[i - 1]();
-  __ESBMC_assume(0);
+  for(short i = atexit_index - 1; i >= 0; --i)
+    atexit_func[i]();
 }
 
 int atexit(void (*func)(void))
 {
-__ESBMC_HIDE:;
   // Max of 32 functions can be registered
   if(atexit_index == 32)
     return 1;
@@ -35,12 +32,14 @@ __ESBMC_HIDE:;
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
 void exit(int status)
 {
-  __ESBMC_atexit();
+  __atexit_handler();
+  __ESBMC_assume(0);
 }
 
 void abort(void)
 {
-  __ESBMC_atexit();
+  __atexit_handler();
+  __ESBMC_assume(0);
 }
 
 void _Exit(int exit_code)

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -32,10 +32,6 @@ __ESBMC_HIDE:;
 
   atexit_func[atexit_index] = func;
   ++atexit_index;
-
-  // Hack so we can pull the __ESBMC_atexit symbol
-  void *hax = &__ESBMC_atexit;
-  (void)hax;
   return 0;
 }
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -36,7 +36,6 @@ void exit(int status)
 
 void abort(void)
 {
-  __ESBMC_atexit_handler();
   __ESBMC_assume(0);
 }
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -8,15 +8,8 @@
 #undef atol
 #undef getenv
 
-short atexit_index = 0;
+int atexit_index = 0;
 __attribute__((annotate("__ESBMC_inf_size"))) void (*__ESBMC_atexit_func[1])();
-
-void __ESBMC_atexit_handler()
-{
-__ESBMC_HIDE:;
-  for(short i = atexit_index - 1; i >= 0; --i)
-    __ESBMC_atexit_func[i]();
-}
 
 int atexit(void (*func)(void))
 {
@@ -28,9 +21,11 @@ __ESBMC_HIDE:;
 
 #pragma clang diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
-void exit(int status)
+void exit(int)
 {
-  __ESBMC_atexit_handler();
+__ESBMC_HIDE:;
+  for(int i = atexit_index - 1; i >= 0; --i)
+    __ESBMC_atexit_func[i]();
   __ESBMC_assume(0);
 }
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -293,7 +293,6 @@ _Bool __ESBMC_same_object(const void *, const void *);
 void __ESBMC_yield();
 void __ESBMC_atomic_begin();
 void __ESBMC_atomic_end();
-void __ESBMC_atexit_handler();
 
 int __ESBMC_abs(int);
 long int __ESBMC_labs(long int);

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -293,6 +293,7 @@ _Bool __ESBMC_same_object(const void *, const void *);
 void __ESBMC_yield();
 void __ESBMC_atomic_begin();
 void __ESBMC_atomic_end();
+void __ESBMC_atexit();
 
 int __ESBMC_abs(int);
 long int __ESBMC_labs(long int);

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -293,7 +293,7 @@ _Bool __ESBMC_same_object(const void *, const void *);
 void __ESBMC_yield();
 void __ESBMC_atomic_begin();
 void __ESBMC_atomic_end();
-void __ESBMC_atexit();
+void __atexit_handler();
 
 int __ESBMC_abs(int);
 long int __ESBMC_labs(long int);

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -293,6 +293,7 @@ _Bool __ESBMC_same_object(const void *, const void *);
 void __ESBMC_yield();
 void __ESBMC_atomic_begin();
 void __ESBMC_atomic_end();
+void __ESBMC_exit_program();
 
 int __ESBMC_abs(int);
 long int __ESBMC_labs(long int);

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -293,7 +293,7 @@ _Bool __ESBMC_same_object(const void *, const void *);
 void __ESBMC_yield();
 void __ESBMC_atomic_begin();
 void __ESBMC_atomic_end();
-void __atexit_handler();
+void __ESBMC_atexit_handler();
 
 int __ESBMC_abs(int);
 long int __ESBMC_labs(long int);

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -259,8 +259,13 @@ bool clang_main(contextt &context, const messaget &message_handler)
   thread_end_call.location() = symbol.location;
   thread_end_call.function() = symbol_exprt("c:@F@pthread_end_main_hook");
 
+  code_function_callt atexit_call;
+  atexit_call.location() = symbol.location;
+  atexit_call.function() = symbol_exprt("c:@F@__ESBMC_atexit");
+
   init_code.move_to_operands(thread_start_call);
   init_code.move_to_operands(call);
+  init_code.move_to_operands(atexit_call);
   init_code.move_to_operands(thread_end_call);
 
   // add "main"

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -259,13 +259,8 @@ bool clang_main(contextt &context, const messaget &message_handler)
   thread_end_call.location() = symbol.location;
   thread_end_call.function() = symbol_exprt("c:@F@pthread_end_main_hook");
 
-  code_function_callt atexit_call;
-  atexit_call.location() = symbol.location;
-  atexit_call.function() = symbol_exprt("c:@F@__ESBMC_atexit_handler");
-
   init_code.move_to_operands(thread_start_call);
   init_code.move_to_operands(call);
-  init_code.move_to_operands(atexit_call);
   init_code.move_to_operands(thread_end_call);
 
   // add "main"

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -261,7 +261,7 @@ bool clang_main(contextt &context, const messaget &message_handler)
 
   code_function_callt atexit_call;
   atexit_call.location() = symbol.location;
-  atexit_call.function() = symbol_exprt("c:@F@__atexit_handler");
+  atexit_call.function() = symbol_exprt("c:@F@__ESBMC_atexit_handler");
 
   init_code.move_to_operands(thread_start_call);
   init_code.move_to_operands(call);

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -261,7 +261,7 @@ bool clang_main(contextt &context, const messaget &message_handler)
 
   code_function_callt atexit_call;
   atexit_call.location() = symbol.location;
-  atexit_call.function() = symbol_exprt("c:@F@__ESBMC_atexit");
+  atexit_call.function() = symbol_exprt("c:@F@__atexit_handler");
 
   init_code.move_to_operands(thread_start_call);
   init_code.move_to_operands(call);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -676,10 +676,6 @@ void goto_convertt::do_function_call_symbol(
   {
     do_exit(lhs, function, arguments, dest);
   }
-  else if(base_name == "abort")
-  {
-    do_abort(lhs, function, arguments, dest);
-  }
   else if(base_name == "malloc")
   {
     do_malloc(lhs, function, arguments, dest);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -432,25 +432,6 @@ void goto_convertt::do_exit(
   t_a->location = function.location();
 }
 
-void goto_convertt::do_abort(
-  const exprt &,
-  const exprt &function,
-  const exprt::operandst &arguments,
-  goto_programt &dest)
-{
-  if(arguments.size() != 0)
-  {
-    err_location(function);
-    throw "abort expected to have no arguments";
-  }
-
-  // same as assume(false)
-
-  goto_programt::targett t_a = dest.add_instruction(ASSUME);
-  t_a->guard = gen_false_expr();
-  t_a->location = function.location();
-}
-
 void goto_convertt::do_free(
   const exprt &lhs,
   const exprt &function,

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -412,11 +412,6 @@ protected:
     std::list<exprt> &dest);
 
   // some built-in functions
-  void do_abort(
-    const exprt &lhs,
-    const exprt &rhs,
-    const exprt::operandst &arguments,
-    goto_programt &dest);
   void do_atomic_begin(
     const exprt &lhs,
     const exprt &rhs,

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -275,10 +275,9 @@ void execution_statet::symex_step(reachability_treet &art)
       // check whether we reached the end of the main function and
       // whether we are not checking for (local and global) deadlocks and memory leaks.
       // We should end the main thread to avoid exploring further interleavings
-      // TODO: once we support at_exit, we should check this code
       // TODO: we should support verifying memory leaks in multi-threaded C programs.
-      assume(gen_false_expr());
       end_thread();
+      assume(gen_false_expr());
     }
     else
     {

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -267,18 +267,6 @@ void execution_statet::symex_step(reachability_treet &art)
     {
       end_thread();
     }
-    else if(
-      instruction.function == "c:@F@main" &&
-      !options.get_bool_option("deadlock-check") &&
-      !options.get_bool_option("memory-leak-check"))
-    {
-      // check whether we reached the end of the main function and
-      // whether we are not checking for (local and global) deadlocks and memory leaks.
-      // We should end the main thread to avoid exploring further interleavings
-      // TODO: we should support verifying memory leaks in multi-threaded C programs.
-      end_thread();
-      assume(gen_false_expr());
-    }
     else
     {
       // Fall through to base class

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -218,20 +218,6 @@ void execution_statet::symex_step(reachability_treet &art)
   last_insn = &instruction;
 
   merge_gotos();
-  if(break_insn != 0 && break_insn == instruction.location_number)
-  {
-#ifndef _WIN32
-#if !(defined(__arm__) || defined(__aarch64__))
-    __asm__("int $3");
-#else
-    msg.error("Can't trap on ARM, sorry");
-    abort();
-#endif
-#else
-    msg.error("Can't trap on windows, sorry");
-    abort();
-#endif
-  }
 
   // Don't convert if it's a inductive instruction and we are running the base
   // case or forward condition
@@ -257,6 +243,21 @@ void execution_statet::symex_step(reachability_treet &art)
     std::ostringstream oss;
     state.source.pc->output_instruction(ns, "", oss, msg, false);
     msg.result(oss.str());
+  }
+
+  if(break_insn != 0 && break_insn == instruction.location_number)
+  {
+#ifndef _WIN32
+#if !(defined(__arm__) || defined(__aarch64__))
+    __asm__("int $3");
+#else
+    msg.error("Can't trap on ARM, sorry");
+    abort();
+#endif
+#else
+    msg.error("Can't trap on windows, sorry");
+    abort();
+#endif
   }
 
   switch(instruction.type)

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -390,15 +390,16 @@ protected:
   bool run_next_function_ptr_target(bool first);
 
   /**
-   *  Run an intrinsic, something prefixed with __ESBMC.
+   *  Tries to run an intrinsic, something prefixed with __ESBMC.
    *  This looks through a set of intrinsic functions that are implemented in
    *  ESBMC, and calls the appropriate one. Examples include starting a thread,
    *  ending a thread, switching to another thread.
    *  @param call Function call being performed.
    *  @param art Reachability tree we're operating on.
    *  @param symname Name of intrinsic we're calling.
+   *  @return true if a function was called, false otherwise
    */
-  void run_intrinsic(
+  bool run_intrinsic(
     const code_function_call2t &call,
     reachability_treet &art,
     const std::string &symname);

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -293,7 +293,7 @@ void violation_graphml_goto_trace(
         // Due to we reporting the memory leak happening at the end of main's
         // scope, CPA is not able to validate our witness, so let's not add the
         // start_line attribute
-        if(options.get_bool_option("memory-cleanup-check"))
+        if(!options.get_bool_option("memory-cleanup-check"))
           violation_edge.start_line = get_line_number(
             verification_file,
             std::atoi(step.pc->location.get_line().c_str()),

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -291,7 +291,7 @@ void violation_graphml_goto_trace(
         violation_edge.thread_id = std::to_string(step.thread_nr);
 
         // Due to we reporting the memory leak happening at the end of main's
-        // scope, CPA is not able to validate our witness, so let's not add the
+        // scope, CPA is unable to validate our witness, so let's not add the
         // start_line attribute
         if(!options.get_bool_option("memory-cleanup-check"))
           violation_edge.start_line = get_line_number(

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -289,10 +289,15 @@ void violation_graphml_goto_trace(
 
         edget violation_edge(prev_node, violation_node);
         violation_edge.thread_id = std::to_string(step.thread_nr);
-        violation_edge.start_line = get_line_number(
-          verification_file,
-          std::atoi(step.pc->location.get_line().c_str()),
-          options);
+
+        // Due to we reporting the memory leak happening at the end of main's
+        // scope, CPA is not able to validate our witness, so let's not add the
+        // start_line attribute
+        if(options.get_bool_option("memory-cleanup-check"))
+          violation_edge.start_line = get_line_number(
+            verification_file,
+            std::atoi(step.pc->location.get_line().c_str()),
+            options);
 
         graph.edges.push_back(violation_edge);
 

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -513,9 +513,6 @@ void goto_symext::pop_frame()
   cur_state->source.pc = frame.calling_location.pc;
   cur_state->source.prog = frame.calling_location.prog;
 
-  if(!cur_state->guard.is_false())
-    cur_state->guard = frame.entry_guard;
-
   // clear locals from L2 renaming
   for(auto const &it : frame.local_variables)
   {

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -140,6 +140,17 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
     new_state_pc = goto_target; // goto target instruction
     state_pc = cur_state->source.pc;
     state_pc++; // next instruction
+
+    // skip dead instructions
+    if(new_guard_true)
+      while(state_pc != goto_target && !state_pc->is_target())
+        ++state_pc;
+
+    if(state_pc == goto_target)
+    {
+      cur_state->source.pc = goto_target;
+      return; // nothing else to do
+    }
   }
   else
   {

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -598,6 +598,13 @@ bool goto_symext::run_intrinsic(
     return true;
   }
 
+  if(symname == "c:@F@__ESBMC_exit_program")
+  {
+    finish_formula();
+    cur_state->guard.make_false();
+    return true;
+  }
+
   if(symname == "c:@F@__ESBMC_sync_fetch_and_add")
   {
     // Already modelled in builtin_libs

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -569,13 +569,6 @@ void goto_symext::run_intrinsic(
     // Already modelled in builtin_libs
     return;
   }
-  else if(has_prefix(symname, "c:@F@__ESBMC_atexit"))
-  {
-    // Already modelled in builtin_libs
-    expr2tc newcall = func_call.clone();
-    symex_function_call(newcall);
-    return;
-  }
   else
   {
     std::ostringstream oss;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -126,6 +126,12 @@ void goto_symext::assume(const expr2tc &the_assumption)
   if(is_true(assumption))
     return;
 
+  // FIXME: We need to take in consideration if this is actually an assume(0) to
+  // call finish formula (maybe we can pass the assumption and add to the guard of
+  // the assertion?). It is not a big problem right now, because it only checks for
+  // memory leaks
+  finish_formula();
+
   cur_state->guard.guard_expr(assumption);
 
   // Irritatingly, assumption destroys its expr argument

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -126,12 +126,6 @@ void goto_symext::assume(const expr2tc &the_assumption)
   if(is_true(assumption))
     return;
 
-  // FIXME: We need to consider if this is actually an assume(0) to
-  // call finish formula (maybe we can pass the assumption and add to the guard of
-  // the assertion?). It is not a big problem right now, because it only checks for
-  // memory leaks
-  finish_formula();
-
   cur_state->guard.guard_expr(assumption);
 
   // Irritatingly, assumption destroys its expr argument

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -572,6 +572,8 @@ void goto_symext::run_intrinsic(
   else if(has_prefix(symname, "c:@F@__ESBMC_atexit"))
   {
     // Already modelled in builtin_libs
+    expr2tc newcall = func_call.clone();
+    symex_function_call(newcall);
     return;
   }
   else

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -126,7 +126,7 @@ void goto_symext::assume(const expr2tc &the_assumption)
   if(is_true(assumption))
     return;
 
-  // FIXME: We need to take in consideration if this is actually an assume(0) to
+  // FIXME: We need to consider if this is actually an assume(0) to
   // call finish formula (maybe we can pass the assumption and add to the guard of
   // the assertion?). It is not a big problem right now, because it only checks for
   // memory leaks

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -610,12 +610,6 @@ bool goto_symext::run_intrinsic(
     return false;
   }
 
-  if(symname == "c:@F@__ESBMC_atexit_handler")
-  {
-    // Already modelled in builtin_libs
-    return false;
-  }
-
   std::ostringstream oss;
   oss << "Function call to non-intrinsic prefixed with __ESBMC";
   oss << " (fatal)\nThe name in question: " << symname;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -563,6 +563,11 @@ void goto_symext::run_intrinsic(
     // Already modelled in builtin_libs
     return;
   }
+  else if(has_prefix(symname, "c:@F@__ESBMC_atexit"))
+  {
+    // Already modelled in builtin_libs
+    return;
+  }
   else
   {
     std::ostringstream oss;

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/migrate.h>
 #include <util/std_expr.h>
 #include <util/message/default_message.h>
+#include <util/prefix.h>
 
 void symex_target_equationt::debug_print_step(const SSA_stept &step) const
 {
@@ -226,7 +227,16 @@ void symex_target_equationt::convert_internal_step(
 
   if(step.is_assert())
   {
-    step.cond_ast = smt_conv.imply_ast(assumpt_ast, step.cond_ast);
+    // HACK: we need to check for memory leak when a program terminates with an assume(0)
+    // An assume(0) means that every path from the point on will be removed from execution
+    // in practice, it means that every guard with be false, including guards that check
+    // for memory leak. So the hack is to always force memory leak check, despite of the
+    smt_astt the_assumpt = assumpt_ast;
+    if(config.options.get_bool_option("memory-leak-check") &&
+       has_prefix(step.comment, "dereference failure: forgotten memory:"))
+      the_assumpt = smt_conv.convert_ast(gen_true_expr());
+
+    step.cond_ast = smt_conv.imply_ast(the_assumpt, step.cond_ast);
     assertions.push_back(smt_conv.invert_ast(step.cond_ast));
   }
   else if(step.is_assume())

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -227,16 +227,7 @@ void symex_target_equationt::convert_internal_step(
 
   if(step.is_assert())
   {
-    // HACK: we need to check for memory leak when a program terminates with an assume(0)
-    // An assume(0) means that every path from the point on will be removed from execution
-    // in practice, it means that every guard with be false, including guards that check
-    // for memory leak. So the hack is to always force memory leak check, despite of the
-    smt_astt the_assumpt = assumpt_ast;
-    if(config.options.get_bool_option("memory-leak-check") &&
-       has_prefix(step.comment, "dereference failure: forgotten memory:"))
-      the_assumpt = smt_conv.convert_ast(gen_true_expr());
-
-    step.cond_ast = smt_conv.imply_ast(the_assumpt, step.cond_ast);
+    step.cond_ast = smt_conv.imply_ast(assumpt_ast, step.cond_ast);
     assertions.push_back(smt_conv.invert_ast(step.cond_ast));
   }
   else if(step.is_assume())

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -581,6 +581,8 @@ void _create_graph_node(
   pDataSpecification.add("<xmlattr>.key", "specification");
   if(options.get_bool_option("overflow-check"))
     pDataSpecification.put_value("CHECK( init(main()), LTL(G ! overflow) )");
+  else if(options.get_bool_option("memory-cleanup-check"))
+    pDataSpecification.put_value("CHECK( init(main()), LTL(G valid-memcleanup) )");
   else if(options.get_bool_option("memory-leak-check"))
     pDataSpecification.put_value(
       "CHECK( init(main()), LTL(G valid-free|valid-deref|valid-memtrack) )");

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -582,7 +582,8 @@ void _create_graph_node(
   if(options.get_bool_option("overflow-check"))
     pDataSpecification.put_value("CHECK( init(main()), LTL(G ! overflow) )");
   else if(options.get_bool_option("memory-cleanup-check"))
-    pDataSpecification.put_value("CHECK( init(main()), LTL(G valid-memcleanup) )");
+    pDataSpecification.put_value(
+      "CHECK( init(main()), LTL(G valid-memcleanup) )");
   else if(options.get_bool_option("memory-leak-check"))
     pDataSpecification.put_value(
       "CHECK( init(main()), LTL(G valid-free|valid-deref|valid-memtrack) )");
@@ -691,6 +692,7 @@ void check_replace_invalid_assignment(std::string &assignment)
   //std::regex e ("SAME-OBJECT\\((&([a-zA-Z_0-9]+)), (&([a-zA-Z_0-9]+))\\)");
   //assignment = std::regex_replace(assignment, e ,"$1 == $3");
   std::smatch m;
+
   /* looking for undesired in the assignment */
   if(
     std::regex_search(assignment, m, std::regex("&dynamic_([0-9]+)_value")) ||

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -109,7 +109,8 @@ inline bool is_constant_expr(const expr2tc &t)
          t->expr_id == expr2t::constant_struct_id ||
          t->expr_id == expr2t::constant_union_id ||
          t->expr_id == expr2t::constant_array_id ||
-         t->expr_id == expr2t::constant_array_of_id;
+         t->expr_id == expr2t::constant_array_of_id ||
+         (is_symbol2t(t) && to_symbol2t(t).get_symbol_name() == "NULL");
 }
 
 inline bool is_structure_type(const type2tc &t)

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -1724,11 +1724,11 @@ static expr2tc simplify_relations(
   else if(is_pointer_type(simplied_side_1) || is_pointer_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      [](const expr2tc &c) -> bool
-    { return is_symbol2t(c) && (to_symbol2t(c).get_symbol_name() == "NULL"); };
+      [](const expr2tc &c) -> bool {
+      return is_symbol2t(c) && (to_symbol2t(c).get_symbol_name() == "NULL");
+    };
 
-    std::function<int &(expr2tc &)> get_value = [](expr2tc &) -> int &
-    {
+    std::function<int &(expr2tc &)> get_value = [](expr2tc &) -> int & {
       int &&z = 0;
       return z;
     };

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -1721,6 +1721,21 @@ static expr2tc simplify_relations(
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
   }
+  else if(is_pointer_type(simplied_side_1) || is_pointer_type(simplied_side_2))
+  {
+    std::function<bool(const expr2tc &)> is_constant =
+      [](const expr2tc &c) -> bool
+    { return is_symbol2t(c) && (to_symbol2t(c).get_symbol_name() == "NULL"); };
+
+    std::function<int &(expr2tc &)> get_value = [](expr2tc &) -> int &
+    {
+      int &&z = 0;
+      return z;
+    };
+
+    simpl_res = TFunctor<int>::simplify(
+      simplied_side_1, simplied_side_2, is_constant, get_value);
+  }
   else
     return expr2tc();
 


### PR DESCRIPTION
This PR implements atexit support, as shipped in the last SV-COMP.

It also adds some small changes so it works with --memcleanup-check.