### PR TITLE
Guard fix

### DIFF
--- a/regression/esbmc-unix/01_bench_exp1x3_wvr/main.c
+++ b/regression/esbmc-unix/01_bench_exp1x3_wvr/main.c
@@ -1,0 +1,73 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "bench-exp1x3.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+extern unsigned int  __VERIFIER_nondet_uint(void);
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+unsigned int x1, x2, n;
+
+void* thread1() {
+  while (x1 < n) {
+    x1 = x1 + x1;
+  }
+
+  return 0;
+}
+
+void* thread2() {
+  while (x2 < n) {
+    x2 = x2 + x2;
+  }
+
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  x1 = __VERIFIER_nondet_uint();
+  x2 = __VERIFIER_nondet_uint();
+  n  = __VERIFIER_nondet_uint();
+
+  // main method
+  assume_abort_if_not( x1 == x2 && x1 > 0 );
+
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  assume_abort_if_not( x1 != x2 );
+  reach_error();
+
+  return 0;
+}

--- a/regression/esbmc-unix/01_bench_exp1x3_wvr/test.desc
+++ b/regression/esbmc-unix/01_bench_exp1x3_wvr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c 
+--unwind 4 --context-bound 3 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/02_bench_exp1x3_wvr/main.c
+++ b/regression/esbmc-unix/02_bench_exp1x3_wvr/main.c
@@ -1,0 +1,46 @@
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "bench-exp1x3.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+
+extern unsigned int  __VERIFIER_nondet_uint(void);
+
+
+unsigned int x1, x2, n;
+
+void* thread1() {
+  while (x1 == 1){
+    x2 = 1;
+  }
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+  
+  x1 = __VERIFIER_nondet_uint();
+  x2 = __VERIFIER_nondet_uint();
+  
+  if(x1 != x2){
+   return 0;;     
+  }
+
+  pthread_create(&t1, 0, thread1, 0);
+  if(x1 != x2){
+   __assert_fail("0", "bench-exp1x3.wvr.c", 44, __extension__ __PRETTY_FUNCTION__);
+  }
+  return 0;
+}

--- a/regression/esbmc-unix/02_bench_exp1x3_wvr/test.desc
+++ b/regression/esbmc-unix/02_bench_exp1x3_wvr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c 
+--unwind 2 --context-bound 2 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -694,10 +694,7 @@ void execution_statet::execute_guard()
   // Truth of this guard implies the parent is true.
   state_level2->rename(parent_guard);
   do_simplify(parent_guard);
-  //implies2tc assumpt(guard_expr, parent_guard);
 
-  //target->assumption(
-  //  guardt().as_expr(), assumpt, get_active_state().source, first_loop);
   if(active_thread != last_active_thread)
     target->assumption(
       guardt().as_expr(), parent_guard, get_active_state().source, first_loop);

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -697,9 +697,9 @@ void execution_statet::execute_guard()
   //implies2tc assumpt(guard_expr, parent_guard);
 
   //target->assumption(
-    //guardt().as_expr(), assumpt, get_active_state().source, first_loop);
+  //  guardt().as_expr(), assumpt, get_active_state().source, first_loop);
   if(active_thread != last_active_thread)
-   target->assumption(guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
+    target->assumption(guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
   
   // Check to see whether or not the state guard is false, indicating we've
   // found an unviable interleaving. However don't do this if we didn't

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -699,7 +699,8 @@ void execution_statet::execute_guard()
   //target->assumption(
   //  guardt().as_expr(), assumpt, get_active_state().source, first_loop);
   if(active_thread != last_active_thread)
-    target->assumption(guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
+    target->assumption(
+      guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
   
   // Check to see whether or not the state guard is false, indicating we've
   // found an unviable interleaving. However don't do this if we didn't

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -698,7 +698,6 @@ void execution_statet::execute_guard()
 
   //target->assumption(
     //guardt().as_expr(), assumpt, get_active_state().source, first_loop);
-  
   if(active_thread != last_active_thread)
    target->assumption(guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
   

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -701,7 +701,6 @@ void execution_statet::execute_guard()
   if(active_thread != last_active_thread)
     target->assumption(
       guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
-  
   // Check to see whether or not the state guard is false, indicating we've
   // found an unviable interleaving. However don't do this if we didn't
   // /actually/ switch between threads, because it's acceptable to have a

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -694,11 +694,14 @@ void execution_statet::execute_guard()
   // Truth of this guard implies the parent is true.
   state_level2->rename(parent_guard);
   do_simplify(parent_guard);
-  implies2tc assumpt(guard_expr, parent_guard);
+  //implies2tc assumpt(guard_expr, parent_guard);
 
-  target->assumption(
-    guardt().as_expr(), assumpt, get_active_state().source, first_loop);
-
+  //target->assumption(
+    //guardt().as_expr(), assumpt, get_active_state().source, first_loop);
+  
+  if(active_thread != last_active_thread)
+   target->assumption(guardt().as_expr(), parent_guard, get_active_state().source, first_loop);
+  
   // Check to see whether or not the state guard is false, indicating we've
   // found an unviable interleaving. However don't do this if we didn't
   // /actually/ switch between threads, because it's acceptable to have a


### PR DESCRIPTION
This PR is the fix of the concurrency flag '--no-goto-merge', we add the guard of the previous active thread after a context switch. Because the new active thread runs under the previous guard condition (assumes it is true) while we didn't guard it in the formula.

