### PR TITLE
[clang-c] fixed double type adjustment

### DIFF
--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -37,8 +37,6 @@ bool clang_c_adjust::adjust()
   Forall_symbol_list(it, symbol_list)
   {
     symbolt &symbol = **it;
-    adjust_type(symbol.type);
-
     if(symbol.is_type)
       continue;
 


### PR DESCRIPTION
Fixed duplicate type adjustment in clang C adjuster. 
