### PR TITLE
[ci] sanity check for push

### DIFF
--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -1,0 +1,36 @@
+name: Build ESBMC - early warning on push
+
+on: [push]
+
+jobs:
+
+  # Check testing tool suite
+  testing-tool:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Runs testing tool unit test
+      run: cd regression && python3 testing_tool_test.py
+
+  # just keep the linux job
+  build-unix:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    name: Build ESBMC (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build ESBMC
+      run: ./scripts/build.sh -b Debug
+    - uses: actions/upload-artifact@v1
+      with:
+        name: release-unix
+        path: ./release
+    - name: Run tests
+      run: cd build/ && ctest -j4 --output-on-failure --progress .
+    - uses: actions/upload-artifact@v2 # We shouldn't throw errors for now
+      with:
+        name: csmith-unix
+        path: ./build/csmith-error
+        if-no-files-found: ignore

--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -1,3 +1,5 @@
+# For a quick check-up on dev branch pushes, giving early warning or good news.
+# just a duplicate of build.yml with Linux job only
 name: Build ESBMC - early warning on push
 
 on: [push]


### PR DESCRIPTION
For a quick check-up on dev branch pushes, giving early warning or good news. 
just a duplicate of build.yml with Linux job only

![Screenshot 2023-07-04 at 08 44 46](https://github.com/esbmc/esbmc/assets/32592800/ebff0897-0901-4433-86cf-016f587b442f)
