### PR TITLE
Replaced throw with assert in string OM

### DIFF
--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -442,9 +442,9 @@ CC_DIAGNOSTIC_POP()
 		    "The parameter must to be different than NULL");
 		if ((pos > sLen) || (pos > n))
     {
-      // TODO: when we support try-catch, replace the assert with the throw statement below
-		  //throw out_of_range();
-      __ESBMC_assert(0, "string append failed, out_of_range");
+		// TODO: when we support try-catch, replace the assert with the throw statement below
+		//throw out_of_range();
+		__ESBMC_assert(0, "string append failed, out_of_range");
     }
 
 		int totalLength = this->size();
@@ -1121,7 +1121,9 @@ char string::at(size_t pos) const {
 			"Error! Invalid access memory area");
 	int i;
 	if (pos > this->length()) {
-		throw out_of_range();
+		// TODO: when we support try-catch, replace the assert with the throw statement below
+		//throw out_of_range();
+		__ESBMC_assert(0, "string append failed, out_of_range");
 	} else {
 		return this->str[pos];
 	}
@@ -1407,7 +1409,9 @@ size_t string::copy(char* s, size_t n, size_t pos) const {
 	__ESBMC_assert(s != NULL, "The parameter must to be different than NULL");
 	size_t aux = n + pos;
 	if (pos > this->size()) {
-		throw out_of_range();
+		// TODO: when we support try-catch, replace the assert with the throw statement below
+		//throw out_of_range();
+		__ESBMC_assert(0, "string append failed, out_of_range");
 	}
 	if (s == NULL) {
 		s = new char[n];
@@ -1432,7 +1436,11 @@ string& string::append(const char* s, size_t n) {
 	__ESBMC_assert(s != NULL, "The parameter must to be different than NULL");
 	if(n>1)
 	  if (n > strlen(s))
-	    throw out_of_range();
+	  {
+		// TODO: when we support try-catch, replace the assert with the throw statement below
+		//throw out_of_range();
+		__ESBMC_assert(0, "string append failed, out_of_range");
+	  }
 
 	int rhsLen = n;
 	int totalLen = this->_size + rhsLen;
@@ -1454,7 +1462,11 @@ string& string::append(string& s, size_t pos, size_t n) {
 	__ESBMC_assert(s.str != NULL,
 			"The parameter must to be different than NULL");
 	if ((pos > s._size) || (n > (s._size - pos)))
-		throw out_of_range();
+	{
+		// TODO: when we support try-catch, replace the assert with the throw statement below
+		//throw out_of_range();
+		__ESBMC_assert(0, "string append failed, out_of_range");
+	}
 
 	int rhsLen = n;
 	int totalLen = this->_size + rhsLen;


### PR DESCRIPTION
Fixed https://github.com/esbmc/esbmc/issues/1159. 

Since we don't support exception handling at the moment, just replaced throw with assert with some additional comments added. 