### PR TITLE
[C++ frontend] Improve code structure/ add new methods

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/1126_issue/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1126_issue/main.cpp
@@ -1,0 +1,18 @@
+#include <assert.h>
+struct dim3
+{
+    unsigned int x, y, z;
+};
+
+int main() 
+{
+  dim3 s1= {1,2,3};
+
+  dim3 s2;
+
+  s2 = s1;
+
+  assert(s2.z == 3);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1126_issue/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1126_issue/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+ --memlimit 14000000 --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1126_issue_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/1126_issue_fail/main.cpp
@@ -1,0 +1,18 @@
+#include <assert.h>
+struct dim3
+{
+    unsigned int x, y, z;
+};
+
+int main() 
+{
+  dim3 s1= {1,2,3};
+
+  dim3 s2;
+
+  s2 = s1;
+
+  assert(s2.z == 0); //z should be 3
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/1126_issue_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1126_issue_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+ --memlimit 14000000 --timeout 900
+
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -711,9 +711,8 @@ bool clang_c_convertert::get_function_param(
   param.type() = param_type;
   param.cmt_base_name(name);
 
-  if(name.empty())
-    if(!name_param_and_continue(pd, id, name, param))
-      return false;
+  if(name.empty() && name_param_and_continue(pd, id, name, param))
+    return true;
 
   locationt location_begin;
   get_location_from_decl(pd, location_begin);

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3530,13 +3530,6 @@ bool clang_c_convertert::is_field_global_storage(const clang::FieldDecl *field)
   return false;
 }
 
-bool clang_c_convertert::is_ConstructorOrDestructor(
-  const clang::FunctionDecl &fd)
-{
-  return fd.getKind() == clang::Decl::CXXConstructor ||
-         fd.getKind() == clang::Decl::CXXDestructor;
-}
-
 bool clang_c_convertert::perform_virtual_dispatch(const clang::MemberExpr &)
 {
   // It just can't happen in C

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -711,8 +711,8 @@ bool clang_c_convertert::get_function_param(
   param.type() = param_type;
   param.cmt_base_name(name);
 
-  if(name.empty() && name_param_and_continue(pd, id, name, param))
-    return true;
+  if(id.empty() && name.empty())
+    name_param_and_continue(pd, id, name, param);
 
   locationt location_begin;
   get_location_from_decl(pd, location_begin);
@@ -750,7 +750,7 @@ bool clang_c_convertert::get_function_param(
   return false;
 }
 
-bool clang_c_convertert::name_param_and_continue(
+void clang_c_convertert::name_param_and_continue(
   const clang::ParmVarDecl &,
   std::string &,
   std::string &,
@@ -762,7 +762,6 @@ bool clang_c_convertert::name_param_and_continue(
    * when the function is defined, the exprt is filled for the sake of
    * beautification
    */
-  return false;
 }
 
 bool clang_c_convertert::get_type(

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -580,12 +580,6 @@ bool clang_c_convertert::get_function(
   const clang::FunctionDecl &fd,
   exprt &new_expr)
 {
-  // Don't convert if implicit, unless it's a constructor or destructor
-  // A compiler-generated default ctor/dtor is considered implicit, but we have
-  // to parse it.
-  if(fd.isImplicit() && !is_ConstructorOrDestructor(fd))
-    return false;
-
   // If the function is not defined but this is not the definition, skip it
   if(fd.isDefined() && !fd.isThisDeclarationADefinition())
   {

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -135,7 +135,7 @@ protected:
    *  name: name for this function parameter
    *  param: ESBMC's IR representing the function parameter
    */
-  virtual bool name_param_and_continue(
+  virtual void name_param_and_continue(
     const clang::ParmVarDecl &pd,
     std::string &id,
     std::string &name,

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -272,13 +272,6 @@ protected:
   bool is_field_global_storage(const clang::FieldDecl *field);
 
   /*
-   * check if a method is constructor or destructor
-   * Arguments:
-   *  fd: clang AST representing a C++ method
-   */
-  bool is_ConstructorOrDestructor(const clang::FunctionDecl &fd);
-
-  /*
    * Function to check whether a member function call refers to
    * a virtual/overriding method.
    *

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1582,3 +1582,10 @@ bool clang_cpp_convertert::is_CopyOrMoveOperator(const clang::FunctionDecl &fd)
 
   return false;
 }
+
+bool clang_cpp_convertert::is_ConstructorOrDestructor(
+  const clang::FunctionDecl &fd)
+{
+  return fd.getKind() == clang::Decl::CXXConstructor ||
+         fd.getKind() == clang::Decl::CXXDestructor;
+}

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -200,7 +200,7 @@ protected:
     const clang::CXXMethodDecl &cxxmdd,
     typet &rtn_type);
   bool is_cpyctor(const clang::DeclContext &dcxt);
-  bool is_defaulted_ctor(const clang::DeclContext &dcxt);
+  bool is_defaulted_ctor(const clang::CXXMethodDecl &md);
 
   /*
    * When getting a function call to ctor, we might call the base ctor from a derived class ctor

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -519,7 +519,6 @@ protected:
     const exprt &vtable_ptr_deref);
 
   bool is_aggregate_type(const clang::QualType &q_type) override;
-
   /*
    * check if a method is Copy assignment Operator or 
    * Move assignment Operator
@@ -527,6 +526,12 @@ protected:
    *  fd: clang AST representing a C++ method
    */
   bool is_CopyOrMoveOperator(const clang::FunctionDecl &fd);
+  /*
+   * check if a method is constructor or destructor
+   * Arguments:
+   *  fd: clang AST representing a C++ method
+   */
+  bool is_ConstructorOrDestructor(const clang::FunctionDecl &fd);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -56,28 +56,13 @@ protected:
     const clang::FunctionDecl &fd,
     code_typet::argumentst &params) override;
 
-  bool name_param_and_continue(
+  void name_param_and_continue(
     const clang::ParmVarDecl &pd,
     std::string &id,
     std::string &name,
     exprt &param) override;
 
-  /*
-   * This function assigns a name and an id to the unnamed const ref
-   * in an implicit defaulted copy constructor added by the compiler.
-   *
-   * Params:
-   *  pd: the clang AST node for the function parameter we are currently dealing with
-   *  id: id for this function parameter
-   *  name: name for this function parameter
-   *  param: ESBMC's IR representing the function parameter
-   */
-  void get_cpyctor_name(
-    const clang::CXXConstructorDecl &cxxctor,
-    std::string &id,
-    std::string &name,
-    exprt &param);
-  std::string cpyctor_constref_suffix = "ref";
+  std::string constref_suffix = "ref";
 
   /**
    *  Add implicit `this' when parsing C++ class member functions, e.g:

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -34,6 +34,8 @@ protected:
 
   bool get_type(const clang::Type &the_type, typet &new_type) override;
 
+  bool get_method(const clang::FunctionDecl &fd, exprt &new_expr);
+
   bool get_function(const clang::FunctionDecl &fd, exprt &new_expr) override;
 
   /**
@@ -517,6 +519,14 @@ protected:
     const exprt &vtable_ptr_deref);
 
   bool is_aggregate_type(const clang::QualType &q_type) override;
+
+  /*
+   * check if a method is Copy assignment Operator or 
+   * Move assignment Operator
+   * Arguments:
+   *  fd: clang AST representing a C++ method
+   */
+  bool is_CopyOrMoveOperator(const clang::FunctionDecl &fd);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -526,6 +526,26 @@ protected:
    *  fd: clang AST representing a C++ method
    */
   bool is_CopyOrMoveOperator(const clang::FunctionDecl &fd);
+  bool is_CopyOrMoveOperator(const clang::DeclContext *dcxt);
+
+  bool is_defaulted_op(const clang::DeclContext *dcxt);
+
+  /*
+   * This function assigns a name and an id to the unnamed const ref
+   * in an implicit defaulted copy constructor added by the compiler.
+   *
+   * Params:
+   *  pd: the clang AST node for the function parameter we are currently dealing with
+   *  id: id for this function parameter
+   *  name: name for this function parameter
+   *  param: ESBMC's IR representing the function parameter
+   */
+  void get_op_name(
+    const clang::CXXMethodDecl *cxxmd,
+    std::string &id,
+    std::string &name,
+    exprt &param);
+  std::string op_constref_suffix = "ref";
   /*
    * check if a method is constructor or destructor
    * Arguments:

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -34,9 +34,7 @@ protected:
 
   bool get_type(const clang::Type &the_type, typet &new_type) override;
 
-  bool get_method(const clang::FunctionDecl &fd, exprt &new_expr);
-
-  bool get_function(const clang::FunctionDecl &fd, exprt &new_expr) override;
+  bool get_method(const clang::CXXMethodDecl &md, exprt &new_expr);
 
   /**
    *  Get reference for constructor callsite
@@ -75,7 +73,7 @@ protected:
    *  param: ESBMC's IR representing the function parameter
    */
   void get_cpyctor_name(
-    const clang::CXXConstructorDecl *cxxctor,
+    const clang::CXXConstructorDecl &cxxctor,
     std::string &id,
     std::string &name,
     exprt &param);
@@ -112,7 +110,7 @@ protected:
   */
   template <typename TemplateDecl>
   bool get_template_decl(
-    const TemplateDecl *D,
+    const TemplateDecl &D,
     bool DumpExplicitInst,
     exprt &new_expr);
 
@@ -135,7 +133,7 @@ protected:
    *  comp: the `component` representing the field
    */
   bool annotate_class_field(
-    const clang::FieldDecl *field,
+    const clang::FieldDecl &field,
     const struct_union_typet &type,
     struct_typet::componentt &comp);
 
@@ -145,13 +143,13 @@ protected:
    *    * access: public
    */
   bool annotate_class_field_access(
-    const clang::FieldDecl *field,
+    const clang::FieldDecl &field,
     struct_typet::componentt &comp);
 
   /*
    * Get access from any clang Decl (field, method .etc)
    */
-  bool get_access_from_decl(const clang::Decl *decl, std::string &access);
+  bool get_access_from_decl(const clang::Decl &decl, std::string &access);
 
   /*
    * Get the symbol from the context for a C++ function
@@ -178,10 +176,8 @@ protected:
    *  new_expr: the `component` in class/struct/union symbol type
    *  fd: clang AST node representing the function declaration we are dealing with
    */
-  bool annotate_class_method(
-    const clang::CXXMethodDecl *cxxmdd,
-    exprt &new_expr,
-    const clang::FunctionDecl &fd);
+  bool
+  annotate_class_method(const clang::CXXMethodDecl &cxxmdd, exprt &new_expr);
   /*
    * Flag copy constructor.
    *
@@ -189,7 +185,7 @@ protected:
    *  cxxmdd: clang AST node representing the constructor we are dealing with
    *  rtn_type: the corresponding return type node
    */
-  void annotate_cpyctor(const clang::CXXMethodDecl *cxxmdd, typet &rtn_type);
+  void annotate_cpyctor(const clang::CXXMethodDecl &cxxmdd, typet &rtn_type);
   /*
    * Flag return type in ctor or dtor, e.g.
    * A default copy constructor would have the return type below:
@@ -201,10 +197,10 @@ protected:
    *  rtn_type: the corresponding return type node
    */
   void annotate_ctor_dtor_rtn_type(
-    const clang::CXXMethodDecl *cxxmdd,
+    const clang::CXXMethodDecl &cxxmdd,
     typet &rtn_type);
-  bool is_cpyctor(const clang::DeclContext *dcxt);
-  bool is_defaulted_ctor(const clang::DeclContext *dcxt);
+  bool is_cpyctor(const clang::DeclContext &dcxt);
+  bool is_defaulted_ctor(const clang::DeclContext &dcxt);
 
   /*
    * When getting a function call to ctor, we might call the base ctor from a derived class ctor
@@ -232,7 +228,7 @@ protected:
   /*
    * Methods to pull bases in
    */
-  using base_map = std::map<std::string, const clang::CXXRecordDecl *>;
+  using base_map = std::map<std::string, const clang::CXXRecordDecl &>;
   /*
    * Recursively get the bases for this derived class.
    *
@@ -240,7 +236,7 @@ protected:
    *  - cxxrd: clang AST representing the class/struct we are currently dealing with
    *  - map: this map contains all base class(es) of this class std::map<class_id, pointer to clang AST of base class>
    */
-  void get_base_map(const clang::CXXRecordDecl *cxxrd, base_map &map);
+  void get_base_map(const clang::CXXRecordDecl &cxxrd, base_map &map);
   /*
    * Check whether we've already got this component in a class type
    * Avoid copying duplicate component from a base class type to the derived class type.
@@ -284,7 +280,7 @@ protected:
   std::string thunk_prefix = "thunk::";
   using function_switch = std::map<irep_idt, exprt>;
   using switch_table = std::map<irep_idt, function_switch>;
-  using overriden_map = std::map<std::string, const clang::CXXMethodDecl *>;
+  using overriden_map = std::map<std::string, const clang::CXXMethodDecl &>;
   /*
    * traverse methods to:
    *  1. convert virtual methods and add them to class' type
@@ -302,7 +298,7 @@ protected:
    *  instantiated from the vtable type symbols)
    */
   bool get_struct_class_virtual_methods(
-    const clang::CXXRecordDecl *cxxrd,
+    const clang::CXXRecordDecl &cxxrd,
     struct_typet &type);
   /*
    * additional annotations for virtual or overriding methods
@@ -313,7 +309,7 @@ protected:
    *    this `component` represents the type of the virtual method
    */
   bool annotate_virtual_overriding_methods(
-    const clang::CXXMethodDecl *md,
+    const clang::CXXMethodDecl &md,
     struct_typet::componentt &comp);
   /*
    * Check the existence of virtual table type symbol.
@@ -355,7 +351,7 @@ protected:
    *  - map: key: a map that takes method id as key and pointer to the overriden method AST
    */
   void
-  get_overriden_methods(const clang::CXXMethodDecl *md, overriden_map &map);
+  get_overriden_methods(const clang::CXXMethodDecl &md, overriden_map &map);
   /*
    * add a thunk function for each overriding method
    *
@@ -365,7 +361,7 @@ protected:
    *  - type: ESBMC IR representing the derived class' type
    */
   void add_thunk_method(
-    const clang::CXXMethodDecl *md,
+    const clang::CXXMethodDecl &md,
     const struct_typet::componentt &component,
     struct_typet &type);
   /*
@@ -437,7 +433,7 @@ protected:
    *  - vft_value_map: representing the vtable value maps for this class/struct we are currently dealing with
    */
   void setup_vtable_struct_variables(
-    const clang::CXXRecordDecl *cxxrd,
+    const clang::CXXRecordDecl &cxxrd,
     const struct_typet &type);
   /*
    * This function builds the vtable value map -
@@ -472,7 +468,7 @@ protected:
    *  - vtable_value_map: representing the vtable value maps for this class/struct we are currently dealing with
    */
   void add_vtable_variable_symbols(
-    const clang::CXXRecordDecl *cxxrd,
+    const clang::CXXRecordDecl &cxxrd,
     const struct_typet &struct_type,
     const switch_table &vtable_value_map);
 
@@ -523,35 +519,15 @@ protected:
    * check if a method is Copy assignment Operator or 
    * Move assignment Operator
    * Arguments:
-   *  fd: clang AST representing a C++ method
+   *  md: clang AST representing a C++ method
    */
-  bool is_CopyOrMoveOperator(const clang::FunctionDecl &fd);
-  bool is_CopyOrMoveOperator(const clang::DeclContext *dcxt);
-
-  bool is_defaulted_op(const clang::DeclContext *dcxt);
-
-  /*
-   * This function assigns a name and an id to the unnamed const ref
-   * in an implicit defaulted copy constructor added by the compiler.
-   *
-   * Params:
-   *  pd: the clang AST node for the function parameter we are currently dealing with
-   *  id: id for this function parameter
-   *  name: name for this function parameter
-   *  param: ESBMC's IR representing the function parameter
-   */
-  void get_op_name(
-    const clang::CXXMethodDecl *cxxmd,
-    std::string &id,
-    std::string &name,
-    exprt &param);
-  std::string op_constref_suffix = "ref";
+  bool is_CopyOrMoveOperator(const clang::CXXMethodDecl &md);
   /*
    * check if a method is constructor or destructor
    * Arguments:
-   *  fd: clang AST representing a C++ method
+   *  md: clang AST representing a C++ method
    */
-  bool is_ConstructorOrDestructor(const clang::FunctionDecl &fd);
+  bool is_ConstructorOrDestructor(const clang::CXXMethodDecl &md);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -27,10 +27,10 @@ CC_DIAGNOSTIC_POP()
 #include <util/expr_util.h>
 
 bool clang_cpp_convertert::get_struct_class_virtual_methods(
-  const clang::CXXRecordDecl *cxxrd,
+  const clang::CXXRecordDecl &cxxrd,
   struct_typet &type)
 {
-  for(const auto &md : cxxrd->methods())
+  for(const auto &md : cxxrd.methods())
   {
     if(!md->isVirtual())
       continue;
@@ -43,7 +43,7 @@ bool clang_cpp_convertert::get_struct_class_virtual_methods(
       return true;
 
     // additional annotations for virtual/overriding methods
-    if(annotate_virtual_overriding_methods(md, comp))
+    if(annotate_virtual_overriding_methods(*md, comp))
       return true;
     type.methods().push_back(comp);
 
@@ -80,7 +80,7 @@ bool clang_cpp_convertert::get_struct_class_virtual_methods(
        * method in each level.
        */
       overriden_map cxxmethods_overriden;
-      get_overriden_methods(md, cxxmethods_overriden);
+      get_overriden_methods(*md, cxxmethods_overriden);
 
       for(const auto &overriden_md_entry : cxxmethods_overriden)
         add_thunk_method(overriden_md_entry.second, comp, type);
@@ -97,18 +97,18 @@ bool clang_cpp_convertert::get_struct_class_virtual_methods(
 }
 
 bool clang_cpp_convertert::annotate_virtual_overriding_methods(
-  const clang::CXXMethodDecl *md,
+  const clang::CXXMethodDecl &md,
   struct_typet::componentt &comp)
 {
   std::string method_id, method_name;
-  clang_c_convertert::get_decl_name(*md, method_name, method_id);
+  clang_c_convertert::get_decl_name(md, method_name, method_id);
 
   comp.type().set("#is_virtual", true);
   comp.type().set("#virtual_name", method_name);
   comp.set("is_virtual", true);
   comp.set("virtual_name", method_name);
 
-  if(md->isPure())
+  if(md.isPure())
     comp.set("is_pure_virtual", true);
 
   return false;
@@ -223,7 +223,7 @@ void clang_cpp_convertert::add_vtable_type_entry(
 }
 
 void clang_cpp_convertert::add_thunk_method(
-  const clang::CXXMethodDecl *md,
+  const clang::CXXMethodDecl &md,
   const struct_typet::componentt &component,
   struct_typet &type)
 {
@@ -259,7 +259,7 @@ void clang_cpp_convertert::add_thunk_method(
    */
 
   std::string base_class_id, base_class_name;
-  get_decl_name(*md->getParent(), base_class_name, base_class_id);
+  get_decl_name(*md.getParent(), base_class_name, base_class_id);
 
   // Create the thunk method symbol
   symbolt thunk_func_symb;
@@ -469,7 +469,7 @@ void clang_cpp_convertert::add_thunk_component_to_type(
 }
 
 void clang_cpp_convertert::setup_vtable_struct_variables(
-  const clang::CXXRecordDecl *cxxrd,
+  const clang::CXXRecordDecl &cxxrd,
   const struct_typet &type)
 {
   /*
@@ -534,7 +534,7 @@ void clang_cpp_convertert::build_vtable_map(
 }
 
 void clang_cpp_convertert::add_vtable_variable_symbols(
-  const clang::CXXRecordDecl *cxxrd,
+  const clang::CXXRecordDecl &cxxrd,
   const struct_typet &type,
   const switch_table &vtable_value_map)
 {
@@ -558,7 +558,7 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
 
     // This is the class we are currently dealing with
     std::string class_id, class_name;
-    get_decl_name(*cxxrd, class_name, class_id);
+    get_decl_name(cxxrd, class_name, class_id);
 
     symbolt vt_symb_var;
     vt_symb_var.id = vt_symb_type.id.as_string() + "@" + class_id;
@@ -597,18 +597,18 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
 }
 
 void clang_cpp_convertert::get_overriden_methods(
-  const clang::CXXMethodDecl *md,
+  const clang::CXXMethodDecl &md,
   overriden_map &map)
 {
   /*
    * This function gets all the overriden methods to which we need to create a thunk
    */
-  for(const auto &md_overriden : md->overridden_methods())
+  for(const auto &md_overriden : md.overridden_methods())
   {
     if(
       md_overriden->begin_overridden_methods() !=
       md_overriden->end_overridden_methods())
-      get_overriden_methods(md_overriden, map);
+      get_overriden_methods(*md_overriden, map);
 
     // get the id for this overriden method
     std::string method_id, method_name;
@@ -618,7 +618,7 @@ void clang_cpp_convertert::get_overriden_methods(
     if(map.find(method_id) != map.end())
       continue;
 
-    auto status = map.insert({method_id, md_overriden});
+    auto status = map.insert({method_id, *md_overriden});
     assert(status.second);
   }
 }


### PR DESCRIPTION
1. The part of calling get function in C++ front-end is optimized, and some methods belonging to C++ are reclassified.
2.  The judgment method of copy assignment operator and move assignment operator is added.

~~As for the operator, we still need some changes to make it work properly, so, there is no corresponding TC for this PR.~~