### PR TITLE
Enforce cmake >= 3.18 due to new cmake_language construct 

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,6 +14,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 |-----------|----------|-----------------|
 | clang     | yes      | 11.0.0          |
 | boost     | yes      | 1.77            |
+| CMake     | yes      | 3.18.0          |
 | Boolector | no       | 3.2.2           |
 | CVC4      | no       | 1.8             |
 | MathSAT   | no       | 5.5.4           |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #################################
 # Project Information           #
 #################################
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.18)
 
 # HACK: This msvc policy needs to be setted before project()
 # This can be removed when we move to CMake >= 3.15


### PR DESCRIPTION
In c2goto/CMakeLists.txt we use this construct to build the cartesian product of up to 3 different sets of options.

The new construct requires cmake >= 3.18 and the PR introducing it forgot to bump the min-version requirement. So here it is. Closes #1169.