### PR TITLE
Updated TC verdict

### DIFF
--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^PARSING ERROR$
+^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
@@ -2,4 +2,4 @@ KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^PARSING ERROR$
+^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_1/test.desc
@@ -2,4 +2,4 @@ KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^PARSING ERROR$
+^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_2/test.desc
@@ -2,4 +2,4 @@ KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^CONVERSION ERROR$
+^PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^PARSING ERROR$
+^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/polymorphism_common_error_4/test.desc
@@ -2,4 +2,4 @@ KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 
-^CONVERSION ERROR$
+^PARSING ERROR$


### PR DESCRIPTION
What used to be "CONVERSION ERROR" now becomes "PARSING ERROR", since clang has a more powerful parser which is able to report error before generating the AST for ESBMC's converter. 

This patch enabled the 4 more TCs: 
dynamic_cast_void_error
polymorphism_common_error_1
polymorphism_common_error_2
polymorphism_common_error_4 
