### PR TITLE
[OM] cstring

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cstring/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstring/main.cpp
@@ -1,0 +1,4 @@
+#include <cstring>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cstring/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstring/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/cstring
+++ b/src/cpp/library/cstring
@@ -13,312 +13,312 @@
 #include "definitions.h"
 
 char *strcpy(char *d, const char *s) {
-	int i;
+  int i;
 
-	for (i = 0; s[i] != 0; i++) {
-		d[i] = s[i];
-	}
+  for (i = 0; s[i] != 0; i++) {
+    d[i] = s[i];
+  }
 
-	d[i] = '\0';
+  d[i] = '\0';
 
-	return d;
+  return d;
 }
 
 char *strncpy(char *d, const char *s, size_t n) {
 
-	size_t i=0;
-	char ch;
-	bool end;
+  size_t i=0;
+  char ch;
+  bool end;
 
-	for(end=0; i<n; i++)
-	{
-		ch=end?0:s[i];
-		d[i]=ch;
-		end=end || ch==(char)0;
-	}
-	return d;
+  for(end=0; i<n; i++)
+  {
+    ch=end?0:s[i];
+    d[i]=ch;
+    end=end || ch==(char)0;
+  }
+  return d;
 }
 
 char *strcat(char d[], const char s[]) {
-	int i, e;
+  int i, e;
 
-	for (e = 0; d[e] != '\0'; e++)
-		;
+  for (e = 0; d[e] != '\0'; e++)
+    ;
 
-	for (i = 0; s[i] != '\0'; i++) {
-		d[e + i] = s[i];
-	}
+  for (i = 0; s[i] != '\0'; i++) {
+    d[e + i] = s[i];
+  }
 
-	d[e + i] = '\0';
+  d[e + i] = '\0';
 
-	return d;
+  return d;
 }
 
 char *strncat(char d[], const char s[], size_t n) {
-	size_t i, e;
+  size_t i, e;
 
-	for (e = 0; d[e] != '\0'; e++)
-		;
+  for (e = 0; d[e] != '\0'; e++)
+    ;
 
-	for (i = 0; s[i] != '\0' && i < n; i++) {
-		d[e + i] = s[i];
-	}
+  for (i = 0; s[i] != '\0' && i < n; i++) {
+    d[e + i] = s[i];
+  }
 
-	d[e + i] = '\0';
+  d[e + i] = '\0';
 
-	return d;
+  return d;
 }
 
 int strcmp(const char *s1, const char *s2) {
-	int i;
+  int i;
 
-	for (i = 0;; i++) {
-		if (s1[i] == s2[i]) {
-			if (s1[i] == '\0')
-				return 0;
-			continue;
-		}
-		if (s1[i] == '\0')
-			return -1;
-		if (s2[i] == '\0')
-			return 1;
-		if (s1[i] < s2[i])
-			return -1;
-		else
-			return 1;
-	}
+  for (i = 0;; i++) {
+    if (s1[i] == s2[i]) {
+      if (s1[i] == '\0')
+        return 0;
+      continue;
+    }
+    if (s1[i] == '\0')
+      return -1;
+    if (s2[i] == '\0')
+      return 1;
+    if (s1[i] < s2[i])
+      return -1;
+    else
+      return 1;
+  }
 }
 
 int strncmp(const char *s1, const char *s2, size_t n) {
-	int i;
+  int i;
 
-	for (i = 0; i < n; i++) {
-		if (s1[i] == s2[i]) {
-			if (s1[i] == '\0')
-				return 0;
-			continue;
-		}
-		if (s1[i] == '\0')
-			return -1;
-		if (s2[i] == '\0')
-			return 1;
-		if (s1[i] < s2[i])
-			return -1;
-		else
-			return 1;
-	}
+  for (i = 0; i < n; i++) {
+    if (s1[i] == s2[i]) {
+      if (s1[i] == '\0')
+        return 0;
+      continue;
+    }
+    if (s1[i] == '\0')
+      return -1;
+    if (s2[i] == '\0')
+      return 1;
+    if (s1[i] < s2[i])
+      return -1;
+    else
+      return 1;
+  }
 
-	return 0;
+  return 0;
 }
 
 char *strchr(const char *s, int c) {
-	while (*s != (char) c)
-		if (!*s++)
-			return 0;
-	return (char *) s;
+  while (*s != (char) c)
+    if (!*s++)
+      return 0;
+  return (char *) s;
 }
 
 size_t strcspn(const char *s1, const char *s2) {
-	size_t ret = 0;
-	while (*s1)
-		if (strchr(s2, *s1))
-			return ret;
-		else
-			s1++, ret++;
-	return ret;
+  size_t ret = 0;
+  while (*s1)
+    if (strchr(s2, *s1))
+      return ret;
+    else
+      s1++, ret++;
+  return ret;
 }
 
 size_t strspn(const char *s1, const char *s2) {
-	size_t ret = 0;
-	while (*s1 && strchr(s2, *s1++))
-		ret++;
-	return ret;
+  size_t ret = 0;
+  while (*s1 && strchr(s2, *s1++))
+    ret++;
+  return ret;
 }
 
 size_t strlen(const char *s) {
-	__ESBMC_assert(s != NULL, "string must contain any character");
-	size_t len = 0;
-	while (*s != '\0') { //until the end of string
-		s++;
-		len++;
-	}
-	return len;
+  __ESBMC_assert(s != NULL, "string must contain any character");
+  size_t len = 0;
+  while (*s != '\0') { //until the end of string
+    s++;
+    len++;
+  }
+  return len;
 }
 
 char *strtok_r(char *str, const char *delim, char **saveptr) {
-	size_t i;
-	size_t j;
-	bool delimp;
+  size_t i;
+  size_t j;
+  bool delimp;
 
-	if (str) {
-		*saveptr = str;
-	} else {
-		if (!*saveptr) {
-			return NULL;
-		} else {
-			str = *saveptr;
-		}
-	}
+  if (str) {
+    *saveptr = str;
+  } else {
+    if (!*saveptr) {
+      return NULL;
+    } else {
+      str = *saveptr;
+    }
+  }
 
-	for (i = 0; str[i]; i++) {
-		delimp = false;
+  for (i = 0; str[i]; i++) {
+    delimp = false;
 
-		for (j = 0; delim[j]; j++) {
-			if (str[i] == delim[j]) {
-				delimp = true;
-				break;
-			}
-		}
+    for (j = 0; delim[j]; j++) {
+      if (str[i] == delim[j]) {
+        delimp = true;
+        break;
+      }
+    }
 
-		if (!delimp) {
-			break;
-		}
-	}
+    if (!delimp) {
+      break;
+    }
+  }
 
-	for (; str[i]; i++) {
-		for (j = 0; delim[j]; j++) {
-			if (str[i] == delim[j]) {
-				str[i] = '\0';
-				*saveptr = &str[i + 1];
-				return str;
-			}
-		}
-	}
+  for (; str[i]; i++) {
+    for (j = 0; delim[j]; j++) {
+      if (str[i] == delim[j]) {
+        str[i] = '\0';
+        *saveptr = &str[i + 1];
+        return str;
+      }
+    }
+  }
 
-	*saveptr = NULL;
-	return str;
+  *saveptr = NULL;
+  return str;
 }
 
 char *strtok(char *str, const char *delim) {
-	static char *saveptr = NULL;
-	char *token;
+  static char *saveptr = NULL;
+  char *token;
 
-	token = strtok_r(str, delim, &saveptr);
+  token = strtok_r(str, delim, &saveptr);
 
-	if (!token) {
-		saveptr = NULL;
-	}
+  if (!token) {
+    saveptr = NULL;
+  }
 
-	return token;
+  return token;
 }
 
 static bool is_accepted(char c, const char *accept) {
-	size_t i;
+  size_t i;
 
-	for (i = 0; accept[i]; i++) {
-		if (c == accept[i]) {
-			return true;
-		}
-	}
-	return false;
+  for (i = 0; accept[i]; i++) {
+    if (c == accept[i]) {
+      return true;
+    }
+  }
+  return false;
 }
 
 char *strpbrk(const char *s, const char *accept) {
-	size_t i;
+  size_t i;
 
-	for (i = 0; s[i]; i++) {
-		if (is_accepted(s[i], accept)) {
-			return (char*) &s[i];
-		}
-	}
+  for (i = 0; s[i]; i++) {
+    if (is_accepted(s[i], accept)) {
+      return (char*) &s[i];
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
 
 char *strrchr(const char *s, char c) {
-	size_t i;
+  size_t i;
 
-	for (i = 0; s[i]; i++)
-		;
+  for (i = 0; s[i]; i++)
+    ;
 
-	for (; i; i--) {
-		if (s[i] == c) {
-			return (char*) &s[i];
-		}
-	}
+  for (; i; i--) {
+    if (s[i] == c) {
+      return (char*) &s[i];
+    }
+  }
 
-	if (s[0] == c) {
-		return (char*) s;
-	}
+  if (s[0] == c) {
+    return (char*) s;
+  }
 
-	return NULL;
+  return NULL;
 }
 
 char *strstr(const char *s1, const char *s2) {
-	size_t i, j;
+  size_t i, j;
 
-	for (i = 0; s1[i]; i++) {
-		for (j = 0; s2[j] && s1[i + j]; j++) {
-			if (s1[i + j] != s2[j]) {
-				break;
-			}
-		}
-		if (s2[j] == '\0') {
-			return (char*) &s1[i];
-		}
-	}
+  for (i = 0; s1[i]; i++) {
+    for (j = 0; s2[j] && s1[i + j]; j++) {
+      if (s1[i + j] != s2[j]) {
+        break;
+      }
+    }
+    if (s2[j] == '\0') {
+      return (char*) &s1[i];
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
 
 void *memcpy(void *dst, const void *src, size_t n) {
-	__ESBMC_HIDE:
+  __ESBMC_HIDE:
   char *cdst = static_cast<char *>(dst);
   const char *csrc = static_cast<const char *>(src);
   for (size_t i = 0; i < n; i++)
-		cdst[i] = csrc[i];
-	return dst;
+    cdst[i] = csrc[i];
+  return dst;
 }
 
 void *memmove(void *dest, const void *src, size_t n) {
-	__ESBMC_HIDE:
+  __ESBMC_HIDE:
   char *cdst = static_cast<char *>(dest);
   const char *csrc = static_cast<const char *>(src);
   if (cdst - csrc >= n) {
-		for (size_t i = 0; i < n; i++)
-			cdst[i] = csrc[i];
-	} else {
-		for (size_t i = n; i > 0; i--)
-			cdst[i - 1] = csrc[i - 1];
-	}
-	return dest;
+    for (size_t i = 0; i < n; i++)
+      cdst[i] = csrc[i];
+  } else {
+    for (size_t i = n; i > 0; i--)
+      cdst[i - 1] = csrc[i - 1];
+  }
+  return dest;
 }
 
 int memcmp(const void *p1, const void *p2, size_t n) {
-	char *v1 = (char*) p1;
-	char *v2 = (char*) p2;
-	size_t i;
+  char *v1 = (char*) p1;
+  char *v2 = (char*) p2;
+  size_t i;
 
-	for (i = 0; i < n; i++) {
-		if (v1[i] != v2[i]) {
-			return 1;
-		}
-	}
+  for (i = 0; i < n; i++) {
+    if (v1[i] != v2[i]) {
+      return 1;
+    }
+  }
 
-	return 0;
+  return 0;
 }
 
 void *memchr(void *s, int c, size_t n) {
-	size_t i;
-	char *src = (char*) s;
+  size_t i;
+  char *src = (char*) s;
 
-	for (i = 0; i < n; i++) {
-		if (src[i] == c)
-			return &src[i];
-	}
+  for (i = 0; i < n; i++) {
+    if (src[i] == c)
+      return &src[i];
+  }
 
-	return &src[i];
+  return &src[i];
 }
 
 void *memset(void *s, int c, size_t n) {
-	size_t i;
-	char *src = (char*) s;
+  size_t i;
+  char *src = (char*) s;
 
-	for (i = 0; i < n; i++) {
-		src[i] = c;
-	}
+  for (i = 0; i < n; i++) {
+    src[i] = c;
+  }
 
-	return src;
+  return src;
 }
 
 #endif

--- a/src/cpp/library/cstring
+++ b/src/cpp/library/cstring
@@ -138,7 +138,7 @@ size_t strspn(const char *s1, const char *s2) {
 size_t strlen(const char *s) {
 	__ESBMC_assert(s != NULL, "string must contain any character");
 	size_t len = 0;
-	while (*s != NULL) { //until the end of string
+	while (*s != '\0') { //until the end of string
 		s++;
 		len++;
 	}
@@ -263,18 +263,18 @@ char *strstr(const char *s1, const char *s2) {
 
 void *memcpy(void *dst, const void *src, size_t n) {
 	__ESBMC_HIDE:
-        char *cdst = static_cast<char *>(dst);
-        const char *csrc = static_cast<const char *>(src);
-        for (size_t i = 0; i < n; i++)
+  char *cdst = static_cast<char *>(dst);
+  const char *csrc = static_cast<const char *>(src);
+  for (size_t i = 0; i < n; i++)
 		cdst[i] = csrc[i];
 	return dst;
 }
 
 void *memmove(void *dest, const void *src, size_t n) {
 	__ESBMC_HIDE:
-        char *cdst = static_cast<char *>(dest);
-        const char *csrc = static_cast<const char *>(src);
-        if (dest - src >= n) {
+  char *cdst = static_cast<char *>(dest);
+  const char *csrc = static_cast<const char *>(src);
+  if (cdst - csrc >= n) {
 		for (size_t i = 0; i < n; i++)
 			cdst[i] = csrc[i];
 	} else {


### PR DESCRIPTION
Continuation of https://github.com/esbmc/esbmc/pull/958
Working towards passing regression/esbmc-cpp/stream/istream_get_1/main.cpp, following [the Guidelines for OM fixes](https://github.com/esbmc/esbmc/wiki/Guidelines-for-Fixing-Operational-Models-(OM)-in-ESBMC)

N.B This PR needs rebasing when https://github.com/esbmc/esbmc/pull/958 is merged

Fixed the error:
```
ESBMC version 7.1.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing
In file included from cstdlib_sanity_check.cpp:1:
In file included from master_library/cstdlib:18:
master_library/cstring:141:12: warning: comparison between NULL and non-pointer ('char' and NULL) [-Wnull-arithmetic]
        while (*s != NULL) { //until the end of string
               ~~ ^  ~~~~
master_library/cstring:277:18: error: arithmetic on pointers to void
        if (dest - src >= n) {
            ~~~~ ^ ~~~
In file included from cstdlib_sanity_check.cpp:1:
master_library/cstdlib:115:9: warning: address of stack memory associated with local variable 'tmp' returned [-Wreturn-stack-address]
        return tmp;
               ^~~
ERROR: PARSING ERROR
```

This PR addresses a few level-3 dependency OM `cstring` as shown in the following include tree:

![fix_2](https://user-images.githubusercontent.com/32592800/230125437-b291864a-253e-4159-a7ef-2076bca8daac.png)


