### PR TITLE
[OM]fixed cstdlib

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cstdlib/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdlib/main.cpp
@@ -1,0 +1,4 @@
+#include <cstdlib>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdlib/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdlib/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/cstdlib
+++ b/src/cpp/library/cstdlib
@@ -110,7 +110,7 @@ unsigned long int strtoul(const char * str, char ** endptr, int base);
 
 char * getenv(const char * name) {
 	size_t size = strlen(name) + 1;
-	char tmp[size];
+	char* tmp = (char*)malloc(size);
 	strcpy(tmp, name);
 	return tmp;
 }
@@ -154,14 +154,15 @@ char get_char(int digit) {
 	return charstr[digit];
 }
 
-void rev(char *p) {
-	char *q = &p[strlen(p) - 1];
+void rev(char *p) {	
+	char *q = p + strlen(p) - 1;	
 	char *r = p;
 	for (; q > r; q--, r++) {
 		char s = *q;
 		*q = *r;
 		*r = s;
 	}
+	
 }
 
 #endif


### PR DESCRIPTION
This PR is for the CUDA opreational model, starting with a simple cuda program. Here are the dependencies.
```
. /home/lxzy/libraries/cuda.h
.. /home/lxzy/libraries/sm_atomic_functions.h
... /home/lxzy/libraries/vector_types.h
.... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
..... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/__stddef_max_align_t.h
.... /home/lxzy/libraries/stdlib.h
..... /home/lxzy/libraries/cstdlib                                                       ←Occurrence warning
...... /home/lxzy/libraries/cstring                                                      ←Errors and warnings occur
....... /home/lxzy/libraries/definitions.h
........ /home/lxzy/libraries/cstddef
......... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
.... /home/lxzy/libraries/builtin_types.h
..... /home/lxzy/libraries/driver_types.h
...... /home/lxzy/libraries/host_defines.h
...... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/limits.h
....... /usr/include/limits.h
........ /usr/include/x86_64-linux-gnu/bits/libc-header-start.h
......... /usr/include/features.h
.......... /usr/include/features-time64.h
........... /usr/include/x86_64-linux-gnu/bits/wordsize.h
........... /usr/include/x86_64-linux-gnu/bits/timesize.h
............ /usr/include/x86_64-linux-gnu/bits/wordsize.h
.......... /usr/include/stdc-predef.h
.......... /usr/include/x86_64-linux-gnu/sys/cdefs.h
........... /usr/include/x86_64-linux-gnu/bits/wordsize.h
........... /usr/include/x86_64-linux-gnu/bits/long-double.h
.......... /usr/include/x86_64-linux-gnu/gnu/stubs.h
........... /usr/include/x86_64-linux-gnu/gnu/stubs-64.h
........ /usr/include/x86_64-linux-gnu/bits/posix1_lim.h
......... /usr/include/x86_64-linux-gnu/bits/wordsize.h
......... /usr/include/x86_64-linux-gnu/bits/local_lim.h
.......... /usr/include/linux/limits.h
.......... /usr/include/x86_64-linux-gnu/bits/pthread_stack_min-dynamic.h
........ /usr/include/x86_64-linux-gnu/bits/posix2_lim.h
........ /usr/include/x86_64-linux-gnu/bits/xopen_lim.h
......... /usr/include/x86_64-linux-gnu/bits/uio_lim.h
...... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
.. /home/lxzy/libraries/curand_kernel.h
... /home/lxzy/libraries/curand_precalc.h
... /home/lxzy/libraries/math.h
.... /home/lxzy/libraries/cmath
... /home/lxzy/libraries/curand.h
.. /home/lxzy/libraries/cuda_runtime_api.h
... /home/lxzy/libraries/cuda.h
... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
... /home/lxzy/libraries/stdio.h
.... /home/lxzy/libraries/cstdio                                             
..... /home/lxzy/libraries/cstddef                                          
...... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
..... /home/lxzy/libraries/cstdarg
... /home/lxzy/libraries/builtin_types.h
... /home/lxzy/libraries/cuda_device_runtime_api.h
.. /home/lxzy/libraries/call_kernel.h
... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
... /home/lxzy/libraries/string.h
... /usr/c2goto/headers/pthread.h
... /usr/include/assert.h
... /home/lxzy/libraries/device_launch_parameters.h
.... /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
.... /home/lxzy/libraries/stdlib.h
... /home/lxzy/libraries/new
.... /home/lxzy/libraries/exception
.. /home/lxzy/ESBMC_Project/clang11/lib/clang/11.0.0/include/stddef.h
.. /home/lxzy/libraries/string.h
.. /usr/include/assert.h
```

Fix warnings and errors that occurred during parsing.
```
./cstring:141:12: warning: comparison between NULL and non-pointer ('char' and NULL) [-Wnull-arithmetic]
        while (*s != NULL) { //until the end of string
               ~~ ^  ~~~~
./cstring:277:18: error: arithmetic on pointers to void
        if (dest - src >= n) {
            ~~~~ ^ ~~~
In file included from main.cpp:1:
./cstdlib:115:9: warning: address of stack memory associated with local variable 'tmp' returned [-Wreturn-stack-address]
        return tmp;
```