### PR TITLE
Scrutinize test cases for inheritance and polymorphism

### DIFF
--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1/main.cpp
@@ -1,0 +1,59 @@
+/*
+ * Single inheritance, dynamic cast, late binding
+ */
+#include <cassert>
+
+class CPolygon {
+protected:
+  int width, height;
+public:
+  CPolygon(){}
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  virtual int area (void) =0;
+};
+
+class CRectangle: public CPolygon {
+public:
+  CRectangle(int w, int h)
+  {
+    width = w;
+    height = h;
+
+  }
+  int area (void)
+    { return (width * height); }
+};
+
+class CTriangle: public CPolygon {
+public:
+  CTriangle(int w, int h)
+  {
+  	width = w;
+  	height = h;
+
+  }
+  int area (void)
+    { return ((width * height) / 2); }
+};
+
+int main () {
+	CPolygon* polygons[4];
+
+	polygons[0] = new CTriangle(20,25);  //CRectangle(20,30);
+	polygons[1] = new CRectangle(20,30); //new CTriangle(20,25);
+
+	for(int i = 0; i < 2; i++)
+	{
+		CTriangle* trin = dynamic_cast <CTriangle *> (polygons[i]);
+		if (trin != 0)
+		{
+			assert(trin->area() == 250); // PASS
+
+			trin->set_values(10, 10); // access base method from the casted ptr
+			assert(trin->area() == 50); // PASS
+		}
+	}
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1/main.cpp
@@ -38,7 +38,7 @@ public:
 };
 
 int main () {
-	CPolygon* polygons[4];
+	CPolygon* polygons[2];
 
 	polygons[0] = new CTriangle(20,25);  //CRectangle(20,30);
 	polygons[1] = new CRectangle(20,30); //new CTriangle(20,25);
@@ -54,6 +54,9 @@ int main () {
 			assert(trin->area() == 50); // PASS
 		}
 	}
+
+	for(int i = 0; i < 2; i++)
+    delete polygons[i];
 
   return 0;
 }

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1_fail/main.cpp
@@ -1,0 +1,56 @@
+#include <cassert>
+
+class CPolygon {
+protected:
+  int width, height;
+public:
+  CPolygon(){}
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  virtual int area (void) =0;
+};
+
+class CRectangle: public CPolygon {
+public:
+  CRectangle(int w, int h)
+  {
+    width = w;
+    height = h;
+
+  }
+  int area (void)
+    { return (width * height); }
+};
+
+class CTriangle: public CPolygon {
+public:
+  CTriangle(int w, int h)
+  {
+  	width = w;
+  	height = h;
+
+  }
+  int area (void)
+    { return ((width * height) / 2); }
+};
+
+int main () {
+	CPolygon* polygons[4];
+
+	polygons[0] = new CTriangle(20,25);  //CRectangle(20,30);
+	polygons[1] = new CRectangle(20,30); //new CTriangle(20,25);
+
+	for(int i = 0; i < 2; i++)
+	{
+		CTriangle* trin = dynamic_cast <CTriangle *> (polygons[i]);
+		if (trin != 0)
+		{
+			assert(trin->area() == 250); // PASS
+
+			trin->set_values(10, 10); // access base method from the casted ptr
+			assert(trin->area() == 15); // FAIL, should be 50
+		}
+	}
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1_fail/main.cpp
@@ -35,7 +35,7 @@ public:
 };
 
 int main () {
-	CPolygon* polygons[4];
+	CPolygon* polygons[2];
 
 	polygons[0] = new CTriangle(20,25);  //CRectangle(20,30);
 	polygons[1] = new CRectangle(20,30); //new CTriangle(20,25);
@@ -51,6 +51,9 @@ int main () {
 			assert(trin->area() == 15); // FAIL, should be 50
 		}
 	}
+
+	for(int i = 0; i < 2; i++)
+    delete polygons[i];
 
   return 0;
 }

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast1_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/main.cpp
@@ -1,0 +1,19 @@
+/*
+ * dynamic cast, check address
+ */
+#include <cassert>
+using namespace std;
+
+struct A {
+  virtual ~A() { };
+};
+
+struct B : A { };
+
+int main() {
+  B bobj;
+  A* ap = &bobj;
+  void * vp = dynamic_cast<void *>(ap);
+  assert(vp == &bobj);
+}
+

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/main.cpp
@@ -1,0 +1,19 @@
+/*
+ * dynamic cast, check address
+ */
+#include <cassert>
+using namespace std;
+
+struct A {
+  virtual ~A() { };
+};
+
+struct B : A { };
+
+int main() {
+  B bobj;
+  A* ap = &bobj;
+  void * vp = dynamic_cast<void *>(ap);
+  assert(vp != &bobj); // FAIL, should be the same address
+}
+

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5/main.cpp
@@ -1,0 +1,41 @@
+/*
+ * dynamic cast, late binding, passing ptr to function
+ */
+#include <cassert>
+
+int x;
+
+struct A {
+  virtual void f() { x+=1;}
+};
+
+struct B : A {
+  virtual void f() { }
+};
+
+struct C : A {
+  virtual void f() { x+=2;}
+};
+
+void f(A* arg) {
+  B* bp = dynamic_cast<B*>(arg);
+  C* cp = dynamic_cast<C*>(arg);
+
+  if (bp)
+    bp->f();
+  else if (cp)
+    cp->f();
+  else
+    arg->f();
+};
+
+int main() {
+  A aobj;
+  C cobj;
+  A* ap = &cobj;
+  A* ap2 = &aobj;
+  f(ap);
+  f(ap2);
+  assert(x==3);
+}
+

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5_fail/main.cpp
@@ -1,0 +1,41 @@
+/*
+ * dynamic cast, late binding, passing ptr to function
+ */
+#include <cassert>
+
+int x;
+
+struct A {
+  virtual void f() { x+=1;}
+};
+
+struct B : A {
+  virtual void f() { }
+};
+
+struct C : A {
+  virtual void f() { x+=2;}
+};
+
+void f(A* arg) {
+  B* bp = dynamic_cast<B*>(arg);
+  C* cp = dynamic_cast<C*>(arg);
+
+  if (bp)
+    bp->f();
+  else if (cp)
+    cp->f();
+  else
+    arg->f();
+};
+
+int main() {
+  A aobj;
+  C cobj;
+  A* ap = &cobj;
+  A* ap2 = &aobj;
+  f(ap);
+  f(ap2);
+  assert(x==1); // FAIL, should be 3
+}
+

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast5_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2/main.cpp
@@ -1,0 +1,34 @@
+/*
+ * just dynamic cast
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+  CPolygon(int w, int h)
+  {
+    width = w;
+    height = h;
+  }
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  int area (void)
+    { return (width * height); }
+};
+
+int main () {
+  CPolygon* polygons;
+
+  polygons = new CPolygon(20,30);
+
+  CPolygon* rec = dynamic_cast <CPolygon *> (polygons);
+  if (rec != 0)
+  {
+    rec->set_values(10, 10);
+    assert(rec->area() == 100);
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2_fail/main.cpp
@@ -1,0 +1,34 @@
+/*
+ * just dynamic cast
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+  CPolygon(int w, int h)
+  {
+    width = w;
+    height = h;
+  }
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  int area (void)
+    { return (width * height); }
+};
+
+int main () {
+  CPolygon* polygons;
+
+  polygons = new CPolygon(20,30);
+
+  CPolygon* rec = dynamic_cast <CPolygon *> (polygons);
+  if (rec != 0)
+  {
+    rec->set_values(10, 10);
+    assert(rec->area() == 99); // FAIL, should be 100
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * dynamic cast test: cast derived class ptr to base class ptr, late binding
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+  CPolygon(){}
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  virtual int area (void) =0;
+};
+
+class CRectangle: public CPolygon {
+  public:
+  CRectangle(int w, int h)
+  {
+    width = w;
+    height = h;
+  }
+  int area (void)
+    { return (width * height); }
+};
+
+int main () {
+
+  CRectangle* polygons = new CRectangle(20,30);
+
+  // cast derived class ptr to base class ptr
+  CPolygon* rec = dynamic_cast <CPolygon *> (polygons);
+  if (rec != 0)
+  {
+    rec->set_values(10, 10);
+    assert(rec->area() == 100);
+  }
+
+   return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3_fail/main.cpp
@@ -1,0 +1,40 @@
+/*
+ * dynamic cast test: cast derived class ptr to base class ptr, late binding
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+  CPolygon(){}
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  virtual int area (void) =0;
+};
+
+class CRectangle: public CPolygon {
+  public:
+  CRectangle(int w, int h)
+  {
+    width = w;
+    height = h;
+  }
+  int area (void)
+    { return (width * height); }
+};
+
+int main () {
+
+  CRectangle* polygons = new CRectangle(20,30);
+
+  // cast derived class ptr to base class ptr
+  CPolygon* rec = dynamic_cast <CPolygon *> (polygons);
+  if (rec != 0)
+  {
+    rec->set_values(10, 10);
+    assert(rec->area() == 200); // FAIL, should be 100
+  }
+
+   return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple3_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/main.cpp
@@ -1,0 +1,53 @@
+/*
+ * dynamic cast test: cast from void* should fail
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+  CPolygon(){}
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+  };
+
+class CRectangle: public CPolygon {
+  public:
+  CRectangle(int w, int h)
+  {
+	width = w;
+	height = h;
+
+  }
+    int area (void)
+      { return (width * height); }
+  };
+
+class CTriangle: public CPolygon {
+  public:
+  CTriangle(int w, int h)
+  {
+	width = w;
+	height = h;
+
+  }
+    int area (void)
+      { return ((width * height) / 2); }
+  };
+
+int main () {
+	void* polygons;
+
+	polygons = new CRectangle(20,30);
+
+	CTriangle* trin = dynamic_cast <CTriangle *> (polygons); // FAIL, unable to cast from void*
+	if (trin != 0)
+	{
+		trin->set_values(10, 10);
+		assert(trin->area() == 300);
+	}
+
+	return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance01/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance01/main.cpp
@@ -1,3 +1,6 @@
+/*
+ * Multiple inheritance: methods call
+ */
 #include <cassert>
 
 // Base class Shape

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance01/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance01/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance02/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance02/main.cpp
@@ -1,0 +1,52 @@
+/*
+ * Multiple inheritance: call base method in derived class
+ */
+#include <cassert>
+
+class exforsys
+{
+public:
+    exforsys(void) { x=0; }
+    void f(int n1)
+    {
+      x= n1*5;
+    }
+
+    void add_one(void) { ++x; }
+    int getX() { return x; }
+private:
+    int x;
+};
+
+class sample: virtual public exforsys
+{
+public:
+    sample(void) { s1=0; }
+
+    void f1(int n1)
+    {
+      s1=n1*10;
+    }
+
+    void add_one(void)
+    {
+      exforsys::add_one();
+      ++s1;
+    }
+    int getS1() { return s1; }
+
+private:
+    int s1;
+};
+
+int main(void)
+{
+    sample s;
+    s.f(10);
+    assert(s.getX() == 50); // PASS
+    s.f1(20);
+    assert(s.getS1() == 200); // PASS
+    s.add_one();
+    assert(s.getX() == 51); // PASS
+    assert(s.getS1() == 201); // PASS
+}

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance02/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance02/test.desc
@@ -1,5 +1,5 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance02_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance02_fail/main.cpp
@@ -1,0 +1,49 @@
+#include <cassert>
+
+class exforsys
+{
+public:
+    exforsys(void) { x=0; }
+    void f(int n1)
+    {
+      x= n1*5;
+    }
+
+    void add_one(void) { ++x; }
+    int getX() { return x; }
+private:
+    int x;
+};
+
+class sample: virtual public exforsys
+{
+public:
+    sample(void) { s1=0; }
+
+    void f1(int n1)
+    {
+      s1=n1*10;
+    }
+
+    void add_one(void)
+    {
+      exforsys::add_one();
+      ++s1;
+    }
+    int getS1() { return s1; }
+
+private:
+    int s1;
+};
+
+int main(void)
+{
+    sample s;
+    s.f(10);
+    assert(s.getX() == 50); // PASS
+    s.f1(20);
+    assert(s.getS1() == 200); // PASS
+    s.add_one();
+    assert(s.getX() == 51); // PASS
+    assert(s.getS1() == 200); // FAIL, should be 201
+}

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance02_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance02_fail/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07/main.cpp
@@ -1,0 +1,71 @@
+/*
+ * Multiple inheritance: access base attributes in derived class
+ */
+#include <cassert>
+
+// Base class Shape
+class Shape
+{
+public:
+  void setWidth(int w)
+  {
+    width = w;
+  }
+  void setHeight(int h)
+  {
+    height = h;
+  }
+  void setNumber()
+  {
+    number = 2;
+  }
+  int getNumber()
+  {
+    return number;
+  }
+
+protected:
+  int width;
+  int height;
+  int number;
+};
+
+// Base class PaintCost
+class PaintCost
+{
+public:
+  int getCost(int area)
+  {
+    return area * 70;
+  }
+};
+
+// Derived class
+class Rectangle: public Shape, public PaintCost
+{
+public:
+  int getArea()
+  {
+    return (width * height);
+  }
+};
+
+int main(void)
+{
+  Rectangle Rect;
+  int area;
+  int totalCost;
+
+  Rect.setWidth(5);
+  Rect.setHeight(7);
+
+  Rect.setNumber();
+  assert(Rect.getNumber() == 2);
+
+  area = Rect.getArea();
+  assert(area == 35);
+  totalCost = Rect.getCost(area) * Rect.getNumber();
+  assert(totalCost == 4900); // PASS
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07/test.desc
@@ -1,5 +1,5 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/main.cpp
@@ -1,0 +1,68 @@
+#include <cassert>
+
+// Base class Shape
+class Shape
+{
+public:
+  void setWidth(int w)
+  {
+    width = w;
+  }
+  void setHeight(int h)
+  {
+    height = h;
+  }
+  void setNumber()
+  {
+    number = 2;
+  }
+  int getNumber()
+  {
+    return number;
+  }
+
+protected:
+  int width;
+  int height;
+  int number;
+};
+
+// Base class PaintCost
+class PaintCost
+{
+public:
+  int getCost(int area)
+  {
+    return area * 70;
+  }
+};
+
+// Derived class
+class Rectangle: public Shape, public PaintCost
+{
+public:
+  int getArea()
+  {
+    return (width * height);
+  }
+};
+
+int main(void)
+{
+  Rectangle Rect;
+  int area;
+  int totalCost;
+
+  Rect.setWidth(5);
+  Rect.setHeight(7);
+
+  Rect.setNumber();
+  assert(Rect.getNumber() == 2);
+
+  area = Rect.getArea();
+  assert(area == 35);
+  totalCost = Rect.getCost(area) * Rect.getNumber();
+  assert(totalCost == 4901); // FAIL, should be 4900
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09/main.cpp
@@ -1,0 +1,72 @@
+/*
+ * Multiple inheritance: base pointer to derived class object
+ */
+#include <cassert>
+
+class Base1 {
+public:
+   Base1( int parameterValue )
+   {
+      value = parameterValue;
+   }
+
+   int getData() const
+   {
+      return value;
+   }
+
+protected:
+   int value;
+};
+
+class Base2
+{
+public:
+   Base2( char characterData )
+   {
+      letter = characterData;
+   }
+
+   char getData() const
+   {
+      return letter;
+   }
+protected:
+   char letter;
+};
+
+class Derived : public Base1, public Base2
+{
+public:
+   Derived( int integer, char character, double double1 )
+      : Base1( integer ), Base2( character ), real( double1 ) { }
+
+   double getReal() const {
+      return real;
+   }
+
+private:
+   double real;
+};
+
+
+int main()
+{
+   Base1 base1( 10 ), *base1Ptr = 0;
+   Base2 base2( 'Z' ), *base2Ptr = 0;
+   Derived derived( 7, 'A', 3.5 );
+
+   assert(base1.getData() == 10);
+   assert(base2.getData() == 'Z');
+
+   assert(derived.Base1::getData() == 7);
+   assert(derived.Base2::getData() == 'A');
+   assert(derived.getReal() == 3.5);
+
+   base1Ptr = &derived;
+   assert(base1Ptr->getData() == 7);
+
+   base2Ptr = &derived;
+   assert(base2Ptr->getData() == 'A');
+   return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09/test.desc
@@ -1,5 +1,5 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/main.cpp
@@ -1,0 +1,69 @@
+#include <cassert>
+
+class Base1 {
+public:
+   Base1( int parameterValue )
+   {
+      value = parameterValue;
+   }
+
+   int getData() const
+   {
+      return value;
+   }
+
+protected:
+   int value;
+};
+
+class Base2
+{
+public:
+   Base2( char characterData )
+   {
+      letter = characterData;
+   }
+
+   char getData() const
+   {
+      return letter;
+   }
+protected:
+   char letter;
+};
+
+class Derived : public Base1, public Base2
+{
+public:
+   Derived( int integer, char character, double double1 )
+      : Base1( integer ), Base2( character ), real( double1 ) { }
+
+   double getReal() const {
+      return real;
+   }
+
+private:
+   double real;
+};
+
+
+int main()
+{
+   Base1 base1( 10 ), *base1Ptr = 0;
+   Base2 base2( 'Z' ), *base2Ptr = 0;
+   Derived derived( 7, 'A', 3.5 );
+
+   assert(base1.getData() == 10);
+   assert(base2.getData() == 'Z');
+
+   assert(derived.Base1::getData() == 7);
+   assert(derived.Base2::getData() == 'A');
+   assert(derived.getReal() == 3.5);
+
+   base1Ptr = &derived;
+   assert(base1Ptr->getData() == 7);
+
+   base2Ptr = &derived;
+   assert(base2Ptr->getData() == 'B'); // FAIL, should be 'A'
+   return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance-wrong/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance-wrong/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * multiple inheritance: unable to free due to missing dtors
+ */
+#include <cassert>
+
+class Base1
+{
+public:
+    virtual int f(void) { return 21; }
+};
+
+class Base2
+{
+public:
+    virtual int g(void) { return 21; }
+};
+
+class Derived: public Base1, public Base2
+{
+public:
+    virtual int f(void) { return 42; }
+    virtual int g(void) { return 42; }
+};
+
+int main()
+{
+    Base2 *o = new Derived();
+    int r = o->g();
+    delete o;
+    assert(r == 42);
+    return r;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance/main.cpp
@@ -1,0 +1,35 @@
+/*
+ * multiple inheritance: able to free
+ */
+#include <cassert>
+
+class Base1
+{
+public:
+    virtual ~Base1() {}
+    virtual int f(void) { return 21; }
+};
+
+class Base2
+{
+public:
+    virtual ~Base2() {}
+    virtual int g(void) { return 21; }
+};
+
+class Derived: public Base1, public Base2
+{
+public:
+    virtual ~Derived() {}
+    virtual int f(void) { return 42; }
+    virtual int g(void) { return 42; }
+};
+
+int main()
+{
+    Base2 *o = new Derived();
+    int r = o->g();
+    delete o;
+    assert(r == 42);
+    return r;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_multiple_inheritance/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance-wrong/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance-wrong/main.cpp
@@ -1,0 +1,42 @@
+/*
+ * Diamond problem: missing one of the base initializers
+ */
+#include <cassert>
+
+class A
+{
+public:
+    A() {}
+    A(int x) : m_x(x) {};
+    int getX() { return m_x; }
+protected:
+    int m_x;
+};
+
+class B : virtual public A
+{
+public:
+    B() {}
+    B(int x) : A(x) {}
+};
+
+class C : virtual public A
+{
+public:
+    C() {}
+    C(int x) : A(x) {}
+};
+
+class D : public B, public C
+{
+public:
+    D() {}
+    D(int x) : B(x), C(x) {}
+};
+
+int main()
+{
+    A *a = new D(42);
+    assert(a->getX() == 42);
+    return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance-wrong/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance-wrong/testllvm.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance-wrong/testllvm.desc
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-inheritance</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=2 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+</test-case>

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance/main.cpp
@@ -1,0 +1,39 @@
+#include <cassert>
+
+class A
+{
+public:
+    A() {}
+    A(int x) : m_x(x) {};
+    int getX() { return m_x; }
+protected:
+    int m_x;
+};
+
+class B : virtual public A
+{
+public:
+    B() {}
+    B(int x) : A(x) {}
+};
+
+class C : virtual public A
+{
+public:
+    C() {}
+    C(int x) : A(x) {}
+};
+
+class D : public B, public C
+{
+public:
+    D() {}
+    D(int x) : A(x), B(x), C(x) {}
+};
+
+int main()
+{
+    A *a = new D(42);
+    assert(a->getX() == 42);
+    return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/llbmc_virtual_inheritance/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance/main.cpp
@@ -1,0 +1,30 @@
+/*
+ * multiple inheritance: late binding
+ */
+#include <cassert>
+
+class Base1 {
+  public:
+  virtual int f(void) { return 21; }
+};
+
+class Base2 {
+  public:
+    virtual int f(void) { return 42; }
+};
+
+class Derived: public Base1, public Base2 {
+  public:
+    virtual int g(void) { return 42; }
+};
+
+int main(){
+  Derived *d = new Derived();
+  assert(d->Base1::f() == 21);
+  assert(d->Base2::f() == 42);
+  assert(d->g() == 42);
+  delete d;
+
+  return 0;
+}
+

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance/testllvm.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance/testllvm.desc
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-inheritance</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=10 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+</test-case>

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2/main.cpp
@@ -1,0 +1,36 @@
+/*
+ * multiple inheritance: diamond problem, late binding
+ */
+#include <cassert>
+
+class File {
+  public:
+  virtual int f(void) { return 21; }
+};
+
+class InputFile: virtual public File {
+  public:
+    virtual int f(void) { return 42; }
+};
+
+class OutputFile: virtual public File {
+  public:
+    virtual int f(void) { return 63; }
+};
+
+class IOFile: public InputFile, public OutputFile {
+  public:
+    virtual int f(void) { return 52; }
+};
+
+int main(){
+  IOFile *iofile = new IOFile();
+  assert(iofile->File::f() == 21);
+  assert(iofile->InputFile::f() == 42);
+  assert(iofile->OutputFile::f() == 63);
+  assert(iofile->f() == 52);
+  delete iofile;
+  return 0;
+}
+
+

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2_fail/main.cpp
@@ -1,0 +1,36 @@
+/*
+ * multiple inheritance: diamond problem, late binding
+ */
+#include <cassert>
+
+class File {
+  public:
+  virtual int f(void) { return 21; }
+};
+
+class InputFile: virtual public File {
+  public:
+    virtual int f(void) { return 42; }
+};
+
+class OutputFile: virtual public File {
+  public:
+    virtual int f(void) { return 63; }
+};
+
+class IOFile: public InputFile, public OutputFile {
+  public:
+    virtual int f(void) { return 52; }
+};
+
+int main(){
+  IOFile *iofile = new IOFile();
+  assert(iofile->File::f() == 21);
+  assert(iofile->InputFile::f() == 42);
+  assert(iofile->OutputFile::f() == 63);
+  assert(iofile->f() == 51); // FAIL, should be 52
+  delete iofile;
+  return 0;
+}
+
+

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_2_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_fail/main.cpp
@@ -1,0 +1,30 @@
+/*
+ * multiple inheritance: late binding
+ */
+#include <cassert>
+
+class Base1 {
+  public:
+  virtual int f(void) { return 21; }
+};
+
+class Base2 {
+  public:
+    virtual int f(void) { return 42; }
+};
+
+class Derived: public Base1, public Base2 {
+  public:
+    virtual int g(void) { return 42; }
+};
+
+int main(){
+  Derived *d = new Derived();
+  assert(d->Base1::f() == 21);
+  assert(d->Base2::f() == 42);
+  assert(d->g() == 21); // FAIL, should be 42
+  delete d;
+
+  return 0;
+}
+

--- a/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/multiple_inheritance_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * abstract base class
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+  };
+
+class CRectangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height); }
+  };
+
+class CTriangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height / 2); }
+  };
+
+int main () {
+  CRectangle rect;
+  CTriangle trgl;
+  CPolygon * ppoly1 = &rect;
+  CPolygon * ppoly2 = &trgl;
+  ppoly1->set_values (4,5);
+  ppoly2->set_values (4,5);
+  assert(ppoly1->area() == 20);
+  assert(ppoly2->area() == 10);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class_fail/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * abstract base class
+ */
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+  };
+
+class CRectangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height); }
+  };
+
+class CTriangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height / 2); }
+  };
+
+int main () {
+  CRectangle rect;
+  CTriangle trgl;
+  CPolygon * ppoly1 = &rect;
+  CPolygon * ppoly2 = &trgl;
+  ppoly1->set_values (4,5);
+  ppoly2->set_values (4,5);
+  assert(ppoly1->area() == 20);
+  assert(ppoly2->area() == 5); // FAIL, should be 10
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_abstract_base_class_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/main.cpp
@@ -1,0 +1,34 @@
+//common error: after setting a base class pointer to an derived class object, attempt to reference exclusive members of derived class with base class pointer
+//it generates a compilation error
+
+class CPolygon {
+protected:
+  int width, height;
+public:
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  virtual int area (void) =0;
+};
+
+class CRectangle: public CPolygon {
+public:
+  int area (void)
+    { return (width * height); }
+  int randomVariable;
+};
+
+class CTriangle: public CPolygon {
+public:
+  int area (void)
+    { return (width * height / 2); }
+  int randomVariable2;
+};
+
+int main () {
+  CRectangle *rect = new CPolygon;
+  rect.randomVariable = 15;
+  CTriangle *trin = new CPolygon;
+  trin.randomVariable2 = 20;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/main.cpp
@@ -1,0 +1,32 @@
+//treat with a base class object like a derived class object
+//it can generate a compilation error
+
+class CPolygon {
+protected:
+  int width, height;
+public:
+  void set_values (int a, int b)
+    { width=a; height=b; }
+  virtual int area (void) =0;
+};
+
+class CRectangle: public CPolygon {
+public:
+  int area (void)
+    { return (width * height); }
+  int randomVariable;
+};
+
+class CTriangle: public CPolygon {
+public:
+  int area (void)
+    { return (width * height / 2); }
+  int randomVariable2;
+};
+
+int main () {
+  CPolygon *polygon = new CPolygon;
+  polygon.set_values(10, 10);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_3/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_3/main.cpp
@@ -1,0 +1,41 @@
+//treat with a base class object like a derived class object
+//it can generate a compilation error
+
+class Shape{
+  public:
+    virtual int area (void);
+    virtual void printArea(void);
+};
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+    void printarea (void)
+      {
+        // print something here
+      }
+  };
+
+class CRectangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height); }
+    int randomVariable;
+  };
+
+class CTriangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height / 2); }
+    int randomVariable2;
+  };
+
+int main () {
+  Shape *sh = new Shape;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_3/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/main.cpp
@@ -1,0 +1,42 @@
+//treat with a base class object like a derived class object
+//it can generate a compilation error
+
+class Shape{
+  public:
+    virtual int area (void);
+    virtual void printArea(void);
+};
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+    void printarea (void)
+      {
+        // print something here
+      }
+};
+
+class CRectangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height); }
+    int randomVariable;
+};
+
+class CTriangle: public CPolygon {
+  public:
+    long area (void)
+      { return (width * height / 2); }
+    int randomVariable2;
+};
+
+int main () {
+  CPolygon *trin = new CTriangle;
+  trin.set_values(10,10);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation/main.cpp
@@ -1,0 +1,39 @@
+// dynamic allocation and polymorphism
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+    int getArea (void)
+      { return this->area(); }
+  };
+
+class CRectangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height); }
+  };
+
+class CTriangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height / 2); }
+  };
+
+int main () {
+  CPolygon * ppoly1 = new CRectangle;
+  CPolygon * ppoly2 = new CTriangle;
+  ppoly1->set_values (4,5);
+  ppoly2->set_values (4,5);
+
+  assert(ppoly1->getArea() == 20);
+  assert(ppoly2->getArea() == 10);
+
+  delete ppoly1;
+  delete ppoly2;
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation_fail/main.cpp
@@ -1,0 +1,39 @@
+// dynamic allocation and polymorphism
+#include <cassert>
+
+class CPolygon {
+  protected:
+    int width, height;
+  public:
+    void set_values (int a, int b)
+      { width=a; height=b; }
+    virtual int area (void) =0;
+    int getArea (void)
+      { return this->area(); }
+  };
+
+class CRectangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height); }
+  };
+
+class CTriangle: public CPolygon {
+  public:
+    int area (void)
+      { return (width * height / 2); }
+  };
+
+int main () {
+  CPolygon * ppoly1 = new CRectangle;
+  CPolygon * ppoly2 = new CTriangle;
+  ppoly1->set_values (4,5);
+  ppoly2->set_values (4,5);
+
+  assert(ppoly1->getArea() == 20);
+  assert(ppoly2->getArea() == 20); // FAIL, should be 10
+
+  delete ppoly1;
+  delete ppoly2;
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_dynamic_allocation_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Inspecting and refactoring our exirsting inheritance/polymorphism test cases (TCs) to: 
1. get rid of dependencies on operational modesl (e.g. iostreams)
2. remove deplicate TCs
3. add test description in each representative TC

**~~N.B. This PR needs to be rebased after merging https://github.com/esbmc/esbmc/pull/884~~ (merged, done)**

Some findings are summarized below for future reference: 

**Deplicate TCs:**
inheritance08: same test objective as 07
inheritance10: same test objective as 09
inheritance11: same test objective as 09
inheritance13: same test objective as 07
inheritance15: same test objective as 14
ch22_1: same test objective as inheritance12
ch22_2: same test objective as inheritance12
inheritance08: same test objective as 07
inheritance10: same test objective as 09
inheritance11: same test objective as 09
inheritance13: same test objective as 07
inheritance15: same test objective as 14
ch22_1: same test objective as inheritance12
ch22_2: same test objective as inheritance12
dynamic_cast2_bug: same test objective as dynamic_cast1
dynamic_cast_simple: same test objective as dynamic_cast_simple3
inheritance-cbmc: same test objective as multiple_inheritance
paper_inheritance_example: same test objective as multiple_inheritance
paper_inheritance_example_fail: same test objective as multiple_inheritance


**TCs ignored:**
dynamic_cast3_bug: mixed with try-catch
dynamic_cast6: mixed with try-catch


**Multi files:**
inheritance04
inheritance05
inheritance06
ch13_25
ch22_4


