### PR TITLE
Clang-14 support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,22 @@ It is recommended that the RAM should be 6 GB at least.
 
 Before starting, note that ESBMC is mainly distributed under the terms of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), so please make sure to read it carefully.
 
-## Installing Dependencies
+## Dependency overview
+
+| package   | required | minimum version | recommended version |
+|-----------|----------|-----------------|---------------------|
+| clang     | yes      | 11.0.0          |                     |
+| boost     | yes      | 1.77            |                     |
+| Boolector | no       | 2.3.2           |                     |
+| CVC4      | no       | 1.8             |                     |
+| MathSAT   | no       | 5.5.4           |                     |
+| Yices     | no       | 2.6.1           |                     |
+| Z3        | no       | 4.8.9           | 4.8.18              |
+| Bitwuzla  | no       | smtcomp-2021    |                     |
+
+The version requirements are usually pretty stable, but can change between releases.
+
+## Installing build tools and basic dependencies
 
 We need to install some dependencies before moving into next steps.
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -7,6 +7,7 @@
 #include <clang/AST/ParentMapContext.h>
 #include <clang/AST/QualTypeNames.h>
 #include <clang/AST/Type.h>
+#include <clang/Basic/Version.inc>
 #include <clang/Index/USRGeneration.h>
 #include <clang/Frontend/ASTUnit.h>
 #include <llvm/Support/raw_os_ostream.h>
@@ -1042,10 +1043,16 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     break;
   }
 
-  case clang::Type::ExtInt:
+#if CLANG_VERSION_MAJOR < 14
+#define BITINT_TAG clang::Type::ExtInt
+#define BITINT_TYPE clang::ExtIntType
+#else
+#define BITINT_TAG clang::Type::BitInt
+#define BITINT_TYPE clang::BitIntType
+#endif
+  case BITINT_TAG:
   {
-    const clang::ExtIntType &eit =
-      static_cast<const clang::ExtIntType &>(the_type);
+    const BITINT_TYPE &eit = static_cast<const BITINT_TYPE &>(the_type);
 
     const unsigned n = eit.getNumBits();
     if(eit.isSigned())
@@ -1059,6 +1066,8 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     new_type.set("#extint", true);
     break;
   }
+#undef BITINT_TAG
+#undef BITINT_TYPE
 
   default:
     std::ostringstream oss;


### PR DESCRIPTION
In #790 @rafaelsamenezes noted that Clang-14 builds are broken because of an API change.

This PR fixes it by supporting the new and the old name, depending on the major version number (14). As discussed in the issue, this PR also clarifies "minimum" and "recommended" versions for building ESBMC manually in the build instructions.