### PR TITLE
[dereference] RFC: missed first pointer_guard

### DIFF
--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -690,7 +690,7 @@ expr2tc boolector_convt::get_array_elem(
     throw type2t::symbolic_type_excp();
 
   uint32_t size;
-  char **indicies, **values;
+  char **indicies = nullptr, **values = nullptr;
   boolector_array_assignment(btor, ast->a, &indicies, &values, &size);
 
   expr2tc ret = gen_zero(subtype);


### PR DESCRIPTION
This PR is a request for comments on the way target expressions for pointer-dereferences are built:

The general strategy is:
1. get the value-set of the pointer (this is the set of all statically known expressions referring into existing symbols or `unknown2t`/`invalid2t`)
2. for each element of this value-set, reconstruct a canonical expression corresponding to the proper member/index/etc. of the referenced symbol
3. combine all these possible target expressions into a single (potentially big) if-then-else chain that looks something like this:
   ```
   pointer_guard ? deref-expression :
   pointer_guard' ? deref-expression' :
   [...] :
   pointer_guard'' ? deref-expression'' :
   deref-expression'''
   ```
   where each pointer-guard (usually) just says "ptr points into target object" (`same_object2t`).

In particular, if there are n > 0 "deref-expression"s in the expr constructed in step 3., then there are only (n-1) "pointer_guard" conditions. The pointer_guard''' for the last one is missing.

- Q1: Is this deliberate? If so, why is it OK to ignore this condition?

In case there are no deref-expressions constructed in step 3., the final result will only contain an "failed symbol". My understanding is that this is done in order for the formula to be well-typed, according to the comment.

In the changes below (ontop of #734, but that's unrelated to this RFC) I modified 3. to always include the last pointer_guard''' this way:
```
[...] pointer_guard''' ? deref-expression''' : failed-symbol
```

Obviously, this is where the timeouts on the regression test come from and why I wouldn't consider this PR for merging.

But it also uncovers
```
The following tests FAILED:
	126 - regression/esbmc-unix/03_bzip2smp_comb_01 (Failed)
	127 - regression/esbmc-unix/03_bzip2smp_comb_01_new (Failed)
```
and those I would argue should indeed fail (maybe more gracefully, but nonetheless), because of #584:
```
esbmc: /home/runner/work/esbmc/esbmc/src/pointer-analysis/value_set.cpp:1477: expr2tc value_sett::make_member(const expr2tc&, const irep_idt&): Assertion `is_struct_type(type) || is_union_type(type)' failed.
```
Here, a member into an integer is being constructed for the call to the variadic `fprintf()` - for `--64`, not for `--32`, because `va_list` is an integer on 32-bit but a struct on 64-bit. Currently, ESBMC does not discover this error.

- Q2: Should ESBMC discover this error and should these two tests actually fail at present given that #584 is still open?
- Q3: Could the detection of the above error be performed elsewhere without this performance impact?
- Q4: The commented check for compatibility of `code`-typed expressions https://github.com/esbmc/esbmc/compare/fb/clean-deref...fb/fix-deref-ptr-guard?expand=1#diff-9dcd999b4a44708c24c5034535db0651d745530f1a99331df62b32c2f9621c6cR543-R559 would result in further regression tests being identified as broken (see comment there). Should they? 