### PR TITLE
[smt] smt_dump is no longer an error for Text

### DIFF
--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2735,8 +2735,7 @@ smt_astt smt_ast::project(
 
 void smt_convt::dump_smt()
 {
-  log_error("SMT dump not implemented for {}", solver_text());
-  abort();
+  log_status("SMT dump was sent to --output file");  
 }
 
 void smt_convt::print_model()

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2735,7 +2735,8 @@ smt_astt smt_ast::project(
 
 void smt_convt::dump_smt()
 {
-  log_status("SMT dump was sent to --output file");  
+  log_error("SMT dump not implemented for {}", solver_text());
+  abort();
 }
 
 void smt_convt::print_model()

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -105,12 +105,9 @@ smt_convt *create_new_smtlib_solver(
   fp_convt **fp_api)
 {
   if(!options.get_bool_option("smt-formula-only"))
-  {
-    log_error(
-      "[smtlib] the smtlib interface does not support solving for now. Please, "
-      "use it with --smt-formula-only");
-    abort();
-  }
+    log_warning(
+      "[smtlib] the smtlib interface solving is unstable. Please, "
+      "use it with --smt-formula-only for production");
   smtlib_convt *conv = new smtlib_convt(ns, options);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -909,13 +909,22 @@ smt_astt smtlib_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 
 smt_astt smtlib_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
 {
+  log_debug("[smt_ast] mk_zero_ext with {} width", topwidth);
   smt_astt z = mk_smt_bv(0, mk_bv_sort(topwidth));
   return mk_concat(z, a);
 }
 
 smt_astt smtlib_convt::mk_concat(smt_astt a, smt_astt b)
 {
-  smtlib_smt_ast *ast = new smtlib_smt_ast(this, a->sort, SMT_FUNC_CONCAT);
+  /**
+   * (concat (_ BitVec i) (_ BitVec j) (_ BitVec m))
+      - concatenation of bitvectors of size i and j to get a new bitvector of
+        size m, where m = i + j
+  */
+  smtlib_smt_ast *ast = new smtlib_smt_ast(
+    this,
+    mk_bv_sort(a->sort->get_data_width() + b->sort->get_data_width()),
+    SMT_FUNC_CONCAT);
   ast->args.push_back(a);
   ast->args.push_back(b);
   return ast;

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -104,10 +104,36 @@ smt_convt *create_new_smtlib_solver(
   array_iface **array_api,
   fp_convt **fp_api)
 {
+  if(!options.get_bool_option("smt-formula-only"))
+  {
+    log_error(
+      "[smtlib] the smtlib interface does not support solving for now. Please, "
+      "use it with --smt-formula-only");
+    abort();
+  }
   smtlib_convt *conv = new smtlib_convt(ns, options);
   *array_api = static_cast<array_iface *>(conv);
   *fp_api = static_cast<fp_convt *>(conv);
   return conv;
+}
+
+void smtlib_convt::dump_smt()
+{
+  auto cmd = config.options.get_option("output");
+  if(cmd != "")
+  {
+    // TODO: this is a hack, in time we should fix this whole interface
+    pre_solve();
+    fprintf(out_stream, "(check-sat)\n");
+    fflush(out_stream);
+    fclose(out_stream);
+    log_status("SMT formula generated into output file {}", cmd);
+    return;
+  }
+  log_error(
+    "[smtlib] current interface is limited to output only. Please, specify "
+    "(--output)");
+  abort();
 }
 
 smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -1462,41 +1462,43 @@ smtlib_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
 smt_sortt smtlib_convt::mk_bool_sort()
 {
-  return new smt_sort(SMT_SORT_BOOL, 1);
+  return new smtlib_smt_sort(SMT_SORT_BOOL);
 }
 
 smt_sortt smtlib_convt::mk_real_sort()
 {
-  return new smt_sort(SMT_SORT_INT);
+  return new smtlib_smt_sort(SMT_SORT_INT);
 }
 
 smt_sortt smtlib_convt::mk_int_sort()
 {
-  return new smt_sort(SMT_SORT_REAL);
+  return new smtlib_smt_sort(SMT_SORT_REAL);
 }
 
 smt_sortt smtlib_convt::mk_bv_sort(std::size_t width)
 {
-  return new smt_sort(SMT_SORT_BV, width);
+  return new smtlib_smt_sort(SMT_SORT_BV, width);
 }
 
 smt_sortt smtlib_convt::mk_fbv_sort(std::size_t width)
 {
+  return new smtlib_smt_sort(SMT_SORT_FIXEDBV, width);
   return new smt_sort(SMT_SORT_FIXEDBV, width);
 }
 
 smt_sortt smtlib_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 {
-  return new smt_sort(
-    SMT_SORT_ARRAY, domain->get_data_width(), range->get_data_width());
+  const smtlib_smt_sort *d = static_cast<const smtlib_smt_sort *>(domain);
+  const smtlib_smt_sort *r = static_cast<const smtlib_smt_sort *>(range);
+  return new smtlib_smt_sort(SMT_SORT_ARRAY, d, r);
 }
 
 smt_sortt smtlib_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
-  return new smt_sort(SMT_SORT_BVFP, ew + sw + 1, sw + 1);
+  return new smtlib_smt_sort(SMT_SORT_BVFP, ew + sw + 1, sw + 1);
 }
 
 smt_sortt smtlib_convt::mk_bvfp_rm_sort()
 {
-  return new smt_sort(SMT_SORT_BVFP_RM, 3);
+  return new smtlib_smt_sort(SMT_SORT_BVFP_RM, 3);
 }

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -271,6 +271,8 @@ public:
   void push_ctx() override;
   void pop_ctx() override;
 
+  void dump_smt() override;
+
   // Members
   FILE *out_stream;
   FILE *in_stream;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -135,6 +135,8 @@ class smtlib_smt_sort : public smt_sort
 {
 public:
   explicit smtlib_smt_sort(smt_sort_kind k, unsigned int w) : smt_sort(k, w){};
+  explicit smtlib_smt_sort(smt_sort_kind k, unsigned int w1, unsigned int w2)
+    : smt_sort(k, w1, w2){};
   explicit smtlib_smt_sort(smt_sort_kind k) : smt_sort(k)
   {
   }
@@ -142,9 +144,7 @@ public:
     smt_sort_kind k,
     const smtlib_smt_sort *dom,
     const smtlib_smt_sort *rag)
-    : smt_sort(k, dom->get_data_width(), rag->get_domain_width()),
-      domain(dom),
-      range(rag)
+    : smt_sort(k, dom->get_data_width(), rag), domain(dom), range(rag)
   {
   }
 


### PR DESCRIPTION
Running --smtlib --output gives an error because smt_dump is not supported by the interface. ESBMC, however, requires all solvers to have it.