### PR TITLE
Fix union initializer type

### DIFF
--- a/regression/esbmc/github_885-valid/test.desc
+++ b/regression/esbmc/github_885-valid/test.desc
@@ -1,0 +1,4 @@
+CORE
+test_abort.c
+--function func1 --no-slice
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_885-valid/test_abort.c
+++ b/regression/esbmc/github_885-valid/test_abort.c
@@ -1,0 +1,10 @@
+//test_abort.c:
+#include "test_abort.h"
+
+ void func1 (int y);
+void func1 (int y)
+{
+	__ESBMC_assume(y >= 0);
+	__ESBMC_assume(y < 1);
+                func2(y);
+}

--- a/regression/esbmc/github_885-valid/test_abort.c
+++ b/regression/esbmc/github_885-valid/test_abort.c
@@ -1,10 +1,10 @@
 //test_abort.c:
 #include "test_abort.h"
 
- void func1 (int y);
-void func1 (int y)
+void func1(int y);
+void func1(int y)
 {
-	__ESBMC_assume(y >= 0);
-	__ESBMC_assume(y < 1);
-                func2(y);
+  __ESBMC_assume(y >= 0);
+  __ESBMC_assume(y < 1);
+  func2(y);
 }

--- a/regression/esbmc/github_885-valid/test_abort.h
+++ b/regression/esbmc/github_885-valid/test_abort.h
@@ -1,76 +1,63 @@
 
- typedef union {
+typedef union
+{
+  unsigned int uint_val;
 
-     unsigned int uint_val;
+  float fl_val;
 
-     float fl_val;
+} float_u;
 
-}float_u;
-
- typedef struct
+typedef struct
 
 {
+  float_u s1;
 
-    float_u s1;
+} struct_1_t;
 
-}struct_1_t;
+struct_1_t struct_1_var = {
 
- struct_1_t struct_1_var = {
+  .s1.fl_val = 0,
 
-                                        .s1.fl_val =   0,
+};
 
-                                       };
+typedef enum
+{
 
- typedef enum {
+  ENUM_1_1,
 
-    ENUM_1_1,
-
-    ALL_ENUMS_1
+  ALL_ENUMS_1
 
 } enum1_e;
-
- 
 
 typedef enum
 
 {
 
-    ENUM_2_1,
+  ENUM_2_1,
 
-    ENUM_2_2 = ENUM_2_1,
+  ENUM_2_2 = ENUM_2_1,
 
-    ALL_ENUM2_2
+  ALL_ENUM2_2
 
-}enum2_e;
+} enum2_e;
 
- 
+typedef struct
+{
+  enum2_e s2;
 
-typedef struct {
-
-    enum2_e s2;
-
-}struct_2_t;
-
- 
+} struct_2_t;
 
 typedef struct
 
 {
+  const struct_2_t s3[ALL_ENUMS_1];
 
-    const struct_2_t s3[ALL_ENUMS_1];
-
-}struct_3_t;
-
- 
+} struct_3_t;
 
 extern struct_3_t struct3_var;
-
- 
 
 void func2(enum1_e int_id)
 
 {
-
-    int x1 = struct3_var.s3[int_id].s2;
-
+  int x1 = struct3_var.s3[int_id].s2;
 }

--- a/regression/esbmc/github_885-valid/test_abort.h
+++ b/regression/esbmc/github_885-valid/test_abort.h
@@ -1,0 +1,76 @@
+
+ typedef union {
+
+     unsigned int uint_val;
+
+     float fl_val;
+
+}float_u;
+
+ typedef struct
+
+{
+
+    float_u s1;
+
+}struct_1_t;
+
+ struct_1_t struct_1_var = {
+
+                                        .s1.fl_val =   0,
+
+                                       };
+
+ typedef enum {
+
+    ENUM_1_1,
+
+    ALL_ENUMS_1
+
+} enum1_e;
+
+ 
+
+typedef enum
+
+{
+
+    ENUM_2_1,
+
+    ENUM_2_2 = ENUM_2_1,
+
+    ALL_ENUM2_2
+
+}enum2_e;
+
+ 
+
+typedef struct {
+
+    enum2_e s2;
+
+}struct_2_t;
+
+ 
+
+typedef struct
+
+{
+
+    const struct_2_t s3[ALL_ENUMS_1];
+
+}struct_3_t;
+
+ 
+
+extern struct_3_t struct3_var;
+
+ 
+
+void func2(enum1_e int_id)
+
+{
+
+    int x1 = struct3_var.s3[int_id].s2;
+
+}

--- a/regression/esbmc/github_885/test.desc
+++ b/regression/esbmc/github_885/test.desc
@@ -1,0 +1,5 @@
+CORE
+test_abort.c
+--function func1 --no-slice
+^VERIFICATION FAILED$
+\sarray upper bound$

--- a/regression/esbmc/github_885/test.desc
+++ b/regression/esbmc/github_885/test.desc
@@ -2,4 +2,4 @@ CORE
 test_abort.c
 --function func1 --no-slice
 ^VERIFICATION FAILED$
-\sarray upper bound$
+\sarray (upper|lower) bound$

--- a/regression/esbmc/github_885/test_abort.c
+++ b/regression/esbmc/github_885/test_abort.c
@@ -1,8 +1,8 @@
 //test_abort.c:
 #include "test_abort.h"
 
- void func1 (int y);
-void func1 (int y)
+void func1(int y);
+void func1(int y)
 {
-                func2(y);
+  func2(y);
 }

--- a/regression/esbmc/github_885/test_abort.c
+++ b/regression/esbmc/github_885/test_abort.c
@@ -1,0 +1,8 @@
+//test_abort.c:
+#include "test_abort.h"
+
+ void func1 (int y);
+void func1 (int y)
+{
+                func2(y);
+}

--- a/regression/esbmc/github_885/test_abort.h
+++ b/regression/esbmc/github_885/test_abort.h
@@ -1,76 +1,63 @@
 
- typedef union {
+typedef union
+{
+  unsigned int uint_val;
 
-     unsigned int uint_val;
+  float fl_val;
 
-     float fl_val;
+} float_u;
 
-}float_u;
-
- typedef struct
+typedef struct
 
 {
+  float_u s1;
 
-    float_u s1;
+} struct_1_t;
 
-}struct_1_t;
+struct_1_t struct_1_var = {
 
- struct_1_t struct_1_var = {
+  .s1.fl_val = 0,
 
-                                        .s1.fl_val =   0,
+};
 
-                                       };
+typedef enum
+{
 
- typedef enum {
+  ENUM_1_1,
 
-    ENUM_1_1,
-
-    ALL_ENUMS_1
+  ALL_ENUMS_1
 
 } enum1_e;
-
- 
 
 typedef enum
 
 {
 
-    ENUM_2_1,
+  ENUM_2_1,
 
-    ENUM_2_2 = ENUM_2_1,
+  ENUM_2_2 = ENUM_2_1,
 
-    ALL_ENUM2_2
+  ALL_ENUM2_2
 
-}enum2_e;
+} enum2_e;
 
- 
+typedef struct
+{
+  enum2_e s2;
 
-typedef struct {
-
-    enum2_e s2;
-
-}struct_2_t;
-
- 
+} struct_2_t;
 
 typedef struct
 
 {
+  const struct_2_t s3[ALL_ENUMS_1];
 
-    const struct_2_t s3[ALL_ENUMS_1];
-
-}struct_3_t;
-
- 
+} struct_3_t;
 
 extern struct_3_t struct3_var;
-
- 
 
 void func2(enum1_e int_id)
 
 {
-
-    int x1 = struct3_var.s3[int_id].s2;
-
+  int x1 = struct3_var.s3[int_id].s2;
 }

--- a/regression/esbmc/github_885/test_abort.h
+++ b/regression/esbmc/github_885/test_abort.h
@@ -1,0 +1,76 @@
+
+ typedef union {
+
+     unsigned int uint_val;
+
+     float fl_val;
+
+}float_u;
+
+ typedef struct
+
+{
+
+    float_u s1;
+
+}struct_1_t;
+
+ struct_1_t struct_1_var = {
+
+                                        .s1.fl_val =   0,
+
+                                       };
+
+ typedef enum {
+
+    ENUM_1_1,
+
+    ALL_ENUMS_1
+
+} enum1_e;
+
+ 
+
+typedef enum
+
+{
+
+    ENUM_2_1,
+
+    ENUM_2_2 = ENUM_2_1,
+
+    ALL_ENUM2_2
+
+}enum2_e;
+
+ 
+
+typedef struct {
+
+    enum2_e s2;
+
+}struct_2_t;
+
+ 
+
+typedef struct
+
+{
+
+    const struct_2_t s3[ALL_ENUMS_1];
+
+}struct_3_t;
+
+ 
+
+extern struct_3_t struct3_var;
+
+ 
+
+void func2(enum1_e int_id)
+
+{
+
+    int x1 = struct3_var.s3[int_id].s2;
+
+}

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1881,7 +1881,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
        * The init expression has to be the only operand to this expression
        * regardless of the position the initialized field is being declared. */
       inits = gen_zero(t);
-      if(init_stmt.getNumInits() > 0) {
+      if(init_stmt.getNumInits() > 0)
+      {
         assert(init_stmt.getNumInits() == 1);
         exprt init;
         if(get_expr(*init_stmt.getInit(0), init))


### PR DESCRIPTION
Fixes the issue raised in #885.

The Clang frontend set the initialized field name of constant union expressions, but did not set the right type. This PR modifies the parser to handle union initializer lists different from struct/array/vector following the way the Clang AST is structured: either exactly one initializer or none (in case of empty union type). This differs from the way struct initializers are represented (by implicit init AST nodes) and thus warrants a different handling in the Clang frontend.