### PR TITLE
Goto contractor: support for multiple operators.

### DIFF
--- a/regression/goto-contractor/operator_and_fail/main.c
+++ b/regression/goto-contractor/operator_and_fail/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(x >= y && x <=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_and_fail/main.c
+++ b/regression/goto-contractor/operator_and_fail/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_and_fail/test.desc
+++ b/regression/goto-contractor/operator_and_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION FAILED$

--- a/regression/goto-contractor/operator_and_success/main.c
+++ b/regression/goto-contractor/operator_and_success/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(x >= y && x >=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_and_success/main.c
+++ b/regression/goto-contractor/operator_and_success/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_and_success/test.desc
+++ b/regression/goto-contractor/operator_and_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION SUCCESSFUL$

--- a/regression/goto-contractor/operator_eq_fail/main.c
+++ b/regression/goto-contractor/operator_eq_fail/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_eq_fail/main.c
+++ b/regression/goto-contractor/operator_eq_fail/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x++;
+  }
+  assert(x == y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_eq_fail/test.desc
+++ b/regression/goto-contractor/operator_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION FAILED$

--- a/regression/goto-contractor/operator_eq_success/main.c
+++ b/regression/goto-contractor/operator_eq_success/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_eq_success/main.c
+++ b/regression/goto-contractor/operator_eq_success/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 0;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x++;
+  }
+  assert(x == y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_eq_success/test.desc
+++ b/regression/goto-contractor/operator_eq_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION SUCCESSFUL$

--- a/regression/goto-contractor/operator_multiple_assert_fail/main.c
+++ b/regression/goto-contractor/operator_multiple_assert_fail/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(x >= y);
+  assert(x <=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_multiple_assert_fail/main.c
+++ b/regression/goto-contractor/operator_multiple_assert_fail/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_multiple_assert_fail/test.desc
+++ b/regression/goto-contractor/operator_multiple_assert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION FAILED$

--- a/regression/goto-contractor/operator_multiple_assert_success/main.c
+++ b/regression/goto-contractor/operator_multiple_assert_success/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_multiple_assert_success/main.c
+++ b/regression/goto-contractor/operator_multiple_assert_success/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(x >= y);
+  assert(x >=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_multiple_assert_success/test.desc
+++ b/regression/goto-contractor/operator_multiple_assert_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION SUCCESSFUL$

--- a/regression/goto-contractor/operator_neg_fail/main.c
+++ b/regression/goto-contractor/operator_neg_fail/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(-x >= -y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_neg_fail/main.c
+++ b/regression/goto-contractor/operator_neg_fail/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_neg_fail/test.desc
+++ b/regression/goto-contractor/operator_neg_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION FAILED$

--- a/regression/goto-contractor/operator_neg_success/main.c
+++ b/regression/goto-contractor/operator_neg_success/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(x >=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_neg_success/main.c
+++ b/regression/goto-contractor/operator_neg_success/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_neg_success/test.desc
+++ b/regression/goto-contractor/operator_neg_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION SUCCESSFUL$

--- a/regression/goto-contractor/operator_neq_fail/main.c
+++ b/regression/goto-contractor/operator_neq_fail/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_neq_fail/main.c
+++ b/regression/goto-contractor/operator_neq_fail/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 0;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x++;
+  }
+  assert(x != y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_neq_fail/test.desc
+++ b/regression/goto-contractor/operator_neq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION FAILED$

--- a/regression/goto-contractor/operator_neq_success/main.c
+++ b/regression/goto-contractor/operator_neq_success/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x++;
+  }
+  assert(x != y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_neq_success/main.c
+++ b/regression/goto-contractor/operator_neq_success/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_neq_success/test.desc
+++ b/regression/goto-contractor/operator_neq_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION SUCCESSFUL$

--- a/regression/goto-contractor/operator_or_fail/main.c
+++ b/regression/goto-contractor/operator_or_fail/main.c
@@ -1,0 +1,14 @@
+int main()
+{
+  int x, y;
+  x = 0;
+  y = 0;
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x -= y;
+  }
+  assert(x >= y || x >=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_or_fail/main.c
+++ b/regression/goto-contractor/operator_or_fail/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_or_fail/test.desc
+++ b/regression/goto-contractor/operator_or_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION FAILED$

--- a/regression/goto-contractor/operator_or_success/main.c
+++ b/regression/goto-contractor/operator_or_success/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x, y;
+  x = 1;
+  y = 0;
+  __ESBMC_assume(x >= 0);
+  __ESBMC_assume(y >= 0);
+  while(y <= 1000 && nondet_int())
+  {
+    y++;
+    x += y;
+  }
+  assert(x >= y || x >=-y);
+  return 0;
+}

--- a/regression/goto-contractor/operator_or_success/main.c
+++ b/regression/goto-contractor/operator_or_success/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 int main()
 {
   int x, y;

--- a/regression/goto-contractor/operator_or_success/test.desc
+++ b/regression/goto-contractor/operator_or_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check --goto-contractor --incremental-bmc --unlimited-k-step --k-step 100
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -132,7 +132,8 @@ void goto_contractort::insert_assume(goto_functionst goto_functions)
       symbol2tc X = var.second.getSymbol();
       if(var.second.isIntervalChanged())
       {
-        auto lb = create_value_expr(var.second.getInterval().lb(), int_type2());
+        auto lb =
+          create_value_expr(var.second.getInterval().lb(), double_type2());
         auto cond = create_greaterthanequal_relation(X, lb);
         goto_programt tmp_e;
         auto e = tmp_e.add_instruction(ASSUME);
@@ -141,7 +142,8 @@ void goto_contractort::insert_assume(goto_functionst goto_functions)
         e->location = loop_exit->location;
         goto_function.body.destructive_insert(loop_exit, tmp_e);
 
-        auto ub = create_value_expr(var.second.getInterval().ub(), int_type2());
+        auto ub =
+          create_value_expr(var.second.getInterval().ub(), double_type2());
         auto cond2 = create_lessthanequal_relation(X, ub);
         goto_programt tmp_e2;
         auto e2 = tmp_e2.add_instruction(ASSUME);
@@ -391,10 +393,7 @@ int goto_contractort::create_variable_from_expr2t(irep_container<expr2t> expr)
     }
     return index;
   }
-  else if(is_index2t(expr))
-  {
-    return map.NOT_FOUND;
-  }
+  return map.NOT_FOUND;
 }
 
 bool goto_contractort::initialize_main_function_loops()

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -12,7 +12,6 @@ void goto_contractort::get_constraints(goto_functionst goto_functions)
   auto function = goto_functions.function_map.find("c:@F@main");
   for(const auto &ins : function->second.body.instructions)
   {
-    //TODO: replace constraint with set of contractors
     if(ins.is_assert())
       constraint = create_constraint_from_expr2t(ins.guard);
     else if(
@@ -22,6 +21,27 @@ void goto_contractort::get_constraints(goto_functionst goto_functions)
           .get_symbol_name() == "c:@F@__VERIFIER_assert")
       constraint = create_constraint_from_expr2t(
         to_code_function_call2t(ins.code).operands[0]);
+  }
+}
+
+void goto_contractort::get_contractors(goto_functionst goto_functions)
+{
+  //TODO: Test
+  auto function = goto_functions.function_map.find("c:@F@main");
+  for(const auto &ins : function->second.body.instructions)
+  {
+    if(ins.is_assert())
+      contractors.insert_contractor(
+        create_contractor_from_expr2t(ins.guard), ins.location_number);
+    else if(
+      ins.is_function_call() &&
+      is_symbol2t(to_code_function_call2t(ins.code).function) &&
+      to_symbol2t(to_code_function_call2t(ins.code).function)
+          .get_symbol_name() == "c:@F@__VERIFIER_assert")
+      contractors.insert_contractor(
+        create_contractor_from_expr2t(
+          to_code_function_call2t(ins.code).operands[0]),
+        ins.location_number);
   }
 }
 

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -176,13 +176,16 @@ void goto_contractort::apply_contractor()
   log_status("{}", oss.str());
 }
 
-ibex::Ctc *goto_contractort::create_contractor_from_expr2t(const expr2tc& expr)
+ibex::Ctc *goto_contractort::create_contractor_from_expr2t(const expr2tc &expr)
 {
   ibex::Ctc *contractor = nullptr;
   auto base_object = get_base_object(expr);
 
-  if((is_comp_expr(base_object) && !is_notequal2t(base_object)) || is_arith_expr(base_object))
-    contractor = new ibex::CtcFwdBwd(*create_constraint_from_expr2t(base_object));
+  if(
+    (is_comp_expr(base_object) && !is_notequal2t(base_object)) ||
+    is_arith_expr(base_object))
+    contractor =
+      new ibex::CtcFwdBwd(*create_constraint_from_expr2t(base_object));
   else
   {
     std::shared_ptr<logic_2ops> logic_op;
@@ -208,10 +211,8 @@ ibex::Ctc *goto_contractort::create_contractor_from_expr2t(const expr2tc& expr)
       rel = std::dynamic_pointer_cast<relation_data>(base_object);
       ibex::Function *f = create_function_from_expr2t(rel->side_1);
       ibex::Function *g = create_function_from_expr2t(rel->side_2);
-      auto *side1 =
-        new ibex::NumConstraint(*vars, (*f)(*vars) > (*g)(*vars));
-      auto *side2 =
-        new ibex::NumConstraint(*vars, (*f)(*vars) < (*g)(*vars));
+      auto *side1 = new ibex::NumConstraint(*vars, (*f)(*vars) > (*g)(*vars));
+      auto *side2 = new ibex::NumConstraint(*vars, (*f)(*vars) < (*g)(*vars));
       auto *c_side1 = new ibex::CtcFwdBwd(*side1);
       auto *c_side2 = new ibex::CtcFwdBwd(*side2);
       contractor = new ibex::CtcUnion(*c_side1, *c_side2);
@@ -229,7 +230,7 @@ ibex::Ctc *goto_contractort::create_contractor_from_expr2t(const expr2tc& expr)
 }
 
 ibex::NumConstraint *
-goto_contractort::create_constraint_from_expr2t(const expr2tc& expr)
+goto_contractort::create_constraint_from_expr2t(const expr2tc &expr)
 {
   ibex::NumConstraint *c;
 
@@ -279,12 +280,12 @@ goto_contractort::create_constraint_from_expr2t(const expr2tc& expr)
   return c;
 }
 
-bool goto_contractort::is_unsupported_operator(const expr2tc& expr)
+bool goto_contractort::is_unsupported_operator(const expr2tc &expr)
 {
   expr2tc e = get_base_object(expr);
   return is_arith_expr(e) || is_constant_number(e) || is_symbol2t(e) ||
-         is_notequal2t(e) || is_not2t(e) ||
-         is_modulus2t(e) || is_or2t(e) || is_and2t(e);
+         is_notequal2t(e) || is_not2t(e) || is_modulus2t(e) || is_or2t(e) ||
+         is_and2t(e);
 }
 
 ibex::Function *
@@ -335,7 +336,7 @@ goto_contractort::create_function_from_expr2t(irep_container<expr2t> expr)
   case expr2t::expr_ids::neg_id:
   {
     h = create_function_from_expr2t(to_neg2t(expr).value);
-    f = new ibex::Function(*vars, - (*h)(*vars));
+    f = new ibex::Function(*vars, -(*h)(*vars));
     break;
   }
   case expr2t::expr_ids::index_id:
@@ -366,8 +367,8 @@ goto_contractort::create_function_from_expr2t(irep_container<expr2t> expr)
   }
   case expr2t::expr_ids::constant_floatbv_id:
   {
-    const ibex::ExprConstant &c =
-      ibex::ExprConstant::new_scalar(to_constant_floatbv2t(expr).value.to_double());
+    const ibex::ExprConstant &c = ibex::ExprConstant::new_scalar(
+      to_constant_floatbv2t(expr).value.to_double());
     f = new ibex::Function(*vars, c);
     break;
   }

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -174,7 +174,7 @@ ibex::Ctc *goto_contractort::create_contractor_from_expr2t(const expr2tc &expr)
   ibex::Ctc *contractor = nullptr;
   auto base_object = get_base_object(expr);
 
-  if(is_unsupported_operator_in_contractor(expr))
+  if(is_constraint_operator(expr))
   {
     auto cons = create_constraint_from_expr2t(base_object);
     if(cons == nullptr)
@@ -231,8 +231,7 @@ ibex::Ctc *goto_contractort::create_contractor_from_expr2t(const expr2tc &expr)
   return contractor;
 }
 
-bool goto_contractort::is_unsupported_operator_in_contractor(
-  const expr2tc &expr)
+bool goto_contractort::is_constraint_operator(const expr2tc &expr)
 {
   expr2tc e = get_base_object(expr);
   return (is_comp_expr(e) && !is_notequal2t(e)) || is_arith_expr(e);
@@ -378,7 +377,7 @@ ibex::Function *goto_contractort::create_function_from_expr2t(expr2tc expr)
   return f;
 }
 
-int goto_contractort::create_variable_from_expr2t(irep_container<expr2t> expr)
+int goto_contractort::create_variable_from_expr2t(expr2tc expr)
 {
   if(is_symbol2t(expr))
   {

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -134,8 +134,7 @@ void goto_contractort::insert_assume(goto_functionst goto_functions)
       symbol2tc X = var.second.getSymbol();
       if(var.second.isIntervalChanged())
       {
-        auto lb =
-          create_value_expr(var.second.getInterval().lb(), int_type2());
+        auto lb = create_value_expr(var.second.getInterval().lb(), int_type2());
         auto cond = create_greaterthanequal_relation(X, lb);
         goto_programt tmp_e;
         auto e = tmp_e.add_instruction(ASSUME);
@@ -144,8 +143,7 @@ void goto_contractort::insert_assume(goto_functionst goto_functions)
         e->location = loop_exit->location;
         goto_function.body.destructive_insert(loop_exit, tmp_e);
 
-        auto ub =
-          create_value_expr(var.second.getInterval().ub(), int_type2());
+        auto ub = create_value_expr(var.second.getInterval().ub(), int_type2());
         auto cond2 = create_lessthanequal_relation(X, ub);
         goto_programt tmp_e2;
         auto e2 = tmp_e2.add_instruction(ASSUME);

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -365,7 +365,9 @@ public:
       get_contractors(_goto_functions);
       if(contractors.is_empty())
       {
-        log_status("Contractors: expression not supported, No Contractors were created.");
+        log_status(
+          "Contractors: expression not supported, No Contractors were "
+          "created.");
         return;
       }
       contractors.dump();

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -186,39 +186,33 @@ public:
     }
     log_debug("{}", oss.str());
   }
+  std::ostringstream list_to_oss(ibex::Array<ibex::Ctc> *list, bool is_compo)
+  {
+    std::ostringstream oss;
+    auto it = list->begin();
+    oss << "( " << to_oss(&*it).str();
+    it++;
+    while(it != list->end())
+    {
+      oss << (is_compo ? " && " : " || ") << to_oss(&*it).str();
+      it++;
+    }
+    oss << " )";
+    return oss;
+  }
   std::ostringstream to_oss(ibex::Ctc *c)
   {
     std::ostringstream oss;
-    auto type = boost::core::demangle(typeid(*c).name());
-    if(type == "ibex::CtcCompo" || type == "ibex::CtcUnion")
-    {
-      bool is_compo = false;
-      ibex::Array<ibex::Ctc> *list;
-      if(type == "ibex::CtcCompo")
-      {
-        list = &(dynamic_cast<ibex::CtcCompo *>(c)->list);
-        is_compo = true;
-      }
-      else
-        list = &(dynamic_cast<ibex::CtcUnion *>(c)->list);
-
-      auto it = list->begin();
-      oss << "( " << to_oss(&*it).str();
-      it++;
-      while(it != list->end())
-      {
-        oss << (is_compo ? " && " : " || ") << to_oss(&*it).str();
-        it++;
-      }
-      oss << " )";
-    }
-    else if(type == "ibex::CtcFwdBwd")
-    {
-      auto fwdbwd = dynamic_cast<ibex::CtcFwdBwd *>(c);
+    if(auto ctc_compo = dynamic_cast<ibex::CtcCompo *>(c))
+      oss = list_to_oss(&ctc_compo->list, true);
+    else if(auto ctc_union = dynamic_cast<ibex::CtcUnion *>(c))
+      oss = list_to_oss(&ctc_union->list, false);
+    else if(auto fwdbwd = dynamic_cast<ibex::CtcFwdBwd *>(c))
       oss << fwdbwd->ctr;
-    }
+
     return oss;
   }
+
   void add_contractor(ibex::Ctc *ctc, unsigned int loc)
   {
     if(ctc != nullptr)

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -41,6 +41,39 @@ public:
   void setIntervalChanged(bool intervalChanged);
   const symbol2tc &getSymbol() const;
 };
+
+class Contractorc
+{
+  ibex::Ctc *outer;
+  ibex::Ctc *inner;
+  unsigned int location;
+
+  ibex::Ctc *get_complement_contractor(ibex::Ctc *c)
+  {
+    //TODO: implement.
+    return c;
+  }
+  Contractorc(ibex::Ctc *c, unsigned int loc)
+  {
+    outer = c;
+    location = loc;
+    inner = get_complement_contractor(c);
+
+  }
+};
+
+class Contractorsc
+{
+  Contractorc contractors[];
+
+  Contractorc *get_contractors_up_to_loc(unsigned int loc)
+  {
+    Contractorc *c;
+    //TODO: implement intersection and unioin of contractors up to a given location.
+    return c;
+  }
+};
+
 /**
  * This class is for mapping the variables with their names and intervals.
  * It includes functionalities such as search for a variable by name and add
@@ -50,7 +83,7 @@ public:
 class CspMap
 {
 public:
-  static constexpr int MAX_VAR = 10;
+  static constexpr int MAX_VAR = 26;
   static constexpr int NOT_FOUND = -1;
 
   std::map<std::string, vart> var_map;
@@ -186,6 +219,7 @@ private:
   /// constraint is where the constraint for CSP will be stored.
   ibex::NumConstraint *constraint = nullptr;
 
+
   unsigned number_of_functions = 0;
 
   typedef std::list<loopst> function_loopst;
@@ -235,12 +269,13 @@ private:
    */
   void insert_assume(goto_functionst goto_functions);
 
-  bool is_unsupported_operator(expr2tc expr);
-  ibex::NumConstraint *create_constraint_from_expr2t(irep_container<expr2t>);
-  ibex::Function *create_function_from_expr2t(irep_container<expr2t>);
-  int create_variable_from_expr2t(irep_container<expr2t>);
+  bool is_unsupported_operator(expr2tc);
+  ibex::Ctc *create_contractor_from_expr2t(expr2tc);
+  ibex::NumConstraint *create_constraint_from_expr2t(expr2tc);
+  ibex::Function *create_function_from_expr2t(expr2tc);
+  int create_variable_from_expr2t(expr2tc);
 
-  void parse_intervals(irep_container<expr2t> expr);
+  void parse_intervals(expr2tc);
 
   bool initialize_main_function_loops();
 };

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -466,7 +466,7 @@ private:
   ibex::Function *create_function_from_expr2t(expr2tc);
   int create_variable_from_expr2t(expr2tc);
 
-  void parse_error(const expr2tc&);
+  void parse_error(const expr2tc &);
 
   void parse_intervals(expr2tc);
 

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -55,8 +55,7 @@ public:
     location = loc;
     inner = get_complement_contractor(c);
   }
-  Contractor()
-  = default;
+  Contractor() = default;
   void set_outer(ibex::Ctc *outer)
   {
     Contractor::outer = outer;
@@ -438,9 +437,9 @@ private:
    */
   void insert_assume(goto_functionst goto_functions);
 
-  static bool is_unsupported_operator(const expr2tc&);
-  ibex::Ctc *create_contractor_from_expr2t(const expr2tc&);
-  ibex::NumConstraint *create_constraint_from_expr2t(const expr2tc&);
+  static bool is_unsupported_operator(const expr2tc &);
+  ibex::Ctc *create_contractor_from_expr2t(const expr2tc &);
+  ibex::NumConstraint *create_constraint_from_expr2t(const expr2tc &);
   ibex::Function *create_function_from_expr2t(expr2tc);
   int create_variable_from_expr2t(expr2tc);
 


### PR DESCRIPTION
Hello everyone,

This is an update to the --goto-contractor option. This update includes support for operators &&, ||, ==, !=, and multiple asserts. Regression tests show the new features. Instead of creating one constraint and one contractor, the algorithm will create multiple contractors and save their location in the program. This will enable the algorithm to take the intersection and union of multiple properties and create their complement. The saved location helps get the properties to a given point in the program. 

I am happy to answer any questions you have.

Regards,
-Mohannad