### PR TITLE
Fixed nested MemberExpr to struct/class method

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates28/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates28/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/gcc-template-tests/spec10/test.desc
+++ b/regression/esbmc-cpp/gcc-template-tests/spec10/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -86,8 +86,10 @@ void clang_cpp_adjust::adjust_member(member_exprt &expr)
    * dot operator, e.g. OBJECT.setX();
    * or arrow operator, e.g.OBJECT->setX();
    */
-  if((expr.struct_op().is_symbol() || expr.struct_op().is_dereference()) && expr.type().is_code())
+  if(expr.type().is_code() && !expr.get_string("component_name").empty())
+  {
     adjust_cpp_member(expr);
+  }
 }
 
 void clang_cpp_adjust::adjust_cpp_member(member_exprt &expr)
@@ -112,10 +114,12 @@ void clang_cpp_adjust::adjust_cpp_member(member_exprt &expr)
    *      * type: ...
    *      * id: <setX_clang_ID>
    */
-  const symbolt *method_symb =
-    namespacet(context).lookup(expr.component_name());
-  assert(method_symb);
-  exprt method_call = symbol_expr(*method_symb);
+  const symbolt *comp_symb = namespacet(context).lookup(expr.component_name());
+  assert(comp_symb);
+  // compoment's type shall be the same as member_exprt's type
+  // and both are of the type `code`
+  assert(comp_symb->type.is_code());
+  exprt method_call = symbol_expr(*comp_symb);
   expr.swap(method_call);
 }
 

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -86,9 +86,7 @@ void clang_cpp_adjust::adjust_member(member_exprt &expr)
    * dot operator, e.g. OBJECT.setX();
    * or arrow operator, e.g.OBJECT->setX();
    */
-  if(
-    (expr.struct_op().is_symbol() && expr.type().is_code()) ||
-    (expr.struct_op().is_dereference() && expr.type().is_code()))
+  if((expr.struct_op().is_symbol() || expr.struct_op().is_dereference()) && expr.type().is_code())
     adjust_cpp_member(expr);
 }
 

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -16,6 +16,7 @@ CC_DIAGNOSTIC_POP()
 #include <util/show_symbol_table.h>
 #include <iostream>
 #include <util/show_symbol_table.h>
+#include <iostream>
 
 languaget *new_clang_cpp_language()
 {

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -13,10 +13,6 @@ CC_DIAGNOSTIC_POP()
 #include <clang-cpp-frontend/clang_cpp_language.h>
 #include <clang-cpp-frontend/expr2cpp.h>
 #include <regex>
-#include <util/show_symbol_table.h>
-#include <iostream>
-#include <util/show_symbol_table.h>
-#include <iostream>
 
 languaget *new_clang_cpp_language()
 {


### PR DESCRIPTION
Fixed https://github.com/esbmc/esbmc/issues/1082
enabled 2 TCs: 
`cbmc/Templates28`
`gcc-template-tests/spec10` ---> failed with v2.1 but now passing with the new cpp frontend