### PR TITLE
Don't overload guards when leaving a frame

### DIFF
--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -207,9 +207,6 @@ public:
      */
     unsigned int va_index;
 
-    /** Record the entry guard of the function */
-    guardt entry_guard;
-
     /** Record if the function body is hidden */
     bool hidden;
 

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -270,7 +270,6 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   frame.level1.thread_id = cur_state->source.thread_nr;
 
   frame.calling_location = cur_state->source;
-  frame.entry_guard = cur_state->guard;
 
   // assign arguments
   type2tc tmp_type = migrate_type(goto_function.type);

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -499,9 +499,6 @@ void goto_symext::pop_frame()
   cur_state->source.pc = frame.calling_location.pc;
   cur_state->source.prog = frame.calling_location.prog;
 
-  if(!cur_state->guard.is_false())
-    cur_state->guard = frame.entry_guard;
-
   // clear locals from L2 renaming
   for(auto const &it : frame.local_variables)
   {


### PR DESCRIPTION
This is a very weird piece of code that I don't really understand why it should be there.

Pushed here to check the regressions, @rafaelsamenezes can you run this patch in SV-COMP and send me the results?