### PR TITLE
[cpp] quick fix for more zombie codet operand

### DIFF
--- a/regression/esbmc/github_839/main.cpp
+++ b/regression/esbmc/github_839/main.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+
+class Bird {
+  public:
+  virtual int f(void) { return 21; }
+  virtual int g(void) { return 21; }
+  virtual ~Bird(){}
+};
+
+class FlyingBird: public Bird {
+  public:
+    virtual void fly();
+    virtual int g(void) { return 42; }
+};
+
+class Penguin: public Bird {
+  public:
+    virtual int f(void) { return 42; }
+};
+
+void FlyingBird::fly() { }
+
+int main(){
+  Bird *b = new Bird();
+  FlyingBird *f = new FlyingBird();
+  Penguin *p = new Penguin();
+  assert(b->f() == 21);
+  assert(f->g() == 42);
+  assert(p->f() == 42);
+  assert(p->g() == 21);
+  delete b;
+  delete f;
+  delete p;
+  return 0;
+}
+

--- a/regression/esbmc/github_839/test.desc
+++ b/regression/esbmc/github_839/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900 --old-frontend --goto-functions-only
+END_FUNCTION$

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -206,6 +206,14 @@ codet cpp_typecheckt::cpp_constructor(
       assign.move_to_operands(member, val);
       typecheck_side_effect_assignment(assign);
       code_expressiont code_exp;
+
+      if(code_exp.operands().size() == 1)
+      {
+        // remove zombie operands
+        if(code_exp.operands().front().id() == "")
+          code_exp.operands().clear();
+      }
+
       code_exp.move_to_operands(assign);
       block.move_to_operands(code_exp);
     }

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -261,6 +261,12 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
     make_ptr_typecast(this_expr, tmp_this.type());
     tmp_this.swap(this_expr);
     code = code_expressiont();
+    if(code.operands().size() == 1)
+    {
+      // remove zombie operands
+      if(code.operands().front().id() == "")
+        code.operands().clear();
+    }
     code.move_to_operands(initializer);
   }
   else
@@ -329,6 +335,14 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
         assign.copy_to_operands(symbol_expr, code.op0());
         typecheck_side_effect_assignment(assign);
         code_expressiont new_code;
+
+        if(new_code.operands().size() == 1)
+        {
+          // remove zombie operands
+          if(new_code.operands().front().id() == "")
+            new_code.operands().clear();
+        }
+
         new_code.move_to_operands(assign);
         code.swap(new_code);
       }
@@ -466,6 +480,14 @@ void cpp_typecheckt::typecheck_assign(codet &code)
   typecheck_expr(expr);
 
   code_expressiont code_expr;
+
+  if(code_expr.operands().size() == 1)
+  {
+    // remove zombie operands
+    if(code_expr.operands().front().id() == "")
+      code_expr.operands().clear();
+  }
+
   code_expr.copy_to_operands(expr);
   code_expr.location() = code.location();
 


### PR DESCRIPTION
Fixed old cpp frontend for test case `single_inheritance` to generate the goto programs.

### Before:
```
Converting
Generating GOTO Program
ERROR: expression statement takes one operand
``` 
due to empty operands[0]:
```
code
  * type: code
      * arguments:
  * operands:
    0: code
        * type: code
            * arguments:
        * operands:
          0:
            * type:
          1: sideeffect
              * type: pointer
                  * subtype: symbol
                      * identifier: virtual_table::tag.Bird
              * operands:
```

### After:
Now ESBMC is able to generate goto functions using old cpp frontend: 
[goto_programs.txt](https://github.com/esbmc/esbmc/files/9374957/goto_programs.txt)

