### PR TITLE
Added OM sanity check for cstdio

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cstdio/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdio/main.cpp
@@ -1,0 +1,4 @@
+#include <cstdio>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdio/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdio/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/cstdio
+++ b/src/cpp/library/cstdio
@@ -5,6 +5,9 @@
 
  Date: September 2012
 
+ Ref:
+  https://cplusplus.com/reference/cstdio/
+  https://en.cppreference.com/w/cpp/header/cstdio
  \*******************************************************************/
 
 #ifndef STL_CSTDIO
@@ -113,8 +116,6 @@ extern "C" {
   int sprintf(char * str, const char * format, ...);
 
   int snprintf(char * s, size_t n, const char * format, ...);
-
-  int vsnprintf(char * s, size_t n, const char * format, va_list arg);
 
   int vsnprintf(char * s, size_t n, const char * format, va_list arg);
 }


### PR DESCRIPTION
Continuation of https://github.com/esbmc/esbmc/pull/943 
Working towards passing `regression/esbmc-cpp/stream/istream_get_1/main.cpp`

This PR addresses level-5 dependencies as shown in the following include tree:

![Screenshot 2023-03-28 at 14 11 40](https://user-images.githubusercontent.com/32592800/228247849-295195e6-929e-48f2-9103-f6edd588626f.png)

### Dev notes:
1. Reviewed cstdio OM:
  * added references
  * removed duplicate declarations
2. Added TC for OM sanity check