### PR TITLE
[compiler] added a new header to center compiler definitions

### DIFF
--- a/src/ansi-c/ansi_c_convert_type.h
+++ b/src/ansi-c/ansi_c_convert_type.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ansi-c/c_storage_spec.h>
 #include <util/c_qualifiers.h>
 #include <util/c_types.h>
+#include <sstream>
 
 class ansi_c_convert_typet
 {

--- a/src/big-int/bigint.cpp
+++ b/src/big-int/bigint.cpp
@@ -63,7 +63,7 @@ inline int digit_cmp(onedig_t const *a, onedig_t const *b, unsigned n)
 }
 
 // Add unsigned digit strings, return carry. Assumes l1 >= l2!
-static _fast onedig_t digit_add(
+static onedig_t digit_add(
   onedig_t const *d1,
   unsigned l1,
   onedig_t const *d2,
@@ -95,7 +95,7 @@ copy:
 }
 
 // Subtract unsigned digit strings, return carry. Assumes l1 >= l2!
-static _fast void digit_sub(
+static void digit_sub(
   onedig_t const *d1,
   unsigned l1,
   onedig_t const *d2,
@@ -129,7 +129,7 @@ copy:
 
 // Multiply unsigned digit string by single digit, replaces argument
 // with product and returns overflowing digit.
-static _fast onedig_t digit_mul(onedig_t *b, unsigned l, onedig_t d)
+static onedig_t digit_mul(onedig_t *b, unsigned l, onedig_t d)
 {
   twodig_t p = 0;
   for(int i = l; --i >= 0;)
@@ -144,7 +144,7 @@ static _fast onedig_t digit_mul(onedig_t *b, unsigned l, onedig_t d)
 // Multiply two digit strings. Writes result into a third digit string
 // which must have the appropriate size and must not be same as one of
 // the arguments.
-static _fast void digit_mul(
+static void digit_mul(
   onedig_t const *a,
   unsigned la,
   onedig_t const *b,
@@ -169,7 +169,7 @@ static _fast void digit_mul(
 
 // Divide unsigned digit string by single digit, replaces argument
 // with quotient and returns remainder.
-static _fast onedig_t digit_div(onedig_t *b, unsigned l, onedig_t d)
+static onedig_t digit_div(onedig_t *b, unsigned l, onedig_t d)
 {
   twodig_t r = 0;
   for(int i = l; --i >= 0;)
@@ -212,7 +212,7 @@ inline onedig_t guess_q(onedig_t const *r, onedig_t const *y)
 
 // Multiply divisor with quotient digit and subtract from dividend.
 // Returns overflow.
-static _fast onedig_t
+static onedig_t
 multiply_and_subtract(onedig_t *r, onedig_t const *y, unsigned l, onedig_t q)
 {
   twodig_t p = 0;
@@ -236,7 +236,7 @@ multiply_and_subtract(onedig_t *r, onedig_t const *y, unsigned l, onedig_t q)
 
 // Add back divisor digits to dividend, corresponds to a correction of
 // the guessed quotient digit by -1.
-static _fast void add_back(onedig_t *r, onedig_t const *y, unsigned l)
+static void add_back(onedig_t *r, onedig_t const *y, unsigned l)
 {
   twodig_t h = 0;
   for(unsigned i = 0; i < l; i++)
@@ -251,7 +251,7 @@ static _fast void add_back(onedig_t *r, onedig_t const *y, unsigned l)
 
 // Divide two digit strings. Divides r by y/yl. Stores quotient in
 // q/ql and leaves the remainder in r. Size of r is yl+ql.
-static _fast void
+static void
 digit_div(onedig_t *r, const onedig_t *y, unsigned yl, onedig_t *q, unsigned ql)
 {
   r += ql;

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <utility>
-#include <util/compiler_defs.h>
 
 // This one is pretty simple but has a fair divide implementation.
 // Though I'm not ambitious enough to do that FFT-like stuff.
@@ -117,73 +116,73 @@ private:
   inline void adjust();
 
   // Assign to this.
-  void assign(llong_t) _fast;
-  void assign(ullong_t) _fast;
+  void assign(llong_t);
+  void assign(ullong_t);
 
   // Aux methods, only for internal use.
   inline int ucompare(BigInt const &) const;
-  void add(onedig_t const *, unsigned, bool) _fast;
-  void mul(onedig_t const *, unsigned, bool) _fast;
+  void add(onedig_t const *, unsigned, bool);
+  void mul(onedig_t const *, unsigned, bool);
 
   // Auxiliary constructor used for temporary or static BigInt.
   // Sets size=0 which indicates that ~BigInt must not delete[].
-  inline BigInt(onedig_t *, unsigned, bool) _fast;
+  inline BigInt(onedig_t *, unsigned, bool);
 
 public:
-  ~BigInt() _fast;
+  ~BigInt();
 
-  BigInt() _fast;
-  BigInt(int) _fast;
-  BigInt(unsigned) _fast;
+  BigInt();
+  BigInt(int);
+  BigInt(unsigned);
 
-  BigInt(long signed int x) _fast;
-  BigInt(long unsigned int x) _fast;
+  BigInt(long signed int x);
+  BigInt(long unsigned int x);
 
-  BigInt(llong_t) _fast;
-  BigInt(ullong_t) _fast;
-  BigInt(BigInt const &) _fast;
-  BigInt(BigInt &&) _fast;
-  BigInt(char const *, onedig_t = 10) _fast;
+  BigInt(llong_t);
+  BigInt(ullong_t);
+  BigInt(BigInt const &);
+  BigInt(BigInt &&);
+  BigInt(char const *, onedig_t = 10);
 
-  BigInt &operator=(BigInt const &) _fast;
-  BigInt &operator=(BigInt &&) _fast;
+  BigInt &operator=(BigInt const &);
+  BigInt &operator=(BigInt &&);
 
   // Input conversion from text.
 
-  char const *scan_on(char const *, onedig_t = 10) _fast;
-  char const *scan(char const *, onedig_t = 10) _fast;
+  char const *scan_on(char const *, onedig_t = 10);
+  char const *scan(char const *, onedig_t = 10);
 
   // Output conversion into text.
 
   // Return an upper bound for the number of digits the textual
   // representation of this might have.
-  unsigned digits(onedig_t = 10) const _fast;
+  unsigned digits(onedig_t = 10) const;
 
   // Convert into string, right adjusted in field of specified width.
   // Returns pointer to start of number or NULL if field too small.
-  char *as_string(char *, unsigned, onedig_t = 10) const _fasta;
+  char *as_string(char *, unsigned, onedig_t = 10) const;
 
   // Convert to/from a binary representation.
 
   // Write and read in a compact byte-wise binary form. Effectively
   // print in base 256 with the most significant digit first. Also
   // read back from such a representation. Return success.
-  bool dump(unsigned char *, unsigned) _fast const;
-  void load(unsigned char const *, unsigned) _fast;
+  bool dump(unsigned char *, unsigned) const;
+  void load(unsigned char const *, unsigned);
 
   // Conversions to elementary types.
 
-  bool is_int64() const _fast;
+  bool is_int64() const;
   bool is_uint64() const
   {
     return length <= small;
   }
 
   // disabled by DK: makes operators ambigous
-  //operator llong_t() const _fast;
-  //operator ullong_t() const _fast;
-  uint64_t to_uint64() const _fast;
-  int64_t to_int64() const _fast;
+  //operator llong_t() const;
+  //operator ullong_t() const;
+  uint64_t to_uint64() const;
+  int64_t to_int64() const;
 
 #ifndef bool
   // Like int: non-zero is true. Equivalent to !is_zero().
@@ -192,9 +191,9 @@ public:
 
   // All comparisions are done with these primitives.
 
-  int compare(llong_t) const _fast;
-  int compare(ullong_t) const _fast;
-  int compare(BigInt const &) const _fast;
+  int compare(llong_t) const;
+  int compare(ullong_t) const;
+  int compare(BigInt const &) const;
 
   // Eliminate need for explicit casts when comparing.
 
@@ -252,11 +251,11 @@ public:
   }
 
 #define IN_PLACE_OPERATOR(TYPE)                                                \
-  BigInt &operator+=(TYPE) _fast;                                              \
-  BigInt &operator-=(TYPE) _fast;                                              \
-  BigInt &operator*=(TYPE) _fast;                                              \
-  BigInt &operator/=(TYPE) _fast;                                              \
-  BigInt &operator%=(TYPE) _fast;
+  BigInt &operator+=(TYPE);                                              \
+  BigInt &operator-=(TYPE);                                              \
+  BigInt &operator*=(TYPE);                                              \
+  BigInt &operator/=(TYPE);                                              \
+  BigInt &operator%=(TYPE);
 
   IN_PLACE_OPERATOR(const BigInt &)
   IN_PLACE_OPERATOR(llong_t)
@@ -301,15 +300,15 @@ public:
   } // predecrement
 
   static void
-  div(BigInt const &, BigInt const &, BigInt &quot, BigInt &rem) _fasta;
+  div(BigInt const &, BigInt const &, BigInt &quot, BigInt &rem);
 
   // Returns the largest x such that 2^x <= abs() or 0 if input is 0
   // Not part of original BigInt.
-  unsigned floorPow2() const _fast;
+  unsigned floorPow2() const;
 
   // Sets the number to the power of two given by the exponent
   // Not part of original BigInt.
-  void setPower2(unsigned exponent) _fast;
+  void setPower2(unsigned exponent);
 
   void swap(BigInt &other)
   {

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <util/compiler_defs.h>
 
 // This one is pretty simple but has a fair divide implementation.
 // Though I'm not ambitious enough to do that FFT-like stuff.
@@ -54,33 +55,6 @@
 //
 // You may however use and modify this without restriction.
 
-// Add your losing compiler to this list.
-#if !defined bool &&                                                           \
-  (defined __SUNPRO_CC && (__SUNPRO_CC < 0x500 || __SUNPRO_CC_COMPAT < 5) ||   \
-   defined __xlC__ || defined __DECCXX && __DECCXX_VER < 60000000 ||           \
-   defined _MSC_VER && _MSC_VER < 1100)
-#undef bool
-#undef false
-#undef true
-#define bool int
-#define false 0
-#define true 1
-#endif
-
-// Minor optimization for gcc on some intel platforms.
-#if !defined _fast
-#if defined __GNUC__ && defined __i386__ && defined NDEBUG
-#define _fast __attribute__((__regparm__(3), __stdcall__))
-#if defined _WIN32
-#define _fasta       // Mingw-gcc crashes when alloca is used
-#else                // inside a function declared regparm
-#define _fasta _fast // or stdcall (don't know which).
-#endif
-#else
-#define _fast
-#define _fasta
-#endif
-#endif
 
 class BigInt
 {

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -27,7 +27,7 @@
 #include <boost/preprocessor/list/for_each.hpp>
 #include <cstdarg>
 #include <functional>
-#include <util/config.h>
+#include <util/compiler_defs.h>
 #include <util/crypto_hash.h>
 #include <util/dstring.h>
 #include <util/irep.h>

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -428,3 +428,36 @@ const expr2tc &object_descriptor2t::get_root_object() const
       return *tmp;
   } while(1);
 }
+
+arith_2ops::arith_2ops(
+  const type2tc &t,
+  arith_ops::expr_ids id,
+  const expr2tc &v1,
+  const expr2tc &v2)
+  : arith_ops(t, id), side_1(v1), side_2(v2)
+{
+#ifndef NDEBUG /* only check consistency in non-Release builds */
+  bool p1 = is_pointer_type(v1);
+  bool p2 = is_pointer_type(v2);
+  auto is_bv_type = [](const type2tc &t) {
+    return t->type_id == type2t::unsignedbv_id ||
+           t->type_id == type2t::signedbv_id;
+  };
+  if(p1 && p2)
+  {
+    assert(id == expr2t::sub_id);
+    assert(is_bv_type(t));
+    assert(t->get_width() == config.ansi_c.pointer_width);
+  }
+  else if(!(is_vector_type(v1->type) || is_vector_type(v2->type)))
+  {
+    assert(
+      p2 || (is_bv_type(t) == is_bv_type(v1->type) &&
+             t->get_width() == v1->type->get_width()));
+    assert(
+      p1 || (is_bv_type(t) == is_bv_type(v2->type) &&
+             t->get_width() == v2->type->get_width()));
+  }
+  // TODO: Add consistency checks for vectors
+#endif
+}

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -496,34 +496,8 @@ public:
     const type2tc &t,
     arith_ops::expr_ids id,
     const expr2tc &v1,
-    const expr2tc &v2)
-    : arith_ops(t, id), side_1(v1), side_2(v2)
-  {
-#ifndef NDEBUG /* only check consistency in non-Release builds */
-    bool p1 = is_pointer_type(v1);
-    bool p2 = is_pointer_type(v2);
-    auto is_bv_type = [](const type2tc &t) {
-      return t->type_id == type2t::unsignedbv_id ||
-             t->type_id == type2t::signedbv_id;
-    };
-    if(p1 && p2)
-    {
-      assert(id == expr2t::sub_id);
-      assert(is_bv_type(t));
-      assert(t->get_width() == config.ansi_c.pointer_width);
-    }
-    else if(!(is_vector_type(v1->type) || is_vector_type(v2->type)))
-    {
-      assert(
-        p2 || (is_bv_type(t) == is_bv_type(v1->type) &&
-               t->get_width() == v1->type->get_width()));
-      assert(
-        p1 || (is_bv_type(t) == is_bv_type(v2->type) &&
-               t->get_width() == v2->type->get_width()));
-    }
-    // TODO: Add consistency checks for vectors
-#endif
-  }
+    const expr2tc &v2);
+
   arith_2ops(const arith_2ops &ref) = default;
 
   expr2tc side_1;

--- a/src/util/compiler_defs.h
+++ b/src/util/compiler_defs.h
@@ -1,0 +1,64 @@
+#pragma once
+
+/// Header to define some properties that are OS or Compiler specific
+
+#ifndef GNUC_PREREQ
+#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#define GNUC_PREREQ(maj, min, patch)                                           \
+  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >=          \
+   ((maj) << 20) + ((min) << 10) + (patch))
+#elif defined(__GNUC__) && defined(__GNUC_MINOR__)
+#define GNUC_PREREQ(maj, min, patch)                                           \
+  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
+#else
+#define GNUC_PREREQ(maj, min, patch) 0
+#endif
+#endif
+
+#if __has_attribute(noinline) || GNUC_PREREQ(3, 4, 0)
+#define ATTRIBUTE_NOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define ATTRIBUTE_NOINLINE __declspec(noinline)
+#else
+#define ATTRIBUTE_NOINLINE
+#endif
+
+#if __has_attribute(used) || GNUC_PREREQ(3, 1, 0)
+#define ATTRIBUTE_USED __attribute__((__used__))
+#else
+#define ATTRIBUTE_USED
+#endif
+
+#if !defined(NDEBUG)
+#define DUMP_METHOD ATTRIBUTE_NOINLINE ATTRIBUTE_USED
+#else
+#define DUMP_METHOD ATTRIBUTE_NOINLINE
+#endif
+
+// Add your losing compiler to this list.
+#if !defined bool &&                                                           \
+  (defined __SUNPRO_CC && (__SUNPRO_CC < 0x500 || __SUNPRO_CC_COMPAT < 5) ||   \
+   defined __xlC__ || defined __DECCXX && __DECCXX_VER < 60000000 ||           \
+   defined _MSC_VER && _MSC_VER < 1100)
+#undef bool
+#undef false
+#undef true
+#define bool int
+#define false 0
+#define true 1
+#endif
+
+// Minor optimization for gcc on some intel platforms.
+#if !defined _fast
+#if defined __GNUC__ && defined __i386__ && defined NDEBUG
+#define _fast __attribute__((__regparm__(3), __stdcall__))
+#if defined _WIN32
+#define _fasta       // Mingw-gcc crashes when alloca is used
+#else                // inside a function declared regparm
+#define _fasta _fast // or stdcall (don't know which).
+#endif
+#else
+#define _fast
+#define _fasta
+#endif
+#endif

--- a/src/util/compiler_defs.h
+++ b/src/util/compiler_defs.h
@@ -34,31 +34,3 @@
 #else
 #define DUMP_METHOD ATTRIBUTE_NOINLINE
 #endif
-
-// Add your losing compiler to this list.
-#if !defined bool &&                                                           \
-  (defined __SUNPRO_CC && (__SUNPRO_CC < 0x500 || __SUNPRO_CC_COMPAT < 5) ||   \
-   defined __xlC__ || defined __DECCXX && __DECCXX_VER < 60000000 ||           \
-   defined _MSC_VER && _MSC_VER < 1100)
-#undef bool
-#undef false
-#undef true
-#define bool int
-#define false 0
-#define true 1
-#endif
-
-// Minor optimization for gcc on some intel platforms.
-#if !defined _fast
-#if defined __GNUC__ && defined __i386__ && defined NDEBUG
-#define _fast __attribute__((__regparm__(3), __stdcall__))
-#if defined _WIN32
-#define _fasta       // Mingw-gcc crashes when alloca is used
-#else                // inside a function declared regparm
-#define _fasta _fast // or stdcall (don't know which).
-#endif
-#else
-#define _fast
-#define _fasta
-#endif
-#endif

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -5,39 +5,7 @@
 #include <util/cmdline.h>
 #include <util/options.h>
 #include <langapi/mode.h>
-
-#ifndef GNUC_PREREQ
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#define GNUC_PREREQ(maj, min, patch)                                           \
-  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >=          \
-   ((maj) << 20) + ((min) << 10) + (patch))
-#elif defined(__GNUC__) && defined(__GNUC_MINOR__)
-#define GNUC_PREREQ(maj, min, patch)                                           \
-  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
-#else
-#define GNUC_PREREQ(maj, min, patch) 0
-#endif
-#endif
-
-#if __has_attribute(noinline) || GNUC_PREREQ(3, 4, 0)
-#define ATTRIBUTE_NOINLINE __attribute__((noinline))
-#elif defined(_MSC_VER)
-#define ATTRIBUTE_NOINLINE __declspec(noinline)
-#else
-#define ATTRIBUTE_NOINLINE
-#endif
-
-#if __has_attribute(used) || GNUC_PREREQ(3, 1, 0)
-#define ATTRIBUTE_USED __attribute__((__used__))
-#else
-#define ATTRIBUTE_USED
-#endif
-
-#if !defined(NDEBUG)
-#define DUMP_METHOD ATTRIBUTE_NOINLINE ATTRIBUTE_USED
-#else
-#define DUMP_METHOD ATTRIBUTE_NOINLINE
-#endif
+#include <util/compiler_defs.h>
 
 class configt
 {


### PR DESCRIPTION
This will add a new header to put our OS/Compiler specific definitions. I mainly did this because it was causing an unneeded dependency between `config.h` and `irep2.h` which is causing difficulties while implementing comments from https://github.com/esbmc/esbmc/pull/827