### PR TITLE
Interval Analysis: get_interval function is more generic

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -280,34 +280,30 @@ T interval_domaint::get_interval(const expr2tc &e) const
 
   // Arithmetic?
   auto arith_op = std::dynamic_pointer_cast<arith_2ops>(e);
-  auto ieee_arith_op = std::dynamic_pointer_cast<ieee_arith_2ops>(e);
-
-  if(arith_op && enable_interval_arithmetic) // TODO: add support for float ops
+  if(arith_op && enable_interval_arithmetic)
   {
-    // It should be safe to mix integers/floats in here.
-    // The worst that can happen is an overaproximation
-    auto lhs =
-      get_interval<T>(arith_op ? arith_op->side_1 : ieee_arith_op->side_1);
-    auto rhs =
-      get_interval<T>(arith_op ? arith_op->side_2 : ieee_arith_op->side_2);
+    auto lhs = get_interval<T>(arith_op->side_1);
+    auto rhs = get_interval<T>(arith_op->side_2);
 
-    if(is_add2t(e) || is_ieee_add2t(e))
-      return lhs + rhs;
+    if(enable_interval_arithmetic)
+    {
+      if(is_add2t(e))
+        return lhs + rhs;
 
-    if(is_sub2t(e) || is_ieee_sub2t(e))
-      return lhs - rhs;
+      if(is_sub2t(e))
+        return lhs - rhs;
 
-    if(is_mul2t(e) || is_ieee_mul2t(e))
-      return lhs * rhs;
+      if(is_mul2t(e))
+        return lhs * rhs;
 
-    if(is_div2t(e) || is_ieee_div2t(e))
-      return lhs / rhs;
+      if(is_div2t(e))
+        return lhs / rhs;
 
-    if(is_modulus2t(e))
-      return lhs % rhs;
-
-    // TODO: Add more as needed.
+      if(is_modulus2t(e))
+        return lhs % rhs;
+    }
   }
+
   // We could not generate from the expr. Return top
   T result; // (-infinity, infinity)
   return result;

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -58,7 +58,8 @@ void interval_domaint::update_symbol_interval(
 }
 
 template <>
-integer_intervalt interval_domaint::get_interval_from_const(const expr2tc &e)
+integer_intervalt
+interval_domaint::get_interval_from_const(const expr2tc &e) const
 {
   integer_intervalt result; // (-infinity, infinity)
   if(!is_constant_int2t(e))
@@ -72,7 +73,7 @@ integer_intervalt interval_domaint::get_interval_from_const(const expr2tc &e)
 #include <cmath>
 
 template <>
-real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e)
+real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e) const
 {
   real_intervalt result; // (-infinity, infinity)
   if(!is_constant_floatbv2t(e))
@@ -112,7 +113,8 @@ real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e)
 }
 
 template <>
-wrapped_interval interval_domaint::get_interval_from_const(const expr2tc &e)
+wrapped_interval
+interval_domaint::get_interval_from_const(const expr2tc &e) const
 {
   wrapped_interval result(e->type); // [0, 2^(length(e->type)) - 1]
   if(!is_constant_int2t(e))
@@ -247,7 +249,7 @@ T interval_domaint::interpolate_intervals(const T &before, const T &after)
 }
 
 template <class T>
-T interval_domaint::get_interval(const expr2tc &e)
+T interval_domaint::get_interval(const expr2tc &e) const
 {
   if(is_symbol2t(e))
     return get_interval_from_symbol<T>(to_symbol2t(e));
@@ -295,7 +297,7 @@ T interval_domaint::get_interval(const expr2tc &e)
 }
 
 template <>
-wrapped_interval interval_domaint::get_interval(const expr2tc &e)
+wrapped_interval interval_domaint::get_interval(const expr2tc &e) const
 {
   // This needs to come before constant number
   if(is_constant_bool2t(e))

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -328,26 +328,27 @@ T interval_domaint::get_interval(const expr2tc &e) const
       return i.logical_right_shift(k);
     }
 
+#endif
+
     if(is_bitor2t(e))
     {
-      auto rhs = get_interval<wrapped_interval>(to_bitor2t(e).side_2);
-      auto lhs = get_interval<wrapped_interval>(to_bitor2t(e).side_1);
+      auto rhs = get_interval<T>(to_bitor2t(e).side_2);
+      auto lhs = get_interval<T>(to_bitor2t(e).side_1);
       return lhs | rhs;
     }
 
     if(is_bitand2t(e))
     {
-      auto rhs = get_interval<wrapped_interval>(to_bitand2t(e).side_2);
-      auto lhs = get_interval<wrapped_interval>(to_bitand2t(e).side_1);
+      auto rhs = get_interval<T>(to_bitand2t(e).side_2);
+      auto lhs = get_interval<T>(to_bitand2t(e).side_1);
       return lhs & rhs;
     }
     if(is_bitxor2t(e))
     {
-      auto rhs = get_interval<wrapped_interval>(to_bitxor2t(e).side_2);
-      auto lhs = get_interval<wrapped_interval>(to_bitxor2t(e).side_1);
+      auto rhs = get_interval<T>(to_bitxor2t(e).side_2);
+      auto lhs = get_interval<T>(to_bitxor2t(e).side_1);
       return lhs ^ rhs;
     }
-#endif
 
     if(is_bitnot2t(e))
     {

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -304,6 +304,58 @@ T interval_domaint::get_interval(const expr2tc &e) const
     }
   }
 
+  if(enable_interval_bitwise_arithmetic)
+  {
+#if 0
+    if(is_shl2t(e))
+    {
+      auto k = get_interval<wrapped_interval>(to_shl2t(e).side_2);
+      auto i = get_interval<wrapped_interval>(to_shl2t(e).side_1);
+      return i.left_shift(k);
+    }
+
+    if(is_ashr2t(e))
+    {
+      auto k = get_interval<wrapped_interval>(to_ashr2t(e).side_2);
+      auto i = get_interval<wrapped_interval>(to_ashr2t(e).side_1);
+      return i.arithmetic_right_shift(k);
+    }
+
+    if(is_lshr2t(e))
+    {
+      auto k = get_interval<wrapped_interval>(to_lshr2t(e).side_2);
+      auto i = get_interval<wrapped_interval>(to_lshr2t(e).side_1);
+      return i.logical_right_shift(k);
+    }
+
+    if(is_bitor2t(e))
+    {
+      auto rhs = get_interval<wrapped_interval>(to_bitor2t(e).side_2);
+      auto lhs = get_interval<wrapped_interval>(to_bitor2t(e).side_1);
+      return lhs | rhs;
+    }
+
+    if(is_bitand2t(e))
+    {
+      auto rhs = get_interval<wrapped_interval>(to_bitand2t(e).side_2);
+      auto lhs = get_interval<wrapped_interval>(to_bitand2t(e).side_1);
+      return lhs & rhs;
+    }
+    if(is_bitxor2t(e))
+    {
+      auto rhs = get_interval<wrapped_interval>(to_bitxor2t(e).side_2);
+      auto lhs = get_interval<wrapped_interval>(to_bitxor2t(e).side_1);
+      return lhs ^ rhs;
+    }
+#endif
+
+    if(is_bitnot2t(e))
+    {
+      auto lhs = get_interval<T>(to_bitnot2t(e).value);
+      return T::bitnot(lhs);
+    }
+  }
+
   // We could not generate from the expr. Return top
   T result; // (-infinity, infinity)
   return result;

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -272,6 +272,12 @@ T interval_domaint::get_interval(const expr2tc &e) const
     return T::ternary_if(cond, lhs, rhs);
   }
 
+  if(is_typecast2t(e))
+  {
+    auto inner = get_interval<T>(to_typecast2t(e).from);
+    return T::cast(inner, to_typecast2t(e).type);
+  }
+
   // Arithmetic?
   auto arith_op = std::dynamic_pointer_cast<arith_2ops>(e);
   auto ieee_arith_op = std::dynamic_pointer_cast<ieee_arith_2ops>(e);

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -303,6 +303,9 @@ T interval_domaint::get_interval(const expr2tc &e) const
     if(is_div2t(e) || is_ieee_div2t(e))
       return lhs / rhs;
 
+    if(is_modulus2t(e))
+      return lhs % rhs;
+
     // TODO: Add more as needed.
   }
   // We could not generate from the expr. Return top

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -231,6 +231,21 @@ wrapped_interval interval_domaint::extrapolate_intervals(
   return wrapped_interval::extrapolate_to(before, after);
 }
 
+template <class Interval>
+Interval interval_domaint::get_top_interval_from_expr(const expr2tc &) const
+{
+  Interval result;
+  return result;
+}
+
+template <>
+wrapped_interval
+interval_domaint::get_top_interval_from_expr(const expr2tc &e) const
+{
+  wrapped_interval result(e->type);
+  return result;
+}
+
 template <class T>
 T interval_domaint::interpolate_intervals(const T &before, const T &after)
 {
@@ -251,15 +266,20 @@ T interval_domaint::interpolate_intervals(const T &before, const T &after)
 template <class T>
 T interval_domaint::get_interval(const expr2tc &e) const
 {
+  // This needs to come before constant number
+  if(is_constant_bool2t(e))
+  {
+    auto r = get_top_interval_from_expr<T>(e);
+    r.lower = to_constant_bool2t(e).is_true();
+    r.upper = to_constant_bool2t(e).is_true();
+    return r;
+  }
+
   if(is_symbol2t(e))
     return get_interval_from_symbol<T>(to_symbol2t(e));
 
   if(is_neg2t(e))
     return -get_interval<T>(to_neg2t(e).value);
-
-  // We do not care about overflows/overlaps for now
-  if(is_typecast2t(e))
-    return get_interval<T>(to_typecast2t(e).from);
 
   if(is_constant_number(e))
     return get_interval_from_const<T>(e);
@@ -355,125 +375,7 @@ T interval_domaint::get_interval(const expr2tc &e) const
   }
 
   // We could not generate from the expr. Return top
-  T result; // (-infinity, infinity)
-  return result;
-}
-
-template <>
-wrapped_interval interval_domaint::get_interval(const expr2tc &e) const
-{
-  // This needs to come before constant number
-  if(is_constant_bool2t(e))
-  {
-    wrapped_interval r(e->type);
-    r.lower = to_constant_bool2t(e).is_true();
-    r.upper = to_constant_bool2t(e).is_true();
-    return r;
-  }
-
-  if(is_symbol2t(e))
-    return get_interval_from_symbol<wrapped_interval>(to_symbol2t(e));
-
-  if(is_constant_number(e))
-    return get_interval_from_const<wrapped_interval>(e);
-
-  if(is_neg2t(e))
-    return -get_interval<wrapped_interval>(to_neg2t(e).value);
-
-  if(is_if2t(e))
-  {
-    auto cond = get_interval<wrapped_interval>(to_if2t(e).cond);
-    auto lhs = get_interval<wrapped_interval>(to_if2t(e).true_value);
-    auto rhs = get_interval<wrapped_interval>(to_if2t(e).false_value);
-
-    return wrapped_interval::ternary_if(cond, lhs, rhs);
-  }
-
-  if(enable_interval_bitwise_arithmetic)
-  {
-    if(is_shl2t(e))
-    {
-      auto k = get_interval<wrapped_interval>(to_shl2t(e).side_2);
-      auto i = get_interval<wrapped_interval>(to_shl2t(e).side_1);
-      return wrapped_interval::left_shift(i, k);
-    }
-
-    if(is_ashr2t(e))
-    {
-      auto k = get_interval<wrapped_interval>(to_ashr2t(e).side_2);
-      auto i = get_interval<wrapped_interval>(to_ashr2t(e).side_1);
-      return wrapped_interval::arithmetic_right_shift(i, k);
-    }
-
-    if(is_lshr2t(e))
-    {
-      auto k = get_interval<wrapped_interval>(to_lshr2t(e).side_2);
-      auto i = get_interval<wrapped_interval>(to_lshr2t(e).side_1);
-      return wrapped_interval::logical_right_shift(i, k);
-    }
-
-    if(is_bitor2t(e))
-    {
-      auto rhs = get_interval<wrapped_interval>(to_bitor2t(e).side_2);
-      auto lhs = get_interval<wrapped_interval>(to_bitor2t(e).side_1);
-      return lhs | rhs;
-    }
-
-    if(is_bitand2t(e))
-    {
-      auto rhs = get_interval<wrapped_interval>(to_bitand2t(e).side_2);
-      auto lhs = get_interval<wrapped_interval>(to_bitand2t(e).side_1);
-      return lhs & rhs;
-    }
-    if(is_bitxor2t(e))
-    {
-      auto rhs = get_interval<wrapped_interval>(to_bitxor2t(e).side_2);
-      auto lhs = get_interval<wrapped_interval>(to_bitxor2t(e).side_1);
-      return lhs ^ rhs;
-    }
-
-    if(is_bitnot2t(e))
-    {
-      auto lhs = get_interval<wrapped_interval>(to_bitnot2t(e).value);
-      return wrapped_interval::bitnot(lhs);
-    }
-  }
-
-  if(is_typecast2t(e))
-  {
-    auto inner = get_interval<wrapped_interval>(to_typecast2t(e).from);
-    return wrapped_interval::cast(inner, to_typecast2t(e).type);
-  }
-
-  auto arith_op = std::dynamic_pointer_cast<arith_2ops>(e);
-  if(arith_op && enable_interval_arithmetic)
-  {
-    // It should be safe to mix integers/floats in here.
-    // The worst that can happen is an overaproximation
-    auto lhs = get_interval<wrapped_interval>(arith_op->side_1);
-    auto rhs = get_interval<wrapped_interval>(arith_op->side_2);
-
-    if(is_sub2t(e))
-      return lhs - rhs;
-
-    if(is_add2t(e))
-      return lhs + rhs;
-
-    if(is_mul2t(e))
-      return lhs * rhs;
-
-    if(is_div2t(e))
-      return lhs / rhs;
-
-    if(is_modulus2t(e))
-      return lhs % rhs;
-
-    // TODO: Add more as needed.
-  }
-
-  // We could not generate from the expr. Return top
-  wrapped_interval result(e->type); // (-infinity, infinity)
-  return result;
+  return get_top_interval_from_expr<T>(e);
 }
 
 template <class Interval>

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -264,6 +264,14 @@ T interval_domaint::get_interval(const expr2tc &e) const
   if(is_constant_number(e))
     return get_interval_from_const<T>(e);
 
+  if(is_if2t(e))
+  {
+    auto cond = get_interval<T>(to_if2t(e).cond);
+    auto lhs = get_interval<T>(to_if2t(e).true_value);
+    auto rhs = get_interval<T>(to_if2t(e).false_value);
+    return T::ternary_if(cond, lhs, rhs);
+  }
+
   // Arithmetic?
   auto arith_op = std::dynamic_pointer_cast<arith_2ops>(e);
   auto ieee_arith_op = std::dynamic_pointer_cast<ieee_arith_2ops>(e);
@@ -323,8 +331,7 @@ wrapped_interval interval_domaint::get_interval(const expr2tc &e) const
     auto lhs = get_interval<wrapped_interval>(to_if2t(e).true_value);
     auto rhs = get_interval<wrapped_interval>(to_if2t(e).false_value);
 
-    auto result = wrapped_interval::over_join(lhs, rhs);
-    return result;
+    return wrapped_interval::ternary_if(cond, lhs, rhs);
   }
 
   if(enable_interval_bitwise_arithmetic)

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -306,29 +306,26 @@ T interval_domaint::get_interval(const expr2tc &e) const
 
   if(enable_interval_bitwise_arithmetic)
   {
-#if 0
     if(is_shl2t(e))
     {
-      auto k = get_interval<wrapped_interval>(to_shl2t(e).side_2);
-      auto i = get_interval<wrapped_interval>(to_shl2t(e).side_1);
-      return i.left_shift(k);
+      auto k = get_interval<T>(to_shl2t(e).side_2);
+      auto i = get_interval<T>(to_shl2t(e).side_1);
+      return T::left_shift(i, k);
     }
 
     if(is_ashr2t(e))
     {
-      auto k = get_interval<wrapped_interval>(to_ashr2t(e).side_2);
-      auto i = get_interval<wrapped_interval>(to_ashr2t(e).side_1);
-      return i.arithmetic_right_shift(k);
+      auto k = get_interval<T>(to_ashr2t(e).side_2);
+      auto i = get_interval<T>(to_ashr2t(e).side_1);
+      return T::arithmetic_right_shift(i, k);
     }
 
     if(is_lshr2t(e))
     {
-      auto k = get_interval<wrapped_interval>(to_lshr2t(e).side_2);
-      auto i = get_interval<wrapped_interval>(to_lshr2t(e).side_1);
-      return i.logical_right_shift(k);
+      auto k = get_interval<T>(to_lshr2t(e).side_2);
+      auto i = get_interval<T>(to_lshr2t(e).side_1);
+      return T::logical_right_shift(i, k);
     }
-
-#endif
 
     if(is_bitor2t(e))
     {
@@ -398,21 +395,21 @@ wrapped_interval interval_domaint::get_interval(const expr2tc &e) const
     {
       auto k = get_interval<wrapped_interval>(to_shl2t(e).side_2);
       auto i = get_interval<wrapped_interval>(to_shl2t(e).side_1);
-      return i.left_shift(k);
+      return wrapped_interval::left_shift(i, k);
     }
 
     if(is_ashr2t(e))
     {
       auto k = get_interval<wrapped_interval>(to_ashr2t(e).side_2);
       auto i = get_interval<wrapped_interval>(to_ashr2t(e).side_1);
-      return i.arithmetic_right_shift(k);
+      return wrapped_interval::arithmetic_right_shift(i, k);
     }
 
     if(is_lshr2t(e))
     {
       auto k = get_interval<wrapped_interval>(to_lshr2t(e).side_2);
       auto i = get_interval<wrapped_interval>(to_lshr2t(e).side_1);
-      return i.logical_right_shift(k);
+      return wrapped_interval::logical_right_shift(i, k);
     }
 
     if(is_bitor2t(e))

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -314,7 +314,7 @@ protected:
    * @return Interval
    */
   template <class Interval>
-  Interval get_interval(const expr2tc &e);
+  Interval get_interval(const expr2tc &e) const;
 
   /**
    * @brief Get the interval from symbol object or top
@@ -334,7 +334,7 @@ protected:
    * @return Interval
    */
   template <class Interval>
-  Interval get_interval_from_const(const expr2tc &sym);
+  Interval get_interval_from_const(const expr2tc &sym) const;
 
   /**
    * @brief Sets new interval for symbol

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -336,6 +336,9 @@ protected:
   template <class Interval>
   Interval get_interval_from_const(const expr2tc &sym) const;
 
+  template <class Interval>
+  Interval get_top_interval_from_expr(const expr2tc &sym) const;
+
   /**
    * @brief Sets new interval for symbol
    *

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -433,6 +433,30 @@ public:
     return s;
   }
 
+  friend interval_templatet<T>
+  operator&(const interval_templatet<T> &, const interval_templatet<T> &)
+  {
+    log_debug("No support for bitand");
+    interval_templatet<T> result;
+    return result;
+  }
+
+  friend interval_templatet<T>
+  operator|(const interval_templatet<T> &, const interval_templatet<T> &)
+  {
+    log_debug("No support for bitor");
+    interval_templatet<T> result;
+    return result;
+  }
+
+  friend interval_templatet<T>
+  operator^(const interval_templatet<T> &, const interval_templatet<T> &)
+  {
+    log_debug("No support for bitxor");
+    interval_templatet<T> result;
+    return result;
+  }
+
   static interval_templatet<T> bitnot(const interval_templatet<T> &w)
   {
     interval_templatet<T> result;

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -419,6 +419,13 @@ public:
     return result;
   }
 
+  static interval_templatet<T>
+  cast(const interval_templatet<T> &old, const type2tc &)
+  {
+    log_debug("No support for typecasting");
+    return old;
+  }
+
   /// This is just to check if a value has changed. This is not the same as an interval comparation!
   bool inline has_changed(const interval_templatet<T> &i)
   {

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -426,6 +426,13 @@ public:
     return old;
   }
 
+  friend interval_templatet<T>
+  operator%(const interval_templatet<T> &s, const interval_templatet<T> &)
+  {
+    log_debug("No support for mod");
+    return s;
+  }
+
   /// This is just to check if a value has changed. This is not the same as an interval comparation!
   bool inline has_changed(const interval_templatet<T> &i)
   {

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -457,6 +457,32 @@ public:
     return result;
   }
 
+  static interval_templatet<T> logical_right_shift(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &)
+  {
+    log_debug("No support for logical right shift");
+    interval_templatet<T> result;
+    return result;
+  }
+
+  static interval_templatet<T>
+  left_shift(const interval_templatet<T> &, const interval_templatet<T> &)
+  {
+    log_debug("No support for left shift");
+    interval_templatet<T> result;
+    return result;
+  }
+
+  static interval_templatet<T> arithmetic_right_shift(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &)
+  {
+    log_debug("No support for arithmetic right shift");
+    interval_templatet<T> result;
+    return result;
+  }
+
   static interval_templatet<T> bitnot(const interval_templatet<T> &w)
   {
     interval_templatet<T> result;

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -403,6 +403,22 @@ public:
     return result;
   }
 
+  static interval_templatet<T> ternary_if(
+    const interval_templatet<T> &cond,
+    const interval_templatet<T> &true_value,
+    const interval_templatet<T> &false_value)
+  {
+    if(!cond.contains(0))
+      return true_value;
+
+    if(cond.singleton())
+      return false_value;
+
+    interval_templatet<T> result = true_value;
+    result.join(false_value);
+    return result;
+  }
+
   /// This is just to check if a value has changed. This is not the same as an interval comparation!
   bool inline has_changed(const interval_templatet<T> &i)
   {

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -433,6 +433,14 @@ public:
     return s;
   }
 
+  static interval_templatet<T> bitnot(const interval_templatet<T> &w)
+  {
+    interval_templatet<T> result;
+    result.set_lower(-w.get_upper() - 1);
+    result.set_upper(-w.get_lower() - 1);
+    return result;
+  }
+
   /// This is just to check if a value has changed. This is not the same as an interval comparation!
   bool inline has_changed(const interval_templatet<T> &i)
   {

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -826,15 +826,16 @@ public:
     return result;
   }
 
-  wrapped_interval left_shift(const wrapped_interval &k) const
+  static wrapped_interval
+  left_shift(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    if(is_bottom())
-      return *this;
+    if(lhs.is_bottom())
+      return lhs;
 
-    if(k.lower == k.upper && !k.is_bottom())
-      return left_shift(k.get_lower().to_uint64());
+    if(rhs.lower == rhs.upper && !rhs.is_bottom())
+      return lhs.left_shift(rhs.get_lower().to_uint64());
 
-    wrapped_interval result(t);
+    wrapped_interval result(lhs.t);
     return result;
   }
 
@@ -859,15 +860,16 @@ public:
     return result;
   }
 
-  wrapped_interval logical_right_shift(const wrapped_interval &k) const
+  static wrapped_interval
+  logical_right_shift(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    if(is_bottom())
-      return *this;
+    if(lhs.is_bottom())
+      return lhs;
 
-    if(k.lower == k.upper && !k.is_bottom())
-      return logical_right_shift(k.get_lower().to_uint64());
+    if(rhs.lower == rhs.upper && !rhs.is_bottom())
+      return lhs.logical_right_shift(rhs.get_lower().to_uint64());
 
-    wrapped_interval result(t);
+    wrapped_interval result(lhs.t);
     return result;
   }
 
@@ -893,15 +895,17 @@ public:
     return result;
   }
 
-  wrapped_interval arithmetic_right_shift(const wrapped_interval &k) const
+  static wrapped_interval arithmetic_right_shift(
+    const wrapped_interval &lhs,
+    const wrapped_interval &rhs)
   {
-    if(is_bottom())
-      return *this;
+    if(lhs.is_bottom())
+      return lhs;
 
-    if(k.lower == k.upper && !k.is_bottom())
-      return arithmetic_right_shift(k.get_lower().to_uint64());
+    if(rhs.lower == rhs.upper && !rhs.is_bottom())
+      return lhs.arithmetic_right_shift(rhs.get_lower().to_uint64());
 
-    wrapped_interval result(t);
+    wrapped_interval result(lhs.t);
     return result;
   }
 

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -1319,6 +1319,20 @@ public:
 
   type2tc t;
 
+  static wrapped_interval ternary_if(
+    const wrapped_interval &cond,
+    const wrapped_interval &true_value,
+    const wrapped_interval &false_value)
+  {
+    if(!cond.contains(0))
+      return true_value;
+
+    if(cond.singleton())
+      return false_value;
+
+    return over_join(true_value, false_value);
+  }
+
 protected:
   BigInt upper_bound;
 

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -248,6 +248,61 @@ TEST_CASE("Interval Analysis - Base Unsigned", "[ai][interval-analysis]")
   T.run_configs();
 }
 
+TEST_CASE("Interval Analysis - Ternary", "[ai][interval-analysis]")
+{
+  // Setup global options here
+  ait<interval_domaint> interval_analysis;
+
+  test_program T;
+  T.code =
+    "int main() {\n"
+    "char a = nondet_uchar() ? 2 : 4;\n"
+    "return a;\n"
+    "}";
+
+  T.property["3"].push_back({"@F@main@a", 2, true});
+  T.property["3"].push_back({"@F@main@a", 4, true});
+  T.property["3"].push_back({"@F@main@a", 10, false});
+
+  T.run_configs();
+}
+
+TEST_CASE("Interval Analysis - Ternary (false)", "[ai][interval-analysis]")
+{
+  // Setup global options here
+  ait<interval_domaint> interval_analysis;
+
+  test_program T;
+  T.code =
+    "int main() {\n"
+    "char a = 0 ? 2 : 4;\n"
+    "return a;\n"
+    "}";
+
+  T.property["3"].push_back({"@F@main@a", 2, false});
+  T.property["3"].push_back({"@F@main@a", 4, true});
+
+  T.run_configs();
+}
+
+TEST_CASE("Interval Analysis - Ternary (true)", "[ai][interval-analysis]")
+{
+  // Setup global options here
+  ait<interval_domaint> interval_analysis;
+
+  test_program T;
+  T.code =
+    "int main() {\n"
+    "char a = 1 ? 2 : 4;\n"
+    "return a;\n"
+    "}";
+
+  T.property["3"].push_back({"@F@main@a", 2, true});
+  T.property["3"].push_back({"@F@main@a", 4, false});
+
+  T.run_configs();
+}
+
 TEST_CASE(
   "Interval Analysis - If/Else Statement LHS (Unsigned)",
   "[ai][interval-analysis]")

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -780,7 +780,7 @@ TEST_CASE(
   T.property["4"].push_back({"@F@main@b", 0, true});
   T.property["4"].push_back({"@F@main@b", 1, false});
 
-  T.run_configs();
+  T.run_configs(true);
 }
 
 TEST_CASE(


### PR DESCRIPTION
Just a refactoring over the get_interval function to prepare for further development (more operators). It also adds support for booleans in infinite precision integers. I will also run in sv-comp before merging.