### PR TITLE
[DO NOT MERGE] An under-approximated operational model for the scanf function 

### DIFF
--- a/regression/esbmc/github_955_fail/main.c
+++ b/regression/esbmc/github_955_fail/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+int main(int argc, char *argv[])
+{
+  char reg_name[12];
+  printf("Enter your username:");
+  scanf("%s", reg_name); //Buffer overflow here
+  printf("The program is now registered to %s.\n", reg_name);
+  return 0;
+}

--- a/regression/esbmc/github_955_fail/test.desc
+++ b/regression/esbmc/github_955_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -45,6 +45,14 @@ __ESBMC_HIDE:;
   return ret;
 }
 
+int scanf(const char *restrict format, ...)
+{
+__ESBMC_HIDE:;
+  // scanf is unsafe since it disregards the length of the string typed by the user;
+  // it can accept a string longer than the array size that stores the string.
+  __ESBMC_assert(0, "the `scanf' function is unsafe to use.");
+}
+
 // Reads characters from the standard input (stdin)
 // and stores them as a C string into str until a newline character
 // or the end-of-file is reached.

--- a/src/cpp/library/cstdio
+++ b/src/cpp/library/cstdio
@@ -49,8 +49,6 @@ extern "C" {
 
   int fscanf(FILE * stream, const char * format, ...);
 
-  int scanf(const char * format, ...);
-
   int sscanf(const char * str, const char * format, ...);
 
   int vfprintf(FILE * stream, const char * format, va_list arg);


### PR DESCRIPTION
The scanf function is unsafe since it disregards the length of the string typed by the user; so, it can accept a string longer than the array size that stores that respective string.

This PR adds an assertion that will fail with the message ```The `scanf' function is unsafe to use.```. 

So, this PR will allow one ESBMC user to advance their studies on using ESBMC to find software vulnerabilities in open-source applications.