### PR TITLE
Green Reordering algorithm

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -6,6 +6,10 @@ target_include_directories(algorithms
 add_library(cache cache.cpp)
 target_link_libraries(cache algorithms)
 
+add_library(green_reordering green_reordering.cpp)
+target_link_libraries(green_reordering algorithms)
+
+
 add_library(filesystem filesystem.cpp)
 target_include_directories(filesystem
     PRIVATE ${Boost_INCLUDE_DIRS}

--- a/src/util/algorithms.h
+++ b/src/util/algorithms.h
@@ -105,4 +105,16 @@ public:
   {
   }
 };
+
+/**
+ * @brief Base interface for ssa-step algorithms
+ */
+class expr2tc_algorithm : public algorithm<expr2tc>
+{
+public:
+  explicit expr2tc_algorithm(bool sideffect) : algorithm(sideffect)
+  {
+  }
+};
+
 #endif //ESBMC_ALGORITHM_H

--- a/src/util/green_reordering.cpp
+++ b/src/util/green_reordering.cpp
@@ -1,0 +1,217 @@
+#include <util/green_reordering.h>
+#include <array>
+
+bool expr_variable_reordering::run(expr2tc &e)
+{
+  switch(e->expr_id)
+  {
+    // BINARY OPS
+  case expr2t::expr_ids::add_id:
+  case expr2t::expr_ids::mul_id:
+    run_on_binop(e);
+    break;
+    // RELATIONS
+  case expr2t::expr_ids::equality_id:
+  case expr2t::expr_ids::notequal_id:
+  case expr2t::expr_ids::lessthan_id:
+  case expr2t::expr_ids::greaterthan_id:
+  case expr2t::expr_ids::lessthanequal_id:
+  case expr2t::expr_ids::greaterthanequal_id:
+    run_on_relation(e);
+    break;
+    // Negations
+  case expr2t::expr_ids::neg_id:
+  case expr2t::expr_ids::not_id:
+    run_on_negation(e);
+    break;
+  default:
+    break; // don't care
+  }
+  return true;
+}
+
+void expr_variable_reordering::run_on_binop(expr2tc &expr)
+{
+  std::shared_ptr<arith_2ops> arith;
+  arith = std::dynamic_pointer_cast<arith_2ops>(expr);
+  // If arith is false then the cast failed
+  assert(arith);
+
+  /** Reorder both sides recursively
+   *
+   * The idea of this algorithm is to parse all symbols and values of a
+   * expression with the same operator and rewrite it.
+   *
+   * 1. Create a list of symbols and values
+   * 2. Order it in crescent order
+   * 3. Change all values
+   */
+
+  run(arith->side_1);
+  run(arith->side_2);
+
+  symbols_vec symbols; // annotates all inner symbols
+  values_vec values;   // annotates all inner values
+
+  // 1. Create a list of symbols and values
+  this->transverse_read_binop(arith, symbols, values);
+
+  // 2. Order it in crescent order
+  sort(symbols.begin(), symbols.end(), [](const auto &lhs, const auto &rhs) {
+    return lhs->get_symbol_name() > rhs->get_symbol_name();
+  });
+
+  // A constant propagation should have been executed prior to this
+  assert(values.size() <= 1);
+
+  // 3. Change all values
+  this->transverse_replace_binop(arith, symbols, values);
+}
+
+void expr_variable_reordering::run_on_negation(expr2tc &expr)
+{
+  if(expr->expr_id == expr2t::expr_ids::neg_id)
+  {
+    std::shared_ptr<arith_1op> arith;
+    arith = std::dynamic_pointer_cast<arith_1op>(expr);
+    // If arith is false then the cast failed
+    assert(arith);
+    run(arith->value);
+  }
+  else if(expr->expr_id == expr2t::expr_ids::not_id)
+  {
+    std::shared_ptr<bool_1op> arith;
+    arith = std::dynamic_pointer_cast<bool_1op>(expr);
+    // If arith is false then the cast failed
+    assert(arith);
+    run(arith->value);
+  }
+}
+
+void expr_variable_reordering::run_on_relation(expr2tc &expr)
+{
+  std::shared_ptr<relation_data> relation;
+  relation = std::dynamic_pointer_cast<relation_data>(expr);
+
+  // If relation is false then the cast failed
+  assert(relation);
+
+  // Reorder both sides
+  run(relation->side_1);
+  run(relation->side_2);
+}
+
+inline void expr_variable_reordering::transverse_read_binop(
+  const std::shared_ptr<arith_2ops> op,
+  expr_variable_reordering::symbols_vec &symbols,
+  expr_variable_reordering::values_vec &values)
+{
+  transverse_binop(op, symbols, values, TRANSVERSE_MODE::READ);
+}
+
+inline void expr_variable_reordering::transverse_replace_binop(
+  const std::shared_ptr<arith_2ops> op,
+  expr_variable_reordering::symbols_vec &symbols,
+  expr_variable_reordering::values_vec &values)
+{
+  transverse_binop(op, symbols, values, TRANSVERSE_MODE::REPLACE);
+}
+
+void expr_variable_reordering::parse_arith_side(
+  const std::shared_ptr<arith_2ops> op,
+  expr_variable_reordering::symbols_vec &symbols,
+  expr_variable_reordering::values_vec &values,
+  expr_variable_reordering::TRANSVERSE_MODE mode,
+  bool is_lhs)
+{
+  bool side_is_same_operand = is_lhs ? op->side_1->expr_id == op->expr_id
+                                     : op->side_2->expr_id == op->expr_id;
+  // Check if LHS is the same binary operation of parent
+  if(side_is_same_operand)
+  {
+    std::shared_ptr<arith_2ops> arith;
+    arith =
+      std::dynamic_pointer_cast<arith_2ops>(is_lhs ? op->side_1 : op->side_2);
+    transverse_binop(arith, symbols, values, mode);
+  }
+
+  switch(mode)
+  {
+  case TRANSVERSE_MODE::READ:
+  {
+    add_value(op, is_lhs, symbols, values);
+    break;
+  }
+  case TRANSVERSE_MODE::REPLACE:
+  {
+    replace_value(op, is_lhs, symbols, values);
+    break;
+  }
+  }
+}
+
+void expr_variable_reordering::transverse_binop(
+  const std::shared_ptr<arith_2ops> op,
+  expr_variable_reordering::symbols_vec &symbols,
+  expr_variable_reordering::values_vec &values,
+  expr_variable_reordering::TRANSVERSE_MODE mode)
+{
+  parse_arith_side(op, symbols, values, mode, true);  // LHS
+  parse_arith_side(op, symbols, values, mode, false); // RHS
+}
+
+void expr_variable_reordering::add_value(
+  const std::shared_ptr<arith_2ops> op,
+  bool is_lhs,
+  expr_variable_reordering::symbols_vec &symbols,
+  expr_variable_reordering::values_vec &values)
+{
+  auto side_expr = is_lhs ? op->side_1 : op->side_2;
+  switch(side_expr->expr_id)
+  {
+  case expr2t::expr_ids::symbol_id:
+  {
+    symbol2tc symbol;
+    symbol = side_expr;
+    symbols.push_back(symbol);
+    break;
+  }
+  case expr2t::expr_ids::constant_int_id:
+  {
+    constant_int2tc value;
+    value = side_expr;
+    values.push_back(value);
+    break;
+  }
+  default:; // Continue parsing without adding anything
+  }
+}
+
+void expr_variable_reordering::replace_value(
+  const std::shared_ptr<arith_2ops> op,
+  bool is_lhs,
+  symbols_vec &symbols,
+  values_vec &values)
+{
+  auto side_expr = is_lhs ? op->side_1 : op->side_2;
+  bool should_change = side_expr->expr_id == expr2t::expr_ids::symbol_id ||
+                       side_expr->expr_id == expr2t::expr_ids::constant_int_id;
+  if(should_change)
+  {
+    expr2tc to_add;
+    if(!values.empty())
+    {
+      to_add = values.back();
+      values.pop_back();
+    }
+    else
+    {
+      to_add = symbols.back();
+      symbols.pop_back();
+    }
+    if(is_lhs)
+      op->side_1 = to_add;
+    else
+      op->side_2 = to_add;
+  }
+}

--- a/src/util/green_reordering.h
+++ b/src/util/green_reordering.h
@@ -1,0 +1,179 @@
+#pragma once
+#include <util/algorithms.h>
+
+/**
+ *  This class will reorder a expression based on lexical order,
+ *  the idea is that a expression in the format:
+ *
+ *  c + a + b + 4 + d == b + a
+ *
+ *  Becomes:
+ *
+ *  4 + a + b + c + d == a + b
+ *
+ *  Note that that this assumes that a constant propagation algorithm
+ *  was executed, so an expression should have at max 1 constant value.
+ *
+ *  Supported Operators: [+, *]
+ *  Supported Types (constants/symbols): [Signed BV, Unsigned BV]
+ *  Supported Relations: [==, !=, <, >, <=, >=]
+ *
+ */
+class expr_variable_reordering : public expr2tc_algorithm
+{
+  typedef std::vector<symbol2tc> symbols_vec;
+  typedef std::vector<constant_int2tc> values_vec;
+
+public:
+  explicit expr_variable_reordering() : expr2tc_algorithm(true)
+  {
+  }
+
+  bool run(expr2tc &) override;
+
+private:
+  /**
+   * Parse a binary operation and reorders it
+   *
+   * Since some operators have precedence this implementation
+   * should take it into account.
+   *
+   * The reorder will check if LHS and RHS are symbols/values
+   * the precedence will be: x OP y OP z OP value
+   *
+   *
+   * @param expr binary_operation
+   */
+  void run_on_binop(expr2tc &expr);
+
+  /**
+   * Parse a relation by reordering the LHS and RHS
+   *
+   * @param expr relation
+   */
+  void run_on_relation(expr2tc &expr);
+
+  /**
+   * Parse the inner contents of a negation
+   *
+   * @param expr relation
+   */
+  void run_on_negation(expr2tc &expr);
+
+  /**
+   * Parses and adds the symbol or value
+   *
+   * This receives a reference and generates a copy of it to be later used
+   *
+   * @param op parent of the operation
+   * @param is_lhs truth value to determine which side of the op will be checked
+   * @param symbols
+   * @param values
+   */
+  static void add_value(
+    const std::shared_ptr<arith_2ops> op,
+    bool is_lhs,
+    symbols_vec &symbols,
+    values_vec &values);
+
+  /**
+   * Parses and replaces symbols and values
+   *
+   * This works by tacking an expression and manually replacing its inner
+   * expressions with the ordered symbols and values
+   *
+   * Example:
+   *
+   * op: (ADD ("b") ( (ADD ("7") ("a") ) -------> b + (7 + a)
+   * symbols: ["a", "b"]
+   * values: ["7"]
+   *
+   * The expression would be parsed/replaced in the following order:
+   *
+   * (ADD (1) ( (ADD (2) (3)) )
+   *
+   * 1 -> "a"
+   * 2 -> "b"
+   * 3 -> "7"
+   *
+   * @param op parent of the operation
+   * @param is_lhs truth value to determine which side of the op will be checked
+   * @param symbols
+   * @param values
+   */
+  static void replace_value(
+    const std::shared_ptr<arith_2ops> op,
+    bool is_lhs,
+    symbols_vec &symbols,
+    values_vec &values);
+
+  enum class TRANSVERSE_MODE
+  {
+    READ,    /// to extract the expressions
+    REPLACE, /// to replace the expressions
+  };
+
+  /**
+   * @brief Helper method to be used internally with transverse_binop
+   *
+   * @param op binaop arith
+   * @param symbols symbolic variable list
+   * @param values constants list
+   * @param mode reading/replacing
+   * @param is_lhs which side of binary operation to be checked
+   */
+  void parse_arith_side(
+    std::shared_ptr<arith_2ops> op,
+    symbols_vec &symbols,
+    values_vec &values,
+    TRANSVERSE_MODE mode,
+    bool is_lhs);
+
+  /**
+   * Default strategy to execute an algorithm while transversing the expr
+   * @param op binary operation
+   * @param symbols vector of all symbols expressions
+   * @param values vector of all values expressions
+   */
+  void transverse_binop(
+    std::shared_ptr<arith_2ops> op,
+    symbols_vec &symbols,
+    values_vec &values,
+    TRANSVERSE_MODE mode);
+
+  /**
+   * Recursively extracts all symbols and values of a binary operation
+   *
+   * The logic is that an expr is like a lisp:
+   *
+   *  (BINOP (BINOP (x) (y)) (7))
+   *
+   *  So the output would be:
+   *
+   *  symbols = [x,y], values = [7]
+   *
+   *
+   * @param op binary operation
+   * @param symbols vector of all symbols expressions
+   * @param values vector of all values expressions
+   */
+  void transverse_read_binop(
+    std::shared_ptr<arith_2ops> op,
+    symbols_vec &symbols,
+    values_vec &values);
+
+  /**
+   * Transverse the expression replacing its inner symbols and values
+   * in alphabetical order
+   *
+   * This assumes that symbols is ordered and values has at most 1 element
+   *
+   * @param op binary operation
+   * @param symbols vector of all symbols expressions
+   * @param values vector of all values expressions
+   */
+  void transverse_replace_binop(
+    std::shared_ptr<arith_2ops> op,
+    symbols_vec &symbols,
+    values_vec &values);
+};

--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(cache_fuzz_utils PUBLIC util_esbmc cache_test_utils)
 
 new_unit_test(irep2test "irep2.test.cpp" "util_esbmc;irep2;bigint")
 new_unit_test(green_reorder_test "green_reordering.test.cpp" "util_esbmc;irep2;bigint;cache_test_utils;green_reordering")
-new_fuzz_test(green_reorder_fuzz "green_reordering.fuzz.cpp" "util_esbmc;irep2;bigint;cache_test_utils;cache_fuzz_utils;green_reordering;")
+new_fast_fuzz_test(green_reorder_fuzz "green_reordering.fuzz.cpp" "util_esbmc;irep2;bigint;cache_test_utils;cache_fuzz_utils;green_reordering;")

--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(cache_fuzz_utils PUBLIC util_esbmc cache_test_utils)
 
 new_unit_test(irep2test "irep2.test.cpp" "util_esbmc;irep2;bigint")
 new_unit_test(green_reorder_test "green_reordering.test.cpp" "util_esbmc;irep2;bigint;cache_test_utils;green_reordering")
-new_fuzz_test(green_reorder_fuzz "green_reordering.fuzz.cpp" "util_esbmc;irep2;bigint;cache_test_utils;green_reordering;cache_fuzz_utils")
+new_fuzz_test(green_reorder_fuzz "green_reordering.fuzz.cpp" "util_esbmc;irep2;bigint;cache_test_utils;cache_fuzz_utils;green_reordering;")

--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -1,1 +1,9 @@
+add_library(cache_test_utils cache_test_utils.cpp)
+target_link_libraries(cache_test_utils PUBLIC util_esbmc)
+
+add_library(cache_fuzz_utils cache_fuzz_utils.cpp)
+target_link_libraries(cache_fuzz_utils PUBLIC util_esbmc cache_test_utils)
+
 new_unit_test(irep2test "irep2.test.cpp" "util_esbmc;irep2;bigint")
+new_unit_test(green_reorder_test "green_reordering.test.cpp" "util_esbmc;irep2;bigint;cache_test_utils;green_reordering")
+new_fuzz_test(green_reorder_fuzz "green_reordering.fuzz.cpp" "util_esbmc;irep2;bigint;cache_test_utils;green_reordering;cache_fuzz_utils")

--- a/unit/irep2/cache_fuzz_utils.cpp
+++ b/unit/irep2/cache_fuzz_utils.cpp
@@ -1,0 +1,154 @@
+#include "cache_fuzz_utils.h"
+#include <climits>
+namespace
+{
+inline char convert_char_to_letter(const char input)
+{
+  const char a = 'a';
+  const char z = 'z';
+  if(input >= a && input <= z)
+    return input;
+  const char range = z - a;
+  const char result = (input % range) + a;
+  return result;
+}
+} // namespace
+
+expr2tc expr_generator_fuzzer::convert_input_to_expression()
+{
+  return convert_vectors_to_expression(lhs_names, rhs_names);
+}
+
+expr2tc expr_generator_fuzzer::get_correct_expression(
+  expr_generator_fuzzer::relation,
+  expr_generator_fuzzer::binary_operation,
+  std::vector<char> lhs,
+  std::vector<char> rhs)
+{
+  return convert_vectors_to_expression(lhs, rhs);
+}
+
+expr2tc expr_generator_fuzzer::convert_char_vector_to_expression(
+  std::vector<char> entries,
+  expr_generator_fuzzer::binary_operation)
+{
+  assert(entries.size() != 0);
+
+  // Check trivial case
+  if(entries.size() == 1)
+    return create_unsigned_32_symbol_expr(std::string(1, entries[0]));
+
+  /**
+   * If it is not the trivial case then we create the initial add and apply
+   * a fold like algorithm in a way that:
+   *
+   * a, b, c
+   *
+   * Becomes:
+   *
+   * (ADD (a) (b))   [c]
+   *
+   * Then:
+   *
+   * (ADD (ADD (a) (b)) (c))
+   *
+   */
+  symbol2tc first = create_unsigned_32_symbol_expr(std::string(1, entries[0]));
+
+  symbol2tc second = create_unsigned_32_symbol_expr(std::string(1, entries[1]));
+
+  // TODO: We only support add for now
+  // This is the base (ADD (a) (b))
+  add2tc result = create_unsigned_32_add_expr(first, second);
+
+  // Fold like algorithm applying the binary operation
+  for(size_t i = 2; i < entries.size(); i++)
+  {
+    symbol2tc rhs = create_unsigned_32_symbol_expr(std::string(1, entries[i]));
+
+    // TODO: We only support add for now
+    add2tc old_add = result;
+    result = create_unsigned_32_add_expr(old_add, rhs);
+  }
+
+  return result;
+}
+
+expr2tc expr_generator_fuzzer::convert_vectors_to_expression(
+  std::vector<char> lhs,
+  std::vector<char> rhs)
+{
+  /**
+   * Conversion steps:
+   *
+   * 0 - Check preconditions
+   * 1 - Process LHS
+   * 2 - Process RHS
+   * 3 - Unify
+   */
+
+  /* 0 - Check preconditions */
+  assert(lhs.size() > 0);
+  assert(rhs.size() > 0);
+
+  /* 1 - Process LHS */
+  expr2tc lhs_expr = convert_char_vector_to_expression(lhs, this->expr_binop);
+
+  /* 2 - Process RHS */
+  expr2tc rhs_expr = convert_char_vector_to_expression(rhs, this->expr_binop);
+
+  /* 3 - Unify */
+  // TODO: We only support equality for now
+  return create_equality_relation(lhs_expr, rhs_expr);
+}
+
+bool expr_generator_fuzzer::is_valid_input()
+{
+  // 0 - Check the size
+  // The minimum valid expression will be in the format 00a%a
+  if(data.size() < 5)
+    return false;
+
+  /* Since this uses a integer as a index, then the size of the input
+   * shouldn't be greater thant max_int
+   */
+  if((size_t)data.size() > (size_t)INT_MAX)
+    return false;
+
+  // 1 - Get the relation
+  expr_relation = relation_from_unsigned((unsigned)data[0]);
+  expr_binop = binop_from_unsigned((unsigned)data[0]);
+
+  // 2 - Parse the LHS
+  int rhs_index = -1; // storing for later use
+
+  // The LHS begins after the binary operation and goes until a '%' is found
+  // it must contain at least one symbol.
+  for(size_t i = 2; i < data.size(); i++)
+  {
+    char buf = data[i];
+    if(buf == '%')
+    {
+      rhs_index = i + 1;
+      break;
+    }
+    lhs_names.push_back(convert_char_to_letter(buf));
+  }
+
+  if(rhs_index == -1)
+    return false; // The expression must contain '%'
+
+  if(lhs_names.size() == 0)
+    return false;
+
+  // Parse RHS
+
+  // For RHS we only need to parse the rest of the string.
+  for(size_t i = rhs_index; i < data.size(); i++)
+  {
+    char buf = data[i];
+    rhs_names.push_back(convert_char_to_letter(buf));
+  }
+
+  return rhs_names.size() != 0;
+}

--- a/unit/irep2/cache_fuzz_utils.h
+++ b/unit/irep2/cache_fuzz_utils.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <utility>
+
+#include "cache_test_utils.h"
+
+/**
+ * Helper class to be used in fuzzing targets,
+ * this will help create valid expr to validate the algorithms
+ *
+ * The main class will work by receiving a string and parsing it as follows:
+ *
+ * RELATION BINOP [SYMBOLS] % SYMBOLS
+ *
+ * 00abc%a => a + b + c == a => (EQUAL (ADD (A) (ADD) (B) (C))) (A))
+ *
+ */
+class expr_generator_fuzzer
+{
+public:
+  expr_generator_fuzzer(std::string input) : data(std::move(input))
+  {
+    is_valid = is_valid_input();
+  }
+
+  bool is_expr_valid() const
+  {
+    return is_valid;
+  }
+
+  const std::vector<char> get_lhs_names()
+  {
+    return lhs_names;
+  }
+  const std::vector<char> get_rhs_names()
+  {
+    return rhs_names;
+  }
+
+protected:
+  /**
+   * Process data and validates if it is in the right format
+   * @return if the input is valid
+   */
+  bool is_valid_input();
+
+private:
+  const std::string data;      /// Contains the input from fuzzer
+  bool is_valid;               /// Saves if the input is valid and can be used
+  std::vector<char> lhs_names; // Stores LHS side of the input
+  std::vector<char> rhs_names; // Stores RHS side of the input
+
+  /**
+   * Used for relation, the value from fuzzer mod 6 will be used
+   */
+  enum class relation
+  {
+    EQUAL,
+    UNEQUAL,
+    LESSER,
+    LESSER_EQUAL,
+    GREATER,
+    GREATER_EQUAL
+  };
+
+  /**
+   * To be used for relation, the value from fuzzer mod 3 will used
+   */
+  enum class binary_operation
+  {
+    ADD,
+    SUB,
+    MUL
+  };
+
+  relation expr_relation = relation::EQUAL;
+  binary_operation expr_binop = binary_operation::ADD;
+
+  static inline relation relation_from_unsigned(unsigned)
+  {
+    // TODO: support all relations
+    return relation::EQUAL;
+  }
+  static inline binary_operation binop_from_unsigned(unsigned)
+  {
+    // TODO: support all binary operations
+    return binary_operation::ADD;
+  }
+
+  /**
+   * Flatten lhs of rhs applying the expr_binop and expr_relation
+   * @param lhs of relation with binop
+   * @param rhs of relation with binop
+   * @return relation expression
+   *
+   * @pre @lhs and @rhs are not empty
+   */
+  expr2tc
+  convert_vectors_to_expression(std::vector<char> lhs, std::vector<char> rhs);
+
+  /**
+   * Flatten a char vector into an expressions using a binary operator
+   * @param entries
+   * @param binop
+   * @return bionop expression
+   *
+   * @pre @entries is not empty
+   */
+  static expr2tc convert_char_vector_to_expression(
+    std::vector<char> entries,
+    binary_operation binop);
+
+public:
+  /**
+   * Parses data and convert it to an expr2tc
+   *
+   * @return the expression generated
+   *
+   * @pre @this->data is a valid input
+   */
+  expr2tc convert_input_to_expression();
+
+  /**
+   * Parses data and convert it to an expr2tc
+   * @param expr_relation
+   * @param binop
+   * @param lhs
+   * @param rhs
+   * @return the expression generated
+   *
+   * @pre @lhs and @rhs are not empty
+   */
+  virtual expr2tc get_correct_expression(
+    relation expr_relation,
+    binary_operation binop,
+    std::vector<char> lhs,
+    std::vector<char> rhs);
+
+  relation get_relation() const
+  {
+    return expr_relation;
+  }
+  binary_operation get_binop() const
+  {
+    return expr_binop;
+  }
+};

--- a/unit/irep2/cache_test_utils.cpp
+++ b/unit/irep2/cache_test_utils.cpp
@@ -1,0 +1,316 @@
+#include "cache_test_utils.h"
+
+bool is_symbols_equal(expr2tc &v1, expr2tc &v2)
+{
+  assert(v1->expr_id == expr2t::expr_ids::symbol_id);
+  assert(v2->expr_id == expr2t::expr_ids::symbol_id);
+
+  std::shared_ptr<symbol_data> symbol1;
+  symbol1 = std::dynamic_pointer_cast<symbol_data>(v1);
+
+  std::shared_ptr<symbol_data> symbol2;
+  symbol2 = std::dynamic_pointer_cast<symbol_data>(v2);
+
+  auto name1 = symbol1->get_symbol_name();
+  auto name2 = symbol2->get_symbol_name();
+  return symbol1->get_symbol_name() == symbol2->get_symbol_name();
+}
+
+bool is_unsigned_equal(expr2tc &v1, expr2tc &v2)
+{
+  assert(v1->expr_id == expr2t::expr_ids::constant_int_id);
+  assert(v2->expr_id == expr2t::expr_ids::constant_int_id);
+
+  constant_int2tc value1 = v1;
+  constant_int2tc value2 = v2;
+
+  return value1->value.compare(value2->value) == 0;
+}
+
+symbol2tc create_unsigned_32_symbol_expr(std::string name)
+{
+  unsignedbv_type2tc u32type(32);
+  irep_idt var(name);
+  symbol2tc expression(u32type, var);
+  return expression;
+}
+
+constant_int2tc create_unsigned_32_value_expr(unsigned value)
+{
+  unsignedbv_type2tc u32type(32);
+  BigInt num(value);
+  constant_int2tc expression(u32type, num);
+  return expression;
+}
+
+constant_int2tc create_signed_32_value_expr(int value)
+{
+  signedbv_type2tc i32type(32);
+  BigInt num(value);
+  constant_int2tc expression(i32type, num);
+  return expression;
+}
+
+add2tc create_unsigned_32_add_expr(expr2tc &side1, expr2tc &side2)
+{
+  unsignedbv_type2tc type(32);
+  add2tc expression(type, side1, side2);
+  return expression;
+}
+
+neg2tc create_unsigned_32_neg_expr(expr2tc &value)
+{
+  unsignedbv_type2tc type(32);
+  neg2tc expression(type, value);
+  return expression;
+}
+
+not2tc create_not_expr(expr2tc &value)
+{
+  not2tc expression(value);
+  return expression;
+}
+
+add2tc create_signed_32_add_expr(expr2tc &side1, expr2tc &side2)
+{
+  signedbv_type2tc type(32);
+  add2tc expression(type, side1, side2);
+  return expression;
+}
+
+mul2tc create_unsigned_32_mul_expr(expr2tc &side1, expr2tc &side2)
+{
+  unsignedbv_type2tc type(32);
+  mul2tc expression(type, side1, side2);
+  return expression;
+}
+
+mul2tc create_signed_32_mul_expr(expr2tc &side1, expr2tc &side2)
+{
+  signedbv_type2tc type(32);
+  mul2tc expression(type, side1, side2);
+  return expression;
+}
+
+lessthan2tc create_lesser_relation(expr2tc &lhs, expr2tc &rhs)
+{
+  lessthan2tc relation(lhs, rhs);
+  return relation;
+}
+
+lessthanequal2tc create_lessthanequal_relation(expr2tc &lhs, expr2tc &rhs)
+{
+  lessthanequal2tc relation(lhs, rhs);
+  return relation;
+}
+
+greaterthanequal2tc create_greaterthanequal_relation(expr2tc &lhs, expr2tc &rhs)
+{
+  greaterthanequal2tc relation(lhs, rhs);
+  return relation;
+}
+
+greaterthan2tc create_greater_relation(expr2tc &lhs, expr2tc &rhs)
+{
+  greaterthan2tc relation(lhs, rhs);
+  return relation;
+}
+
+equality2tc create_equality_relation(expr2tc &lhs, expr2tc &rhs)
+{
+  equality2tc relation(lhs, rhs);
+  return relation;
+}
+
+void create_assignment(symex_target_equationt::SSA_stepst &output, expr2tc &rhs)
+{
+  symex_target_equationt::SSA_stept step1;
+  step1.type = goto_trace_stept::ASSIGNMENT;
+  step1.rhs = rhs;
+  output.push_back(step1);
+}
+
+void create_assumption(
+  symex_target_equationt::SSA_stepst &output,
+  expr2tc &cond)
+{
+  symex_target_equationt::SSA_stept step1;
+  step1.type = goto_trace_stept::ASSUME;
+  step1.cond = cond;
+  output.push_back(step1);
+}
+
+void create_assert(symex_target_equationt::SSA_stepst &output, expr2tc &cond)
+{
+  symex_target_equationt::SSA_stept step1;
+  step1.type = goto_trace_stept::ASSERT;
+  step1.cond = cond;
+  output.push_back(step1);
+}
+
+// Pre-Built expressions
+// These expressions will be used thorough the
+// test cases as simple validations.
+// The fuzzer should use the above method as a way to construct
+// and validate expressions
+
+namespace
+{
+symbol2tc Y = create_unsigned_32_symbol_expr("Y");
+symbol2tc X = create_unsigned_32_symbol_expr("X");
+constant_int2tc values[10];
+constant_int2tc neg_values[10];
+
+} // namespace
+
+void init_test_values()
+{
+  static bool is_initialized = false;
+  if(is_initialized)
+    return;
+  for(int i = 0; i < 10; i++)
+  {
+    values[i] = create_signed_32_value_expr(i);
+    neg_values[i] = create_signed_32_value_expr(0 - i);
+  }
+  is_initialized = true;
+}
+
+// ((y + x) + 7) == 9
+expr2tc equality_1()
+{
+  add2tc add_1 = create_signed_32_add_expr(Y, X);
+  add2tc add_2 = create_signed_32_add_expr(add_1, values[7]);
+  equality2tc result = create_equality_relation(add_2, values[9]);
+  return result;
+}
+
+// (7 + (x + y)) == 9
+expr2tc equality_1_ordered()
+{
+  add2tc add_1 = create_signed_32_add_expr(values[7], X);
+  add2tc add_2 = create_signed_32_add_expr(add_1, Y);
+  equality2tc result = create_equality_relation(add_2, values[9]);
+  return result;
+}
+
+// (-2 + (x + y)) == 0
+expr2tc equality_1_green_normal()
+{
+  add2tc add_1 = create_signed_32_add_expr(neg_values[2], X);
+  add2tc add_2 = create_signed_32_add_expr(add_1, Y);
+  equality2tc result = create_equality_relation(add_2, values[0]);
+  return result;
+}
+
+void is_equality_1_equivalent(expr2tc &actual, expr2tc &expected)
+{
+  std::shared_ptr<equality2t> actual_relation;
+  actual_relation = std::dynamic_pointer_cast<equality2t>(actual);
+  std::shared_ptr<equality2t> expected_relation;
+  expected_relation = std::dynamic_pointer_cast<equality2t>(expected);
+
+  // RHS OF RELATION
+  bool is_rhs_value_equal =
+    is_unsigned_equal(actual_relation->side_2, expected_relation->side_2);
+  assert(is_rhs_value_equal);
+
+  // LHS OF RELATION
+
+  std::shared_ptr<arith_2ops> actual_outter_add;
+  actual_outter_add =
+    std::dynamic_pointer_cast<arith_2ops>(actual_relation->side_1);
+
+  std::shared_ptr<arith_2ops> expected_outter_add;
+  expected_outter_add =
+    std::dynamic_pointer_cast<arith_2ops>(expected_relation->side_1);
+
+  // First symbol
+  bool outter_symbol =
+    is_unsigned_equal(actual_outter_add->side_2, expected_outter_add->side_2);
+  assert(outter_symbol);
+
+  // Inner add
+  std::shared_ptr<arith_2ops> actual_inner_add;
+  actual_inner_add =
+    std::dynamic_pointer_cast<arith_2ops>(actual_outter_add->side_1);
+
+  std::shared_ptr<arith_2ops> expected_inner_add;
+  expected_inner_add =
+    std::dynamic_pointer_cast<arith_2ops>(expected_outter_add->side_1);
+
+  assert(
+    is_symbols_equal(actual_inner_add->side_1, expected_inner_add->side_1));
+  assert(
+    is_symbols_equal(actual_inner_add->side_2, expected_inner_add->side_2));
+
+  assert(actual->crc() == expected->crc());
+}
+
+// (1 + x) == 0
+expr2tc equality_2()
+{
+  add2tc add_1 = create_signed_32_add_expr(values[1], X);
+  equality2tc result = create_equality_relation(add_1, values[0]);
+  return result;
+}
+
+// (1 + x) == 0
+expr2tc equality_2_ordered()
+{
+  add2tc add_1 = create_signed_32_add_expr(values[1], X);
+  equality2tc result = create_equality_relation(add_1, values[0]);
+  return result;
+}
+
+// (x + 1) == 0
+expr2tc equality_2_green_normal()
+{
+  return equality_2_ordered();
+}
+
+// (y + 4) == 8
+expr2tc equality_3()
+{
+  add2tc add_1 = create_signed_32_add_expr(Y, values[4]);
+  equality2tc result = create_equality_relation(add_1, values[8]);
+  return result;
+}
+
+// (4 + y) == 8
+expr2tc equality_3_ordered()
+{
+  add2tc add_1 = create_signed_32_add_expr(values[4], Y);
+  equality2tc result = create_equality_relation(add_1, values[8]);
+  return result;
+}
+
+// (y - 4) == 0
+expr2tc equality_3_green_normal()
+{
+  add2tc add_1 = create_signed_32_add_expr(Y, neg_values[4]);
+  equality2tc result = create_equality_relation(add_1, values[0]);
+  return result;
+}
+
+// (x + 0) == 0
+expr2tc equality_4()
+{
+  add2tc add_1 = create_signed_32_add_expr(X, values[0]);
+  equality2tc result = create_equality_relation(add_1, values[0]);
+  return result;
+}
+
+// (0 + x) == 0
+expr2tc equality_4_ordered()
+{
+  add2tc add_1 = create_signed_32_add_expr(values[0], X);
+  equality2tc result = create_equality_relation(add_1, values[0]);
+  return result;
+}
+
+// (x + 0) == 0
+expr2tc equality_4_green_normal()
+{
+  return equality_4();
+}

--- a/unit/irep2/cache_test_utils.h
+++ b/unit/irep2/cache_test_utils.h
@@ -1,0 +1,76 @@
+#pragma once
+#include <irep2/irep2.h>
+#include <irep2/irep2_utils.h>
+#include <goto-symex/symex_target_equation.h>
+
+bool is_symbols_equal(expr2tc &v1, expr2tc &v2);
+
+bool is_unsigned_equal(expr2tc &v1, expr2tc &v2);
+
+symbol2tc create_unsigned_32_symbol_expr(std::string name);
+
+constant_int2tc create_unsigned_32_value_expr(unsigned value);
+
+constant_int2tc create_signed_32_value_expr(int value);
+
+add2tc create_unsigned_32_add_expr(expr2tc &side1, expr2tc &side2);
+
+neg2tc create_unsigned_32_neg_expr(expr2tc &value);
+
+not2tc create_not_expr(expr2tc &value);
+
+add2tc create_signed_32_add_expr(expr2tc &side1, expr2tc &side2);
+
+mul2tc create_unsigned_32_mul_expr(expr2tc &side1, expr2tc &side2);
+
+mul2tc create_signed_32_mul_expr(expr2tc &side1, expr2tc &side2);
+
+lessthan2tc create_lesser_relation(expr2tc &lhs, expr2tc &rhs);
+
+lessthanequal2tc create_lessthanequal_relation(expr2tc &lhs, expr2tc &rhs);
+
+greaterthanequal2tc
+create_greaterthanequal_relation(expr2tc &lhs, expr2tc &rhs);
+
+greaterthan2tc create_greater_relation(expr2tc &lhs, expr2tc &rhs);
+
+equality2tc create_equality_relation(expr2tc &lhs, expr2tc &rhs);
+
+void create_assignment(
+  symex_target_equationt::SSA_stepst &output,
+  expr2tc &rhs);
+
+void create_assumption(
+  symex_target_equationt::SSA_stepst &output,
+  expr2tc &cond);
+
+void create_assert(symex_target_equationt::SSA_stepst &output, expr2tc &cond);
+
+// Pre-Built expressions
+// These expressions will be used thorough the
+// test cases as simple validations.
+// The fuzzer should use the above method as a way to construct
+// and validate expressions
+void init_test_values();
+
+// ((y + x) + 7) == 9
+expr2tc equality_1();
+// ((x + y) + 7) == 9
+expr2tc equality_1_ordered();
+
+void is_equality_1_equivalent(expr2tc &actual, expr2tc &expected);
+
+// (1 + x) == 0
+expr2tc equality_2();
+// (x + 1) == 0
+expr2tc equality_2_ordered();
+
+// (y + 4) == 8
+expr2tc equality_3();
+// (y + 4) == 8
+expr2tc equality_3_ordered();
+
+// (x + 0) == 0
+expr2tc equality_4();
+// (x + 0) == 0
+expr2tc equality_4_ordered();

--- a/unit/irep2/green_reordering.fuzz.cpp
+++ b/unit/irep2/green_reordering.fuzz.cpp
@@ -1,0 +1,46 @@
+#include <cctype>
+#include <cassert>
+#include <util/green_reordering.h>
+#include "cache_fuzz_utils.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const char *Data, size_t Size)
+{
+  std::string input(Data);
+  expr_generator_fuzzer fuzzer(input);
+  if(fuzzer.is_expr_valid())
+  {
+    // Check original expression
+    expr2tc actual = fuzzer.convert_input_to_expression();
+
+    auto relation = fuzzer.get_relation();
+    auto binop = fuzzer.get_binop();
+    auto lhs = fuzzer.get_lhs_names();
+    auto rhs = fuzzer.get_rhs_names();
+
+    // Checks if the function recreates the expression correctly
+    expr2tc original_recreated =
+      fuzzer.get_correct_expression(relation, binop, lhs, rhs);
+
+    assert(actual->crc() == original_recreated->crc());
+
+    // Sort each side
+    sort(lhs.begin(), lhs.end(), [](const auto &x, const auto &y) {
+      return x < y;
+    });
+
+    sort(rhs.begin(), rhs.end(), [](const auto &x, const auto &y) {
+      return x < y;
+    });
+
+    // Recreate it sorted
+    expr2tc expected = fuzzer.get_correct_expression(relation, binop, lhs, rhs);
+
+    // Apply sorting on original
+    expr_variable_reordering f;
+    f.run(actual);
+
+    // Check if expected == actual
+    assert(actual->crc() == expected->crc());
+  }
+  return 0;
+}

--- a/unit/irep2/green_reordering.test.cpp
+++ b/unit/irep2/green_reordering.test.cpp
@@ -1,0 +1,249 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <irep2/irep2.h>
+#include <util/green_reordering.h>
+#include "cache_test_utils.h"
+// ** Check if trivial cases are ok
+// expressions which does not contain a symbol/value or only one at max
+
+TEST_CASE("variable reordering tests", "[caching]")
+{
+  expr_variable_reordering algorithm;
+  SECTION("unsigned_expr_should_not_change_value")
+  {
+    constant_int2tc life_expr = create_unsigned_32_value_expr(42);
+    auto crc = life_expr->crc();
+    algorithm.run(life_expr);
+
+    REQUIRE(life_expr->value.compare(42) == 0);
+    REQUIRE(life_expr->crc() == crc);
+  }
+
+  SECTION("signed_expr_should_not_change_value")
+  {
+    int meaning_of_death = ~42;
+    constant_int2tc death_expr = create_signed_32_value_expr(meaning_of_death);
+    auto crc = death_expr->crc();
+
+    algorithm.run(death_expr);
+
+    REQUIRE(death_expr->value.compare(meaning_of_death) == 0);
+    REQUIRE(death_expr->crc() == crc);
+  }
+
+  SECTION("symbol_expr_should_not_change_value")
+  {
+    symbol2tc x = create_unsigned_32_symbol_expr("X");
+    auto crc = x->crc();
+
+    algorithm.run(x);
+
+    REQUIRE(x->get_symbol_name() == "X");
+    REQUIRE(x->crc() == crc);
+  }
+
+  SECTION("a_add_b_should_become_a_add_b")
+  {
+    symbol2tc a = create_unsigned_32_symbol_expr("a");
+    symbol2tc b = create_unsigned_32_symbol_expr("b");
+
+    // a + b => a + b
+    add2tc add = create_unsigned_32_add_expr(a, b);
+    auto crc = add->crc();
+
+    // Check if object is created as expected
+    REQUIRE(is_symbols_equal(add->side_1, a));
+    REQUIRE(is_symbols_equal(add->side_2, b));
+
+    algorithm.run(add);
+
+    std::shared_ptr<arith_2ops> arith;
+    arith = std::dynamic_pointer_cast<arith_2ops>(add);
+
+    // Check if object is reordered correctly
+    REQUIRE(is_symbols_equal(a, arith->side_1));
+    REQUIRE(is_symbols_equal(b, arith->side_2));
+
+    REQUIRE(add->crc() == crc);
+  }
+
+  SECTION("b_add_a_should_become_a_add_b")
+  {
+    symbol2tc a = create_unsigned_32_symbol_expr("a");
+    symbol2tc b = create_unsigned_32_symbol_expr("b");
+
+    // b + a => a + b
+    add2tc add = create_unsigned_32_add_expr(b, a);
+    auto crc = add->crc();
+
+    // Check if object is created as expected
+    REQUIRE(is_symbols_equal(add->side_1, b));
+    REQUIRE(is_symbols_equal(add->side_2, a));
+
+    algorithm.run(add);
+
+    // Check if object is reordered correctly
+    REQUIRE(is_symbols_equal(add->side_1, a));
+    REQUIRE(is_symbols_equal(add->side_2, b));
+
+    REQUIRE(add->crc() != crc);
+  }
+
+  SECTION("a_add_value_should_become_value_add_a")
+  {
+    symbol2tc a = create_unsigned_32_symbol_expr("a");
+    constant_int2tc value = create_unsigned_32_value_expr(42);
+
+    // a + 42 => a + 42
+    add2tc add = create_unsigned_32_add_expr(a, value);
+
+    // Check if object is created as expected
+    REQUIRE(is_symbols_equal(add->side_1, a));
+    REQUIRE(is_unsigned_equal(add->side_2, value));
+
+    auto crc = add->crc();
+
+    algorithm.run(add);
+
+    // Check if object is reordered correctly
+    REQUIRE(is_unsigned_equal(add->side_1, value));
+    REQUIRE(is_symbols_equal(add->side_2, a));
+    REQUIRE(add->crc() != crc);
+  }
+
+  SECTION("value_add_a_should_become_value_add_a")
+  {
+    symbol2tc a = create_unsigned_32_symbol_expr("a");
+    constant_int2tc value = create_unsigned_32_value_expr(42);
+
+    // 42 + a => a + 42
+    add2tc add = create_unsigned_32_add_expr(value, a);
+
+    // Check if object is created as expected
+    REQUIRE(is_unsigned_equal(add->side_1, value));
+    REQUIRE(is_symbols_equal(add->side_2, a));
+
+    auto crc = add->crc();
+
+    algorithm.run(add);
+
+    // Check if object is reordered correctly
+    REQUIRE(is_symbols_equal(add->side_2, a));
+    REQUIRE(is_unsigned_equal(add->side_1, value));
+    REQUIRE(add->crc() == crc);
+  }
+
+  SECTION("not_b_add_a_should_become_a_add_b")
+  {
+    symbol2tc a = create_unsigned_32_symbol_expr("a");
+    symbol2tc b = create_unsigned_32_symbol_expr("b");
+
+    // b + a
+    add2tc add = create_unsigned_32_add_expr(b, a);
+
+    // !(b + a)
+    not2tc neg = create_not_expr(add);
+
+    // Check if object is created as expected
+    REQUIRE(is_symbols_equal(add->side_1, b));
+    REQUIRE(is_symbols_equal(add->side_2, a));
+
+    algorithm.run(neg);
+
+    add2tc new_value(neg->value);
+    // Check if object is reordered correctly
+    REQUIRE(is_symbols_equal(new_value->side_1, a));
+    REQUIRE(is_symbols_equal(new_value->side_2, b));
+  }
+
+  SECTION("neg_b_add_a_should__become_a_add_b")
+  {
+    symbol2tc a = create_unsigned_32_symbol_expr("a");
+    symbol2tc b = create_unsigned_32_symbol_expr("b");
+
+    // b + a
+    add2tc add = create_unsigned_32_add_expr(b, a);
+
+    // !(b + a)
+    neg2tc neg = create_unsigned_32_neg_expr(add);
+
+    // Check if object is created as expected
+    REQUIRE(is_symbols_equal(add->side_1, b));
+    REQUIRE(is_symbols_equal(add->side_2, a));
+
+    algorithm.run(neg);
+
+    add2tc new_value(neg->value);
+    // Check if object is reordered correctly
+    REQUIRE(is_symbols_equal(new_value->side_1, a));
+    REQUIRE(is_symbols_equal(new_value->side_2, b));
+  }
+
+  SECTION("equality_1_check")
+  {
+    init_test_values();
+
+    // ((y + x) + 7) == 9
+    auto actual = equality_1();
+
+    // (7 + (x + y)) == 9
+    auto expected = equality_1_ordered();
+
+    REQUIRE(actual->crc() != expected->crc());
+
+    algorithm.run(actual);
+
+    REQUIRE(actual->crc() == expected->crc());
+  }
+
+  SECTION("equality_2_check")
+  {
+    init_test_values();
+
+    // (1 + x) == 0
+    auto actual = equality_2();
+
+    // (1 + x) == 0
+    auto expected = equality_2_ordered();
+
+    REQUIRE(actual->crc() == expected->crc());
+
+    algorithm.run(actual);
+
+    REQUIRE(actual->crc() == expected->crc());
+  }
+
+  SECTION("equality_3_check")
+  {
+    init_test_values();
+
+    // (y + 4) == 8
+    auto actual = equality_3();
+
+    // (y + 4) == 8
+    auto expected = equality_3_ordered();
+
+    REQUIRE(actual->crc() != expected->crc());
+
+    algorithm.run(actual);
+
+    REQUIRE(actual->crc() == expected->crc());
+  }
+
+  SECTION("equality_4_check")
+  {
+    init_test_values();
+
+    // (x + 0) == 0
+    auto actual = equality_4();
+
+    // (0 + x) == 0
+    auto expected = equality_4_ordered();
+
+    REQUIRE(actual->crc() != expected->crc());
+
+    algorithm.run(actual);
+
+    REQUIRE(actual->crc() == expected->crc());
+  }
+}


### PR DESCRIPTION
This is the first algorithm for the canonization (normalization and renaming are missing for now) process of expr2t, which is based on this [paper](https://dl.acm.org/doi/abs/10.1145/2393596.2393665). The idea is that given an arithmetic expression, e.g `e + a + 42 + b = b + a` will convert it into `a + b + e + 42 = b + a`.

In future this will be used for the caching.