### PR TITLE
[ub-shift-check] Add new checks and improve tests

### DIFF
--- a/regression/esbmc/00_bitshift_04/main.c
+++ b/regression/esbmc/00_bitshift_04/main.c
@@ -3,5 +3,10 @@
 int main() {
   int n = 256 << 1;
   assert(n == 512);
+
+  unsigned char a = 200;
+  unsigned char b = a << 4;
+  assert(b == 128);
+
   return 0;
 }

--- a/regression/esbmc/00_bitshift_04/test.desc
+++ b/regression/esbmc/00_bitshift_04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---shift-ub-check
+--ub-shift-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/shift_02_negative_ub/main.c
+++ b/regression/esbmc/shift_02_negative_ub/main.c
@@ -1,4 +1,0 @@
-int main() {
-  int n = 1 << -1;
-  return 0;
-}

--- a/regression/esbmc/shift_03_overflow_ub/main.c
+++ b/regression/esbmc/shift_03_overflow_ub/main.c
@@ -1,4 +1,0 @@
-int main() {
-  int n = 256 << 1024;
-  return 0;
-}

--- a/regression/esbmc/ub_01_shift_left_negative_op2/main.c
+++ b/regression/esbmc/ub_01_shift_left_negative_op2/main.c
@@ -1,0 +1,10 @@
+/*
+ * According with the section "Bitwise shift operators" of the C99 ISO specification:
+ * "If the value of the right operand is negative or is greater than or equal to the
+    width of the promoted left operand, the behaviour is undefined."
+ */
+
+int main() {
+  int n = 1 << -1; // right operand is negative
+  return 0;
+}

--- a/regression/esbmc/ub_01_shift_left_negative_op2/test.desc
+++ b/regression/esbmc/ub_01_shift_left_negative_op2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---shift-ub-check
+--ub-shift-check
 ^VERIFICATION FAILED$

--- a/regression/esbmc/ub_02_shift_right_negative_op2/main.c
+++ b/regression/esbmc/ub_02_shift_right_negative_op2/main.c
@@ -1,0 +1,10 @@
+/*
+ * According with the section "Bitwise shift operators" of the C99 ISO specification:
+ * "If the value of the right operand is negative or is greater than or equal to the
+    width of the promoted left operand, the behaviour is undefined."
+ */
+
+int main() {
+  int n = 1 >> -1;  // right operand is negative
+  return 0;
+}

--- a/regression/esbmc/ub_02_shift_right_negative_op2/test.desc
+++ b/regression/esbmc/ub_02_shift_right_negative_op2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---shift-ub-check
+--ub-shift-check
 ^VERIFICATION FAILED$

--- a/regression/esbmc/ub_03_shift_left_negative_op1/main.c
+++ b/regression/esbmc/ub_03_shift_left_negative_op1/main.c
@@ -1,0 +1,12 @@
+/*
+ * The section "Bitwise shift operators" of the C99 ISO specifies the following about shift left:
+ * "If E1 has a signed type and nonnegative value, and E1 × 2^E2 is representable in the result type,
+ * then that is the resulting value; otherwise, the behaviour is undefined."
+ */
+
+int main() {
+  int e1 = -2;
+  int e2 = 1;
+  int n = e1 << e2;  // E1 has a signed type and negative value
+  return 0;
+}

--- a/regression/esbmc/ub_03_shift_left_negative_op1/test.desc
+++ b/regression/esbmc/ub_03_shift_left_negative_op1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ub-shift-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/ub_04_shift_left_overflow/main.c
+++ b/regression/esbmc/ub_04_shift_left_overflow/main.c
@@ -1,0 +1,15 @@
+/*
+ * The section "Bitwise shift operators" of the C99 ISO specifies the following about shift left:
+ * If E1 has a signed type and nonnegative value, and E1 × 2^E2 is representable in the result type,
+ * then that is the resulting value; otherwise, the behaviour is undefined.
+ */
+
+#include <limits.h>
+
+int main()
+{
+  int e1 = INT_MAX;
+  int e2 = 10;
+  int v = e1 << e2; // E1 × 2^E2 is not representable in the result type
+  return 0;
+}

--- a/regression/esbmc/ub_04_shift_left_overflow/test.desc
+++ b/regression/esbmc/ub_04_shift_left_overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ub-shift-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/ub_05_shift_left_op2_size/main.c
+++ b/regression/esbmc/ub_05_shift_left_op2_size/main.c
@@ -1,0 +1,14 @@
+/*
+ * According with the section "Bitwise shift operators" of the C99 ISO specification:
+ * "If the value of the right operand is negative or is greater than or equal to the
+    width of the promoted left operand, the behaviour is undefined."
+ */
+
+#include <limits.h>
+
+int main() {
+  const int shift = CHAR_BIT * sizeof(int);
+  const int a = 1;
+  int b = a << shift; // right operand is equal to the width of the left operand
+  return 0;
+}

--- a/regression/esbmc/ub_05_shift_left_op2_size/test.desc
+++ b/regression/esbmc/ub_05_shift_left_op2_size/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ub-shift-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/ub_06_shift_right_op2_size/main.c
+++ b/regression/esbmc/ub_06_shift_right_op2_size/main.c
@@ -1,0 +1,14 @@
+/*
+ * According with the section "Bitwise shift operators" of the C99 ISO specification:
+ * "If the value of the right operand is negative or is greater than or equal to the
+    width of the promoted left operand, the behaviour is undefined."
+ */
+
+#include <limits.h>
+
+int main() {
+  const int shift = CHAR_BIT * sizeof(int);
+  const int a = 1;
+  int b = a >> shift; // right operand is equal to the width of the left operand
+  return 0;
+}

--- a/regression/esbmc/ub_06_shift_right_op2_size/test.desc
+++ b/regression/esbmc/ub_06_shift_right_op2_size/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ub-shift-check
+^VERIFICATION FAILED$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -344,9 +344,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("disable-inductive-step", true);
   }
 
-  if(cmdline.isset("shift-ub-check"))
+  if(cmdline.isset("ub-shift-check"))
   {
-    options.set_option("shift-ub-check", true);
+    options.set_option("ub-shift-check", true);
   }
 
   if(cmdline.isset("timeout"))

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -244,7 +244,7 @@ const struct group_opt_templ all_cmd_options[] = {
     {"nan-check", NULL, "check floating-point for NaN"},
     {"memory-leak-check", NULL, "enable memory leak check"},
     {"overflow-check", NULL, "enable arithmetic over- and underflow check"},
-    {"shift-ub-check",
+    {"ub-shift-check",
      NULL,
      "enable undefined behaviour check on shift operations"},
     {"struct-fields-check",

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -204,7 +204,7 @@ void goto_checkt::overflow_check(
     return;
 
   // Don't check shift right
-  if(!is_shl2t(expr))
+  if(is_lshr2t(expr) || is_ashr2t(expr))
     return;
 
   // First, check type.

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -259,9 +259,10 @@ void goto_checkt::shift_check(
 
   and2tc ub_check(right_op_non_negative, right_op_size_check);
 
-  if (is_shl2t(expr)) {
-	greaterthanequal2tc left_op_non_negative(left_op, zero);
-	ub_check = and2tc(ub_check, left_op_non_negative);
+  if(is_shl2t(expr))
+  {
+    greaterthanequal2tc left_op_non_negative(left_op, zero);
+    ub_check = and2tc(ub_check, left_op_non_negative);
   }
 
   add_guarded_claim(

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -21,7 +21,7 @@ public:
       disable_pointer_relation_check(
         options.get_bool_option("no-pointer-relation-check")),
       enable_overflow_check(options.get_bool_option("overflow-check")),
-      enable_shift_ub_check(options.get_bool_option("shift-ub-check")),
+      enable_ub_shift_check(options.get_bool_option("ub-shift-check")),
       enable_nan_check(options.get_bool_option("nan-check"))
   {
   }
@@ -84,7 +84,7 @@ protected:
   bool disable_div_by_zero_check;
   bool disable_pointer_relation_check;
   bool enable_overflow_check;
-  bool enable_shift_ub_check;
+  bool enable_ub_shift_check;
   bool enable_nan_check;
 };
 
@@ -200,7 +200,11 @@ void goto_checkt::overflow_check(
   const guardt &guard,
   const locationt &loc)
 {
-  if(!enable_overflow_check)
+  if(!enable_overflow_check && !enable_ub_shift_check)
+    return;
+
+  // Don't check shift right
+  if(!is_shl2t(expr))
     return;
 
   // First, check type.
@@ -236,24 +240,29 @@ void goto_checkt::shift_check(
   const guardt &guard,
   const locationt &loc)
 {
-  if(!enable_shift_ub_check)
+  if(!enable_ub_shift_check)
     return;
 
-  assert(is_shl2t(expr));
+  auto right_op = (*expr->get_sub_expr(1));
 
-  auto bv_type = (*expr->get_sub_expr(0))->type;
-  auto constant = (*expr->get_sub_expr(1));
-
-  expr2tc zero = gen_zero(constant->type);
+  expr2tc zero = gen_zero(right_op->type);
   assert(!is_nil_expr(zero));
 
-  greaterthanequal2tc const_gte_zero(constant, zero);
+  greaterthanequal2tc right_op_non_negative(right_op, zero);
 
-  expr2tc bv_type_size(
-    new constant_int2t(bv_type, BigInt(bv_type->get_width())));
-  lessthanequal2tc const_lte_type_size(constant, bv_type_size);
+  auto left_op = (*expr->get_sub_expr(0));
+  auto left_op_type = left_op->type;
+  expr2tc left_op_type_size(
+    new constant_int2t(left_op_type, BigInt(left_op_type->get_width())));
 
-  and2tc ub_check(const_gte_zero, const_lte_type_size);
+  lessthan2tc right_op_size_check(right_op, left_op_type_size);
+
+  and2tc ub_check(right_op_non_negative, right_op_size_check);
+
+  if (is_shl2t(expr)) {
+	greaterthanequal2tc left_op_non_negative(left_op, zero);
+	ub_check = and2tc(ub_check, left_op_non_negative);
+  }
 
   add_guarded_claim(
     ub_check,
@@ -537,6 +546,8 @@ void goto_checkt::check_rec(
     /* fallthrough */
 
   case expr2t::shl_id:
+  case expr2t::ashr_id:
+  case expr2t::lshr_id:
     shift_check(expr, guard, loc);
     /* fallthrough */
   case expr2t::neg_id:


### PR DESCRIPTION
- Add ub check on shift right operations

- Improve regression tests

- The C language standard specifies the behavior of the shift operators as below

![image](https://user-images.githubusercontent.com/1334363/233062903-f9f3ecae-85d8-4014-9487-c332bcf3d745.png)
