### PR TITLE
Added support for Jimple location

### DIFF
--- a/src/jimple-frontend/AST/jimple_ast.h
+++ b/src/jimple-frontend/AST/jimple_ast.h
@@ -205,7 +205,7 @@ protected:
   }
 
 public:
-  /// location of this instruction
+  /// instruction location
   int line_location = -1;
 };
 

--- a/src/jimple-frontend/AST/jimple_ast.h
+++ b/src/jimple-frontend/AST/jimple_ast.h
@@ -203,6 +203,10 @@ protected:
       l.set_function(function_name);
     return l;
   }
+
+public:
+  /// location of this instruction
+  int line_location = -1;
 };
 
 // These functions are used by nlohmann::json. Making it easier to

--- a/src/jimple-frontend/AST/jimple_method_body.cpp
+++ b/src/jimple-frontend/AST/jimple_method_body.cpp
@@ -50,7 +50,6 @@ void jimple_full_method_body::from_json(const json &stmts)
       std::string location_str;
       stmt.at("line").get_to(location_str);
       inner_location = std::stoi(location_str);
-      //log_debug("Setting location as: {}", inner_location);
       continue;
     }
     case statement::Identity:

--- a/src/jimple-frontend/AST/jimple_method_body.cpp
+++ b/src/jimple-frontend/AST/jimple_method_body.cpp
@@ -41,7 +41,7 @@ void jimple_full_method_body::from_json(const json &stmts)
   /* In Jimple, locations are set through attributes and it
      * applied to every instruction after it:
      *
-     *  \/* 2  *\/
+     *  \* 2  \*  <--- Comment
      *  a = 3;
      *  b = 4;
      *

--- a/src/jimple-frontend/AST/jimple_method_body.h
+++ b/src/jimple-frontend/AST/jimple_method_body.h
@@ -72,7 +72,8 @@ public:
     Goto,          // goto 1;
     If,            // if <expr> goto <Label>
     Declaration,   // int a;
-    Throw          // throw <expr>
+    Throw,         // throw <expr>
+    Location       // Extra, reffers to the line number
   };
 
   std::vector<std::shared_ptr<jimple_method_field>> members;
@@ -89,7 +90,8 @@ private:
     {"Goto", statement::Goto},
     {"SetVariable", statement::Assignment},
     {"If", statement::If},
-    {"Throw", statement::Throw}};
+    {"Throw", statement::Throw},
+    {"Location", statement::Location}};
 
   std::map<statement, std::string> to_map = {
     {statement::Identity, "Identity"},
@@ -102,7 +104,8 @@ private:
     {statement::Assignment, "Assignment"},
     {statement::If, "If"},
     {statement::Declaration, "Declaration"},
-    {statement::Throw, "Throw"}};
+    {statement::Throw, "Throw"},
+    {statement::Location, "Location"}};
 };
 
 #endif //ESBMC_JIMPLE_METHOD_BODY_H


### PR DESCRIPTION
Jimple frontend is now able to generate the line location for instructions. This relies on the latest changes of the [parser](https://github.com/rafaelsamenezes/jimple2json)