### PR TITLE
Experimental simplification for memsafety assertions

### DIFF
--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -968,6 +968,8 @@ protected:
 
   void rename(expr2tc &expr) override;
 
+  expr2tc constant_propagation(expr2tc &expr);
+
   void
   dump_internal_state(const std::list<struct internal_item> &data) override;
   bool is_live_variable(const expr2tc &sym) override;

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -8,7 +8,8 @@
 
 expr2tc symex_dereference_statet::constant_propagation(expr2tc &expr)
 {
-  auto size_type = [this](expr2tc &e) -> unsigned {
+  auto size_type = [this](expr2tc &e) -> unsigned
+  {
     // Lets's check whether this symbol was reallocated
     // this is important because now we need to be able to check the entire
     // symbolic expression of alloc_size to know what is the actual size
@@ -35,11 +36,12 @@ expr2tc symex_dereference_statet::constant_propagation(expr2tc &expr)
     }
   };
 
-  auto deref_symbol = [this](expr2tc &e) -> expr2tc {
+  auto deref_symbol = [this](expr2tc &e) -> expr2tc
+  {
     if (!is_symbol2t(e))
       return expr2tc();
     goto_symex.internal_deref_items.clear();
-    dereference2tc deref(get_empty_type(), e);
+    auto deref = dereference2tc(get_empty_type(), e);
     goto_symex.dereference(deref, dereferencet::INTERNAL);
     if (goto_symex.internal_deref_items.size() != 1)
       return expr2tc();
@@ -172,7 +174,7 @@ expr2tc symex_dereference_statet::constant_propagation(expr2tc &expr)
       }
       else
       {
-        log_debug("Could not simplify! {} != {}", *origin, *symbol);
+        log_debug(nullptr, "Could not simplify! {} != {}", *origin, *symbol);
         return gen_false_expr();
       }
     }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -8,8 +8,7 @@
 
 expr2tc symex_dereference_statet::constant_propagation(expr2tc &expr)
 {
-  auto size_type = [this](expr2tc &e) -> unsigned
-  {
+  auto size_type = [this](expr2tc &e) -> unsigned {
     // Lets's check whether this symbol was reallocated
     // this is important because now we need to be able to check the entire
     // symbolic expression of alloc_size to know what is the actual size
@@ -36,8 +35,7 @@ expr2tc symex_dereference_statet::constant_propagation(expr2tc &expr)
     }
   };
 
-  auto deref_symbol = [this](expr2tc &e) -> expr2tc
-  {
+  auto deref_symbol = [this](expr2tc &e) -> expr2tc {
     if (!is_symbol2t(e))
       return expr2tc();
     goto_symex.internal_deref_items.clear();

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -580,6 +580,21 @@ struct DivModtor
     const std::function<bool(const expr2tc &)> &is_constant,
     std::function<constant_type &(expr2tc &)> get_value)
   {
+    // Are we dividing by a multiplication of the same value?
+    if(is_mul2t(op1))
+    {
+      if((to_mul2t(op1).side_1 == op2))
+      {
+        log_debug("[Divtor] Simplifying a*b/a = b");
+        return to_mul2t(op1).side_2;
+      }
+
+      if((to_mul2t(op1).side_2 == op2))
+      {
+        log_debug("[Divtor] Simplifying b*a/a = b");
+        return to_mul2t(op2).side_1;
+      }
+    }
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -73,13 +73,15 @@ expr2tc expr2t::simplify() const
     // An operand has been changed; clone ourselves and update.
     expr2tc new_us = clone();
     std::list<expr2tc>::iterator it2 = newoperands.begin();
-    new_us->Foreach_operand([&it2](expr2tc &e) {
-      if (!*it2)
-        ; // No change in operand;
-      else
-        e = *it2; // Operand changed; overwrite with new one.
-      it2++;
-    });
+    new_us->Foreach_operand(
+      [&it2](expr2tc &e)
+      {
+        if (!*it2)
+          ; // No change in operand;
+        else
+          e = *it2; // Operand changed; overwrite with new one.
+        it2++;
+      });
 
     // Finally, attempt simplification again.
     expr2tc tmp = new_us->do_simplify();
@@ -132,8 +134,8 @@ static void fetch_ops_from_this_type(
 {
   if (expr->expr_id == id)
   {
-    expr->foreach_operand(
-      [&ops, id](const expr2tc &e) { fetch_ops_from_this_type(ops, id, e); });
+    expr->foreach_operand([&ops, id](const expr2tc &e)
+                          { fetch_ops_from_this_type(ops, id, e); });
   }
   else
   {
@@ -162,9 +164,8 @@ static bool rebalance_associative_tree(
   // faster than stringly stuff.
 
   // Extract immediate operands
-  expr.foreach_operand([&ops, &expr](const expr2tc &e) {
-    fetch_ops_from_this_type(ops, expr.expr_id, e);
-  });
+  expr.foreach_operand([&ops, &expr](const expr2tc &e)
+                       { fetch_ops_from_this_type(ops, expr.expr_id, e); });
 
   // Are there enough constant values in there?
   unsigned int const_values = 0;
@@ -294,11 +295,10 @@ static expr2tc simplify_arith_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -306,11 +306,10 @@ static expr2tc simplify_arith_2ops(
   else if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -326,7 +325,7 @@ static expr2tc simplify_arith_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -337,11 +336,10 @@ static expr2tc simplify_arith_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_bool2t;
+      (bool (*)(const expr2tc &))&is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
-      return to_constant_bool2t(c).value;
-    };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
+    { return to_constant_bool2t(c).value; };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -364,9 +362,8 @@ struct Addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-        return add2tc(t, e1, e2);
-      };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      { return add2tc(t, e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -441,7 +438,8 @@ expr2tc add2t::do_simplify() const
 
   // Attempt associative simplification
   std::function<expr2tc(const expr2tc &arg1, const expr2tc &arg2)> add_wrapper =
-    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc {
+    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc
+  {
     expr2tc a = arg1, b = arg2;
     type2tc t = common_arith_op2_type(a, b);
     return add2tc(t, a, b);
@@ -462,9 +460,8 @@ struct Subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-        return sub2tc(t, e1, e2);
-      };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      { return sub2tc(t, e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -517,9 +514,8 @@ struct Multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-        return mul2tc(t, e1, e2);
-      };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      { return mul2tc(t, e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -585,20 +581,21 @@ struct DivModtor
     {
       if ((to_mul2t(op1).side_1 == op2))
       {
-        log_debug("[Divtor] Simplifying a*b/a = b");
+        log_debug(nullptr, "[Divtor] Simplifying a*b/a = b");
         return to_mul2t(op1).side_2;
       }
 
       if ((to_mul2t(op1).side_2 == op2))
       {
-        log_debug("[Divtor] Simplifying b*a/a = b");
+        log_debug(nullptr, "[Divtor] Simplifying b*a/a = b");
         return to_mul2t(op2).side_1;
       }
     }
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      {
         if constexpr (Div)
           return div2tc(t, e1, e2);
         else
@@ -1170,11 +1167,10 @@ static expr2tc simplify_logic_2ops(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1182,7 +1178,7 @@ static expr2tc simplify_logic_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1193,12 +1189,11 @@ static expr2tc simplify_logic_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1206,11 +1201,10 @@ static expr2tc simplify_logic_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_bool2t;
+      (bool (*)(const expr2tc &))&is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
-      return to_constant_bool2t(c).value;
-    };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
+    { return to_constant_bool2t(c).value; };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1488,9 +1482,8 @@ expr2tc bitand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitand2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitand2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1504,9 +1497,8 @@ expr2tc bitor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1520,9 +1512,8 @@ expr2tc bitxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitxor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitxor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1536,9 +1527,8 @@ expr2tc bitnand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnand2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitnand2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1552,9 +1542,8 @@ expr2tc bitnor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitnor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1568,9 +1557,8 @@ expr2tc bitnxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnxor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitnxor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1601,9 +1589,8 @@ expr2tc shl2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return shl2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return shl2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1616,9 +1603,8 @@ expr2tc lshr2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return lshr2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return lshr2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1627,7 +1613,8 @@ expr2tc lshr2t::do_simplify() const
 
 expr2tc ashr2t::do_simplify() const
 {
-  auto op = [](uint64_t op1, uint64_t op2) {
+  auto op = [](uint64_t op1, uint64_t op2)
+  {
     /* simulating the arithmetic right shift in C++ requires LHS to be signed */
     return (int64_t)op1 >> op2;
   };
@@ -1635,9 +1622,8 @@ expr2tc ashr2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return ashr2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return ashr2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1947,11 +1933,10 @@ static expr2tc simplify_relations(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1959,7 +1944,7 @@ static expr2tc simplify_relations(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1970,12 +1955,11 @@ static expr2tc simplify_relations(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1983,7 +1967,8 @@ static expr2tc simplify_relations(
   else if (is_pointer_type(simplied_side_1) || is_pointer_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      [&](const expr2tc &t) -> bool {
+      [&](const expr2tc &t) -> bool
+    {
       if (is_pointer_type(t) && is_symbol2t(t))
       {
         symbol2t s = to_symbol2t(t);
@@ -1993,9 +1978,8 @@ static expr2tc simplify_relations(
       return false;
     };
 
-    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int {
-      return 0xbadbeef;
-    };
+    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int
+    { return 0xbadbeef; };
 
     simpl_res = TFunctor<int>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2028,12 +2012,11 @@ static expr2tc simplify_floatbv_relations(
     if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
     {
       std::function<bool(const expr2tc &)> is_constant =
-        (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+        (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
       std::function<ieee_floatt &(expr2tc &)> get_value =
-        [](expr2tc &c) -> ieee_floatt & {
-        return to_constant_floatbv2t(c).value;
-      };
+        [](expr2tc &c) -> ieee_floatt &
+      { return to_constant_floatbv2t(c).value; };
 
       simpl_res = TFunctor<ieee_floatt>::simplify(
         simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2096,9 +2079,8 @@ struct Equalitytor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc, expr2tc e1, expr2tc e2) {
-        return equality2tc(e1, e2);
-      };
+      auto op = [](type2tc, expr2tc e1, expr2tc e2)
+      { return equality2tc(e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2715,12 +2697,11 @@ static expr2tc simplify_floatbv_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2728,12 +2709,11 @@ static expr2tc simplify_floatbv_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2757,9 +2737,8 @@ struct IEEE_addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_add2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_add2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2803,9 +2782,8 @@ struct IEEE_subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_sub2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_sub2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the subtraction
@@ -2848,9 +2826,8 @@ struct IEEE_multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_mul2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_mul2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2893,9 +2870,8 @@ struct IEEE_divtor
   {
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_div2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_div2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the division

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -73,15 +73,13 @@ expr2tc expr2t::simplify() const
     // An operand has been changed; clone ourselves and update.
     expr2tc new_us = clone();
     std::list<expr2tc>::iterator it2 = newoperands.begin();
-    new_us->Foreach_operand(
-      [&it2](expr2tc &e)
-      {
-        if (!*it2)
-          ; // No change in operand;
-        else
-          e = *it2; // Operand changed; overwrite with new one.
-        it2++;
-      });
+    new_us->Foreach_operand([&it2](expr2tc &e) {
+      if (!*it2)
+        ; // No change in operand;
+      else
+        e = *it2; // Operand changed; overwrite with new one.
+      it2++;
+    });
 
     // Finally, attempt simplification again.
     expr2tc tmp = new_us->do_simplify();
@@ -134,8 +132,8 @@ static void fetch_ops_from_this_type(
 {
   if (expr->expr_id == id)
   {
-    expr->foreach_operand([&ops, id](const expr2tc &e)
-                          { fetch_ops_from_this_type(ops, id, e); });
+    expr->foreach_operand(
+      [&ops, id](const expr2tc &e) { fetch_ops_from_this_type(ops, id, e); });
   }
   else
   {
@@ -164,8 +162,9 @@ static bool rebalance_associative_tree(
   // faster than stringly stuff.
 
   // Extract immediate operands
-  expr.foreach_operand([&ops, &expr](const expr2tc &e)
-                       { fetch_ops_from_this_type(ops, expr.expr_id, e); });
+  expr.foreach_operand([&ops, &expr](const expr2tc &e) {
+    fetch_ops_from_this_type(ops, expr.expr_id, e);
+  });
 
   // Are there enough constant values in there?
   unsigned int const_values = 0;
@@ -295,10 +294,11 @@ static expr2tc simplify_arith_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -306,10 +306,11 @@ static expr2tc simplify_arith_2ops(
   else if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -325,7 +326,7 @@ static expr2tc simplify_arith_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -336,10 +337,11 @@ static expr2tc simplify_arith_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_bool2t;
+      (bool (*)(const expr2tc &)) & is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
-    { return to_constant_bool2t(c).value; };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
+      return to_constant_bool2t(c).value;
+    };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -362,8 +364,9 @@ struct Addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      { return add2tc(t, e1, e2); };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+        return add2tc(t, e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -438,8 +441,7 @@ expr2tc add2t::do_simplify() const
 
   // Attempt associative simplification
   std::function<expr2tc(const expr2tc &arg1, const expr2tc &arg2)> add_wrapper =
-    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc
-  {
+    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc {
     expr2tc a = arg1, b = arg2;
     type2tc t = common_arith_op2_type(a, b);
     return add2tc(t, a, b);
@@ -460,8 +462,9 @@ struct Subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      { return sub2tc(t, e1, e2); };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+        return sub2tc(t, e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -514,8 +517,9 @@ struct Multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      { return mul2tc(t, e1, e2); };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+        return mul2tc(t, e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -594,8 +598,7 @@ struct DivModtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      {
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
         if constexpr (Div)
           return div2tc(t, e1, e2);
         else
@@ -1167,10 +1170,11 @@ static expr2tc simplify_logic_2ops(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1178,7 +1182,7 @@ static expr2tc simplify_logic_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1189,11 +1193,12 @@ static expr2tc simplify_logic_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1201,10 +1206,11 @@ static expr2tc simplify_logic_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_bool2t;
+      (bool (*)(const expr2tc &)) & is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
-    { return to_constant_bool2t(c).value; };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
+      return to_constant_bool2t(c).value;
+    };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1482,8 +1488,9 @@ expr2tc bitand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitand2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitand2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1497,8 +1504,9 @@ expr2tc bitor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1512,8 +1520,9 @@ expr2tc bitxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitxor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitxor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1527,8 +1536,9 @@ expr2tc bitnand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitnand2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitnand2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1542,8 +1552,9 @@ expr2tc bitnor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitnor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitnor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1557,8 +1568,9 @@ expr2tc bitnxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitnxor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitnxor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1589,8 +1601,9 @@ expr2tc shl2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return shl2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return shl2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1603,8 +1616,9 @@ expr2tc lshr2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return lshr2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return lshr2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1613,8 +1627,7 @@ expr2tc lshr2t::do_simplify() const
 
 expr2tc ashr2t::do_simplify() const
 {
-  auto op = [](uint64_t op1, uint64_t op2)
-  {
+  auto op = [](uint64_t op1, uint64_t op2) {
     /* simulating the arithmetic right shift in C++ requires LHS to be signed */
     return (int64_t)op1 >> op2;
   };
@@ -1622,8 +1635,9 @@ expr2tc ashr2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return ashr2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return ashr2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1933,10 +1947,11 @@ static expr2tc simplify_relations(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1944,7 +1959,7 @@ static expr2tc simplify_relations(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1955,11 +1970,12 @@ static expr2tc simplify_relations(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1967,8 +1983,7 @@ static expr2tc simplify_relations(
   else if (is_pointer_type(simplied_side_1) || is_pointer_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      [&](const expr2tc &t) -> bool
-    {
+      [&](const expr2tc &t) -> bool {
       if (is_pointer_type(t) && is_symbol2t(t))
       {
         symbol2t s = to_symbol2t(t);
@@ -1978,8 +1993,9 @@ static expr2tc simplify_relations(
       return false;
     };
 
-    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int
-    { return 0xbadbeef; };
+    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int {
+      return 0xbadbeef;
+    };
 
     simpl_res = TFunctor<int>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2012,11 +2028,12 @@ static expr2tc simplify_floatbv_relations(
     if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
     {
       std::function<bool(const expr2tc &)> is_constant =
-        (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+        (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
       std::function<ieee_floatt &(expr2tc &)> get_value =
-        [](expr2tc &c) -> ieee_floatt &
-      { return to_constant_floatbv2t(c).value; };
+        [](expr2tc &c) -> ieee_floatt & {
+        return to_constant_floatbv2t(c).value;
+      };
 
       simpl_res = TFunctor<ieee_floatt>::simplify(
         simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2079,8 +2096,9 @@ struct Equalitytor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc, expr2tc e1, expr2tc e2)
-      { return equality2tc(e1, e2); };
+      auto op = [](type2tc, expr2tc e1, expr2tc e2) {
+        return equality2tc(e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2697,11 +2715,12 @@ static expr2tc simplify_floatbv_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2709,11 +2728,12 @@ static expr2tc simplify_floatbv_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2737,8 +2757,9 @@ struct IEEE_addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_add2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_add2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2782,8 +2803,9 @@ struct IEEE_subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_sub2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_sub2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the subtraction
@@ -2826,8 +2848,9 @@ struct IEEE_multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_mul2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_mul2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2870,8 +2893,9 @@ struct IEEE_divtor
   {
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_div2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_div2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the division

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -592,7 +592,7 @@ struct DivModtor
       if ((to_mul2t(op1).side_2 == op2))
       {
         log_debug(nullptr, "[Divtor] Simplifying b*a/a = b");
-        return to_mul2t(op2).side_1;
+        return to_mul2t(op1).side_1;
       }
     }
     // Is a vector operation ? Apply the op

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -581,15 +581,15 @@ struct DivModtor
     std::function<constant_type &(expr2tc &)> get_value)
   {
     // Are we dividing by a multiplication of the same value?
-    if(is_mul2t(op1))
+    if (is_mul2t(op1))
     {
-      if((to_mul2t(op1).side_1 == op2))
+      if ((to_mul2t(op1).side_1 == op2))
       {
         log_debug("[Divtor] Simplifying a*b/a = b");
         return to_mul2t(op1).side_2;
       }
 
-      if((to_mul2t(op1).side_2 == op2))
+      if ((to_mul2t(op1).side_2 == op2))
       {
         log_debug("[Divtor] Simplifying b*a/a = b");
         return to_mul2t(op2).side_1;


### PR DESCRIPTION
This PR is to try out some simplifications over:

- same-object.
- deref over `alloc_size` array
- deref over `alloc` array
- Add an option to stop propagation of invalid-object