### PR TITLE
Added an option to ignore strings

### DIFF
--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -37,6 +37,8 @@ bool clang_c_convertert::convert_string_literal(
   if(get_type(string_literal.getType(), type))
     return true;
 
+  // When strings are just used for initialization, it might be worth
+  // to just replace them by null. See https://github.com/esbmc/esbmc/pull/1185#issuecomment-1631166527
   if(config.options.get_bool_option("no-string-literal"))
   {
     auto value = gen_zero(type);

--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -37,8 +37,16 @@ bool clang_c_convertert::convert_string_literal(
   if(get_type(string_literal.getType(), type))
     return true;
 
-  string_constantt string(string_literal.getBytes().str(), type);
-  dest.swap(string);
+  if(config.options.get_bool_option("no-string-literal"))
+  {
+    auto value = gen_zero(type);
+    dest.swap(value);
+  }
+  else
+  {
+    string_constantt string(string_literal.getBytes().str(), type);
+    dest.swap(string);
+  }
 
   return false;
 }

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -95,6 +95,7 @@ const struct group_opt_templ all_cmd_options[] = {
     {"document-subgoals", NULL, "generate subgoals documentation"},
     {"no-arch", NULL, "don't set up an architecture"},
     {"no-library", NULL, "disable built-in abstract C library"},
+    {"no-string-literal", NULL, "ignores string literals (replace to NULL)"},
     {"output-goto",
      boost::program_options::value<std::string>(),
      "export generated goto program"},

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -95,7 +95,7 @@ const struct group_opt_templ all_cmd_options[] = {
     {"document-subgoals", NULL, "generate subgoals documentation"},
     {"no-arch", NULL, "don't set up an architecture"},
     {"no-library", NULL, "disable built-in abstract C library"},
-    {"no-string-literal", NULL, "ignores string literals (replace to NULL)"},
+    {"no-string-literal", NULL, "ignores string literals (replace by NULL)"},
     {"output-goto",
      boost::program_options::value<std::string>(),
      "export generated goto program"},


### PR DESCRIPTION
ESBMC models strings as new memory objects (which is correct). This usually isn't a problem as the slicer can remove most of them if they aren't used.

However, there is a the corner case when a field of a struct is a string. The slicer can't remove the field, causing the entire formula to be huge for no reason.

This PRs then adds a flag to treat all constant strings as a NULL ptr.