### PR TITLE
Winci refine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,8 @@ jobs:
       run: |
         Write-Host "Set TLS1.2"
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
-        choco install -y nsis.portable winflexbison --ignore-checksums
+        choco install -y nsis.portable --ignore-checksums
+        ./scripts/winflexbison_install.ps1
     - name: Check if od is on path
       run: od.exe --version
     - name: Update vcpkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
         run: |
           Write-Host "Set TLS1.2"
           [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
-          choco install -y nsis.portable winflexbison --ignore-checksums
+          choco install -y nsis.portable --ignore-checksums
+          ./scripts/winflexbison_install.ps1
       - name: Check if od is on path
         run: od.exe --version
       - name: Update vcpkg

--- a/scripts/winflexbison_install.ps1
+++ b/scripts/winflexbison_install.ps1
@@ -1,5 +1,8 @@
 $success = $false
-while (-not $success) {
+$tries = 0
+$maxTries = 20
+
+while (-not $success -and $tries -lt $maxTries) {
     Write-Host "Installing winflexbison..."
     $output = choco install -y winflexbison --ignore-checksums
     if ($LASTEXITCODE -eq 0) {
@@ -8,5 +11,10 @@ while (-not $success) {
     } else {
         Write-Host "Installation failed. Retrying in 10 seconds..."
         Start-Sleep -Seconds 10
+        $tries++
     }
 }
+
+if (-not $success) {
+    Write-Host "Installation failed after $maxTries attempts."
+ }

--- a/scripts/winflexbison_install.ps1
+++ b/scripts/winflexbison_install.ps1
@@ -1,0 +1,12 @@
+$success = $false
+while (-not $success) {
+    Write-Host "Installing nsis.portable and winflexbison..."
+    $output = choco install -y winflexbison --ignore-checksums
+    if ($LASTEXITCODE -eq 0) {
+        $success = $true
+        Write-Host "Installation successful!"
+    } else {
+        Write-Host "Installation failed. Retrying in 10 seconds..."
+        Start-Sleep -Seconds 10
+    }
+}

--- a/scripts/winflexbison_install.ps1
+++ b/scripts/winflexbison_install.ps1
@@ -1,6 +1,6 @@
 $success = $false
 while (-not $success) {
-    Write-Host "Installing nsis.portable and winflexbison..."
+    Write-Host "Installing winflexbison..."
     $output = choco install -y winflexbison --ignore-checksums
     if ($LASTEXITCODE -eq 0) {
         $success = $true


### PR DESCRIPTION
Windows CI sometimes fails to install the package winflexbison,
This PR can prevent restarting the Actions job if the error occurs.
Specifically, we retry installing the package for a couple of times (20) until the installation is successful.