### PR TITLE
[dereference] support dyn-off structures w/ array members from byte-arrays

### DIFF
--- a/regression/esbmc/github_1087/gh-1087.c
+++ b/regression/esbmc/github_1087/gh-1087.c
@@ -1,0 +1,51 @@
+//FormAI DATASET v0.1 Category: Resume Parsing System ; Style: multiplayer
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Player struct to hold player information
+typedef struct Player {
+    char name[20];
+    int score;
+} Player;
+
+// Function to display player information
+void displayPlayer(Player p) {
+    printf("Player: %s\n", p.name);
+    printf("Score: %d\n", p.score);
+}
+
+// Function to compare player scores for sorting
+int compare(Player a, Player b) {
+    return b.score - a.score;
+}
+
+int main() {
+    int num_players;
+    printf("Enter number of players:");
+    scanf("%d", &num_players);
+    Player* players = (Player*)malloc(num_players * sizeof(Player));
+
+    // Input player information
+    for (int i = 0; i < num_players; i++) {
+        printf("\nEnter details of player %d:\n", i+1);
+        printf("Name: ");
+        scanf("%s", players[i].name);
+        printf("Score: ");
+        scanf("%d", &players[i].score);
+    }
+
+    // Sort players based on score
+    qsort(players, num_players, sizeof(Player), (void*)compare);
+
+    // Display sorted player information
+    printf("\nSorted player information:\n");
+    for (int i = 0; i < num_players; i++) {
+        displayPlayer(players[i]);
+    }
+
+    // Free memory allocated for players
+    free(players);
+
+    return 0;
+}

--- a/regression/esbmc/github_1087/test.desc
+++ b/regression/esbmc/github_1087/test.desc
@@ -1,0 +1,4 @@
+CORE
+gh-1087.c
+--unwind 1
+^VERIFICATION FAILED$

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -813,7 +813,6 @@ enum target_flags
   flag_is_dyn_offs = 0,
 };
 
-
 /*
  * Legend:
  * - src = value


### PR DESCRIPTION
Fixes #1087. I've also added a table that summarizes the cases the trampoline `build_reference_rec()` handles. There are a few notes attached to this table. Whenever the notes between constant and dynamic offsets differ (or there is no or just restricted recursion for composite types), there is cause for suspicion.

The fix basically reproduces the handling of array members from other places such as `construct_from_dyn_struct_offset()`, `construct_struct_ref_from_const_offset_array()`. Ideally, these different copies of the same handling would be unified, though that is not in scope of this PR.