### PR TITLE
Support for Guard simplification through interval analysis

### DIFF
--- a/regression/esbmc/github_1054/main.c
+++ b/regression/esbmc/github_1054/main.c
@@ -1,0 +1,11 @@
+int main()
+{
+  unsigned int a;
+
+  if(a < 10)
+  {
+    __ESBMC_assert(a > 10, "");
+  }
+
+  return 0;
+}

--- a/regression/esbmc/github_1054/test.desc
+++ b/regression/esbmc/github_1054/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis  --interval-analysis-simplify
+^VERIFICATION FAILED$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -264,7 +264,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
     if concurrency:
       command_line += "--no-pointer-check --no-bounds-check "
     else:
-      command_line += "--no-pointer-check --no-bounds-check --interval-analysis --error-label ERROR --goto-unwind --unlimited-goto-unwind "
+      command_line += "--no-pointer-check --no-bounds-check --interval-analysis --interval-analysis-simplify --error-label ERROR --goto-unwind --unlimited-goto-unwind "
   else:
     print("Unknown property")
     exit(1)

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -264,7 +264,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
     if concurrency:
       command_line += "--no-pointer-check --no-bounds-check "
     else:
-      command_line += "--no-pointer-check --no-bounds-check --interval-analysis --interval-analysis-simplify --error-label ERROR --goto-unwind --unlimited-goto-unwind "
+      command_line += "--no-pointer-check --no-bounds-check --interval-analysis --error-label ERROR --goto-unwind --unlimited-goto-unwind "
   else:
     print("Unknown property")
     exit(1)

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -275,7 +275,8 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
   elif strat == "fixed":
     command_line += "--k-induction --max-inductive-step 3 "
   elif strat == "kinduction":
-    command_line += "--k-induction --max-inductive-step 3 "
+    command_line += "--incremental-bmc "
+   # command_line += "--k-induction --max-inductive-step 3 "
   elif strat == "falsi":
     command_line += "--falsification "
   elif strat == "incr":

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -275,8 +275,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
   elif strat == "fixed":
     command_line += "--k-induction --max-inductive-step 3 "
   elif strat == "kinduction":
-    command_line += "--incremental-bmc "
-   # command_line += "--k-induction --max-inductive-step 3 "
+    command_line += "--k-induction --max-inductive-step 3 "
   elif strat == "falsi":
     command_line += "--falsification "
   elif strat == "incr":
@@ -304,16 +303,16 @@ def witness_to_sha256(benchmark):
     data = f.read().encode('utf-8')
     sha256hash = sha256(data).hexdigest()
   witness = os.path.basename(benchmark) + ".graphml"
-  
+
   fin = open(witness, "rt")
   data = fin.readlines()
   fin.close()
-  
+
   fin = open(witness, "wt")
   for line in data:
     if '<data key="programhash">' in line:
       line = line.replace(line[line.index('>')+1:line.index('</data>')], sha256hash)
-      
+
     if '<data key="creationtime">' in line:
       time = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
       line = line.replace(line[line.index('>')+1:line.index('</data>')], time)

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -451,21 +451,6 @@ int esbmc_parseoptionst::doit()
     return 0;
   }
 
-  // initialize goto_functions algorithms
-  {
-    // loop unroll
-    if(cmdline.isset("goto-unwind") && !cmdline.isset("unwind"))
-    {
-      size_t unroll_limit = cmdline.isset("unlimited-goto-unwind") ? -1 : 1000;
-      goto_preprocess_algorithms.push_back(
-        std::make_unique<bounded_loop_unroller>(unroll_limit));
-    }
-
-    // mark declarations as nondet
-    if(cmdline.isset("initialize-nondet-variables"))
-      goto_preprocess_algorithms.emplace_back(
-        std::make_unique<mark_decl_as_non_det>(context));
-  }
   if(cmdline.isset("termination"))
     return doit_termination();
 
@@ -1579,6 +1564,23 @@ bool esbmc_parseoptionst::process_goto_program(
     if(cmdline.isset("interval-analysis") || cmdline.isset("goto-contractor"))
     {
       interval_analysis(goto_functions, ns, options);
+    }
+
+    // initialize goto_functions algorithms
+    {
+      // loop unroll
+      if(cmdline.isset("goto-unwind") && !cmdline.isset("unwind"))
+      {
+        size_t unroll_limit =
+          cmdline.isset("unlimited-goto-unwind") ? -1 : 1000;
+        goto_preprocess_algorithms.push_back(
+          std::make_unique<bounded_loop_unroller>(unroll_limit));
+      }
+
+      // mark declarations as nondet
+      if(cmdline.isset("initialize-nondet-variables"))
+        goto_preprocess_algorithms.emplace_back(
+          std::make_unique<mark_decl_as_non_det>(context));
     }
 
     if(

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -451,6 +451,21 @@ int esbmc_parseoptionst::doit()
     return 0;
   }
 
+  // initialize goto_functions algorithms
+  {
+    // loop unroll
+    if(cmdline.isset("goto-unwind") && !cmdline.isset("unwind"))
+    {
+      size_t unroll_limit = cmdline.isset("unlimited-goto-unwind") ? -1 : 1000;
+      goto_preprocess_algorithms.push_back(
+        std::make_unique<bounded_loop_unroller>(unroll_limit));
+    }
+
+    // mark declarations as nondet
+    if(cmdline.isset("initialize-nondet-variables"))
+      goto_preprocess_algorithms.emplace_back(
+        std::make_unique<mark_decl_as_non_det>(context));
+  }
   if(cmdline.isset("termination"))
     return doit_termination();
 
@@ -1564,23 +1579,6 @@ bool esbmc_parseoptionst::process_goto_program(
     if(cmdline.isset("interval-analysis") || cmdline.isset("goto-contractor"))
     {
       interval_analysis(goto_functions, ns, options);
-    }
-
-    // initialize goto_functions algorithms
-    {
-      // loop unroll
-      if(cmdline.isset("goto-unwind") && !cmdline.isset("unwind"))
-      {
-        size_t unroll_limit =
-          cmdline.isset("unlimited-goto-unwind") ? -1 : 1000;
-        goto_preprocess_algorithms.push_back(
-          std::make_unique<bounded_loop_unroller>(unroll_limit));
-      }
-
-      // mark declarations as nondet
-      if(cmdline.isset("initialize-nondet-variables"))
-        goto_preprocess_algorithms.emplace_back(
-          std::make_unique<mark_decl_as_non_det>(context));
     }
 
     if(

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -384,6 +384,13 @@ const struct group_opt_templ all_cmd_options[] = {
     {"interval-analysis-no-contract",
      NULL,
      "disables use of contractors in abstract states (Integers, Reals)"},
+    {"interval-analysis-assume-asserts",
+     NULL,
+     "propagates asserts as being assertions (Integers, Reals)"},
+    {"interval-analysis-eval-assumptions",
+     NULL,
+     "evaluates assumptions/guards as boolean operators, accelerating the "
+     "convergence (Integers, Reals)"},
     {"interval-analysis-extrapolate",
      NULL,
      "enables use of extrapolation in abstract states (all)"},

--- a/src/goto-programs/abstract-interpretation/bitwise_bounds.h
+++ b/src/goto-programs/abstract-interpretation/bitwise_bounds.h
@@ -1,0 +1,1075 @@
+#ifndef BITWISE_BOUNDS_H_INCLUDED
+#define BITWISE_BOUNDS_H_INCLUDED
+
+#define UINT_X unsigned /// replace this with appropriate unsigned integer type
+#define INT_X int       /// replace this with appropriate signed integer type
+
+/**
+ * Adaptation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * for unsigned integers of any width, by scanning from the least significant bit.
+ * @author Edoardo Manino.
+ * @brief Maximum value of x | y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_max_or(UINT_X a, UINT_X b, UINT_X c, UINT_X d)
+{
+  UINT_X extra_bits = 0;
+
+  // scan all the bits that are active in both upper bounds
+  UINT_X cand_bits = b & d;
+  while(cand_bits != 0)
+  {
+    // isolate the least significant candidate bit
+    // e.g. cand_bits = 0b01101010 yields least_bit = 0b00000010
+    UINT_X least_bit = cand_bits & (-cand_bits);
+
+    // reduce b and d by removing least_bit and activating all the less significant ones
+    // e.g. b = 0b00101100 and least_bit = 0b00001000 yields alternate_b = 0b00100111
+    UINT_X alternate_b = (b - least_bit) | (least_bit - 1);
+    UINT_X alternate_d = (d - least_bit) | (least_bit - 1);
+
+    // stop only if both alternate values are outside of the valid interval
+    if(alternate_b < a && alternate_d < c)
+      break;
+
+    // collect the extra activated bits
+    // e.g. least_bit = 0b00001000 yields extra_bits |= 0b00000111
+    extra_bits |= (least_bit - 1);
+
+    // remove the least significant bit from the candidates until none is left
+    cand_bits &= (cand_bits - 1);
+  }
+
+  // the maximum value is the disjunction of both upper bounds and the extra bits
+  return b | d | extra_bits;
+}
+
+/**
+ * Adaptation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * for unsigned integers of any width, by scanning from the least significant bit.
+ * @author Edoardo Manino.
+ * @brief Minimum value of x | y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_min_or(UINT_X a, UINT_X b, UINT_X c, UINT_X d)
+{
+  UINT_X best_a = a;
+  UINT_X best_c = c;
+
+  // scan all the bits that are already active in the other lower bound
+  UINT_X cand_bits = ~a & c;
+  while(cand_bits != 0)
+  {
+    // isolate the least significant candidate bit
+    // e.g. cand_bits = 0b01101010 yields least_bit = 0b00000010
+    UINT_X least_bit = cand_bits & (-cand_bits);
+
+    // increase a by adding least_bit and de-activating all the less significant ones
+    // e.g. a = 0b00101100 and least_bit = 0b00010000 yields alternate_a = 0b00110000
+    UINT_X alternate_a = (a | least_bit) & (-least_bit);
+
+    // stop if the alternate value is outside of the valid interval
+    if(alternate_a > b)
+      break;
+
+    // keep track of the best value of a found so far
+    best_a = alternate_a;
+
+    // remove the least significant bit from the candidates until none is left
+    cand_bits &= (cand_bits - 1);
+  }
+
+  // repeat the same procedure for the interval y in [c,d]
+  cand_bits = a & ~c;
+  while(cand_bits != 0)
+  {
+    UINT_X least_bit = cand_bits & (-cand_bits);
+    UINT_X alternate_c = (c | least_bit) & (-least_bit);
+    if(alternate_c > d)
+      break;
+    best_c = alternate_c;
+    cand_bits &= (cand_bits - 1);
+  }
+
+  // compute two separate bounds with the modified a and c
+  // note: since best_a >= a and best_c >= c,
+  // using best_a | best_c could give unsound results
+  UINT_X min_1 = best_a | c;
+  UINT_X min_2 = a | best_c;
+
+  // return the lowest bound
+  return (min_1 < min_2) ? min_1 : min_2;
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of x & y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_max_and(UINT_X a, UINT_X b, UINT_X c, UINT_X d)
+{
+  return ~unsigned_min_or(~b, ~a, ~d, ~c);
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Minimum value of x & y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_min_and(UINT_X a, UINT_X b, UINT_X c, UINT_X d)
+{
+  return ~unsigned_max_or(~b, ~a, ~d, ~c);
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of x ^ y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_max_xor(UINT_X a, UINT_X b, UINT_X c, UINT_X d)
+{
+  return unsigned_max_or(
+    0, unsigned_max_and(a, b, ~d, ~c), 0, unsigned_max_and(~b, ~a, c, d));
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Minimum value of x ^ y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_min_xor(UINT_X a, UINT_X b, UINT_X c, UINT_X d)
+{
+  return unsigned_min_and(a, b, ~d, ~c) | unsigned_min_and(~b, ~a, c, d);
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of ~x given x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ */
+UINT_X unsigned_max_not(UINT_X a, UINT_X)
+{
+  return ~a;
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Minimum value of ~x given x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ */
+UINT_X unsigned_min_not(UINT_X, UINT_X b)
+{
+  return ~b;
+}
+
+/**
+ * Upper bound on interval left shift
+ * @author Edoardo Manino.
+ * @brief Maximum value of x << y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_max_left_shift(UINT_X, UINT_X b, UINT_X, UINT_X d)
+{
+  return b << d;
+}
+
+/**
+ * Lower bound on interval left shift
+ * @author Edoardo Manino.
+ * @brief Minimum value of x << y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_min_left_shift(UINT_X a, UINT_X, UINT_X c, UINT_X)
+{
+  return a << c;
+}
+
+/**
+ * Upper bound on interval right shift
+ * @author Edoardo Manino.
+ * @brief Maximum value of x >> y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_max_right_shift(UINT_X, UINT_X b, UINT_X c, UINT_X)
+{
+  return b >> c;
+}
+
+/**
+ * Lower bound on interval right shift
+ * @author Edoardo Manino.
+ * @brief Minimum value of x >> y given x in [a,b] and y in [c,d]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+UINT_X unsigned_min_right_shift(UINT_X a, UINT_X, UINT_X, UINT_X d)
+{
+  return a >> d;
+}
+
+/**
+ * Upper bound on unsigned to unsigned interval truncation
+ * @author Edoardo Manino.
+ * @brief Maximum value of unsigned truncate(x, n) given n bits and unsigned x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+UINT_X unsigned_2_unsigned_max_truncate(UINT_X a, UINT_X b, UINT_X n)
+{
+  // set the n least significant bits to one
+  UINT_X sign_bit = 1 << (n - 1);
+  UINT_X mask = sign_bit | (sign_bit - 1);
+
+  // compute the maximum value of x & mask
+  return unsigned_max_and(a, b, mask, mask);
+}
+
+/**
+ * Lower bound on unsigned to unsigned interval truncation
+ * @author Edoardo Manino.
+ * @brief Minimum value of unsigned truncate(x, n) given n bits and unsigned x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+UINT_X unsigned_2_unsigned_min_truncate(UINT_X a, UINT_X b, UINT_X n)
+{
+  // set the n least significant bits to one
+  UINT_X sign_bit = 1 << (n - 1);
+  UINT_X mask = sign_bit | (sign_bit - 1);
+
+  // compute the minimum value of x & mask
+  return unsigned_min_and(a, b, mask, mask);
+}
+
+/**
+ * Upper bound on signed to unsigned interval truncation
+ * @author Edoardo Manino.
+ * @brief Maximum value of unsigned truncate(x, n) given n bits and signed x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+UINT_X signed_2_unsigned_max_truncate(INT_X a, INT_X b, UINT_X n)
+{
+  // if the input interval contains zero, return truncated -1
+  if(a < 0 && b >= 0)
+    return (1 << n) - 1;
+
+  // otherwise interpret [a,b] as an unsigned interval
+  else
+    return unsigned_2_unsigned_max_truncate(a, b, n);
+}
+
+/**
+ * Lower bound on signed to unsigned interval truncation
+ * @author Edoardo Manino.
+ * @brief Minimum value of unsigned truncate(x, n) given n bits and signed x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+UINT_X signed_2_unsigned_min_truncate(INT_X a, INT_X b, UINT_X n)
+{
+  // if the input interval contains zero, return zero
+  if(a < 0 && b >= 0)
+    return 0;
+
+  // otherwise interpret [a,b] as an unsigned interval
+  else
+    return unsigned_2_unsigned_min_truncate(a, b, n);
+}
+
+/**
+ * Upper bound on the unsigned extension of an n bit signed interval
+ * @author Edoardo Manino.
+ * @brief Maximum value of unsigned extend(x, n) given n bits and signed x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the input
+ */
+UINT_X signed_2_unsigned_max_extend(INT_X a, INT_X b, UINT_X n)
+{
+  // isolate the sign bit of the input
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // set the n least significant bits to one
+  UINT_X mask = sign_bit | (sign_bit - 1);
+
+  // if a <= 0 and b > 0, return the n-bit representation of -1
+  if((a & sign_bit) != 0 && (b & sign_bit) == 0)
+    return -1 & mask;
+
+  // otherwise, extend the upper bound
+  return b & mask;
+}
+
+/**
+ * Lower bound on the unsigned extension of an n bit signed interval
+ * @author Edoardo Manino.
+ * @brief Minimum value of unsigned extend(x, n) given n bits and signed x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the input
+ */
+UINT_X signed_2_unsigned_min_extend(INT_X a, INT_X b, UINT_X n)
+{
+  // isolate the sign bit of the input
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // set the n least significant bits to one
+  UINT_X mask = sign_bit | (sign_bit - 1);
+
+  // if a <= 0 and b > 0, return zero
+  if((a & sign_bit) != 0 && (b & sign_bit) == 0)
+    return 0;
+
+  // otherwise, extend the upper bound
+  return a & mask;
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of x | y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_max_or(INT_X a, INT_X b, INT_X c, INT_X d)
+{
+  if(a < 0)
+  {
+    if(b < 0)
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return unsigned_max_or(a, b, c, d); // a < 0, b < 0, c < 0, d < 0
+        }
+        else
+        {
+          return -1; // a < 0, b < 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_max_or(a, b, c, d); // a < 0, b < 0, c >= 0, d >= 0
+      }
+    }
+    else
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return -1; // a < 0, b >= 0, c < 0, d < 0
+        }
+        else
+        {
+          return unsigned_max_or(0, b, 0, d); // a < 0, b >= 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_max_or(0, b, c, d); // a < 0, b >= 0, c >= 0, d >= 0
+      }
+    }
+  }
+  else
+  {
+    if(c < 0)
+    {
+      if(d < 0)
+      {
+        return unsigned_max_or(a, b, c, d); // a >= 0, b >= 0, c < 0, d < 0
+      }
+      else
+      {
+        return unsigned_max_or(a, b, 0, d); // a >= 0, b >= 0, c < 0, d >= 0
+      }
+    }
+    else
+    {
+      return unsigned_max_or(a, b, c, d); // a >= 0, b >= 0, c >= 0, d >= 0
+    }
+  }
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Minimum value of x | y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_min_or(INT_X a, INT_X b, INT_X c, INT_X d)
+{
+  if(a < 0)
+  {
+    if(b < 0)
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return unsigned_min_or(a, b, c, d); // a < 0, b < 0, c < 0, d < 0
+        }
+        else
+        {
+          return a; // a < 0, b < 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_min_or(a, b, c, d); // a < 0, b < 0, c >= 0, d >= 0
+      }
+    }
+    else
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return c; // a < 0, b >= 0, c < 0, d < 0
+        }
+        else
+        {
+          return (a < c) ? a : c; // a < 0, b >= 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_min_or(a, -1, c, d); // a < 0, b >= 0, c >= 0, d >= 0
+      }
+    }
+  }
+  else
+  {
+    if(c < 0)
+    {
+      if(d < 0)
+      {
+        return unsigned_min_or(a, b, c, d); // a >= 0, b >= 0, c < 0, d < 0
+      }
+      else
+      {
+        return unsigned_min_or(a, b, c, -1); // a >= 0, b >= 0, c < 0, d >= 0
+      }
+    }
+    else
+    {
+      return unsigned_min_or(a, b, c, d); // a >= 0, b >= 0, c >= 0, d >= 0
+    }
+  }
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of x & y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_max_and(INT_X a, INT_X b, INT_X c, INT_X d)
+{
+  return ~signed_min_or(~b, ~a, ~d, ~c);
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Minimum value of x & y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_min_and(INT_X a, INT_X b, INT_X c, INT_X d)
+{
+  return ~signed_max_or(~b, ~a, ~d, ~c);
+}
+
+/**
+ * Original upper bound on signed interval XOR, inspired by the case-based algorithm
+ * for signed interval OR in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of x ^ y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_max_xor(INT_X a, INT_X b, INT_X c, INT_X d)
+{
+  if(a < 0)
+  {
+    if(b < 0)
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return unsigned_max_xor(a, b, c, d); // a < 0, b < 0, c < 0, d < 0
+        }
+        else
+        {
+          return unsigned_max_xor(a, b, c, -1); // a < 0, b < 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_max_xor(a, b, c, d); // a < 0, b < 0, c >= 0, d >= 0
+      }
+    }
+    else
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return unsigned_max_xor(a, -1, c, d); // a < 0, b >= 0, c < 0, d < 0
+        }
+        else
+        {
+          INT_X e = unsigned_max_xor(a, -1, c, -1);
+          INT_X f = unsigned_max_xor(0, b, 0, d);
+          return (e > f) ? e : f; // a < 0, b >= 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_max_xor(0, b, c, d); // a < 0, b >= 0, c >= 0, d >= 0
+      }
+    }
+  }
+  else
+  {
+    if(c < 0)
+    {
+      if(d < 0)
+      {
+        return unsigned_max_xor(a, b, c, d); // a >= 0, b >= 0, c < 0, d < 0
+      }
+      else
+      {
+        return unsigned_max_xor(a, b, 0, d); // a >= 0, b >= 0, c < 0, d >= 0
+      }
+    }
+    else
+    {
+      return unsigned_max_xor(a, b, c, d); // a >= 0, b >= 0, c >= 0, d >= 0
+    }
+  }
+}
+
+/**
+ * Original lower bound on signed interval XOR, inspired by the case-based algorithm
+ * for signed interval OR in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of x ^ y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_min_xor(INT_X a, INT_X b, INT_X c, INT_X d)
+{
+  if(a < 0)
+  {
+    if(b < 0)
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return unsigned_min_xor(a, b, c, d); // a < 0, b < 0, c < 0, d < 0
+        }
+        else
+        {
+          return unsigned_min_xor(a, b, 0, d); // a < 0, b < 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_min_xor(a, b, c, d); // a < 0, b < 0, c >= 0, d >= 0
+      }
+    }
+    else
+    {
+      if(c < 0)
+      {
+        if(d < 0)
+        {
+          return unsigned_min_xor(0, b, c, d); // a < 0, b >= 0, c < 0, d < 0
+        }
+        else
+        {
+          INT_X e = unsigned_min_xor(a, -1, 0, d);
+          INT_X f = unsigned_min_xor(0, b, c, -1);
+          return (e < f) ? e : f; // a < 0, b >= 0, c < 0, d >= 0
+        }
+      }
+      else
+      {
+        return unsigned_min_xor(a, -1, c, d); // a < 0, b >= 0, c >= 0, d >= 0
+      }
+    }
+  }
+  else
+  {
+    if(c < 0)
+    {
+      if(d < 0)
+      {
+        return unsigned_min_xor(a, b, c, d); // a >= 0, b >= 0, c < 0, d < 0
+      }
+      else
+      {
+        return unsigned_min_xor(a, b, c, -1); // a >= 0, b >= 0, c < 0, d >= 0
+      }
+    }
+    else
+    {
+      return unsigned_min_xor(a, b, c, d); // a >= 0, b >= 0, c >= 0, d >= 0
+    }
+  }
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Maximum value of ~x given x in [a,b], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ */
+INT_X signed_max_not(INT_X a, INT_X)
+{
+  return ~a;
+}
+
+/**
+ * Implementation of the algorithm in Henry S. Warren Jr., "Hacker's Delight", 2003
+ * @author Edoardo Manino.
+ * @brief Minimum value of ~x given x in [a,b], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ */
+INT_X signed_min_not(INT_X, INT_X b)
+{
+  return ~b;
+}
+
+/**
+ * Upper bound on interval left shift
+ * @author Edoardo Manino.
+ * @brief Maximum value of x << y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_max_left_shift(INT_X, INT_X b, UINT_X c, UINT_X d)
+{
+  if(b >= 0)
+    return b << d;
+  else
+    return b << c;
+}
+
+/**
+ * Lower bound on interval left shift
+ * @author Edoardo Manino.
+ * @brief Minimum value of x << y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_min_left_shift(INT_X a, INT_X, UINT_X c, UINT_X d)
+{
+  if(a >= 0)
+    return a << c;
+  else
+    return a << d;
+}
+
+/**
+ * Upper bound on interval right shift
+ * @author Edoardo Manino.
+ * @brief Maximum value of x >> y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_max_right_shift(INT_X, INT_X b, UINT_X c, UINT_X d)
+{
+  if(b >= 0)
+    return b >> c;
+  else
+    return b >> d;
+}
+
+/**
+ * Lower bound on interval right shift
+ * @author Edoardo Manino.
+ * @brief Minimum value of x >> y given x in [a,b] and y in [c,d], potentially negative
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param c Min value of variable y
+ * @param d Max value of variable y
+ */
+INT_X signed_min_right_shift(INT_X a, INT_X, UINT_X c, UINT_X d)
+{
+  if(a >= 0)
+    return a >> d;
+  else
+    return a >> c;
+}
+
+/**
+ * Cast a limited-width unsigned integer to signed integer
+ * @author Edoardo Manino.
+ * @brief Compute cas(x, n) given an n-bit unsigned input x
+ * @param x Value to be converted
+ * @param n Number of bits of the result
+ */
+INT_X unsigned_2_signed(UINT_X x, UINT_X n)
+{
+  // isolate the sign bit of the truncated output
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // set the n least significant bits to one
+  UINT_X mask = sign_bit | (sign_bit - 1);
+
+  // if the input is positive, just truncate and cast
+  if((x & sign_bit) == 0)
+    return (INT_X)x & mask;
+
+  // if the input is negative, convert it to positive with relation -x = (~x) + 1,
+  // truncate it, cast it to signed integer and return the negative result
+  INT_X positive_x = (~x & mask) + 1;
+  return -positive_x;
+}
+
+/**
+ * Upper bound on unsigned to signed interval truncation
+ * @author Edoardo Manino.
+ * @brief Maximum value of signed truncate(x, n) given n bits and unsigned x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+INT_X unsigned_2_signed_max_truncate(UINT_X a, UINT_X b, UINT_X n)
+{
+  // isolate the sign bit of the truncated output
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // keep the bits of the upper bound that are at least as significant
+  // as the sign bit of the truncated output
+  // e.g. b = 0b01101010 and n = 4 yields cand_bits = 0b01101000
+  UINT_X cand_bits = b & (-sign_bit);
+
+  // isolate the least significant candidate bit
+  // e.g. cand_bits = 0b01101010 yields least_bit = 0b00000010
+  UINT_X least_bit = cand_bits & (-cand_bits);
+
+  // reduce b by removing least_bit and activating all the less significant ones
+  // e.g. b = 0b00101100 and least_bit = 0b00001000 yields alternate_b = 0b00100111
+  UINT_X alternate_b = (b - least_bit) | (least_bit - 1);
+
+  // reduce b further by setting the sign bit to zero
+  // this operation ensures that the result is positive
+  UINT_X positive_b = alternate_b & ~sign_bit;
+
+  // check if the reduced positive b still belongs to the input interval
+  if(positive_b >= a && positive_b <= b)
+    return unsigned_2_signed(positive_b, n);
+
+  // otherwise, try to use the upper bound (if positive)
+  if((b & sign_bit) == 0)
+    return unsigned_2_signed(b, n);
+
+  // if we are forced to return a negative number, try to maximise it
+  if(alternate_b >= a && alternate_b <= b)
+    return unsigned_2_signed(alternate_b, n);
+
+  // otherwise, just use the negative upper bound
+  return unsigned_2_signed(b, n);
+}
+
+/**
+ * Lower bound on unsigned to signed interval truncation
+ * @author Edoardo Manino.
+ * @brief Minimum value of signed truncate(x, n) given n bits and unsigned x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+INT_X unsigned_2_signed_min_truncate(UINT_X a, UINT_X b, UINT_X n)
+{
+  // isolate the sign bit of the truncated output
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // flip the bits of the upper bound that are at least as significant
+  // as the sign bit of the truncated output
+  // e.g. a = 0b01100010 and n = 4 yields cand_bits = 0b10011000
+  UINT_X cand_bits = ~a & (-sign_bit);
+
+  // isolate the least significant candidate bit
+  // e.g. cand_bits = 0b01101010 yields least_bit = 0b00000010
+  UINT_X least_bit = cand_bits & (-cand_bits);
+
+  // increase a by adding least_bit and removing all the less significant ones
+  // e.g. a = 0b00110100 and least_bit = 0b00001000 yields alternate_a = 0b00111000
+  UINT_X alternate_a = (a | least_bit) & (-least_bit);
+
+  // increase a further by setting the sign bit to one
+  // this operation ensures that the result is positive
+  UINT_X negative_a = alternate_a | sign_bit;
+
+  // check if the increased negative a still belongs to the input interval
+  if(negative_a >= a && negative_a <= b)
+    return unsigned_2_signed(negative_a, n);
+
+  // otherwise, try to use the lower bound (if negative)
+  if((a & sign_bit) != 0)
+    return unsigned_2_signed(a, n);
+
+  // if we are forced to return a positive number, try to minimise it
+  if(alternate_a >= a && alternate_a <= b)
+    return unsigned_2_signed(alternate_a, n);
+
+  // otherwise, just use the upper bound
+  return unsigned_2_signed(a, n);
+}
+
+/**
+ * Upper bound on signed to signed interval truncation
+ * @author Edoardo Manino.
+ * @brief Maximum value of signed truncate(x, n) given n bits and signed x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+INT_X signed_2_signed_max_truncate(INT_X a, INT_X b, UINT_X n)
+{
+  // if the input interval contains zero, split it
+  if(a < 0 && b >= 0)
+  {
+    INT_X c = unsigned_2_signed_max_truncate(a, -1, n);
+    INT_X d = unsigned_2_signed_max_truncate(0, b, n);
+    return (c > d) ? c : d;
+  }
+
+  // otherwise interpret [a,b] as an unsigned interval
+  return unsigned_2_signed_max_truncate(a, b, n);
+}
+
+/**
+ * Lower bound on signed to signed interval truncation
+ * @author Edoardo Manino.
+ * @brief Minimum value of signed truncate(x, n) given n bits and signed x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the result
+ */
+INT_X signed_2_signed_min_truncate(INT_X a, INT_X b, UINT_X n)
+{
+  // if the input interval contains zero, split it
+  if(a < 0 && b >= 0)
+  {
+    INT_X c = unsigned_2_signed_min_truncate(a, -1, n);
+    INT_X d = unsigned_2_signed_min_truncate(0, b, n);
+    return (c < d) ? c : d;
+  }
+
+  // otherwise interpret [a,b] as an unsigned interval
+  return unsigned_2_signed_min_truncate(a, b, n);
+}
+
+/**
+ * Upper bound on the signed extension of an n bit unsigned interval
+ * @author Edoardo Manino.
+ * @brief Maximum value of signed extend(x, n) given n bits and unsigned x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the input
+ */
+INT_X unsigned_2_signed_max_extend(UINT_X a, UINT_X b, UINT_X n)
+{
+  // isolate the sign bit of the input
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // if a > 0 and b <= 0, return the largest positive number
+  if((b & sign_bit) != 0)
+  {
+    if((a & sign_bit) == 0)
+      return sign_bit - 1;
+
+    // if both a <= 0 and b <= 0, extend the sign of the upper bound
+    return unsigned_2_signed(b, n);
+  }
+
+  // otherwise, keep the positive upper bound
+  return b;
+}
+
+/**
+ * Lower bound on the signed extension of an n bit unsigned interval
+ * @author Edoardo Manino.
+ * @brief Minimum value of signed extend(x, n) given n bits and unsigned x in [a,b]
+ * @param a Min value of variable x
+ * @param b Max value of variable x
+ * @param n Number of bits of the input
+ */
+INT_X unsigned_2_signed_min_extend(UINT_X a, UINT_X b, UINT_X n)
+{
+  // isolate the sign bit of the input
+  UINT_X sign_bit = 1 << (n - 1);
+
+  // if a > 0 and b <= 0, return the smallest negative number
+  if((b & sign_bit) != 0)
+  {
+    if((a & sign_bit) == 0)
+      return unsigned_2_signed(sign_bit, n);
+
+    // if both a <= 0 and b <= 0, extend the sign of the lower bound
+    return unsigned_2_signed(a, n);
+  }
+
+  // otherwise, keep the positive lower bound
+  return a;
+}
+
+#define IS_UINT(LHS, RHS)                                                      \
+  LHS.get_lower().is_uint64() && LHS.get_upper().is_uint64() &&                \
+    RHS.get_lower().is_uint64() && RHS.get_upper().is_uint64()
+
+#define UINT_FUNC(FUNC, LHS, RHS)                                              \
+  FUNC(                                                                        \
+    LHS.get_lower().to_uint64(),                                               \
+    LHS.get_upper().to_uint64(),                                               \
+    RHS.get_lower().to_uint64(),                                               \
+    RHS.get_upper().to_uint64())
+
+#define IS_INT(LHS, RHS)                                                       \
+  LHS.get_lower().is_int64() && LHS.get_upper().is_int64() &&                  \
+    RHS.get_lower().is_int64() && RHS.get_upper().is_int64()
+
+#define INT_FUNC(FUNC, LHS, RHS)                                               \
+  FUNC(                                                                        \
+    LHS.get_lower().to_int64(),                                                \
+    LHS.get_upper().to_int64(),                                                \
+    RHS.get_lower().to_int64(),                                                \
+    RHS.get_upper().to_int64())
+
+#define GET_BIT_INTERVALS(NAME, MIN_UFUNC, MAX_UFUNC, MIN_FUNC, MAX_FUNC)      \
+  template <>                                                                  \
+  interval_templatet<BigInt> interval_templatet<BigInt>::NAME(                 \
+    const interval_templatet<BigInt> &lhs,                                     \
+    const interval_templatet<BigInt> &rhs) const                               \
+  {                                                                            \
+    interval_templatet<BigInt> result;                                         \
+    if(IS_UINT(lhs, rhs))                                                      \
+    {                                                                          \
+      result.set_lower(UINT_FUNC(MIN_UFUNC, lhs, rhs));                        \
+      result.set_upper(UINT_FUNC(MAX_UFUNC, lhs, rhs));                        \
+    }                                                                          \
+    else if(IS_INT(lhs, rhs))                                                  \
+    {                                                                          \
+      result.set_lower(INT_FUNC(MIN_FUNC, lhs, rhs));                          \
+      result.set_upper(INT_FUNC(MAX_FUNC, lhs, rhs));                          \
+    }                                                                          \
+    return result;                                                             \
+  }
+
+#include <big-int/bigint.hh>
+
+GET_BIT_INTERVALS(
+  interval_bitand,
+  unsigned_min_and,
+  unsigned_max_and,
+  signed_min_and,
+  signed_max_and)
+
+GET_BIT_INTERVALS(
+  interval_bitor,
+  unsigned_min_or,
+  unsigned_max_or,
+  signed_min_or,
+  signed_max_or)
+
+GET_BIT_INTERVALS(
+  interval_bitxor,
+  unsigned_min_xor,
+  unsigned_max_xor,
+  signed_min_xor,
+  signed_max_xor)
+
+GET_BIT_INTERVALS(
+  interval_logical_right_shift,
+  unsigned_min_right_shift,
+  unsigned_max_right_shift,
+  signed_min_right_shift,
+  signed_max_right_shift)
+
+GET_BIT_INTERVALS(
+  interval_left_shift,
+  unsigned_min_left_shift,
+  unsigned_max_left_shift,
+  signed_min_left_shift,
+  signed_max_left_shift)
+
+#undef IS_UINT
+#undef IS_INT
+#undef UINT_FUNC
+#undef INT_FUNC
+#undef GET_BIT_INTERVALS
+
+#endif // BITWISE_BOUNDS_H_INCLUDED

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -27,17 +27,15 @@ static inline void get_symbols(
 
 static inline void simplify_guard(expr2tc &expr, const interval_domaint &state)
 {
-  expr->Foreach_operand(
-    [&state](expr2tc &e) -> void
-    {
-      tvt result = interval_domaint::eval_boolean_expression(e, state);
-      if(result.is_true())
-        e = gen_true_expr();
-      else if(result.is_false())
-        e = gen_false_expr();
-      else
-        simplify_guard(e, state);
-    });
+  expr->Foreach_operand([&state](expr2tc &e) -> void {
+    tvt result = interval_domaint::eval_boolean_expression(e, state);
+    if(result.is_true())
+      e = gen_true_expr();
+    else if(result.is_false())
+      e = gen_false_expr();
+    else
+      simplify_guard(e, state);
+  });
   simplify(expr);
 }
 
@@ -173,8 +171,7 @@ void dump_intervals(
   forall_goto_program_instructions(i_it, goto_function.body)
   {
     const interval_domaint &d = interval_analysis[i_it];
-    auto print_vars = [&out, &i_it](const auto &map)
-    {
+    auto print_vars = [&out, &i_it](const auto &map) {
       for(const auto &interval : map)
       {
         // "state,var,min,max,bot,top";

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -637,6 +637,22 @@ void interval_domaint::output(std::ostream &out) const
   }
 }
 
+bool contains_float(const expr2tc &e)
+{
+  if(is_floatbv_type(e->type))
+    return true;
+
+  bool inner_float = false;
+  e->foreach_operand(
+    [&inner_float](auto &it){
+      if(contains_float(it))
+        inner_float = true;
+    }
+  );
+
+  return inner_float;
+}
+
 void interval_domaint::transform(
   goto_programt::const_targett from,
   goto_programt::const_targett to,
@@ -691,7 +707,9 @@ void interval_domaint::transform(
 
   case ASSERT:
   {
-    assume(instruction.guard);
+    // There is a bug in Floats that need to be investigated! regression-float/nextafter
+    if(!contains_float(instruction.guard))
+      assume(instruction.guard);
     break;
   }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1122,42 +1122,20 @@ bool interval_domaint::ai_simplify(expr2tc &condition, const namespacet &ns)
   if(!enable_assertion_simplification)
     return true;
 
-  bool unchanged = true;
-  interval_domaint d(*this);
-
-  // merge intervals to properly handle conjunction
-  if(is_and2t(condition)) // May be directly representable
+  tvt eval = eval_boolean_expression(condition, *this);
+  if(eval.is_true())
   {
-    // TODO: This is not working, reimplement this using other logic
-    log_debug("[interval] Conjuction");
-    interval_domaint a;
-    a.make_top();        // a is everything
-    a.assume(condition); // Restrict a to an over-approximation
-                         //  of when condition is true
-    if(!a.join(d))       // If d (this) is included in a...
-    {                    // Then the condition is always true
-      unchanged = is_true(condition);
-      condition = gen_true_expr();
-    }
-  }
-  else if(is_symbol2t(condition))
-  {
-    // TODO: we have to handle symbol expression
-  }
-  else // Less likely to be representable
-  {
-    log_debug("[interval] not");
-    expr2tc not_condition = condition;
-    make_not(not_condition);
-    d.assume(not_condition); // Restrict to when condition is false
-    if(d.is_bottom())        // If there there are none...
-    {                        // Then the condition is always true
-      unchanged = is_true(condition);
-      condition = gen_true_expr();
-    }
+    // TODO: convert to 1?
   }
 
-  return unchanged;
+  if(eval.is_false())
+  {
+    // TODO: convert to 0?
+  }
+
+  // TODO: contract expression (implication?)
+
+  return false;
 }
 
 void interval_domaint::set_options(const optionst &options)

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1000,7 +1000,7 @@ void interval_domaint::assume(const expr2tc &cond)
   if(eval_boolean_expression(new_cond, *this).is_false())
   {
     log_debug("The expr {} is always false. Returning bottom", *cond);
-    make_bottom();
+    //make_bottom();
     return;
   }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -383,9 +383,8 @@ T interval_domaint::get_interval(const expr2tc &e) const
       break;
     }
 
-    log_error(
-      "[interval] Arrived at get_interval with unsupported expression: {}", *e);
-    abort();
+    log_debug("Could not simplify: {}", *e);
+    break;
   }
 
   case expr2t::if_id:

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -471,7 +471,8 @@ T interval_domaint::get_interval(const expr2tc &e) const
   }
 
   default:
-    log_debug("Could't compute interval for expr: {}", *e);
+    log_error("Could't compute interval for expr: {}", *e);
+    abort();
   }
 
   return result;

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -687,8 +687,7 @@ expr2tc interval_domaint::make_expression_helper<wrapped_interval>(
     // Interval: [a,b]
     std::vector<expr2tc> disjuncts;
 
-    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w)
-    {
+    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w) {
       assert(w.lower <= w.upper);
 
       std::vector<expr2tc> s_conjuncts;
@@ -728,8 +727,7 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
     return gen_false_expr();
 
   std::vector<expr2tc> conjuncts;
-  auto typecast = [&symbol](expr2tc v)
-  {
+  auto typecast = [&symbol](expr2tc v) {
     c_implicit_typecast(v, symbol->type, *migrate_namespace_lookup);
     return v;
   };
@@ -806,12 +804,10 @@ bool contains_float(const expr2tc &e)
     return true;
 
   bool inner_float = false;
-  e->foreach_operand(
-    [&inner_float](auto &it)
-    {
-      if(contains_float(it))
-        inner_float = true;
-    });
+  e->foreach_operand([&inner_float](auto &it) {
+    if(contains_float(it))
+      inner_float = true;
+  });
 
   return inner_float;
 }
@@ -1079,6 +1075,8 @@ void interval_domaint::assume(const expr2tc &cond)
 {
   expr2tc new_cond = cond;
   simplify(new_cond);
+
+#if 0
   // Let's check whether this condition is always false
   if(
     enable_eval_assumptions &&
@@ -1088,6 +1086,7 @@ void interval_domaint::assume(const expr2tc &cond)
     make_bottom();
     return;
   }
+#endif
 
   assume_rec(new_cond, false);
 }

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -687,8 +687,7 @@ expr2tc interval_domaint::make_expression_helper<wrapped_interval>(
     // Interval: [a,b]
     std::vector<expr2tc> disjuncts;
 
-    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w)
-    {
+    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w) {
       assert(w.lower <= w.upper);
 
       std::vector<expr2tc> s_conjuncts;
@@ -728,8 +727,7 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
     return gen_false_expr();
 
   std::vector<expr2tc> conjuncts;
-  auto typecast = [&symbol](expr2tc v)
-  {
+  auto typecast = [&symbol](expr2tc v) {
     c_implicit_typecast(v, symbol->type, *migrate_namespace_lookup);
     return v;
   };
@@ -806,12 +804,10 @@ bool contains_float(const expr2tc &e)
     return true;
 
   bool inner_float = false;
-  e->foreach_operand(
-    [&inner_float](auto &it)
-    {
-      if(contains_float(it))
-        inner_float = true;
-    });
+  e->foreach_operand([&inner_float](auto &it) {
+    if(contains_float(it))
+      inner_float = true;
+  });
 
   return inner_float;
 }

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -526,8 +526,13 @@ T interval_domaint::get_interval(const expr2tc &e) const
     break;
   }
 
+  case expr2t::sideeffect_id:
+    // This is probably a nondet
+    log_debug("[Interval] returning top for side effect {}", *e);
+    break;
+
   default:
-    log_error("Could't compute interval for expr: {}", *e);
+    log_error("Couldn't compute interval for expr: {}", *e);
     abort();
   }
 
@@ -682,7 +687,8 @@ expr2tc interval_domaint::make_expression_helper<wrapped_interval>(
     // Interval: [a,b]
     std::vector<expr2tc> disjuncts;
 
-    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w) {
+    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w)
+    {
       assert(w.lower <= w.upper);
 
       std::vector<expr2tc> s_conjuncts;
@@ -722,7 +728,8 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
     return gen_false_expr();
 
   std::vector<expr2tc> conjuncts;
-  auto typecast = [&symbol](expr2tc v) {
+  auto typecast = [&symbol](expr2tc v)
+  {
     c_implicit_typecast(v, symbol->type, *migrate_namespace_lookup);
     return v;
   };
@@ -799,10 +806,12 @@ bool contains_float(const expr2tc &e)
     return true;
 
   bool inner_float = false;
-  e->foreach_operand([&inner_float](auto &it) {
-    if(contains_float(it))
-      inner_float = true;
-  });
+  e->foreach_operand(
+    [&inner_float](auto &it)
+    {
+      if(contains_float(it))
+        inner_float = true;
+    });
 
   return inner_float;
 }

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -532,8 +532,8 @@ T interval_domaint::get_interval(const expr2tc &e) const
     break;
 
   default:
-    log_error("Couldn't compute interval for expr: {}", *e);
-    abort();
+    log_debug("[Interval] Couldn't compute interval for expr: {}", *e);
+    break;
   }
 
   return result;

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1055,7 +1055,7 @@ void interval_domaint::assume(const expr2tc &cond)
   if(eval_boolean_expression(new_cond, *this).is_false())
   {
     log_debug("The expr {} is always false. Returning bottom", *cond);
-    //make_bottom();
+    make_bottom();
     return;
   }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -2,6 +2,7 @@
 /// Interval Domain
 // TODO: Ternary operators, lessthan into lessthanequal for integers
 #include <goto-programs/abstract-interpretation/interval_domain.h>
+#include <goto-programs/abstract-interpretation/bitwise_bounds.h>
 #include <util/arith_tools.h>
 #include <util/c_typecast.h>
 #include <util/std_expr.h>
@@ -452,6 +453,9 @@ T interval_domaint::get_interval(const expr2tc &e) const
   case expr2t::bitor_id:
   case expr2t::bitand_id:
   case expr2t::bitxor_id:
+  case expr2t::bitnand_id:
+  case expr2t::bitnor_id:
+  case expr2t::bitnxor_id:
     if(enable_interval_bitwise_arithmetic)
     {
       auto bit_op = std::dynamic_pointer_cast<bit_2ops>(e);
@@ -474,6 +478,13 @@ T interval_domaint::get_interval(const expr2tc &e) const
         result = lhs & rhs;
       else if(is_bitxor2t(e))
         result = lhs ^ rhs;
+
+      else if(is_bitnand2t(e))
+        result = T::bitnot(lhs & rhs);
+      else if(is_bitnor2t(e))
+        result = T::bitnot(lhs | rhs);
+      else if(is_bitnxor2t(e))
+        result = T::bitnot(lhs ^ rhs);
     }
     break;
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -295,8 +295,9 @@ T interval_domaint::get_interval(const expr2tc &e) const
   case expr2t::or_id:
   case expr2t::and_id:
   {
-    tvt lhs = eval_boolean_expression(to_and2t(e).side_1, *this);
-    tvt rhs = eval_boolean_expression(to_and2t(e).side_2, *this);
+    auto logic_op = std::dynamic_pointer_cast<logic_2ops>(e);
+    tvt lhs = eval_boolean_expression(logic_op->side_1, *this);
+    tvt rhs = eval_boolean_expression(logic_op->side_2, *this);
 
     if(is_and2t(e))
     {

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -85,6 +85,9 @@ public:
     return wrap_map;
   }
 
+  // Compute whether `cond` is a tautology for the abstract state
+  bool forward_check(const expr2tc &cond);
+
 protected:
   /**
   * Sets *this to the mathematical join between the two domains. This can be

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -11,6 +11,7 @@
 #include <util/ieee_float.h>
 #include <irep2/irep2_utils.h>
 #include <util/mp_arith.h>
+#include <util/threeval.h>
 #include <boost/multiprecision/cpp_bin_float.hpp>
 typedef interval_templatet<BigInt> integer_intervalt;
 using real_intervalt =
@@ -85,8 +86,9 @@ public:
     return wrap_map;
   }
 
-  // Compute whether `cond` is a tautology for the abstract state
-  bool forward_check(const expr2tc &cond);
+  /// Eval whether a boolean expression is always true, always false, or either (for the current state)
+  static tvt
+  eval_boolean_expression(const expr2tc &cond, const interval_domaint &id);
 
 protected:
   /**

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -56,7 +56,7 @@ public:
   static bool
     enable_wrapped_intervals; /// Enabled wrapped intervals (disables Integers)
   static bool
-    enable_real_intervals;    /// Enabled wrapped intervals (disables Integers)
+    enable_real_intervals; /// Enabled wrapped intervals (disables Integers)
   static bool enable_assume_asserts; /// Asserts are propagates as assumptions
   static bool
     enable_eval_assumptions; /// Try to evaluate in a guard in a TVT to accelerate bottoms

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -56,8 +56,10 @@ public:
   static bool
     enable_wrapped_intervals; /// Enabled wrapped intervals (disables Integers)
   static bool
-    enable_real_intervals; /// Enabled wrapped intervals (disables Integers)
-
+    enable_real_intervals;    /// Enabled wrapped intervals (disables Integers)
+  static bool enable_assume_asserts; /// Asserts are propagates as assumptions
+  static bool
+    enable_eval_assumptions; /// Try to evaluate in a guard in a TVT to accelerate bottoms
   // Widening options
   static unsigned
     fixpoint_limit; /// Sets a limit for number of iteartions before widening

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -435,8 +435,9 @@ public:
     return s;
   }
 
-  friend interval_templatet<T>
-  operator&(const interval_templatet<T> &, const interval_templatet<T> &)
+  interval_templatet<T> interval_bitand(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &) const
   {
     log_debug("No support for bitand");
     interval_templatet<T> result;
@@ -444,7 +445,14 @@ public:
   }
 
   friend interval_templatet<T>
-  operator|(const interval_templatet<T> &, const interval_templatet<T> &)
+  operator&(const interval_templatet<T> &lhs, const interval_templatet<T> &rhs)
+  {
+    return lhs.interval_bitand(lhs, rhs);
+  }
+
+  interval_templatet<T> interval_bitor(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &) const
   {
     log_debug("No support for bitor");
     interval_templatet<T> result;
@@ -452,37 +460,62 @@ public:
   }
 
   friend interval_templatet<T>
-  operator^(const interval_templatet<T> &, const interval_templatet<T> &)
+  operator|(const interval_templatet<T> &lhs, const interval_templatet<T> &rhs)
+  {
+    return lhs.interval_bitor(lhs, rhs);
+  }
+
+  interval_templatet<T> interval_bitxor(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &) const
   {
     log_debug("No support for bitxor");
     interval_templatet<T> result;
     return result;
   }
 
-  static interval_templatet<T> logical_right_shift(
-    const interval_templatet<T> &,
-    const interval_templatet<T> &)
+  friend interval_templatet<T>
+  operator^(const interval_templatet<T> &lhs, const interval_templatet<T> &rhs)
   {
-    log_debug("No support for logical right shift");
+    return lhs.interval_bitxor(lhs, rhs);
+  }
+
+  interval_templatet<T> interval_logical_right_shift(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &) const
+  {
+    log_debug("No support for lshr");
+    interval_templatet<T> result;
+    return result;
+  }
+
+  static interval_templatet<T> logical_right_shift(
+    const interval_templatet<T> &lhs,
+    const interval_templatet<T> &rhs)
+  {
+    return lhs.interval_logical_right_shift(lhs, rhs);
+  }
+
+  interval_templatet<T> interval_left_shift(
+    const interval_templatet<T> &,
+    const interval_templatet<T> &) const
+  {
+    log_debug("No support for shl");
     interval_templatet<T> result;
     return result;
   }
 
   static interval_templatet<T>
-  left_shift(const interval_templatet<T> &, const interval_templatet<T> &)
+  left_shift(const interval_templatet<T> &lhs, const interval_templatet<T> &rhs)
   {
-    log_debug("No support for left shift");
-    interval_templatet<T> result;
-    return result;
+    return lhs.interval_left_shift(lhs, rhs);
   }
 
   static interval_templatet<T> arithmetic_right_shift(
-    const interval_templatet<T> &,
-    const interval_templatet<T> &)
+    const interval_templatet<T> &lhs,
+    const interval_templatet<T> &rhs)
   {
-    log_debug("No support for arithmetic right shift");
-    interval_templatet<T> result;
-    return result;
+    return lhs.interval_left_shift(lhs, rhs);
   }
 
   static interval_templatet<T> bitnot(const interval_templatet<T> &w)
@@ -751,5 +784,4 @@ std::ostream &operator<<(std::ostream &out, const interval_templatet<T> &i)
 
   return out;
 }
-
 #endif // CPROVER_ANALYSES_INTERVAL_TEMPLATE_H

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -909,6 +909,64 @@ public:
     return result;
   }
 
+  static wrapped_interval
+  equality(const wrapped_interval &lhs, const wrapped_interval &)
+  {
+    log_debug("[wrapped] no support for equality");
+    wrapped_interval result(lhs.t);
+    return result;
+  }
+
+  static wrapped_interval invert_bool(const wrapped_interval &i)
+  {
+    if(!i.singleton())
+      return i;
+
+    auto result = i;
+    auto inverted = result.get_lower() == 0 ? 1 : 0;
+    result.set_lower(inverted);
+    result.set_upper(inverted);
+    return result;
+  }
+
+  static wrapped_interval
+  not_equal(const wrapped_interval &lhs, const wrapped_interval &rhs)
+  {
+    return invert_bool(equality(lhs, rhs));
+  }
+
+  static wrapped_interval
+  less_than(const wrapped_interval &lhs, const wrapped_interval &)
+  {
+    log_debug("[wrapped] no support for less than");
+    wrapped_interval result(lhs.t);
+    return result;
+  }
+
+  static wrapped_interval
+  less_than_equal(const wrapped_interval &lhs, const wrapped_interval &)
+  {
+    log_debug("[wrapped] no support for less than");
+    wrapped_interval result(lhs.t);
+    return result;
+  }
+
+  static wrapped_interval
+  greater_than_equal(const wrapped_interval &lhs, const wrapped_interval &)
+  {
+    log_debug("[wrapped] no support for greater than equal");
+    wrapped_interval result(lhs.t);
+    return result;
+  }
+
+  static wrapped_interval
+  greater_than(const wrapped_interval &lhs, const wrapped_interval &)
+  {
+    log_debug("[wrapped] no support for greater than");
+    wrapped_interval result(lhs.t);
+    return result;
+  }
+
   wrapped_interval sign_extension(const type2tc &cast) const
   {
     std::vector<wrapped_interval> parts;

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -910,10 +910,19 @@ public:
   }
 
   static wrapped_interval
-  equality(const wrapped_interval &lhs, const wrapped_interval &)
+  equality(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    log_debug("[wrapped] no support for equality");
     wrapped_interval result(lhs.t);
+    if(lhs.singleton() && rhs.singleton() && lhs.get_lower() == rhs.get_lower())
+    {
+      result.set_lower(1);
+      result.set_upper(1);
+    }
+    else if(intersection(lhs, rhs).empty())
+    {
+      result.set_lower(0);
+      result.set_upper(0);
+    }
     return result;
   }
 
@@ -936,35 +945,59 @@ public:
   }
 
   static wrapped_interval
-  less_than(const wrapped_interval &lhs, const wrapped_interval &)
+  less_than(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    log_debug("[wrapped] no support for less than");
     wrapped_interval result(lhs.t);
+    if(lhs.get_upper() < rhs.get_lower())
+    {
+      result.set_lower(1);
+      result.set_upper(1);
+    }
+    else if(lhs.get_lower() >= rhs.get_upper())
+    {
+      result.set_lower(0);
+      result.set_upper(0);
+    }
+    else
+    {
+      result.set_lower(0);
+      result.set_upper(1);
+    }
     return result;
   }
 
   static wrapped_interval
-  less_than_equal(const wrapped_interval &lhs, const wrapped_interval &)
+  less_than_equal(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    log_debug("[wrapped] no support for less than");
     wrapped_interval result(lhs.t);
+    if(lhs.get_upper() <= rhs.get_lower())
+    {
+      result.set_lower(1);
+      result.set_upper(1);
+    }
+    else if(lhs.get_lower() > rhs.get_upper())
+    {
+      result.set_lower(0);
+      result.set_upper(0);
+    }
+    else
+    {
+      result.set_lower(0);
+      result.set_upper(1);
+    }
     return result;
   }
 
   static wrapped_interval
-  greater_than_equal(const wrapped_interval &lhs, const wrapped_interval &)
+  greater_than_equal(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    log_debug("[wrapped] no support for greater than equal");
-    wrapped_interval result(lhs.t);
-    return result;
+    return less_than(rhs, lhs);
   }
 
   static wrapped_interval
-  greater_than(const wrapped_interval &lhs, const wrapped_interval &)
+  greater_than(const wrapped_interval &lhs, const wrapped_interval &rhs)
   {
-    log_debug("[wrapped] no support for greater than");
-    wrapped_interval result(lhs.t);
-    return result;
+    return less_than_equal(rhs, lhs);
   }
 
   wrapped_interval sign_extension(const type2tc &cast) const

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -314,13 +314,13 @@ TEST_CASE(
     "int main() {\n"
     "unsigned int a = nondet_uint(); unsigned int b=0;\n "
     "if(a < 50){\n"
-    "b = 2;\n" // a: [0, 50)
+    "b = 2;\n"    // a: [0, 50)
     "a = 52;\n"
-    "b = 2;\n" // a: [52, 52]
+    "b = 2;\n"    // a: [52, 52]
     "} else {\n"
-    "b = 4;\n" // a: [50, MAX_UINT]
+    "b = 4;\n"    // a: [50, MAX_UINT]
     "a = 51;\n"
-    "b = 4;\n" // a: [51, 51]
+    "b = 4;\n"    // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -357,13 +357,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(a < 50){\n"
-    "b = 2;\n" // a: [MIN_INT, 50)
+    "b = 2;\n"    // a: [MIN_INT, 50)
     "a = 52;\n"
-    "b = 2;\n" // a: [52, 52]
+    "b = 2;\n"    // a: [52, 52]
     "} else {\n"
-    "b = 4;\n" // a: [50, MAX_INT]
+    "b = 4;\n"    // a: [50, MAX_INT]
     "a = 51;\n"
-    "b = 4;\n" // a: [51, 51]
+    "b = 4;\n"    // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -389,14 +389,14 @@ TEST_CASE(
   T.code =
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
-    "if(a < -50){\n"
-    "b = 2;\n" // a: [MIN_INT, -50)
+    "if(a <= -50){\n"
+    "b = 2;\n"    // a: [MIN_INT, -50)
     "a = -52;\n"
-    "b = 2;\n" // a: [-52, -52]
+    "b = 2;\n"    // a: [-52, -52]
     "} else {\n"
-    "b = 4;\n" // a: [-50, MAX_INT]
+    "b = 4;\n"    // a: [-50, MAX_INT]
     "a = 51;\n"
-    "b = 4;\n" // a: [51, 51]
+    "b = 4;\n"    // a: [51, 51]
     "}\n"
     "return a;\n" // a : [-52,51]
     "}";
@@ -423,13 +423,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(50 < a){\n"
-    "b = 2;\n" // a: [51, MAX_INT)
+    "b = 2;\n"    // a: [51, MAX_INT)
     "a = 52;\n"
-    "b = 2;\n" // a: [52, 52]
+    "b = 2;\n"    // a: [52, 52]
     "} else {\n"
-    "b = 4;\n" // a: [MIN_INT, 50]
+    "b = 4;\n"    // a: [MIN_INT, 50]
     "a = 51;\n"
-    "b = 4;\n" // a: [51, 51]
+    "b = 4;\n"    // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -456,13 +456,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(-50 < a){\n"
-    "b = 2;\n" // a: [-49, MAX_INT)
+    "b = 2;\n"    // a: [-49, MAX_INT)
     "a = 52;\n"
-    "b = 2;\n" // a: [52, 52]
+    "b = 2;\n"    // a: [52, 52]
     "} else {\n"
-    "b = 4;\n" // a: [MIN_INT, -50]
+    "b = 4;\n"    // a: [MIN_INT, -50]
     "a = 51;\n"
-    "b = 4;\n" // a: [51, 51]
+    "b = 4;\n"    // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -495,9 +495,9 @@ TEST_CASE(
     "b = 5;\n"
     "a = 10;\n"
     "}\n"
-    "c = 0;\n" // a: [1,10] or [10,1] b: [0,5] or [5,0]
+    "c = 0;\n"    // a: [1,10] or [10,1] b: [0,5] or [5,0]
     "if(a < b) {\n"
-    "c = 5;\n" // a: must contain 1, b: must contain 5
+    "c = 5;\n"    // a: must contain 1, b: must contain 5
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -524,9 +524,9 @@ TEST_CASE("Interval Analysis - While Statement", "[ai][interval-analysis]")
     "while(a < 100) {\n" // a: [0,100]
     "b = 1;\n"           // a: [0, 99]
     "a++;\n"
-    "b = 1;\n" // a: [1, 100]
+    "b = 1;\n"           // a: [1, 100]
     "}\n"
-    "return a;\n" // a : [100, 100]
+    "return a;\n"        // a : [100, 100]
     "}";
 
   T.property["2"].push_back({"@F@main@a", 0, true});

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -314,13 +314,13 @@ TEST_CASE(
     "int main() {\n"
     "unsigned int a = nondet_uint(); unsigned int b=0;\n "
     "if(a < 50){\n"
-    "b = 2;\n"    // a: [0, 50)
+    "b = 2;\n" // a: [0, 50)
     "a = 52;\n"
-    "b = 2;\n"    // a: [52, 52]
+    "b = 2;\n" // a: [52, 52]
     "} else {\n"
-    "b = 4;\n"    // a: [50, MAX_UINT]
+    "b = 4;\n" // a: [50, MAX_UINT]
     "a = 51;\n"
-    "b = 4;\n"    // a: [51, 51]
+    "b = 4;\n" // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -357,13 +357,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(a < 50){\n"
-    "b = 2;\n"    // a: [MIN_INT, 50)
+    "b = 2;\n" // a: [MIN_INT, 50)
     "a = 52;\n"
-    "b = 2;\n"    // a: [52, 52]
+    "b = 2;\n" // a: [52, 52]
     "} else {\n"
-    "b = 4;\n"    // a: [50, MAX_INT]
+    "b = 4;\n" // a: [50, MAX_INT]
     "a = 51;\n"
-    "b = 4;\n"    // a: [51, 51]
+    "b = 4;\n" // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -390,13 +390,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(a <= -50){\n"
-    "b = 2;\n"    // a: [MIN_INT, -50)
+    "b = 2;\n" // a: [MIN_INT, -50)
     "a = -52;\n"
-    "b = 2;\n"    // a: [-52, -52]
+    "b = 2;\n" // a: [-52, -52]
     "} else {\n"
-    "b = 4;\n"    // a: [-50, MAX_INT]
+    "b = 4;\n" // a: [-50, MAX_INT]
     "a = 51;\n"
-    "b = 4;\n"    // a: [51, 51]
+    "b = 4;\n" // a: [51, 51]
     "}\n"
     "return a;\n" // a : [-52,51]
     "}";
@@ -423,13 +423,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(50 < a){\n"
-    "b = 2;\n"    // a: [51, MAX_INT)
+    "b = 2;\n" // a: [51, MAX_INT)
     "a = 52;\n"
-    "b = 2;\n"    // a: [52, 52]
+    "b = 2;\n" // a: [52, 52]
     "} else {\n"
-    "b = 4;\n"    // a: [MIN_INT, 50]
+    "b = 4;\n" // a: [MIN_INT, 50]
     "a = 51;\n"
-    "b = 4;\n"    // a: [51, 51]
+    "b = 4;\n" // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -456,13 +456,13 @@ TEST_CASE(
     "int main() {\n"
     "int a = nondet_int(); int b=0;\n "
     "if(-50 < a){\n"
-    "b = 2;\n"    // a: [-49, MAX_INT)
+    "b = 2;\n" // a: [-49, MAX_INT)
     "a = 52;\n"
-    "b = 2;\n"    // a: [52, 52]
+    "b = 2;\n" // a: [52, 52]
     "} else {\n"
-    "b = 4;\n"    // a: [MIN_INT, -50]
+    "b = 4;\n" // a: [MIN_INT, -50]
     "a = 51;\n"
-    "b = 4;\n"    // a: [51, 51]
+    "b = 4;\n" // a: [51, 51]
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -495,9 +495,9 @@ TEST_CASE(
     "b = 5;\n"
     "a = 10;\n"
     "}\n"
-    "c = 0;\n"    // a: [1,10] or [10,1] b: [0,5] or [5,0]
+    "c = 0;\n" // a: [1,10] or [10,1] b: [0,5] or [5,0]
     "if(a < b) {\n"
-    "c = 5;\n"    // a: must contain 1, b: must contain 5
+    "c = 5;\n" // a: must contain 1, b: must contain 5
     "}\n"
     "return a;\n" // a : [51,52]
     "}";
@@ -524,9 +524,9 @@ TEST_CASE("Interval Analysis - While Statement", "[ai][interval-analysis]")
     "while(a < 100) {\n" // a: [0,100]
     "b = 1;\n"           // a: [0, 99]
     "a++;\n"
-    "b = 1;\n"           // a: [1, 100]
+    "b = 1;\n" // a: [1, 100]
     "}\n"
-    "return a;\n"        // a : [100, 100]
+    "return a;\n" // a : [100, 100]
     "}";
 
   T.property["2"].push_back({"@F@main@a", 0, true});


### PR DESCRIPTION
Blocked by: #1092 

Closes #1054 

For now the PR is forcing Incremental for reachability

This PR:

1. Threats booleans as [0,1] intervals for all operations. This adds support for: arithmethic, relations, logic and all sorts of operations over intervals.
2. Adds the method `eval_boolean_expression` that evaluates an expression (under an abstract state) returning a tvt to whether that expression results in TRUE, FALSE or MAYBE.
3. Adds support for more expressions at the get_interval function (which computes the interval of a expression in an abstract state).
4. Simplifies guard expressions by replacing the sub-expr with truth values when possible.
5. Replaces intructions (ASSUMES,ASSERTS,GOTO) with Skips or trivial cases when possible,