### PR TITLE
Fixing arch for 32-bit arm analysis as armv6

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -179,7 +179,11 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
      * 'soft': the system's <fenv.h> won't work.
      */
     if(config.ansi_c.target.is_arm() && config.ansi_c.word_size == 32)
+    {
+      compiler_args.emplace_back("-arch");
+      compiler_args.emplace_back("armv6");
       compiler_args.push_back("-mfloat-abi=softfp");
+    }
   }
 
   if(config.ansi_c.target.is_windows_abi())


### PR DESCRIPTION
After latest M1 update https://github.com/esbmc/esbmc/pull/810 is happening again. This fixes it.