### PR TITLE
Fix for TC template2 in 1108

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/1108_ref_integral/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_integral/main.cpp
@@ -1,0 +1,16 @@
+// TC description:
+//  Test function argument and return are both lvalue references.
+
+#include<cassert>
+
+int& Value1(int &value)
+{
+  return value;
+}
+
+int main()
+{
+    int x=5;
+    assert(Value1(x)==5);
+    return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_integral/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_integral/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_integral_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_integral_fail/main.cpp
@@ -1,0 +1,13 @@
+#include<cassert>
+
+int& Value1(int &value)
+{
+  return value;
+}
+
+int main()
+{
+    int x=5;
+    assert(Value1(x)==10); // should be 5
+    return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_integral_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_integral_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/template/template_1/main.cpp
+++ b/regression/esbmc-cpp/template/template_1/main.cpp
@@ -1,3 +1,5 @@
+// TC description:
+//  - lvalue reference to an array in function template argument
 #include<cassert>
 
 template< class T >

--- a/regression/esbmc-cpp/template/template_1_bug/main.cpp
+++ b/regression/esbmc-cpp/template/template_1_bug/main.cpp
@@ -1,3 +1,5 @@
+// TC description:
+//  - lvalue reference to an array in function template argument
 #include<cassert>
 
 template< class T >

--- a/regression/esbmc-cpp/template/template_2/main.cpp
+++ b/regression/esbmc-cpp/template/template_2/main.cpp
@@ -1,18 +1,6 @@
+// TC description:
+//  lvalue reference argument to an integral in function template
 #include<cassert>
-
-template< class T, class T1>
-class FixedArray25
-{
-  public:
-    T anValue[25];
-};
-
-// Returns a reference to the nIndex element of rArray
-template< class T, class T1>
-T& Value( FixedArray25<T, T1> &rArray, int nIndex)
-{
-  return rArray.anValue[nIndex];
-}
 
 template< class T>
 T& Value1(T &value)
@@ -22,17 +10,8 @@ T& Value1(T &value)
 
 int main()
 {
-    FixedArray25<float, char> sMyArray;
-    FixedArray25<int, char> sMyArray1;
-
     int x=5;
     assert(Value1(x)==5);
-
-    Value(sMyArray, 10) = 5.0;
-    assert(sMyArray.anValue[10] == 5.0);
-    Value(sMyArray, 15) = 10.0;
-    assert(sMyArray.anValue[15] == 10.0);
-    assert(sMyArray.anValue[10] == 5.0);
 
     return 0;
 }

--- a/regression/esbmc-cpp/template/template_2_bug/main.cpp
+++ b/regression/esbmc-cpp/template/template_2_bug/main.cpp
@@ -1,18 +1,6 @@
+// TC description:
+//  lvalue reference argument to an integral in function template
 #include<cassert>
-
-template< class T, class T1>
-class FixedArray25
-{
-  public:
-    T anValue[25];
-};
-
-// Returns a reference to the nIndex element of rArray
-template< class T, class T1>
-T& Value( FixedArray25<T, T1> &rArray, int nIndex)
-{
-  return rArray.anValue[nIndex];
-}
 
 template< class T>
 T& Value1(T &value)
@@ -22,17 +10,8 @@ T& Value1(T &value)
 
 int main()
 {
-    FixedArray25<float, char> sMyArray;
-    FixedArray25<int, char> sMyArray1;
-
     int x=5;
-    assert(Value1(x)==5);
-
-    Value(sMyArray, 10) = 5.0;
-    assert(sMyArray.anValue[10] == 5.0);
-    Value(sMyArray, 15) = 10.0;
-    assert(sMyArray.anValue[15] == 10.0);
-    assert(sMyArray.anValue[10] != 5.0);
+    assert(Value1(x)!=5); // should be 5
 
     return 0;
 }

--- a/regression/esbmc-cpp/template/template_3/main.cpp
+++ b/regression/esbmc-cpp/template/template_3/main.cpp
@@ -1,0 +1,32 @@
+// TC description:
+//  - This TC is just a variant of template_1, using float instead of int
+//    for the type parameter of class template
+//  - lvalue reference to an array in function template argument
+#include<cassert>
+
+template< class T, class T1>
+class FixedArray25
+{
+  public:
+    T anValue[25];
+};
+
+// Returns a reference to the nIndex element of rArray
+template< class T, class T1>
+T& Value( FixedArray25<T, T1> &rArray, int nIndex)
+{
+  return rArray.anValue[nIndex];
+}
+
+int main()
+{
+    FixedArray25<float, char> sMyArray;
+
+    Value(sMyArray, 10) = 5.0;
+    assert(sMyArray.anValue[10] == 5.0);
+    Value(sMyArray, 15) = 10.0;
+    assert(sMyArray.anValue[15] == 10.0);
+    assert(sMyArray.anValue[10] == 5.0);
+
+    return 0;
+}

--- a/regression/esbmc-cpp/template/template_3/test.desc
+++ b/regression/esbmc-cpp/template/template_3/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>CORE</item_10_mode>
+<item_10_mode>KNOWNBUG</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/template_3/testllvm.desc
+++ b/regression/esbmc-cpp/template/template_3/testllvm.desc
@@ -1,13 +1,12 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <test-case>
   <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=10 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/template_3_bug/main.cpp
+++ b/regression/esbmc-cpp/template/template_3_bug/main.cpp
@@ -1,0 +1,32 @@
+// TC description:
+//  - This TC is just a variant of template_1, using float instead of int
+//    for the type parameter of class template
+//  - lvalue reference to an array in function template argument
+#include<cassert>
+
+template< class T, class T1>
+class FixedArray25
+{
+  public:
+    T anValue[25];
+};
+
+// Returns a reference to the nIndex element of rArray
+template< class T, class T1>
+T& Value( FixedArray25<T, T1> &rArray, int nIndex)
+{
+  return rArray.anValue[nIndex];
+}
+
+int main()
+{
+    FixedArray25<float, char> sMyArray;
+
+    Value(sMyArray, 10) = 5.0;
+    assert(sMyArray.anValue[10] == 5.0);
+    Value(sMyArray, 15) = 10.0;
+    assert(sMyArray.anValue[15] == 10.0);
+    assert(sMyArray.anValue[10] != 5.0); // should be 5.0
+
+    return 0;
+}

--- a/regression/esbmc-cpp/template/template_3_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_3_bug/test.desc
@@ -5,7 +5,7 @@
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
   <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>

--- a/regression/esbmc-cpp/template/template_3_bug/testllvm.desc
+++ b/regression/esbmc-cpp/template/template_3_bug/testllvm.desc
@@ -1,13 +1,12 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <test-case>
   <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
+  <item_04_file_C_to_test>main.bc</item_04_file_C_to_test>
+  <item_05_option_to_run_esbmc>--ignore-missing-function-bodies --max-loop-iterations=10 --no-max-loop-iterations-checks</item_05_option_to_run_esbmc>
+  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -49,7 +49,7 @@ protected:
   void adjust_expr_shifts(exprt &expr);
   void adjust_expr_unary_boolean(exprt &expr);
   void adjust_expr_binary_boolean(exprt &expr);
-  void adjust_expr_rel(exprt &expr);
+  virtual void adjust_expr_rel(exprt &expr);
   void adjust_float_arith(exprt &expr);
   void adjust_index(index_exprt &index);
   void adjust_dereference(exprt &deref);

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -189,6 +189,7 @@ void clang_c_adjust::adjust_symbol(exprt &expr)
       expr.swap(tmp);
     }
 
+#if 0
     if(expr.type().get_bool("#reference")) // lvalue reference
     {
       // r is an lvalue ref.
@@ -197,6 +198,7 @@ void clang_c_adjust::adjust_symbol(exprt &expr)
       tmp.location() = expr.location();
       expr.swap(tmp);
     }
+#endif
   }
 }
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -48,6 +48,9 @@ bool clang_c_adjust::adjust()
 
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
+  if(symbol.id == "c:@F@Value1#&I#")
+    printf("Got Value1\n");
+
   if(!symbol.value.is_nil())
     adjust_expr(symbol.value);
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -48,9 +48,6 @@ bool clang_c_adjust::adjust()
 
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
-  if(symbol.id == "c:@F@main#")
-    printf("Got it\n");
-
   if(!symbol.value.is_nil())
     adjust_expr(symbol.value);
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -188,17 +188,6 @@ void clang_c_adjust::adjust_symbol(exprt &expr)
       tmp.location() = expr.location();
       expr.swap(tmp);
     }
-
-#if 0
-    if(expr.type().get_bool("#reference")) // lvalue reference
-    {
-      // r is an lvalue ref.
-      // turn `r = 1;` into `*r = 1;`
-      dereference_exprt tmp(expr, expr.type());
-      tmp.location() = expr.location();
-      expr.swap(tmp);
-    }
-#endif
   }
 }
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -48,8 +48,8 @@ bool clang_c_adjust::adjust()
 
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
-  if(symbol.id == "c:@F@Value1#&I#")
-    printf("Got Value1\n");
+  if(symbol.id == "c:@F@main#")
+    printf("Got it\n");
 
   if(!symbol.value.is_nil())
     adjust_expr(symbol.value);

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -638,9 +638,6 @@ bool clang_c_convertert::get_function(
   added_symbol.type = type;
   new_expr.type() = type;
 
-  if(id == "c:@F@Value1#&I#")
-    printf("Got it\n");
-
   // We need: a type, a name, and an optional body
   if(fd.hasBody())
   {

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -638,6 +638,9 @@ bool clang_c_convertert::get_function(
   added_symbol.type = type;
   new_expr.type() = type;
 
+  if(id == "c:@F@Value1#&I#")
+    printf("Got it\n");
+
   // We need: a type, a name, and an optional body
   if(fd.hasBody())
   {
@@ -677,7 +680,7 @@ bool clang_c_convertert::get_function_params(
   {
     code_typet::argumentt param;
     if(get_function_param(*pdecl, param))
-      return true; // return true if failling to parse a parameter
+      return true; // return true if failing to parse a parameter
 
     params.push_back(param);
   }
@@ -738,7 +741,7 @@ bool clang_c_convertert::get_function_param(
   const clang::FunctionDecl &fd =
     static_cast<const clang::FunctionDecl &>(*pd.getParentFunctionOrMethod());
 
-  // If the function is not defined, we don't need to add it's parameter
+  // If the function is not defined, we don't need to add its parameter
   // to the context, they will never be used
   if(!fd.isDefined())
     return false;

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -42,6 +42,7 @@ public:
   void adjust_member(member_exprt &expr) override;
   void adjust_side_effect(side_effect_exprt &expr) override;
   void adjust_side_effect_assign(side_effect_exprt &expr);
+  void adjust_expr_rel(exprt &expr) override;
   void adjust_new(exprt &expr);
   void adjust_cpp_member(member_exprt &expr);
 
@@ -74,6 +75,7 @@ public:
    * ancillary methods to support the expr/code adjustments above
    */
   void convert_expression_to_code(exprt &expr);
+  void convert_lvalue_ref_to_deref(exprt &expr);
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -128,7 +128,7 @@ void clang_cpp_adjust::adjust_side_effect_assign(side_effect_exprt &expr)
   // sideeffect assign got be representing a binary operator
   assert(expr.operands().size() == 2);
 
-  //exprt &lhs = expr.op0();
+  exprt &lhs = expr.op0();
   exprt &rhs = expr.op1();
 
   if(
@@ -159,6 +159,15 @@ void clang_cpp_adjust::adjust_side_effect_assign(side_effect_exprt &expr)
     // there's no missing adjustment we need to carry out
     clang_c_adjust::adjust_side_effect_function_call(
       to_side_effect_expr_function_call(expr));
+  }
+  else if(lhs.is_symbol() && lhs.type().get_bool("#reference"))
+  {
+    // since we modelled lvalue reference as pointers
+    // turn assign expression r = 1, where r is an lvalue reference
+    // into *r = 1
+    dereference_exprt tmp(lhs, lhs.type());
+    tmp.location() = expr.location();
+    lhs.swap(tmp);
   }
   else
     clang_c_adjust::adjust_side_effect(expr);

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -81,7 +81,7 @@ bool clang_cpp_languaget::typecheck(
   if(adjuster.adjust())
     return true;
 
-#if 1
+#if 0
   printf("symbol table after adjust\n");
   std::ostringstream oss;
   ::show_symbol_table_plain(namespacet(new_context), oss);

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -15,8 +15,6 @@ CC_DIAGNOSTIC_POP()
 #include <regex>
 #include <util/filesystem.h>
 #include <fstream>
-#include <util/show_symbol_table.h>
-#include <iostream>
 
 languaget *new_clang_cpp_language()
 {
@@ -70,23 +68,9 @@ bool clang_cpp_languaget::typecheck(
   if(converter.convert())
     return true;
 
-#if 0
-  printf("symbol table before adjust\n");
-  std::ostringstream oss;
-  ::show_symbol_table_plain(namespacet(new_context), oss);
-  std::cout << oss.str() << std::endl;
-#endif
-
   clang_cpp_adjust adjuster(new_context);
   if(adjuster.adjust())
     return true;
-
-#if 0
-  printf("symbol table after adjust\n");
-  std::ostringstream oss;
-  ::show_symbol_table_plain(namespacet(new_context), oss);
-  std::cout << oss.str() << std::endl;
-#endif
 
   if(c_link(context, new_context, module))
     return true;

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -15,6 +15,8 @@ CC_DIAGNOSTIC_POP()
 #include <regex>
 #include <util/filesystem.h>
 #include <fstream>
+#include <util/show_symbol_table.h>
+#include <iostream>
 
 languaget *new_clang_cpp_language()
 {
@@ -68,9 +70,23 @@ bool clang_cpp_languaget::typecheck(
   if(converter.convert())
     return true;
 
+#if 0
+  printf("symbol table before adjust\n");
+  std::ostringstream oss;
+  ::show_symbol_table_plain(namespacet(new_context), oss);
+  std::cout << oss.str() << std::endl;
+#endif
+
   clang_cpp_adjust adjuster(new_context);
   if(adjuster.adjust())
     return true;
+
+#if 1
+  printf("symbol table after adjust\n");
+  std::ostringstream oss;
+  ::show_symbol_table_plain(namespacet(new_context), oss);
+  std::cout << oss.str() << std::endl;
+#endif
 
   if(c_link(context, new_context, module))
     return true;

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,10 +33,20 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
+    {
+      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+      out << s.type.pretty(0) << "\n";
+      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
+    }
 
     if(s.value.is_not_nil())
+    {
+      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+      out << s.value.pretty(0) << "\n";
+      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
+    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,20 +33,10 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
-    {
-      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
-      out << s.type.pretty(0) << "\n";
-      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
-    }
 
     if(s.value.is_not_nil())
-    {
-      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
-      out << s.value.pretty(0) << "\n";
-      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
-    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
Fixed lvalue reference for Template2 in https://github.com/esbmc/esbmc/issues/1108

Enabled: 
- `template/template_2`

Also added two more TCs to test lvalue reference for function parameter without template 
- `bug_fixes/1108_ref_integral/` and `bug_fixes/1108_ref_integral_fail` 

The orginal `template/template_2` has been splitted into `template/template_2` (for integral lvalue ref) and `template/template_3`(a variant of `template/template_1`). 1 and 3 will be fixed in the next PR. 