### PR TITLE
Added regression tests for rvalue

### DIFF
--- a/regression/esbmc/github_300_failed/main.c
+++ b/regression/esbmc/github_300_failed/main.c
@@ -1,0 +1,29 @@
+#include <stdbool.h>
+#include <stdint.h>
+#ifndef uint32_t
+#define uint32_t unsigned int
+#endif
+typedef union
+{
+  uint32_t field1;
+  struct
+  {
+    uint32_t field2;
+  };
+} str1_t;
+extern str1_t global_str;
+struct str2_s
+{
+  bool field1;
+  str1_t field2;
+};
+void bar(struct str2_s *str2_p)
+{
+  str2_p->field2 = global_str;
+}
+void foo(void)
+{
+  struct str2_s str2_info;
+  bar(&str2_info);
+  assert(str2_info.field2);
+}

--- a/regression/esbmc/github_300_failed/test.desc
+++ b/regression/esbmc/github_300_failed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function foo
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_300_success/main.c
+++ b/regression/esbmc/github_300_success/main.c
@@ -1,0 +1,28 @@
+#include <stdbool.h>
+#include <stdint.h>
+#ifndef uint32_t
+#define uint32_t unsigned int
+#endif
+typedef union
+{
+  uint32_t field1;
+  struct
+  {
+    uint32_t field2;
+  };
+} str1_t;
+extern str1_t global_str;
+struct str2_s
+{
+  bool field1;
+  str1_t field2;
+};
+void bar(struct str2_s *str2_p)
+{
+  str2_p->field2 = global_str;
+}
+void foo(void)
+{
+  struct str2_s str2_info;
+  bar(&str2_info);
+}

--- a/regression/esbmc/github_300_success/test.desc
+++ b/regression/esbmc/github_300_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--function foo
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Added regression tests regarding rvalue reference to array type during dereference.

The master branch seems to handle the test cases described in https://github.com/esbmc/esbmc/issues/300.

@fbrausse, @mikhailramalho, @rafaelsamenezes: I'm still determining whether we already have similar test cases in our regression. It would be good to have them in the repo before closing the issue https://github.com/esbmc/esbmc/issues/300.