### PR TITLE
[OM] definitions, cassert and stdexcept

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cassert/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cassert/main.cpp
@@ -1,0 +1,4 @@
+#include <cassert>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cassert/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cassert/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/definitions/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/definitions/main.cpp
@@ -1,0 +1,4 @@
+#include "definitions.h"
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/definitions/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/definitions/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/stdexcept/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/stdexcept/main.cpp
@@ -1,0 +1,4 @@
+#include <stdexcept>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/stdexcept/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/stdexcept/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/exception
+++ b/src/cpp/library/exception
@@ -87,7 +87,7 @@ public:
 
   exception& operator=(const exception&) throw();
 
-  virtual ~exception() throw() {}
+  virtual ~exception() {}
 
   virtual const char* what() const throw() {
     /**


### PR DESCRIPTION
Continuation of https://github.com/esbmc/esbmc/pull/954
Working towards passing regression/esbmc-cpp/stream/istream_get_1/main.cpp, following [the Guidelines for OM fixes](https://github.com/esbmc/esbmc/wiki/Guidelines-for-Fixing-Operational-Models-(OM)-in-ESBMC)

Fixed the error: 
```
ESBMC version 7.1.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing
In file included from stdexcept_sanity_check.cpp:1:
library/stdexcept:70:11: error: exception specification of overriding function is more lax than base version
  virtual ~logic_error() {
          ^
library/exception:90:11: note: overridden virtual function is here
  virtual ~exception() throw() {}
          ^
ERROR: PARSING ERROR
```

The destructor `~exception()` should not have exception specifier (c.f. [std::exception::~exception reference](https://en.cppreference.com/w/cpp/error/exception/%7Eexception))

This PR addresses a few level-3 dependency OMs as shown in the following include tree:
![Screenshot 2023-04-05 at 12 35 08](https://user-images.githubusercontent.com/32592800/230089788-71bbc2d5-03f3-43dd-93a4-f0d7ec0e9e7f.png)


