### PR TITLE
Support not slicing particular symbols

### DIFF
--- a/regression/esbmc/github_666-id/no_slice.c
+++ b/regression/esbmc/github_666-id/no_slice.c
@@ -1,0 +1,8 @@
+int main() {
+        int foo;
+        foo = 42;
+        int asd = foo + 10;
+        foo = 15;
+        __ESBMC_assert(0, "bar");
+        return 0;
+}

--- a/regression/esbmc/github_666-id/test.desc
+++ b/regression/esbmc/github_666-id/test.desc
@@ -1,0 +1,5 @@
+CORE
+no_slice.c
+--no-slice-id c:no_slice.c@21@F@main@foo?1!0&0#2
+\bfoo = 15\b
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_666-name/no_slice.c
+++ b/regression/esbmc/github_666-name/no_slice.c
@@ -1,0 +1,8 @@
+int main() {
+        int foo;
+        foo = 42;
+        int asd = foo + 10;
+        foo = 15;
+        __ESBMC_assert(0, "bar");
+        return 0;
+}

--- a/regression/esbmc/github_666-name/test.desc
+++ b/regression/esbmc/github_666-name/test.desc
@@ -1,0 +1,6 @@
+CORE
+no_slice.c
+--no-slice-name c:no_slice.c@21@F@main@foo
+\bfoo = 42\b
+\bfoo = 15\b
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_666/config.json
+++ b/regression/esbmc/github_666/config.json
@@ -1,0 +1,5 @@
+{
+        "no-slice-symbols": [
+                "c:no_slice.c@14@F@main@foo"
+        ]
+}

--- a/regression/esbmc/github_666/config.json
+++ b/regression/esbmc/github_666/config.json
@@ -1,5 +1,0 @@
-{
-        "no-slice-symbols": [
-                "c:no_slice.c@14@F@main@foo"
-        ]
-}

--- a/regression/esbmc/github_666/no_slice.c
+++ b/regression/esbmc/github_666/no_slice.c
@@ -1,0 +1,8 @@
+int main() {
+        int foo __attribute__ ((annotate("__ESBMC_no_slice")));
+        foo = 42;
+        int asd = foo + 10;
+        foo = 15;
+        __ESBMC_assert(0, "bar");
+        return 0;
+}

--- a/regression/esbmc/github_666/test.desc
+++ b/regression/esbmc/github_666/test.desc
@@ -1,0 +1,4 @@
+CORE
+no_slice.c
+--json-options-input config.json
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_666/test.desc
+++ b/regression/esbmc/github_666/test.desc
@@ -1,4 +1,4 @@
 CORE
 no_slice.c
---json-options-input config.json
+
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_666/test.desc
+++ b/regression/esbmc/github_666/test.desc
@@ -1,4 +1,6 @@
 CORE
 no_slice.c
 
+\bfoo = 42\b
+\bfoo = 15\b
 ^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -447,23 +447,30 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
     return true;
 
   // Check if we annotated it to be have an infinity size
+  bool no_slice = false;
   if(vd.hasAttrs())
   {
     for(auto const &attr : vd.getAttrs())
     {
       if(const auto *a = llvm::dyn_cast<clang::AnnotateAttr>(attr))
       {
-        if(a->getAnnotation().str() == "__ESBMC_inf_size")
+        const std::string &name = a->getAnnotation().str();
+        if(name == "__ESBMC_inf_size")
         {
           assert(t.is_array());
           t.size(exprt("infinity", uint_type()));
         }
+        else if(name == "__ESBMC_no_slice")
+          no_slice = true;
       }
     }
   }
 
   std::string id, name;
   get_decl_name(vd, name, id);
+
+  if(no_slice)
+    config.no_slice_names.emplace(id);
 
   locationt location_begin;
   get_location_from_decl(vd, location_begin);

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -570,10 +570,28 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
   {
     fine_timet slice_start = current_time();
     BigInt ignored;
-    if(!options.get_bool_option("no-slice"))
-      ignored = slice(eq, options.get_bool_option("slice-assumes"));
-    else
+    if(options.get_bool_option("no-slice"))
       ignored = simple_slice(eq);
+    else
+    {
+      struct
+      {
+        const std::unordered_set<std::string> &names, &ids;
+
+        bool operator()(const symbol2t &sym) const
+        {
+          return names.count(sym.thename.as_string()) ||
+                 ids.count(sym.get_symbol_name());
+        }
+      } no_slice_symbol = {
+        config.no_slice_names,
+        config.no_slice_ids,
+      };
+
+      ignored =
+        slice(eq, options.get_bool_option("slice-assumes"), no_slice_symbol);
+    }
+
     fine_timet slice_stop = current_time();
 
     log_status(

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -569,28 +569,7 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
   try
   {
     fine_timet slice_start = current_time();
-    BigInt ignored;
-    if(options.get_bool_option("no-slice"))
-      ignored = simple_slice(eq);
-    else
-    {
-      struct
-      {
-        const std::unordered_set<std::string> &names, &ids;
-
-        bool operator()(const symbol2t &sym) const
-        {
-          return names.count(sym.thename.as_string()) ||
-                 ids.count(sym.get_symbol_name());
-        }
-      } no_slice_symbol = {
-        config.no_slice_names,
-        config.no_slice_ids,
-      };
-
-      ignored =
-        slice(eq, options.get_bool_option("slice-assumes"), no_slice_symbol);
-    }
+    BigInt ignored = slice(eq);
 
     fine_timet slice_stop = current_time();
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -148,6 +148,14 @@ const struct group_opt_templ all_cmd_options[] = {
     {"partial-loops", NULL, "permit paths with partial loops"},
     {"unroll-loops", NULL, ""},
     {"no-slice", NULL, "do not remove unused equations"},
+    {"no-slice-name",
+     boost::program_options::value<std::vector<std::string>>()
+       ->value_name("name"),
+     "disable slicing for all symbols generated with the given name"},
+    {"no-slice-id",
+     boost::program_options::value<std::vector<std::string>>()
+       ->value_name("id"),
+     "disable slicing for the symbol with the given id"},
     {"initialize-nondet-variables",
      NULL,
      "initialize declarations with nondet expression (if it hasn`t a default "

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -149,12 +149,12 @@ const struct group_opt_templ all_cmd_options[] = {
     {"unroll-loops", NULL, ""},
     {"no-slice", NULL, "do not remove unused equations"},
     {"no-slice-name",
-     boost::program_options::value<std::vector<std::string>>()
-       ->value_name("name"),
+     boost::program_options::value<std::vector<std::string>>()->value_name(
+       "name"),
      "disable slicing for all symbols generated with the given name"},
     {"no-slice-id",
-     boost::program_options::value<std::vector<std::string>>()
-       ->value_name("id"),
+     boost::program_options::value<std::vector<std::string>>()->value_name(
+       "id"),
      "disable slicing for the symbol with the given id"},
     {"initialize-nondet-variables",
      NULL,

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -2,25 +2,111 @@
 
 namespace
 {
+/**
+ * @brief Class for the symex-slicer, this slicer is to be executed
+ * on SSA formula in order to remove every symbol that does not depends
+ * on it
+ *
+ * It works by constructing a symbol dependency list by transversing
+ * the SSA formula in reverse order. If any assume, assignment, or renumber
+ * step does not belong into this dependency, then it will be ignored.
+ */
 class symex_slicet
 {
 public:
   explicit symex_slicet(bool assume);
+
+  /**
+   * Iterate over all steps of the \eq in REVERSE order,
+   * getting symbol dependencies. If an
+   * assignment, renumber or assume does not contain one
+   * of the dependency symbols, then it will be ignored.
+   *
+   * @param eq symex formula to be sliced
+   */
   void slice(std::shared_ptr<symex_target_equationt> &eq);
 
-  typedef std::unordered_set<std::string> symbol_sett;
-  symbol_sett depends;
-  BigInt ignored;
+  /**
+   * Holds the symbols the current equation depends on.
+   */
+  std::unordered_set<std::string> depends;
+
+  BigInt ignored; /// tracks how many steps were sliced
 
 protected:
   bool slice_assumes;
 
+  /**
+   * Recursively explores the operands of an expression \expr
+   * If a symbol is found, then it is added into the #depends
+   * member if `Add` is true, otherwise returns true.
+   *
+   * @param expr expression to extract every symbol
+   * @return true if at least one symbol was found
+   */
   template <bool Add>
   bool get_symbols(const expr2tc &expr);
 
+  /**
+   * Helper function, it is used to select specialization will
+   * be used, i.e. assume, assignment or renumber
+   *
+   * Note 1: ASSERTS are not sliced, only their symbols are added
+   * into the #depends
+   *
+   * Note 2: Similar to ASSERTS, if 'slice-assumes' option is
+   * is not enabled. Then only its symbols are added into the
+   * #depends
+   *
+   * TODO: All slice specialization can be converted into a lambda
+   *
+   * @param SSA_step any kind of SSA expression
+   */
   void slice(symex_target_equationt::SSA_stept &SSA_step);
+
+  /**
+   * Remove unneeded assumes from the formula
+   *
+   * Check if the Assume cond symbol is in the #depends, if
+   * it is not then mark the \SSA_Step as ignored.
+   *
+   * If the assume cond is in the #depends, then add its guards
+   * and cond into the #depends
+   *
+   * Note 1: All the conditions operands are going to be added
+   * into the #depends. This makes that the condition itself as
+   * a "reverse taint"
+   *
+   * TODO: What happens if the ASSUME would result in false?
+   *
+   * @param SSA_step an assume step
+   */
   void slice_assume(symex_target_equationt::SSA_stept &SSA_step);
+
+  /**
+   * Remove unneeded assignments from the formula
+   *
+   * Check if the LHS symbol is in the #depends, if
+   * it is not then mark the \SSA_Step as ignored.
+   *
+   * If the assume cond is in the #depends, then add its guards
+   * and cond into the #depends
+   *
+   * @param SSA_step an assignment step
+   */
   void slice_assignment(symex_target_equationt::SSA_stept &SSA_step);
+
+  /**
+   * Remove unneeded renumbers from the formula
+   *
+   * Check if the LHS symbol is in the #depends, if
+   * it is not then mark the \SSA_Step as ignored.
+   *
+   * If the assume cond is in the #depends, then add its guards
+   * and cond into the #depends
+   *
+   * @param SSA_step an renumber step
+   */
   void slice_renumber(symex_target_equationt::SSA_stept &SSA_step);
 };
 
@@ -40,6 +126,7 @@ template <bool Add>
 bool symex_slicet::get_symbols(const expr2tc &expr)
 {
   bool res = false;
+  // Recursively look if any of the operands has a inner symbol
   expr->foreach_operand([this, &res](const expr2tc &e) {
     if(!is_nil_expr(e))
       res |= get_symbols<Add>(e);
@@ -128,6 +215,7 @@ void symex_slicet::slice_assume(symex_target_equationt::SSA_stept &SSA_step)
 void symex_slicet::slice_assignment(symex_target_equationt::SSA_stept &SSA_step)
 {
   assert(is_symbol2t(SSA_step.lhs));
+  // TODO: create an option to ignore nondet symbols (test case generation)
 
   if(!get_symbols<false>(SSA_step.lhs))
   {
@@ -166,6 +254,11 @@ void symex_slicet::slice_renumber(symex_target_equationt::SSA_stept &SSA_step)
   // Don't collect the symbol; this insn has no effect on dependencies.
 }
 
+/**
+ * Naive slicer: slice every step after the last assertion
+ * @param eq symex formula to be sliced
+ * @return number of steps that were ignored
+ */
 static BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq)
 {
   BigInt ignored = 0;

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -110,6 +110,12 @@ void symex_slicet::slice_assume(symex_target_equationt::SSA_stept &SSA_step)
     // we don't really need it
     SSA_step.ignore = true;
     ++ignored;
+    if(is_symbol2t(SSA_step.cond))
+      log_debug(
+        "slice ignoring assume symbol {}",
+        to_symbol2t(SSA_step.cond).get_symbol_name());
+    else
+      log_debug("slide ignoring assume expression");
   }
   else
   {
@@ -128,6 +134,9 @@ void symex_slicet::slice_assignment(symex_target_equationt::SSA_stept &SSA_step)
     // we don't really need it
     SSA_step.ignore = true;
     ++ignored;
+    log_debug(
+      "slice ignoring assignment to symbol {}",
+      to_symbol2t(SSA_step.lhs).get_symbol_name());
   }
   else
   {
@@ -149,6 +158,9 @@ void symex_slicet::slice_renumber(symex_target_equationt::SSA_stept &SSA_step)
     // we don't really need it
     SSA_step.ignore = true;
     ++ignored;
+    log_debug(
+      "slice ignoring renumbering symbol {}",
+      to_symbol2t(SSA_step.lhs).get_symbol_name());
   }
 
   // Don't collect the symbol; this insn has no effect on dependencies.

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -5,13 +5,16 @@
 #include <goto-symex/symex_target_equation.h>
 #include <unordered_set>
 
-BigInt slice(std::shared_ptr<symex_target_equationt> &eq, bool slice_assume);
+BigInt slice(
+  std::shared_ptr<symex_target_equationt> &eq,
+  bool slice_assume,
+  std::function<bool(const symbol2t &)> no_slice);
 BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq);
 
 class symex_slicet
 {
 public:
-  symex_slicet(bool assume);
+  symex_slicet(bool assume, std::function<bool(const symbol2t &)> no_slice);
   void slice(std::shared_ptr<symex_target_equationt> &eq);
 
   typedef std::unordered_set<std::string> symbol_sett;
@@ -20,6 +23,7 @@ public:
 
 protected:
   bool slice_assumes;
+  std::function<bool(const symbol2t &)> no_slice;
 
   template <bool Add>
   bool get_symbols(const expr2tc &expr);

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -1,37 +1,8 @@
 #ifndef CPROVER_GOTO_SYMEX_SLICE_H
 #define CPROVER_GOTO_SYMEX_SLICE_H
 
-#include <goto-symex/renaming.h>
 #include <goto-symex/symex_target_equation.h>
-#include <unordered_set>
 
-BigInt slice(
-  std::shared_ptr<symex_target_equationt> &eq,
-  bool slice_assume,
-  std::function<bool(const symbol2t &)> no_slice);
-BigInt simple_slice(std::shared_ptr<symex_target_equationt> &eq);
-
-class symex_slicet
-{
-public:
-  symex_slicet(bool assume, std::function<bool(const symbol2t &)> no_slice);
-  void slice(std::shared_ptr<symex_target_equationt> &eq);
-
-  typedef std::unordered_set<std::string> symbol_sett;
-  symbol_sett depends;
-  BigInt ignored;
-
-protected:
-  bool slice_assumes;
-  std::function<bool(const symbol2t &)> no_slice;
-
-  template <bool Add>
-  bool get_symbols(const expr2tc &expr);
-
-  void slice(symex_target_equationt::SSA_stept &SSA_step);
-  void slice_assume(symex_target_equationt::SSA_stept &SSA_step);
-  void slice_assignment(symex_target_equationt::SSA_stept &SSA_step);
-  void slice_renumber(symex_target_equationt::SSA_stept &SSA_step);
-};
+BigInt slice(std::shared_ptr<symex_target_equationt> &eq);
 
 #endif

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -3,6 +3,21 @@
 
 #include <goto-symex/symex_target_equation.h>
 
+/**
+ * Marks SSA_steps to be ignored which have no effects on the target equation,
+ * according to the options set in the `config`.
+ *
+ * Notably, this function depends on the global `config`:
+ *  - "no-slice" in `options` -> perform only simple slicing: ignore everything
+ *    after the final assertion
+ *  - "slice-assumes" in `options` -> also perform slicing of assumption steps
+ *  - `config.no_slice_names` and `config.no_slice_ids` -> suppress slicing of
+ *    particular symbols in non-simple slicing mode.
+ *
+ * @param eq The target equation containing the SSA steps to perform program
+ *           slicing on.
+ * @return The number of ignored SSA steps due to this slicing.
+ */
 BigInt slice(std::shared_ptr<symex_target_equationt> &eq);
 
 #endif

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -20,10 +20,9 @@ public:
 
 protected:
   bool slice_assumes;
-  std::function<bool(const symbol2t &)> add_to_deps;
 
-  bool
-  get_symbols(const expr2tc &expr, std::function<bool(const symbol2t &)> fn);
+  template <bool Add>
+  bool get_symbols(const expr2tc &expr);
 
   void slice(symex_target_equationt::SSA_stept &SSA_step);
   void slice_assume(symex_target_equationt::SSA_stept &SSA_step);

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -115,6 +115,18 @@ bool configt::set(const cmdlinet &cmdline)
     return true;
   }
 
+  if(cmdline.isset("no-slice-name"))
+  {
+    const std::list<std::string> &args = cmdline.get_values("no-slice-name");
+    no_slice_names = {begin(args), end(args)};
+  }
+
+  if(cmdline.isset("no-slice-id"))
+  {
+    const std::list<std::string> &args = cmdline.get_values("no-slice-id");
+    no_slice_ids = {begin(args), end(args)};
+  }
+
   ansi_c.use_fixed_for_float = cmdline.isset("fixedbv");
 
   // this is the default

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -1,6 +1,7 @@
 #ifndef CPROVER_UTIL_CONFIG_H
 #define CPROVER_UTIL_CONFIG_H
 
+#include <unordered_set>
 #include <util/cmdline.h>
 #include <util/options.h>
 #include <langapi/mode.h>
@@ -128,6 +129,8 @@ public:
   } ansi_c;
 
   std::string main;
+  std::unordered_set<std::string> no_slice_names;
+  std::unordered_set<std::string> no_slice_ids;
 
   bool set(const cmdlinet &cmdline);
 


### PR DESCRIPTION
This PR is an alternative to #667. It implements @rafaelsamenezes idea to suppress slicing of SSA steps when the symbol is unused. Two methods of specifying these symbols are included:
1. via annotation `__attribute__((annotate("__ESBMC_no_slice")))`
2. via one of the new cmdline options `--no-slice-name <name>` and `--no-slice-id <id>`, where the latter allows more fine-grained control of the explicit renumbered symbol and the former applies to all instances of that symbol

I don't want to steal any ideas here, it just presents a different approach that also turned out to be helpful with the slicing problems in #781. Additionally, this PR includes a simplification of the slicer: the generality of `get_symbol(symb, fn)` is not needed since this internal function is only used with 2 different callbacks `fn` ever. Represent that by a `template <bool Add>`.