### PR TITLE
[clang-cpp-frontend] Fix cpp reference

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
                     cbmc cstd llvm floats floats-regression
                     k-induction esbmc-cpp/cpp esbmc-cpp/cbmc csmith
                     k-induction-parallel nonz3 ${REGRESSIONS_BITWUZLA}
-                    incremental-smt esbmc-cpp11/cpp esbmc-cpp11/cbmc-constructors 
+                    incremental-smt esbmc-cpp11/cpp esbmc-cpp11/cbmc-constructors esbmc-cpp11/reference
                     ${REGRESSIONS_GOTO_CONTRACTOR} ${REGRESSIONS_JIMPLE})
 endif()
 

--- a/regression/esbmc-cpp11/reference/Reference1-fail/main.cpp
+++ b/regression/esbmc-cpp11/reference/Reference1-fail/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+
+class t1 {
+public:
+  int i;
+
+  t1(): i(0)
+  {
+  }
+};
+
+int main()
+{
+  t1 instance1;
+  t1 &r = instance1;
+  assert(r.i == 0); // pass
+  r.i = 1;
+  assert(r.i == 2); // fail
+}

--- a/regression/esbmc-cpp11/reference/Reference1-fail/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference1-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/reference/Reference1/main.cpp
+++ b/regression/esbmc-cpp11/reference/Reference1/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+
+class t1 {
+public:
+  int i;
+
+  t1(): i(0)
+  {
+  }
+};
+
+int main()
+{
+  t1 instance1;
+  t1 &r = instance1;
+  assert(r.i == 0); // pass
+  r.i = 1;
+  assert(r.i == 1); // fail
+}

--- a/regression/esbmc-cpp11/reference/Reference1/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/reference/Reference2-fail/main.cpp
+++ b/regression/esbmc-cpp11/reference/Reference2-fail/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+class t1 {
+public:
+  int i;
+
+  t1(): i(0)
+  {
+  }
+};
+
+// Test object reference as function argument
+void increment(t1 &t) {
+  t.i += 1;
+}
+
+int main()
+{
+  t1 instance1;
+  t1 &r = instance1;
+  assert(r.i == 0); // pass
+  increment(r);
+  assert(r.i == 2); // fail
+}

--- a/regression/esbmc-cpp11/reference/Reference2-fail/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference2-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/reference/Reference2/main.cpp
+++ b/regression/esbmc-cpp11/reference/Reference2/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+class t1 {
+public:
+  int i;
+
+  t1(): i(0)
+  {
+  }
+};
+
+// Test object reference as function argument
+void increment(t1 &t) {
+  t.i += 1;
+}
+
+int main()
+{
+  t1 instance1;
+  t1 &r = instance1;
+  assert(r.i == 0); // pass
+  increment(r);
+  assert(r.i == 1); // pass
+}

--- a/regression/esbmc-cpp11/reference/Reference2/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1225,10 +1225,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
   switch(stmt.getStmtClass())
   {
-  /*
-       The following enum values are the the expr of a program,
-       defined on the Expr class
-    */
+  //The following enum values are the the expr of a program,
+  //defined on the Expr class
 
   // Objects that are implicit defined on the code syntax.
   // One example is the gcc ternary operator, which can be:
@@ -1256,6 +1254,10 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     if(get_decl_ref(dcl, new_expr))
       return true;
+
+    // if type is lvalue ref, convert to dereference subtree
+    if(is_lvalue_reference(dcl))
+      assert(!"TODO - convert to dereference subtree");
 
     break;
   }
@@ -3115,4 +3117,19 @@ clang_c_convertert::get_top_FunctionDecl_from_Stmt(const clang::Stmt &stmt)
   }
 
   return nullptr;
+}
+
+bool clang_c_convertert::is_lvalue_reference(const clang::Decl &d)
+{
+  if(const auto *nd = llvm::dyn_cast<clang::ValueDecl>(&d))
+  {
+    const clang::QualType &q_type = nd->getType();
+    const clang::Type &the_type = *q_type.getTypePtrOrNull();
+    if(the_type.getTypeClass() == clang::Type::LValueReference)
+    {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -506,7 +506,19 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
     if(get_expr(*vd.getInit(), val))
       return true;
 
-    gen_typecast(ns, val, t);
+    if (is_lvalue_reference(vd))
+    {
+      // We have converted lvalue reference to pointer in a declaration statement with initialisation.
+      // As a result, generate address_of to match the pointer type.
+      exprt result_expr = exprt("address_of", t);
+      result_expr.move_to_operands(val);
+      val.swap(result_expr);
+    }
+    else
+    {
+      // just typecast to match the type of LHS
+      gen_typecast(ns, val, t);
+    }
 
     added_symbol.value = val;
     decl.operands().push_back(val);

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1257,7 +1257,18 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
     // if type is lvalue ref, convert to dereference subtree
     if(is_lvalue_reference(dcl))
-      assert(!"TODO - convert to dereference subtree");
+    {
+      // get type and make a dereference subtree
+      typet deref_type = new_expr.type().subtype();
+      exprt deref_expr = exprt("dereference", deref_type);
+      // the original subtree will be the operand of dereference subtree
+      deref_expr.move_to_operands(new_expr);
+
+      new_expr.swap(deref_expr);
+
+      // add location node
+      new_expr.location() = location;
+    }
 
     break;
   }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -560,9 +560,9 @@ bool clang_c_convertert::get_function(const clang::FunctionDecl &fd, exprt &)
   std::string id, name;
   get_decl_name(fd, name, id);
 
-  if(id == "c:@F@function#&I#")
+  if(id == "c:@F@main#")
   {
-    printf("Got function\n");
+    printf("Got main\n");
   }
 
   symbolt symbol;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -572,11 +572,6 @@ bool clang_c_convertert::get_function(const clang::FunctionDecl &fd, exprt &)
   std::string id, name;
   get_decl_name(fd, name, id);
 
-  if(id == "c:@F@main#")
-  {
-    printf("Got main\n");
-  }
-
   symbolt symbol;
   get_default_symbol(
     symbol,

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -982,6 +982,17 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     break;
   }
 
+  case clang::Type::LValueReference:
+  {
+    const clang::LValueReferenceType &lvrt =
+      static_cast<const clang::LValueReferenceType &>(the_type);
+
+    if(get_type(lvrt.getPointeeTypeAsWritten(), new_type))
+      return true;
+
+    break;
+  }
+
   case clang::Type::MacroQualified:
   {
     const clang::MacroQualifiedType &macro =

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -560,6 +560,11 @@ bool clang_c_convertert::get_function(const clang::FunctionDecl &fd, exprt &)
   std::string id, name;
   get_decl_name(fd, name, id);
 
+  if (id == "c:@F@function#&I#")
+  {
+    printf("Got function\n");
+  }
+
   symbolt symbol;
   get_default_symbol(
     symbol,
@@ -972,17 +977,6 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
       static_cast<const clang::TypeOfType &>(the_type);
 
     if(get_type(toft.desugar(), new_type))
-      return true;
-
-    break;
-  }
-
-  case clang::Type::LValueReference:
-  {
-    const clang::LValueReferenceType &lvrt =
-      static_cast<const clang::LValueReferenceType &>(the_type);
-
-    if(get_type(lvrt.getPointeeTypeAsWritten(), new_type))
       return true;
 
     break;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1277,7 +1277,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if(is_lvalue_reference(dcl))
     {
       // mark the subtree for adjuster to convert lvalue reference DeclRefExpr
-      printf("@@ Mark the irep and move conversion to adjuster\n");
+      new_expr.set("reference", 1);
       /*
       // get type and make a dereference subtree
       typet deref_type = new_expr.type().subtype();

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -560,7 +560,7 @@ bool clang_c_convertert::get_function(const clang::FunctionDecl &fd, exprt &)
   std::string id, name;
   get_decl_name(fd, name, id);
 
-  if (id == "c:@F@function#&I#")
+  if(id == "c:@F@function#&I#")
   {
     printf("Got function\n");
   }

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -206,6 +206,8 @@ protected:
   const clang::Decl *get_top_FunctionDecl_from_Stmt(const clang::Stmt &stmt);
 
   void gen_typecast_to_union(exprt &dest, const typet &type);
+
+  bool is_lvalue_reference(const clang::Decl &d);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -157,6 +157,18 @@ bool clang_cpp_convertert::get_type(
 {
   switch(the_type.getTypeClass())
   {
+  case clang::Type::LValueReference:
+  {
+    assert(!"cool");
+    const clang::LValueReferenceType &lvrt =
+      static_cast<const clang::LValueReferenceType &>(the_type);
+
+    if(get_type(lvrt.getPointeeTypeAsWritten(), new_type))
+      return true;
+
+    break;
+  }
+
   case clang::Type::SubstTemplateTypeParm:
   {
     const clang::SubstTemplateTypeParmType &substmpltt =

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -159,13 +159,15 @@ bool clang_cpp_convertert::get_type(
   {
   case clang::Type::LValueReference:
   {
-    assert(!"cool");
     const clang::LValueReferenceType &lvrt =
       static_cast<const clang::LValueReferenceType &>(the_type);
 
-    if(get_type(lvrt.getPointeeTypeAsWritten(), new_type))
+    // an lvalue reference is converted to a pointer typet subtree
+    typet sub_type;
+    if(get_type(lvrt.getPointeeTypeAsWritten(), sub_type))
       return true;
 
+    new_type = gen_pointer_type(sub_type);
     break;
   }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -170,7 +170,6 @@ bool clang_cpp_convertert::get_type(
     new_type = gen_pointer_type(sub_type);
     break;
   }
-
   case clang::Type::SubstTemplateTypeParm:
   {
     const clang::SubstTemplateTypeParmType &substmpltt =

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -159,10 +159,11 @@ bool clang_cpp_convertert::get_type(
   {
   case clang::Type::LValueReference:
   {
+    // lvalue reference case:
+    // an lvalue reference is converted to a pointer typet subtree
     const clang::LValueReferenceType &lvrt =
       static_cast<const clang::LValueReferenceType &>(the_type);
 
-    // an lvalue reference is converted to a pointer typet subtree
     typet sub_type;
     if(get_type(lvrt.getPointeeTypeAsWritten(), sub_type))
       return true;
@@ -693,6 +694,7 @@ bool clang_cpp_convertert::get_constructor_call(
     call.arguments().push_back(single_arg);
   }
 
+  // set "constructor" node for adjuster
   call.set("constructor", 1);
 
   // Now, if we built a new object, then we must build a temporary

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -46,20 +46,10 @@ void show_symbol_table_plain(
       std::string type_str, value_str;
 
       if(s.type.is_not_nil())
-      {
-        out << "@@ Printing type for: " << s.id.c_str() << "\n";
-        out << s.type.pretty(0) << "\n";
-        out << "@@ Done printing type for: " << s.id.c_str() << "\n";
         p->from_type(s.type, type_str, ns);
-      }
 
       if(s.value.is_not_nil())
-      {
-        out << "@@ Printing value for: " << s.id.c_str() << "\n";
-        out << s.value.pretty(0) << "\n";
-        out << "@@ Done printing value for: " << s.id.c_str() << "\n";
         p->from_expr(s.value, value_str, ns);
-      }
 
       out << "Symbol......: " << s.id << "\n";
       out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -46,10 +46,20 @@ void show_symbol_table_plain(
       std::string type_str, value_str;
 
       if(s.type.is_not_nil())
+      {
+        out << "@@ Printing type for: " << s.id.c_str() << "\n";
+        out << s.type.pretty(0) << "\n";
+        out << "@@ Done printing type for: " << s.id.c_str() << "\n";
         p->from_type(s.type, type_str, ns);
+      }
 
       if(s.value.is_not_nil())
+      {
+        out << "@@ Printing value for: " << s.id.c_str() << "\n";
+        out << s.value.pretty(0) << "\n";
+        out << "@@ Done printing value for: " << s.id.c_str() << "\n";
         p->from_expr(s.value, value_str, ns);
+      }
 
       out << "Symbol......: " << s.id << "\n";
       out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -46,10 +46,20 @@ void show_symbol_table_plain(
       std::string type_str, value_str;
 
       if(s.type.is_not_nil())
+      {
+        out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+        out << s.type.pretty(0) << "\n";
+        out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
         p->from_type(s.type, type_str, ns);
+      }
 
       if(s.value.is_not_nil())
+      {
+        out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+        out << s.value.pretty(0) << "\n";
+        out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
         p->from_expr(s.value, value_str, ns);
+      }
 
       out << "Symbol......: " << s.id << "\n";
       out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
Implemented generalized method to handle lvalue reference in Issue https://github.com/esbmc/esbmc/issues/736 

Also resolved problems for lvalue reference in function callsite (CallExpr) and initialisation (DeclStmt) documented in https://github.com/esbmc/esbmc/issues/736#issuecomment-1157590502 and https://github.com/esbmc/esbmc/issues/736#issuecomment-1157607950. 
