### PR TITLE
Fixed base initializer argument size

### DIFF
--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/main.cpp
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/main.cpp
@@ -1,3 +1,7 @@
+/*
+ * diamond problem.
+ * The most derived class is responsible for constructing the top base class.
+ */
 #include <cassert>
 
 class A

--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance/main.cpp
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance/main.cpp
@@ -1,3 +1,7 @@
+/*
+ * diamond problem.
+ * The most derived class is responsible for constructing the top base class.
+ */
 #include <cassert>
 
 class A

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1228,7 +1228,7 @@ void clang_cpp_convertert::gen_typecast_base_ctor_call(
   const code_typet::argumentst &base_ctor_arguments =
     base_ctor_code_type.arguments();
   // just one argument representing `this` in base class ctor
-  assert(base_ctor_arguments.size() == 1);
+  assert(base_ctor_arguments.size() >= 1);
   const typet base_ctor_this_type = base_ctor_arguments.at(0).type();
 
   // get derived class ctor implicit this

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1227,8 +1227,9 @@ void clang_cpp_convertert::gen_typecast_base_ctor_call(
   const code_typet &base_ctor_code_type = to_code_type(callee_decl.type());
   const code_typet::argumentst &base_ctor_arguments =
     base_ctor_code_type.arguments();
-  // just one argument representing `this` in base class ctor
+  // at least one argument representing `this` in base class ctor
   assert(base_ctor_arguments.size() >= 1);
+  // Get the type of base `this` represented by the base class ctor
   const typet base_ctor_this_type = base_ctor_arguments.at(0).type();
 
   // get derived class ctor implicit this

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,10 +33,20 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
+    {
+      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+      out << s.type.pretty(0) << "\n";
+      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
+    }
 
     if(s.value.is_not_nil())
+    {
+      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+      out << s.value.pretty(0) << "\n";
+      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
+    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,20 +33,10 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
-    {
-      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
-      out << s.type.pretty(0) << "\n";
-      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
-    }
 
     if(s.value.is_not_nil())
-    {
-      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
-      out << s.value.pretty(0) << "\n";
-      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
-    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
This patch enabled two more test cases: 
`polymorphism_bringup/llbmc_virtual_inheritance/`
`inheritance_bringup/inheritance09_fail`

Base initializer argument size should be ">= 1" not "== 1", e.g. 
```cpp
// class A ctor
A(int x) : data_a(x) { }
...
// class B ctor
B(int y) : data_b(y) { }
...
// class D : public A, public B
D(int a): A(a), B(a) { }
```


