### PR TITLE
Fix 961  - Issue 2

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/961_issue2/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/961_issue2/main.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+
+class Vehicle
+{
+public:
+  int x;
+  Vehicle()
+  {
+    x = 1;
+  }
+
+  int do_something()
+  {
+    return x;
+  }
+};
+
+int main()
+{
+  Vehicle xx;
+  int y = xx.do_something();
+  assert(y == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/961_issue2/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/961_issue2/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/961_issue2_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/961_issue2_fail/main.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+
+class Vehicle
+{
+public:
+  int x;
+  Vehicle()
+  {
+    x = 1;
+  }
+
+  int do_something()
+  {
+    return x;
+  }
+};
+
+int main()
+{
+  Vehicle xx;
+  int y = xx.do_something();
+  assert(y == 0); // FAIL as it should be 1
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/961_issue2_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/961_issue2_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/llbmc_simple_inheritance/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_simple_inheritance/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXConstructExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXConstructExpr</item_11_issue></test-case>

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
@@ -149,8 +149,6 @@ void clang_cpp_adjust::adjust_decl_block(codet &code)
     if(it->is_code() && (it->statement() == "skip"))
       continue;
 
-    adjust_expr(*it);
-
     code_declt &code_decl = to_code_decl(to_code(*it));
 
     if(code_decl.operands().size() == 2)
@@ -197,6 +195,8 @@ void clang_cpp_adjust::adjust_decl_block(codet &code)
         rhs.swap(result_expr);
       }
     }
+
+    adjust_expr(*it);
 
     new_block.copy_to_operands(code_decl);
   }

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
@@ -149,6 +149,8 @@ void clang_cpp_adjust::adjust_decl_block(codet &code)
     if(it->is_code() && (it->statement() == "skip"))
       continue;
 
+    adjust_expr(*it);
+
     code_declt &code_decl = to_code_decl(to_code(*it));
 
     if(code_decl.operands().size() == 2)


### PR DESCRIPTION
Fixed Issue 2 in https://github.com/esbmc/esbmc/issues/961#issuecomment-1505956463 and added the corresponding TCs.

Dev notes:
1. Fixed the error (see below) due to missing adjustment for member expression in decl_block. 
```
ERROR: unexpected function argument: member
```