### PR TITLE
[clang-cpp-frontend] Fix template member functions support

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates4/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates4/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/struct_template_member/main.cpp
+++ b/regression/esbmc-cpp/template/struct_template_member/main.cpp
@@ -1,0 +1,12 @@
+struct Foo {
+    template<class T>
+    T bar() {
+       return T();
+    }
+};
+
+int main(void) {
+  Foo f;
+  f.bar<int>();
+  return 0;
+}

--- a/regression/esbmc-cpp/template/struct_template_member/test.desc
+++ b/regression/esbmc-cpp/template/struct_template_member/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -328,8 +328,7 @@ bool clang_cpp_convertert::get_struct_union_class_methods_decls(
         llvm::dyn_cast<clang::FunctionTemplateDecl>(decl))
     {
       assert(ftd->isThisDeclarationADefinition());
-      log_error("template is not supported in {}", __func__);
-      abort();
+      get_template_decl(ftd, true, comp);
     }
     else
     {


### PR DESCRIPTION
Fix crash regarding definition of template functions in structs.
It is related to #924.