### PR TITLE
Don't interpret __builtin_unreachable() for SV-COMP

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -211,6 +211,8 @@ esbmc_path = "./esbmc "
 # ESBMC default commands: this is the same for every submission
 esbmc_dargs = "--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets "
 esbmc_dargs += "--no-align-check --k-step 2 --floatbv --unlimited-k-steps "
+# <https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/issues/1296>
+esbmc_dargs += "-D'__builtin_unreachable()' "
 
 import re
 def check_if_benchmark_contains_pthread(benchmark):


### PR DESCRIPTION
SV-COMP doesn't define a body for it and it doesn't give rules about it either. See <https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/issues/1296>.
So there's no point in treating it as `assert(0)` like ESBMC does by default.
This triggered us to return an incorrect FALSE_REACH result for (at least)

	c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--mtd--devices--docg3.ko.cil.i

I'll run it over the benchmarks...