### PR TITLE
[dyn-mem] explicitely unify interpretations of "valid"/"alloc" and "dealloc" expressions

### DIFF
--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -41,7 +41,6 @@ static void internal_additions(std::string &code)
     // malloc / alloca
     "unsigned __ESBMC_constant_infinity_uint;\n"
     "_Bool __ESBMC_alloc[__ESBMC_constant_infinity_uint];\n"
-    "_Bool __ESBMC_deallocated[__ESBMC_constant_infinity_uint];\n"
     "_Bool __ESBMC_is_dynamic[__ESBMC_constant_infinity_uint];\n"
     "unsigned long __ESBMC_alloc_size[__ESBMC_constant_infinity_uint];\n"
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -309,9 +309,6 @@ __attribute__((annotate("__ESBMC_inf_size")))
 _Bool __ESBMC_alloc[1];
 
 __attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_deallocated[1];
-
-__attribute__((annotate("__ESBMC_inf_size")))
 _Bool __ESBMC_is_dynamic[1];
 
 __attribute__((annotate("__ESBMC_inf_size")))

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -81,8 +81,6 @@ void cpp_languaget::internal_additions(std::ostream &out)
   out << "bool __ESBMC_alloc[__CPROVER::constant_infinity_uint];" << std::endl;
   out << "unsigned __ESBMC_alloc_size[__CPROVER::constant_infinity_uint];"
       << std::endl;
-  out << "bool __ESBMC_deallocated[__CPROVER::constant_infinity_uint];"
-      << std::endl;
   out << "bool __ESBMC_is_dynamic[__CPROVER::constant_infinity_uint];"
       << std::endl;
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -319,10 +319,6 @@ void goto_convertt::do_cpp_new(
   valid_expr.copy_to_operands(lhs);
   exprt neg_valid_expr = gen_not(valid_expr);
 
-  exprt deallocated_expr("deallocated_object", typet("bool"));
-  deallocated_expr.copy_to_operands(lhs);
-  exprt neg_deallocated_expr = gen_not(deallocated_expr);
-
   exprt pointer_offset_expr("pointer_offset", pointer_type());
   pointer_offset_expr.copy_to_operands(lhs);
 
@@ -352,12 +348,6 @@ void goto_convertt::do_cpp_new(
   assign = code_assignt(valid_expr, true_exprt());
   migrate_expr(assign, t_s_a->code);
   t_s_a->location = rhs.find_location();
-
-  //now set deallocated bit
-  goto_programt::targett t_d_i = dest.add_instruction(ASSIGN);
-  codet tmp = code_assignt(deallocated_expr, false_exprt());
-  migrate_expr(tmp, t_d_i->code);
-  t_d_i->location = rhs.find_location();
 
   // run initializer
   dest.destructive_append(tmp_initializer);

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -242,11 +242,6 @@ void goto_symext::track_new_pointer(
   truth = gen_true_expr();
   symex_assign(code_assign2tc(valid_index_expr, truth), true);
 
-  symbol2tc dealloc_sym(sym_type, deallocd_arr_name);
-  index2tc dealloc_index_expr(get_bool_type(), dealloc_sym, ptr_obj);
-  expr2tc falseity = gen_false_expr();
-  symex_assign(code_assign2tc(dealloc_index_expr, falseity), true);
-
   type2tc sz_sym_type =
     type2tc(new array_type2t(uint_type2(), expr2tc(), true));
   symbol2tc sz_sym(sz_sym_type, alloc_size_arr_name);
@@ -330,16 +325,11 @@ void goto_symext::symex_free(const expr2tc &expr)
     }
   }
 
-  // Clear the alloc bit, and set the deallocated bit.
+  // Clear the alloc bit.
   type2tc sym_type =
     type2tc(new array_type2t(get_bool_type(), expr2tc(), true));
   expr2tc ptr_obj = pointer_object2tc(pointer_type2(), code.operand);
   dereference(ptr_obj, dereferencet::READ);
-
-  symbol2tc dealloc_sym(sym_type, deallocd_arr_name);
-  index2tc dealloc_index_expr(get_bool_type(), dealloc_sym, ptr_obj);
-  expr2tc truth = gen_true_expr();
-  symex_assign(code_assign2tc(dealloc_index_expr, truth), true);
 
   symbol2tc valid_sym(sym_type, valid_ptr_arr_name);
   index2tc valid_index_expr(get_bool_type(), valid_sym, ptr_obj);

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -813,8 +813,7 @@ protected:
    *  These irep_idts contain the names of the arrays being used to store data
    *  modelling what pointers are active, which are freed, and so forth. They
    *  can change between C and C++, unfortunately. */
-  irep_idt valid_ptr_arr_name, alloc_size_arr_name, deallocd_arr_name,
-    dyn_info_arr_name;
+  irep_idt valid_ptr_arr_name, alloc_size_arr_name, dyn_info_arr_name;
   /** List of all allocated objects.
    *  Used to track what we should level memory-leak-assertions against when the
    *  program execution has finished */

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -74,7 +74,6 @@ goto_symext::goto_symext(
 
   valid_ptr_arr_name = "c:@__ESBMC_alloc";
   alloc_size_arr_name = "c:@__ESBMC_alloc_size";
-  deallocd_arr_name = "c:@__ESBMC_deallocated";
   dyn_info_arr_name = "c:@__ESBMC_is_dynamic";
 
   symbolt sym;
@@ -119,7 +118,6 @@ goto_symext &goto_symext::operator=(const goto_symext &sym)
 
   valid_ptr_arr_name = sym.valid_ptr_arr_name;
   alloc_size_arr_name = sym.alloc_size_arr_name;
-  deallocd_arr_name = sym.deallocd_arr_name;
   dyn_info_arr_name = sym.dyn_info_arr_name;
 
   dynamic_memory = sym.dynamic_memory;


### PR DESCRIPTION
"valid_object" and !"deallocated_obj" have been functionally equivalent
already as they're always updated together. Both have been backed by
symbolic arrays indexed by the object number.

The `__ESBMC_deallocated` symbol goes back to
7e1fb8e39c33fbe16a06799846d8786dec7fc845, where it was introduced appearently
to give these two expressions a more orthogonal meaning, presumably with the
intent to make stack symbols "valid objects" at some point. This never
happened: only dynamic objects are ever "valid".

Removes the `__ESBMC_deallocated` symbol and replace the "deallocated_obj"
expression in symex with the equivalent to "not(valid)": `!__ESBMC_alloc[obj]`.

Fixes #774.

SV-COMP benchmarks [running](https://github.com/esbmc/esbmc/actions/runs/2608375982) just to double-check that it really doesn't break anything.