### PR TITLE
[goto-programs] Enable GOTO conversion to deal with cpp_delete

### DIFF
--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -109,6 +109,7 @@ protected:
   void
   remove_function_call(exprt &expr, goto_programt &dest, bool result_is_used);
   void remove_cpp_new(exprt &expr, goto_programt &dest, bool result_is_used);
+  void remove_cpp_delete(exprt &expr, goto_programt &dest);
   void remove_temporary_object(exprt &expr, goto_programt &dest);
   void remove_statement_expression(
     exprt &expr,

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -105,6 +105,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   auto it = functions.function_map.find(identifier);
   if(it == functions.function_map.end())
     functions.function_map.emplace(identifier, message_handler);
+
   goto_functiont &f = functions.function_map.at(identifier);
   f.type = to_code_type(symbol.type);
   f.body_available = symbol.value.is_not_nil();

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -287,6 +287,8 @@ void goto_convertt::remove_sideeffects(
       remove_pre(expr, dest, result_is_used);
     else if(statement == "cpp_new" || statement == "cpp_new[]")
       remove_cpp_new(expr, dest, result_is_used);
+    else if(statement == "cpp_delete" || statement == "cpp_delete[]")
+      remove_cpp_delete(expr, dest);
     else if(statement == "temporary_object")
       remove_temporary_object(expr, dest);
     else if(statement == "nondet")
@@ -745,6 +747,20 @@ void goto_convertt::remove_cpp_new(
     expr.make_nil();
 
   convert(call, dest);
+}
+
+void goto_convertt::remove_cpp_delete(exprt &expr, goto_programt &dest)
+{
+  assert(expr.operands().size() == 1); // cpp_delete expects one operand
+
+  codet tmp(expr.statement());
+  tmp.location() = expr.location();
+  tmp.copy_to_operands(to_unary_expr(expr).op0());
+  tmp.set("destructor", expr.find("destructor"));
+
+  convert_cpp_delete(tmp, dest);
+
+  expr.make_nil();
 }
 
 void goto_convertt::remove_temporary_object(exprt &expr, goto_programt &dest)

--- a/src/goto-symex/dynamic_allocation.cpp
+++ b/src/goto-symex/dynamic_allocation.cpp
@@ -31,7 +31,9 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
     pointer_object2tc obj_expr(pointer_type2(), obj.value);
 
     expr2tc alloc_arr_2;
-    migrate_expr(symbol_expr(*ns.lookup(valid_ptr_arr_name)), alloc_arr_2);
+    const symbolt * tmp_symbol_ptr = ns.lookup(valid_ptr_arr_name);
+    assert(tmp_symbol_ptr);
+    migrate_expr(symbol_expr(*tmp_symbol_ptr), alloc_arr_2);
 
     index2tc index_expr(get_bool_type(), alloc_arr_2, obj_expr);
     expr = index_expr;

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -385,6 +385,13 @@ public:
 const index_exprt &to_index_expr(const exprt &expr);
 index_exprt &to_index_expr(exprt &expr);
 
+extern inline const unary_exprt &to_unary_expr(const exprt &expr)
+{
+  const unary_exprt &ret = static_cast<const unary_exprt &>(expr);
+  assert(ret.operands().size() == 1); // unary must have one operand
+  return ret;
+}
+
 class array_of_exprt : public exprt
 {
 public:


### PR DESCRIPTION
Resolves error previously mentioned in https://github.com/esbmc/esbmc/pull/811#issue-1304605397: 

### Error BEFORE the fix: 
```
Generating GOTO Program
cannot remove side effect (cpp_delete)
terminate called after throwing an instance of 'int'
```

### Error AFTER the fix: 
```
Generating GOTO Program
GOTO program creation time: 0.151s
GOTO program processing time: 0.001s
Starting Bounded Model Checking
**** WARNING: no body for function pthread_start_main_hook
Segmentation fault (core dumped)
```

### GOTO program generated:
```
main (main()):
        // 5 file main.cpp line 14
        class t2 * p;
        // 6 no location
        class t2 * new_ptr$1;
        // 7 file main.cpp line 14
        new_ptr$1=new class t2;
        // 8 file main.cpp line 14
        ASSUME !(VALID_OBJECT(new_ptr$1))
        // 9 file main.cpp line 14
        DYNAMIC_SIZE(new_ptr$1)=1;
        // 10 file main.cpp line 14
        VALID_OBJECT(new_ptr$1)=true;
        // 11 file main.cpp line 14
        FUNCTION_CALL:  t2(&(*new_ptr$1))
        // 12 file main.cpp line 14
        p=new_ptr$1;
        // 13 file main.cpp line 15
        ASSERT p->i == 2
        // 14 file main.cpp line 16
        FUNCTION_CALL:  ~t2(&(*p))
        // 15 file main.cpp line 16
        cpp_delete
  * type:
  * operands:
    0: symbol
        * type: pointer
            * subtype: symbol
                * identifier: tag.t2
        * identifier: main::main()::1::p
        // 16 file main.cpp line 16
        VALID_OBJECT(p)=false;
        // 17 file main.cpp line 16
        DEALLOCATED_OBJECT(p)=true;
```

Now we have `DYNAMIC_SIZE`, `VALID_OBJECT`, `DEALLOCATED_OBJECT` in GOTO. 

TODO: 
- `cpp_delete` statement is not getting printed properly on both symbol level and GOTO level. Need to look into it. 
- fix the seg fault in BMC. 

