### PR TITLE
Inductive step now checks the next unwind

### DIFF
--- a/regression/k-induction/github_1092/main.c
+++ b/regression/k-induction/github_1092/main.c
@@ -1,0 +1,41 @@
+#define __VERIFIER_assert(cond)                                                \
+  do                                                                           \
+  {                                                                            \
+    if(!(cond))                                                                \
+    {                                                                          \
+      __ESBMC_assert(0, "");                                                   \
+      abort();                                                                 \
+    }                                                                          \
+  } while(0)
+
+#include <stdlib.h>
+extern int __VERIFIER_nondet_int(void);
+extern void abort(void);
+#include <assert.h>
+void reach_error()
+{
+  assert(0);
+}
+
+int main()
+{
+  int status = 0;
+
+  while(__VERIFIER_nondet_int())
+  {
+    if(!status)
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+    else if(status >= 2)
+    {
+      status = 3;
+    }
+  }
+  __VERIFIER_assert(status != 3);
+  return 0;
+}

--- a/regression/k-induction/github_1092/test.desc
+++ b/regression/k-induction/github_1092/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_1092_1_false/main.c
+++ b/regression/k-induction/github_1092_1_false/main.c
@@ -1,0 +1,23 @@
+int main()
+{
+  int status = 0;
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+
+  do
+  {
+    __ESBMC_assert(status != 2, "");
+  } while(0);
+
+  return 0;
+}

--- a/regression/k-induction/github_1092_1_false/test.desc
+++ b/regression/k-induction/github_1092_1_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_1092_1_true/main.c
+++ b/regression/k-induction/github_1092_1_true/main.c
@@ -14,6 +14,7 @@ int main()
     }
   } // status = 1 U 2
 
+  // Kind algorithm struggles with this
   do
   {
     __ESBMC_assert(status != 3, "");

--- a/regression/k-induction/github_1092_1_true/main.c
+++ b/regression/k-induction/github_1092_1_true/main.c
@@ -1,0 +1,23 @@
+int main()
+{
+  int status = 0;
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+
+  do
+  {
+    __ESBMC_assert(status != 3, "");
+  } while(0);
+
+  return 0;
+}

--- a/regression/k-induction/github_1092_1_true/test.desc
+++ b/regression/k-induction/github_1092_1_true/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --interval-analysis
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_1_true/test.desc
+++ b/regression/k-induction/github_1092_1_true/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_1_true/test.desc
+++ b/regression/k-induction/github_1092_1_true/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction --interval-analysis
+--k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_2_false/main.c
+++ b/regression/k-induction/github_1092_2_false/main.c
@@ -1,0 +1,21 @@
+int main()
+{
+  int status = 0;
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+
+  while(1)
+    __ESBMC_assert(status != 2, "");
+
+  return 0;
+}

--- a/regression/k-induction/github_1092_2_false/test.desc
+++ b/regression/k-induction/github_1092_2_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_1092_2_true/main.c
+++ b/regression/k-induction/github_1092_2_true/main.c
@@ -1,0 +1,21 @@
+int main()
+{
+  int status = 0;
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+
+  while(1)
+    __ESBMC_assert(status != 3, "");
+
+  return 0;
+}

--- a/regression/k-induction/github_1092_2_true/test.desc
+++ b/regression/k-induction/github_1092_2_true/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_3_false/main.c
+++ b/regression/k-induction/github_1092_3_false/main.c
@@ -1,0 +1,21 @@
+int main()
+{
+  int status = 0;
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+
+  while(nondet_int())
+    __ESBMC_assert(status != 2, "");
+
+  return 0;
+}

--- a/regression/k-induction/github_1092_3_false/test.desc
+++ b/regression/k-induction/github_1092_3_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_1092_3_true/main.c
+++ b/regression/k-induction/github_1092_3_true/main.c
@@ -1,0 +1,21 @@
+int main()
+{
+  int status = 0;
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+
+  while(nondet_int())
+    __ESBMC_assert(status != 3, "");
+
+  return 0;
+}

--- a/regression/k-induction/github_1092_3_true/test.desc
+++ b/regression/k-induction/github_1092_3_true/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_4_false/main.c
+++ b/regression/k-induction/github_1092_4_false/main.c
@@ -13,6 +13,8 @@ int main()
       status = 2;
     }
   } // status = 1 U 2
+
+  // Kind struggles with do-while(0) loops
   do
   {
     __ESBMC_assert(status != 2, "");

--- a/regression/k-induction/github_1092_4_false/main.c
+++ b/regression/k-induction/github_1092_4_false/main.c
@@ -1,0 +1,21 @@
+int status = 0;
+int main()
+{
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+  do
+  {
+    __ESBMC_assert(status != 2, "");
+  } while(0);
+  return 0;
+}

--- a/regression/k-induction/github_1092_4_false/test.desc
+++ b/regression/k-induction/github_1092_4_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_1092_4_true/main.c
+++ b/regression/k-induction/github_1092_4_true/main.c
@@ -1,0 +1,21 @@
+int status = 0;
+int main()
+{
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+  do
+  {
+    __ESBMC_assert(status != 3, "");
+  } while(0);
+  return 0;
+}

--- a/regression/k-induction/github_1092_4_true/test.desc
+++ b/regression/k-induction/github_1092_4_true/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --interval-analysis
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_4_true/test.desc
+++ b/regression/k-induction/github_1092_4_true/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_4_true/test.desc
+++ b/regression/k-induction/github_1092_4_true/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction --interval-analysis
+--k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_1092_5_false/main.c
+++ b/regression/k-induction/github_1092_5_false/main.c
@@ -1,0 +1,30 @@
+int status = 0;
+int foo()
+{
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+}
+
+int bar()
+{
+  do
+  {
+    __ESBMC_assert(status != 2, "");
+  } while(0);
+}
+int main()
+{
+  foo();
+  bar();
+  return 0;
+}

--- a/regression/k-induction/github_1092_5_false/test.desc
+++ b/regression/k-induction/github_1092_5_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/k-induction/github_1092_5_true/main.c
+++ b/regression/k-induction/github_1092_5_true/main.c
@@ -1,0 +1,30 @@
+int status = 0;
+int foo()
+{
+  // status = *
+  while(__VERIFIER_nondet_int()) // __verifier_nondet_int$1 = *
+  {
+    if(!status) // status = *
+    {
+      status = 1;
+    }
+    else if(status == 1)
+    {
+      status = 2;
+    }
+  } // status = 1 U 2
+}
+
+int bar()
+{
+  do
+  {
+    __ESBMC_assert(status != 3, "");
+  } while(0);
+}
+int main()
+{
+  foo();
+  bar();
+  return 0;
+}

--- a/regression/k-induction/github_1092_5_true/test.desc
+++ b/regression/k-induction/github_1092_5_true/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -566,6 +566,12 @@ void goto_convertt::do_function_call_symbol(
       log_error("{} expected not to have LHS", id2string(base_name));
       abort();
     }
+
+    // ASSERTIONS BECOME ASSUMES :)
+    goto_programt::targett a = dest.add_instruction(ASSUME);
+    a->guard = t->guard;
+    a->location = function.location();
+    a->location.user_provided(true);
   }
   else if(
     base_name == "__VERIFIER_error" || base_name == "reach_error" ||

--- a/src/goto-programs/goto_k_induction.cpp
+++ b/src/goto-programs/goto_k_induction.cpp
@@ -7,20 +7,18 @@
 
 void goto_k_induction(goto_functionst &goto_functions)
 {
-  loopst::loop_varst inductive_vars;
   Forall_goto_functions(it, goto_functions)
     if(it->second.body_available)
-      goto_k_inductiont(it->first, goto_functions, it->second, inductive_vars);
+      goto_k_inductiont(it->first, goto_functions, it->second);
 
   goto_functions.update();
 }
 
 void goto_termination(goto_functionst &goto_functions)
 {
-  loopst::loop_varst inductive_vars;
   Forall_goto_functions(it, goto_functions)
     if(it->second.body_available)
-      goto_k_inductiont(it->first, goto_functions, it->second, inductive_vars);
+      goto_k_inductiont(it->first, goto_functions, it->second);
   goto_functions.update();
 
   auto function = goto_functions.function_map.find("__ESBMC_main");
@@ -52,32 +50,13 @@ void goto_termination(goto_functionst &goto_functions)
   function->second.body.insert_swap(it, dest);
 }
 
-// TODO: change this to reverse_view when we go for C++20
-#include <boost/range/adaptor/reversed.hpp>
-
 void goto_k_inductiont::goto_k_induction()
 {
   // Full unwind the program
-  for(auto &function_loop : boost::adaptors::reverse(function_loops))
+  for(auto &function_loop : function_loops)
   {
-    for(auto &v : function_loop.get_modified_loop_vars())
-      inductive_vars.insert(v);
-
     if(function_loop.get_modified_loop_vars().empty())
-    {
-      bool should_skip = true;
-
-      for(auto v : function_loop.get_unmodified_loop_vars())
-      {
-        if(inductive_vars.count(v))
-        {
-          should_skip = false;
-          break;
-        }
-      }
-      if(should_skip)
-        continue;
-    }
+      continue;
 
     // Start the loop conversion
     convert_finite_loop(function_loop);

--- a/src/goto-programs/goto_k_induction.h
+++ b/src/goto-programs/goto_k_induction.h
@@ -16,8 +16,10 @@ public:
   goto_k_inductiont(
     const irep_idt &_function_name,
     goto_functionst &_goto_functions,
-    goto_functiont &_goto_function)
-    : goto_loopst(_function_name, _goto_functions, _goto_function)
+    goto_functiont &_goto_function,
+    loopst::loop_varst _inductive_vars)
+    : goto_loopst(_function_name, _goto_functions, _goto_function),
+      inductive_vars(_inductive_vars)
   {
     if(function_loops.size())
       goto_k_induction();
@@ -29,6 +31,8 @@ protected:
 
   typedef std::unordered_map<unsigned, guardt> guardst;
   guardst guards;
+
+  loopst::loop_varst &inductive_vars;
 
   void goto_k_induction();
 

--- a/src/goto-programs/goto_k_induction.h
+++ b/src/goto-programs/goto_k_induction.h
@@ -16,10 +16,9 @@ public:
   goto_k_inductiont(
     const irep_idt &_function_name,
     goto_functionst &_goto_functions,
-    goto_functiont &_goto_function,
-    loopst::loop_varst _inductive_vars)
-    : goto_loopst(_function_name, _goto_functions, _goto_function),
-      inductive_vars(_inductive_vars)
+    goto_functiont &_goto_function)
+    : goto_loopst(_function_name, _goto_functions, _goto_function)
+
   {
     if(function_loops.size())
       goto_k_induction();
@@ -31,8 +30,6 @@ protected:
 
   typedef std::unordered_map<unsigned, guardt> guardst;
   guardst guards;
-
-  loopst::loop_varst &inductive_vars;
 
   void goto_k_induction();
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -435,7 +435,7 @@ bool goto_symext::get_unwind(
   const BigInt &unwind)
 {
   unsigned id = source.pc->loop_number;
-  BigInt this_loop_max_unwind = max_unwind;
+  BigInt this_loop_max_unwind = inductive_step ? max_unwind : max_unwind + 1;
 
   if(unwind_set.count(id) != 0)
     this_loop_max_unwind = unwind_set[id];

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -435,7 +435,7 @@ bool goto_symext::get_unwind(
   const BigInt &unwind)
 {
   unsigned id = source.pc->loop_number;
-  BigInt this_loop_max_unwind = inductive_step ? max_unwind : max_unwind + 1;
+  BigInt this_loop_max_unwind = !inductive_step ? max_unwind : max_unwind + 1;
 
   if(unwind_set.count(id) != 0)
     this_loop_max_unwind = unwind_set[id];

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -58,7 +58,7 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
   if(inductive_step && first_loop && !cur_state->source.pc->inductive_assertion)
   {
     BigInt unwind = cur_state->loop_iterations[first_loop];
-    if(unwind < (max_unwind - 1))
+    if(unwind < (max_unwind - 2))
     {
       assume(claim_expr);
       return;


### PR DESCRIPTION
Fixes #1092 

This PR does two things:

1. Forces the max unwind of loops to be of k+1 (also, applies to the Assertions during symex).

2. Propagates esbmc Asserts into assumes after their execution. I am not so sure about this fix as I did it because reach error does it (and this fix the issue). @mikhailramalho any idea on the reasoning here?