### PR TITLE
Some small things

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -10,6 +10,10 @@ on:
         description: 'Timeout for each benchmarks (in seconds)'
         required: true
         default: '10'
+      options:
+        description: 'Command-line flags to pass via ESBMC_OPTS'
+        required: false
+        default: ''
 
 
 jobs:
@@ -53,6 +57,7 @@ jobs:
       - name: Run Benchexec
         env:
           TIMEOUT: ${{ inputs.timeout }}
+          ESBMC_OPTS: ${{ inputs.options }}
         run: |
           rm -rf $HOME/output-action 
           mkdir $HOME/output-action

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -33,10 +33,12 @@ jobs:
         run: tar xf clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz && mv clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04 clang
       - name: Setup boolector
         run: git clone https://github.com/boolector/boolector && cd boolector && git reset --hard 3.2.2 && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./configure.sh --prefix $PWD/../boolector-release && cd build && make -j9 && make install
+      - name: Setup Z3
+        run: wget https://github.com/fbrausse/esbmc/raw/_assets/z3-ea2a84332513a7823e8e5c96f039fd048cb43dc5-Ubuntu20.04.zip && unzip z3-ea2a84332513a7823e8e5c96f039fd048cb43dc5-Ubuntu20.04.zip && mv release/ z3
       - name: Get current folder and files
         run: pwd && ls
       - name: Configure CMake
-        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release
+        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DBUILD_STATIC=On -DBoolector_DIR=$PWD/../boolector-release -DZ3_DIR=$PWD/../z3
       - name: Build ESBMC
         run: cd build && cmake --build .
       - uses: actions/upload-artifact@v1

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -36,6 +36,9 @@ endif()
 if(ENABLE_GOTO_CONTRACTOR)
     set(REGRESSIONS_GOTO_CONTRACTOR goto-contractor)
 endif()
+if(ENABLE_OLD_FRONTEND)
+    set(REGRESSIONS_OLD_FRONTEND esbmc-old)
+endif()
 
 # NOTE: In order to make the best of the concurrency set sort the tests from the slowest to fastest.
 if(APPLE)
@@ -48,7 +51,8 @@ elseif(WIN32)
     set(REGRESSIONS esbmc cbmc cstd llvm floats k-induction)
 else()
     set(REGRESSIONS esbmc-unix esbmc-unix2 esbmc ${REGRESSIONS_SOLIDITY}
-                    esbmc-old cbmc cstd llvm floats floats-regression
+                    ${REGRESSIONS_OLD_FRONTEND}
+                    cbmc cstd llvm floats floats-regression
                     k-induction esbmc-cpp/cpp esbmc-cpp/cbmc csmith
                     k-induction-parallel nonz3 ${REGRESSIONS_BITWUZLA}
                     incremental-smt esbmc-cpp11/cpp esbmc-cpp11/constructors ${REGRESSIONS_GOTO_CONTRACTOR})

--- a/scripts/competitions/svcomp/stats-10s-z3.txt
+++ b/scripts/competitions/svcomp/stats-10s-z3.txt
@@ -1,0 +1,9 @@
+Statistics:          15648 Files
+  correct:            7084
+    correct true:     4533
+    correct false:    2551
+  incorrect:           103
+    incorrect true:     85
+    incorrect false:    18
+  unknown:            8461
+  Score:              8609 (max: 25567)

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -1,5 +1,6 @@
 #include <esbmc/esbmc_parseoptions.h>
 #include <fstream>
+#include <solvers/solver_config.h>
 #include <util/cmdline.h>
 
 const struct group_opt_templ all_cmd_options[] = {
@@ -175,6 +176,13 @@ const struct group_opt_templ all_cmd_options[] = {
     {"bv", NULL, "use solver with bit-vector arithmetic"},
     {"ir", NULL, "use solver with integer/real arithmetic"},
     {"smtlib", NULL, "use SMT lib format"},
+    {"default-solver",
+     boost::program_options::value<std::string>()->value_name("<solver>"),
+     "override default solver used if no concrete one is specified"
+#ifdef BOOLECTOR
+     " (Boolector)"
+#endif
+    },
     {"non-supported-models-as-zero",
      NULL,
      "if ESBMC can't extract a type/expression from the solver, then the value "

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -95,6 +95,9 @@ static solver_creator &pick_solver(
   }
 
   if(solver_name == "")
+    solver_name = options.get_option("default-solver");
+
+  if(solver_name == "")
     solver_name = pick_default_solver(msg);
 
   auto it = esbmc_solvers.find(solver_name);


### PR DESCRIPTION
This PR does a few unrelated things:
- disable regression tests for old frontends when they are not built in
- add an option `--default-solver <solver>` to ESBMC overriding the default; it takes a free-form string parameter
- the benchexec action now allows to pass arbitrary command line flags via the `ESBMC_OPTS` envvar

I can split this into multiple ones, if needed.

The rationale for the new cmdline option is that it allows us to run the regression tests and also SV-COMP benchmarks with another default solver, e.g. Z3 for #752. I always found it inconvenient not to be able to give multiple solver parameters on the cmdline with the last one winning. The `--default-solver` now circumvents this somewhat.