### PR TITLE
[dereference] simplify resolving dereferences in non-scalar expressions

### DIFF
--- a/scripts/competitions/svcomp/stats-300s.txt
+++ b/scripts/competitions/svcomp/stats-300s.txt
@@ -1,9 +1,9 @@
 Statistics:          15648 Files
-  correct:            8439
+  correct:            8435
     correct true:     5129
-    correct false:    3310
+    correct false:    3306
   incorrect:            53
     incorrect true:     24
     incorrect false:    29
-  unknown:            7156
-  Score:             12336 (max: 25567)
+  unknown:            7160
+  Score:             12332 (max: 25567)

--- a/scripts/competitions/svcomp/stats-300s.txt
+++ b/scripts/competitions/svcomp/stats-300s.txt
@@ -1,9 +1,9 @@
 Statistics:          15648 Files
-  correct:            8435
-    correct true:     5129
-    correct false:    3306
+  correct:            8439
+    correct true:     5130
+    correct false:    3309
   incorrect:            53
     incorrect true:     24
     incorrect false:    29
-  unknown:            7160
-  Score:             12332 (max: 25567)
+  unknown:            7156
+  Score:             12337 (max: 25567)

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -2884,6 +2884,7 @@ public:
   index2t(const type2tc &type, const expr2tc &source, const expr2tc &index)
     : index_expr_methods(type, index_id, source, index)
   {
+    assert(is_array_type(source) || is_string_type(source));
   }
   index2t(const index2t &ref) = default;
 

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -362,7 +362,6 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     // Check that either the base type that these steps are applied to matches
     // the type of the object we're wrapping in these steps. It's a type error
     // if there isn't a match.
-    // assert((*scalar_step_list.front()->get_sub_expr(0))->type == expr->type);
     type2tc base_of_steps_type = ns.follow(expr->type);
 
     if(dereference_type_compare(expr, base_of_steps_type))
@@ -400,12 +399,8 @@ expr2tc dereferencet::dereference_expr_nonscalar(
   }
 
   if(is_member2t(expr))
-  {
-    member2t &memb = to_member2t(expr);
-    expr2tc res =
-      dereference_expr_nonscalar(memb.source_value, guard, mode, base);
-    return res;
-  }
+    return dereference_expr_nonscalar(
+      to_member2t(expr).source_value, guard, mode, base);
 
   if(is_index2t(expr))
   {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -432,6 +432,8 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 
   if(is_if2t(expr) && !is_scalar_type(expr))
   {
+    assert(0);
+
     guardt g1 = guard, g2 = guard;
     const if2t &theif = to_if2t(expr);
     g1.add(theif.cond);

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -396,29 +396,6 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     return result;
   }
 
-  if(is_index2t(expr) && is_pointer_type(to_index2t(expr).source_value))
-  {
-    assert(0);
-    index2t &index = to_index2t(expr);
-
-    // Determine offset accumulated to this point (computed in bytes)
-    expr2tc size_check_expr =
-      wrap_in_scalar_step_list(expr, scalar_step_list, guard);
-    expr2tc offset_to_scalar = compute_pointer_offset_bits(size_check_expr);
-    simplify(offset_to_scalar);
-
-    // first make sure there are no dereferences in there
-    dereference_expr(index.source_value, guard, dereferencet::READ);
-    dereference_expr(index.index, guard, dereferencet::READ);
-
-    add2tc tmp(index.source_value->type, index.source_value, index.index);
-
-    const type2tc &to_type = scalar_step_list.back()->type;
-
-    expr2tc result = dereference(tmp, to_type, guard, mode, offset_to_scalar);
-    return result;
-  }
-
   if(is_typecast2t(expr))
   {
     // Just blast straight through

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -171,8 +171,20 @@ void dereferencet::dereference_expr(expr2tc &expr, guardt &guard, modet mode)
     break;
 
   case expr2t::dereference_id:
-    dereference_deref(expr, guard, mode);
+  {
+    /* Interpret an actual dereference expression. First dereferences the
+     * pointer expression, then dereferences the pointer itself, and stores the
+     * result in 'expr'. */
+    assert(is_dereference2t(expr));
+    dereference2t &deref = to_dereference2t(expr);
+    // first make sure there are no dereferences in there
+    dereference_expr(deref.value, guard, dereferencet::READ);
+
+    expr2tc tmp_obj = deref.value;
+    expr2tc result = dereference(tmp_obj, deref.type, guard, mode, expr2tc());
+    expr = result;
     break;
+  }
 
   case expr2t::index_id:
   case expr2t::member_id:
@@ -336,18 +348,6 @@ void dereferencet::dereference_addrof_expr(
   // arithmetic that contains another dereference. So we need to re-deref this
   // new expression.
   dereference_expr(expr, guard, mode);
-}
-
-void dereferencet::dereference_deref(expr2tc &expr, guardt &guard, modet mode)
-{
-  assert(is_dereference2t(expr));
-  dereference2t &deref = to_dereference2t(expr);
-  // first make sure there are no dereferences in there
-  dereference_expr(deref.value, guard, dereferencet::READ);
-
-  expr2tc tmp_obj = deref.value;
-  expr2tc result = dereference(tmp_obj, deref.type, guard, mode, expr2tc());
-  expr = result;
 }
 
 expr2tc dereferencet::dereference_expr_nonscalar(

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -398,6 +398,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 
   if(is_index2t(expr) && is_pointer_type(to_index2t(expr).source_value))
   {
+    assert(0);
     index2t &index = to_index2t(expr);
 
     // Determine offset accumulated to this point (computed in bytes)

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -351,7 +351,7 @@ void dereferencet::dereference_addrof_expr(
 }
 
 expr2tc dereferencet::dereference_expr_nonscalar(
-  expr2tc &expr,
+  const expr2tc &expr,
   guardt &guard,
   modet mode,
   std::list<expr2tc> &scalar_step_list)
@@ -392,7 +392,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     expr2tc offset_to_scalar = compute_pointer_offset_bits(size_check_expr);
     simplify(offset_to_scalar);
 
-    dereference2t &deref = to_dereference2t(expr);
+    dereference2t deref = to_dereference2t(expr);
     // first make sure there are no dereferences in there
     dereference_expr(deref.value, guard, dereferencet::READ);
 
@@ -421,10 +421,11 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 
   if(is_index2t(expr))
   {
-    dereference_expr(to_index2t(expr).index, guard, dereferencet::READ);
-    scalar_step_list.push_front(expr);
+    index2tc index = to_index2t(expr);
+    dereference_expr(index->index, guard, dereferencet::READ);
+    scalar_step_list.push_front(index);
     expr2tc res = dereference_expr_nonscalar(
-      to_index2t(expr).source_value, guard, mode, scalar_step_list);
+      index->source_value, guard, mode, scalar_step_list);
     scalar_step_list.pop_front();
     return res;
   }
@@ -432,7 +433,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
   if(is_if2t(expr) && !is_scalar_type(expr))
   {
     guardt g1 = guard, g2 = guard;
-    if2t &theif = to_if2t(expr);
+    const if2t &theif = to_if2t(expr);
     g1.add(theif.cond);
     g2.add(not2tc(theif.cond));
 
@@ -457,7 +458,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 
   if(is_constant_union2t(expr))
   {
-    constant_union2t &u = to_constant_union2t(expr);
+    const constant_union2t &u = to_constant_union2t(expr);
     /* In the frontend (until the SMT counter-example), constant union
      * expressions should have a single initializer expression, see also the
      * comment for constant_union2t in <irep2/itep2_expr.h>. */

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -368,6 +368,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     // if there isn't a match.
     type2tc base_of_steps_type =
       (*scalar_step_list.front()->get_sub_expr(0))->type;
+    assert(base_of_steps_type == expr->type);
     base_of_steps_type = ns.follow(base_of_steps_type);
 
     expr2tc size_check_expr = expr;

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -411,29 +411,6 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     return res;
   }
 
-  if(is_if2t(expr) && !is_scalar_type(expr))
-  {
-    assert(0);
-
-    guardt g1 = guard, g2 = guard;
-    if2t &theif = to_if2t(expr);
-    g1.add(theif.cond);
-    g2.add(not2tc(theif.cond));
-
-    expr2tc res1 = dereference_expr_nonscalar(theif.true_value, g1, mode, base);
-
-    expr2tc res2 =
-      dereference_expr_nonscalar(theif.false_value, g2, mode, base);
-
-    if(is_nil_expr(res1))
-      res1 = theif.true_value;
-    if(is_nil_expr(res2))
-      res2 = theif.true_value;
-
-    expr2tc fin = if2tc(res1->type, theif.cond, res1, res2);
-    return fin;
-  }
-
   if(is_constant_union2t(expr))
   {
     constant_union2t &u = to_constant_union2t(expr);

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -341,35 +341,13 @@ void dereferencet::dereference_addrof_expr(
 void dereferencet::dereference_deref(expr2tc &expr, guardt &guard, modet mode)
 {
   assert(is_dereference2t(expr));
-  if(1)
-  {
-    dereference2t &deref = to_dereference2t(expr);
-    // first make sure there are no dereferences in there
-    dereference_expr(deref.value, guard, dereferencet::READ);
+  dereference2t &deref = to_dereference2t(expr);
+  // first make sure there are no dereferences in there
+  dereference_expr(deref.value, guard, dereferencet::READ);
 
-    expr2tc tmp_obj = deref.value;
-    expr2tc result = dereference(tmp_obj, deref.type, guard, mode, expr2tc());
-    expr = result;
-  }
-  else
-  {
-    // This is an index applied to a pointer, which is essentially a dereference
-    // with an offset.
-    assert(is_index2t(expr) && is_pointer_type(to_index2t(expr).source_value));
-    std::list<expr2tc> scalar_step_list;
-    assert(
-      (is_scalar_type(expr) || is_code_type(expr)) &&
-      "Can't dereference to a nonscalar type");
-    index2t &idx = to_index2t(expr);
-
-    // first make sure there are no dereferences in there
-    dereference_expr(idx.index, guard, dereferencet::READ);
-    dereference_expr(idx.source_value, guard, mode);
-
-    add2tc tmp(idx.source_value->type, idx.source_value, idx.index);
-    // Result discarded.
-    expr = dereference(tmp, tmp->type, guard, mode, expr2tc());
-  }
+  expr2tc tmp_obj = deref.value;
+  expr2tc result = dereference(tmp_obj, deref.type, guard, mode, expr2tc());
+  expr = result;
 }
 
 expr2tc dereferencet::dereference_expr_nonscalar(

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -413,9 +413,10 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 
   if(is_member2t(expr))
   {
+    const member2t &memb = to_member2t(expr);
     scalar_step_list.push_front(expr);
     expr2tc res = dereference_expr_nonscalar(
-      to_member2t(expr).source_value, guard, mode, scalar_step_list);
+      memb.source_value, guard, mode, scalar_step_list);
     scalar_step_list.pop_front();
     return res;
   }

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -340,7 +340,8 @@ void dereferencet::dereference_addrof_expr(
 
 void dereferencet::dereference_deref(expr2tc &expr, guardt &guard, modet mode)
 {
-  if(is_dereference2t(expr))
+  assert(is_dereference2t(expr));
+  if(1)
   {
     dereference2t &deref = to_dereference2t(expr);
     // first make sure there are no dereferences in there

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -379,6 +379,10 @@ expr2tc dereferencet::dereference_expr_nonscalar(
 {
   if(is_dereference2t(expr))
   {
+    /* The first expression we're called with is index2t, member2t or non-scalar
+     * if2t. That expression is at the end of scalar_step_list. */
+    assert(!scalar_step_list.empty());
+
     // Check that either the base type that these steps are applied to matches
     // the type of the object we're wrapping in these steps. It's a type error
     // if there isn't a match.

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -359,7 +359,8 @@ expr2tc dereferencet::dereference_expr_nonscalar(
   if(is_dereference2t(expr))
   {
     /* The first expression we're called with is index2t, member2t or non-scalar
-     * if2t. That expression is at the end of scalar_step_list. */
+     * if2t. That expression (or one of its branches in case of if2t) is at the
+     * end of scalar_step_list. */
     assert(!scalar_step_list.empty());
 
     // Check that either the base type that these steps are applied to matches

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -363,14 +363,9 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     // the type of the object we're wrapping in these steps. It's a type error
     // if there isn't a match.
     type2tc base_of_steps_type = ns.follow(expr->type);
-
-    if(dereference_type_compare(expr, base_of_steps_type))
+    if(!dereference_type_compare(expr, base_of_steps_type))
     {
-      // We can just reconstruct this.
-    }
-    else
-    {
-      // We can't reconstruct this. The base types are incompatible.
+      // The base types are incompatible.
       bad_base_type_failure(
         guard, get_type_id(*expr->type), get_type_id(*base_of_steps_type));
       return expr2tc();
@@ -384,11 +379,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     // first make sure there are no dereferences in there
     dereference_expr(deref.value, guard, dereferencet::READ);
 
-    const type2tc &to_type = base->type;
-
-    expr2tc result =
-      dereference(deref.value, to_type, guard, mode, offset_to_scalar);
-    return result;
+    return dereference(deref.value, base->type, guard, mode, offset_to_scalar);
   }
 
   if(is_typecast2t(expr))
@@ -406,9 +397,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
   {
     index2t &index = to_index2t(expr);
     dereference_expr(index.index, guard, dereferencet::READ);
-    expr2tc res =
-      dereference_expr_nonscalar(index.source_value, guard, mode, base);
-    return res;
+    return dereference_expr_nonscalar(index.source_value, guard, mode, base);
   }
 
   if(is_constant_union2t(expr))
@@ -419,9 +408,8 @@ expr2tc dereferencet::dereference_expr_nonscalar(
      * comment for constant_union2t in <irep2/itep2_expr.h>. */
     assert(u.datatype_members.size() == 1);
     assert(mode != WRITE);
-    expr2tc res =
-      dereference_expr_nonscalar(u.datatype_members.front(), guard, mode, base);
-    return res;
+    return dereference_expr_nonscalar(
+      u.datatype_members.front(), guard, mode, base);
   }
 
   // there should be no sudden transition back to scalars, except through

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -387,9 +387,9 @@ private:
     const expr2tc &byte_array,
     expr2tc offset_bits,
     const guardt &guard);
-  void wrap_in_scalar_step_list(
-    expr2tc &value,
-    std::list<expr2tc> *scalar_step_list,
+  expr2tc wrap_in_scalar_step_list(
+    const expr2tc &value,
+    const std::list<expr2tc> &scalar_step_list,
     const guardt &guard);
   void dereference_failure(
     const std::string &error_class,

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -277,15 +277,6 @@ private:
   virtual void
   dereference_addrof_expr(expr2tc &expr, guardt &guard, modet mode);
 
-  /** Interpret an actual dereference (or pointer-index) expression. First
-   *  dereferences the pointer expression, then dereferences the pointer itself,
-   *  and stores the result in 'expr'.
-   *  @param expr The expression we're going to be dereferencing.
-   *  @param guard Guard of this expression being evaluated.
-   *  @param mode The manner iin which the result of this deref is accessed.
-   */
-  virtual void dereference_deref(expr2tc &expr, guardt &guard, modet mode);
-
   /** Interpret an expression that accesses a nonscalar type. This means that
    *  it's an index or member (or some other glue expr) on top of a dereference
    *  that evaluates to an array or struct. This code collects all of these

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -291,10 +291,10 @@ private:
    *         to build a scalar access to an aggregate type.
    */
   virtual expr2tc dereference_expr_nonscalar(
-    const expr2tc &dest,
+    expr2tc &dest,
     guardt &guard,
     modet mode,
-    std::list<expr2tc> &scalar_step_list);
+    const expr2tc &base);
 
   /** Check whether an (aggregate) type is compatible with the desired
    *  dereference type. This looks at various things, such as whether the given

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -284,9 +284,9 @@ private:
    *  that we can directly build a reference to the field this expr wants. This
    *  means that we don't have to build any intermediate struct or array
    *  references, which is beneficial.
-   *  @param dest The expression that we're dereferencing.
+   *  @param dest The expression that we're resolving dereferences in.
    *  @param guard Guard of this expression being evaluated.
-   *  @param mode The manner iin which the result of this deref is accessed.
+   *  @param mode The manner in which the result of this deref is accessed.
    *  @param scalar_step_list A list in which we're accumulating the exprs used
    *         to build a scalar access to an aggregate type.
    */

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -387,10 +387,6 @@ private:
     const expr2tc &byte_array,
     expr2tc offset_bits,
     const guardt &guard);
-  expr2tc wrap_in_scalar_step_list(
-    const expr2tc &value,
-    const std::list<expr2tc> &scalar_step_list,
-    const guardt &guard);
   void dereference_failure(
     const std::string &error_class,
     const std::string &error_name,

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -291,7 +291,7 @@ private:
    *         to build a scalar access to an aggregate type.
    */
   virtual expr2tc dereference_expr_nonscalar(
-    expr2tc &dest,
+    const expr2tc &dest,
     guardt &guard,
     modet mode,
     std::list<expr2tc> &scalar_step_list);

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -279,19 +279,26 @@ private:
 
   /** Interpret an expression that accesses a nonscalar type. This means that
    *  it's an index or member (or some other glue expr) on top of a dereference
-   *  that evaluates to an array or struct. This code collects all of these
-   *  expressions into a list, and supplies it to other dereference code, so
-   *  that we can directly build a reference to the field this expr wants. This
-   *  means that we don't have to build any intermediate struct or array
-   *  references, which is beneficial.
-   *  @param dest The expression that we're resolving dereferences in.
+   *  that evaluates to an array or struct. This code tracks all of these
+   *  index/member expressions, and supplies it to other dereference code, so
+   *  that we can directly build a reference to the field this expr wants by
+   *  the offset selected by the `base` expression. This means that we don't
+   *  have to build any intermediate struct or array references, which is
+   *  beneficial.
+   *
+   *  Note that `expr` is modified in order to remove dereferences such as for
+   *  `array[*ptr]`. On success the result of the member/index chain `base` with
+   *  a dereference at the end is returned. Otherwise the empty expr2tc() is
+   *  returned to indicate that there was no dereference at the end of the
+   *  index/member chain.
+   *
+   *  @param expr The expression that we're resolving dereferences in.
    *  @param guard Guard of this expression being evaluated.
    *  @param mode The manner in which the result of this deref is accessed.
-   *  @param scalar_step_list A list in which we're accumulating the exprs used
-   *         to build a scalar access to an aggregate type.
+   *  @param base The expression matching the initial `expr` in this recursion.
    */
   virtual expr2tc dereference_expr_nonscalar(
-    expr2tc &dest,
+    expr2tc &expr,
     guardt &guard,
     modet mode,
     const expr2tc &base);


### PR DESCRIPTION
`dereference_expr_nonscalar()` is invoked for member and index accesses and should perform all necessary dereferences inside such an expression. It does feature an optimization by which the intermediate arrays, structs or unions are not created but the target of right type is extracted from the intended offset. This was done through re-construction of the original expression but with the intermediate dereferences resolved. Building this re-constructed expression is not necessary.

This PR
- simplifies the computation by avoiding reconstruction of the basic expression and instead modifying the given one,
- introduces an assertion that index2t only operates on array- or string-typed source expressions (which already holds true), and
- thus removes all cases where the dereference_expr_*() checked for index2t applied to a pointer source operand.

I realize the last item is contrary to @mikhailramalho's suggestion in #725. I'm open to re-introduce these cases later. At least the `scalar_step_list` issue would be gone with these non-functional changes and they provide a basis for moving further on #725, I think.