### PR TITLE
[z3] delete all smt_asts before destroying the z3_ctx

### DIFF
--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -58,6 +58,12 @@ z3_convt::z3_convt(
   Z3_set_error_handler(z3_ctx, error_handler);
 }
 
+z3_convt::~z3_convt()
+{
+  // delete ASTs before destructing z3_ctx: this speeds up the latter, see #752
+  delete_all_asts();
+}
+
 void z3_convt::push_ctx()
 {
   smt_convt::push_ctx();

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -29,6 +29,8 @@ public:
   void dump() const override;
 };
 
+/* Be sure to not make smt_convt a *virtual* base class: our dtor ~z3_convt()
+ * erases all smt_asts early. */
 class z3_convt : public smt_convt,
                  public tuple_iface,
                  public array_iface,
@@ -36,7 +38,7 @@ class z3_convt : public smt_convt,
 {
 public:
   z3_convt(const namespacet &ns, const optionst &options, const messaget &msg);
-  ~z3_convt() override = default;
+  ~z3_convt() override;
 
 public:
   void push_ctx() override;


### PR DESCRIPTION
Fixes the performance regression noted in #752.

Some unknown interplay between Z3's context dtor mechanics and
the order in which we build some expressions, such as in concat_tree(),
leads to a huge slow-down of the Z3 context destruction.

By deleting all stored smt_asts early in ~z3_convt() we avoid these
mechanics and solving times becomes more normal. For --smt-formula-only
on regression/esbmc/github_732-2-2:

> Encoding to solver time: 0.486s
> 2.86user 0.17system 0:03.04elapsed 100%CPU (0avgtext+0avgdata 640052maxresident)k

Before it was 116 seconds and also 640M.

The memory issue still seems to be open.