### PR TITLE
Add support for malloc-scanf overflow checking

### DIFF
--- a/regression/cstd/scanf_float_bug/main.c
+++ b/regression/cstd/scanf_float_bug/main.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+int main(int argc, char *argv[])
+{
+  float *arr = (float *)malloc(3 * sizeof(float));
+  for(int i = 0; i < 3; i++)
+  {
+    scanf("%13f", &arr[i]);
+  }
+  for(int i = 0; i < 3; i++)
+  {
+    printf("%f", &arr[i]);
+  }
+}

--- a/regression/cstd/scanf_float_bug/test.desc
+++ b/regression/cstd/scanf_float_bug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_float_bug_2/main.c
+++ b/regression/cstd/scanf_float_bug_2/main.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+#include <stdio.h>
+int main(int argc, char *argv[])
+{
+    float tmp;
+    scanf("%13f", &tmp);
+    printf("%f",tmp);
+}

--- a/regression/cstd/scanf_float_bug_2/test.desc
+++ b/regression/cstd/scanf_float_bug_2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_malloc_2/main.c
+++ b/regression/cstd/scanf_malloc_2/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+  char *toParseStr = (char *)malloc(11);
+  printf("Enter string here: ");
+  scanf("%10s", toParseStr);
+  printf("%s", toParseStr);
+  free(toParseStr);
+}

--- a/regression/cstd/scanf_malloc_2/test.desc
+++ b/regression/cstd/scanf_malloc_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/cstd/scanf_malloc_2_bug/main.c
+++ b/regression/cstd/scanf_malloc_2_bug/main.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+  char *toParseStr = (char *)malloc(11);
+  printf("Enter string here: ");
+  scanf("%12s", toParseStr);
+  printf("%s", toParseStr);
+  free(toParseStr);
+}

--- a/regression/cstd/scanf_malloc_2_bug/test.desc
+++ b/regression/cstd/scanf_malloc_2_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_malloc_3/main.c
+++ b/regression/cstd/scanf_malloc_3/main.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+int main(int argc, char *argv[])
+{
+  int *arr = (int *)malloc(3 * sizeof(int));
+  for(int i = 0; i < 3; i++)
+  {
+    scanf("%10d", &arr[i]);
+  }
+  for(int i = 0; i < 3; i++)
+  {
+    printf("%d", &arr[i]);
+  }
+}

--- a/regression/cstd/scanf_malloc_3/test.desc
+++ b/regression/cstd/scanf_malloc_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/cstd/scanf_malloc_bug/main.c
+++ b/regression/cstd/scanf_malloc_bug/main.c
@@ -1,0 +1,37 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+void search(int arr[], int n, int x) {
+    int flag = 0, index = 0;
+    for(int i = 0; i < n; i++) {
+        if(arr[i] == x) {
+            flag = 1;
+            index = i;
+            break;
+        }
+    }
+    if(flag) {
+        printf("%d is found at index %d", x, index);
+    } else {
+        printf("%d is not present in array", x);
+    }
+}
+
+int main() {
+    int n, x;
+    printf("Enter size of array: ");
+    scanf("%d", &n);
+
+    int *arr = (int*) malloc(10 * sizeof(int));
+    printf("Enter %d elements: ", n);
+    for(int i = 0; i < 10; i++) {
+        scanf("%d", &arr[i]);
+    }
+
+    printf("Enter element to search: ");
+    scanf("%d", &x);
+
+    search(arr, n, x);
+
+    return 0;
+}  

--- a/regression/cstd/scanf_malloc_bug/test.desc
+++ b/regression/cstd/scanf_malloc_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --k-induction
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_malloc_bug_3/main.c
+++ b/regression/cstd/scanf_malloc_bug_3/main.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+int main(int argc, char *argv[])
+{
+  int *arr = (int *)malloc(3 * sizeof(int));
+  for(int i = 0; i < 3; i++)
+  {
+    scanf("%13d", &arr[i]);
+  }
+  for(int i = 0; i < 3; i++)
+  {
+    printf("%d", &arr[i]);
+  }
+}

--- a/regression/cstd/scanf_malloc_bug_3/test.desc
+++ b/regression/cstd/scanf_malloc_bug_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_malloc_false/main.c
+++ b/regression/cstd/scanf_malloc_false/main.c
@@ -1,0 +1,37 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+void search(int arr[], int n, int x) {
+    int flag = 0, index = 0;
+    for(int i = 0; i < n; i++) {
+        if(arr[i] == x) {
+            flag = 1;
+            index = i;
+            break;
+        }
+    }
+    if(flag) {
+        printf("%d is found at index %d", x, index);
+    } else {
+        printf("%d is not present in array", x);
+    }
+}
+
+int main() {
+    int n, x;
+    printf("Enter size of array: ");
+    scanf("%d", &n);
+
+    int *arr = (int*) malloc(10 * sizeof(int));
+    printf("Enter %d elements: ", n);
+    for(int i = 0; i < 10; i++) {
+        scanf("%d", &arr[i]);
+    }
+
+    printf("Enter element to search: ");
+    scanf("%d", &x);
+
+    search(arr, n, x);
+
+    return 0;
+}  

--- a/regression/cstd/scanf_malloc_false/test.desc
+++ b/regression/cstd/scanf_malloc_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --k-induction --no-unlimited-scanf-check
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -70,6 +70,10 @@ protected:
 
   /** check for the buffer overflow in scanf/fscanf */
   void input_overflow_check(const expr2tc &expr, const locationt &loc);
+  /* check for signed/unsigned_bv */
+  void input_overflow_check_int(int width, int limit, bool &buf_overflow);
+  /* check for string/malloc array */
+  void input_overflow_check_arr(int width, int limit, bool &buf_overflow);
 
   void
   shift_check(const expr2tc &expr, const guardt &guard, const locationt &loc);
@@ -247,6 +251,53 @@ void goto_checkt::overflow_check(
     guard);
 }
 
+void goto_checkt::input_overflow_check_int(
+  int width,
+  int limit,
+  bool &buf_overflow)
+{
+  switch(width)
+  {
+  case 8:
+  {
+    if(limit > 3)
+      buf_overflow = true;
+    break;
+  }
+  case 16:
+  {
+    if(limit > 5)
+      buf_overflow = true;
+    break;
+  }
+  case 32:
+  {
+    if(limit > 10)
+      buf_overflow = true;
+    break;
+  }
+  case 64:
+  {
+    if(limit > 19)
+      buf_overflow = true;
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+void goto_checkt::input_overflow_check_arr(
+  int width,
+  int limit,
+  bool &buf_overflow)
+{
+  if(limit + 1 > width) // plus one as string always ends up with a null char
+  {
+    buf_overflow = true;
+  }
+}
+
 void goto_checkt::input_overflow_check(
   const expr2tc &expr,
   const locationt &loc)
@@ -305,17 +356,38 @@ void goto_checkt::input_overflow_check(
   for(long unsigned int i = fmt_idx + 1; i <= number_of_format_args + fmt_idx;
       i++)
   {
-    arg_names.push_back(get_string_argument(func_call.operands[i]));
+    irep_idt arg_name = get_string_argument(func_call.operands[i]);
+
+    // e.g
+    // int *arr = (int*) malloc(10 * sizeof(int));
+    // scanf("%10d",&arr[0]);  --> overflow
+    if(arg_name.empty())
+    {
+      expr2tc deref = get_base_object(func_call.operands[i]);
+      exprt ptr = migrate_expr_back(deref);
+
+      // not the format we expected
+      if(!ptr.type().is_pointer())
+        return;
+
+      arg_name = ptr.operands()[0].identifier();
+    }
+    arg_names.push_back(arg_name);
   }
 
-  assert(
-    (limits.size() == arg_names.size()) &&
-    "the format specifiers do not match with the arguments");
+  if(limits.size() != arg_names.size())
+  {
+    log_error("the format specifiers do not match with the arguments");
+    return;
+  }
 
   // do checks
   bool buf_overflow = false;
   for(long unsigned int i = 0; i < arg_names.size(); i++)
   {
+    if(arg_names.at(i).empty())
+      return;
+
     const symbolt &arg = *ns.lookup(arg_names.at(i));
     const irep_idt type_id = arg.type.id();
     std::string width;
@@ -333,52 +405,52 @@ void goto_checkt::input_overflow_check(
     if(type_id == "array")
     {
       width = to_array_type(arg.type).size().cformat().as_string();
-      if(
-        stoi(limits.at(i)) + 1 >
-        stoi(width)) // plus one as string always ends up with a null char
-      {
-        buf_overflow = true;
-        break;
-      }
+      input_overflow_check_arr(stoi(width), stoi(limits.at(i)), buf_overflow);
     }
     else if(type_id == "unsignedbv" || type_id == "signedbv")
     {
       width = arg.type.width().as_string();
-      switch(stoi(width))
-      {
-      case 8:
-      {
-        if(stoi(limits.at(i)) > 3)
-          buf_overflow = true;
-        break;
-      }
-      case 16:
-      {
-        if(stoi(limits.at(i)) > 5)
-          buf_overflow = true;
-        break;
-      }
-      case 32:
-      {
-        if(stoi(limits.at(i)) > 10)
-          buf_overflow = true;
-        break;
-      }
-      case 64:
-      {
-        if(stoi(limits.at(i)) > 19)
-          buf_overflow = true;
-        break;
-      }
-      default:
-        break;
-      }
+      input_overflow_check_int(stoi(width), stoi(limits.at(i)), buf_overflow);
     }
     else if(type_id == "floatbv" || type_id == "fixedbv")
     {
       // TODO
       break;
     }
+    else if(type_id == "pointer")
+    {
+      // remove typecast
+      assert(arg.value.is_typecast());
+      const exprt out_operands = to_typecast_expr(arg.value).op();
+      const exprt::operandst operands = out_operands.op1().operands();
+
+      if(!operands[0].has_operands())
+      {
+        // e.g
+        // char *toParseStr = (char*)malloc(11);
+        // scanf("%13s",toParseStr);  --> overflow
+        const exprt &it = operands[0];
+        width = integer2string(
+          binary2integer(it.value().as_string(), it.id() == "signedbv"));
+        input_overflow_check_arr(stoi(width), stoi(limits.at(i)), buf_overflow);
+      }
+
+      else if(operands[0].operands().size() == 2)
+      {
+        // e.g
+        // int *arr = (int*) malloc(10 * sizeof(int));
+        // scanf("%12d",&arr[0]);  --> overflow
+        const exprt &it = operands[0].op1();
+        width = it.c_sizeof_type().width().as_string();
+        input_overflow_check_int(stoi(width), stoi(limits.at(i)), buf_overflow);
+      }
+
+      else
+        return;
+    }
+    else
+      log_status(
+        "Unsupported type {}, skip overflow checking", type_id.as_string());
   }
 
   if(buf_overflow) // FIX ME! add assert(0) to output the error msg

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -441,8 +441,25 @@ void goto_checkt::input_overflow_check(
         // int *arr = (int*) malloc(10 * sizeof(int));
         // scanf("%12d",&arr[0]);  --> overflow
         const exprt &it = operands[0].op1();
-        width = it.c_sizeof_type().width().as_string();
-        input_overflow_check_int(stoi(width), stoi(limits.at(i)), buf_overflow);
+
+        if(
+          it.c_sizeof_type().id() == typet::t_signedbv ||
+          it.c_sizeof_type().id() == typet::t_unsignedbv)
+        {
+          width = it.c_sizeof_type().width().as_string();
+          input_overflow_check_int(
+            stoi(width), stoi(limits.at(i)), buf_overflow);
+        }
+
+        else if(
+          it.c_sizeof_type().id() == typet::t_floatbv ||
+          it.c_sizeof_type().id() == typet::t_fixedbv)
+        {
+          // TODO
+          break;
+        }
+        else
+          return;
       }
 
       else

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -360,7 +360,7 @@ void goto_checkt::input_overflow_check(
 
     // e.g
     // int *arr = (int*) malloc(10 * sizeof(int));
-    // scanf("%10d",&arr[0]);  --> overflow
+    // scanf("%13d",&arr[0]);  --> overflow
     if(arg_name.empty())
     {
       expr2tc deref = get_base_object(func_call.operands[i]);

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -281,6 +281,9 @@ const expr2tc &get_base_object(const expr2tc &expr)
   if(is_address_of2t(expr))
     return get_base_object(to_address_of2t(expr).ptr_obj);
 
+  if(is_dereference2t(expr))
+    return get_base_object(to_dereference2t(expr).value);
+
   return expr;
 }
 


### PR DESCRIPTION
Relative issue: #1051 and #984 

- `input_overflow_check` can now find bugs like

```c++
    int *arr = (int*) malloc(10 * sizeof(int));
    scanf("%12d",&arr[0]);  --> overflow
```
and

```c++
        char *toParseStr = (char*)malloc(11);
        scanf("%13s",toParseStr);  --> overflow
```