### PR TITLE
Fixed inconsistent template specialization ids

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates11/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates11/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates12/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates12/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates14/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates14/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates16/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates16/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates17/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates17/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates18/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates18/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates2/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates2/test.desc
@@ -9,6 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates21/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates21/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates24/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates24/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates26/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates26/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates27/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates27/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates29/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates29/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates3/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates3/test.desc
@@ -9,6 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates30/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates30/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates32/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates32/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates4/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates4/test.desc
@@ -10,5 +10,4 @@
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
   <item_10_mode>CORE</item_10_mode>
-<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates5/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates5/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates7/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates7/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates9/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates9/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cpp/class-specialization/test.desc
+++ b/regression/esbmc-cpp/cpp/class-specialization/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/llbmc_non_type_template/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_non_type_template/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/llbmc_template_class/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_template_class/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/llbmc_template_specialization/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_template_specialization/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/call1/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/call1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/conv3/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/conv3/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/partial1/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/partial1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/qual2/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/qual2/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/qualttp16/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/qualttp16/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/using1/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/using1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/using17/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/using17/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/using3/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/using3/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/using4/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/using4/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/nested_method_template/test.desc
+++ b/regression/esbmc-cpp/template/nested_method_template/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/template_1_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_1_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/template_2_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_2_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -297,17 +297,6 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
 
   std::string id, name;
   get_decl_name(rd, name, id);
-  if(id == "c:@S@int_array>#VI3")
-  {
-    printf("Got c:@S@int_array>#VI3\n");
-  }
-  if(id == "tag-int_array<3>")
-  {
-    printf("Got tag-int_array<3>\n");
-  }
-
-  std::string id1, name1;
-  get_decl_name(rd, name1, id1);
 
   // Check if the symbol is already added to the context, do nothing if it is
   // already in the context.

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3155,6 +3155,7 @@ void clang_c_convertert::get_decl_name(
 
   case clang::Decl::Record:
   case clang::Decl::CXXRecord:
+  case clang::Decl::ClassTemplateSpecialization:
   {
     const clang::RecordDecl &rd = static_cast<const clang::RecordDecl &>(nd);
     name = getFullyQualifiedName(ASTContext->getTagDeclType(&rd), *ASTContext);

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -297,6 +297,17 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
 
   std::string id, name;
   get_decl_name(rd, name, id);
+  if(id == "c:@S@int_array>#VI3")
+  {
+    printf("Got c:@S@int_array>#VI3\n");
+  }
+  if(id == "tag-int_array<3>")
+  {
+    printf("Got tag-int_array<3>\n");
+  }
+
+  std::string id1, name1;
+  get_decl_name(rd, name1, id1);
 
   // Check if the symbol is already added to the context, do nothing if it is
   // already in the context.

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -23,9 +23,8 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
    *  copied to the `components` list in its type, which should have been
    *  done in the converter.
    */
-  if(
-    !symbol.value.need_vptr_init() || symbol.value.is_nil() ||
-    !symbol.value.has_operands())
+  if(!symbol.value.need_vptr_init() || symbol.value.is_nil() ||
+     !symbol.value.has_operands())
     return;
 
   /*

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -23,7 +23,9 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
    *  copied to the `components` list in its type, which should have been
    *  done in the converter.
    */
-  if(!symbol.value.need_vptr_init() || symbol.value.is_nil())
+  if(
+    !symbol.value.need_vptr_init() || symbol.value.is_nil() ||
+    !symbol.value.has_operands())
     return;
 
   /*

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -23,8 +23,7 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
    *  copied to the `components` list in its type, which should have been
    *  done in the converter.
    */
-  if(!symbol.value.need_vptr_init() || symbol.value.is_nil() ||
-     !symbol.value.has_operands())
+  if(!symbol.value.need_vptr_init() || symbol.value.is_nil())
     return;
 
   /*

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -313,6 +313,10 @@ bool clang_cpp_convertert::get_struct_union_class_methods_decls(
     if(decl->getKind() == clang::Decl::Field)
       continue;
 
+    // ignore self-referring implicit class node
+    if(decl->getKind() == clang::Decl::CXXRecord && decl->isImplicit())
+      continue;
+
     // virtual methods were already added
     if(decl->getKind() == clang::Decl::CXXMethod)
     {
@@ -900,6 +904,14 @@ bool clang_cpp_convertert::get_function_this_pointer_param(
   const clang::CXXMethodDecl &cxxmd,
   code_typet::argumentst &params)
 {
+  std::string id, name;
+  get_decl_name(cxxmd, name, id);
+
+  if(id == "c:@S@int_array>#VI3@F@int_array#")
+  {
+    printf("Got ctor\n");
+  }
+
   // Parse this pointer
   code_typet::argumentt this_param;
   if(get_type(cxxmd.getThisType(), this_param.type()))
@@ -908,8 +920,8 @@ bool clang_cpp_convertert::get_function_this_pointer_param(
   locationt location_begin;
   get_location_from_decl(cxxmd, location_begin);
 
-  std::string id, name;
-  get_decl_name(cxxmd, name, id);
+  //std::string id, name;
+  //get_decl_name(cxxmd, name, id);
 
   name = "this";
   id += name;

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -373,6 +373,8 @@ bool clang_cpp_convertert::get_struct_union_class_methods_decls(
     }
   }
 
+  has_vptr_component = false;
+
   return false;
 }
 
@@ -1273,7 +1275,7 @@ bool clang_cpp_convertert::annotate_class_method(
        * we indicate the need for vptr initializations in contructor.
        * vptr initializations will be added in the adjuster.
        */
-      fd_symb->value.need_vptr_init(true);
+      fd_symb->value.need_vptr_init(has_vptr_component);
     }
   }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -328,7 +328,9 @@ bool clang_cpp_convertert::get_struct_union_class_methods_decls(
         llvm::dyn_cast<clang::FunctionTemplateDecl>(decl))
     {
       assert(ftd->isThisDeclarationADefinition());
-      get_template_decl(ftd, true, comp);
+      //get_template_decl(ftd, true, comp);
+      log_error("template is not supported in {}", __func__);
+      abort();
     }
     else
     {

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -906,14 +906,6 @@ bool clang_cpp_convertert::get_function_this_pointer_param(
   const clang::CXXMethodDecl &cxxmd,
   code_typet::argumentst &params)
 {
-  std::string id, name;
-  get_decl_name(cxxmd, name, id);
-
-  if(id == "c:@S@int_array>#VI3@F@int_array#")
-  {
-    printf("Got ctor\n");
-  }
-
   // Parse this pointer
   code_typet::argumentt this_param;
   if(get_type(cxxmd.getThisType(), this_param.type()))
@@ -922,8 +914,8 @@ bool clang_cpp_convertert::get_function_this_pointer_param(
   locationt location_begin;
   get_location_from_decl(cxxmd, location_begin);
 
-  //std::string id, name;
-  //get_decl_name(cxxmd, name, id);
+  std::string id, name;
+  get_decl_name(cxxmd, name, id);
 
   name = "this";
   id += name;

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -102,6 +102,12 @@ protected:
     const clang::RecordDecl &rd,
     struct_typet &type) override;
 
+  /*
+   * Deal with ClassTemplateDecl or FunctionTemplateDecl or
+   * a class or function template declaration respectively.
+   * For C++14 and above, this function might be extended to deal
+   * with VarTemplateDecl for variable template.
+  */
   template <typename TemplateDecl>
   bool get_template_decl(
     const TemplateDecl *D,

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -118,7 +118,6 @@ protected:
   bool get_template_decl_specialization(
     const SpecializationDecl *D,
     bool DumpExplicitInst,
-    bool DumpRefOnly,
     exprt &new_expr);
 
   bool get_expr(const clang::Stmt &stmt, exprt &new_expr) override;

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -277,6 +277,8 @@ protected:
    */
   std::string vtable_type_prefix = "virtual_table::";
   std::string vtable_ptr_suffix = "@vtable_pointer";
+  // if a class/struct has vptr component, it needs to be initialized in ctor
+  bool has_vptr_component = false;
   std::string thunk_prefix = "thunk::";
   using function_switch = std::map<irep_idt, exprt>;
   using switch_table = std::map<irep_idt, function_switch>;

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -180,6 +180,8 @@ void clang_cpp_convertert::add_vptr(struct_typet &type)
   component.set("access", "public");
   // add to the class' type
   type.components().push_back(component);
+
+  has_vptr_component = true;
 }
 
 void clang_cpp_convertert::add_vtable_type_entry(

--- a/src/clang-cpp-frontend/expr2cpp.cpp
+++ b/src/clang-cpp-frontend/expr2cpp.cpp
@@ -177,7 +177,7 @@ std::string expr2cppt::convert_rec(
     const symbolt *symbol = ns.lookup(identifier);
     if(!symbol)
     {
-      log_error("could not find symbol {} in the context", identifier);
+      log_error("could not find symbol {} in the context in {}", identifier, __func__);
       abort();
     }
 

--- a/src/clang-cpp-frontend/expr2cpp.cpp
+++ b/src/clang-cpp-frontend/expr2cpp.cpp
@@ -174,30 +174,36 @@ std::string expr2cppt::convert_rec(
   {
     const irep_idt &identifier = src.identifier();
 
-    const symbolt &symbol = *ns.lookup(identifier);
+    const symbolt *symbol = ns.lookup(identifier);
+    if(!symbol)
+    {
+      log_error("could not find symbol {} in the context", identifier);
+      abort();
+    }
 
-    if(symbol.type.id() == "struct" || symbol.type.id() == "incomplete_struct")
+    if(
+      symbol->type.id() == "struct" || symbol->type.id() == "incomplete_struct")
     {
       std::string dest = new_qualifiers.as_string();
 
-      if(symbol.type.get_bool("#class"))
+      if(symbol->type.get_bool("#class"))
         dest += "class";
-      else if(symbol.type.get_bool("#interface"))
+      else if(symbol->type.get_bool("#interface"))
         dest += "__interface"; // MS-specific
       else
         dest += "struct";
 
-      dest += " " + id2string(symbol.name);
+      dest += " " + id2string(symbol->name);
       dest += d;
       return dest;
     }
-    if(symbol.type.id() == "c_enum")
+    if(symbol->type.id() == "c_enum")
     {
       std::string dest = new_qualifiers.as_string();
 
       dest += "enum";
 
-      dest += " " + id2string(symbol.name);
+      dest += " " + id2string(symbol->name);
       dest += d;
       return dest;
     }

--- a/src/clang-cpp-frontend/expr2cpp.cpp
+++ b/src/clang-cpp-frontend/expr2cpp.cpp
@@ -177,7 +177,8 @@ std::string expr2cppt::convert_rec(
     const symbolt *symbol = ns.lookup(identifier);
     if(!symbol)
     {
-      log_error("could not find symbol {} in the context in {}", identifier, __func__);
+      log_error(
+        "could not find symbol {} in the context in {}", identifier, __func__);
       abort();
     }
 

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -22,15 +22,6 @@ bool contextt::move(symbolt &symbol, symbolt *&new_symbol)
   std::pair<symbolst::iterator, bool> result =
     symbols.insert(std::pair<irep_idt, symbolt>(symbol.id, tmp));
 
-  if(symbol.id == "c:@S@int_array>#VI3")
-  {
-    printf("Moving c:@S@int_array>#VI3\n");
-  }
-  if(symbol.id == "tag-int_array<3>")
-  {
-    printf("Moving tag-int_array<3>\n");
-  }
-
   if(!result.second)
   {
     new_symbol = &result.first->second;

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -22,6 +22,15 @@ bool contextt::move(symbolt &symbol, symbolt *&new_symbol)
   std::pair<symbolst::iterator, bool> result =
     symbols.insert(std::pair<irep_idt, symbolt>(symbol.id, tmp));
 
+  if(symbol.id == "c:@S@int_array>#VI3")
+  {
+    printf("Moving c:@S@int_array>#VI3\n");
+  }
+  if(symbol.id == "tag-int_array<3>")
+  {
+    printf("Moving tag-int_array<3>\n");
+  }
+
   if(!result.second)
   {
     new_symbol = &result.first->second;

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,10 +33,20 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
+    {
+      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+      out << s.type.pretty(0) << "\n";
+      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
+    }
 
     if(s.value.is_not_nil())
+    {
+      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+      out << s.value.pretty(0) << "\n";
+      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
+    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,20 +33,10 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
-    {
-      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
-      out << s.type.pretty(0) << "\n";
-      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
-    }
 
     if(s.value.is_not_nil())
-    {
-      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
-      out << s.value.pretty(0) << "\n";
-      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
-    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
Fixed https://github.com/esbmc/esbmc/issues/1074 and https://github.com/esbmc/esbmc/issues/1075

Enabled 34 TCs: 
```
regression/esbmc-cpp/cpp/class-specialization
regression/esbmc-cpp/cpp/llbmc_non_type_template
regression/esbmc-cpp/cpp/llbmc_template_class
regression/esbmc-cpp/cpp/llbmc_template_specialization
regression/esbmc-cpp/cbmc/Templates11
regression/esbmc-cpp/cbmc/Templates12
regression/esbmc-cpp/cbmc/Templates14
regression/esbmc-cpp/cbmc/Templates16
regression/esbmc-cpp/cbmc/Templates17
regression/esbmc-cpp/cbmc/Templates18
regression/esbmc-cpp/cbmc/Templates2
regression/esbmc-cpp/cbmc/Templates21
regression/esbmc-cpp/cbmc/Templates24
regression/esbmc-cpp/cbmc/Templates26
regression/esbmc-cpp/cbmc/Templates27
regression/esbmc-cpp/cbmc/Templates29
regression/esbmc-cpp/cbmc/Templates3
regression/esbmc-cpp/cbmc/Templates30
regression/esbmc-cpp/cbmc/Templates32
regression/esbmc-cpp/cbmc/Templates5
regression/esbmc-cpp/cbmc/Templates7
regression/esbmc-cpp/cbmc/Templates9
regression/esbmc-cpp/gcc-template-tests/call1
regression/esbmc-cpp/gcc-template-tests/conv3
regression/esbmc-cpp/gcc-template-tests/partial1
regression/esbmc-cpp/gcc-template-tests/qual2
regression/esbmc-cpp/gcc-template-tests/qualttp16
regression/esbmc-cpp/gcc-template-tests/using1
regression/esbmc-cpp/gcc-template-tests/using17
regression/esbmc-cpp/gcc-template-tests/using3
regression/esbmc-cpp/gcc-template-tests/using4
regression/esbmc-cpp/template/nested_method_template
regression/esbmc-cpp/template/template_1_bug (might be false positive)
regression/esbmc-cpp/template/template_2_bug (might be false positive)
```