### PR TITLE
Return a constant for MemberExpr to an enumerator

### DIFF
--- a/regression/esbmc-cpp/cbmc/Templates35/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates35/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1609,10 +1609,10 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       static_cast<const clang::MemberExpr &>(stmt);
 
     // special treatment for MemberExpr referring to an enumerator
-    if(is_member_decl_enum(member))
-    {
+    if(
       const auto *e =
-        llvm::dyn_cast<clang::EnumConstantDecl>(member.getMemberDecl());
+        llvm::dyn_cast<clang::EnumConstantDecl>(member.getMemberDecl()))
+    {
       get_enum_value(e, new_expr);
       break;
     }
@@ -3489,13 +3489,4 @@ bool clang_c_convertert::is_member_decl_static(const clang::MemberExpr &member)
   }
 
   return false;
-}
-
-bool clang_c_convertert::is_member_decl_enum(const clang::MemberExpr &member)
-{
-  // returns true if a MemberExpr refers to an enumerator
-  // coming from an enum
-  const clang::ValueDecl &mbr_vd = *member.getMemberDecl();
-  const clang::Decl &mbrd = static_cast<const clang::Decl &>(mbr_vd);
-  return (mbrd.getKind() == clang::Decl::EnumConstant);
 }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1608,12 +1608,12 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::MemberExpr &member =
       static_cast<const clang::MemberExpr &>(stmt);
 
-    exprt comp;
-    if(get_decl(*member.getMemberDecl(), comp))
-      return true;
-
     if(!perform_virtual_dispatch(member))
     {
+      exprt comp;
+      if(get_decl(*member.getMemberDecl(), comp))
+        return true;
+
       if(!is_member_decl_static(member))
       {
         exprt base;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3482,8 +3482,7 @@ bool clang_c_convertert::is_member_decl_static(const clang::MemberExpr &member)
   return false;
 }
 
-bool clang_c_convertert::is_member_decl_enum(
-  const clang::MemberExpr &member)
+bool clang_c_convertert::is_member_decl_enum(const clang::MemberExpr &member)
 {
   // returns true if a MemberExpr refers to an enumerator
   // coming from an enum

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1608,6 +1608,13 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::MemberExpr &member =
       static_cast<const clang::MemberExpr &>(stmt);
 
+    // special treatment for MemberExpr referring to an enumerator
+    if(is_member_decl_enum(member))
+    {
+      get_decl_ref(*member.getMemberDecl(), new_expr);
+      break;
+    }
+
     if(!perform_virtual_dispatch(member))
     {
       exprt comp;
@@ -3473,4 +3480,14 @@ bool clang_c_convertert::is_member_decl_static(const clang::MemberExpr &member)
   }
 
   return false;
+}
+
+bool clang_c_convertert::is_member_decl_enum(
+  const clang::MemberExpr &member)
+{
+  // returns true if a MemberExpr refers to an enumerator
+  // coming from an enum
+  const clang::ValueDecl &mbr_vd = *member.getMemberDecl();
+  const clang::Decl &mbrd = static_cast<const clang::Decl &>(mbr_vd);
+  return (mbrd.getKind() == clang::Decl::EnumConstant);
 }

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -320,6 +320,11 @@ protected:
    * Function to check whether a MemberExpr references to a static variable
    */
   bool is_member_decl_static(const clang::MemberExpr &member);
+
+  /*
+   * Function to check whether a MemberExor references to an enumerator
+   */
+  bool is_member_decl_enum(const clang::MemberExpr &member);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -323,11 +323,6 @@ protected:
    * Function to check whether a MemberExpr references to a static variable
    */
   bool is_member_decl_static(const clang::MemberExpr &member);
-
-  /*
-   * Function to check whether a MemberExor references to an enumerator
-   */
-  bool is_member_decl_enum(const clang::MemberExpr &member);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -40,6 +40,7 @@ class FloatingLiteral;
 class TagDecl;
 class FieldDecl;
 class MemberExpr;
+class EnumConstantDecl;
 } // namespace clang
 
 std::string
@@ -177,6 +178,8 @@ protected:
   bool get_builtin_type(const clang::BuiltinType &bt, typet &new_type);
 
   virtual bool get_expr(const clang::Stmt &stmt, exprt &new_expr);
+
+  void get_enum_value(const clang::EnumConstantDecl *e, exprt &new_expr);
 
   virtual bool get_decl_ref(const clang::Decl &decl, exprt &new_expr);
 


### PR DESCRIPTION
Fixed https://github.com/esbmc/esbmc/issues/1107 

Return a constant for MemberExpr to an enumerator regardless of the enumaration being scoped or unscoped, named or annoymous. 

Enabled 1 TC: 
- `cbmc/Templates35`