### PR TITLE
Restore some smtlib functionality with external solver

### DIFF
--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -233,7 +233,6 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
       abort();
     }
   }
-#endif
   // Execution continues as the parent ESBMC process. Child dying will
   // trigger SIGPIPE or an EOF eventually, which we'll be able to detect
   // and crash upon.
@@ -299,6 +298,7 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
     solver_name,
     solver_version,
     solver_proc_pid);
+#endif
 }
 
 smtlib_convt::process_emitter::~process_emitter() noexcept
@@ -307,8 +307,10 @@ smtlib_convt::process_emitter::~process_emitter() noexcept
     fclose(out_stream);
   if(in_stream)
     fclose(in_stream);
+#ifndef _WIN32
   if(org_sigpipe_handler)
     signal(SIGPIPE, reinterpret_cast<void (*)(int)>(org_sigpipe_handler));
+#endif
 }
 
 smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -159,7 +159,6 @@ void smtlib_convt::dump_smt()
 smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
   : smt_convt(_ns, _options), array_iface(false, false), fp_convt(this)
 {
-  temp_sym_count.push_back(1);
   std::string cmd;
 
   std::string logic =
@@ -802,8 +801,9 @@ bool smtlib_convt::get_bool(smt_astt a)
   emit("(get-value (");
 
   std::string output;
+  unsigned long temp_sym_counter = 1UL;
   unsigned int brace_level =
-    emit_ast(static_cast<const smtlib_smt_ast *>(a), output, temp_sym_count.back());
+    emit_ast(static_cast<const smtlib_smt_ast *>(a), output, temp_sym_counter);
   emit("%s", output.c_str());
 
   // Emit a ton of end braces.
@@ -884,7 +884,8 @@ void smtlib_convt::assert_ast(smt_astt a)
   // braces are required.
   // This is inspired by the output from Z3 that I've seen.
   std::string output;
-  unsigned int brace_level = emit_ast(sa, output, temp_sym_count.back());
+  unsigned long temp_sym_counter = 1UL;
+  unsigned int brace_level = emit_ast(sa, output, temp_sym_counter);
 
   // Emit the final temporary symbol - this is what gets asserted.
   emit("%s", output.c_str());
@@ -1043,7 +1044,6 @@ int smtliberror(int startsym [[maybe_unused]], const std::string &error)
 void smtlib_convt::push_ctx()
 {
   smt_convt::push_ctx();
-  temp_sym_count.push_back(temp_sym_count.back());
 
   emit("(push 1)\n");
 }
@@ -1550,7 +1550,6 @@ void smtlib_convt::pop_ctx()
   // Wipe this level of symbol table.
   symbol_tablet::nth_index<1>::type &syms_numindex = symbol_table.get<1>();
   syms_numindex.erase(ctx_level);
-  temp_sym_count.pop_back();
 
   smt_convt::pop_ctx();
 }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -7,8 +7,8 @@
 #include <smtlib_tok.hpp>
 #include <sstream>
 #ifndef _WIN32
-# include <unistd.h>
-# include <signal.h>
+#include <unistd.h>
+#include <signal.h>
 #endif
 
 /** Mapping of SMT function IDs to their names. */
@@ -145,7 +145,7 @@ void smtlib_convt::dump_smt()
 }
 
 smtlib_convt::file_emitter::file_emitter(const std::string &path)
-: out_stream(nullptr)
+  : out_stream(nullptr)
 {
   // We may be being instructed to just output to a file.
   if(path == "")
@@ -167,9 +167,7 @@ smtlib_convt::file_emitter::~file_emitter()
 }
 
 smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
-: out_stream(nullptr)
-, in_stream(nullptr)
-, org_sigpipe_handler(nullptr)
+  : out_stream(nullptr), in_stream(nullptr), org_sigpipe_handler(nullptr)
 {
   if(cmd == "")
     return;
@@ -360,9 +358,9 @@ std::string smtlib_convt::sort_to_string(const smt_sort *s) const
   }
 }
 
-unsigned int
-smtlib_convt::emit_terminal_ast(const smtlib_smt_ast *ast, std::string &output)
-  const
+unsigned int smtlib_convt::emit_terminal_ast(
+  const smtlib_smt_ast *ast,
+  std::string &output) const
 {
   std::stringstream ss;
   const smtlib_smt_sort *sort = static_cast<const smtlib_smt_sort *>(ast->sort);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -269,7 +269,7 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
   delete smtlib_output;
 
   // Duplicate / boilerplate;
-  emit("(get-info :version)\n");
+  emit("%s", "(get-info :version)\n");
   flush();
   smtlib_send_start_code = 1;
   smtlibparse(TOK_START_INFO);
@@ -468,7 +468,7 @@ unsigned int smtlib_convt::emit_ast(
     emit(" %s", args[i].c_str());
 
   // End func enclosing brace, then operand to let (two braces).
-  emit(")))\n");
+  emit("%s", ")))\n");
 
   // We end with one additional brace level.
   output = tempname;
@@ -507,7 +507,7 @@ void smtlib_smt_ast::dump() const
   FILE *tmp_proc = std::exchange(ctx_m->emit_proc.out_stream, nullptr);
 
   ctx->emit_ast(this);
-  ctx->emit("\n");
+  ctx->emit("%s", "\n");
   ctx->flush();
 
   ctx_m->emit_opt_output.out_stream = tmp_file;
@@ -523,7 +523,7 @@ smt_convt::resultt smtlib_convt::dec_solve()
   // Emit constraints
   // check-sat
 
-  emit("(check-sat)\n");
+  emit("%s", "(check-sat)\n");
 
   // Flush out command, starting model check
   flush();
@@ -853,11 +853,11 @@ bool smtlib_convt::get_bool(smt_astt a)
 {
   assert(emit_proc);
 
-  emit("(get-value (");
+  emit("%s", "(get-value (");
 
   emit_ast(static_cast<const smtlib_smt_ast *>(a));
 
-  emit("))\n");
+  emit("%s", "))\n");
   flush();
 
   smtlib_send_start_code = 1;
@@ -923,12 +923,12 @@ void smtlib_convt::assert_ast(smt_astt a)
   const smtlib_smt_ast *sa = static_cast<const smtlib_smt_ast *>(a);
 
   // Encode an assertion
-  emit("(assert\n");
+  emit("%s", "(assert\n");
 
   emit_ast(sa);
 
   // Final brace for closing the 'assert'.
-  emit(")\n");
+  emit("%s", ")\n");
 }
 
 smt_astt smtlib_convt::mk_smt_int(const BigInt &theint)
@@ -1075,7 +1075,7 @@ void smtlib_convt::push_ctx()
 {
   smt_convt::push_ctx();
 
-  emit("(push 1)\n");
+  emit("%s", "(push 1)\n");
 }
 
 smt_astt smtlib_convt::mk_add(smt_astt a, smt_astt b)
@@ -1575,7 +1575,7 @@ smt_astt smtlib_convt::mk_isint(smt_astt a)
 
 void smtlib_convt::pop_ctx()
 {
-  emit("(pop 1)\n");
+  emit("%s", "(pop 1)\n");
 
   // Wipe this level of symbol table.
   symbol_tablet::nth_index<1>::type &syms_numindex = symbol_table.get<1>();

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -214,7 +214,7 @@ smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
     close(inpipe[1]);
 
     // Voila
-    execlp(cmd.c_str(), cmd.c_str(), NULL);
+    execlp("sh", "sh", "-c", cmd.c_str(), NULL);
     log_error("Exec of smtlib solver failed");
     abort();
   }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -213,9 +213,17 @@ smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
     close(outpipe[0]);
     close(inpipe[1]);
 
+    const char *shell = getenv("SHELL");
+    if(!shell || !*shell)
+      shell = "sh";
+
     // Voila
-    execlp("sh", "sh", "-c", cmd.c_str(), NULL);
-    log_error("Exec of smtlib solver failed");
+    execlp(shell, shell, "-c", cmd.c_str(), NULL);
+    log_error(
+      "Exec of smtlib solver failed: {} -c {}: {}",
+      shell,
+      cmd,
+      strerror(errno));
     abort();
   }
   else

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -241,9 +241,9 @@ smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
   // Point lexer input at output stream
   smtlib_tokin = in_stream;
 
+  fprintf(out_stream, "(set-option :produce-models true)\n");
   fprintf(out_stream, "(set-logic %s)\n", logic.c_str());
   fprintf(out_stream, "(set-info :status unknown)\n");
-  fprintf(out_stream, "(set-option :produce-models true)\n");
 
   // Fetch solver name and version.
   fprintf(out_stream, "(get-info :name)\n");

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -284,7 +284,7 @@ smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
     "More than one sexpr response to get-info version");
   class sexpr &v = sexpr->sexpr_list.front();
 
-  if(v.token == 0 && v.sexpr_list.size() == 2)
+  if(v.token == 0 && v.sexpr_list.size() != 2)
   {
     log_error("Bad solver version fmt");
     abort();

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -392,10 +392,10 @@ smtlib_convt::emit_terminal_ast(const smtlib_smt_ast *ast, std::string &output)
         sort->get_data_width() <= 64 &&
         "smtlib printer assumes no numbers more "
         "than 64 bits wide, sorry");
-      unsigned int theval = ast->intval.to_uint64();
+      uint64_t theval = ast->intval.to_uint64();
       if(sort->get_data_width() < 64)
       {
-        unsigned int mask = 1ULL << sort->get_data_width();
+        uint64_t mask = 1ULL << sort->get_data_width();
         mask -= 1;
         theval &= mask;
       }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -11,7 +11,8 @@
 # include <signal.h>
 #endif
 
-const std::string smtlib_convt::smt_func_name_table[expr2t::end_expr_id] = {
+/** Mapping of SMT function IDs to their names. */
+static const std::array smt_func_name_table = {
   "hack_func_id",
   "invalid_func_id",
   "int_func_id",
@@ -424,6 +425,7 @@ unsigned int
 smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output)
 {
   unsigned int brace_level = 0;
+  assert(ast->args.size() <= 4);
   std::string args[4];
 
   switch(ast->kind)
@@ -454,7 +456,7 @@ smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output)
   emit("(let ((%s (", tempname.c_str());
 
   // This asts function
-  assert(static_cast<int>(ast->kind) <= static_cast<int>(expr2t::end_expr_id));
+  assert(static_cast<size_t>(ast->kind) < smt_func_name_table.size());
   if(ast->kind == SMT_FUNC_EXTRACT)
   {
     // Extract is an indexed function
@@ -462,7 +464,7 @@ smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output)
   }
   else
   {
-    emit("%s", smt_func_name_table[ast->kind].c_str());
+    emit("%s", smt_func_name_table[ast->kind]);
   }
 
   // Its operands

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -413,8 +413,10 @@ unsigned int smtlib_convt::emit_terminal_ast(
   }
 }
 
-unsigned int
-smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output, unsigned long &temp_sym_counter) const
+unsigned int smtlib_convt::emit_ast(
+  const smtlib_smt_ast *ast,
+  std::string &output,
+  unsigned long &temp_sym_counter) const
 {
   unsigned int brace_level = 0;
   assert(ast->args.size() <= 4);
@@ -434,8 +436,10 @@ smtlib_convt::emit_ast(const smtlib_smt_ast *ast, std::string &output, unsigned 
   }
 
   for(unsigned long int i = 0; i < ast->args.size(); i++)
-    brace_level +=
-      emit_ast(static_cast<const smtlib_smt_ast *>(ast->args[i]), args[i], temp_sym_counter);
+    brace_level += emit_ast(
+      static_cast<const smtlib_smt_ast *>(ast->args[i]),
+      args[i],
+      temp_sym_counter);
 
   // Get a temporary sym name
   unsigned int tempnum = temp_sym_counter++;
@@ -783,13 +787,13 @@ static std::string read_all(FILE *in)
 {
   std::string r;
   char buf[4096];
-  for (size_t rd; (rd = fread(buf, 1, sizeof(buf), in));)
+  for(size_t rd; (rd = fread(buf, 1, sizeof(buf), in));)
     r.insert(r.size(), buf, rd);
   return r;
 }
 
 template <typename... Ts>
-void smtlib_convt::emit(const Ts &... ts) const
+void smtlib_convt::emit(const Ts &...ts) const
 {
   if(emit_proc)
     emit_proc.emit(ts...);
@@ -811,7 +815,7 @@ smtlib_convt::process_emitter::operator bool() const noexcept
 }
 
 template <typename... Ts>
-void smtlib_convt::process_emitter::emit(Ts &&... ts) const
+void smtlib_convt::process_emitter::emit(Ts &&...ts) const
 {
   /* TODO: other error handling */
   errno = 0;
@@ -833,7 +837,7 @@ smtlib_convt::file_emitter::operator bool() const noexcept
 }
 
 template <typename... Ts>
-void smtlib_convt::file_emitter::emit(Ts &&... ts) const
+void smtlib_convt::file_emitter::emit(Ts &&...ts) const
 {
   /* TODO: error handling */
   fprintf(out_stream, ts...);
@@ -983,10 +987,7 @@ smt_astt smtlib_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
     return a;
 
   // As this is the first time, declare that symbol to the solver.
-  emit(
-    "(declare-fun |%s| () %s)\n",
-    name.c_str(),
-    sort_to_string(s).c_str());
+  emit("(declare-fun |%s| () %s)\n", name.c_str(), sort_to_string(s).c_str());
 
   return a;
 }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -226,7 +226,7 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
     out_stream = fdopen(outpipe[1], "w");
     in_stream = fdopen(inpipe[0], "r");
 
-    org_sigpipe_handler = (void *)signal(SIGPIPE, SIG_IGN);
+    org_sigpipe_handler = reinterpret_cast<void *>(signal(SIGPIPE, SIG_IGN));
     if(org_sigpipe_handler == SIG_ERR)
     {
       log_error("registering SIGPIPE handler: {}", strerror(errno));
@@ -308,7 +308,7 @@ smtlib_convt::process_emitter::~process_emitter() noexcept
   if(in_stream)
     fclose(in_stream);
   if(org_sigpipe_handler)
-    signal(SIGPIPE, (sighandler_t)org_sigpipe_handler);
+    signal(SIGPIPE, reinterpret_cast<void (*)(int)>(org_sigpipe_handler));
 }
 
 smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -160,7 +160,7 @@ smtlib_convt::file_emitter::file_emitter(const std::string &path)
   }
 }
 
-smtlib_convt::file_emitter::~file_emitter()
+smtlib_convt::file_emitter::~file_emitter() noexcept
 {
   if(out_stream)
     fclose(out_stream);
@@ -301,7 +301,7 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
     solver_proc_pid);
 }
 
-smtlib_convt::process_emitter::~process_emitter()
+smtlib_convt::process_emitter::~process_emitter() noexcept
 {
   if(out_stream)
     fclose(out_stream);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -815,11 +815,11 @@ smtlib_convt::process_emitter::operator bool() const noexcept
 }
 
 template <typename... Ts>
-void smtlib_convt::process_emitter::emit(Ts &&...ts) const
+void smtlib_convt::process_emitter::emit(const char *fmt, Ts &&...ts) const
 {
   /* TODO: other error handling */
   errno = 0;
-  if(fprintf(out_stream, ts...) < 0 && errno == EPIPE)
+  if(fprintf(out_stream, fmt, ts...) < 0 && errno == EPIPE)
     throw external_process_died(read_all(in_stream));
 }
 
@@ -837,10 +837,10 @@ smtlib_convt::file_emitter::operator bool() const noexcept
 }
 
 template <typename... Ts>
-void smtlib_convt::file_emitter::emit(Ts &&...ts) const
+void smtlib_convt::file_emitter::emit(const char *fmt, Ts &&...ts) const
 {
   /* TODO: error handling */
-  fprintf(out_stream, ts...);
+  fprintf(out_stream, fmt, ts...);
 }
 
 void smtlib_convt::file_emitter::flush() const

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -242,7 +242,7 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
   smtlib_tokin = in_stream;
 
   // Fetch solver name and version.
-  emit("(get-info :name)\n");
+  emit("%s", "(get-info :name)\n");
   flush();
   smtlib_send_start_code = 1;
   smtlibparse(TOK_START_INFO);
@@ -321,9 +321,9 @@ smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
   std::string logic =
     options.get_bool_option("int-encoding") ? "QF_AUFLIRA" : "QF_AUFBV";
 
-  emit("(set-option :produce-models true)\n");
+  emit("%s", "(set-option :produce-models true)\n");
   emit("(set-logic %s)\n", logic.c_str());
-  emit("(set-info :status unknown)\n");
+  emit("%s", "(set-info :status unknown)\n");
 }
 
 smtlib_convt::~smtlib_convt()

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -267,12 +267,16 @@ public:
   get_array_elem(smt_astt array, uint64_t index, const type2tc &type) override;
 
   std::string sort_to_string(const smt_sort *s) const;
+
   unsigned int
   emit_terminal_ast(const smtlib_smt_ast *a, std::string &output) const;
+
   unsigned int emit_ast(
     const smtlib_smt_ast *ast,
     std::string &output,
     unsigned long &temp_sym_counter) const;
+
+  void emit_ast(const smtlib_smt_ast *ast) const;
 
   void push_ctx() override;
   void pop_ctx() override;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -284,15 +284,51 @@ public:
   void dump_smt() override;
 
   template <typename... Ts>
-  void emit(Ts &&...) const;
+  void emit(const Ts &...) const;
   void flush() const;
 
   // Members
-  FILE *out_stream;
-  FILE *in_stream;
-  void *org_sigpipe_handler;
-  std::string solver_name;
-  std::string solver_version;
+
+  struct process_emitter
+  {
+    FILE *out_stream;
+    FILE *in_stream;
+    void *org_sigpipe_handler; /* TODO: static */
+
+    std::string solver_name;
+    std::string solver_version;
+
+    explicit process_emitter(const std::string &cmd);
+    process_emitter(const process_emitter &) = delete;
+
+    ~process_emitter() noexcept;
+
+    process_emitter & operator=(const process_emitter &) = delete;
+
+    template <typename... Ts>
+    void emit(Ts &&...) const;
+    void flush() const;
+
+    explicit operator bool() const noexcept;
+  } emit_proc;
+
+  struct file_emitter
+  {
+    FILE *out_stream;
+
+    explicit file_emitter(const std::string &path);
+    file_emitter(const file_emitter &) = delete;
+
+    ~file_emitter() noexcept;
+
+    file_emitter & operator=(const file_emitter &) = delete;
+
+    template <typename... Ts>
+    void emit(Ts &&...) const;
+    void flush() const;
+
+    explicit operator bool() const noexcept;
+  } emit_opt_output;
 
   // Actual solving data
   // The set of symbols and their sorts.

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -303,7 +303,7 @@ public:
 
     ~process_emitter() noexcept;
 
-    process_emitter & operator=(const process_emitter &) = delete;
+    process_emitter &operator=(const process_emitter &) = delete;
 
     template <typename... Ts>
     void emit(Ts &&...) const;
@@ -321,7 +321,7 @@ public:
 
     ~file_emitter() noexcept;
 
-    file_emitter & operator=(const file_emitter &) = delete;
+    file_emitter &operator=(const file_emitter &) = delete;
 
     template <typename... Ts>
     void emit(Ts &&...) const;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -306,7 +306,7 @@ public:
     process_emitter &operator=(const process_emitter &) = delete;
 
     template <typename... Ts>
-    void emit(Ts &&...) const;
+    void emit(const char *fmt, Ts &&...) const;
     void flush() const;
 
     explicit operator bool() const noexcept;
@@ -324,7 +324,7 @@ public:
     file_emitter &operator=(const file_emitter &) = delete;
 
     template <typename... Ts>
-    void emit(Ts &&...) const;
+    void emit(const char *fmt, Ts &&...) const;
     void flush() const;
 
     explicit operator bool() const noexcept;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -308,9 +308,6 @@ public:
   std::vector<unsigned long> temp_sym_count;
   static const std::string temp_prefix;
 
-  /** Mapping of SMT function IDs to their names. XXX, incorrect size. */
-  static const std::string smt_func_name_table[expr2t::end_expr_id];
-
   struct external_process_died : std::runtime_error
   {
     using std::runtime_error::runtime_error;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -311,7 +311,7 @@ public:
     symbol_tablet;
 
   symbol_tablet symbol_table;
-  std::vector<unsigned long> temp_sym_count;
+
   static const std::string temp_prefix;
 
   struct external_process_died : std::runtime_error

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -265,8 +265,12 @@ public:
   get_array_elem(smt_astt array, uint64_t index, const type2tc &type) override;
 
   std::string sort_to_string(const smt_sort *s) const;
-  unsigned int emit_terminal_ast(const smtlib_smt_ast *a, std::string &output);
-  unsigned int emit_ast(const smtlib_smt_ast *ast, std::string &output);
+  unsigned int
+  emit_terminal_ast(const smtlib_smt_ast *a, std::string &output) const;
+  unsigned int emit_ast(
+    const smtlib_smt_ast *ast,
+    std::string &output,
+    unsigned long &temp_sym_counter) const;
 
   void push_ctx() override;
   void pop_ctx() override;
@@ -274,8 +278,8 @@ public:
   void dump_smt() override;
 
   template <typename... Ts>
-  void emit(Ts &&...);
-  void flush();
+  void emit(Ts &&...) const;
+  void flush() const;
 
   // Members
   FILE *out_stream;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -273,9 +273,14 @@ public:
 
   void dump_smt() override;
 
+  template <typename... Ts>
+  void emit(Ts &&...);
+  void flush();
+
   // Members
   FILE *out_stream;
   FILE *in_stream;
+  void *org_sigpipe_handler;
   std::string solver_name;
   std::string solver_version;
 
@@ -305,6 +310,11 @@ public:
 
   /** Mapping of SMT function IDs to their names. XXX, incorrect size. */
   static const std::string smt_func_name_table[expr2t::end_expr_id];
+
+  struct external_process_died : std::runtime_error
+  {
+    using std::runtime_error::runtime_error;
+  };
 };
 
 #endif /* _ESBMC_SOLVERS_SMTLIB_SMTLIB_CONV_H */

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -161,6 +161,8 @@ public:
   }
   ~smtlib_smt_ast() override = default;
 
+  void dump() const override;
+
   smt_func_kind kind;
   std::string symname;
   BigInt intval;


### PR DESCRIPTION
This PR is based on #1049 and does the following:
- the string given to `--smtlib-solver-prog` is now interpreted by `$SHELL -c` (default: `sh` if SHELL is not set). This allows for easier interaction, such that e.g. the following examples are now usable:
  - `--smtlib-solver-prog 'z3 -in'`
  - `--smtlib-solver-prog 'cvc4 -L smt2'`
  - `--smtlib-solver-prog 'tee in | yices-smt2 | tee out'` to dump input and output to separate files
- fixes communication with yices-smt2, which expects setting `:produce-models` before `(set-logic [...])`
- fixes interpreting the `(get-info :version)` response and unquotes solver's name and version
- handles early death of external process more gracefully by reading its final output and throwing an exception with that string; this mainly affects Yices since it dies after writing an smtlib2 (error [...]) message.
- allows specification of both, `--output` and `--smtlib-solver-prog`, simultaneously; this is done by preventing the textual "rendering" of the ASTs to modify state (in this case, by removing unnecessary internal state) and writing the same text to both files.
- adds the `dump()` method for smtlib's AST nodes, this is a bit hacky but I provided my reasoning why the way it's done for the intended debugging usage still is OK in a comment.

The smtlib backend still needs further fixes to be entirely usable again.