### PR TITLE
Fixed missing argument in copy constructor

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates19/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates19/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -457,7 +457,7 @@ void goto_convertt::convert_expression(const codet &code, goto_programt &dest)
   }
   else
   {
-    remove_sideeffects(expr, dest, false); // result not used
+    remove_sideeffects(expr, dest, false);
 
     if(expr.is_not_nil())
     {

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -131,8 +131,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   targets.has_return_value = f.type.return_type().id() != "empty" &&
                              f.type.return_type().id() != "constructor" &&
                              f.type.return_type().id() != "destructor";
-  if(symbol.id == "c:@F@main#")
-    printf("Got it\n");
+
   goto_convert_rec(code, f.body);
 
   // add non-det return value, if needed

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -83,6 +83,8 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   irep_idt identifier = symbol.id;
 
   // Apply a SFINAE test: discard unused C++ templates.
+  // Note: can be removed probably? as the new clang-cpp-frontend should've
+  // done a pretty good job at resolving template overloading
   if(
     symbol.value.get("#speculative_template") == "1" &&
     symbol.value.get("#template_in_use") != "1")
@@ -363,7 +365,7 @@ void goto_convert_functionst::thrash_type_symbols()
   // in a struct to itself, this breaks down. Therefore, don't rename types of
   // pointers; they have a type already; they're pointers.
 
-  // Collect a list of all type names. This it required before this entire
+  // Collect a list of all type names. This is required before this entire
   // thing has no types, and there's no way (in C++ converted code at least)
   // to decide what name is a type or not.
   typename_sett names;

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -131,7 +131,8 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   targets.has_return_value = f.type.return_type().id() != "empty" &&
                              f.type.return_type().id() != "constructor" &&
                              f.type.return_type().id() != "destructor";
-
+  if(symbol.id == "c:@F@main#")
+    printf("Got it\n");
   goto_convert_rec(code, f.body);
 
   // add non-det return value, if needed

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -166,7 +166,7 @@ void goto_functionst::dump() const
 {
   std::ostringstream oss;
   output(*migrate_namespace_lookup, oss);
-  log_debug("{}", oss.str());
+  log_status("{}", oss.str());
 }
 
 void goto_functionst::output(const namespacet &ns, std::ostream &out) const

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -6,7 +6,7 @@ void goto_programt::instructiont::dump() const
 {
   std::ostringstream oss;
   output_instruction(*migrate_namespace_lookup, "", oss);
-  log_debug("{}", oss.str());
+  log_status("{}", oss.str());
 }
 
 void goto_programt::instructiont::output_instruction(
@@ -488,7 +488,7 @@ void goto_programt::dump() const
 {
   std::ostringstream oss;
   output(*migrate_namespace_lookup, "", oss);
-  log_debug("{}", oss.str());
+  log_status("{}", oss.str());
 }
 
 void goto_programt::get_decl_identifiers(

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -581,43 +581,9 @@ public:
   //! Copy a full goto program, preserving targets
   void copy_from(const goto_programt &src);
 
-  //! Does the goto program have an assertion?
-  bool has_assertion() const;
-
   typedef std::set<irep_idt> decl_identifierst;
   /// get the variables in decl statements
   void get_decl_identifiers(decl_identifierst &decl_identifiers) const;
-
-  // Template for extracting instructions /from/ a goto program, to a type
-  // abstract something else.
-  template <
-    typename OutList,
-    typename ListAppender,
-    typename OutElem,
-    typename SetAttrObj,
-    typename SetAttrNil>
-  void extract_instructions(
-    OutList &list,
-    ListAppender listappend,
-    SetAttrObj setattrobj,
-    SetAttrNil setattrnil) const;
-
-  // Template for extracting instructions /from/ a type abstract something,
-  // to a goto program.
-  template <
-    typename InList,
-    typename InElem,
-    typename FetchElem,
-    typename ElemToInsn,
-    typename GetAttr,
-    typename IsAttrNil>
-  void inject_instructions(
-    InList list,
-    unsigned int len,
-    FetchElem fetchelem,
-    ElemToInsn elemtoinsn,
-    GetAttr getattr,
-    IsAttrNil isattrnil);
 };
 
 bool operator<(


### PR DESCRIPTION
Fixed https://github.com/esbmc/esbmc/issues/1104

GOTO before:
```
        A return_value$_A$1;
        // 39 
        FUNCTION_CALL:  return_value$_A$1=A(&a2)
```

GOTO after:
```
        A return_value$_A$1;
        // 39
        FUNCTION_CALL:  A(&return_value$_A$1, &a2)
```

Enabled 1 TC: 
- `cbmc/Templates19`