### PR TITLE
Fixed and added OM sanity check for exception

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/exception/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/exception/main.cpp
@@ -1,0 +1,4 @@
+#include <exception>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/exception/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/exception/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/exception
+++ b/src/cpp/library/exception
@@ -2,8 +2,12 @@
  Module:
 
  Author: Felipe Rodrigues
+ Created in: September 2012
+ Updated in: March 2023 by Kunjian Song
 
- Date: September 2012
+ Ref:
+ https://en.cppreference.com/w/cpp/header/exception
+ https://cplusplus.com/reference/exception/
 
  \*******************************************************************/
 
@@ -19,18 +23,27 @@ const char* message;
 typedef void (*terminate_handler)();
 typedef void (*unexpected_handler)();
 
-bool uncaught_exception() throw ();
+bool uncaught_exception() throw();
 
 // Default terminate function: calls abort
-void default_terminate() throw ()
+void default_terminate() throw()
 {
   __ESBMC_assert(0, "Aborted");
   // Allow now further execution.
   __ESBMC_assume(0);
 }
 
+// Default terminate function for unexpected: calls abort
+// A quick workaround model for "throw"
+void default_terminate_unexpected_exception() throw()
+{
+  __ESBMC_assert(0, "Aborted - unexpected exceptions");
+  // Allow now further execution.
+  __ESBMC_assume(0);
+}
+
 // Default unexpected function: calls terminate
-void default_unexpected() throw ()
+void default_unexpected() throw()
 {
   default_terminate();
 }
@@ -38,14 +51,16 @@ void default_unexpected() throw ()
 terminate_handler terminate_pf=default_terminate;
 unexpected_handler unexpected_pf=default_unexpected;
 
-terminate_handler set_terminate(terminate_handler f) throw ()
+terminate_handler set_terminate(terminate_handler f) throw()
 {
   terminate_pf=f;
+  return terminate_pf;
 }
 
-unexpected_handler set_unexpected(unexpected_handler f) throw ()
+unexpected_handler set_unexpected(unexpected_handler f) throw()
 {
   unexpected_pf=f;
+  return unexpected_pf;
 }
 
 // Model for unexpected function: calls the current
@@ -53,7 +68,9 @@ unexpected_handler set_unexpected(unexpected_handler f) throw ()
 void unexpected()
 {
   unexpected_pf();
-  throw;
+  // TODO: For the time being, we use a terminate function as a workaround.
+  //   probably should rethrow the exception and just use throw.
+  default_terminate_unexpected_exception();
 }
 
 // Model for terminate function: calls the current
@@ -65,18 +82,18 @@ void terminate()
 
 class exception {
 public:
-  exception() throw () {};
-  exception(const exception&) throw () {};
+  exception() throw() {};
+  exception(const exception&) throw() {};
 
-  exception& operator=(const exception&) throw ();
+  exception& operator=(const exception&) throw();
 
-  virtual ~exception() throw () {}
+  virtual ~exception() throw() {}
 
-  virtual const char* what() const throw () {
+  virtual const char* what() const throw() {
     /**
      *Returns a null terminated character sequence containing a generic description of the exception.
      *Both the wording of such description and the character width are implementation-defined.
-     *source: http://www.cplusplus.com/reference/std/exception/exception/
+     *source: https://cplusplus.com/reference/exception/exception/what/
      **/
     return (const char*) message;
   }
@@ -87,11 +104,9 @@ public:
  **/
 class bad_exception: public exception {
 public:
-  bad_exception() {}
-
-  virtual ~bad_exception() {}
-
-  virtual const char* what() const {
+  bad_exception() throw() {}
+  bad_exception& operator=( const bad_exception& other ) throw();
+  virtual const char* what() const throw() {
     return (const char*) message;
   }
 };


### PR DESCRIPTION
Continuation of https://github.com/esbmc/esbmc/pull/944
Working towards passing regression/esbmc-cpp/stream/istream_get_1/main.cpp, following [the Guidelines for OM fixes](https://github.com/esbmc/esbmc/wiki/Guidelines-for-Fixing-Operational-Models-(OM)-in-ESBMC)

This PR addresses level-4 dependency `exception` OM as shown in the following include tree:
![Screenshot 2023-03-28 at 20 30 26](https://user-images.githubusercontent.com/32592800/228628728-2415219c-e4d0-4420-b479-396850a3462f.png)

### Dev notes:
1. Reviewed exception OM:
   * added reference links
   * fixed PARSE ERRORs reported by clang
2. Added the TC for OM sanity check
