### PR TITLE
Fix scanf bigint bug

### DIFF
--- a/regression/cstd/scanf_bigint_1/main.c
+++ b/regression/cstd/scanf_bigint_1/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+int main() {
+    int n;
+    printf("Enter an integer: ");
+    scanf("%1000000000000000000000000d", &n);
+    printf("%d\n",n);
+    return 0;
+}

--- a/regression/cstd/scanf_bigint_1/test.desc
+++ b/regression/cstd/scanf_bigint_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/regression/cstd/scanf_bigint_2/main.c
+++ b/regression/cstd/scanf_bigint_2/main.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+int main(int argc, char *argv[])
+{
+  int *arr = (int *)malloc(100000000000 * sizeof(int));
+  for(int i = 0; i < 3; i++)
+  {
+    scanf("%100000000000d", &arr[i]);
+  }
+  for(int i = 0; i < 3; i++)
+  {
+    printf("%d", &arr[i]);
+  }
+}

--- a/regression/cstd/scanf_bigint_2/test.desc
+++ b/regression/cstd/scanf_bigint_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -72,8 +72,10 @@ protected:
   /** check for the buffer overflow in scanf/fscanf */
   void input_overflow_check(const expr2tc &expr, const locationt &loc);
   /* check for signed/unsigned_bv */
-  void
-  input_overflow_check_int(std::string width, BigInt limit, bool &buf_overflow);
+  void input_overflow_check_int(
+    const std::string width,
+    BigInt limit,
+    bool &buf_overflow);
   /* check for string/malloc array */
   void input_overflow_check_arr(BigInt width, BigInt limit, bool &buf_overflow);
 
@@ -254,7 +256,7 @@ void goto_checkt::overflow_check(
 }
 
 void goto_checkt::input_overflow_check_int(
-  std::string width,
+  const std::string width,
   BigInt limit,
   bool &buf_overflow)
 {

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -73,11 +73,14 @@ protected:
   void input_overflow_check(const expr2tc &expr, const locationt &loc);
   /* check for signed/unsigned_bv */
   void input_overflow_check_int(
-    const std::string width,
-    BigInt limit,
+    const BigInt &width,
+    const BigInt &limit,
     bool &buf_overflow);
   /* check for string/malloc array */
-  void input_overflow_check_arr(BigInt width, BigInt limit, bool &buf_overflow);
+  void input_overflow_check_arr(
+    const BigInt &width,
+    const BigInt &limit,
+    bool &buf_overflow);
 
   void
   shift_check(const expr2tc &expr, const guardt &guard, const locationt &loc);
@@ -256,19 +259,19 @@ void goto_checkt::overflow_check(
 }
 
 void goto_checkt::input_overflow_check_int(
-  const std::string width,
-  BigInt limit,
+  const BigInt &width,
+  const BigInt &limit,
   bool &buf_overflow)
 {
   if(
-    (width == "8" && limit > 3) || (width == "16" && limit > 5) ||
-    (width == "32" && limit > 10) || (width == "64" && limit > 19))
+    (width == 8 && limit > 3) || (width == 16 && limit > 5) ||
+    (width == 32 && limit > 10) || (width == 64 && limit > 19))
     buf_overflow = true;
 }
 
 void goto_checkt::input_overflow_check_arr(
-  BigInt width,
-  BigInt limit,
+  const BigInt &width,
+  const BigInt &limit,
   bool &buf_overflow)
 {
   if(limit + 1 > width) // plus one as string always ends up with a null char
@@ -391,7 +394,7 @@ void goto_checkt::input_overflow_check(
     {
       width = arg.type.width().as_string();
       input_overflow_check_int(
-        width, string2integer(limits.at(i)), buf_overflow);
+        string2integer(width), string2integer(limits.at(i)), buf_overflow);
     }
     else if(type_id == "floatbv" || type_id == "fixedbv")
     {
@@ -430,7 +433,7 @@ void goto_checkt::input_overflow_check(
         {
           width = it.c_sizeof_type().width().as_string();
           input_overflow_check_int(
-            width, string2integer(limits.at(i)), buf_overflow);
+            string2integer(width), string2integer(limits.at(i)), buf_overflow);
         }
 
         else if(


### PR DESCRIPTION
Relative issue: #1066 

- the bug was caused by `stoi(very_large_int)`
- Instead, we should use `BigInt` and `string2integer()`