### PR TITLE
VFT fix

### DIFF
--- a/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXConstructExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXConstructExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class_fail/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXConstructExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXConstructExpr</item_11_issue></test-case>

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -565,6 +565,10 @@ bool clang_c_convertert::get_function(
   if(fd.isImplicit() && !is_ConstructorOrDestructor(fd))
     return false;
 
+  // If the function is not defined but this is not the definition, skip it
+  if(fd.isDefined() && !fd.isThisDeclarationADefinition())
+    return false;
+
   // Save old_functionDecl, to be restored at the end of this method
   const clang::FunctionDecl *old_functionDecl = current_functionDecl;
   current_functionDecl = &fd;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -567,7 +567,11 @@ bool clang_c_convertert::get_function(
 
   // If the function is not defined but this is not the definition, skip it
   if(fd.isDefined() && !fd.isThisDeclarationADefinition())
-    return false;
+  {
+    // Continue for virtual method as we need its type to make virtual function table
+    if(!is_fd_virtual_or_overriding(fd))
+      return false;
+  }
 
   // Save old_functionDecl, to be restored at the end of this method
   const clang::FunctionDecl *old_functionDecl = current_functionDecl;
@@ -3349,6 +3353,13 @@ bool clang_c_convertert::is_ConstructorOrDestructor(
 
 bool clang_c_convertert::perform_virtual_dispatch(
   const clang::MemberExpr &member)
+{
+  // It just can't happen in C
+  return false;
+}
+
+bool clang_c_convertert::is_fd_virtual_or_overriding(
+  const clang::FunctionDecl &fd)
 {
   // It just can't happen in C
   return false;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -565,10 +565,6 @@ bool clang_c_convertert::get_function(
   if(fd.isImplicit() && !is_ConstructorOrDestructor(fd))
     return false;
 
-  // If the function is not defined but this is not the definition, skip it
-  if(fd.isDefined() && !fd.isThisDeclarationADefinition())
-    return false;
-
   // Save old_functionDecl, to be restored at the end of this method
   const clang::FunctionDecl *old_functionDecl = current_functionDecl;
   current_functionDecl = &fd;

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -253,7 +253,7 @@ protected:
   virtual bool perform_virtual_dispatch(const clang::MemberExpr &member);
 
   /*
-   * Function to for virtual function table dynamic binding for "->" operator
+   * Function to get the ESBMC IR representing a virtual function table dynamic binding for "->" operator
    * Turning
    *  x->F
    * into
@@ -267,6 +267,17 @@ protected:
    */
   virtual bool
   get_vft_binding_expr(const clang::MemberExpr &member, exprt &new_expr);
+
+  /*
+   * Function to check whether a clang::FunctionDec represents a
+   * clang::CXXMethodDecl that is virtual OR overrides another function
+   *
+   * Params:
+   *  - fd: a clang::FunctionDec we are currently dealing with
+   *
+   * For C, it always return false.
+   */
+  virtual bool is_fd_virtual_or_overriding(const clang::FunctionDecl &fd);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -412,7 +412,8 @@ protected:
    * Methods for resolving a clang::MemberExpr to virtual/overriding method
    */
   bool perform_virtual_dispatch(const clang::MemberExpr &member) override;
-  bool is_virtual_or_overriding(const clang::CXXMethodDecl &cxxmd);
+  bool is_md_virtual_or_overriding(const clang::CXXMethodDecl &cxxmd);
+  bool is_fd_virtual_or_overriding(const clang::FunctionDecl &fd) override;
   bool get_vft_binding_expr(const clang::MemberExpr &member, exprt &new_expr)
     override;
   /*

--- a/src/clang-cpp-frontend/clang_cpp_convert_bind.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_bind.cpp
@@ -52,7 +52,7 @@ bool clang_cpp_convertert::perform_virtual_dispatch(
     if(
       member.performsVirtualDispatch(langOpts) &&
       cxxmd.getKind() != clang::Decl::CXXConstructor &&
-      (is_virtual_or_overriding(cxxmd)))
+      (is_md_virtual_or_overriding(cxxmd)))
       return true;
 
     break;
@@ -64,12 +64,21 @@ bool clang_cpp_convertert::perform_virtual_dispatch(
   return false;
 }
 
-bool clang_cpp_convertert::is_virtual_or_overriding(
+bool clang_cpp_convertert::is_md_virtual_or_overriding(
   const clang::CXXMethodDecl &cxxmd)
 {
   return (
     cxxmd.isVirtual() ||
     cxxmd.begin_overridden_methods() != cxxmd.end_overridden_methods());
+}
+
+bool clang_cpp_convertert::is_fd_virtual_or_overriding(
+  const clang::FunctionDecl &fd)
+{
+  if(const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(&fd))
+    return is_md_virtual_or_overriding(*md);
+  else
+    return false;
 }
 
 bool clang_cpp_convertert::get_vft_binding_expr(


### PR DESCRIPTION
This patch enabled 2 more test cases - vmd_defined_outside_class and vmd_defined_outside_class_fail
Total pass rate: 38/45 in `regression/esbmc-cpp/polymorphism_bringup` suite. 

### Dev notes: 
- Fixed the condition in get_function method to get the type for virtual/overriding method. 
-- Because  we need the type of virtual/overriding method to figure out the number of arguments when creating thunk functions and vtable. 