### PR TITLE
More smtlib fixes

### DIFF
--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -704,9 +704,7 @@ expr2tc bitwuzla_convt::get_array_elem(
   uint64_t index,
   const type2tc &subtype)
 {
-  const bitw_smt_ast *ast = dynamic_cast<const bitw_smt_ast *>(array);
-  if(ast == nullptr)
-    throw type2t::symbolic_type_excp();
+  const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(array);
 
   size_t size;
   BitwuzlaTerm **indicies, **values, *default_value;

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -677,12 +677,7 @@ expr2tc boolector_convt::get_array_elem(
   uint64_t index,
   const type2tc &subtype)
 {
-  // We do the cast directly here instead of using to_solver_smt_ast because
-  // in release mode the dynamic_cast is converted to a static_cast, but we
-  // want to catch if the conversion fails
-  const btor_smt_ast *ast = dynamic_cast<const btor_smt_ast *>(array);
-  if(ast == nullptr)
-    throw type2t::symbolic_type_excp();
+  const btor_smt_ast *ast = to_solver_smt_ast<btor_smt_ast>(array);
 
   uint32_t size;
   char **indicies = nullptr, **values = nullptr;

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -477,9 +477,12 @@ array_convt::get_array_elem(smt_astt a, uint64_t index, const type2tc &subtype)
   if(!is_unbounded_array(a->sort) && (index < mast->array_fields.size()))
     return ctx->get_by_ast(subtype, mast->array_fields[index]);
 
-  // This is an array that was not previously converted, therefore doesn't
-  // appear in the valuation table. Therefore, all its values are free.
-  assert(mast->base_array_id >= array_valuation.size());
+  if(mast->base_array_id >= array_valuation.size())
+  {
+    // This is an array that was not previously converted, therefore doesn't
+    // appear in the valuation table. Therefore, all its values are free.
+    return expr2tc();
+  }
 
   // Fetch all the indexes
   const idx_record_containert &indexes = array_indexes[mast->base_array_id];
@@ -500,7 +503,11 @@ array_convt::get_array_elem(smt_astt a, uint64_t index, const type2tc &subtype)
       break;
   }
 
-  assert(it == indexes.end());
+  if(it == indexes.end())
+  {
+    // Then this index wasn't modelled in any way.
+    return expr2tc();
+  }
 
   // We've found an index; pick its value out, convert back to expr.
   const ast_vect &solver_values =

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1819,10 +1819,15 @@ unsigned long calculate_array_domain_width(const array_type2t &arr)
   // Index arrays by the smallest integer required to represent its size.
   // Unless it's either infinite or dynamic in size, in which case use the
   // machine word size.
-  if(!is_nil_expr(arr.array_size) && is_constant_int2t(arr.array_size))
+  if(!is_nil_expr(arr.array_size))
   {
-    constant_int2tc thesize = arr.array_size;
-    return size_to_bit_width(thesize->value.to_uint64());
+    if(is_constant_int2t(arr.array_size))
+    {
+      constant_int2tc thesize = arr.array_size;
+      return size_to_bit_width(thesize->value.to_uint64());
+    }
+
+    return arr.array_size->type->get_width();
   }
 
   return config.ansi_c.word_size;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1785,8 +1785,6 @@ expr2tc smt_convt::fix_array_idx(const expr2tc &idx, const type2tc &arr_sort)
 
   smt_sortt s = convert_sort(arr_sort);
   size_t domain_width = s->get_domain_width();
-  if(domain_width == config.ansi_c.int_width)
-    return idx;
 
   // Otherwise, we need to extract the lower bits out of this.
   return typecast2tc(

--- a/src/solvers/smt/tuple/smt_tuple.h
+++ b/src/solvers/smt/tuple/smt_tuple.h
@@ -53,6 +53,11 @@ public:
   virtual expr2tc tuple_get(const expr2tc &expr) = 0;
   virtual expr2tc tuple_get(const type2tc &type, smt_astt a) = 0;
 
+  virtual expr2tc tuple_get_array_elem(
+    smt_astt array,
+    uint64_t index,
+    const type2tc &subtype) = 0;
+
   virtual void add_tuple_constraints_for_solving(){};
   virtual void push_tuple_ctx(){};
   virtual void pop_tuple_ctx(){};

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -223,6 +223,15 @@ expr2tc smt_tuple_node_flattener::tuple_get_rec(tuple_node_smt_astt tuple)
   return outstruct;
 }
 
+expr2tc smt_tuple_node_flattener::tuple_get_array_elem(
+  smt_astt array,
+  uint64_t index,
+  const type2tc &subtype)
+{
+  return array_conv.get_array_elem(
+    array, index, ctx->get_flattened_array_subtype(subtype));
+}
+
 smt_astt smt_tuple_node_flattener::tuple_array_of(
   const expr2tc &init_val,
   unsigned long array_size)

--- a/src/solvers/smt/tuple/smt_tuple_node.h
+++ b/src/solvers/smt/tuple/smt_tuple_node.h
@@ -29,6 +29,9 @@ public:
 
   expr2tc tuple_get_rec(tuple_node_smt_astt tuple);
 
+  expr2tc
+  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+
   smt_astt mk_tuple_array_symbol(const expr2tc &expr) override;
   smt_astt tuple_array_of(const expr2tc &init_value, unsigned long domain_width)
     override;

--- a/src/solvers/smt/tuple/smt_tuple_sym.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym.cpp
@@ -200,6 +200,18 @@ smt_astt smt_tuple_sym_flattener::tuple_array_of(
   return newsym;
 }
 
+expr2tc smt_tuple_sym_flattener::tuple_get_array_elem(
+  smt_astt array,
+  uint64_t index,
+  const type2tc &subtype)
+{
+  /* TODO: missing implementation */
+  throw type2t::symbolic_type_excp();
+  (void)array;
+  (void)index;
+  (void)subtype;
+}
+
 smt_sortt smt_tuple_sym_flattener::mk_struct_sort(const type2tc &type)
 {
   if(is_array_type(type))

--- a/src/solvers/smt/tuple/smt_tuple_sym.h
+++ b/src/solvers/smt/tuple/smt_tuple_sym.h
@@ -27,6 +27,9 @@ public:
   expr2tc tuple_get(const expr2tc &expr) override;
   expr2tc tuple_get(const type2tc &type, smt_astt a) override;
 
+  expr2tc
+  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+
   expr2tc tuple_get_rec(tuple_sym_smt_astt tuple);
   smt_astt tuple_array_create(
     const type2tc &array_type,

--- a/src/solvers/smtlib/CMakeLists.txt
+++ b/src/solvers/smtlib/CMakeLists.txt
@@ -15,3 +15,13 @@ target_include_directories(smtlib
     PRIVATE ${CMAKE_BINARY_DIR}/src
     PRIVATE ${Boost_INCLUDE_DIRS}
 )
+
+# The smtlib backend needs a larger-than-default stack size (at least in Debug
+# builds) because the data structures built for the S-exprs in solver responses
+# could be very large and the std::list destructors use a lot of stack space
+set(stacksize 20971520)  # 20 MB ought to be enough for everyone
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:${stacksize}" CACHE STRING "Linker flags" FORCE)
+else()
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=${stacksize}" CACHE STRING "Linker flags" FORCE)
+endif()

--- a/src/solvers/smtlib/smtlib.ypp
+++ b/src/solvers/smtlib/smtlib.ypp
@@ -12,7 +12,7 @@
 #undef yyerror
 #define yyerror smtliberror
 
-#define YYMAXDEPTH 100000
+#define YYMAXDEPTH 250000
 
 int smtliblex(int startsym);
 int smtliberror(int startsym, const std::string &error);

--- a/src/solvers/smtlib/smtlib.ypp
+++ b/src/solvers/smtlib/smtlib.ypp
@@ -12,6 +12,8 @@
 #undef yyerror
 #define yyerror smtliberror
 
+#define YYMAXDEPTH 100000
+
 int smtliblex(int startsym);
 int smtliberror(int startsym, const std::string &error);
 

--- a/src/solvers/smtlib/smtlib.ypp
+++ b/src/solvers/smtlib/smtlib.ypp
@@ -162,7 +162,7 @@ numlist: TOK_NUMERAL
            sexpr tok;
            tok.token = TOK_NUMERAL;
            tok.data = std::string($1);
-           $$->sexpr_list.push_back(tok);
+           $$->sexpr_list.emplace_back(std::move(tok));
            free($1);
          }
          | numlist TOK_NUMERAL
@@ -171,7 +171,7 @@ numlist: TOK_NUMERAL
            sexpr tok;
            tok.token = TOK_NUMERAL;
            tok.data = std::string($2);
-           $$->sexpr_list.push_back(tok);
+           $$->sexpr_list.emplace_back(std::move(tok));
            free($2);
          }
 
@@ -188,12 +188,13 @@ identifier: symbol
            sexpr uscore;
            $$->token = 0;
            uscore.token = TOK_KW_USCORE;
-           $$->sexpr_list.push_back(uscore);
-           uscore.token = TOK_SIMPLESYM;
-           uscore.data = *$3;
+           $$->sexpr_list.emplace_back(std::move(uscore));
+           sexpr sym;
+           sym.token = TOK_SIMPLESYM;
+           sym.data = std::move(*$3);
            delete $3;
-           $$->sexpr_list.push_back(uscore);
-           $$->sexpr_list.push_back(*$4);
+           $$->sexpr_list.emplace_back(std::move(sym));
+           $$->sexpr_list.emplace_back(std::move(*$4));
            delete $4;
          }
 
@@ -204,7 +205,7 @@ sexpr_list:
          | sexpr_list s_expr
          {
            $$ = $1;
-           $1->push_back(*$2);
+           $1->emplace_back(std::move(*$2));
            delete $2;
          }
 
@@ -226,7 +227,7 @@ s_expr: spec_constant
        | TOK_LPAREN sexpr_list TOK_RPAREN
          {
            $$ = new sexpr();
-           $$->sexpr_list = *$2;
+           $$->sexpr_list = std::move(*$2);
            delete $2;
            $$->token = 0;
          }
@@ -242,7 +243,7 @@ attribute_value: spec_constant
        | TOK_LPAREN sexpr_list TOK_RPAREN
          {
            $$ = new sexpr();
-           $$->sexpr_list = *$2;
+           $$->sexpr_list = std::move(*$2);
            $$->token = 0;
            delete $2;
          }
@@ -256,18 +257,14 @@ attribute: TOK_KEYWORD
          }
        | TOK_KEYWORD attribute_value
          {
-           sexpr *s = new sexpr();
-           s->token = TOK_KEYWORD;
-           s->data = std::string($1);
+           sexpr s;
+           s.token = TOK_KEYWORD;
+           s.data = std::string($1);
            free($1);
            $$ = new sexpr();
-           $$->sexpr_list.push_front(*s);
-           if ($2->token == 0)
-             $$->sexpr_list.push_back(*$2);
-           else
-             $$->sexpr_list.push_back(*$2);
+           $$->sexpr_list.emplace_back(std::move(s));
+           $$->sexpr_list.push_back(std::move(*$2));
            delete $2;
-           delete s;
          }
 
 attr_list: attribute | attr_list attribute
@@ -276,13 +273,13 @@ sort_list: sort
          {
            $$ = new sexpr();
            $$->token = 0;
-           $$->sexpr_list.push_back(*$1);
+           $$->sexpr_list.emplace_back(std::move(*$1));
            delete $1;
          }
        | sort_list sort
          {
            $$ = $1;
-           $$->sexpr_list.push_back(*$2);
+           $$->sexpr_list.push_back(std::move(*$2));
            delete $2;
          }
 
@@ -291,8 +288,8 @@ sort: identifier
          {
            $$ = new sexpr();
            $$->token = 0;
-           $$->sexpr_list.push_back(*$2);
-           $$->sexpr_list.push_back(*$3);
+           $$->sexpr_list.emplace_back(std::move(*$2));
+           $$->sexpr_list.emplace_back(std::move(*$3));
            delete $2;
            delete $3;
          }
@@ -304,8 +301,8 @@ qual_identifier: identifier
            $$->token = 0;
            sexpr tok;
            tok.token = TOK_KW_AS;
-           $$->sexpr_list.push_back(*$3);
-           $$->sexpr_list.push_back(*$4);
+           $$->sexpr_list.push_back(std::move(*$3));
+           $$->sexpr_list.push_back(std::move(*$4));
            delete $3;
            delete $4;
          }
@@ -316,9 +313,9 @@ var_binding: TOK_LPAREN symbol term TOK_RPAREN
            $$->token = 0;
            sexpr tok;
            tok.token = TOK_SIMPLESYM;
-           tok.data = *$2;
-           $$->sexpr_list.push_back(tok);
-           $$->sexpr_list.push_back(*$3);
+           tok.data = std::move(*$2);
+           $$->sexpr_list.emplace_back(std::move(tok));
+           $$->sexpr_list.emplace_back(std::move(*$3));
            delete $2;
            delete $3;
          }
@@ -327,13 +324,13 @@ varbind_list: var_binding
          {
            $$ = new sexpr();
            $$->token = 0;
-           $$->sexpr_list.push_back(*$1);
+           $$->sexpr_list.emplace_back(std::move(*$1));
            delete $1;
          }
        | varbind_list var_binding
          {
            $$ = $1;
-           $$->sexpr_list.push_back(*$2);
+           $$->sexpr_list.emplace_back(std::move(*$2));
            delete $2;
          }
 
@@ -358,9 +355,9 @@ term: spec_constant
            $$->token = 0;
            sexpr tok;
            tok.token = TOK_KW_LET;
-           $$->sexpr_list.push_back(tok);
-           $$->sexpr_list.push_back(*$4);
-           $$->sexpr_list.push_back(*$6);
+           $$->sexpr_list.emplace_back(std::move(tok));
+           $$->sexpr_list.emplace_back(std::move(*$4));
+           $$->sexpr_list.emplace_back(std::move(*$6));
            delete $4;
            delete $6;
          }
@@ -427,37 +424,36 @@ info_response: attribute
        | TOK_KEYWORD info_response_arg
          {
            $$ = new sexpr();
-           sexpr *s = new sexpr();
-           s->token = TOK_KEYWORD;
-           s->data = std::string($1);
+           sexpr s;
+           s.token = TOK_KEYWORD;
+           s.data = std::string($1);
            free($1);
            $$->token = 0;
-           $$->sexpr_list.push_front(*s);
-           delete s;
-           s = new sexpr();
-           s->token = TOK_KEYWORD;
-           s->data = std::string($2);
-           $$->sexpr_list.push_back(*s);
+           $$->sexpr_list.emplace_back(std::move(s));
+           sexpr t;
+           t.token = TOK_KEYWORD;
+           t.data = std::string($2);
+           $$->sexpr_list.emplace_back(std::move(t));
            free($2);
          }
 
 info_response_list: info_response
          {
            $$ = new std::list<sexpr>();
-           $$->push_back(*$1);
+           $$->emplace_back(std::move(*$1));
            delete $1;
          }
        | info_response_list info_response
          {
            $$ = $1;
-           $$->push_back(*$2);
+           $$->emplace_back(std::move(*$2));
            delete $2;
          }
 
 get_info_response: TOK_LPAREN info_response_list TOK_RPAREN
          {
            $$ = new sexpr();
-           $$->sexpr_list = *$2;
+           $$->sexpr_list = std::move(*$2);
            $$->token = 0;
            delete $2;
          }
@@ -474,8 +470,8 @@ valuation_pair: TOK_LPAREN term term TOK_RPAREN
          {
            $$ = new sexpr();
            $$->token = 0;
-           $$->sexpr_list.push_back(*$2);
-           $$->sexpr_list.push_back(*$3);
+           $$->sexpr_list.emplace_back(std::move(*$2));
+           $$->sexpr_list.emplace_back(std::move(*$3));
            delete $2;
            delete $3;
          }
@@ -484,12 +480,12 @@ valuation_pair_list: valuation_pair
          {
            $$ = new sexpr();
            $$->token = 0;
-           $$->sexpr_list.push_back(*$1);
+           $$->sexpr_list.emplace_back(std::move(*$1));
            delete $1;
          }
        | valuation_pair_list valuation_pair
          {
-           $$->sexpr_list.push_back(*$2);
+           $$->sexpr_list.push_back(std::move(*$2));
            delete $2;
          }
 

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -367,6 +367,7 @@ std::string smtlib_convt::sort_to_string(const smt_sort *s) const
     return "Real";
   case SMT_SORT_FIXEDBV:
   case SMT_SORT_BV:
+  case SMT_SORT_BVFP:
     ss << "(_ BitVec " << sort->get_data_width() << ")";
     return ss.str();
   case SMT_SORT_ARRAY:

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -609,8 +609,7 @@ static BigInt interp_numeric(const sexpr &respval, bool is_signed)
   case TOK_BINNUM:
     return binary2integer(respval.data.substr(2), is_signed);
   default:
-    log_error(
-      "interpreting token type " + std::to_string(tok) + " as an integer");
+    log_error("interpreting S-expr of token type {} as an integer", tok);
     abort();
   }
 }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -403,19 +403,24 @@ unsigned int smtlib_convt::emit_terminal_ast(
     // Construct a bitvector
     {
       // Irritatingly, the number may be higher than the actual bitwidth permits.
-      assert(
-        sort->get_data_width() <= 64 &&
-        "smtlib printer assumes no numbers more "
-        "than 64 bits wide, sorry");
-      uint64_t theval = ast->intval.to_uint64();
-      if(sort->get_data_width() < 64)
+      size_t n = sort->get_data_width();
+      assert(n > 0);
+      if(n <= 64)
       {
-        uint64_t mask = 1ULL << sort->get_data_width();
-        mask -= 1;
-        theval &= mask;
+        uint64_t theval = ast->intval.to_uint64();
+        if(n < 64)
+        {
+          uint64_t mask = 1ULL << n;
+          mask -= 1;
+          theval &= mask;
+        }
+        ss << "(_ bv" << theval << " " << n << ")";
       }
-      assert(sort->get_data_width() != 0);
-      ss << "(_ bv" << theval << " " << sort->get_data_width() << ")";
+      else
+      {
+        /* Two's complement, n bits wide */
+        ss << "#b" << integer2binary(ast->intval, n);
+      }
       output = ss.str();
       return 0;
     }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -121,6 +121,7 @@ int smtlibparse(int startval);
 extern int smtlib_send_start_code;
 extern sexpr *smtlib_output;
 
+#if 0
 static std::string unquote(const std::string_view &s)
 {
   size_t n = s.size();
@@ -140,6 +141,7 @@ static std::string unquote(const std::string_view &s)
   }
   return r;
 }
+#endif
 
 smt_convt *create_new_smtlib_solver(
   const optionst &options,
@@ -262,6 +264,7 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
   smtlib_tokin = in_stream;
 
   // Fetch solver name and version.
+#if 0
   emit("%s", "(get-info :name)\n");
   flush();
   smtlib_send_start_code = 1;
@@ -319,6 +322,10 @@ smtlib_convt::process_emitter::process_emitter(const std::string &cmd)
     solver_name,
     solver_version,
     solver_proc_pid);
+#else
+  log_status(
+    "Using external solver cmd '{}' with PID {}", cmd, solver_proc_pid);
+#endif
 #endif
 }
 

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -412,7 +412,6 @@ unsigned int smtlib_convt::emit_terminal_ast(
   case SMT_FUNC_BVINT:
     // Construct a bitvector
     {
-      // Irritatingly, the number may be higher than the actual bitwidth permits.
       size_t n = sort->get_data_width();
       assert(n > 0);
       /* Two's complement, n bits wide */

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -952,7 +952,7 @@ bool smtlib_convt::get_bool(smt_astt a)
 const std::string smtlib_convt::solver_text()
 {
   if(emit_proc)
-    return emit_proc.solver_name + " version " + emit_proc.solver_version;
+    return "'" + options.get_option("smtlib-solver-prog") + "'";
 
   if(emit_opt_output)
     return "Text output";

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -1579,7 +1579,8 @@ smt_astt smtlib_convt::mk_select(smt_astt a, smt_astt b)
 {
   assert(a->sort->id == SMT_SORT_ARRAY);
   assert(a->sort->get_domain_width() == b->sort->get_data_width());
-  smtlib_smt_ast *ast = new smtlib_smt_ast(this, b->sort, SMT_FUNC_SELECT);
+  smtlib_smt_ast *ast =
+    new smtlib_smt_ast(this, a->sort->get_range_sort(), SMT_FUNC_SELECT);
   ast->args.push_back(a);
   ast->args.push_back(b);
   return ast;

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -677,15 +677,8 @@ smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
 {
   assert(emit_proc);
 
-  if(dynamic_cast<const array_ast *>(array))
-  {
-    assert(dynamic_cast<smt_tuple_node_flattener *>(tuple_api));
-    return static_cast<smt_tuple_node_flattener *>(tuple_api)
-      ->array_conv.get_array_elem(array, index, t);
-  }
-
   // This should always be a symbol.
-  const smtlib_smt_ast *sa = static_cast<const smtlib_smt_ast *>(array);
+  const smtlib_smt_ast *sa = to_solver_smt_ast<smtlib_smt_ast>(array);
   assert(sa->kind == SMT_FUNC_SYMBOL && "Non-symbol in smtlib get_array_elem");
   std::string name = sa->symname;
 

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -603,10 +603,10 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
 
   // This should always be a symbol.
   const smtlib_smt_ast *sa = static_cast<const smtlib_smt_ast *>(a);
-  assert(sa->kind == SMT_FUNC_SYMBOL && "Non-symbol in smtlib expr get_bv()");
-  std::string name = sa->symname;
 
-  emit("(get-value (|%s|))\n", name.c_str());
+  emit("%s", "(get-value (");
+  emit_ast(sa);
+  emit("%s\n", "))");
   flush();
   smtlib_send_start_code = 1;
   smtlibparse(TOK_START_VALUE);
@@ -638,11 +638,6 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
   std::list<sexpr>::iterator it = response.sexpr_list.begin();
   sexpr &symname = *it++;
   sexpr &respval = *it++;
-  if(!(symname.token == TOK_SIMPLESYM && symname.data == name))
-  {
-    log_error("smtlib solver returned different symbol from get-value");
-    abort();
-  }
 
   // Attempt to read an integer.
   BigInt m;
@@ -655,7 +650,6 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
     log_error("Numeral value for integer symbol from smtlib solver");
     abort();
   }
-
   else if(respval.token == TOK_HEXNUM)
   {
     std::string data = respval.data.substr(2);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -415,22 +415,8 @@ unsigned int smtlib_convt::emit_terminal_ast(
       // Irritatingly, the number may be higher than the actual bitwidth permits.
       size_t n = sort->get_data_width();
       assert(n > 0);
-      if(n <= 64)
-      {
-        uint64_t theval = ast->intval.to_uint64();
-        if(n < 64)
-        {
-          uint64_t mask = 1ULL << n;
-          mask -= 1;
-          theval &= mask;
-        }
-        ss << "(_ bv" << theval << " " << n << ")";
-      }
-      else
-      {
-        /* Two's complement, n bits wide */
-        ss << "#b" << integer2binary(ast->intval, n);
-      }
+      /* Two's complement, n bits wide */
+      ss << "#b" << integer2binary(ast->intval, n);
       output = ss.str();
       return 0;
     }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -334,7 +334,7 @@ smtlib_convt::process_emitter::~process_emitter() noexcept
 
 smtlib_convt::smtlib_convt(const namespacet &_ns, const optionst &_options)
   : smt_convt(_ns, _options),
-    array_iface(false, false),
+    array_iface(true, false),
     fp_convt(this),
     emit_proc(_options.get_option("smtlib-solver-prog")),
     emit_opt_output(_options.get_option("output"))

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -546,6 +546,8 @@ void smtlib_smt_ast::dump() const
 
   ctx->emit_ast(this);
   ctx->emit("%s", "\n");
+  std::string sort_str = ctx->sort_to_string(sort);
+  ctx->emit("sort: %s\n", sort_str.c_str());
   ctx->flush();
 
   ctx_m->emit_opt_output.out_stream = tmp_file;

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -636,7 +636,7 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
     "Expected 2 operands in "
     "valuation_pair_list from smtlib solver");
   std::list<sexpr>::iterator it = response.sexpr_list.begin();
-  sexpr &symname = *it++;
+  sexpr &symname [[maybe_unused]] = *it++;
   sexpr &respval = *it++;
 
   // Attempt to read an integer.

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -5,6 +5,8 @@
 #include <smtlib.hpp>
 #include <smtlib_tok.hpp>
 
+#include <solvers/smt/tuple/smt_tuple_node.h>
+
 #include <cinttypes>
 #include <regex>
 #include <sstream>
@@ -674,6 +676,13 @@ expr2tc
 smtlib_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &t)
 {
   assert(emit_proc);
+
+  if(dynamic_cast<const array_ast *>(array))
+  {
+    assert(dynamic_cast<smt_tuple_node_flattener *>(tuple_api));
+    return static_cast<smt_tuple_node_flattener *>(tuple_api)
+      ->array_conv.get_array_elem(array, index, t);
+  }
 
   // This should always be a symbol.
   const smtlib_smt_ast *sa = static_cast<const smtlib_smt_ast *>(array);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -641,8 +641,8 @@ BigInt smtlib_convt::get_bv(smt_astt a, bool is_signed)
     "Expected 2 operands in "
     "valuation_pair_list from smtlib solver");
   std::list<sexpr>::iterator it = response.sexpr_list.begin();
-  sexpr &symname [[maybe_unused]] = *it++;
-  sexpr &respval = *it++;
+  /* sexpr &symname = *it; */
+  sexpr &respval = *++it;
 
   // Attempt to read an integer.
   BigInt m;

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -125,7 +125,7 @@ struct sexpr
   sexpr(sexpr &&) noexcept = default;
   sexpr &operator=(sexpr &&) noexcept = default;
 
-  unsigned int token = 0; // If zero, then an sexpr list
+  int token = 0; // If zero, then an sexpr list
   std::list<sexpr> sexpr_list;
   std::string data; // Text rep of parsed token.
 };

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -119,17 +119,19 @@ enum smt_func_kind
   SMT_FUNC_FLOAT2BV,
 };
 
-class sexpr
+struct sexpr
 {
-public:
-  sexpr() : token(0)
-  {
-    sexpr_list.clear();
-  }
-  unsigned int token; // If zero, then an sexpr list
+  sexpr() = default;
+  sexpr(sexpr &&) noexcept = default;
+  sexpr &operator=(sexpr &&) noexcept = default;
+
+  unsigned int token = 0; // If zero, then an sexpr list
   std::list<sexpr> sexpr_list;
   std::string data; // Text rep of parsed token.
 };
+
+static_assert(std::is_nothrow_move_constructible_v<sexpr>);
+static_assert(std::is_nothrow_move_assignable_v<sexpr>);
 
 class smtlib_smt_sort : public smt_sort
 {

--- a/src/solvers/smtlib/smtlib_tok.lpp
+++ b/src/solvers/smtlib/smtlib_tok.lpp
@@ -23,7 +23,7 @@ int smtlib_send_start_code = 0;
 lparen        \(
 rparen        \)
 numeral       (0|[1-9][0-9]*)
-decimal       {numeral}.0*{numeral}
+decimal       {numeral}\.0*{numeral}
 hexnum        #x[a-fA-F0-9]+
 binnum        #b[01]+
 stringlit     \"((.|\\\\|\\\")*)\"

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -841,6 +841,14 @@ expr2tc yices_convt::get_array_elem(
   return get_by_ast(subtype, container);
 }
 
+expr2tc yices_convt::tuple_get_array_elem(
+  smt_astt array,
+  uint64_t index,
+  const type2tc &subtype)
+{
+  return get_array_elem(array, index, get_flattened_array_subtype(subtype));
+}
+
 void yices_smt_ast::assign(smt_convt *ctx, smt_astt sym) const
 {
   if(sort->id == SMT_SORT_ARRAY)

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -144,6 +144,9 @@ public:
   expr2tc tuple_get(const expr2tc &expr) override;
   expr2tc tuple_get(const type2tc &type, smt_astt a) override;
 
+  expr2tc
+  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+
   bool get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1279,6 +1279,14 @@ z3_convt::get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
   return get_by_ast(subtype, new_ast(e, convert_sort(subtype)));
 }
 
+expr2tc z3_convt::tuple_get_array_elem(
+  smt_astt array,
+  uint64_t index,
+  const type2tc &subtype)
+{
+  return get_array_elem(array, index, get_flattened_array_subtype(subtype));
+}
+
 void z3_smt_ast::dump() const
 {
   std::string ast(Z3_ast_to_string(a.ctx(), a));

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -171,6 +171,9 @@ public:
   expr2tc tuple_get(const expr2tc &expr) override;
   expr2tc tuple_get(const type2tc &type, smt_astt sym) override;
 
+  expr2tc
+  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+
   smt_astt tuple_array_create(
     const type2tc &array_type,
     smt_astt *input_args,


### PR DESCRIPTION
This PR aims at improving the ratio of successful regression tests with `--default-solver smtlib --smtlib-solver-prog CMD` for the following values of CMD. The numbers given are for a Debug build and a ctest timeout of 300s on my machine while the CI does not support running ctest like this. I've included the version numbers of the external solvers below as well.
- `yices-smt2 --incremental` v2.6.4 w/ GMP: 128 tests failed out of 3441 d3428d22641a0219104cf748f73e7fdac6e56539
  <details>
  96% tests passed, 128 tests failed out of 3441
  
  Total Test time (real) = 4590.35 sec
  
  The following tests FAILED:
	   90 - regression/esbmc-unix/00_bbuf_02 (Timeout)
	   91 - regression/esbmc-unix/00_bbuf_02_new (Timeout)
	  224 - regression/esbmc-unix/github_28_successful (Failed)
	  291 - regression/esbmc-unix2/01_pthread59 (Timeout)
	  293 - regression/esbmc-unix2/01_pthread60 (Timeout)
	  294 - regression/esbmc-unix2/01_pthread61 (Timeout)
	  295 - regression/esbmc-unix2/01_pthread62 (Timeout)
	  297 - regression/esbmc-unix2/01_pthread64 (Timeout)
	  299 - regression/esbmc-unix2/01_pthread66 (Failed)
	  304 - regression/esbmc-unix2/01_pthread70 (Failed)
	  306 - regression/esbmc-unix2/01_pthread72 (Failed)
	  446 - regression/esbmc/02_eureka22 (Timeout)
	  455 - regression/esbmc/07_bs_new (Timeout)
	  469 - regression/esbmc/12_lms_new (Failed)
	  564 - regression/esbmc/github_1068 (Timeout)
	  570 - regression/esbmc/github_123 (Failed)
	  626 - regression/esbmc/github_287_1 (Timeout)
	  628 - regression/esbmc/github_28_successful (Failed)
	  637 - regression/esbmc/github_302 (Timeout)
	  639 - regression/esbmc/github_306 (Timeout)
	  698 - regression/esbmc/github_562 (Timeout)
	  720 - regression/esbmc/github_629 (Failed)
	  728 - regression/esbmc/github_644_init_as_nondet (Failed)
	  751 - regression/esbmc/github_691 (Failed)
	  779 - regression/esbmc/github_841 (Timeout)
	  783 - regression/esbmc/github_877 (Timeout)
	  784 - regression/esbmc/github_879 (Timeout)
	  808 - regression/esbmc/math_exp01 (Timeout)
	  809 - regression/esbmc/math_exp02 (Timeout)
	  810 - regression/esbmc/math_exp03 (Timeout)
	  812 - regression/esbmc/math_log02 (Timeout)
	  841 - regression/esbmc/overflow_10_fir (Failed)
	  846 - regression/esbmc/overflow_16_fir_new (Failed)
	  894 - regression/esbmc/to_union_github_314_float (Timeout)
	  1034 - regression/cbmc/01_cbmc_Malloc2 (Failed)
	  1036 - regression/cbmc/01_cbmc_Malloc21 (Failed)
	  1038 - regression/cbmc/01_cbmc_Malloc23 (Failed)
	  1050 - regression/cbmc/01_cbmc_Mod1 (Failed)
	  1181 - regression/cstd/intrinsic_memset_array_struct (Timeout)
	  1212 - regression/cstd/memcpy (Failed)
	  1213 - regression/cstd/memcpy_bug (Failed)
	  1292 - regression/llvm/double (Timeout)
	  1328 - regression/floats/Double-to-float-no-simp1 (Failed)
	  1329 - regression/floats/Double-to-float-no-simp1-fix1 (Failed)
	  1330 - regression/floats/Double-to-float-no-simp1-fix2 (Failed)
	  1332 - regression/floats/Float-Rounding1 (Timeout)
	  1334 - regression/floats/Float-data-dependent-rounding (Timeout)
	  1335 - regression/floats/Float-div1 (Timeout)
	  1336 - regression/floats/Float-div2 (Timeout)
	  1337 - regression/floats/Float-div3 (Timeout)
	  1338 - regression/floats/Float-flags-no-simp1 (Failed)
	  1340 - regression/floats/Float-no-simp1 (Failed)
	  1341 - regression/floats/Float-no-simp2 (Failed)
	  1342 - regression/floats/Float-no-simp2_1 (Failed)
	  1343 - regression/floats/Float-no-simp3 (Failed)
	  1347 - regression/floats/Float-no-simp6 (Failed)
	  1348 - regression/floats/Float-no-simp7 (Timeout)
	  1349 - regression/floats/Float-no-simp8 (Timeout)
	  1350 - regression/floats/Float-no-simp9 (Failed)
	  1353 - regression/floats/Float-to-double1 (Timeout)
	  1354 - regression/floats/Float-to-double2 (Timeout)
	  1355 - regression/floats/Float-zero-sum1 (Failed)
	  1358 - regression/floats/Float12 (Timeout)
	  1363 - regression/floats/Float19 (Timeout)
	  1365 - regression/floats/Float20 (Failed)
	  1366 - regression/floats/Float21 (Timeout)
	  1368 - regression/floats/Float23 (Timeout)
	  1369 - regression/floats/Float3 (Timeout)
	  1370 - regression/floats/Float4 (Timeout)
	  1371 - regression/floats/Float4_1 (Timeout)
	  1372 - regression/floats/Float5 (Failed)
	  1374 - regression/floats/Float7 (Timeout)
	  1375 - regression/floats/Float8 (Timeout)
	  1376 - regression/floats/Float8_1 (Timeout)
	  1382 - regression/floats/int-to-float2 (Timeout)
	  1390 - regression/floats-regression/ceil_nondet (Timeout)
	  1399 - regression/floats-regression/floor_nondet (Timeout)
	  1400 - regression/floats-regression/fma (Failed)
	  1412 - regression/floats-regression/lrint (Failed)
	  1413 - regression/floats-regression/modf (Timeout)
	  1415 - regression/floats-regression/nearbyint (Timeout)
	  1416 - regression/floats-regression/nearbyint2 (Timeout)
	  1417 - regression/floats-regression/nextafter (Timeout)
	  1420 - regression/floats-regression/remainder (Failed)
	  1422 - regression/floats-regression/rint (Timeout)
	  1423 - regression/floats-regression/rint2 (Timeout)
	  1424 - regression/floats-regression/round (Timeout)
	  1425 - regression/floats-regression/round_nondet (Timeout)
	  1426 - regression/floats-regression/rounding_functions (Timeout)
	  1427 - regression/floats-regression/sqrt (Failed)
	  1429 - regression/floats-regression/trunc_nondet (Timeout)
	  1430 - regression/floats-regression/trunc_nondet_2 (Timeout)
	  1431 - regression/floats-regression/union_inc (Timeout)
	  1432 - regression/floats-regression/union_inc2 (Timeout)
	  1448 - regression/k-induction/digital-controller (Timeout)
	  1450 - regression/k-induction/eureka_01_bug (Timeout)
	  1505 - regression/k-induction/trex02_bug (Failed)
	  1532 - regression/k-induction-parallel/digital-controller (Timeout)
	  1534 - regression/k-induction-parallel/eureka_01_bug (Timeout)
	  1589 - regression/k-induction-parallel/trex02_bug (Failed)
	  1608 - regression/nonz3/29_exStbHwAcc (Timeout)
	  1614 - regression/nonz3/overflow_12_adpcm (Failed)
	  1628 - regression/bitwuzla/memset-good (Failed)
	  1652 - regression/incremental-smt/incremental-14 (Failed)
	  1653 - regression/incremental-smt/incremental-15 (Failed)
	  1664 - regression/incremental-smt/incremental-26 (Timeout)
	  1843 - regression/esbmc-cpp/cpp/ch20_8 (Timeout)
	  1963 - regression/esbmc-cpp/cpp/ch5_23 (Timeout)
	  2030 - regression/esbmc-cpp/cpp/cstring11_strtok (Timeout)
	  2067 - regression/esbmc-cpp/cpp/llbmc_template_specialization (Failed)
	  2186 - regression/esbmc-cpp/bug_fixes/1032_POD_init (Failed)
	  2187 - regression/esbmc-cpp/bug_fixes/1032_POD_init_fail (Failed)
	  2614 - regression/esbmc-cpp/template/template_3 (Timeout)
	  2615 - regression/esbmc-cpp/template/template_3_bug (Timeout)
	  3286 - regression/extensions/vector_gcc_literal_operator_float_add_no_simplify_false (Timeout)
	  3287 - regression/extensions/vector_gcc_literal_operator_float_add_no_simplify_true (Timeout)
	  3294 - regression/extensions/vector_gcc_literal_operator_float_div_no_simplify_false (Failed)
	  3295 - regression/extensions/vector_gcc_literal_operator_float_div_no_simplify_true (Failed)
	  3302 - regression/extensions/vector_gcc_literal_operator_float_mul_no_simplify_false (Failed)
	  3303 - regression/extensions/vector_gcc_literal_operator_float_mul_no_simplify_true (Failed)
	  3305 - regression/extensions/vector_gcc_literal_operator_float_neg_no_simplify_false (Failed)
	  3306 - regression/extensions/vector_gcc_literal_operator_float_neg_no_simplify_true (Failed)
	  3314 - regression/extensions/vector_gcc_literal_operator_float_sub_no_simplify_false (Timeout)
	  3315 - regression/extensions/vector_gcc_literal_operator_float_sub_no_simplify_true (Timeout)
	  3354 - regression/extensions/vector_gcc_literal_operator_int_div_1_false (Failed)
	  3356 - regression/extensions/vector_gcc_literal_operator_int_div_2_false (Failed)
	  3370 - regression/extensions/vector_gcc_literal_operator_int_mod_1_false (Failed)
	  3372 - regression/extensions/vector_gcc_literal_operator_int_mod_2_false (Failed)
  </details>
- `z3 -in` v4.11.2 w/ GMP: 124 tests failed out of 3441 d3428d22641a0219104cf748f73e7fdac6e56539
  <details>
  96% tests passed, 124 tests failed out of 3441
  
  Total Test time (real) = 10200.01 sec
  
  The following tests FAILED:
	   90 - regression/esbmc-unix/00_bbuf_02 (Timeout)
	   91 - regression/esbmc-unix/00_bbuf_02_new (Timeout)
	  206 - regression/esbmc-unix/05_pfscan-1.0_01 (Timeout)
	  291 - regression/esbmc-unix2/01_pthread59 (Timeout)
	  293 - regression/esbmc-unix2/01_pthread60 (Timeout)
	  294 - regression/esbmc-unix2/01_pthread61 (Timeout)
	  295 - regression/esbmc-unix2/01_pthread62 (Timeout)
	  297 - regression/esbmc-unix2/01_pthread64 (Timeout)
	  299 - regression/esbmc-unix2/01_pthread66 (Failed)
	  304 - regression/esbmc-unix2/01_pthread70 (Failed)
	  306 - regression/esbmc-unix2/01_pthread72 (Failed)
	  446 - regression/esbmc/02_eureka22 (Timeout)
	  455 - regression/esbmc/07_bs_new (Timeout)
	  469 - regression/esbmc/12_lms_new (Timeout)
	  564 - regression/esbmc/github_1068 (Timeout)
	  570 - regression/esbmc/github_123 (Timeout)
	  626 - regression/esbmc/github_287_1 (Timeout)
	  637 - regression/esbmc/github_302 (Timeout)
	  639 - regression/esbmc/github_306 (Timeout)
	  698 - regression/esbmc/github_562 (Timeout)
	  720 - regression/esbmc/github_629 (Timeout)
	  728 - regression/esbmc/github_644_init_as_nondet (Failed)
	  751 - regression/esbmc/github_691 (Failed)
	  779 - regression/esbmc/github_841 (Timeout)
	  783 - regression/esbmc/github_877 (Timeout)
	  784 - regression/esbmc/github_879 (Timeout)
	  808 - regression/esbmc/math_exp01 (Timeout)
	  809 - regression/esbmc/math_exp02 (Timeout)
	  810 - regression/esbmc/math_exp03 (Timeout)
	  812 - regression/esbmc/math_log02 (Timeout)
	  841 - regression/esbmc/overflow_10_fir (Timeout)
	  846 - regression/esbmc/overflow_16_fir_new (Timeout)
	  894 - regression/esbmc/to_union_github_314_float (Timeout)
	  1034 - regression/cbmc/01_cbmc_Malloc2 (Failed)
	  1036 - regression/cbmc/01_cbmc_Malloc21 (Failed)
	  1038 - regression/cbmc/01_cbmc_Malloc23 (Timeout)
	  1050 - regression/cbmc/01_cbmc_Mod1 (Failed)
	  1181 - regression/cstd/intrinsic_memset_array_struct (Timeout)
	  1212 - regression/cstd/memcpy (Timeout)
	  1213 - regression/cstd/memcpy_bug (Timeout)
	  1292 - regression/llvm/double (Timeout)
	  1328 - regression/floats/Double-to-float-no-simp1 (Timeout)
	  1329 - regression/floats/Double-to-float-no-simp1-fix1 (Timeout)
	  1330 - regression/floats/Double-to-float-no-simp1-fix2 (Timeout)
	  1332 - regression/floats/Float-Rounding1 (Timeout)
	  1334 - regression/floats/Float-data-dependent-rounding (Timeout)
	  1335 - regression/floats/Float-div1 (Timeout)
	  1336 - regression/floats/Float-div2 (Timeout)
	  1337 - regression/floats/Float-div3 (Timeout)
	  1338 - regression/floats/Float-flags-no-simp1 (Timeout)
	  1340 - regression/floats/Float-no-simp1 (Timeout)
	  1341 - regression/floats/Float-no-simp2 (Timeout)
	  1342 - regression/floats/Float-no-simp2_1 (Timeout)
	  1343 - regression/floats/Float-no-simp3 (Timeout)
	  1347 - regression/floats/Float-no-simp6 (Timeout)
	  1348 - regression/floats/Float-no-simp7 (Timeout)
	  1349 - regression/floats/Float-no-simp8 (Timeout)
	  1350 - regression/floats/Float-no-simp9 (Timeout)
	  1353 - regression/floats/Float-to-double1 (Timeout)
	  1354 - regression/floats/Float-to-double2 (Timeout)
	  1355 - regression/floats/Float-zero-sum1 (Timeout)
	  1358 - regression/floats/Float12 (Timeout)
	  1363 - regression/floats/Float19 (Timeout)
	  1365 - regression/floats/Float20 (Timeout)
	  1366 - regression/floats/Float21 (Timeout)
	  1368 - regression/floats/Float23 (Timeout)
	  1369 - regression/floats/Float3 (Timeout)
	  1370 - regression/floats/Float4 (Timeout)
	  1371 - regression/floats/Float4_1 (Timeout)
	  1372 - regression/floats/Float5 (Timeout)
	  1374 - regression/floats/Float7 (Timeout)
	  1375 - regression/floats/Float8 (Timeout)
	  1376 - regression/floats/Float8_1 (Timeout)
	  1382 - regression/floats/int-to-float2 (Timeout)
	  1390 - regression/floats-regression/ceil_nondet (Timeout)
	  1399 - regression/floats-regression/floor_nondet (Timeout)
	  1400 - regression/floats-regression/fma (Timeout)
	  1412 - regression/floats-regression/lrint (Timeout)
	  1413 - regression/floats-regression/modf (Timeout)
	  1415 - regression/floats-regression/nearbyint (Timeout)
	  1416 - regression/floats-regression/nearbyint2 (Timeout)
	  1417 - regression/floats-regression/nextafter (Timeout)
	  1420 - regression/floats-regression/remainder (Timeout)
	  1422 - regression/floats-regression/rint (Timeout)
	  1423 - regression/floats-regression/rint2 (Timeout)
	  1424 - regression/floats-regression/round (Timeout)
	  1425 - regression/floats-regression/round_nondet (Timeout)
	  1426 - regression/floats-regression/rounding_functions (Timeout)
	  1427 - regression/floats-regression/sqrt (Timeout)
	  1429 - regression/floats-regression/trunc_nondet (Timeout)
	  1430 - regression/floats-regression/trunc_nondet_2 (Timeout)
	  1431 - regression/floats-regression/union_inc (Timeout)
	  1432 - regression/floats-regression/union_inc2 (Timeout)
	  1448 - regression/k-induction/digital-controller (Timeout)
	  1450 - regression/k-induction/eureka_01_bug (Timeout)
	  1505 - regression/k-induction/trex02_bug (Failed)
	  1532 - regression/k-induction-parallel/digital-controller (Timeout)
	  1534 - regression/k-induction-parallel/eureka_01_bug (Timeout)
	  1589 - regression/k-induction-parallel/trex02_bug (Failed)
	  1608 - regression/nonz3/29_exStbHwAcc (Timeout)
	  1614 - regression/nonz3/overflow_12_adpcm (Failed)
	  1628 - regression/bitwuzla/memset-good (Failed)
	  1652 - regression/incremental-smt/incremental-14 (Timeout)
	  1653 - regression/incremental-smt/incremental-15 (Failed)
	  1664 - regression/incremental-smt/incremental-26 (Timeout)
	  1666 - regression/incremental-smt/incremental-28 (Timeout)
	  1843 - regression/esbmc-cpp/cpp/ch20_8 (Failed)
	  1963 - regression/esbmc-cpp/cpp/ch5_23 (Timeout)
	  2030 - regression/esbmc-cpp/cpp/cstring11_strtok (Timeout)
	  2067 - regression/esbmc-cpp/cpp/llbmc_template_specialization (Timeout)
	  2186 - regression/esbmc-cpp/bug_fixes/1032_POD_init (Timeout)
	  2187 - regression/esbmc-cpp/bug_fixes/1032_POD_init_fail (Timeout)
	  2614 - regression/esbmc-cpp/template/template_3 (Timeout)
	  2615 - regression/esbmc-cpp/template/template_3_bug (Timeout)
	  3286 - regression/extensions/vector_gcc_literal_operator_float_add_no_simplify_false (Timeout)
	  3287 - regression/extensions/vector_gcc_literal_operator_float_add_no_simplify_true (Timeout)
	  3294 - regression/extensions/vector_gcc_literal_operator_float_div_no_simplify_false (Timeout)
	  3295 - regression/extensions/vector_gcc_literal_operator_float_div_no_simplify_true (Timeout)
	  3302 - regression/extensions/vector_gcc_literal_operator_float_mul_no_simplify_false (Timeout)
	  3303 - regression/extensions/vector_gcc_literal_operator_float_mul_no_simplify_true (Timeout)
	  3305 - regression/extensions/vector_gcc_literal_operator_float_neg_no_simplify_false (Timeout)
	  3306 - regression/extensions/vector_gcc_literal_operator_float_neg_no_simplify_true (Timeout)
	  3314 - regression/extensions/vector_gcc_literal_operator_float_sub_no_simplify_false (Timeout)
	  3315 - regression/extensions/vector_gcc_literal_operator_float_sub_no_simplify_true (Timeout)
  </details>
- ~`cvc4 -L smt2` v1.8 w/ SymFPU, CLN~ I don't have the resources to run this, too much memory and too much time
- `boolector --incremental` v3.2.2 w/ GMP, picosat: 124 tests failed out of 3441 d3428d22641a0219104cf748f73e7fdac6e56539
  <details>
  96% tests passed, 124 tests failed out of 3441
  
  Total Test time (real) = 5020.19 sec
  
  The following tests FAILED:
	   90 - regression/esbmc-unix/00_bbuf_02 (Timeout)
	   91 - regression/esbmc-unix/00_bbuf_02_new (Timeout)
	  206 - regression/esbmc-unix/05_pfscan-1.0_01 (Timeout)
	  291 - regression/esbmc-unix2/01_pthread59 (Timeout)
	  293 - regression/esbmc-unix2/01_pthread60 (Timeout)
	  294 - regression/esbmc-unix2/01_pthread61 (Timeout)
	  295 - regression/esbmc-unix2/01_pthread62 (Timeout)
	  297 - regression/esbmc-unix2/01_pthread64 (Timeout)
	  299 - regression/esbmc-unix2/01_pthread66 (Failed)
	  304 - regression/esbmc-unix2/01_pthread70 (Failed)
	  306 - regression/esbmc-unix2/01_pthread72 (Failed)
	  446 - regression/esbmc/02_eureka22 (Timeout)
	  455 - regression/esbmc/07_bs_new (Timeout)
	  469 - regression/esbmc/12_lms_new (Timeout)
	  564 - regression/esbmc/github_1068 (Timeout)
	  570 - regression/esbmc/github_123 (Timeout)
	  626 - regression/esbmc/github_287_1 (Timeout)
	  637 - regression/esbmc/github_302 (Timeout)
	  639 - regression/esbmc/github_306 (Timeout)
	  698 - regression/esbmc/github_562 (Timeout)
	  720 - regression/esbmc/github_629 (Timeout)
	  728 - regression/esbmc/github_644_init_as_nondet (Failed)
	  751 - regression/esbmc/github_691 (Failed)
	  779 - regression/esbmc/github_841 (Timeout)
	  783 - regression/esbmc/github_877 (Timeout)
	  784 - regression/esbmc/github_879 (Timeout)
	  808 - regression/esbmc/math_exp01 (Timeout)
	  809 - regression/esbmc/math_exp02 (Timeout)
	  810 - regression/esbmc/math_exp03 (Timeout)
	  812 - regression/esbmc/math_log02 (Timeout)
	  841 - regression/esbmc/overflow_10_fir (Timeout)
	  846 - regression/esbmc/overflow_16_fir_new (Timeout)
	  894 - regression/esbmc/to_union_github_314_float (Timeout)
	  1034 - regression/cbmc/01_cbmc_Malloc2 (Failed)
	  1036 - regression/cbmc/01_cbmc_Malloc21 (Failed)
	  1038 - regression/cbmc/01_cbmc_Malloc23 (Timeout)
	  1050 - regression/cbmc/01_cbmc_Mod1 (Failed)
	  1181 - regression/cstd/intrinsic_memset_array_struct (Timeout)
	  1212 - regression/cstd/memcpy (Timeout)
	  1213 - regression/cstd/memcpy_bug (Timeout)
	  1292 - regression/llvm/double (Timeout)
	  1328 - regression/floats/Double-to-float-no-simp1 (Timeout)
	  1329 - regression/floats/Double-to-float-no-simp1-fix1 (Timeout)
	  1330 - regression/floats/Double-to-float-no-simp1-fix2 (Timeout)
	  1332 - regression/floats/Float-Rounding1 (Timeout)
	  1334 - regression/floats/Float-data-dependent-rounding (Timeout)
	  1335 - regression/floats/Float-div1 (Timeout)
	  1336 - regression/floats/Float-div2 (Timeout)
	  1337 - regression/floats/Float-div3 (Timeout)
	  1338 - regression/floats/Float-flags-no-simp1 (Timeout)
	  1340 - regression/floats/Float-no-simp1 (Timeout)
	  1341 - regression/floats/Float-no-simp2 (Timeout)
	  1342 - regression/floats/Float-no-simp2_1 (Timeout)
	  1343 - regression/floats/Float-no-simp3 (Timeout)
	  1347 - regression/floats/Float-no-simp6 (Timeout)
	  1348 - regression/floats/Float-no-simp7 (Timeout)
	  1349 - regression/floats/Float-no-simp8 (Timeout)
	  1350 - regression/floats/Float-no-simp9 (Timeout)
	  1353 - regression/floats/Float-to-double1 (Timeout)
	  1354 - regression/floats/Float-to-double2 (Timeout)
	  1355 - regression/floats/Float-zero-sum1 (Timeout)
	  1358 - regression/floats/Float12 (Timeout)
	  1363 - regression/floats/Float19 (Timeout)
	  1365 - regression/floats/Float20 (Timeout)
	  1366 - regression/floats/Float21 (Timeout)
	  1368 - regression/floats/Float23 (Timeout)
	  1369 - regression/floats/Float3 (Timeout)
	  1370 - regression/floats/Float4 (Timeout)
	  1371 - regression/floats/Float4_1 (Timeout)
	  1372 - regression/floats/Float5 (Timeout)
	  1374 - regression/floats/Float7 (Timeout)
	  1375 - regression/floats/Float8 (Timeout)
	  1376 - regression/floats/Float8_1 (Timeout)
	  1382 - regression/floats/int-to-float2 (Timeout)
	  1390 - regression/floats-regression/ceil_nondet (Timeout)
	  1399 - regression/floats-regression/floor_nondet (Timeout)
	  1400 - regression/floats-regression/fma (Timeout)
	  1412 - regression/floats-regression/lrint (Timeout)
	  1413 - regression/floats-regression/modf (Timeout)
	  1415 - regression/floats-regression/nearbyint (Timeout)
	  1416 - regression/floats-regression/nearbyint2 (Timeout)
	  1417 - regression/floats-regression/nextafter (Timeout)
	  1420 - regression/floats-regression/remainder (Timeout)
	  1422 - regression/floats-regression/rint (Timeout)
	  1423 - regression/floats-regression/rint2 (Timeout)
	  1424 - regression/floats-regression/round (Timeout)
	  1425 - regression/floats-regression/round_nondet (Timeout)
	  1426 - regression/floats-regression/rounding_functions (Timeout)
	  1427 - regression/floats-regression/sqrt (Timeout)
	  1429 - regression/floats-regression/trunc_nondet (Timeout)
	  1430 - regression/floats-regression/trunc_nondet_2 (Timeout)
	  1431 - regression/floats-regression/union_inc (Timeout)
	  1432 - regression/floats-regression/union_inc2 (Timeout)
	  1448 - regression/k-induction/digital-controller (Timeout)
	  1450 - regression/k-induction/eureka_01_bug (Timeout)
	  1505 - regression/k-induction/trex02_bug (Failed)
	  1532 - regression/k-induction-parallel/digital-controller (Timeout)
	  1534 - regression/k-induction-parallel/eureka_01_bug (Timeout)
	  1589 - regression/k-induction-parallel/trex02_bug (Failed)
	  1608 - regression/nonz3/29_exStbHwAcc (Timeout)
	  1610 - regression/nonz3/github_1070 (Failed)
	  1614 - regression/nonz3/overflow_12_adpcm (Failed)
	  1628 - regression/bitwuzla/memset-good (Failed)
	  1652 - regression/incremental-smt/incremental-14 (Timeout)
	  1653 - regression/incremental-smt/incremental-15 (Failed)
	  1664 - regression/incremental-smt/incremental-26 (Timeout)
	  1843 - regression/esbmc-cpp/cpp/ch20_8 (Failed)
	  1963 - regression/esbmc-cpp/cpp/ch5_23 (Timeout)
	  2030 - regression/esbmc-cpp/cpp/cstring11_strtok (Timeout)
	  2067 - regression/esbmc-cpp/cpp/llbmc_template_specialization (Timeout)
	  2186 - regression/esbmc-cpp/bug_fixes/1032_POD_init (Timeout)
	  2187 - regression/esbmc-cpp/bug_fixes/1032_POD_init_fail (Timeout)
	  2614 - regression/esbmc-cpp/template/template_3 (Timeout)
	  2615 - regression/esbmc-cpp/template/template_3_bug (Timeout)
	  3286 - regression/extensions/vector_gcc_literal_operator_float_add_no_simplify_false (Timeout)
	  3287 - regression/extensions/vector_gcc_literal_operator_float_add_no_simplify_true (Timeout)
	  3294 - regression/extensions/vector_gcc_literal_operator_float_div_no_simplify_false (Timeout)
	  3295 - regression/extensions/vector_gcc_literal_operator_float_div_no_simplify_true (Timeout)
	  3302 - regression/extensions/vector_gcc_literal_operator_float_mul_no_simplify_false (Timeout)
	  3303 - regression/extensions/vector_gcc_literal_operator_float_mul_no_simplify_true (Timeout)
	  3305 - regression/extensions/vector_gcc_literal_operator_float_neg_no_simplify_false (Timeout)
	  3306 - regression/extensions/vector_gcc_literal_operator_float_neg_no_simplify_true (Timeout)
	  3314 - regression/extensions/vector_gcc_literal_operator_float_sub_no_simplify_false (Timeout)
	  3315 - regression/extensions/vector_gcc_literal_operator_float_sub_no_simplify_true (Timeout)
  </details>

Note that `--default-solver BACKEND` is different from `--BACKEND`. In particular, the latter overrides the former, so tests hardcoding the latter behave the same for all the above combinations, i.e., they're unaffected and not tested with the `smtlib` backend. This is a limitation of how the current command-line parsing of ESBMC works and it is not addressed in this PR.

Related: #1118