### PR TITLE
Decouple TC20/36/39 from zero initialization

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/1103_TC20/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC20/main.cpp
@@ -1,0 +1,43 @@
+// This is the original TC for cbmc/Templates20, WITH zero init assumption
+#include <cassert>
+
+struct A
+{
+  int i;
+  A():i(10){}
+
+private:
+  A(const A& a); // disabled
+};
+
+template <class T>
+class B: A {
+public:
+  T t;
+  B(){};
+  int get_i(){ return i; }
+
+private:
+  B(B<T>& b); // disabled
+};
+
+
+template <>
+class B<bool>: A {
+public:
+  bool b;
+  B():b(true){};
+  int get_i(){ return i; }
+
+private:
+  B(B<bool>& b); // disabled
+};
+
+B<int> b1;
+
+int main()
+{
+  assert(b1.t == 0);
+  B<bool> b2;
+  assert(b2.b == true);
+}

--- a/regression/esbmc-cpp/bug_fixes/1103_TC20/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC20/test.desc
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-cpp</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
+  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+  <item_10_mode>KNOWNBUG</item_10_mode>
+</test-case>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC20/testllvm.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC20/testllvm.desc
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-cpp</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=10 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+</test-case>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC36/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC36/main.cpp
@@ -1,0 +1,33 @@
+// This is the original TC for cbmc/Templates36, WITH zero init assumption
+#include<cassert>
+
+// The orering of the following matters!
+class FF
+{
+public:
+  typedef int f;
+};
+
+// declare Z<>
+template <typename T>
+class Z;
+
+// make an instance of Z<>
+typedef Z<FF> my_Z;
+
+// now define Z<>
+template <typename T>
+class Z
+{
+public:
+  typename T::f some;
+};
+
+// trigger elaboration of Z<FF>
+my_Z z;
+
+int main()
+{
+  assert(z.some==0);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1103_TC36/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC36/test.desc
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-cpp</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
+  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+  <item_10_mode>KNOWNBUG</item_10_mode>
+</test-case>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC36/testllvm.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC36/testllvm.desc
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-cpp</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=10 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+</test-case>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC39/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC39/main.cpp
@@ -1,0 +1,32 @@
+// This is the original TC for cbmc/Templates, WITH zero init assumption
+#include<cassert>
+
+// define Z<>
+template <typename T>
+class Z
+{
+public:
+  typename T::f some;
+};
+
+// Forward declaration of FF
+class FF;
+
+// make an instance of Z<FF>
+typedef Z<FF> my_Z;
+
+// Declare FF
+class FF
+{
+public:
+  typedef int f;
+};
+
+// trigger elaboration of Z<FF>
+my_Z z;
+
+int main()
+{
+  assert(z.some==0);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1103_TC39/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC39/test.desc
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-cpp</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
+  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+  <item_10_mode>KNOWNBUG</item_10_mode>
+</test-case>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC39/testllvm.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC39/testllvm.desc
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test-case>
+  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
+  <item_02_id>esbmc-cpp</item_02_id>
+  <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=10 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_07_test_importance>High</item_07_test_importance>
+  <item_08_execution_type>Automated</item_08_execution_type>
+  <item_09_author>Ceteli/UFAM</item_09_author>
+</test-case>

--- a/regression/esbmc-cpp/cbmc/Templates20/main.cpp
+++ b/regression/esbmc-cpp/cbmc/Templates20/main.cpp
@@ -1,3 +1,7 @@
+/*
+ * TC description:
+ *  class template, type parameter, explicit specialization, inheritance
+ */
 #include <cassert>
 
 struct A
@@ -36,7 +40,8 @@ B<int> b1;
 
 int main()
 {
-  assert(b1.t == 0);
+  b1.t = 20;
+  assert(b1.t == 20);
   B<bool> b2;
   assert(b2.b == true);
 }

--- a/regression/esbmc-cpp/cbmc/Templates20/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates20/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates36/main.cpp
+++ b/regression/esbmc-cpp/cbmc/Templates36/main.cpp
@@ -1,3 +1,7 @@
+/*
+ * TC descirption:
+ * class template, UDT for type parameter
+ */
 #include<cassert>
 
 // The orering of the following matters!
@@ -27,6 +31,7 @@ my_Z z;
 
 int main()
 {
-  assert(z.some==0);
+  z.some = 36;
+  assert(z.some==36);
   return 0;
 }

--- a/regression/esbmc-cpp/cbmc/Templates36/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates36/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cbmc/Templates39/main.cpp
+++ b/regression/esbmc-cpp/cbmc/Templates39/main.cpp
@@ -1,3 +1,7 @@
+/*
+ * TC description:
+ *  class template, UDT(class) for type parameter, implicit template instantiation, data member has dependent type
+ */
 #include<cassert>
 
 // define Z<>
@@ -26,6 +30,7 @@ my_Z z;
 
 int main()
 {
-  assert(z.some==0);
+  z.some = 39;
+  assert(z.some==39);
   return 0;
 }

--- a/regression/esbmc-cpp/cbmc/Templates39/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates39/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>


### PR DESCRIPTION
Decouple TC20/36/39 from zero initialization, and enabled these TCs. 

The objective of TCs should focus * ONLY * on template, rather than a mix of template and zero initialization, which is another issue covered by https://github.com/esbmc/esbmc/issues/1103 in our backlog. 


