### PR TITLE
Fix cpp frontend to generate symbols

### DIFF
--- a/src/ansi-c/c_main.cpp
+++ b/src/ansi-c/c_main.cpp
@@ -299,10 +299,10 @@ bool c_main(
 
   code_function_callt thread_start_call;
   thread_start_call.location() = symbol.location;
-  thread_start_call.function() = symbol_exprt("c:@F@pthread_start_main_hook");
+  thread_start_call.function() = symbol_exprt("pthread_start_main_hook");
   code_function_callt thread_end_call;
   thread_end_call.location() = symbol.location;
-  thread_end_call.function() = symbol_exprt("c:@F@pthread_end_main_hook");
+  thread_end_call.function() = symbol_exprt("pthread_end_main_hook");
 
   init_code.move_to_operands(thread_start_call);
   init_code.move_to_operands(call);

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -33,8 +33,8 @@ int get_mode(const std::string &str)
 int get_old_frontend_mode(int current_mode)
 {
   unsigned i;
-  std::string expected(mode_table[current_mode++].name);
-  for(i = current_mode; mode_table[i].name != nullptr; i++)
+  std::string expected(mode_table[current_mode].name);
+  for(i = current_mode + 1; mode_table[i].name != nullptr; i++)
     if(expected == mode_table[i].name)
       return i;
 

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -42,7 +42,7 @@ languaget *new_solidity_language(const messaget &msg);
   }
 #define LANGAPI_HAVE_MODE_CLANG_CPP                                            \
   {                                                                            \
-    "C", &new_clang_cpp_language, extensions_cpp                               \
+    "C++", &new_clang_cpp_language, extensions_cpp                             \
   }
 #define LANGAPI_HAVE_MODE_SOLAST                                               \
   {                                                                            \


### PR DESCRIPTION
This patch fixes esbmc not calling the right frontend when using the `--old-fronted` flag.

@kunjsong01 with this patch you can generate the symbols using the old-frontend by using `--old-fronted --symbol-table-too`. The goto program seems to be broken tho. 