### PR TITLE
[C++ OM] Fix cmath OM

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/cmath/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/cmath/main.cpp
@@ -1,0 +1,4 @@
+#include "cmath"
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/cmath/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cmath/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+-I /__w/esbmc/esbmc/src/cpp/library --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -29,7 +29,7 @@ float sqrt(float n) {
 
 float sqrt(int n) {
 	__ESBMC_assert(n >= 0, "The number must be greater or equal than 0");
-	return nondet_int();
+	return nondet_float();
 }
 
 double sqrt(double n) {
@@ -48,7 +48,7 @@ double sqrt(double n) {
 
 unsigned sqrt(unsigned x) {
 	__ESBMC_assert(x >= 0, "The number must be greater or equal than 0");
-	return nondet_unsigned();
+	return nondet_uint();
 }
 
 float exp(float n) {

--- a/src/cpp/library/math.h
+++ b/src/cpp/library/math.h
@@ -1,0 +1,1 @@
+#include <cmath>


### PR DESCRIPTION
When call `math.h`, the path is the standard library, and Clang currently gives us an error for that.
```
In file included from main.cpp:2:
/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/math.h:38:7: error: use of undeclared identifier 'std'
using std::abs;
      ^
/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/math.h:39:7: error: use of undeclared identifier 'std'
using std::acos;
      ^
```
Dependency was as follows:
```
. /usr/include/math.h
.. /libraries/cmath
```

This PR fixed some issues with cmath file, added math.h file.
