### PR TITLE
Atexit model implementation

### DIFF
--- a/regression/esbmc/atexit-1/main.c
+++ b/regression/esbmc/atexit-1/main.c
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	if (__VERIFIER_nondet_bool()) _Exit(1); // memory leak, but still reachable
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g2);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+	atexit(free_g1);
+	if (__VERIFIER_nondet_bool()) exit(1);
+	f();
+	return 0;
+}

--- a/regression/esbmc/atexit-1/test.desc
+++ b/regression/esbmc/atexit-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-1/test.desc
+++ b/regression/esbmc/atexit-1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success
+--memory-leak-check --force-malloc-success --incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-1/test.desc
+++ b/regression/esbmc/atexit-1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success --incremental-bmc
+--memory-leak-check --force-malloc-success --incremental-bmc --no-simplify
 ^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-2/main.c
+++ b/regression/esbmc/atexit-2/main.c
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	exit(1); // memory leak
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g1);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+	atexit(free_g2);
+//	if (__VERIFIER_nondet_bool()) exit(1);
+	f();
+	return 0;
+}

--- a/regression/esbmc/atexit-2/test.desc
+++ b/regression/esbmc/atexit-2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-2/test.desc
+++ b/regression/esbmc/atexit-2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success
+--memory-leak-check --force-malloc-success --incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-3/main.c
+++ b/regression/esbmc/atexit-3/main.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	exit(1); // memory leak, but still reachable
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g2);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+// 	atexit(free_g1);
+	f();
+	free(*g);
+	free(g);
+	g = NULL;
+	return 0;
+}

--- a/regression/esbmc/atexit-3/test.desc
+++ b/regression/esbmc/atexit-3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-3/test.desc
+++ b/regression/esbmc/atexit-3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success
+--memory-leak-check --force-malloc-success --incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-3/test.desc
+++ b/regression/esbmc/atexit-3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success --incremental-bmc
+--memory-leak-check --force-malloc-success --incremental-bmc --no-simplify
 ^VERIFICATION FAILED$

--- a/regression/esbmc/atexit-4/main.c
+++ b/regression/esbmc/atexit-4/main.c
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* simple regression test for atexit */
+
+int **g = NULL;
+
+void free_g1() {
+	free(g);
+	g = NULL;
+}
+
+void free_g2() {
+	if (g != NULL)
+		free(*g);
+}
+
+void h() {
+	if (__VERIFIER_nondet_bool()) exit(1);
+}
+
+void f() {
+	*g = (int *) malloc(sizeof(int));
+	atexit(free_g2);
+	h();
+}
+
+
+int main() {
+	g = (int **) malloc(sizeof(int *));
+	atexit(free_g1);
+	if (__VERIFIER_nondet_bool()) exit(1);
+	f();
+	return 0;
+}
+

--- a/regression/esbmc/atexit-4/test.desc
+++ b/regression/esbmc/atexit-4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/atexit-4/test.desc
+++ b/regression/esbmc/atexit-4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success
+--memory-leak-check --force-malloc-success --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/atexit-4/test.desc
+++ b/regression/esbmc/atexit-4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---memory-leak-check --force-malloc-success --incremental-bmc
+--memory-leak-check --force-malloc-success --incremental-bmc --no-simplify
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_330_7/test.desc
+++ b/regression/esbmc/github_330_7/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---incremental-bmc --memory-leak-check
+--incremental-bmc --memory-leak-check --force-malloc-success
 ^VERIFICATION SUCCESSFUL$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -115,7 +115,7 @@ def parse_result(the_output, prop):
 
     if prop == Property.memory:
       if memory_leak in the_output:
-        return Result.fail_memtrack
+        return Result.unknown
 
       if invalid_pointer_free in the_output:
         return Result.fail_free
@@ -249,7 +249,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
     command_line += "--memory-leak-check --no-assertions "
     strat = "incr"
   elif prop == Property.memcleanup:
-    command_line += "--no-pointer-check --no-bounds-check --memory-leak-check --memory-cleanup-check --no-assertions "
+    command_line += "--no-pointer-check --no-bounds-check --memory-leak-check --no-assertions "
     strat = "incr"
   elif prop == Property.reach:
     if concurrency:

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -26,9 +26,9 @@ __ESBMC_HIDE:;
   while(__ESBMC_atexits)
   {
     __ESBMC_atexits->atexit_func();
-    __ESBMC_atexit_key *tmp = __ESBMC_atexits->next;
+    __ESBMC_atexit_key *__ESBMC_tmp = __ESBMC_atexits->next;
     free(__ESBMC_atexits);
-    __ESBMC_atexits = tmp;
+    __ESBMC_atexits = __ESBMC_tmp;
   }
 }
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -14,7 +14,7 @@ typedef struct atexit_key
   struct atexit_key *next;
 } __ESBMC_atexit_key;
 
-__ESBMC_atexit_key *__ESBMC_atexits = NULL;
+static __ESBMC_atexit_key *__ESBMC_atexits = NULL;
 
 void __atexit_handler()
 {

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -16,7 +16,7 @@ typedef struct atexit_key
 
 static __ESBMC_atexit_key *head = NULL;
 
-void __ESBMC_atexit()
+void __atexit_handler()
 {
 __ESBMC_HIDE:;
   __ESBMC_atexit_key *tmp = head;
@@ -47,13 +47,13 @@ __ESBMC_HIDE:;
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
 void exit(int status)
 {
-  __ESBMC_atexit();
+  __atexit_handler();
   __ESBMC_assume(0);
 }
 
 void abort(void)
 {
-  __ESBMC_atexit();
+  __atexit_handler();
   __ESBMC_assume(0);
 }
 

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -48,6 +48,7 @@ __ESBMC_HIDE:;
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
 void exit(int status)
 {
+__ESBMC_HIDE:;
   __atexit_handler();
   __ESBMC_finish_formula();
   __ESBMC_assume(0);
@@ -55,6 +56,7 @@ void exit(int status)
 
 void abort(void)
 {
+__ESBMC_HIDE:;
   __atexit_handler();
   __ESBMC_finish_formula();
   __ESBMC_assume(0);
@@ -62,6 +64,7 @@ void abort(void)
 
 void _Exit(int status)
 {
+__ESBMC_HIDE:;
   __ESBMC_finish_formula();
   __ESBMC_assume(0);
 }

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -27,7 +27,7 @@ int atexit(void (*func)(void))
 
 #pragma clang diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-noreturn"
-void exit(int)
+void exit(int status)
 {
   __atexit_handler();
   __ESBMC_finish_formula();
@@ -41,7 +41,7 @@ void abort(void)
   __ESBMC_assume(0);
 }
 
-void _Exit(int)
+void _Exit(int status)
 {
   __ESBMC_finish_formula();
   __ESBMC_assume(0);

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -37,7 +37,8 @@ int atexit(void (*func)(void))
 __ESBMC_HIDE:;
   __ESBMC_atexit_key *l =
     (__ESBMC_atexit_key *)malloc(sizeof(__ESBMC_atexit_key));
-  __ESBMC_assume(l);
+  if(l == NULL)
+    return -1;
   l->atexit_func = func;
   l->next = __ESBMC_atexits;
   __ESBMC_atexits = l;

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -58,7 +58,6 @@ __ESBMC_HIDE:;
 void abort(void)
 {
 __ESBMC_HIDE:;
-  __atexit_handler();
   __ESBMC_memory_leak_checks();
   __ESBMC_assume(0);
 }

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -51,7 +51,7 @@ void exit(int status)
 {
 __ESBMC_HIDE:;
   __atexit_handler();
-  __ESBMC_finish_formula();
+  __ESBMC_memory_leak_checks();
   __ESBMC_assume(0);
 }
 
@@ -59,14 +59,14 @@ void abort(void)
 {
 __ESBMC_HIDE:;
   __atexit_handler();
-  __ESBMC_finish_formula();
+  __ESBMC_memory_leak_checks();
   __ESBMC_assume(0);
 }
 
 void _Exit(int status)
 {
 __ESBMC_HIDE:;
-  __ESBMC_finish_formula();
+  __ESBMC_memory_leak_checks();
   __ESBMC_assume(0);
 }
 #pragma clang diagnostic pop

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -327,6 +327,8 @@ void __ESBMC_finish_formula();
 void pthread_start_main_hook(void);
 void pthread_end_main_hook(void);
 
+void __atexit_handler(void);
+
 // Forward declarations for nondeterministic types.
 int nondet_int();
 unsigned int nondet_uint();

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -319,6 +319,8 @@ int __ESBMC_rounding_mode = 0;
 
 void *__ESBMC_memset(void *, int, unsigned int);
 
+void __ESBMC_finish_formula();
+
 // Forward decs for pthread main thread begin/end hooks. Because they're
 // pulled in from the C library, they need to be declared prior to pulling
 // them in, for type checking.

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -319,7 +319,7 @@ int __ESBMC_rounding_mode = 0;
 
 void *__ESBMC_memset(void *, int, unsigned int);
 
-void __ESBMC_finish_formula();
+void __ESBMC_memory_leak_checks();
 
 // Forward decs for pthread main thread begin/end hooks. Because they're
 // pulled in from the C library, they need to be declared prior to pulling

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -257,8 +257,13 @@ bool clang_main(contextt &context)
   thread_end_call.location() = symbol.location;
   thread_end_call.function() = symbol_exprt("c:@F@pthread_end_main_hook");
 
+  code_function_callt atexit_call;
+  atexit_call.location() = symbol.location;
+  atexit_call.function() = symbol_exprt("c:@F@__atexit_handler");
+
   init_code.move_to_operands(thread_start_call);
   init_code.move_to_operands(call);
+  init_code.move_to_operands(atexit_call);
   init_code.move_to_operands(thread_end_call);
 
   // add "main"

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -409,19 +409,6 @@ void goto_convertt::do_exit(
   t_a->location = function.location();
 }
 
-void goto_convertt::do_abort(
-  const exprt &,
-  const exprt &function,
-  const exprt::operandst &,
-  goto_programt &dest)
-{
-  // same as assume(false)
-
-  goto_programt::targett t_a = dest.add_instruction(ASSUME);
-  t_a->guard = gen_false_expr();
-  t_a->location = function.location();
-}
-
 void goto_convertt::do_free(
   const exprt &,
   const exprt &function,
@@ -643,10 +630,6 @@ void goto_convertt::do_function_call_symbol(
   else if(base_name == "exit")
   {
     do_exit(lhs, function, arguments, dest);
-  }
-  else if(base_name == "abort")
-  {
-    do_abort(lhs, function, arguments, dest);
   }
   else if(base_name == "malloc")
   {

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -141,7 +141,7 @@ public:
    *  This should contain anything that must happen at the end of a program run,
    *  for example assertions about dynamic memory being freed.
    */
-  void finish_formula();
+  void add_memory_leak_checks();
 
 protected:
   /**

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -281,7 +281,7 @@ void reachability_treet::go_next_state()
 
       // For the last one:
       if(execution_states.size() == 1)
-        (*it)->finish_formula();
+        (*it)->add_memory_leak_checks();
 
       execution_states.erase(it);
     }
@@ -561,7 +561,7 @@ reachability_treet::get_next_formula()
       break;
   }
 
-  (*cur_state_it)->finish_formula();
+  (*cur_state_it)->add_memory_leak_checks();
 
   has_complete_formula = false;
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -675,6 +675,10 @@ void goto_symext::run_intrinsic(
 
     return;
   }
+  else if(has_prefix(symname, "c:@F@__ESBMC_finish_formula"))
+  {
+    finish_formula();
+  }
   else
   {
     log_error(

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -708,6 +708,7 @@ void goto_symext::finish_formula()
     equality2tc eq(deallocd, gen_true_expr());
     replace_dynamic_allocation(eq);
     cur_state->rename(eq);
-    assertion(eq, "dereference failure: forgotten memory: " + get_pretty_name(it.name));
+    assertion(
+      eq, "dereference failure: forgotten memory: " + get_pretty_name(it.name));
   }
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -707,17 +707,7 @@ void goto_symext::finish_formula()
 
     equality2tc eq(deallocd, gen_true_expr());
     replace_dynamic_allocation(eq);
-    it.alloc_guard.guard_expr(eq);
     cur_state->rename(eq);
-    target->assertion(
-      it.alloc_guard.as_expr(),
-      eq,
-      "dereference failure: forgotten memory: " + get_pretty_name(it.name),
-      cur_state->gen_stack_trace(),
-      cur_state->source,
-      first_loop);
-
-    total_claims++;
-    remaining_claims++;
+    assertion(eq, "dereference failure: forgotten memory: " + get_pretty_name(it.name));
   }
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -675,9 +675,9 @@ void goto_symext::run_intrinsic(
 
     return;
   }
-  else if(has_prefix(symname, "c:@F@__ESBMC_finish_formula"))
+  else if(has_prefix(symname, "c:@F@__ESBMC_memory_leak_checks"))
   {
-    finish_formula();
+    add_memory_leak_checks();
   }
   else
   {
@@ -691,7 +691,7 @@ void goto_symext::run_intrinsic(
   }
 }
 
-void goto_symext::finish_formula()
+void goto_symext::add_memory_leak_checks()
 {
   if(!memory_leak_check)
     return;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -708,7 +708,7 @@ void goto_symext::add_memory_leak_checks()
     equality2tc eq(deallocd, gen_true_expr());
     replace_dynamic_allocation(eq);
     cur_state->rename(eq);
-    assertion(
+    claim(
       eq, "dereference failure: forgotten memory: " + get_pretty_name(it.name));
   }
 }

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -101,8 +101,7 @@ inline bool is_constant_number(const expr2tc &t)
 
 inline bool is_constant_expr(const expr2tc &t)
 {
-  return is_constant_number(t) ||
-         t->expr_id == expr2t::constant_string_id ||
+  return is_constant_number(t) || t->expr_id == expr2t::constant_string_id ||
          t->expr_id == expr2t::constant_struct_id ||
          t->expr_id == expr2t::constant_union_id ||
          t->expr_id == expr2t::constant_array_id ||

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -101,16 +101,24 @@ inline bool is_constant_number(const expr2tc &t)
 
 inline bool is_constant_expr(const expr2tc &t)
 {
-  return t->expr_id == expr2t::constant_int_id ||
-         t->expr_id == expr2t::constant_fixedbv_id ||
-         t->expr_id == expr2t::constant_floatbv_id ||
-         t->expr_id == expr2t::constant_bool_id ||
+  return is_constant_number(t) ||
          t->expr_id == expr2t::constant_string_id ||
          t->expr_id == expr2t::constant_struct_id ||
          t->expr_id == expr2t::constant_union_id ||
          t->expr_id == expr2t::constant_array_id ||
          t->expr_id == expr2t::constant_array_of_id ||
          t->expr_id == expr2t::constant_vector_id;
+}
+
+inline bool is_constant(const expr2tc &t)
+{
+  if(is_pointer_type(t) && is_symbol2t(t))
+  {
+    symbol2t s = to_symbol2t(t);
+    if(s.thename == "NULL")
+      return true;
+  }
+  return is_constant_expr(t);
 }
 
 inline bool is_structure_type(const type2tc &t)


### PR DESCRIPTION
This PR implements the atexit model and changes ESBMC to always call it when defined by the standard.

The biggest change is that finish_formula now call assertion(), instead of creating the assertion itself. This is necessary so we can encode the memory cleanup check using the appropriate guards.