### PR TITLE
Various fixes for C++ verification

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/1108_ref_array/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_array/main.cpp
@@ -1,0 +1,31 @@
+// TC description:
+//  Test function argument and return are both lvalue references.
+//  This TC is a simplified version of esbmc-cpp/template/template_1 and _3
+
+#include<cassert>
+
+class FixedArray25
+{
+  public:
+    int anValue[25];
+};
+
+// Returns a reference to the nIndex element of rArray
+int& Value( FixedArray25 &rArray, int nIndex)
+{
+  return rArray.anValue[nIndex];
+}
+
+int main()
+{
+    FixedArray25 sMyArray;
+
+    Value(sMyArray, 10) = 5;
+    assert(sMyArray.anValue[10] == 5);
+    Value(sMyArray, 15) = 10;
+    assert(sMyArray.anValue[15] == 10);
+    assert(sMyArray.anValue[10] == 5);
+    //assert(sMyArray.anValue[10] == 10); // should be 5
+
+    return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_array/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_array/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_array_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_array_fail/main.cpp
@@ -1,0 +1,31 @@
+// TC description:
+//  Test function argument and return are both lvalue references.
+//  This TC is a simplified version of esbmc-cpp/template/template_1 and _3
+
+#include<cassert>
+
+class FixedArray25
+{
+  public:
+    int anValue[25];
+};
+
+// Returns a reference to the nIndex element of rArray
+int& Value( FixedArray25 &rArray, int nIndex)
+{
+  return rArray.anValue[nIndex];
+}
+
+int main()
+{
+    FixedArray25 sMyArray;
+
+    Value(sMyArray, 10) = 5;
+    assert(sMyArray.anValue[10] == 5);
+    Value(sMyArray, 15) = 10;
+    assert(sMyArray.anValue[15] == 10);
+    assert(sMyArray.anValue[10] == 5);
+    assert(sMyArray.anValue[10] == 10); // should be 5
+
+    return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_array_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_array_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_integral/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_integral/main.cpp
@@ -1,5 +1,6 @@
 // TC description:
 //  Test function argument and return are both lvalue references.
+//  This TC is a simplified version of esbmc-cpp/template/template_2
 
 #include<cassert>
 

--- a/regression/esbmc-cpp/bug_fixes/1108_ref_integral_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1108_ref_integral_fail/main.cpp
@@ -1,3 +1,7 @@
+// TC description:
+//  Test function argument and return are both lvalue references.
+//  This TC is a simplified version of esbmc-cpp/template/template_2
+
 #include<cassert>
 
 int& Value1(int &value)

--- a/regression/esbmc-cpp/cpp/ch10_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch10_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch11_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch11_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_11/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_13/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_14/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_15/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_16/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_17/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_17/testllvm.desc
+++ b/regression/esbmc-cpp/cpp/ch12_17/testllvm.desc
@@ -9,4 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
+  <item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/cpp/ch12_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_18/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch12_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_7/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch16_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_11/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_14/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_17/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_19/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_20/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_22/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_24/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_24/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_25/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_25/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_26/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_26/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_27/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_27/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_29/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_29/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_30/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_30/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_31/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_31/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch18_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_9/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch19_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch19_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch1_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch1_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch20_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch20_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch20_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch20_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch20_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch20_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch22_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch22_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch22_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch22_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_7/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch22_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_11/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_14/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_15/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_16/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_17/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_18/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch2_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_11/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_15/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_16/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_17/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_18/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_20/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_21/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_22/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_24/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_24/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_25/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_25/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_7/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch3_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_13/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_14/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_16/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_20/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_21/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch4_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_9/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_15/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_16/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_18/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_19/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_21/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_22/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_23/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_23/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch5_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_7/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch6_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch6_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_11/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch6_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch6_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_10/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_11/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_12/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_7/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch8_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch8_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_7/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_1/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_2/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_5/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_6/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_8/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch9_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_9/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring10_strpbrk/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring10_strpbrk/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring11_strtok/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring11_strtok/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring16_memcmp/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring16_memcmp/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring18_memset/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring18_memset/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring20_strncmp_failed/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring20_strncmp_failed/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring3_strncat/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring3_strncat/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring4_strcmp/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring4_strcmp/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring5_strncmp/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring5_strncmp/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring8_strcpn/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring8_strcpn/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/cstring9_strlen/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring9_strlen/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/stream/istream_gcount_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_gcount_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_gcount_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_gcount_2_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_getline_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_getline_2/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_2/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_getline_3_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_3_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_getline_4_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_4_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_ignore_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_ignore_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_ignore_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_ignore_2_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_operator_float/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_float/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_operator_int/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_int/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_operator_short/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_short/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_peek_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_peek_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_peek_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_peek_2_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_putback_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_putback_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_putback_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_putback_2_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_unget_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_unget_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/istream_unget_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_unget_2_bug/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/ostream_operator_bool/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_bool/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/ostream_operator_float/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_float/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/ostream_operator_int/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_int/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/stream/ostream_operator_short/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_short/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/template_1/test.desc
+++ b/regression/esbmc-cpp/template/template_1/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/template/template_3/test.desc
+++ b/regression/esbmc-cpp/template/template_3/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/vector/algorithm59/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm59/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/vector/algorithm60/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm60/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp/vector/algorithm62/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm62/test.desc
@@ -9,5 +9,5 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode>
+<item_10_mode>CORE</item_10_mode>
 </test-case>

--- a/regression/esbmc-cpp11/cpp/ch2_05/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_05/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch2_13/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_01/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_01/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_02/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_07/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_07/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_13/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_14/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_14/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_18/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_18/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions -I ~/libraries/ --memlimit 14000000 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -82,7 +82,8 @@ protected:
    * ancillary methods to support the expr/code adjustments above
    */
   virtual void align_se_function_call_return_type(
-    exprt &f_op, side_effect_expr_function_callt &expr);
+    exprt &f_op,
+    side_effect_expr_function_callt &expr);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_ADJUST_H_ */

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -77,6 +77,12 @@ protected:
   void adjust_decl(codet &code);
   // For class instantiation in C++, we need to adjust the side-effect of constructor
   virtual void adjust_decl_block(codet &code);
+
+  /**
+   * ancillary methods to support the expr/code adjustments above
+   */
+  virtual void align_se_function_call_return_type(
+    exprt &f_op, side_effect_expr_function_callt &expr);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_ADJUST_H_ */

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -59,7 +59,8 @@ protected:
   void adjust_symbol(exprt &expr);
   void adjust_comma(exprt &expr);
   void adjust_builtin_va_arg(exprt &expr);
-  void adjust_function_call_arguments(side_effect_expr_function_callt &expr);
+  virtual void
+  adjust_function_call_arguments(side_effect_expr_function_callt &expr);
   void do_special_functions(side_effect_expr_function_callt &expr);
   void adjust_operands(exprt &expr);
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1219,7 +1219,8 @@ void clang_c_adjust::adjust_operands(exprt &expr)
 }
 
 void clang_c_adjust::align_se_function_call_return_type(
-  exprt &, side_effect_expr_function_callt &)
+  exprt &,
+  side_effect_expr_function_callt &)
 {
   // nothing to be aligned for C
 }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -48,6 +48,9 @@ bool clang_c_adjust::adjust()
 
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
+  if(symbol.id == "c:@F@main#")
+    printf("Got main\n");
+
   if(!symbol.value.is_nil())
     adjust_expr(symbol.value);
 
@@ -615,6 +618,8 @@ void clang_c_adjust::adjust_side_effect_function_call(
     }
     else
     {
+      if(s->id == "c:@F@Value#&$@S@FixedArray25#I#")
+        printf("Got callsite\n");
       // Pull symbol informations, like parameter types and location
 
       // Save previous location
@@ -628,6 +633,11 @@ void clang_c_adjust::adjust_side_effect_function_call(
 
       if(symbol.lvalue)
         f_op.cmt_lvalue(true);
+
+      // align the side effect's type at callsite with the
+      // function return type
+      const typet &return_type = (typet &)f_op.type().return_type();
+      expr.type() = return_type;
     }
   }
   else

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -618,7 +618,7 @@ void clang_c_adjust::adjust_side_effect_function_call(
     }
     else
     {
-      if(s->id == "c:@F@Value#&$@S@FixedArray25#I#")
+      if(s->id == "c:@F@Value1#&I#")
         printf("Got callsite\n");
       // Pull symbol informations, like parameter types and location
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -634,10 +634,7 @@ void clang_c_adjust::adjust_side_effect_function_call(
       if(symbol.lvalue)
         f_op.cmt_lvalue(true);
 
-      // align the side effect's type at callsite with the
-      // function return type
-      const typet &return_type = (typet &)f_op.type().return_type();
-      expr.type() = return_type;
+      align_se_function_call_return_type(f_op, expr);
     }
   }
   else
@@ -1219,4 +1216,10 @@ void clang_c_adjust::adjust_operands(exprt &expr)
 
   for(auto &op : expr.operands())
     adjust_expr(op);
+}
+
+void clang_c_adjust::align_se_function_call_return_type(
+  exprt &, side_effect_expr_function_callt &)
+{
+  // nothing to be aligned for C
 }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -48,9 +48,6 @@ bool clang_c_adjust::adjust()
 
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
-  if(symbol.id == "c:@F@main#")
-    printf("Got main\n");
-
   if(!symbol.value.is_nil())
     adjust_expr(symbol.value);
 
@@ -618,8 +615,6 @@ void clang_c_adjust::adjust_side_effect_function_call(
     }
     else
     {
-      if(s->id == "c:@F@Value1#&I#")
-        printf("Got callsite\n");
       // Pull symbol informations, like parameter types and location
 
       // Save previous location

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -610,6 +610,9 @@ bool clang_c_convertert::get_function(
   std::string id, name;
   get_decl_name(fd, name, id);
 
+  if(id == "c:@F@Value#&$@S@FixedArray25#I#")
+    printf("Got Value\n");
+
   symbolt symbol;
   get_default_symbol(
     symbol,

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -610,9 +610,6 @@ bool clang_c_convertert::get_function(
   std::string id, name;
   get_decl_name(fd, name, id);
 
-  if(id == "c:@F@Value#&$@S@FixedArray25#I#")
-    printf("Got Value\n");
-
   symbolt symbol;
   get_default_symbol(
     symbol,

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -77,7 +77,8 @@ public:
    * ancillary methods to support the expr/code adjustments above
    */
   void convert_expression_to_code(exprt &expr);
-  void convert_lvalue_ref_to_deref(exprt &expr);
+  void convert_lvalue_ref_to_deref_symbol(exprt &expr);
+  void convert_lvalue_ref_to_deref_sideeffect(exprt &expr);
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -42,6 +42,8 @@ public:
   void adjust_member(member_exprt &expr) override;
   void adjust_side_effect(side_effect_exprt &expr) override;
   void adjust_side_effect_assign(side_effect_exprt &expr);
+  void adjust_function_call_arguments(
+    side_effect_expr_function_callt &expr) override;
   void adjust_expr_rel(exprt &expr) override;
   void adjust_new(exprt &expr);
   void adjust_cpp_member(member_exprt &expr);

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -80,7 +80,8 @@ public:
   void convert_lvalue_ref_to_deref_symbol(exprt &expr);
   void convert_lvalue_ref_to_deref_sideeffect(exprt &expr);
   void align_se_function_call_return_type(
-    exprt &f_op, side_effect_expr_function_callt &expr) override;
+    exprt &f_op,
+    side_effect_expr_function_callt &expr) override;
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -79,6 +79,8 @@ public:
   void convert_expression_to_code(exprt &expr);
   void convert_lvalue_ref_to_deref_symbol(exprt &expr);
   void convert_lvalue_ref_to_deref_sideeffect(exprt &expr);
+  void align_se_function_call_return_type(
+    exprt &f_op, side_effect_expr_function_callt &expr) override;
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -167,6 +167,22 @@ void clang_cpp_adjust::adjust_side_effect_assign(side_effect_exprt &expr)
     // into *r = 1
     convert_lvalue_ref_to_deref(lhs);
   }
+  else if(lhs.id() == "sideeffect" && lhs.statement() == "function_call")
+  {
+    // deal with X(a) = 5; where X(a) returns an lvalue reference which
+    // is modelled as a pointer. Hence we got to align the LHS with RHS:
+    // *X(a) = 5;
+    // rather than align RHS with LHS:
+    // X(a) = (int &)5; // which is far removed from the original symatics
+
+    // first adjust LHS to make sure its type aligns with the
+    // function return type
+    adjust_side_effect_function_call(to_side_effect_expr_function_call(lhs));
+    if(lhs.type().get_bool("#reference"))
+    {
+      assert(!"Got it");
+    }
+  }
   else
     clang_c_adjust::adjust_side_effect(expr);
 }

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -268,7 +268,8 @@ void clang_cpp_adjust::adjust_function_call_arguments(
 }
 
 void clang_cpp_adjust::align_se_function_call_return_type(
-  exprt &f_op, side_effect_expr_function_callt &expr)
+  exprt &f_op,
+  side_effect_expr_function_callt &expr)
 {
   // align the side effect's type at callsite with the
   // function return type. But ignore constructors

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -266,3 +266,13 @@ void clang_cpp_adjust::adjust_function_call_arguments(
     }
   }
 }
+
+void clang_cpp_adjust::align_se_function_call_return_type(
+  exprt &f_op, side_effect_expr_function_callt &expr)
+{
+  // align the side effect's type at callsite with the
+  // function return type. But ignore constructors
+  const typet &return_type = (typet &)f_op.type().return_type();
+  if(return_type.id() != "constructor")
+    expr.type() = return_type;
+}

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -212,3 +212,37 @@ void clang_cpp_adjust::convert_lvalue_ref_to_deref(exprt &expr)
   tmp.location() = expr.location();
   expr.swap(tmp);
 }
+
+void clang_cpp_adjust::adjust_function_call_arguments(
+  side_effect_expr_function_callt &expr)
+{
+  clang_c_adjust::adjust_function_call_arguments(expr);
+
+  exprt &f_op = expr.function();
+  const code_typet &code_type = to_code_type(f_op.type());
+  exprt::operandst &arguments = expr.arguments();
+  const code_typet::argumentst &argument_types = code_type.arguments();
+
+  for(unsigned i = 0; i < arguments.size(); i++)
+  {
+    exprt &op = arguments[i];
+    if(op.is_typecast() && op.type().get_bool("#reference"))
+    {
+      // special treatment for lvalue reference in function parameter list
+      // e.g. for F(a), where F is a function taking an int lvalue reference.
+      // Since we've modelled lvalue references as pointers, clang_c_aduster
+      // would have adjusted the parameter to a typecasting expression:
+      //  F((int &)a);
+      // but what we really want is an address_of expression:
+      //  F(*a);
+      address_of_exprt tmp_expr;
+      assert(op.type().is_pointer());
+      tmp_expr.type() = op.type();
+      tmp_expr.operands().resize(0);
+      assert(op.op0().is_symbol());
+      tmp_expr.move_to_operands(op.op0());
+      tmp_expr.location() = op.location();
+      op.swap(tmp_expr);
+    }
+  }
+}

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -222,10 +222,7 @@ void clang_cpp_adjust::adjust_function_call_arguments(
 {
   clang_c_adjust::adjust_function_call_arguments(expr);
 
-  exprt &f_op = expr.function();
-  const code_typet &code_type = to_code_type(f_op.type());
   exprt::operandst &arguments = expr.arguments();
-  const code_typet::argumentst &argument_types = code_type.arguments();
 
   for(unsigned i = 0; i < arguments.size(); i++)
   {

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -15,6 +15,8 @@ CC_DIAGNOSTIC_POP()
 #include <regex>
 #include <util/filesystem.h>
 #include <fstream>
+#include <util/show_symbol_table.h>
+#include <iostream>
 
 languaget *new_clang_cpp_language()
 {
@@ -68,9 +70,23 @@ bool clang_cpp_languaget::typecheck(
   if(converter.convert())
     return true;
 
+#if 0
+  printf("symbol table before adjust\n");
+  std::ostringstream oss;
+  ::show_symbol_table_plain(namespacet(new_context), oss);
+  std::cout << oss.str() << std::endl;
+#endif
+
   clang_cpp_adjust adjuster(new_context);
   if(adjuster.adjust())
     return true;
+
+#if 0
+  printf("symbol table after adjust\n");
+  std::ostringstream oss;
+  ::show_symbol_table_plain(namespacet(new_context), oss);
+  std::cout << oss.str() << std::endl;
+#endif
 
   if(c_link(context, new_context, module))
     return true;

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -15,8 +15,6 @@ CC_DIAGNOSTIC_POP()
 #include <regex>
 #include <util/filesystem.h>
 #include <fstream>
-#include <util/show_symbol_table.h>
-#include <iostream>
 
 languaget *new_clang_cpp_language()
 {
@@ -70,23 +68,9 @@ bool clang_cpp_languaget::typecheck(
   if(converter.convert())
     return true;
 
-#if 0
-  printf("symbol table before adjust\n");
-  std::ostringstream oss;
-  ::show_symbol_table_plain(namespacet(new_context), oss);
-  std::cout << oss.str() << std::endl;
-#endif
-
   clang_cpp_adjust adjuster(new_context);
   if(adjuster.adjust())
     return true;
-
-#if 0
-  printf("symbol table after adjust\n");
-  std::ostringstream oss;
-  ::show_symbol_table_plain(namespacet(new_context), oss);
-  std::cout << oss.str() << std::endl;
-#endif
 
   if(c_link(context, new_context, module))
     return true;

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -70,7 +70,7 @@ bool clang_cpp_languaget::typecheck(
   if(converter.convert())
     return true;
 
-#if 1
+#if 0
   printf("symbol table before adjust\n");
   std::ostringstream oss;
   ::show_symbol_table_plain(namespacet(new_context), oss);

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -70,7 +70,7 @@ bool clang_cpp_languaget::typecheck(
   if(converter.convert())
     return true;
 
-#if 0
+#if 1
   printf("symbol table before adjust\n");
   std::ostringstream oss;
   ::show_symbol_table_plain(namespacet(new_context), oss);

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,10 +33,20 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
+    {
+      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
+      out << s.type.pretty(0) << "\n";
+      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
+    }
 
     if(s.value.is_not_nil())
+    {
+      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
+      out << s.value.pretty(0) << "\n";
+      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
+    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -33,20 +33,10 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::string type_str, value_str;
 
     if(s.type.is_not_nil())
-    {
-      out << "@@ Printing s.type for " << s.id.c_str() << "\n";
-      out << s.type.pretty(0) << "\n";
-      out << "@@ Done printing s.type for " << s.id.c_str() << "\n";
       p->from_type(s.type, type_str, ns);
-    }
 
     if(s.value.is_not_nil())
-    {
-      out << "@@ Printing s.value for " << s.id.c_str() << "\n";
-      out << s.value.pretty(0) << "\n";
-      out << "@@ Done printing s.value for " << s.id.c_str() << "\n";
       p->from_expr(s.value, value_str, ns);
-    }
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";


### PR DESCRIPTION
Fixed: 
1. side effect function call alignment
2. use cases of lvalue reference including:
  - function parameters
  - return statement
  - operator == 
3. Enabled more 168 TCs:
  - `esbmc-cpp/cpp`: 145 TCs
  - `esbmc-cpp/stream`: 21 TCs
  - `esbmc-cpp/vector`: 3 TCs

Also fixed https://github.com/esbmc/esbmc/issues/1108

We now have a pretty good pass rate for the `esbmc-cpp/cpp` - 76%. 