### PR TITLE
Polymorphism Part IV

### DIFF
--- a/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond/main.cpp
+++ b/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond/main.cpp
@@ -1,5 +1,6 @@
 /*
- * multiple inheritance: diamond problem, late binding
+ * Multi-inheritance diamond problem
+ * trivial constructor
  */
 #include <cassert>
 

--- a/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond_fail/main.cpp
+++ b/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond_fail/main.cpp
@@ -1,5 +1,6 @@
 /*
- * multiple inheritance: diamond problem, late binding
+ * Multi-inheritance diamond problem
+ * trivial constructor
  */
 #include <cassert>
 

--- a/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance-wrong/main.cpp
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance-wrong/main.cpp
@@ -1,5 +1,6 @@
 /*
- * Diamond problem: missing one of the base initializers
+ * Multi-inheritance diamond problem
+ * non-trivial constructor
  */
 #include <cassert>
 

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance/main.cpp
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Multi-inheritance diamond problem
+ * non-trivial constructor
  */
 #include <cassert>
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1273,8 +1273,8 @@ symbolt *clang_cpp_convertert::get_fd_symbol(const clang::FunctionDecl &fd)
 }
 
 void clang_cpp_convertert::get_base_map(
-    const clang::CXXRecordDecl *cxxrd,
-    base_map &map)
+  const clang::CXXRecordDecl *cxxrd,
+  base_map &map)
 {
   /*
    * This function gets all the base classes from which we need to get the components/methods
@@ -1303,8 +1303,8 @@ void clang_cpp_convertert::get_base_map(
 }
 
 void clang_cpp_convertert::get_base_components_methods(
-    base_map &map,
-    struct_union_typet &type)
+  base_map &map,
+  struct_union_typet &type)
 {
   for(const auto &base : map)
   {
@@ -1339,12 +1339,12 @@ void clang_cpp_convertert::get_base_components_methods(
 }
 
 bool clang_cpp_convertert::is_duplicate_component(
-    const struct_typet::componentt &component,
-    const struct_union_typet &type)
+  const struct_typet::componentt &component,
+  const struct_union_typet &type)
 {
   const struct_typet &stype = to_struct_type(type);
   const struct_typet::componentst &components = stype.components();
-  for(const auto& existing_component : components)
+  for(const auto &existing_component : components)
   {
     if(component.name() == existing_component.name())
       return true;
@@ -1353,12 +1353,12 @@ bool clang_cpp_convertert::is_duplicate_component(
 }
 
 bool clang_cpp_convertert::is_duplicate_method(
-    const struct_typet::componentt &method,
-    const struct_union_typet &type)
+  const struct_typet::componentt &method,
+  const struct_union_typet &type)
 {
   const struct_typet &stype = to_struct_type(type);
   const struct_typet::componentst &methods = stype.methods();
-  for(const auto& existing_method : methods)
+  for(const auto &existing_method : methods)
   {
     if(method.name() == existing_method.name())
       return true;

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -163,6 +163,54 @@ protected:
   bool need_new_object(const clang::Stmt *parentStmt);
 
   /*
+   * Methods to pull bases in
+   */
+  using base_map = std::map<std::string, const clang::CXXRecordDecl *>;
+  /*
+   * Recursively get the bases for this derived class.
+   *
+   * Params:
+   *  - cxxrd: clang AST representing the class/struct we are currently dealing with
+   *  - map: this map contains all base class(es) of this class std::map<class_id, pointer to clang AST of base class>
+   */
+  void get_base_map(
+      const clang::CXXRecordDecl *cxxrd,
+      base_map &map);
+  /*
+   * Check whether we've already got this component in a class type
+   * Avoid copying duplicate component from a base class type to the derived class type.
+   *
+   * Params:
+   *  - component: the component to be copied from a base class to the derived class type
+   *  - type: ESBMC IR representing the derived class type
+   */
+  bool is_duplicate_component(
+      const struct_typet::componentt &component,
+      const struct_union_typet &type);
+  /*
+   * Check whether we've already got this method in a class type
+   * Avoid copying duplicate method from a base class type to the derived class type.
+   *
+   * Params:
+   *  - method: the method to be copied from a base class to the derived class type
+   *  - type: ESBMC IR representing the derived class type
+   */
+  bool is_duplicate_method(
+      const struct_typet::componentt &method,
+      const struct_union_typet &type);
+  /*
+   * Copy components and methods from base class(es) to the derived class type
+   * For virtual base class, we only copy it once.
+   *
+   * Params:
+   *  - map: this map contains all base class(es) of this class std::map<class_id, pointer to clang AST of base class>
+   *  - type: ESBMC IR representing the class' type
+   */
+  void get_base_components_methods(
+      base_map &map,
+      struct_union_typet &type);
+
+  /*
    * Methods for virtual tables and virtual pointers
    *  TODO: add link to wiki page
    */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -173,9 +173,7 @@ protected:
    *  - cxxrd: clang AST representing the class/struct we are currently dealing with
    *  - map: this map contains all base class(es) of this class std::map<class_id, pointer to clang AST of base class>
    */
-  void get_base_map(
-      const clang::CXXRecordDecl *cxxrd,
-      base_map &map);
+  void get_base_map(const clang::CXXRecordDecl *cxxrd, base_map &map);
   /*
    * Check whether we've already got this component in a class type
    * Avoid copying duplicate component from a base class type to the derived class type.
@@ -185,8 +183,8 @@ protected:
    *  - type: ESBMC IR representing the derived class type
    */
   bool is_duplicate_component(
-      const struct_typet::componentt &component,
-      const struct_union_typet &type);
+    const struct_typet::componentt &component,
+    const struct_union_typet &type);
   /*
    * Check whether we've already got this method in a class type
    * Avoid copying duplicate method from a base class type to the derived class type.
@@ -196,8 +194,8 @@ protected:
    *  - type: ESBMC IR representing the derived class type
    */
   bool is_duplicate_method(
-      const struct_typet::componentt &method,
-      const struct_union_typet &type);
+    const struct_typet::componentt &method,
+    const struct_union_typet &type);
   /*
    * Copy components and methods from base class(es) to the derived class type
    * For virtual base class, we only copy it once.
@@ -206,9 +204,7 @@ protected:
    *  - map: this map contains all base class(es) of this class std::map<class_id, pointer to clang AST of base class>
    *  - type: ESBMC IR representing the class' type
    */
-  void get_base_components_methods(
-      base_map &map,
-      struct_union_typet &type);
+  void get_base_components_methods(base_map &map, struct_union_typet &type);
 
   /*
    * Methods for virtual tables and virtual pointers

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -229,7 +229,7 @@ void clang_cpp_convertert::add_thunk_method(
   struct_typet &type)
 {
   /*
-   * Add a thunk function for a overriding method.
+   * Add a thunk function for an overriding method.
    * This thunk function will be added as a symbol in the symbol table,
    * and considered a `component` to the derived class' type.
    * This thunk function will be used to set up the derived class' vtable
@@ -358,12 +358,15 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
     arg.set("#identifier", arg_symb.id);
 
     // add the argument to the symbol table
-    if(context.move(arg_symb))
+    symbolt *tmp_symbol;
+    if(context.move(arg_symb, tmp_symbol))
     {
       log_error(
-        "Failed to add arg symbol `{}' for thunk function `{}'",
+        "Failed to add arg symbol `{}' for thunk function `{}'.\n"
+        "`{}' already exists",
         arg_symb.id,
-        thunk_func_symb.id);
+        thunk_func_symb.id,
+        tmp_symbol->id);
       abort();
     }
   }
@@ -600,12 +603,12 @@ void clang_cpp_convertert::get_overriden_methods(
    */
   for(const auto &md_overriden : md->overridden_methods())
   {
-    if(md->begin_overridden_methods() != md->end_overridden_methods())
+    if(md_overriden->begin_overridden_methods() != md_overriden->end_overridden_methods())
       get_overriden_methods(md_overriden, map);
 
     // get the id for this overriden method
     std::string method_id, method_name;
-    clang_c_convertert::get_decl_name(*md, method_name, method_id);
+    clang_c_convertert::get_decl_name(*md_overriden, method_name, method_id);
 
     // avoid adding the same overriden method, e.g. in case of diamond problem
     if(map.find(method_id) != map.end())

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -361,7 +361,7 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
     if(context.move(arg_symb))
     {
       log_error(
-        "Failed to add arg symbol {} for thunk function {}",
+        "Failed to add arg symbol `{}' for thunk function `{}'",
         arg_symb.id,
         thunk_func_symb.id);
       abort();

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -603,7 +603,9 @@ void clang_cpp_convertert::get_overriden_methods(
    */
   for(const auto &md_overriden : md->overridden_methods())
   {
-    if(md_overriden->begin_overridden_methods() != md_overriden->end_overridden_methods())
+    if(
+      md_overriden->begin_overridden_methods() !=
+      md_overriden->end_overridden_methods())
       get_overriden_methods(md_overriden, map);
 
     // get the id for this overriden method

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -285,7 +285,7 @@ unsigned int struct_union_data::get_component_number(const irep_idt &comp) const
   else if(count > 1)
   {
     log_error(
-      "Name \"{}\" matches more than one member\" in struct/union \"{}\"",
+      "Name \"{}\" matches more than one member in struct/union \"{}\"",
       comp,
       name);
     abort();

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,10 +33,20 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
+    {
+      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+      out << s.type.pretty(0) << "\n";
+      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
+    }
 
     if(s.value.is_not_nil())
+    {
+      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+      out << s.value.pretty(0) << "\n";
+      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
+    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,20 +33,10 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
-    {
-      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
-      out << s.type.pretty(0) << "\n";
-      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
-    }
 
     if(s.value.is_not_nil())
-    {
-      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
-      out << s.value.pretty(0) << "\n";
-      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
-    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
This patch added support for diamond problem, and enabled TC7. 
Total pass rate: 36/45 in `regression/esbmc-cpp/polymorphism_bringup` suite.

### Dev notes: 
1. Fixed recursive method to get overriden_map to avoid generating duplicate thunk functions in a more complicated scenario (multi-level polymorphism, diamond problem)
2. Fixed recursive method to get bases_map to avoid getting duplicate components/methods from base classes in a more complicated scenario (multi-level polymorphism, diamond problem)
3. Also update some TC descriptions in `regression/esbmc-cpp/polymorphism_bringup` test suite.