### PR TITLE
Fixed macOS M1 build

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -170,10 +170,13 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
     compiler_args.push_back("-U__BLOCKS__");
     compiler_args.push_back("-Wno-nullability-completeness");
     compiler_args.push_back("-Wno-deprecated-register");
-#ifdef __aarch64__
-    if(config.ansi_c.word_size == 32)
+    /*
+     * The float ABI on macOS is 'softfp', but for AArch64 clang defaults
+     * to armv4t in 32-bit mode and the default for that is the incompatible
+     * 'soft': the system's <fenv.h> won't work.
+     */
+    if(config.ansi_c.target.is_arm() && config.ansi_c.word_size == 32)
       compiler_args.push_back("-mfloat-abi=softfp");
-#endif
   }
 
   if(config.ansi_c.target.is_windows_abi())

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -170,6 +170,7 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
     compiler_args.push_back("-U__BLOCKS__");
     compiler_args.push_back("-Wno-nullability-completeness");
     compiler_args.push_back("-Wno-deprecated-register");
+    compiler_args.push_back("-U__SOFTFP__");
   }
 
   if(config.ansi_c.target.is_windows_abi())

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -170,7 +170,10 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
     compiler_args.push_back("-U__BLOCKS__");
     compiler_args.push_back("-Wno-nullability-completeness");
     compiler_args.push_back("-Wno-deprecated-register");
-    compiler_args.push_back("-U__SOFTFP__");
+#ifdef __aarch64__
+    if(config.ansi_c.word_size == 32)
+      compiler_args.push_back("-mfloat-abi=softfp");
+#endif
   }
 
   if(config.ansi_c.target.is_windows_abi())

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -84,6 +84,11 @@ bool configt::triple::is_macos() const
   return std::regex_match(os, MACOS);
 }
 
+bool configt::triple::is_arm() const
+{
+  return std::regex_match(arch, ARM);
+}
+
 std::string configt::triple::to_string() const
 {
   return arch + "-" + vendor + "-" + os + (flavor.empty() ? "" : "-" + flavor);

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -20,6 +20,7 @@ public:
     bool is_windows_abi() const;
     bool is_freebsd() const;
     bool is_macos() const;
+    bool is_arm() const;
     std::string to_string() const;
   };
 


### PR DESCRIPTION
The definition of `SOFTFP` was preventing `fenv.h` to be parsed correctly. Although this is a fix for M1, it should be fine on every macOS.