### PR TITLE
Prepare the test suite for FULL template support

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates11/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates11/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates12/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates12/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates14/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates14/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates15/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates15/test.desc
@@ -5,10 +5,9 @@
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
   <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
+  <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates16/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates16/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates17/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates17/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates18/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates18/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates19/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates19/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates20/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates20/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates21/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates21/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates23/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates23/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates24/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates24/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates25/main.cpp
+++ b/regression/esbmc-cpp/cbmc/Templates25/main.cpp
@@ -5,5 +5,5 @@ bool True(){return true;}
 
 int main()
 {
-  assert(True<int,0>()==true);
+  assert((True<int,0>()));
 }

--- a/regression/esbmc-cpp/cbmc/Templates26/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates26/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates27/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates27/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates28/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates28/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates29/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates29/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates30/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates30/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates32/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates32/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates33/main.cpp
+++ b/regression/esbmc-cpp/cbmc/Templates33/main.cpp
@@ -7,7 +7,6 @@ public:
   typename T::asd asd;
 };
 
-// this won't fail on g++!
 typedef X<char> Z;
 
 int main()

--- a/regression/esbmc-cpp/cbmc/Templates33/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates33/test.desc
@@ -5,10 +5,9 @@
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
   <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
+  <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates34/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates34/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates35/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates35/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates36/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates36/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates37/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates37/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates39/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates39/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates5/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates5/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates6/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates6/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates7/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates7/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates9/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates9/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>


### PR DESCRIPTION
prepared the test suite to extend ESBMC cpp frontend to fully support template: 
1. Enabled two more TCs - 15 and 33
2. Fixed assert error in TC25
3. Removed duplicate mode in all TCs 

Let's start with `esbmc-cpp/cbmc` test suite. 

TC analysis are done in https://github.com/esbmc/esbmc/issues/989#issuecomment-1582357195 . 
