### PR TITLE
[smt] solve: un-export internal symbols and cleanup API

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -56,7 +56,7 @@ bmct::bmct(
   if(options.get_bool_option("smt-during-symex"))
   {
     runtime_solver =
-      std::shared_ptr<smt_convt>(create_solver_factory("", ns, options, msg));
+      std::shared_ptr<smt_convt>(create_solver("", ns, options, msg));
 
     symex = std::make_shared<reachability_treet>(
       funcs,
@@ -667,7 +667,7 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if(!options.get_bool_option("smt-during-symex"))
     {
       runtime_solver =
-        std::shared_ptr<smt_convt>(create_solver_factory("", ns, options, msg));
+        std::shared_ptr<smt_convt>(create_solver("", ns, options, msg));
     }
 
     return run_decision_procedure(runtime_solver, eq);

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -34,7 +34,7 @@
  *  from the solver.
  *
  *  To do that, the user must allocate a solver converter object, which extends
- *  the class smt_convt. Current, create_solver_factory will do this, in the
+ *  the class smt_convt. Current, create_solver() will do this, in the
  *  factory-pattern manner (ish). Each solver converter implements all the
  *  abstract methods of smt_convt. When handed an expression to convert,
  *  smt_convt deconstructs it into a series of function applications, which it
@@ -79,7 +79,7 @@
  *
  *  @see smt_convt
  *  @see symex_target_equationt
- *  @see create_solver_factory
+ *  @see create_solver
  *  @see smt_convt::mk_func_app
  */
 

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -73,7 +73,7 @@ static std::string pick_default_solver(const messaget &msg)
 #endif
 }
 
-static const solver_creator &pick_solver(
+static solver_creator &pick_solver(
   std::string &solver_name,
   const optionst &options,
   const messaget &msg)
@@ -117,7 +117,7 @@ smt_convt *create_solver(
   array_iface *array_api = nullptr;
   fp_convt *fp_api = nullptr;
 
-  const solver_creator &factory = pick_solver(solver_name, options, msg);
+  solver_creator &factory = pick_solver(solver_name, options, msg);
   smt_convt *ctx = factory(options, ns, &tuple_api, &array_api, &fp_api, msg);
 
   bool node_flat = options.get_bool_option("tuple-node-flattener");

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -107,7 +107,7 @@ static const solver_creator &pick_solver(
   abort();
 }
 
-smt_convt *create_solver_factory(
+smt_convt *create_solver(
   std::string solver_name,
   const namespacet &ns,
   const optionst &options,

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -15,7 +15,10 @@ solver_creator create_new_mathsat_solver;
 solver_creator create_new_yices_solver;
 solver_creator create_new_bitwuzla_solver;
 
-const struct esbmc_solver_config esbmc_solvers[] = {
+static const struct {
+  std::string name;
+  solver_creator *create;
+} esbmc_solvers[] = {
   {"smtlib", create_new_smtlib_solver},
 #ifdef Z3
   {"z3", create_new_z3_solver},
@@ -40,7 +43,7 @@ const struct esbmc_solver_config esbmc_solvers[] = {
 #endif
 };
 
-const std::string list_of_all_solvers[] = {
+static const std::string list_of_all_solvers[] = {
   "z3",
   "smtlib",
   "minisat",
@@ -50,11 +53,11 @@ const std::string list_of_all_solvers[] = {
   "yices",
   "bitwuzla"};
 
-const unsigned int total_num_of_solvers =
+static const unsigned int total_num_of_solvers =
   sizeof(list_of_all_solvers) / sizeof(std::string);
 
-const unsigned int esbmc_num_solvers =
-  sizeof(esbmc_solvers) / sizeof(esbmc_solver_config);
+static const unsigned int esbmc_num_solvers =
+  sizeof(esbmc_solvers) / sizeof(*esbmc_solvers);
 
 static smt_convt *create_solver(
   const std::string &&the_solver,

--- a/src/solvers/solve.h
+++ b/src/solvers/solve.h
@@ -15,7 +15,7 @@ typedef smt_convt *(solver_creator)(
   fp_convt **fp_api,
   const messaget &msg);
 
-smt_convt *create_solver_factory(
+smt_convt *create_solver(
   std::string solver_name,
   const namespacet &ns,
   const optionst &options,

--- a/src/solvers/solve.h
+++ b/src/solvers/solve.h
@@ -16,7 +16,7 @@ typedef smt_convt *(solver_creator)(
   const messaget &msg);
 
 smt_convt *create_solver_factory(
-  const std::string &solver_name,
+  std::string solver_name,
   const namespacet &ns,
   const optionst &options,
   const messaget &msg);

--- a/src/solvers/solve.h
+++ b/src/solvers/solve.h
@@ -15,23 +15,6 @@ typedef smt_convt *(solver_creator)(
   fp_convt **fp_api,
   const messaget &msg);
 
-typedef smt_convt *(*solver_creator_ptr)(
-  const optionst &options,
-  const namespacet &ns,
-  tuple_iface **tuple_api,
-  array_iface **array_api,
-  fp_convt **fp_api,
-  const messaget &msg);
-
-struct esbmc_solver_config
-{
-  std::string name;
-  solver_creator_ptr create;
-};
-
-extern const struct esbmc_solver_config esbmc_solvers[];
-extern const unsigned int esbmc_num_solvers;
-
 smt_convt *create_solver_factory(
   const std::string &solver_name,
   const namespacet &ns,


### PR DESCRIPTION
This PR makes the previously exported symbols
- `list_of_all_solvers`
- `esbmc_solvers`

internal, removes the unused ones
- `total_num_of_solvers`
- `esbmc_num_solvers`

as well as unused types from API and simplifies the control flow in solve.cpp by separating picking the solver based on options from creation of the solver context.