### PR TITLE
[goto_check] Avoid shift check on divisions and modulo operator

### DIFF
--- a/regression/esbmc/math_mod01/main.c
+++ b/regression/esbmc/math_mod01/main.c
@@ -1,0 +1,7 @@
+int main(void) {
+  unsigned int i = 101;
+  unsigned int j = 100;
+  unsigned k = (int) i % (int) j;
+  return 0;
+}
+

--- a/regression/esbmc/math_mod01/test.desc
+++ b/regression/esbmc/math_mod01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-bounds-check --no-pointer-check --no-div-by-zero-check --ub-shift-check
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -394,6 +394,10 @@ void goto_checkt::shift_check(
   if(!enable_ub_shift_check)
     return;
 
+  assert(is_lshr2t(expr) || is_ashr2t(expr) || is_shl2t(expr));
+
+  overflow_check(expr, guard, loc);
+
   auto right_op = (*expr->get_sub_expr(1));
 
   expr2tc zero = gen_zero(right_op->type);
@@ -692,16 +696,17 @@ void goto_checkt::check_rec(
     bounds_check(expr, guard, loc);
     return;
 
+  case expr2t::shl_id:
+  case expr2t::ashr_id:
+  case expr2t::lshr_id:
+    shift_check(expr, guard, loc);
+    break;
+
   case expr2t::div_id:
   case expr2t::modulus_id:
     div_by_zero_check(expr, guard, loc);
     /* fallthrough */
 
-  case expr2t::shl_id:
-  case expr2t::ashr_id:
-  case expr2t::lshr_id:
-    shift_check(expr, guard, loc);
-    /* fallthrough */
   case expr2t::neg_id:
   case expr2t::add_id:
   case expr2t::sub_id:

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -391,12 +391,12 @@ void goto_checkt::shift_check(
   const guardt &guard,
   const locationt &loc)
 {
+  overflow_check(expr, guard, loc);
+
   if(!enable_ub_shift_check)
     return;
 
   assert(is_lshr2t(expr) || is_ashr2t(expr) || is_shl2t(expr));
-
-  overflow_check(expr, guard, loc);
 
   auto right_op = (*expr->get_sub_expr(1));
 


### PR DESCRIPTION
This PR addresses the issues found during the execution of svcomp hardware benchmark as detailed at https://github.com/esbmc/esbmc/issues/978#issuecomment-1526557969