### PR TITLE
[crypto_hash] fix buffer over-read

### DIFF
--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1325,22 +1325,20 @@ crypto_hash
 execution_statet::state_hashing_level2t::generate_l2_state_hash() const
 {
   unsigned int total;
+  size_t hash_sz = sizeof(crypto_hash::hash);
 
-  uint8_t *data = (uint8_t *)alloca(
-    current_hashes.size() * CRYPTO_HASH_SIZE * sizeof(uint8_t));
+  uint8_t *data =
+    (uint8_t *)alloca(current_hashes.size() * hash_sz * sizeof(uint8_t));
 
   total = 0;
   for(const auto &current_hashe : current_hashes)
   {
-    memcpy(
-      &data[total * CRYPTO_HASH_SIZE],
-      current_hashe.second.hash,
-      CRYPTO_HASH_SIZE);
+    memcpy(&data[total * hash_sz], current_hashe.second.hash, hash_sz);
     total++;
   }
 
   crypto_hash c;
-  c.ingest(data, total * CRYPTO_HASH_SIZE);
+  c.ingest(data, total * hash_sz);
   c.fin();
   return c;
 }

--- a/src/util/crypto_hash.cpp
+++ b/src/util/crypto_hash.cpp
@@ -15,7 +15,7 @@ public:
   boost::uuids::detail::sha1 s;
 };
 
-bool crypto_hash::operator<(const crypto_hash h2) const
+bool crypto_hash::operator<(const crypto_hash &h2) const
 {
   if(memcmp(hash, h2.hash, sizeof(hash)) < 0)
     return true;

--- a/src/util/crypto_hash.cpp
+++ b/src/util/crypto_hash.cpp
@@ -17,7 +17,7 @@ public:
 
 bool crypto_hash::operator<(const crypto_hash h2) const
 {
-  if(memcmp(hash, h2.hash, CRYPTO_HASH_SIZE) < 0)
+  if(memcmp(hash, h2.hash, sizeof(hash)) < 0)
     return true;
 
   return false;

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -6,8 +6,6 @@
 
 class crypto_hash_private;
 
-#define CRYPTO_HASH_SIZE 32
-
 class crypto_hash
 {
 public:

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -12,7 +12,7 @@ public:
   std::shared_ptr<crypto_hash_private> p_crypto;
   unsigned int hash[5];
 
-  bool operator<(const crypto_hash h2) const;
+  bool operator<(const crypto_hash &h2) const;
 
   std::string to_string() const;
 


### PR DESCRIPTION
The SHA-1 hash backing crypto_hash only has 160 bits, not 256.
Removing the duplicated information about the hash size.
Fixes:

  ==31812== Invalid read of size 16
  ==31812==    at 0x2C3027: memcpy (string_fortified.h:29)
  ==31812==    by 0x2C3027: execution_statet::state_hashing_level2t::generate_l2_state_hash() const (execution_state.cpp:1335)
  ==31812==    by 0x2C3CEC: execution_statet::generate_hash() const (execution_state.cpp:1089)