### PR TITLE
Fix 975

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/istream/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/istream/main.cpp
@@ -1,0 +1,4 @@
+#include <istream>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/istream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/istream/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/975_memberexpr_static/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/975_memberexpr_static/main.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+class istreamX
+{
+public:
+  istreamX()
+  {
+    _gcount = 50;
+  }
+  static int _gcount;
+  //int _gcount; // all good
+};
+
+int istreamX::_gcount = 0;
+
+istreamX& test_function(istreamX& is)
+{
+  is._gcount = 100;
+  return is;
+}
+
+int main()
+{
+  assert(istreamX::_gcount == 0);
+  istreamX obj;
+  assert(istreamX::_gcount == 50);
+  test_function(obj);
+  assert(istreamX::_gcount == 100);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/975_memberexpr_static/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/975_memberexpr_static/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/975_memberexpr_static_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/975_memberexpr_static_fail/main.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+class istreamX
+{
+public:
+  istreamX()
+  {
+    _gcount = 50;
+  }
+  static int _gcount;
+  //int _gcount; // all good
+};
+
+int istreamX::_gcount = 0;
+
+istreamX& test_function(istreamX& is)
+{
+  is._gcount = 100;
+  return is;
+}
+
+int main()
+{
+  assert(istreamX::_gcount == 0);
+  istreamX obj;
+  assert(istreamX::_gcount == 50);
+  test_function(obj);
+  assert(istreamX::_gcount == 50); // FAIL, should be 100
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/975_memberexpr_static_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/975_memberexpr_static_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -473,7 +473,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   symbol.static_lifetime =
     (vd.getStorageClass() == clang::SC_Static) || vd.hasGlobalStorage();
   symbol.is_extern = vd.hasExternalStorage();
-  symbol.file_local = (vd.getStorageClass() != clang::SC_Static) ||
+  symbol.file_local = (vd.getStorageClass() == clang::SC_Static) ||
                       (!vd.isExternallyVisible() && !vd.hasGlobalStorage());
 
   if(symbol.static_lifetime && !symbol.is_extern && !vd.hasInit())

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -298,9 +298,6 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
   std::string id, name;
   get_decl_name(rd, name, id);
 
-  if(id == "tag-istreamX")
-    printf("Got it\n");
-
   // Check if the symbol is already added to the context, do nothing if it is
   // already in the context. See next comment
   if(context.find_symbol(id) != nullptr)
@@ -450,9 +447,6 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
   std::string id, name;
   get_decl_name(vd, name, id);
-
-  if(id == "c:@S@istreamX@_gcount")
-    printf("Got static\n");
 
   if(no_slice)
     config.no_slice_names.emplace(id);

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -298,6 +298,9 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
   std::string id, name;
   get_decl_name(rd, name, id);
 
+  if(id == "tag-istreamX")
+    printf("Got it\n");
+
   // Check if the symbol is already added to the context, do nothing if it is
   // already in the context. See next comment
   if(context.find_symbol(id) != nullptr)
@@ -372,7 +375,7 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
     }
   }
 
-  if(get_struct_union_class_methods(*rd_def, to_struct_type(t)))
+  if(get_struct_union_class_methods_decls(*rd_def, to_struct_type(t)))
     return true;
 
   if(rd.isUnion())
@@ -410,11 +413,11 @@ bool clang_c_convertert::get_struct_union_class_fields(
   return false;
 }
 
-bool clang_c_convertert::get_struct_union_class_methods(
+bool clang_c_convertert::get_struct_union_class_methods_decls(
   const clang::RecordDecl &,
   struct_typet &)
 {
-  // We don't add methods to the struct in C
+  // We don't add methods or static members to the struct in C
   return false;
 }
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -470,7 +470,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   symbol.static_lifetime =
     (vd.getStorageClass() == clang::SC_Static) || vd.hasGlobalStorage();
   symbol.is_extern = vd.hasExternalStorage();
-  symbol.file_local = (vd.getStorageClass() == clang::SC_Static) ||
+  symbol.file_local = (vd.getStorageClass() != clang::SC_Static) ||
                       (!vd.isExternallyVisible() && !vd.hasGlobalStorage());
 
   if(symbol.static_lifetime && !symbol.is_extern && !vd.hasInit())

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -451,6 +451,9 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   std::string id, name;
   get_decl_name(vd, name, id);
 
+  if(id == "c:@S@istreamX@_gcount")
+    printf("Got static\n");
+
   if(no_slice)
     config.no_slice_names.emplace(id);
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1618,7 +1618,19 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       if(get_decl(*member.getMemberDecl(), comp))
         return true;
 
-      new_expr = member_exprt(base, comp.name(), comp.type());
+      if(!comp.name().empty())
+      {
+        // for MemberExpr referring to struct field (an/or method in case of C++)
+        new_expr = member_exprt(base, comp.name(), comp.type());
+      }
+      else
+      {
+        // for MemberExpr in referring to a static member
+        // which is essentially a VarDecl
+        assert(comp.statement() == "decl");
+        assert(comp.op0().is_symbol());
+        new_expr = member_exprt(base, comp.op0().identifier(), comp.type());
+      }
     }
     else
     {

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -153,11 +153,11 @@ protected:
     struct_union_typet &type);
 
   /*
-   * Get the declarations inside a class.
-   * The declarations can be any valid type other than `clang::Decl::Field`,
-   * such as a class' constructor of the type `clang::Decl::CXXConstructor`,
-   * a class' method of the type `clang::Decl::CXXMethod`
-   * or a class' static member of the type `clang::Decl::Var`
+   * This function not only gets class method but also gets
+   * the other declarations inside a class. The declarations can be
+   * of any valid type other than `clang::Decl::Field`,
+   * such as a class constructor of the type `clang::Decl::CXXConstructor`,
+   * or a class static member of the type `clang::Decl::Var`
    *
    * Params:
    *  recordd: clang AST of the class we are currently dealing with

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -141,11 +141,29 @@ protected:
 
   virtual bool get_struct_union_class(const clang::RecordDecl &recordd);
 
+  /*
+   * Get class fields of the type `clang::Decl::Field`
+   *
+   * Params:
+   *  recordd: clang AST of the class we are currently dealing with
+   *  type: ESBMC IR representing the class' type
+   */
   virtual bool get_struct_union_class_fields(
     const clang::RecordDecl &recordd,
     struct_union_typet &type);
 
-  virtual bool get_struct_union_class_methods(
+  /*
+   * Get the declarations inside a class.
+   * The declarations can be any valid type other than `clang::Decl::Field`,
+   * such as a class' constructor of the type `clang::Decl::CXXConstructor`,
+   * a class' method of the type `clang::Decl::CXXMethod`
+   * or a class' static member of the type `clang::Decl::Var`
+   *
+   * Params:
+   *  recordd: clang AST of the class we are currently dealing with
+   *  type: ESBMC IR representing the class' type
+   */
+  virtual bool get_struct_union_class_methods_decls(
     const clang::RecordDecl &recordd,
     struct_typet &type);
 

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -42,7 +42,7 @@ public:
   void adjust_member(member_exprt &expr) override;
   void adjust_side_effect(side_effect_exprt &expr) override;
   void adjust_new(exprt &expr);
-  void adjust_struct_method_call(member_exprt &expr);
+  void adjust_cpp_member(member_exprt &expr);
 
   /**
    * methods for implicit GOTO code generation

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -285,7 +285,7 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
   return false;
 }
 
-bool clang_cpp_convertert::get_struct_union_class_methods(
+bool clang_cpp_convertert::get_struct_union_class_methods_decls(
   const clang::RecordDecl &recordd,
   struct_typet &type)
 {

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -98,7 +98,7 @@ protected:
     const clang::RecordDecl &rd,
     struct_union_typet &type) override;
 
-  bool get_struct_union_class_methods(
+  bool get_struct_union_class_methods_decls(
     const clang::RecordDecl &rd,
     struct_typet &type) override;
 

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,10 +33,20 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
+    {
+      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+      out << s.type.pretty(0) << "\n";
+      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
+    }
 
     if(s.value.is_not_nil())
+    {
+      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+      out << s.value.pretty(0) << "\n";
+      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
+    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,20 +33,10 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
-    {
-      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
-      out << s.type.pretty(0) << "\n";
-      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
-    }
 
     if(s.value.is_not_nil())
-    {
-      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
-      out << s.value.pretty(0) << "\n";
-      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
-    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
Fixed https://github.com/esbmc/esbmc/issues/975 that prevents us from including `istream` OM.

The error message in that PR is caused by empty component name in member_exprt for class static member access.


