### PR TITLE
SSA caching

### DIFF
--- a/regression/esbmc/cache_false/main.c
+++ b/regression/esbmc/cache_false/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+int main() {
+	int arr[50];
+	for(int i = 0; i < 50; i++) {
+		arr[i] = 50 - i;
+		assert(arr[i] == 50 - i); }
+	assert(arr[23] == 72);
+}

--- a/regression/esbmc/cache_false/test.desc
+++ b/regression/esbmc/cache_false/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--verbosity 9 --cache-asserts --incremental-bmc --unlimited-k-steps
+\bCache hits: 50\b
+^VERIFICATION FAILED$

--- a/regression/esbmc/cache_true/main.c
+++ b/regression/esbmc/cache_true/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+int main() {
+	int arr[50];
+	for(int i = 0; i < 50; i++) {
+		arr[i] = 50 - i;
+		assert(arr[i] == 50 - i); }
+
+}

--- a/regression/esbmc/cache_true/test.desc
+++ b/regression/esbmc/cache_true/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--verbosity 9 --cache-asserts --incremental-bmc --unlimited-k-steps
+\bCache hits: 50\b
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -37,6 +37,6 @@ target_include_directories(esbmc
 
 target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${GOTO_CONTRACTOR_TARGETS} ${JIMPLE_FRONTEND_TARGETS} clangcfrontend
   clangcppfrontend filesystem symex pointeranalysis langapi util_esbmc bigint
-  solvers clibs gotoalgorithms ${Boost_LIBRARIES})
+  solvers clibs gotoalgorithms cache ${Boost_LIBRARIES})
 
 install(TARGETS esbmc DESTINATION bin)

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -46,6 +46,15 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
       algorithms.emplace_back(std::make_unique<simple_slice>());
     else
       algorithms.emplace_back(std::make_unique<symex_slicet>(options));
+
+    // Run cache if user has specified the options
+    if(options.get_bool_option("cache-asserts"))
+    {
+      // Store the set between runs
+      static auto cache = assertion_cache::create_empty_set();
+      algorithms.emplace_back(std::make_unique<assertion_cache>(
+        cache, !options.get_bool_option("forward-condition")));
+    }
   }
 
   if(options.get_bool_option("smt-during-symex"))
@@ -598,15 +607,6 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
       result->remaining_claims,
       BigInt(eq->SSA_steps.size()) - ignored);
 
-    // Run cache if user has specified the options
-    if(options.get_bool_option("cache-asserts"))
-    {
-      // Store the set between runs
-      static auto cache = crc_assert_cache::create_empty_set();
-      crc_assert_cache(
-        eq->SSA_steps, cache, !options.get_bool_option("forward-condition"))
-        .run();
-    }
     if(options.get_bool_option("document-subgoals"))
     {
       std::ostringstream oss;

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -51,7 +51,7 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
     if(options.get_bool_option("cache-asserts"))
       // Store the set between runs
       algorithms.emplace_back(std::make_unique<assertion_cache>(
-        config.caching_db, !options.get_bool_option("forward-condition")));
+        config.ssa_caching_db, !options.get_bool_option("forward-condition")));
   }
 
   if(options.get_bool_option("smt-during-symex"))

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -601,8 +601,10 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     // CACHE
     if(options.get_bool_option("cache-asserts"))
     {
-     static auto cache = crc_assert_cache::create_empty_set();
-     crc_assert_cache(eq->SSA_steps, cache, options.get_bool_option("forward-condition")).run();
+      static auto cache = crc_assert_cache::create_empty_set();
+      crc_assert_cache(
+        eq->SSA_steps, cache, options.get_bool_option("forward-condition"))
+        .run();
     }
     if(options.get_bool_option("document-subgoals"))
     {

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -32,6 +32,7 @@
 #include <util/migrate.h>
 #include <util/show_symbol_table.h>
 #include <util/time_stopping.h>
+#include <util/cache.h>
 
 bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
   : options(opts), context(_context), ns(context)
@@ -597,6 +598,12 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
       result->remaining_claims,
       BigInt(eq->SSA_steps.size()) - ignored);
 
+    // CACHE
+    if(options.get_bool_option("cache-asserts"))
+    {
+     static auto cache = crc_assert_cache::create_empty_set();
+     crc_assert_cache(eq->SSA_steps, cache, options.get_bool_option("forward-condition")).run();
+    }
     if(options.get_bool_option("document-subgoals"))
     {
       std::ostringstream oss;

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -49,12 +49,9 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
 
     // Run cache if user has specified the options
     if(options.get_bool_option("cache-asserts"))
-    {
       // Store the set between runs
-      static auto cache = assertion_cache::create_empty_set();
       algorithms.emplace_back(std::make_unique<assertion_cache>(
-        cache, !options.get_bool_option("forward-condition")));
-    }
+        config.caching_db, !options.get_bool_option("forward-condition")));
   }
 
   if(options.get_bool_option("smt-during-symex"))

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -47,7 +47,7 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
     else
       algorithms.emplace_back(std::make_unique<symex_slicet>(options));
 
-    // Run cache if user has specified the options
+    // Run cache if user has specified the option
     if(options.get_bool_option("cache-asserts"))
       // Store the set between runs
       algorithms.emplace_back(std::make_unique<assertion_cache>(

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -598,12 +598,13 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
       result->remaining_claims,
       BigInt(eq->SSA_steps.size()) - ignored);
 
-    // CACHE
+    // Run cache if user has specified the options
     if(options.get_bool_option("cache-asserts"))
     {
+      // Store the set between runs
       static auto cache = crc_assert_cache::create_empty_set();
       crc_assert_cache(
-        eq->SSA_steps, cache, options.get_bool_option("forward-condition"))
+        eq->SSA_steps, cache, !options.get_bool_option("forward-condition"))
         .run();
     }
     if(options.get_bool_option("document-subgoals"))

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -76,6 +76,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "set the sysroot for the frontend"},
     {"force,f", boost::program_options::value<std::vector<std::string>>(), ""},
     {"preprocess", NULL, "stop after preprocessing"},
+    {"cache-asserts", NULL, "cache asserts that were already proven correct"},
     {"no-inlining", NULL, "disable inlining function calls"},
     {"full-inlining", NULL, "perform full inlining of function calls"},
     {"all-claims", NULL, "keep all claims"},

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -3,6 +3,9 @@ target_include_directories(algorithms
     PRIVATE ${Boost_INCLUDE_DIRS}
     )
 
+add_library(cache cache.cpp)
+target_link_libraries(cache algorithms)
+
 add_library(filesystem filesystem.cpp)
 target_include_directories(filesystem
     PRIVATE ${Boost_INCLUDE_DIRS}

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -3,7 +3,9 @@
 #include <utility>
 void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step)
 {
-  crc_pair pair = std::make_pair(step.cond->do_crc(), step.guard->do_crc());
+  auto cond_crc = step.cond->do_crc();
+  auto guard_crc = step.guard->do_crc();
+  crc_pair pair = std::make_pair(guard_crc, cond_crc);
   auto it = crc_set.find(pair);
   if(it == crc_set.end())
   {
@@ -12,7 +14,12 @@ void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step)
   }
   else
   {
-    log_debug("Cache hits: {}", ++hits);
-    step.cond = constant_bool2tc(trivial_value);
+    if((guard_crc == it->first) && (cond_crc == it->second))
+    {
+      log_debug("Cache hits: {}", ++hits);
+      step.cond = constant_bool2tc(trivial_value);
+    }
+    else
+      log_debug("Cache had a hash collision");
   }
 }

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -1,17 +1,18 @@
 #include <util/cache.h>
 #include <util/message.h>
 #include <utility>
-void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step) {
-  crc_pair pair =
-      std::make_pair(step.cond->do_crc(), step.guard->do_crc());
-  auto it =   crc_set.find(pair);
+void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step)
+{
+  crc_pair pair = std::make_pair(step.cond->do_crc(), step.guard->do_crc());
+  auto it = crc_set.find(pair);
   if(it == crc_set.end())
   {
     log_debug("Cache missed");
     crc_set.emplace(pair);
-    }
-    else {
-        log_debug("Cache hits: {}", ++hits);
-        step.cond = constant_bool2tc(!is_forward_condition);
-    }
+  }
+  else
+  {
+    log_debug("Cache hits: {}", ++hits);
+    step.cond = constant_bool2tc(!is_forward_condition);
+  }
 }

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -13,6 +13,6 @@ void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step)
   else
   {
     log_debug("Cache hits: {}", ++hits);
-    step.cond = constant_bool2tc(!is_forward_condition);
+    step.cond = constant_bool2tc(trivial_value);
   }
 }

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -1,0 +1,17 @@
+#include <util/cache.h>
+#include <util/message.h>
+#include <utility>
+void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step) {
+  crc_pair pair =
+      std::make_pair(step.cond->do_crc(), step.guard->do_crc());
+  auto it =   crc_set.find(pair);
+  if(it == crc_set.end())
+  {
+    log_debug("Cache missed");
+    crc_set.emplace(pair);
+    }
+    else {
+        log_debug("Cache hits: {}", ++hits);
+        step.cond = constant_bool2tc(!is_forward_condition);
+    }
+}

--- a/src/util/cache.cpp
+++ b/src/util/cache.cpp
@@ -1,20 +1,32 @@
 #include <util/cache.h>
 #include <util/message.h>
 #include <utility>
-void crc_assert_cache::run_on_assert(symex_target_equationt::SSA_stept &step)
+#include <util/crypto_hash.h>
+
+namespace
 {
-  auto cond_crc = step.cond->do_crc();
-  auto guard_crc = step.guard->do_crc();
-  crc_pair pair = std::make_pair(guard_crc, cond_crc);
-  auto it = crc_set.find(pair);
-  if(it == crc_set.end())
+std::string hash_irep2(const expr2tc e)
+{
+  crypto_hash h;
+  e->hash(h);
+  h.fin();
+  return h.to_string();
+}
+} // namespace
+void assertion_cache::run_on_assert(symex_target_equationt::SSA_stept &step)
+{
+  auto cond_hash = hash_irep2(step.cond);
+  auto guard_hash = hash_irep2(step.guard);
+  assert_pair pair = std::make_pair(guard_hash, cond_hash);
+  auto it = assert_set.find(pair);
+  if(it == assert_set.end())
   {
     log_debug("Cache missed");
-    crc_set.emplace(pair);
+    assert_set.emplace(pair);
   }
   else
   {
-    if((guard_crc == it->first) && (cond_crc == it->second))
+    if((guard_hash == it->first) && (cond_hash == it->second))
     {
       log_debug("Cache hits: {}", ++hits);
       step.cond = constant_bool2tc(trivial_value);

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <set>
+#include <util/algorithms.h>
+
+using crc_hash = unsigned long long;
+using crc_pair = std::pair<crc_hash, crc_hash>;
+class crc_assert_cache : public ssa_algorithm
+{
+public:
+    explicit crc_assert_cache(symex_target_equationt::SSA_stepst &steps, std::set<crc_pair> &crc_set, bool is_forward_condition) : ssa_algorithm(steps, true), crc_set(crc_set), is_forward_condition(is_forward_condition) {}
+
+    void run_on_assert(symex_target_equationt::SSA_stept &) override;
+
+    static std::set<crc_pair> create_empty_set() {
+        return std::set<crc_pair>();
+    }
+
+    unsigned get_hits() { return hits; }
+protected:
+    std::set<crc_pair>  &crc_set;
+    bool is_forward_condition;
+private:
+    unsigned hits = 0;
+};

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -3,18 +3,23 @@
 #include <set>
 #include <util/algorithms.h>
 
-using crc_hash = unsigned long long;
-using crc_pair = std::pair<crc_hash, crc_hash>;
+// Helper definitions
+using crc_hash = size_t; // from irep2_meta_templates.h
+/**
+ * @brief This class stores all asserts conditions and guards
+ *        for a given SSA, if some pair was already added
+ *        then it will convert it to be a trivial case,
+ *        e.g. GUARD => COND ----> GUARD => 1
+ */
 class crc_assert_cache : public ssa_algorithm
 {
 public:
-  explicit crc_assert_cache(
+  using crc_pair = std::pair<crc_hash, crc_hash>;
+  crc_assert_cache(
     symex_target_equationt::SSA_stepst &steps,
     std::set<crc_pair> &crc_set,
-    bool is_forward_condition)
-    : ssa_algorithm(steps, true),
-      crc_set(crc_set),
-      is_forward_condition(is_forward_condition)
+    bool trivial_value)
+    : ssa_algorithm(steps, true), crc_set(crc_set), trivial_value(trivial_value)
   {
   }
 
@@ -32,7 +37,8 @@ public:
 
 protected:
   std::set<crc_pair> &crc_set;
-  bool is_forward_condition;
+  /// value to be set for  the COND
+  bool trivial_value;
 
 private:
   unsigned hits = 0;

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <set>
+#include <unordered_set>
 #include <util/algorithms.h>
 #include <util/time_stopping.h>
 

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -2,44 +2,56 @@
 
 #include <set>
 #include <util/algorithms.h>
-
+#include <util/time_stopping.h>
 // Helper definitions
-using crc_hash = size_t; // from irep2_meta_templates.h
+using hashing_type = std::string; // from irep2_meta_templates.h
 /**
  * @brief This class stores all asserts conditions and guards
  *        for a given SSA, if some pair was already added
  *        then it will convert it to be a trivial case,
  *        e.g. GUARD => COND ----> GUARD => 1
  */
-class crc_assert_cache : public ssa_algorithm
+class assertion_cache : public ssa_step_algorithm
 {
 public:
-  using crc_pair = std::pair<crc_hash, crc_hash>;
-  crc_assert_cache(
-    symex_target_equationt::SSA_stepst &steps,
-    std::set<crc_pair> &crc_set,
-    bool trivial_value)
-    : ssa_algorithm(steps, true), crc_set(crc_set), trivial_value(trivial_value)
+  using assert_pair = std::pair<hashing_type, hashing_type>;
+  assertion_cache(std::set<assert_pair> &assert_set, bool trivial_value)
+    : ssa_step_algorithm(true),
+      assert_set(assert_set),
+      trivial_value(trivial_value)
   {
+  }
+
+  bool run(symex_target_equationt::SSA_stepst &eq) override
+  {
+    fine_timet algorithm_start = current_time();
+    for(auto &step : eq)
+      run_on_step(step);
+    fine_timet algorithm_stop = current_time();
+    log_status(
+      "Caching time: {}s (removed {} assignments)",
+      time2string(algorithm_stop - algorithm_start),
+      hits);
+    return true;
   }
 
   void run_on_assert(symex_target_equationt::SSA_stept &) override;
 
-  static std::set<crc_pair> create_empty_set()
+  static std::set<assert_pair> create_empty_set()
   {
-    return std::set<crc_pair>();
+    return std::set<assert_pair>();
   }
 
-  unsigned get_hits()
+  virtual BigInt ignored() const override
   {
     return hits;
   }
 
 protected:
-  std::set<crc_pair> &crc_set;
+  std::set<assert_pair> &assert_set;
   /// value to be set for  the COND
   bool trivial_value;
 
 private:
-  unsigned hits = 0;
+  BigInt hits = 0;
 };

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -8,18 +8,32 @@ using crc_pair = std::pair<crc_hash, crc_hash>;
 class crc_assert_cache : public ssa_algorithm
 {
 public:
-    explicit crc_assert_cache(symex_target_equationt::SSA_stepst &steps, std::set<crc_pair> &crc_set, bool is_forward_condition) : ssa_algorithm(steps, true), crc_set(crc_set), is_forward_condition(is_forward_condition) {}
+  explicit crc_assert_cache(
+    symex_target_equationt::SSA_stepst &steps,
+    std::set<crc_pair> &crc_set,
+    bool is_forward_condition)
+    : ssa_algorithm(steps, true),
+      crc_set(crc_set),
+      is_forward_condition(is_forward_condition)
+  {
+  }
 
-    void run_on_assert(symex_target_equationt::SSA_stept &) override;
+  void run_on_assert(symex_target_equationt::SSA_stept &) override;
 
-    static std::set<crc_pair> create_empty_set() {
-        return std::set<crc_pair>();
-    }
+  static std::set<crc_pair> create_empty_set()
+  {
+    return std::set<crc_pair>();
+  }
 
-    unsigned get_hits() { return hits; }
+  unsigned get_hits()
+  {
+    return hits;
+  }
+
 protected:
-    std::set<crc_pair>  &crc_set;
-    bool is_forward_condition;
+  std::set<crc_pair> &crc_set;
+  bool is_forward_condition;
+
 private:
-    unsigned hits = 0;
+  unsigned hits = 0;
 };

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -3,8 +3,7 @@
 #include <set>
 #include <util/algorithms.h>
 #include <util/time_stopping.h>
-// Helper definitions
-using hashing_type = std::string; // from irep2_meta_templates.h
+
 /**
  * @brief This class stores all asserts conditions and guards
  *        for a given SSA, if some pair was already added
@@ -14,7 +13,6 @@ using hashing_type = std::string; // from irep2_meta_templates.h
 class assertion_cache : public ssa_step_algorithm
 {
 public:
-  using assert_pair = std::pair<hashing_type, hashing_type>;
   assertion_cache(std::set<assert_pair> &assert_set, bool trivial_value)
     : ssa_step_algorithm(true),
       assert_set(assert_set),
@@ -36,12 +34,6 @@ public:
   }
 
   void run_on_assert(symex_target_equationt::SSA_stept &) override;
-
-  static std::set<assert_pair> create_empty_set()
-  {
-    return std::set<assert_pair>();
-  }
-
   virtual BigInt ignored() const override
   {
     return hits;

--- a/src/util/cache.h
+++ b/src/util/cache.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <unordered_set>
+
 #include <util/algorithms.h>
 #include <util/time_stopping.h>
+#include <util/crypto_hash.h>
+#include <util/cache_defs.h>
 
 /**
- * @brief This class stores all asserts conditions and guards
+ * @Brief This class stores all asserts conditions and guards
  *        for a given SSA, if some pair was already added
  *        then it will convert it to be a trivial case,
  *        e.g. GUARD => COND ----> GUARD => 1
@@ -13,25 +16,12 @@
 class assertion_cache : public ssa_step_algorithm
 {
 public:
-  assertion_cache(std::set<assert_pair> &assert_set, bool trivial_value)
-    : ssa_step_algorithm(true),
-      assert_set(assert_set),
-      trivial_value(trivial_value)
+  assertion_cache(assert_db &db, bool trivial_value)
+    : ssa_step_algorithm(true), db(db), trivial_value(trivial_value)
   {
   }
 
-  bool run(symex_target_equationt::SSA_stepst &eq) override
-  {
-    fine_timet algorithm_start = current_time();
-    for(auto &step : eq)
-      run_on_step(step);
-    fine_timet algorithm_stop = current_time();
-    log_status(
-      "Caching time: {}s (removed {} assignments)",
-      time2string(algorithm_stop - algorithm_start),
-      hits);
-    return true;
-  }
+  bool run(symex_target_equationt::SSA_stepst &) override;
 
   void run_on_assert(symex_target_equationt::SSA_stept &) override;
   virtual BigInt ignored() const override
@@ -40,7 +30,7 @@ public:
   }
 
 protected:
-  std::set<assert_pair> &assert_set;
+  assert_db &db;
   /// value to be set for  the COND
   bool trivial_value;
 

--- a/src/util/cache_defs.h
+++ b/src/util/cache_defs.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <irep2/irep2.h>
+
+// This header will prevent the dependency hell
+// between irep2, message and config
+
+using assert_pair = std::pair<expr2tc, expr2tc>;
+using assert_db = std::unordered_set<assert_pair>;
+
+namespace std
+{
+template <>
+struct hash<assert_pair>
+{
+  auto operator()(const assert_pair &p) const -> size_t
+  {
+    const expr2tc &e1 = p.first;
+    const expr2tc &e2 = p.second;
+    crypto_hash h1, h2;
+    e1->hash(h1);
+    h1.fin();
+    e2->hash(h2);
+    h2.fin();
+    return h1.to_size_t() ^ h2.to_size_t();
+  }
+};
+} // namespace std

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -7,6 +7,10 @@
 #include <langapi/mode.h>
 #include <util/compiler_defs.h>
 
+// Helper definitions
+using hashing_type = std::string; // from irep2_meta_templates.h
+using assert_pair = std::pair<hashing_type, hashing_type>;
+
 class configt
 {
 public:
@@ -22,6 +26,8 @@ public:
     bool is_macos() const;
     std::string to_string() const;
   };
+
+  // std::set<assertion_cache::assert_pair> cache_db;
 
 #define dm(char, short, int, long, addr, word, long_dbl)                       \
   ((uint64_t)(char) | (uint64_t)(short) << 8 | (uint64_t)(int) << 16 |         \
@@ -108,6 +114,9 @@ public:
   static std::string this_operating_system();
 
   static triple host();
+
+  // For caching
+  std::set<assert_pair> caching_db;
 };
 
 extern configt config;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -6,11 +6,7 @@
 #include <util/options.h>
 #include <langapi/mode.h>
 #include <util/compiler_defs.h>
-
-// Helper definitions
-using hashing_type = std::string; // from irep2_meta_templates.h
-using assert_pair = std::pair<hashing_type, hashing_type>;
-
+#include <util/cache_defs.h>
 class configt
 {
 public:
@@ -26,8 +22,6 @@ public:
     bool is_macos() const;
     std::string to_string() const;
   };
-
-  // std::set<assertion_cache::assert_pair> cache_db;
 
 #define dm(char, short, int, long, addr, word, long_dbl)                       \
   ((uint64_t)(char) | (uint64_t)(short) << 8 | (uint64_t)(int) << 16 |         \
@@ -116,7 +110,7 @@ public:
   static triple host();
 
   // For caching
-  std::set<assert_pair> caching_db;
+  assert_db ssa_caching_db;
 };
 
 extern configt config;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -109,7 +109,7 @@ public:
 
   static triple host();
 
-  // For caching
+  // For caching ssa assertions
   assert_db ssa_caching_db;
 };
 

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -27,7 +27,7 @@ public:
     size_t result = hash[0];
     for(int i = 1; i < 5; i++)
       // Do we care about overlaps?
-      result ^= (hash[i] << sizeof(unsigned int));
+        result ^= (hash[i] << (sizeof(unsigned int)*i));
     return result;
   }
 

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -14,20 +14,12 @@ public:
 
   bool operator<(const crypto_hash &h2) const;
 
-  std::array<unsigned int, 5> to_array() const
-  {
-    // TODO: CPP+20 will have a to_array function
-    std::array<unsigned int, 5> result;
-    std::copy(hash, hash + 5, result.begin());
-    return result;
-  }
-
   size_t to_size_t() const
   {
     size_t result = hash[0];
     for(int i = 1; i < 5; i++)
       // Do we care about overlaps?
-        result ^= (hash[i] << (sizeof(unsigned int)*i));
+      result ^= hash[i];
     return result;
   }
 

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -22,6 +22,15 @@ public:
     return result;
   }
 
+  size_t to_size_t() const
+  {
+    size_t result = hash[0];
+    for(int i = 1; i < 5; i++)
+      // Do we care about overlaps?
+      result ^= (hash[i] << sizeof(unsigned int));
+    return result;
+  }
+
   std::string to_string() const;
 
   crypto_hash();

--- a/src/util/crypto_hash.h
+++ b/src/util/crypto_hash.h
@@ -14,6 +14,14 @@ public:
 
   bool operator<(const crypto_hash &h2) const;
 
+  std::array<unsigned int, 5> to_array() const
+  {
+    // TODO: CPP+20 will have a to_array function
+    std::array<unsigned int, 5> result;
+    std::copy(hash, hash + 5, result.begin());
+    return result;
+  }
+
   std::string to_string() const;
 
   crypto_hash();

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -12,4 +12,4 @@ endif()
 
 add_subdirectory(util)
 add_subdirectory(c2goto)
-
+add_subdirectory(irep2)

--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -1,0 +1,1 @@
+new_unit_test(irep2test "irep2.test.cpp" "util_esbmc;irep2;bigint")

--- a/unit/irep2/irep2.test.cpp
+++ b/unit/irep2/irep2.test.cpp
@@ -6,6 +6,12 @@
 
 namespace
 {
+std::array<unsigned int, 5> to_array(const crypto_hash &h)
+{
+  std::array<unsigned int, 5> result;
+  std::copy(h.hash, h.hash + 5, result.begin());
+  return result;
+}
 struct_type2tc testing_struct2t()
 {
   std::vector<type2tc> struct_members{
@@ -46,7 +52,7 @@ void test_constructed_equally(const expr2tc e1, const expr2tc e2)
 
   c_hash.fin();
   c_hash2.fin();
-  REQUIRE(c_hash.to_array() == c_hash2.to_array());
+  REQUIRE(to_array(c_hash) == to_array(c_hash2));
   REQUIRE(c_hash.to_size_t() == c_hash2.to_size_t());
 }
 
@@ -66,7 +72,7 @@ void test_constructed_differently(const expr2tc e1, const expr2tc e2)
 
   c_hash.fin();
   c_hash2.fin();
-  REQUIRE(c_hash.to_array() != c_hash2.to_array());
+  REQUIRE(to_array(c_hash) != to_array(c_hash2));
   REQUIRE(c_hash.to_size_t() != c_hash2.to_size_t());
 }
 

--- a/unit/irep2/irep2.test.cpp
+++ b/unit/irep2/irep2.test.cpp
@@ -47,6 +47,7 @@ void test_constructed_equally(const expr2tc e1, const expr2tc e2)
   c_hash.fin();
   c_hash2.fin();
   REQUIRE(c_hash.to_array() == c_hash2.to_array());
+  REQUIRE(c_hash.to_size_t() == c_hash2.to_size_t());
 }
 
 void test_constructed_differently(const expr2tc e1, const expr2tc e2)
@@ -66,6 +67,7 @@ void test_constructed_differently(const expr2tc e1, const expr2tc e2)
   c_hash.fin();
   c_hash2.fin();
   REQUIRE(c_hash.to_array() != c_hash2.to_array());
+  REQUIRE(c_hash.to_size_t() != c_hash2.to_size_t());
 }
 
 } // namespace

--- a/unit/irep2/irep2.test.cpp
+++ b/unit/irep2/irep2.test.cpp
@@ -1,0 +1,109 @@
+#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
+#include <catch2/catch.hpp>
+#include <irep2/irep2.h>
+#include <irep2/irep2_utils.h>
+#include <util/crypto_hash.h>
+
+namespace
+{
+struct_type2tc testing_struct2t()
+{
+  std::vector<type2tc> struct_members{
+    get_uint_type(config.ansi_c.word_size),
+    get_uint_type(config.ansi_c.word_size)};
+  std::vector<irep_idt> struct_memb_names{"a", "b"};
+  return struct_type2tc(
+    struct_members, struct_memb_names, struct_memb_names, "test_struct");
+}
+
+type2tc testing_overlap2t()
+{
+  return get_uint_type(1);
+}
+
+expr2tc gen_testing_overlap(unsigned v)
+{
+  return constant_int2tc(testing_overlap2t(), BigInt(v));
+}
+
+constant_struct2tc gen_testing_struct(unsigned int a, unsigned int b)
+{
+  std::vector<expr2tc> members{gen_ulong(a), gen_ulong(b)};
+  return constant_struct2tc(testing_struct2t(), members);
+}
+
+void test_constructed_equally(const expr2tc e1, const expr2tc e2)
+{
+  crypto_hash c_hash;
+  crypto_hash c_hash2;
+  // "The == operator should return true"
+  REQUIRE(e1 == e2);
+  // "Their crc should be the same"
+  REQUIRE(e1->do_crc() == e2->do_crc());
+  // Their hash should be the same"
+  e1->hash(c_hash);
+  e2->hash(c_hash2);
+
+  c_hash.fin();
+  c_hash2.fin();
+  REQUIRE(c_hash.to_array() == c_hash2.to_array());
+}
+
+void test_constructed_differently(const expr2tc e1, const expr2tc e2)
+{
+  crypto_hash c_hash;
+  crypto_hash c_hash2;
+
+  // "The == operator should return false"
+  REQUIRE(e1 != e2);
+  // "Their crc should not be the same"
+  REQUIRE(e1->do_crc() != e2->do_crc());
+  // "Their hash should not be the same"
+
+  e1->hash(c_hash);
+  e2->hash(c_hash2);
+
+  c_hash.fin();
+  c_hash2.fin();
+  REQUIRE(c_hash.to_array() != c_hash2.to_array());
+}
+
+} // namespace
+
+SCENARIO("irep2 hashing", "[core][irep2]")
+{
+  GIVEN("Expressions constructed in the same way")
+  {
+    std::vector<std::pair<expr2tc, expr2tc>> expressions{
+      {gen_ulong(42), gen_ulong(42)},
+      {gen_testing_struct(1, 2), gen_testing_struct(1, 2)}};
+
+    THEN("Expressions and hashes should be equal to itself")
+    {
+      for(auto &e : expressions)
+      {
+        test_constructed_equally(e.first, e.first);
+        test_constructed_equally(e.second, e.second);
+      }
+    }
+    THEN("Expressions and hashes between pairs should be equal")
+    {
+      for(auto &e : expressions)
+        test_constructed_equally(e.first, e.second);
+    }
+  }
+  GIVEN("Expressions constructed differently")
+  {
+    std::vector<std::pair<expr2tc, expr2tc>> expressions{
+      {gen_ulong(42), gen_ulong(64)},
+      {gen_testing_struct(1, 2), gen_ulong(1)},
+      {gen_testing_struct(1, 2), gen_ulong(2)},
+      {gen_testing_overlap(0), gen_testing_overlap(2)}, // overlap
+      {gen_testing_struct(1, 2), gen_testing_struct(1, 1)}};
+    THEN("Expressions and hashes between pairs should not be equal")
+    {
+      for(auto &e : expressions)
+        test_constructed_differently(e.first, e.second);
+    }
+  }
+}


### PR DESCRIPTION
This PR is a basis for the full caching framework. This adds:

1. SSA algorithms, which work similarly to the goto algorithms. This will help develop "passes" over SSA
2. A basic CRC caching. Checks if a guard/cond pair was already seen and replace the assertion with a trivial case. I am not sure if it is better to replace the `cond` with 1 or the `guard` with 0.