### PR TITLE
Added OM sanity checks for cstddef and cstdarg

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -78,6 +78,7 @@ else()
                     incremental-smt esbmc-cpp11/cpp esbmc-cpp11/constructors esbmc-cpp11/new-delete esbmc-cpp11/reference esbmc-cpp/inheritance_bringup
                     esbmc-cpp/polymorphism_bringup
                     esbmc-cpp/bug_fixes
+                    esbmc-cpp/OM_sanity_checks
                     ${REGRESSIONS_GOTO_CONTRACTOR} ${REGRESSIONS_JIMPLE} extensions cuda)
   else()
     set(REGRESSIONS $ENV{BENCHMARK_TO_RUN}) # run a single user-specified benchmark

--- a/regression/esbmc-cpp/OM_sanity_checks/README
+++ b/regression/esbmc-cpp/OM_sanity_checks/README
@@ -1,0 +1,8 @@
+Test suite to perform sanity checks on ESBMC's OMs for C++ verification. It works in two-ways:
+1. Make sure the code changes in an ESBMC's OM doesn't generate PARSE ERRORs
+2. Make sure the code changes in clang-cpp frontend doesn't affect the parsing of ESBMC's OMs
+
+Eeach TC corresponds to one ESBMC C++ OM.
+
+Pass criteria:
+  - No parse errors and got "VERIFICATION SUCCESSFUL"

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdarg/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdarg/main.cpp
@@ -1,0 +1,4 @@
+#include <cstdarg>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdarg/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdarg/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cstddef/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstddef/main.cpp
@@ -1,0 +1,4 @@
+#include <cstddef>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cstddef/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstddef/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/cstdarg
+++ b/src/cpp/library/cstdarg
@@ -5,6 +5,10 @@
 
  Date: September 2012
 
+ Ref:
+ https://cplusplus.com/reference/cstdarg/va_copy/
+ https://en.cppreference.com/w/cpp/header/cstdarg
+
  \*******************************************************************/
 
 #ifndef STL_CSTDARG
@@ -12,12 +16,14 @@
 
 typedef int* va_list;
 
-void va_end(va_list ap);
+void va_start(va_list ap, ...);
 
 #ifndef _VA_ARG_DEFINED
 #define va_arg(ap,t) t()
 #endif
 
-void va_start(va_list ap, ...);
+void va_end(va_list ap);
+
+// TODO: va_copy placeholder for C++11
 
 #endif


### PR DESCRIPTION
Some work towards passing `regression/esbmc-cpp/stream/istream_get_1/main.cpp`
Started with fixes/TCs to level-6 dependencies as in the following include tree: 

![Screenshot 2023-03-27 at 14 07 12](https://user-images.githubusercontent.com/32592800/227955780-313e81b4-7cb3-468e-a872-58df9931f14a.png)


### Dev notes:
- started to purge parse errors in our cpp OMs
   * follow the workflows as defined by the [guidelines here](https://github.com/esbmc/esbmc/wiki/Guidelines-for-Fixing-Operational-Models-(OM)-in-ESBMC) 
- added test cases for sanity checks

