### PR TITLE
[smt] tuple-array-ast requires flattened array subtype in tuple-node-flattener

### DIFF
--- a/regression/esbmc/github_1069/gh-1069.c
+++ b/regression/esbmc/github_1069/gh-1069.c
@@ -1,0 +1,244 @@
+//FormAI DATASET v0.1 Category: Chess AI ; Style: asynchronous
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define BOARD_SIZE 8          // Define the board size
+#define BLACK true            // Define a boolean for black
+#define WHITE false           // Define a boolean for white
+
+typedef char piece_type;
+typedef bool color_type;
+
+// Define structs for piece and position
+typedef struct {
+    piece_type type;
+    color_type color;
+} Piece;
+
+typedef struct {
+    int row;
+    int col;
+} Position;
+
+// Define a struct for the chess board
+typedef struct { 
+    Piece *board[BOARD_SIZE][BOARD_SIZE];
+} ChessBoard;
+
+// Function to initialize the board
+void init_board(ChessBoard* board){
+    // Create Black pieces
+    board->board[0][0] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][0]->color = BLACK;
+    board->board[0][0]->type = 'r';
+    board->board[0][1] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][1]->color = BLACK;
+    board->board[0][1]->type = 'n';
+    board->board[0][2] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][2]->color = BLACK;
+    board->board[0][2]->type = 'b';
+    board->board[0][3] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][3]->color = BLACK;
+    board->board[0][3]->type = 'q';
+    board->board[0][4] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][4]->color = BLACK;
+    board->board[0][4]->type = 'k';
+    board->board[0][5] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][5]->color = BLACK;
+    board->board[0][5]->type = 'b';
+    board->board[0][6] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][6]->color = BLACK;
+    board->board[0][6]->type = 'n';
+    board->board[0][7] = (Piece*)malloc(sizeof(Piece));
+    board->board[0][7]->color = BLACK;
+    board->board[0][7]->type = 'r';
+    for(int i=0; i<BOARD_SIZE; i++){
+        board->board[1][i] = (Piece*)malloc(sizeof(Piece));
+        board->board[1][i]->color = BLACK;
+        board->board[1][i]->type = 'p';
+    }
+    // Create White pieces
+    board->board[7][0] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][0]->color = WHITE;
+    board->board[7][0]->type = 'r';
+    board->board[7][1] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][1]->color = WHITE;
+    board->board[7][1]->type = 'n';
+    board->board[7][2] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][2]->color = WHITE;
+    board->board[7][2]->type = 'b';
+    board->board[7][3] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][3]->color = WHITE;
+    board->board[7][3]->type = 'q';
+    board->board[7][4] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][4]->color = WHITE;
+    board->board[7][4]->type = 'k';
+    board->board[7][5] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][5]->color = WHITE;
+    board->board[7][5]->type = 'b';
+    board->board[7][6] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][6]->color = WHITE;
+    board->board[7][6]->type = 'n';
+    board->board[7][7] = (Piece*)malloc(sizeof(Piece));
+    board->board[7][7]->color = WHITE;
+    board->board[7][7]->type = 'r';
+    for(int i=0; i<BOARD_SIZE; i++){
+        board->board[6][i] = (Piece*)malloc(sizeof(Piece));
+        board->board[6][i]->color = WHITE;
+        board->board[6][i]->type = 'p';
+    }
+    // Initialize the empty spaces on the board
+    for(int i=2; i<=5; i++){
+        for(int j=0; j<BOARD_SIZE; j++){
+            board->board[i][j] = NULL;
+        }
+    }
+}
+
+// Function to print the board with ASCII characters
+void print_board(ChessBoard* board){
+    printf("\n  a b c d e f g h\n");
+    for(int i=0; i<BOARD_SIZE; i++){
+        printf("%d ", i+1);
+        for(int j=0; j<BOARD_SIZE; j++){
+            if(board->board[i][j] == NULL){
+                printf(". ");
+            } else {
+                printf("%c ", board->board[i][j]->type);
+            }
+        }
+        printf("%d", i+1);
+        printf("\n");
+    }
+    printf("  a b c d e f g h\n");
+}
+
+// Function to move a piece from one position to another
+void move_piece(ChessBoard* board, Position current_pos, Position new_pos){
+    // Check if move is within the board
+    if(new_pos.row >= BOARD_SIZE || new_pos.row < 0 || new_pos.col >= BOARD_SIZE || new_pos.col < 0){
+        printf("Invalid move.\n");
+        return;
+    }
+    // Check if something is blocking the path
+    int dy = new_pos.row - current_pos.row;
+    int dx = new_pos.col - current_pos.col;
+    int y_dir = dy == 0 ? 0 : dy/abs(dy);
+    int x_dir = dx == 0 ? 0 : dx/abs(dx);
+    int y = current_pos.row + y_dir;
+    int x = current_pos.col + x_dir;
+    while( y != new_pos.row || x != new_pos.col ){
+        if(board->board[y][x] != NULL){
+            printf("Invalid move.\n");
+            return;
+        }
+        y += y_dir;
+        x += x_dir;
+    }
+    // Check if moving piece is a valid piece
+    if(board->board[current_pos.row][current_pos.col] == NULL){
+        printf("Invalid move.\n");
+        return;
+    }
+    // Check if moving the piece is allowed
+    switch(board->board[current_pos.row][current_pos.col]->type){
+        case 'p':
+            // Check for standard pawn moves
+            if((current_pos.col == new_pos.col) && (board->board[new_pos.row][new_pos.col] != NULL)){
+                printf("Invalid move.\n");
+                return;
+            }
+            // Check for pawn attack moves
+            if(abs(current_pos.col - new_pos.col) == 1 && board->board[new_pos.row][new_pos.col] != NULL){
+                if(board->board[current_pos.row][current_pos.col]->color == WHITE){
+                    if(new_pos.row != current_pos.row-1){
+                        printf("Invalid move.\n");
+                        return;
+                    }
+                } else {
+                    if(new_pos.row != current_pos.row+1){
+                        printf("Invalid move.\n");
+                        return;
+                    }
+                }
+            } else {
+                if(board->board[current_pos.row][current_pos.col]->color == WHITE){
+                    if((current_pos.row - new_pos.row) > 2){
+                        printf("Invalid move.\n");
+                        return;
+                    }
+                } else {
+                    if((new_pos.row - current_pos.row) > 2){
+                        printf("Invalid move.\n");
+                        return;
+                    }
+                }
+                if(board->board[new_pos.row][new_pos.col] != NULL){
+                    printf("Invalid move.\n");
+                    return;
+                }
+            }
+            break;
+        case 'r':
+            if(current_pos.row != new_pos.row && current_pos.col != new_pos.col){
+                printf("Invalid move.\n");
+                return;
+            } 
+            break;
+        case 'n':
+            if(!((abs(current_pos.row - new_pos.row) == 2 && abs(current_pos.col - new_pos.col) == 1) 
+                || (abs(current_pos.row - new_pos.row) == 1 && abs(current_pos.col - new_pos.col) == 2))) {
+                printf("Invalid move.\n");
+                return;
+            }
+            break;
+        case 'b':
+            if(abs(current_pos.row - new_pos.row) != abs(current_pos.col - new_pos.col)){
+                printf("Invalid move.\n");
+                return;
+            }
+            break;
+        case 'q':
+            if(!(current_pos.row == new_pos.row || current_pos.col == new_pos.col 
+                || abs(current_pos.row - new_pos.row) == abs(current_pos.col - new_pos.col))) {
+                printf("Invalid move.\n");
+                return;
+            }
+            break;
+        case 'k':
+            if(!((abs(current_pos.row - new_pos.row) == 1 && abs(current_pos.col - new_pos.col) <= 1) 
+                || (abs(current_pos.row - new_pos.row) <= 1 && abs(current_pos.col - new_pos.col) == 1))) {
+                printf("Invalid move.\n");
+                return;
+            }
+            break;
+        default: // Should never happen
+            break;
+    }
+    // Move the piece to the new position
+    board->board[new_pos.row][new_pos.col] = board->board[current_pos.row][current_pos.col];
+    board->board[current_pos.row][current_pos.col] = NULL;
+}
+
+// Example main function to test the asynchronous Chess AI
+int main(){
+    ChessBoard board;
+    init_board(&board);
+    print_board(&board);
+    move_piece(&board, (Position){6, 4}, (Position){4, 4});
+    print_board(&board);
+    move_piece(&board, (Position){0, 1}, (Position){2, 2});
+    print_board(&board);
+    move_piece(&board, (Position){7, 4}, (Position){5, 3});
+    print_board(&board);
+    move_piece(&board, (Position){1, 1}, (Position){2, 1});
+    print_board(&board);
+    move_piece(&board, (Position){0, 6}, (Position){2, 5});
+    print_board(&board);
+    move_piece(&board, (Position){7, 3}, (Position){5, 4});
+    print_board(&board);
+    move_piece(&board, (Position){0, 2}, (Position){3, 5}); //Invalid move
+    print_board(&board);
+return 0;
+}

--- a/regression/esbmc/github_1069/test.desc
+++ b/regression/esbmc/github_1069/test.desc
@@ -1,0 +1,4 @@
+CORE
+gh-1069.c
+--unwind 1
+^VERIFICATION FAILED$

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -35,7 +35,8 @@ void tuple_node_smt_ast::make_free(smt_convt *ctx)
     else if(is_tuple_array_ast_type(it))
     {
       std::string newname = ctx->mk_fresh_name(fieldname);
-      smt_sortt subsort = ctx->convert_sort(ctx->get_flattened_array_subtype(it));
+      smt_sortt subsort =
+        ctx->convert_sort(ctx->get_flattened_array_subtype(it));
       elements[i] = flat.array_conv.mk_array_symbol(newname, newsort, subsort);
     }
     else if(is_array_type(it))

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -35,7 +35,7 @@ void tuple_node_smt_ast::make_free(smt_convt *ctx)
     else if(is_tuple_array_ast_type(it))
     {
       std::string newname = ctx->mk_fresh_name(fieldname);
-      smt_sortt subsort = ctx->convert_sort(get_array_subtype(it));
+      smt_sortt subsort = ctx->convert_sort(ctx->get_flattened_array_subtype(it));
       elements[i] = flat.array_conv.mk_array_symbol(newname, newsort, subsort);
     }
     else if(is_array_type(it))


### PR DESCRIPTION
The array_conv internal to the tuple-node-flattener expects flattened arrays.

Fixes #1069.