### PR TITLE
Disable alignment check for packed structs

### DIFF
--- a/regression/esbmc/github_732-1-align_check/test.desc
+++ b/regression/esbmc/github_732-1-align_check/test.desc
@@ -1,4 +1,5 @@
-KNOWNBUG
+CORE
 main.c
 
+^WARNING: not checking alignment .* packed struct s4$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/packed-1/main.c
+++ b/regression/esbmc/packed-1/main.c
@@ -1,0 +1,14 @@
+#include <string.h>
+
+typedef struct __attribute__((__packed__)) {
+	char a;
+	short b;
+} P;
+
+static P q[17];
+
+short fun1(size_t i)
+{
+	__ESBMC_assume(i < 17);
+	return q[i].b;
+}

--- a/regression/esbmc/packed-1/test.desc
+++ b/regression/esbmc/packed-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function fun1
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/packed-2/main.c
+++ b/regression/esbmc/packed-2/main.c
@@ -1,0 +1,14 @@
+#include <string.h>
+
+typedef struct __attribute__((__packed__)) {
+	char a;
+	short b;
+} P;
+
+static P q[17];
+
+short fun2(P *p, size_t i)
+{
+	__ESBMC_assume(i < 17);
+	return p[i].b;
+}

--- a/regression/esbmc/packed-2/test.desc
+++ b/regression/esbmc/packed-2/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function fun2 --no-pointer-check
+^WARNING: not checking alignment .* packed struct P$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/packed-3/gcc-36566.c
+++ b/regression/esbmc/packed-3/gcc-36566.c
@@ -1,0 +1,14 @@
+/* slightly adapted from <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=36566> */
+
+struct S
+{
+    short   s;
+} __attribute__((aligned(8), packed));
+
+void fun3(struct S *s)
+{
+	/* KNOWNBUG: this should not warn about not checking the alignment
+	 * and actually check the alignment as member `S::s` is actually
+	 * known to be aligned. */
+	s->s;
+}

--- a/regression/esbmc/packed-3/test.desc
+++ b/regression/esbmc/packed-3/test.desc
@@ -1,0 +1,5 @@
+CORE
+gcc-36566.c
+--function fun3 --no-pointer-check
+^WARNING: not checking alignment .* packed struct struct S$
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -180,9 +180,7 @@ void goto_symext::dereference(expr2tc &expr, dereferencet::modet mode)
   cur_state->top().level1.rename(expr);
 
   guardt guard;
-  switch(mode)
-  {
-  case dereferencet::FREE:
+  if(is_free(mode))
   {
     expr2tc tmp = expr;
     while(is_typecast2t(tmp))
@@ -195,10 +193,7 @@ void goto_symext::dereference(expr2tc &expr, dereferencet::modet mode)
 
     dereference.dereference_expr(tmp, guard, dereferencet::FREE);
     expr = tmp;
-    break;
   }
-
-  default:
+  else
     dereference.dereference_expr(expr, guard, mode);
-  }
 }

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -332,6 +332,11 @@ private:
    *  returned to indicate that there was no dereference at the end of the
    *  index/member chain.
    *
+   *  A dereference at the end of the chain may be performed with
+   *  `mode.unaligned` set even if `mode` as passed to this function does not
+   *  have it. This happens in case `expr` refers to a member of a packed
+   *  structure.
+   *
    *  @param expr The expression that we're resolving dereferences in.
    *  @param guard Guard of this expression being evaluated.
    *  @param mode The manner in which the result of this deref is accessed.
@@ -446,7 +451,8 @@ private:
     const expr2tc &value,
     const expr2tc &offset,
     const type2tc &type,
-    const guardt &guard);
+    const guardt &guard,
+    modet mode);
   void check_alignment(
     unsigned long minwidth,
     const expr2tc &&offset,

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -148,10 +148,7 @@ type2tc migrate_type(const typet &type)
     if(name.as_string() == "")
       name = type.get("name"); // C++
 
-    irep_idt ispacked = type.get("packed");
-    bool packed = false;
-    if(ispacked.as_string() == "true")
-      packed = true;
+    bool packed = type.get_bool("packed");
 
     struct_type2t *s =
       new struct_type2t(members, names, pretty_names, name, packed);
@@ -1881,7 +1878,7 @@ typet migrate_type_back(const type2tc &ref)
     thetype.components() = comps;
     thetype.set("tag", irep_idt(ref2.name));
     if(ref2.packed)
-      thetype.set("packed", irep_idt("true"));
+      thetype.set("packed", true);
     return std::move(thetype);
   }
   case type2t::union_id:


### PR DESCRIPTION
This PR is on top of #764. It disables alignment checks during dereference when the dereferencing expression itself goes through a packed type. As this loosens the guarantees ESBMC provides (see also #766), I'll leave this a draft to decide whether this is the right way to go.