### PR TITLE
[mode] factor out language-ID from the mode_table

### DIFF
--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -97,5 +97,5 @@ int main(int argc, const char **argv)
 }
 
 const mode_table_et mode_table[] = {
-  LANGAPI_HAVE_MODE_CLANG_C,
-  LANGAPI_HAVE_MODE_END};
+  LANGAPI_MODE_CLANG_C,
+  LANGAPI_MODE_END};

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -96,6 +96,4 @@ int main(int argc, const char **argv)
   return parseopt.main();
 }
 
-const mode_table_et mode_table[] = {
-  LANGAPI_MODE_CLANG_C,
-  LANGAPI_MODE_END};
+const mode_table_et mode_table[] = {LANGAPI_MODE_CLANG_C, LANGAPI_MODE_END};

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -208,7 +208,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
   if(config.options.get_bool_option("ssa-symbol-table"))
     ::show_symbol_table_plain(ns, oss, msg);
 
-  languagest languages(ns, MODE_C, msg);
+  languagest languages(ns, language_idt::C, msg);
 
   oss << "\nProgram constraints: \n";
 

--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -1,22 +1,18 @@
 #include <langapi/mode.h>
 
 const mode_table_et mode_table[] = {
-  LANGAPI_HAVE_MODE_CLANG_C,
-  LANGAPI_HAVE_MODE_CLANG_CPP,
+  LANGAPI_MODE_CLANG_C,
+  LANGAPI_MODE_CLANG_CPP,
 // put a new mode before old-frontend,
 // otherwise language_uit::parse() will return different mode when old-frontend is enabled
 #ifdef ENABLE_SOLIDITY_FRONTEND
-  LANGAPI_HAVE_MODE_SOLAST,
+  LANGAPI_MODE_SOLAST,
 #endif
 #ifdef ENABLE_OLD_FRONTEND
-  LANGAPI_HAVE_MODE_C,
-  LANGAPI_HAVE_MODE_CPP,
+  LANGAPI_MODE_C,
+  LANGAPI_MODE_CPP,
 #endif
-  LANGAPI_HAVE_MODE_END};
+  LANGAPI_MODE_END};
 
-extern "C" uint8_t buildidstring_buf[1];
-#ifdef _WIN32
-extern "C" uint8_t *esbmc_version_string = buildidstring_buf;
-#else
-uint8_t *esbmc_version_string = buildidstring_buf;
-#endif
+extern "C" const uint8_t buildidstring_buf[];
+extern "C" const uint8_t *const esbmc_version_string = buildidstring_buf;

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -21,7 +21,7 @@ void bmct::show_vcc(
 {
   out << "\nVERIFICATION CONDITIONS:\n\n";
 
-  languagest languages(ns, MODE_C, msg);
+  languagest languages(ns, language_idt::C, msg);
 
   for(symex_target_equationt::SSA_stepst::iterator it = eq->SSA_steps.begin();
       it != eq->SSA_steps.end();

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -209,7 +209,7 @@ void goto_checkt::overflow_check(
 
   // First, check type.
   const type2tc &type = ns.follow(expr->type);
-  if(config.language == "Solidity AST")
+  if(config.language == language_idt::SOLIDITY)
   {
     if(!is_signedbv_type(type) && !is_unsignedbv_type(type))
       return;

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -738,7 +738,7 @@ bool is_valid_witness_step(
   const goto_trace_stept &step,
   const messaget &msg)
 {
-  languagest languages(ns, "C", msg);
+  languagest languages(ns, language_idt::C, msg);
   std::string lhsexpr;
   languages.from_expr(migrate_expr_back(step.lhs), lhsexpr);
   std::string location = step.pc->location.to_string();
@@ -754,7 +754,7 @@ bool is_valid_witness_expr(
   const irep_container<expr2t> &exp,
   const messaget &msg)
 {
-  languagest languages(ns, "C", msg);
+  languagest languages(ns, language_idt::C, msg);
   std::string value;
   languages.from_expr(migrate_expr_back(exp), value);
   return (value.find("__ESBMC") & value.find("stdin") & value.find("stdout") &

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -31,7 +31,8 @@ bool language_uit::parse()
 
 bool language_uit::parse(const std::string &filename)
 {
-  int mode = get_mode_filename(filename);
+  language_idt lang = language_id_by_path(filename);
+  int mode = get_mode(lang);
 
   if(mode < 0)
   {
@@ -49,7 +50,7 @@ bool language_uit::parse(const std::string &filename)
     }
   }
 
-  config.language = mode_table[mode].name;
+  config.language = lang;
 
   // Check that it opens
   std::ifstream infile(filename.c_str());
@@ -74,7 +75,7 @@ bool language_uit::parse(const std::string &filename)
   msg.status("Parsing", filename);
 
 #ifdef ENABLE_SOLIDITY_FRONTEND
-  if(mode == get_mode("Solidity AST"))
+  if(mode == get_mode(language_idt::SOLIDITY))
   {
     language.set_func_name(_cmdline.vm["function"].as<std::string>());
 

--- a/src/langapi/languages.cpp
+++ b/src/langapi/languages.cpp
@@ -11,11 +11,11 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 languagest::languagest(
   const namespacet &_ns,
-  const char *mode,
+  language_idt lang,
   const messaget &msg)
   : ns(_ns), msg(msg)
 {
-  language = new_language(mode, msg);
+  language = new_language(lang, msg);
 }
 
 languagest::~languagest()

--- a/src/langapi/languages.h
+++ b/src/langapi/languages.h
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_LANGUAGES_H
 #define CPROVER_LANGUAGES_H
 
+#include <langapi/mode.h>
 #include <util/language.h>
 
 class languagest
@@ -28,7 +29,7 @@ public:
 
   // constructor / destructor
 
-  languagest(const namespacet &_ns, const char *mode, const messaget &msg);
+  languagest(const namespacet &_ns, language_idt lang, const messaget &msg);
   virtual ~languagest();
 
 protected:

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -6,36 +6,110 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 \*******************************************************************/
 
+#include <cassert>
 #include <cstring>
 #include <langapi/mode.h>
 
-const char *extensions_ansi_c[] = {"c", "i", nullptr};
+static const char *const extensions_ansi_c[] = {"c", "i", nullptr};
 
 #ifdef _WIN32
-const char *extensions_cpp[] = {"cpp", "cc", "ipp", "cxx", NULL};
+static const char *const extensions_cpp[] = {"cpp", "cc", "ipp", "cxx", NULL};
 #else
-const char *extensions_cpp[] = {"cpp", "cc", "ipp", "C", "cxx", nullptr};
+static const char *const extensions_cpp[] =
+  {"cpp", "cc", "ipp", "C", "cxx", nullptr};
 #endif
 
-const char *extensions_sol_ast[] = {"solast", nullptr};
+static const char *const extensions_sol_ast[] = {"solast", nullptr};
 
-int get_mode(const std::string &str)
+static const language_desct language_desc_C = {"C", extensions_ansi_c};
+static const language_desct language_desc_CPP = {"C++", extensions_cpp};
+static const language_desct language_desc_Solidity = {
+  "Solidity",
+  extensions_sol_ast};
+
+const struct language_desct *language_desc(language_idt id)
 {
-  unsigned i;
+  switch(id)
+  {
+  case language_idt::NONE:
+    break;
+  case language_idt::C:
+    return &language_desc_C;
+  case language_idt::CPP:
+    return &language_desc_CPP;
+  case language_idt::SOLIDITY:
+    return &language_desc_Solidity;
+  }
+  return nullptr;
+}
 
-  for(i = 0; mode_table[i].name != nullptr; i++)
-    if(str == mode_table[i].name)
+language_idt language_id_by_name(const std::string &name)
+{
+  for(int i = 0;; i++)
+  {
+    language_idt lid = static_cast<language_idt>(i);
+    const language_desct *desc = language_desc(lid);
+    if(!desc)
+      return language_idt::NONE;
+    if(desc->name == name)
+      return lid;
+  }
+}
+
+language_idt language_id_by_ext(const std::string &ext)
+{
+  for(int i = 0;; i++)
+  {
+    language_idt lid = static_cast<language_idt>(i);
+    const language_desct *desc = language_desc(lid);
+    if(!desc)
+      return language_idt::NONE;
+    for(const char *const *e = desc->filename_extensions; *e; e++)
+      if(*e == ext)
+        return lid;
+  }
+}
+
+language_idt language_id_by_path(const std::string &path)
+{
+  const char *ext = strrchr(path.c_str(), '.');
+
+  if(ext == nullptr)
+    return language_idt::NONE;
+
+  std::string extension = ext + 1;
+
+  if(extension == "")
+    return language_idt::NONE;
+
+  return language_id_by_ext(extension);
+}
+
+int get_mode(language_idt lang)
+{
+  assert(language_desc(lang));
+
+  for(int i = 0; mode_table[i].new_language; i++)
+    if(lang == mode_table[i].language_id)
       return i;
 
   return -1;
 }
 
+int get_mode(const std::string &str)
+{
+  language_idt id = language_id_by_name(str);
+  if(id == language_idt::NONE)
+    return -1;
+
+  return get_mode(id);
+}
+
 int get_old_frontend_mode(int current_mode)
 {
-  unsigned i;
-  std::string expected(mode_table[current_mode].name);
-  for(i = current_mode + 1; mode_table[i].name != nullptr; i++)
-    if(expected == mode_table[i].name)
+  language_idt expected = mode_table[current_mode].language_id;
+  for(int i = current_mode + 1; mode_table[i].new_language; i++)
+    if(expected == mode_table[i].language_id)
       return i;
 
   return -1;
@@ -43,26 +117,14 @@ int get_old_frontend_mode(int current_mode)
 
 int get_mode_filename(const std::string &filename)
 {
-  const char *ext = strrchr(filename.c_str(), '.');
-
-  if(ext == nullptr)
+  language_idt id = language_id_by_path(filename);
+  if(id == language_idt::NONE)
     return -1;
 
-  std::string extension = ext + 1;
-
-  if(extension == "")
-    return -1;
-
-  int mode;
-  for(mode = 0; mode_table[mode].name != nullptr; mode++)
-    for(unsigned i = 0; mode_table[mode].extensions[i] != nullptr; i++)
-      if(mode_table[mode].extensions[i] == extension)
-        return mode;
-
-  return -1;
+  return get_mode(id);
 }
 
-languaget *new_language(const char *mode, const messaget &msg)
+languaget *new_language(language_idt lang, const messaget &msg)
 {
-  return (*mode_table[get_mode(mode)].new_language)(msg);
+  return mode_table[get_mode(lang)].new_language(msg);
 }

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -9,25 +9,43 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_MODE_H
 #define CPROVER_MODE_H
 
-#include <util/language.h>
+#include <string>
+
+/* forward declarations */
+class languaget;
+class messaget;
+
+enum class language_idt : int
+{
+  NONE = -1,
+  C,
+  CPP,
+  SOLIDITY,
+};
+
+struct language_desct
+{
+  const char *name;
+  const char *const *filename_extensions;
+};
+
+const language_desct *language_desc(language_idt id);
+language_idt language_id_by_name(const std::string &name);
+language_idt language_id_by_ext(const std::string &ext);
+language_idt language_id_by_path(const std::string &path);
 
 // Table recording details about language modes
 
 struct mode_table_et
 {
-  const char *name;
+  language_idt language_id;
   languaget *(*new_language)(const messaget &msg);
-  const char **extensions;
 };
 
 // List of language modes that are going to be supported in the final tool.
 // Must be declared by user of langapi, must end with HAVE_MODE_NULL.
 
 extern const mode_table_et mode_table[];
-
-extern const char *extensions_ansi_c[];
-extern const char *extensions_cpp[];
-extern const char *extensions_sol_ast[];
 
 languaget *new_clang_c_language(const messaget &msg);
 languaget *new_clang_cpp_language(const messaget &msg);
@@ -36,38 +54,36 @@ languaget *new_cpp_language(const messaget &msg);
 languaget *new_solidity_language(const messaget &msg);
 
 // List of language entries, one can put in the mode table:
-#define LANGAPI_HAVE_MODE_CLANG_C                                              \
+#define LANGAPI_MODE_CLANG_C                                                   \
   {                                                                            \
-    "C", &new_clang_c_language, extensions_ansi_c                              \
+    language_idt::C, &new_clang_c_language                                     \
   }
-#define LANGAPI_HAVE_MODE_CLANG_CPP                                            \
+#define LANGAPI_MODE_CLANG_CPP                                                 \
   {                                                                            \
-    "C++", &new_clang_cpp_language, extensions_cpp                             \
+    language_idt::CPP, &new_clang_cpp_language                                 \
   }
-#define LANGAPI_HAVE_MODE_SOLAST                                               \
+#define LANGAPI_MODE_SOLAST                                                    \
   {                                                                            \
-    "Solidity AST", &new_solidity_language, extensions_sol_ast                 \
+    language_idt::SOLIDITY, &new_solidity_language                             \
   }
-#define LANGAPI_HAVE_MODE_C                                                    \
+#define LANGAPI_MODE_C                                                         \
   {                                                                            \
-    "C", &new_ansi_c_language, extensions_ansi_c                               \
+    language_idt::C, &new_ansi_c_language                                      \
   }
-#define LANGAPI_HAVE_MODE_CPP                                                  \
+#define LANGAPI_MODE_CPP                                                       \
   {                                                                            \
-    "C++", &new_cpp_language, extensions_cpp                                   \
+    language_idt::CPP, &new_cpp_language                                       \
   }
-#define LANGAPI_HAVE_MODE_END                                                  \
+#define LANGAPI_MODE_END                                                       \
   {                                                                            \
-    NULL, NULL, NULL                                                           \
+    language_idt::NONE, NULL                                                   \
   }
 
+int get_mode(language_idt lang);
 int get_mode(const std::string &str);
 int get_mode_filename(const std::string &filename);
 int get_old_frontend_mode(int current_mode);
 
-languaget *new_language(const char *mode, const messaget &msg);
-
-#define MODE_C "C"
-#define MODE_CPP "C++"
+languaget *new_language(language_idt lang, const messaget &msg);
 
 #endif

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/cmdline.h>
 #include <util/options.h>
+#include <langapi/mode.h>
 
 #ifndef GNUC_PREREQ
 #if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
@@ -82,8 +83,9 @@ public:
 
 #undef dm
 
-  // For frontend language name
-  std::string language = "";
+  // Language the frontend has been parsing
+  language_idt language = language_idt::NONE;
+
   struct ansi_ct
   {
     // for ANSI-C

--- a/unit/testing-utils/goto_factory.cpp
+++ b/unit/testing-utils/goto_factory.cpp
@@ -12,9 +12,9 @@
 #include <util/message/message.h>
 
 const mode_table_et mode_table[] = {
-  LANGAPI_HAVE_MODE_CLANG_C,
-  LANGAPI_HAVE_MODE_CLANG_CPP,
-  LANGAPI_HAVE_MODE_END}; // This is the simplest way to have this
+  LANGAPI_MODE_CLANG_C,
+  LANGAPI_MODE_CLANG_CPP,
+  LANGAPI_MODE_END}; // This is the simplest way to have this
 
 void goto_factory::create_file_from_istream(
   std::istream &c_inputstream,


### PR DESCRIPTION
Give the supported languages proper IDs so we can use the language information
down the line. Before, the language/frontend was identified by a free-form
string only, however, in #776 it was deemed necessary to assign a meaning to
options like `--overflow-check` that depend on the concrete language we're
verifying over.

An additional benefit is that the name of frontends now is independent of the
language they're translating, allowing us to freely assign and show them in the
log later on.

The `mode_table` itself for now retains its weird semantics wrt. the old
frontends.

Further, we get rid of some globally exported symbols and mark others `const`
like `buildidstring_buf` and `esbmc_version_string`, so they do not count
toward global "state" #755.