### PR TITLE
Fixed `Run a Benchmark` workflow

### DIFF
--- a/.github/workflows/benchbringup.yml
+++ b/.github/workflows/benchbringup.yml
@@ -27,27 +27,17 @@ jobs:
     name: Build ESBMC (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 720 # 12h
-    container: rafaelsamenezes/esbmc-ci:clang11
+    #container: rafaelsamenezes/esbmc-ci:clang11
     steps:
-      - name: Small test
-        run: echo ${{ github.event.inputs.timeout }}
-      - name: Checkout code
-        uses: actions/checkout@master
-      - run: apt update  # Only for Docker jobs
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-      - name: Fix dubious ownership
-        run: git config --global --add safe.directory /__w/esbmc/esbmc
       - name: Confirm the benchmark
         run: echo ${{ github.event.inputs.benchmark }}
-      - name: Configure CMake
+      - uses: actions/checkout@v2
+      - name: Build ESBMC
         env:
           TEST_TIMEOUT: ${{ inputs.timeout }}
           BENCHMARK_TO_RUN: ${{ inputs.benchmark }}
           LOG_DIR: ${{ inputs.logdirectory }}
-        run: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja -DClang_DIR=/workspace/clang -DLLVM_DIR=/workspace/clang -DBUILD_STATIC=On -DBoolector_DIR=/workspace/boolector-release -DZ3_DIR=/workspace/z3 -DENABLE_YICES=On -DYices_DIR=/workspace/yices -DCVC4_DIR=/workspace/cvc4 -DGMP_DIR=/workspace/gmp -DBitwuzla_DIR=/workspace/bitwuzla-release -DENABLE_REGRESSION=On -DBENCHBRINGUP=On
-      - name: Build ESBMC
-        run: cd build && cmake --build .
+        run: ./scripts/build.sh -b Debug
       - uses: actions/upload-artifact@v1
         with:
           name: release-linux

--- a/.github/workflows/benchbringup.yml
+++ b/.github/workflows/benchbringup.yml
@@ -27,7 +27,6 @@ jobs:
     name: Build ESBMC (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 720 # 12h
-    #container: rafaelsamenezes/esbmc-ci:clang11
     steps:
       - name: Confirm the benchmark
         run: echo ${{ github.event.inputs.benchmark }}
@@ -37,7 +36,7 @@ jobs:
           TEST_TIMEOUT: ${{ inputs.timeout }}
           BENCHMARK_TO_RUN: ${{ inputs.benchmark }}
           LOG_DIR: ${{ inputs.logdirectory }}
-        run: ./scripts/build.sh -b Release -e On -r On
+        run: ./scripts/build.sh -b Release -r On
       - uses: actions/upload-artifact@v1
         with:
           name: release-linux

--- a/.github/workflows/benchbringup.yml
+++ b/.github/workflows/benchbringup.yml
@@ -37,7 +37,7 @@ jobs:
           TEST_TIMEOUT: ${{ inputs.timeout }}
           BENCHMARK_TO_RUN: ${{ inputs.benchmark }}
           LOG_DIR: ${{ inputs.logdirectory }}
-        run: ./scripts/build.sh -b Debug
+        run: ./scripts/build.sh -b Release -e On -r On
       - uses: actions/upload-artifact@v1
         with:
           name: release-linux

--- a/.github/workflows/benchbringup.yml
+++ b/.github/workflows/benchbringup.yml
@@ -21,8 +21,11 @@ on:
 
 jobs:
   build-linux:
-    name: Build Linux Release
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    name: Build ESBMC (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 720 # 12h
     container: rafaelsamenezes/esbmc-ci:clang11
     steps:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,9 +18,9 @@ ubuntu_setup () {
     # Additional set ups for BASE_ARGS in ubuntu
 
     # run a single benchmark user specified
-    if [[ ! -z "${BENCHMARK_TO_RUN}" ]]; then
-      BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=On"
-    fi
+    #if [[ ! -z "${BENCHMARK_TO_RUN}" ]]; then
+    BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=On"
+    #fi
 }
 
 # macOS setup (pre-config)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,13 @@ ubuntu_setup () {
     sudo apt-get update && sudo apt-get install -y clang clang-tidy python-is-python3 csmith python3 git ccache unzip wget curl libcsmith-dev gperf libgmp-dev cmake bison flex gcc-multilib linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev pkg-config python3-pip python3-toml python-is-python3 openjdk-11-jdk &&
     BASE_ARGS="$BASE_ARGS -DENABLE_OLD_FRONTEND=On  -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
     SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_Z3=ON"
+
+    # Additional set ups for BASE_ARGS in ubuntu
+
+    # run a single benchmark user specified
+    if [[ ! -z "${BENCHMARK_TO_RUN}" ]]; then
+      BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=On"
+    fi
 }
 
 # macOS setup (pre-config)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,20 +40,16 @@ case $OS in
 esac || exit $?
 
 # Setup build flags (release, debug, sanitizer, ...)
-while getopts b:s:e: flag
+while getopts b:s:e:r: flag
 do
     case "${flag}" in
         b) BASE_ARGS="$BASE_ARGS -DCMAKE_BUILD_TYPE=${OPTARG}";;
         s) BASE_ARGS="$BASE_ARGS -DSANITIZER_TYPE=${OPTARG}"
            COMPILER_ARGS="$COMPILER_ARGS CC=clang CXX=clang++";;
-        e) BASE_ARGS="$BASE_ARGS -DENABLE_WERROR=${OPTARG}"
+        e) BASE_ARGS="$BASE_ARGS -DENABLE_WERROR=${OPTARG}";;
+        r) BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=${OPTARG}"
     esac
 done
-
-# run a single benchmark user specified
-#if [[ ! -z "${BENCHMARK_TO_RUN}" ]]; then
-BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=On"
-#fi
 
 # Configure ESBMC
 printf "Running CMake:"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,13 +14,6 @@ ubuntu_setup () {
     sudo apt-get update && sudo apt-get install -y clang clang-tidy python-is-python3 csmith python3 git ccache unzip wget curl libcsmith-dev gperf libgmp-dev cmake bison flex gcc-multilib linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev pkg-config python3-pip python3-toml python-is-python3 openjdk-11-jdk &&
     BASE_ARGS="$BASE_ARGS -DENABLE_OLD_FRONTEND=On  -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
     SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_Z3=ON"
-
-    # Additional set ups for BASE_ARGS in ubuntu
-
-    # run a single benchmark user specified
-    #if [[ ! -z "${BENCHMARK_TO_RUN}" ]]; then
-    BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=On"
-    #fi
 }
 
 # macOS setup (pre-config)
@@ -56,6 +49,11 @@ do
         e) BASE_ARGS="$BASE_ARGS -DENABLE_WERROR=${OPTARG}"
     esac
 done
+
+# run a single benchmark user specified
+#if [[ ! -z "${BENCHMARK_TO_RUN}" ]]; then
+BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=On"
+#fi
 
 # Configure ESBMC
 printf "Running CMake:"


### PR DESCRIPTION
Fixed this workflow to run a user specified benchmark and get the pass rate stats, as well as error/warning signatures if there is any. 

Interesting findings: 
- it appears that build.sh doesn't catch the environment variable set in github container. Got to do it in the way like @rafaelsamenezes' werror patch. 
