### PR TITLE
[dereference] add previously missed pointer_guard when value-set is not known to be exhaustive

### DIFF
--- a/scripts/competitions/svcomp/stats-300s.txt
+++ b/scripts/competitions/svcomp/stats-300s.txt
@@ -1,9 +1,9 @@
 Statistics:          15648 Files
-  correct:            8394
-    correct true:     5082
-    correct false:    3312
-  incorrect:            49
-    incorrect true:     23
-    incorrect false:    26
-  unknown:            7205
-  Score:             12324 (max: 25567)
+  correct:            8457
+    correct true:     5132
+    correct false:    3325
+  incorrect:            54
+    incorrect true:     25
+    incorrect false:    29
+  unknown:            7137
+  Score:             12325 (max: 25567)

--- a/scripts/competitions/svcomp/stats-300s.txt
+++ b/scripts/competitions/svcomp/stats-300s.txt
@@ -1,9 +1,9 @@
 Statistics:          15648 Files
-  correct:            8439
-    correct true:     5130
-    correct false:    3309
-  incorrect:            53
-    incorrect true:     24
-    incorrect false:    29
-  unknown:            7156
-  Score:             12337 (max: 25567)
+  correct:            8394
+    correct true:     5082
+    correct false:    3312
+  incorrect:            49
+    incorrect true:     23
+    incorrect false:    26
+  unknown:            7205
+  Score:             12324 (max: 25567)

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -315,7 +315,7 @@ inline expr2tc gen_zero(const type2tc &type, bool array_as_array_of = false)
   }
 
   case type2t::pointer_id:
-    return symbol2tc(pointer_type2(), "NULL");
+    return symbol2tc(type, "NULL");
 
   case type2t::struct_id:
   {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -467,14 +467,16 @@ expr2tc dereferencet::dereference(
     if(is_nil_expr(new_value))
       continue;
 
+    assert(!is_nil_expr(pointer_guard));
+
     if(!dereference_type_compare(new_value, type))
     {
+      guardt new_guard(guard);
+      new_guard.add(pointer_guard);
       bad_base_type_failure(
-        guard, get_type_id(*type), get_type_id(*new_value->type));
+        new_guard, get_type_id(*type), get_type_id(*new_value->type));
       continue;
     }
-
-    assert(!is_nil_expr(pointer_guard));
 
     // Chain a big if-then-else case.
     value = if2tc(type, pointer_guard, new_value, value);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -981,15 +981,6 @@ void value_sett::get_reference_set_rec(const expr2tc &expr, object_mapt &dest)
   insert(dest, unknown, BigInt(0));
 }
 
-static bool has_sideeffect(const expr2tc &e)
-{
-  if(is_sideeffect2t(e))
-    return true;
-  bool r = false;
-  e->foreach_operand([&r](const expr2tc &e) { r |= has_sideeffect(e); });
-  return r;
-}
-
 void value_sett::assign(
   const expr2tc &lhs,
   const expr2tc &rhs,
@@ -1014,28 +1005,6 @@ void value_sett::assign(
     assign(lhs, xchg_sym, add_to_sets);
 
     erase(xchg_sym->get_symbol_name());
-    return;
-  }
-
-  if(is_if2t(lhs))
-  {
-    /* In case the lhs is an if-expression that means either side could be
-     * assigned to (exclusively). We model this by recording assignments to
-     * both sides, however one of these assignments is guaranteed to be the
-     * identity.
-     */
-    const if2t &ifref = to_if2t(lhs);
-    assert(!has_sideeffect(ifref.cond));
-    assert(!has_sideeffect(ifref.true_value));
-    assert(!has_sideeffect(ifref.false_value));
-    assign(
-      ifref.true_value,
-      if2tc(ifref.type, ifref.cond, rhs, ifref.true_value),
-      add_to_sets);
-    assign(
-      ifref.false_value,
-      if2tc(ifref.type, ifref.cond, ifref.false_value, rhs),
-      add_to_sets);
     return;
   }
 

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -690,7 +690,7 @@ expr2tc boolector_convt::get_array_elem(
     throw type2t::symbolic_type_excp();
 
   uint32_t size;
-  char **indicies, **values;
+  char **indicies = nullptr, **values = nullptr;
   boolector_array_assignment(btor, ast->a, &indicies, &values, &size);
 
   expr2tc ret = gen_zero(subtype);


### PR DESCRIPTION
This PR is a request for comments on the way target expressions for pointer-dereferences are built.

The general strategy is:
1. get the value-set of the pointer (this is the set of all statically known expressions referring into existing symbols or `unknown2t`/`invalid2t`)
2. for each element of this value-set, reconstruct a canonical expression corresponding to the proper member/index/etc. of the referenced symbol
3. combine all these possible target expressions into a single (potentially big) if-then-else chain that looks something like this:
   ```
   pointer_guard ? deref-expression :
   pointer_guard' ? deref-expression' :
   [...] :
   pointer_guard'' ? deref-expression'' :
   deref-expression'''
   ```
   where each pointer-guard (usually) just says "ptr points into target object" (`same_object2t`).

In particular, if there are n > 0 "deref-expression"s in the expr constructed in step 3., then there are only (n-1) "pointer_guard" conditions. The pointer_guard''' for the last one is missing.

- Q1: Is this deliberate? If so, why is it OK to ignore this condition?

In case there are no deref-expressions constructed in step 3., the final result will only contain an "failed symbol". My understanding is that this is done in order for the formula to be well-typed, according to the comment.

**Edit:** @mikhailramalho answered Q1 essentially in positive: In case the value-set is known to be exhaustive and all (n-1) other conditions don't hold, the exhaustiveness guarantee implies that the n'th condition will and thus it does not need to be encoded.

However, the value-set is not known to be exhaustive in presence of unknown2t/invalid2t (whether just for unknown2t expressions is unclear as of yet, but under-approximating the cases when such a guarantee exists does not affect soundness). With this PR, the dereference code in 3. takes into account whether the value-set is known to be exhaustive and if not adds the failed-symbol unconditionally so the now constructed expression for 3. when the exhaustiveness is not guaranteed looks like:
   ```
   pointer_guard ? deref-expression :
   pointer_guard' ? deref-expression' :
   [...] :
   pointer_guard'' ? deref-expression'' :
   pointer_guard''' ? deref-expression''' : failed-symbol
   ```


### *Below considerations not relevant anymore.*

In the changes of this RFC I modified 3. to always include the last pointer_guard''' this way:
```
[...] pointer_guard''' ? deref-expression''' : failed-symbol
```

Obviously, this is where the timeouts on the regression test come from and why I wouldn't consider this PR for merging.

But it also uncovers
```
The following tests FAILED:
	126 - regression/esbmc-unix/03_bzip2smp_comb_01 (Failed)
	127 - regression/esbmc-unix/03_bzip2smp_comb_01_new (Failed)
```
and those I would argue should indeed fail (maybe more gracefully, but nonetheless), because of #584:
```
esbmc: /home/runner/work/esbmc/esbmc/src/pointer-analysis/value_set.cpp:1477: expr2tc value_sett::make_member(const expr2tc&, const irep_idt&): Assertion `is_struct_type(type) || is_union_type(type)' failed.
```
Here, a member into an integer is being constructed for the call to the variadic `fprintf()` - for `--64`, not for `--32`, because `va_list` is an integer on 32-bit but a struct on 64-bit. Currently, ESBMC does not discover this error.

- Q2: Should ESBMC discover this error and should these two tests actually fail at present given that #584 is still open?
- Q3: Could the detection of the above error be performed elsewhere without this performance impact?
- Q4: The commented check for compatibility of `code`-typed expressions https://github.com/esbmc/esbmc/blob/6cbaa832056ddd40dcb5c4b0447aa92ae5a7dff3/src/pointer-analysis/dereference.cpp#L545-L547 would result in further regression tests being identified as broken (see comment there). Should they? 