### PR TITLE
Fix float cast

### DIFF
--- a/regression/esbmc/github_877/main.c
+++ b/regression/esbmc/github_877/main.c
@@ -1,0 +1,8 @@
+int main() {
+   float b = nondet_float();
+   float c = (int)b;
+   assert((long)c > 0); // Crashes with Boolector 
+   assert((short)c > 0); // Crashes with Boolector 
+   assert((char)c > 0); // Crashes with Boolector 
+   assert((float)c > 0); // Works with Boolector
+}

--- a/regression/esbmc/github_877/test.desc
+++ b/regression/esbmc/github_877/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -672,7 +672,8 @@ smt_astt fp_convt::mk_to_bv(smt_astt x, bool is_signed, std::size_t width)
 
   // NaN, Inf, or negative (except -0) -> unspecified
   smt_astt c1 = ctx->mk_or(x_is_nan, x_is_inf);
-  smt_astt unspec_v = ctx->mk_smt_symbol("UNSPEC_FP" + std::to_string(width), ctx->mk_bv_sort(width));
+  smt_astt unspec_v = ctx->mk_smt_symbol(
+    "UNSPEC_FP" + std::to_string(width), ctx->mk_bv_sort(width));
   assert(unspec_v->sort->get_data_width() == width);
   smt_astt v1 = unspec_v;
 

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -673,6 +673,7 @@ smt_astt fp_convt::mk_to_bv(smt_astt x, bool is_signed, std::size_t width)
   // NaN, Inf, or negative (except -0) -> unspecified
   smt_astt c1 = ctx->mk_or(x_is_nan, x_is_inf);
   smt_astt unspec_v = ctx->mk_smt_symbol("UNSPEC_FP" + std::to_string(width), ctx->mk_bv_sort(width));
+  assert(unspec_v->sort->get_data_width() == width);
   smt_astt v1 = unspec_v;
 
   // +-0 -> 0

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -672,7 +672,7 @@ smt_astt fp_convt::mk_to_bv(smt_astt x, bool is_signed, std::size_t width)
 
   // NaN, Inf, or negative (except -0) -> unspecified
   smt_astt c1 = ctx->mk_or(x_is_nan, x_is_inf);
-  smt_astt unspec_v = ctx->mk_smt_symbol("UNSPEC_FP", ctx->mk_bv_sort(width));
+  smt_astt unspec_v = ctx->mk_smt_symbol("UNSPEC_FP" + std::to_string(width), ctx->mk_bv_sort(width));
   smt_astt v1 = unspec_v;
 
   // +-0 -> 0


### PR DESCRIPTION
Fixes issue #877 

In the boolector backend we cache all the symbols created (otherwise, if we try to create a symbol with the same name as an already created symbol, boolector aborts); this causes a crash when verifying the program in issue because:

1. We first create UNSPEC_FP with sort width 32 (`float c = (int)b;`).
2. When converting `(long)c > 0`, we try again to create UNSPEC_FP, but the cache returns the old symbol.
3. The conversion fails because we were actually trying to create UNSPEC_FP with sort width 64.

The fix is simple, add the sort width to the symbol name, so we don't create symbols with the same name but different sort widths.

I also added an assertion to prevent this from happening in the future.