### PR TITLE
[util] replace_symbolt learned to handle argumentt

### DIFF
--- a/regression/esbmc/github_902-extern/file1.c
+++ b/regression/esbmc/github_902-extern/file1.c
@@ -1,0 +1,2 @@
+
+#include "file1.h"

--- a/regression/esbmc/github_902-extern/file1.h
+++ b/regression/esbmc/github_902-extern/file1.h
@@ -1,0 +1,20 @@
+
+typedef struct {
+
+                int arr[33];
+
+} struct_t;
+
+ 
+
+extern struct_t tmp_struct;
+
+ 
+
+static int func1(int i)
+
+{
+
+                return tmp_struct.arr[i];
+
+}

--- a/regression/esbmc/github_902-extern/main.c
+++ b/regression/esbmc/github_902-extern/main.c
@@ -1,0 +1,10 @@
+
+#include "file1.h"
+
+ int main()
+
+{
+
+    func1(32);
+
+}

--- a/regression/esbmc/github_902-extern/test.desc
+++ b/regression/esbmc/github_902-extern/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+file1.c
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_902/file1.c
+++ b/regression/esbmc/github_902/file1.c
@@ -1,0 +1,2 @@
+
+#include "file1.h"

--- a/regression/esbmc/github_902/file1.h
+++ b/regression/esbmc/github_902/file1.h
@@ -1,0 +1,20 @@
+
+typedef struct {
+
+                int arr[33];
+
+} struct_t;
+
+ 
+
+struct_t tmp_struct; /* error: duplicate definition of this symbol */
+
+ 
+
+static int func1(int i)
+
+{
+
+                return tmp_struct.arr[i];
+
+}

--- a/regression/esbmc/github_902/main.c
+++ b/regression/esbmc/github_902/main.c
@@ -1,0 +1,10 @@
+
+#include "file1.h"
+
+ int main()
+
+{
+
+    func1(32);
+
+}

--- a/regression/esbmc/github_902/test.desc
+++ b/regression/esbmc/github_902/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+file1.c
+^VERIFICATION FAILED$

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -6,11 +6,21 @@ bool replace_symbolt::replace(exprt &dest)
   if(dest.id() == "symbol")
   {
     expr_mapt::const_iterator it = expr_map.find(dest.identifier());
-
     if(it != expr_map.end())
     {
       dest = it->second;
       return false;
+    }
+  }
+  else if(dest.id() == "argument")
+  {
+    code_typet::argumentt &a = static_cast<code_typet::argumentt &>(dest);
+    expr_mapt::const_iterator it = expr_map.find(a.get_identifier());
+    if(it != expr_map.end())
+    {
+      a.set_identifier(it->second.identifier());
+      a.type() = it->second.type();
+      a.location() = it->second.location();
     }
   }
 


### PR DESCRIPTION
Fixes #902.

Unlike symbols, arguments to functions are not to be replaced but updated.
That is because they are not symbols and their cmt_identifier() is used to
refer to the corresponding symbol's name. We update the argumentt by
replacing its cmt_identifier, type and location but otherwise leaving it
alone.