### PR TITLE
[OM] ios, iomanip and ostream

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/iomanip/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/iomanip/main.cpp
@@ -1,0 +1,4 @@
+#include <iomanip>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/iomanip/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/iomanip/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/ios/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/ios/main.cpp
@@ -1,0 +1,4 @@
+#include "ios"
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/ios/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/ios/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/ostream/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/ostream/main.cpp
@@ -1,0 +1,4 @@
+#include <ostream>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/ostream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/ostream/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Continuation of https://github.com/esbmc/esbmc/pull/960
Working towards passing `regression/esbmc-cpp/stream/istream_get_1/main.cpp`, following [the Guidelines for OM fixes](https://github.com/esbmc/esbmc/wiki/Guidelines-for-Fixing-Operational-Models-(OM)-in-ESBMC)

This PR addresses the last level-3 dependency OM `ios` in the include tree and a few level-2 dependencies as shown in the following include tree (marked by yellow arrows):
![Screenshot 2023-04-18 at 11 32 03](https://user-images.githubusercontent.com/32592800/232754888-e2c5d906-4bb7-475c-bb2e-1bf5c9ab0c75.png)

### Dev notes:
1. Added sanity check TCs for `ios`, `iomanip` and `ostream`
2. `ios` was not includable due to error below, and this error has been fixed by https://github.com/esbmc/esbmc/pull/969. No additional fixes are required for this PR.
```
esbmc-new: ../src/irep2/irep2_expr.h:2844: member2t::member2t(const type2tc&, const expr2tc&, const irep_idt&): Assertion `source->type->type_id == type2t::struct_id || source->type->type_id == type2t::union_id' failed.
Aborted (core dumped)
```
