### PR TITLE
Fix intrinsic memset errors

### DIFF
--- a/regression/esbmc-unix/github_1199-1/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+++ b/regression/esbmc-unix/github_1199-1/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
@@ -1,0 +1,3279 @@
+extern void abort(void);
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.c", 3, __extension__ __PRETTY_FUNCTION__); })); }
+typedef unsigned short __u16;
+typedef int __s32;
+typedef unsigned int __u32;
+typedef unsigned long long __u64;
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef long long s64;
+typedef unsigned long long u64;
+typedef long __kernel_long_t;
+typedef unsigned long __kernel_ulong_t;
+typedef int __kernel_pid_t;
+typedef unsigned int __kernel_uid32_t;
+typedef unsigned int __kernel_gid32_t;
+typedef __kernel_ulong_t __kernel_size_t;
+typedef __kernel_long_t __kernel_ssize_t;
+typedef long long __kernel_loff_t;
+typedef __kernel_long_t __kernel_time_t;
+typedef __kernel_long_t __kernel_clock_t;
+typedef int __kernel_timer_t;
+typedef int __kernel_clockid_t;
+typedef __u32 __kernel_dev_t;
+typedef __kernel_dev_t dev_t;
+typedef unsigned short umode_t;
+typedef __kernel_pid_t pid_t;
+typedef __kernel_clockid_t clockid_t;
+typedef _Bool bool;
+typedef __kernel_uid32_t uid_t;
+typedef __kernel_gid32_t gid_t;
+typedef __kernel_loff_t loff_t;
+typedef __kernel_size_t size_t;
+typedef __kernel_ssize_t ssize_t;
+typedef __kernel_time_t time_t;
+typedef __s32 int32_t;
+typedef __u32 uint32_t;
+typedef u64 dma_addr_t;
+typedef unsigned int gfp_t;
+struct __anonstruct_atomic_t_7 {
+   int counter ;
+};
+typedef struct __anonstruct_atomic_t_7 atomic_t;
+struct __anonstruct_atomic64_t_8 {
+   long counter ;
+};
+typedef struct __anonstruct_atomic64_t_8 atomic64_t;
+struct list_head {
+   struct list_head *next ;
+   struct list_head *prev ;
+};
+struct hlist_node;
+struct hlist_head {
+   struct hlist_node *first ;
+};
+struct hlist_node {
+   struct hlist_node *next ;
+   struct hlist_node **pprev ;
+};
+struct rcu_head {
+   struct rcu_head *next ;
+   void (*func)(struct rcu_head *head ) ;
+};
+struct module;
+struct module;
+typedef void (*ctor_fn_t)(void);
+struct device;
+struct device;
+struct completion;
+struct completion;
+struct pt_regs;
+struct pt_regs;
+struct pid;
+struct pid;
+struct timespec;
+struct timespec;
+struct page;
+struct page;
+struct task_struct;
+struct task_struct;
+struct task_struct;
+struct mm_struct;
+struct mm_struct;
+struct pt_regs {
+   unsigned long r15 ;
+   unsigned long r14 ;
+   unsigned long r13 ;
+   unsigned long r12 ;
+   unsigned long bp ;
+   unsigned long bx ;
+   unsigned long r11 ;
+   unsigned long r10 ;
+   unsigned long r9 ;
+   unsigned long r8 ;
+   unsigned long ax ;
+   unsigned long cx ;
+   unsigned long dx ;
+   unsigned long si ;
+   unsigned long di ;
+   unsigned long orig_ax ;
+   unsigned long ip ;
+   unsigned long cs ;
+   unsigned long flags ;
+   unsigned long sp ;
+   unsigned long ss ;
+};
+struct __anonstruct____missing_field_name_15 {
+   unsigned int a ;
+   unsigned int b ;
+};
+struct __anonstruct____missing_field_name_16 {
+   u16 limit0 ;
+   u16 base0 ;
+   unsigned int base1 : 8 ;
+   unsigned int type : 4 ;
+   unsigned int s : 1 ;
+   unsigned int dpl : 2 ;
+   unsigned int p : 1 ;
+   unsigned int limit : 4 ;
+   unsigned int avl : 1 ;
+   unsigned int l : 1 ;
+   unsigned int d : 1 ;
+   unsigned int g : 1 ;
+   unsigned int base2 : 8 ;
+};
+union __anonunion____missing_field_name_14 {
+   struct __anonstruct____missing_field_name_15 __annonCompField5 ;
+   struct __anonstruct____missing_field_name_16 __annonCompField6 ;
+};
+struct desc_struct {
+   union __anonunion____missing_field_name_14 __annonCompField7 ;
+} __attribute__((__packed__)) ;
+typedef unsigned long pgdval_t;
+typedef unsigned long pgprotval_t;
+struct pgprot {
+   pgprotval_t pgprot ;
+};
+typedef struct pgprot pgprot_t;
+struct __anonstruct_pgd_t_20 {
+   pgdval_t pgd ;
+};
+typedef struct __anonstruct_pgd_t_20 pgd_t;
+typedef struct page *pgtable_t;
+struct file;
+struct file;
+struct page;
+struct thread_struct;
+struct thread_struct;
+struct mm_struct;
+struct desc_struct;
+struct task_struct;
+struct cpumask;
+struct cpumask;
+struct arch_spinlock;
+struct arch_spinlock;
+struct task_struct;
+struct kernel_vm86_regs {
+   struct pt_regs pt ;
+   unsigned short es ;
+   unsigned short __esh ;
+   unsigned short ds ;
+   unsigned short __dsh ;
+   unsigned short fs ;
+   unsigned short __fsh ;
+   unsigned short gs ;
+   unsigned short __gsh ;
+};
+union __anonunion____missing_field_name_24 {
+   struct pt_regs *regs ;
+   struct kernel_vm86_regs *vm86 ;
+};
+struct math_emu_info {
+   long ___orig_eip ;
+   union __anonunion____missing_field_name_24 __annonCompField8 ;
+};
+struct task_struct;
+struct bug_entry {
+   int bug_addr_disp ;
+   int file_disp ;
+   unsigned short line ;
+   unsigned short flags ;
+};
+struct pt_regs;
+struct cpumask {
+   unsigned long bits[((4096UL + 8UL * sizeof(long )) - 1UL) / (8UL * sizeof(long ))] ;
+};
+typedef struct cpumask cpumask_t;
+typedef struct cpumask *cpumask_var_t;
+struct static_key;
+struct static_key;
+struct pt_regs;
+struct i387_fsave_struct {
+   u32 cwd ;
+   u32 swd ;
+   u32 twd ;
+   u32 fip ;
+   u32 fcs ;
+   u32 foo ;
+   u32 fos ;
+   u32 st_space[20] ;
+   u32 status ;
+};
+struct __anonstruct____missing_field_name_31 {
+   u64 rip ;
+   u64 rdp ;
+};
+struct __anonstruct____missing_field_name_32 {
+   u32 fip ;
+   u32 fcs ;
+   u32 foo ;
+   u32 fos ;
+};
+union __anonunion____missing_field_name_30 {
+   struct __anonstruct____missing_field_name_31 __annonCompField12 ;
+   struct __anonstruct____missing_field_name_32 __annonCompField13 ;
+};
+union __anonunion____missing_field_name_33 {
+   u32 padding1[12] ;
+   u32 sw_reserved[12] ;
+};
+struct i387_fxsave_struct {
+   u16 cwd ;
+   u16 swd ;
+   u16 twd ;
+   u16 fop ;
+   union __anonunion____missing_field_name_30 __annonCompField14 ;
+   u32 mxcsr ;
+   u32 mxcsr_mask ;
+   u32 st_space[32] ;
+   u32 xmm_space[64] ;
+   u32 padding[12] ;
+   union __anonunion____missing_field_name_33 __annonCompField15 ;
+} __attribute__((__aligned__(16))) ;
+struct i387_soft_struct {
+   u32 cwd ;
+   u32 swd ;
+   u32 twd ;
+   u32 fip ;
+   u32 fcs ;
+   u32 foo ;
+   u32 fos ;
+   u32 st_space[20] ;
+   u8 ftop ;
+   u8 changed ;
+   u8 lookahead ;
+   u8 no_update ;
+   u8 rm ;
+   u8 alimit ;
+   struct math_emu_info *info ;
+   u32 entry_eip ;
+};
+struct ymmh_struct {
+   u32 ymmh_space[64] ;
+};
+struct xsave_hdr_struct {
+   u64 xstate_bv ;
+   u64 reserved1[2] ;
+   u64 reserved2[5] ;
+} __attribute__((__packed__)) ;
+struct xsave_struct {
+   struct i387_fxsave_struct i387 ;
+   struct xsave_hdr_struct xsave_hdr ;
+   struct ymmh_struct ymmh ;
+} __attribute__((__packed__, __aligned__(64))) ;
+union thread_xstate {
+   struct i387_fsave_struct fsave ;
+   struct i387_fxsave_struct fxsave ;
+   struct i387_soft_struct soft ;
+   struct xsave_struct xsave ;
+};
+struct fpu {
+   unsigned int last_cpu ;
+   unsigned int has_fpu ;
+   union thread_xstate *state ;
+};
+struct kmem_cache;
+struct perf_event;
+struct perf_event;
+struct thread_struct {
+   struct desc_struct tls_array[3] ;
+   unsigned long sp0 ;
+   unsigned long sp ;
+   unsigned long usersp ;
+   unsigned short es ;
+   unsigned short ds ;
+   unsigned short fsindex ;
+   unsigned short gsindex ;
+   unsigned long fs ;
+   unsigned long gs ;
+   struct perf_event *ptrace_bps[4] ;
+   unsigned long debugreg6 ;
+   unsigned long ptrace_dr7 ;
+   unsigned long cr2 ;
+   unsigned long trap_nr ;
+   unsigned long error_code ;
+   struct fpu fpu ;
+   unsigned long *io_bitmap_ptr ;
+   unsigned long iopl ;
+   unsigned int io_bitmap_max ;
+};
+typedef atomic64_t atomic_long_t;
+typedef u16 __ticket_t;
+typedef u32 __ticketpair_t;
+struct __raw_tickets {
+   __ticket_t head ;
+   __ticket_t tail ;
+};
+union __anonunion____missing_field_name_36 {
+   __ticketpair_t head_tail ;
+   struct __raw_tickets tickets ;
+};
+struct arch_spinlock {
+   union __anonunion____missing_field_name_36 __annonCompField17 ;
+};
+typedef struct arch_spinlock arch_spinlock_t;
+struct task_struct;
+struct lock_class_key {
+};
+struct raw_spinlock {
+   arch_spinlock_t raw_lock ;
+   unsigned int magic ;
+   unsigned int owner_cpu ;
+   void *owner ;
+};
+typedef struct raw_spinlock raw_spinlock_t;
+union __anonunion____missing_field_name_39 {
+   struct raw_spinlock rlock ;
+};
+struct spinlock {
+   union __anonunion____missing_field_name_39 __annonCompField19 ;
+};
+typedef struct spinlock spinlock_t;
+struct seqcount {
+   unsigned int sequence ;
+};
+typedef struct seqcount seqcount_t;
+struct timespec {
+   __kernel_time_t tv_sec ;
+   long tv_nsec ;
+};
+struct __wait_queue_head {
+   spinlock_t lock ;
+   struct list_head task_list ;
+};
+typedef struct __wait_queue_head wait_queue_head_t;
+struct task_struct;
+struct __anonstruct_nodemask_t_42 {
+   unsigned long bits[(((unsigned long )(1 << 10) + 8UL * sizeof(long )) - 1UL) / (8UL * sizeof(long ))] ;
+};
+typedef struct __anonstruct_nodemask_t_42 nodemask_t;
+struct page;
+struct mutex {
+   atomic_t count ;
+   spinlock_t wait_lock ;
+   struct list_head wait_list ;
+   struct task_struct *owner ;
+   char const *name ;
+   void *magic ;
+};
+struct mutex_waiter {
+   struct list_head list ;
+   struct task_struct *task ;
+   void *magic ;
+};
+struct rw_semaphore;
+struct rw_semaphore;
+struct rw_semaphore {
+   long count ;
+   raw_spinlock_t wait_lock ;
+   struct list_head wait_list ;
+};
+struct completion {
+   unsigned int done ;
+   wait_queue_head_t wait ;
+};
+struct page;
+struct device;
+struct device;
+union ktime {
+   s64 tv64 ;
+};
+typedef union ktime ktime_t;
+struct tvec_base;
+struct tvec_base;
+struct timer_list {
+   struct list_head entry ;
+   unsigned long expires ;
+   struct tvec_base *base ;
+   void (*function)(unsigned long ) ;
+   unsigned long data ;
+   int slack ;
+   int start_pid ;
+   void *start_site ;
+   char start_comm[16] ;
+};
+struct hrtimer;
+struct hrtimer;
+enum hrtimer_restart;
+struct work_struct;
+struct work_struct;
+struct work_struct {
+   atomic_long_t data ;
+   struct list_head entry ;
+   void (*func)(struct work_struct *work ) ;
+};
+struct device;
+struct pm_message {
+   int event ;
+};
+typedef struct pm_message pm_message_t;
+struct dev_pm_ops {
+   int (*prepare)(struct device *dev ) ;
+   void (*complete)(struct device *dev ) ;
+   int (*suspend)(struct device *dev ) ;
+   int (*resume)(struct device *dev ) ;
+   int (*freeze)(struct device *dev ) ;
+   int (*thaw)(struct device *dev ) ;
+   int (*poweroff)(struct device *dev ) ;
+   int (*restore)(struct device *dev ) ;
+   int (*suspend_late)(struct device *dev ) ;
+   int (*resume_early)(struct device *dev ) ;
+   int (*freeze_late)(struct device *dev ) ;
+   int (*thaw_early)(struct device *dev ) ;
+   int (*poweroff_late)(struct device *dev ) ;
+   int (*restore_early)(struct device *dev ) ;
+   int (*suspend_noirq)(struct device *dev ) ;
+   int (*resume_noirq)(struct device *dev ) ;
+   int (*freeze_noirq)(struct device *dev ) ;
+   int (*thaw_noirq)(struct device *dev ) ;
+   int (*poweroff_noirq)(struct device *dev ) ;
+   int (*restore_noirq)(struct device *dev ) ;
+   int (*runtime_suspend)(struct device *dev ) ;
+   int (*runtime_resume)(struct device *dev ) ;
+   int (*runtime_idle)(struct device *dev ) ;
+};
+enum rpm_status {
+    RPM_ACTIVE = 0,
+    RPM_RESUMING = 1,
+    RPM_SUSPENDED = 2,
+    RPM_SUSPENDING = 3
+} ;
+enum rpm_request {
+    RPM_REQ_NONE = 0,
+    RPM_REQ_IDLE = 1,
+    RPM_REQ_SUSPEND = 2,
+    RPM_REQ_AUTOSUSPEND = 3,
+    RPM_REQ_RESUME = 4
+} ;
+struct wakeup_source;
+struct wakeup_source;
+struct pm_subsys_data {
+   spinlock_t lock ;
+   unsigned int refcount ;
+};
+struct dev_pm_qos_request;
+struct pm_qos_constraints;
+struct dev_pm_info {
+   pm_message_t power_state ;
+   unsigned int can_wakeup : 1 ;
+   unsigned int async_suspend : 1 ;
+   bool is_prepared : 1 ;
+   bool is_suspended : 1 ;
+   bool ignore_children : 1 ;
+   spinlock_t lock ;
+   struct list_head entry ;
+   struct completion completion ;
+   struct wakeup_source *wakeup ;
+   bool wakeup_path : 1 ;
+   struct timer_list suspend_timer ;
+   unsigned long timer_expires ;
+   struct work_struct work ;
+   wait_queue_head_t wait_queue ;
+   atomic_t usage_count ;
+   atomic_t child_count ;
+   unsigned int disable_depth : 3 ;
+   unsigned int idle_notification : 1 ;
+   unsigned int request_pending : 1 ;
+   unsigned int deferred_resume : 1 ;
+   unsigned int run_wake : 1 ;
+   unsigned int runtime_auto : 1 ;
+   unsigned int no_callbacks : 1 ;
+   unsigned int irq_safe : 1 ;
+   unsigned int use_autosuspend : 1 ;
+   unsigned int timer_autosuspends : 1 ;
+   enum rpm_request request ;
+   enum rpm_status runtime_status ;
+   int runtime_error ;
+   int autosuspend_delay ;
+   unsigned long last_busy ;
+   unsigned long active_jiffies ;
+   unsigned long suspended_jiffies ;
+   unsigned long accounting_timestamp ;
+   ktime_t suspend_time ;
+   s64 max_time_suspended_ns ;
+   struct dev_pm_qos_request *pq_req ;
+   struct pm_subsys_data *subsys_data ;
+   struct pm_qos_constraints *constraints ;
+};
+struct dev_pm_domain {
+   struct dev_pm_ops ops ;
+};
+struct __anonstruct_mm_context_t_112 {
+   void *ldt ;
+   int size ;
+   unsigned short ia32_compat ;
+   struct mutex lock ;
+   void *vdso ;
+};
+typedef struct __anonstruct_mm_context_t_112 mm_context_t;
+struct vm_area_struct;
+struct vm_area_struct;
+struct page;
+struct vm_area_struct;
+struct completion;
+struct rb_node {
+   unsigned long rb_parent_color ;
+   struct rb_node *rb_right ;
+   struct rb_node *rb_left ;
+} __attribute__((__aligned__(sizeof(long )))) ;
+struct rb_root {
+   struct rb_node *rb_node ;
+};
+struct nsproxy;
+struct nsproxy;
+struct cred;
+struct cred;
+struct file;
+struct task_struct;
+typedef __u64 Elf64_Addr;
+typedef __u16 Elf64_Half;
+typedef __u32 Elf64_Word;
+typedef __u64 Elf64_Xword;
+struct elf64_sym {
+   Elf64_Word st_name ;
+   unsigned char st_info ;
+   unsigned char st_other ;
+   Elf64_Half st_shndx ;
+   Elf64_Addr st_value ;
+   Elf64_Xword st_size ;
+};
+typedef struct elf64_sym Elf64_Sym;
+struct file;
+struct sock;
+struct sock;
+struct kobject;
+struct kobject;
+enum kobj_ns_type {
+    KOBJ_NS_TYPE_NONE = 0,
+    KOBJ_NS_TYPE_NET = 1,
+    KOBJ_NS_TYPES = 2
+} ;
+struct kobj_ns_type_operations {
+   enum kobj_ns_type type ;
+   void *(*grab_current_ns)(void) ;
+   void const *(*netlink_ns)(struct sock *sk ) ;
+   void const *(*initial_ns)(void) ;
+   void (*drop_ns)(void * ) ;
+};
+struct kobject;
+struct module;
+enum kobj_ns_type;
+struct attribute {
+   char const *name ;
+   umode_t mode ;
+};
+struct attribute_group {
+   char const *name ;
+   umode_t (*is_visible)(struct kobject * , struct attribute * , int ) ;
+   struct attribute **attrs ;
+};
+struct file;
+struct vm_area_struct;
+struct bin_attribute {
+   struct attribute attr ;
+   size_t size ;
+   void *private ;
+   ssize_t (*read)(struct file * , struct kobject * , struct bin_attribute * , char * ,
+                   loff_t , size_t ) ;
+   ssize_t (*write)(struct file * , struct kobject * , struct bin_attribute * , char * ,
+                    loff_t , size_t ) ;
+   int (*mmap)(struct file * , struct kobject * , struct bin_attribute *attr , struct vm_area_struct *vma ) ;
+};
+struct sysfs_ops {
+   ssize_t (*show)(struct kobject * , struct attribute * , char * ) ;
+   ssize_t (*store)(struct kobject * , struct attribute * , char const * , size_t ) ;
+   void const *(*namespace)(struct kobject * , struct attribute const * ) ;
+};
+struct sysfs_dirent;
+struct sysfs_dirent;
+struct kref {
+   atomic_t refcount ;
+};
+struct kset;
+struct kobj_type;
+struct kobject {
+   char const *name ;
+   struct list_head entry ;
+   struct kobject *parent ;
+   struct kset *kset ;
+   struct kobj_type *ktype ;
+   struct sysfs_dirent *sd ;
+   struct kref kref ;
+   unsigned int state_initialized : 1 ;
+   unsigned int state_in_sysfs : 1 ;
+   unsigned int state_add_uevent_sent : 1 ;
+   unsigned int state_remove_uevent_sent : 1 ;
+   unsigned int uevent_suppress : 1 ;
+};
+struct kobj_type {
+   void (*release)(struct kobject *kobj ) ;
+   struct sysfs_ops const *sysfs_ops ;
+   struct attribute **default_attrs ;
+   struct kobj_ns_type_operations const *(*child_ns_type)(struct kobject *kobj ) ;
+   void const *(*namespace)(struct kobject *kobj ) ;
+};
+struct kobj_uevent_env {
+   char *envp[32] ;
+   int envp_idx ;
+   char buf[2048] ;
+   int buflen ;
+};
+struct kset_uevent_ops {
+   int (* const filter)(struct kset *kset , struct kobject *kobj ) ;
+   char const *(* const name)(struct kset *kset , struct kobject *kobj ) ;
+   int (* const uevent)(struct kset *kset , struct kobject *kobj , struct kobj_uevent_env *env ) ;
+};
+struct sock;
+struct kset {
+   struct list_head list ;
+   spinlock_t list_lock ;
+   struct kobject kobj ;
+   struct kset_uevent_ops const *uevent_ops ;
+};
+struct kernel_param;
+struct kernel_param;
+struct kernel_param_ops {
+   int (*set)(char const *val , struct kernel_param const *kp ) ;
+   int (*get)(char *buffer , struct kernel_param const *kp ) ;
+   void (*free)(void *arg ) ;
+};
+struct kparam_string;
+struct kparam_array;
+union __anonunion____missing_field_name_199 {
+   void *arg ;
+   struct kparam_string const *str ;
+   struct kparam_array const *arr ;
+};
+struct kernel_param {
+   char const *name ;
+   struct kernel_param_ops const *ops ;
+   u16 perm ;
+   s16 level ;
+   union __anonunion____missing_field_name_199 __annonCompField32 ;
+};
+struct kparam_string {
+   unsigned int maxlen ;
+   char *string ;
+};
+struct kparam_array {
+   unsigned int max ;
+   unsigned int elemsize ;
+   unsigned int *num ;
+   struct kernel_param_ops const *ops ;
+   void *elem ;
+};
+struct module;
+struct module;
+struct static_key {
+   atomic_t enabled ;
+};
+struct module;
+struct tracepoint;
+struct tracepoint;
+struct tracepoint_func {
+   void *func ;
+   void *data ;
+};
+struct tracepoint {
+   char const *name ;
+   struct static_key key ;
+   void (*regfunc)(void) ;
+   void (*unregfunc)(void) ;
+   struct tracepoint_func *funcs ;
+};
+struct kernel_symbol {
+   unsigned long value ;
+   char const *name ;
+};
+struct mod_arch_specific {
+};
+struct module;
+struct module_param_attrs;
+struct module_kobject {
+   struct kobject kobj ;
+   struct module *mod ;
+   struct kobject *drivers_dir ;
+   struct module_param_attrs *mp ;
+};
+struct module_attribute {
+   struct attribute attr ;
+   ssize_t (*show)(struct module_attribute * , struct module_kobject * , char * ) ;
+   ssize_t (*store)(struct module_attribute * , struct module_kobject * , char const * ,
+                    size_t count ) ;
+   void (*setup)(struct module * , char const * ) ;
+   int (*test)(struct module * ) ;
+   void (*free)(struct module * ) ;
+};
+struct exception_table_entry;
+struct exception_table_entry;
+enum module_state {
+    MODULE_STATE_LIVE = 0,
+    MODULE_STATE_COMING = 1,
+    MODULE_STATE_GOING = 2
+} ;
+struct module_ref {
+   unsigned long incs ;
+   unsigned long decs ;
+} __attribute__((__aligned__((2) * (sizeof(unsigned long )) ))) ;
+struct module_sect_attrs;
+struct module_notes_attrs;
+struct ftrace_event_call;
+struct module {
+   enum module_state state ;
+   struct list_head list ;
+   char name[64UL - sizeof(unsigned long )] ;
+   struct module_kobject mkobj ;
+   struct module_attribute *modinfo_attrs ;
+   char const *version ;
+   char const *srcversion ;
+   struct kobject *holders_dir ;
+   struct kernel_symbol const *syms ;
+   unsigned long const *crcs ;
+   unsigned int num_syms ;
+   struct kernel_param *kp ;
+   unsigned int num_kp ;
+   unsigned int num_gpl_syms ;
+   struct kernel_symbol const *gpl_syms ;
+   unsigned long const *gpl_crcs ;
+   struct kernel_symbol const *unused_syms ;
+   unsigned long const *unused_crcs ;
+   unsigned int num_unused_syms ;
+   unsigned int num_unused_gpl_syms ;
+   struct kernel_symbol const *unused_gpl_syms ;
+   unsigned long const *unused_gpl_crcs ;
+   struct kernel_symbol const *gpl_future_syms ;
+   unsigned long const *gpl_future_crcs ;
+   unsigned int num_gpl_future_syms ;
+   unsigned int num_exentries ;
+   struct exception_table_entry *extable ;
+   int (*init)(void) ;
+   void *module_init ;
+   void *module_core ;
+   unsigned int init_size ;
+   unsigned int core_size ;
+   unsigned int init_text_size ;
+   unsigned int core_text_size ;
+   unsigned int init_ro_size ;
+   unsigned int core_ro_size ;
+   struct mod_arch_specific arch ;
+   unsigned int taints ;
+   unsigned int num_bugs ;
+   struct list_head bug_list ;
+   struct bug_entry *bug_table ;
+   Elf64_Sym *symtab ;
+   Elf64_Sym *core_symtab ;
+   unsigned int num_symtab ;
+   unsigned int core_num_syms ;
+   char *strtab ;
+   char *core_strtab ;
+   struct module_sect_attrs *sect_attrs ;
+   struct module_notes_attrs *notes_attrs ;
+   char *args ;
+   void *percpu ;
+   unsigned int percpu_size ;
+   unsigned int num_tracepoints ;
+   struct tracepoint * const *tracepoints_ptrs ;
+   unsigned int num_trace_bprintk_fmt ;
+   char const **trace_bprintk_fmt_start ;
+   struct ftrace_event_call **trace_events ;
+   unsigned int num_trace_events ;
+   struct list_head source_list ;
+   struct list_head target_list ;
+   struct task_struct *waiter ;
+   void (*exit)(void) ;
+   struct module_ref *refptr ;
+   ctor_fn_t *ctors ;
+   unsigned int num_ctors ;
+};
+struct klist_node;
+struct klist_node;
+struct klist_node {
+   void *n_klist ;
+   struct list_head n_node ;
+   struct kref n_ref ;
+};
+struct dma_map_ops;
+struct dev_archdata {
+   void *acpi_handle ;
+   struct dma_map_ops *dma_ops ;
+   void *iommu ;
+};
+struct device;
+struct device_private;
+struct device_private;
+struct device_driver;
+struct device_driver;
+struct driver_private;
+struct driver_private;
+struct module;
+struct class;
+struct class;
+struct subsys_private;
+struct subsys_private;
+struct bus_type;
+struct bus_type;
+struct device_node;
+struct device_node;
+struct iommu_ops;
+struct iommu_ops;
+struct bus_attribute {
+   struct attribute attr ;
+   ssize_t (*show)(struct bus_type *bus , char *buf ) ;
+   ssize_t (*store)(struct bus_type *bus , char const *buf , size_t count ) ;
+};
+struct device_attribute;
+struct driver_attribute;
+struct bus_type {
+   char const *name ;
+   char const *dev_name ;
+   struct device *dev_root ;
+   struct bus_attribute *bus_attrs ;
+   struct device_attribute *dev_attrs ;
+   struct driver_attribute *drv_attrs ;
+   int (*match)(struct device *dev , struct device_driver *drv ) ;
+   int (*uevent)(struct device *dev , struct kobj_uevent_env *env ) ;
+   int (*probe)(struct device *dev ) ;
+   int (*remove)(struct device *dev ) ;
+   void (*shutdown)(struct device *dev ) ;
+   int (*suspend)(struct device *dev , pm_message_t state ) ;
+   int (*resume)(struct device *dev ) ;
+   struct dev_pm_ops const *pm ;
+   struct iommu_ops *iommu_ops ;
+   struct subsys_private *p ;
+};
+struct device_type;
+struct of_device_id;
+struct device_driver {
+   char const *name ;
+   struct bus_type *bus ;
+   struct module *owner ;
+   char const *mod_name ;
+   bool suppress_bind_attrs ;
+   struct of_device_id const *of_match_table ;
+   int (*probe)(struct device *dev ) ;
+   int (*remove)(struct device *dev ) ;
+   void (*shutdown)(struct device *dev ) ;
+   int (*suspend)(struct device *dev , pm_message_t state ) ;
+   int (*resume)(struct device *dev ) ;
+   struct attribute_group const **groups ;
+   struct dev_pm_ops const *pm ;
+   struct driver_private *p ;
+};
+struct driver_attribute {
+   struct attribute attr ;
+   ssize_t (*show)(struct device_driver *driver , char *buf ) ;
+   ssize_t (*store)(struct device_driver *driver , char const *buf , size_t count ) ;
+};
+struct class_attribute;
+struct class {
+   char const *name ;
+   struct module *owner ;
+   struct class_attribute *class_attrs ;
+   struct device_attribute *dev_attrs ;
+   struct bin_attribute *dev_bin_attrs ;
+   struct kobject *dev_kobj ;
+   int (*dev_uevent)(struct device *dev , struct kobj_uevent_env *env ) ;
+   char *(*devnode)(struct device *dev , umode_t *mode ) ;
+   void (*class_release)(struct class *class ) ;
+   void (*dev_release)(struct device *dev ) ;
+   int (*suspend)(struct device *dev , pm_message_t state ) ;
+   int (*resume)(struct device *dev ) ;
+   struct kobj_ns_type_operations const *ns_type ;
+   void const *(*namespace)(struct device *dev ) ;
+   struct dev_pm_ops const *pm ;
+   struct subsys_private *p ;
+};
+struct class_attribute {
+   struct attribute attr ;
+   ssize_t (*show)(struct class *class , struct class_attribute *attr , char *buf ) ;
+   ssize_t (*store)(struct class *class , struct class_attribute *attr , char const *buf ,
+                    size_t count ) ;
+   void const *(*namespace)(struct class *class , struct class_attribute const *attr ) ;
+};
+struct device_type {
+   char const *name ;
+   struct attribute_group const **groups ;
+   int (*uevent)(struct device *dev , struct kobj_uevent_env *env ) ;
+   char *(*devnode)(struct device *dev , umode_t *mode ) ;
+   void (*release)(struct device *dev ) ;
+   struct dev_pm_ops const *pm ;
+};
+struct device_attribute {
+   struct attribute attr ;
+   ssize_t (*show)(struct device *dev , struct device_attribute *attr , char *buf ) ;
+   ssize_t (*store)(struct device *dev , struct device_attribute *attr , char const *buf ,
+                    size_t count ) ;
+};
+struct device_dma_parameters {
+   unsigned int max_segment_size ;
+   unsigned long segment_boundary_mask ;
+};
+struct dma_coherent_mem;
+struct device {
+   struct device *parent ;
+   struct device_private *p ;
+   struct kobject kobj ;
+   char const *init_name ;
+   struct device_type const *type ;
+   struct mutex mutex ;
+   struct bus_type *bus ;
+   struct device_driver *driver ;
+   void *platform_data ;
+   struct dev_pm_info power ;
+   struct dev_pm_domain *pm_domain ;
+   int numa_node ;
+   u64 *dma_mask ;
+   u64 coherent_dma_mask ;
+   struct device_dma_parameters *dma_parms ;
+   struct list_head dma_pools ;
+   struct dma_coherent_mem *dma_mem ;
+   struct dev_archdata archdata ;
+   struct device_node *of_node ;
+   dev_t devt ;
+   u32 id ;
+   spinlock_t devres_lock ;
+   struct list_head devres_head ;
+   struct klist_node knode_class ;
+   struct class *class ;
+   struct attribute_group const **groups ;
+   void (*release)(struct device *dev ) ;
+};
+struct wakeup_source {
+   char const *name ;
+   struct list_head entry ;
+   spinlock_t lock ;
+   struct timer_list timer ;
+   unsigned long timer_expires ;
+   ktime_t total_time ;
+   ktime_t max_time ;
+   ktime_t last_time ;
+   unsigned long event_count ;
+   unsigned long active_count ;
+   unsigned long relax_count ;
+   unsigned long hit_count ;
+   unsigned int active : 1 ;
+};
+typedef unsigned long kernel_ulong_t;
+struct of_device_id {
+   char name[32] ;
+   char type[32] ;
+   char compatible[128] ;
+   void *data ;
+};
+struct spi_device_id {
+   char name[32] ;
+   kernel_ulong_t driver_data __attribute__((__aligned__(sizeof(kernel_ulong_t )))) ;
+};
+struct kmem_cache_cpu {
+   void **freelist ;
+   unsigned long tid ;
+   struct page *page ;
+   struct page *partial ;
+   int node ;
+   unsigned int stat[26] ;
+};
+struct kmem_cache_node {
+   spinlock_t list_lock ;
+   unsigned long nr_partial ;
+   struct list_head partial ;
+   atomic_long_t nr_slabs ;
+   atomic_long_t total_objects ;
+   struct list_head full ;
+};
+struct kmem_cache_order_objects {
+   unsigned long x ;
+};
+struct kmem_cache {
+   struct kmem_cache_cpu *cpu_slab ;
+   unsigned long flags ;
+   unsigned long min_partial ;
+   int size ;
+   int objsize ;
+   int offset ;
+   int cpu_partial ;
+   struct kmem_cache_order_objects oo ;
+   struct kmem_cache_order_objects max ;
+   struct kmem_cache_order_objects min ;
+   gfp_t allocflags ;
+   int refcount ;
+   void (*ctor)(void * ) ;
+   int inuse ;
+   int align ;
+   int reserved ;
+   char const *name ;
+   struct list_head list ;
+   struct kobject kobj ;
+   int remote_node_defrag_ratio ;
+   struct kmem_cache_node *node[1 << 10] ;
+};
+struct task_struct;
+struct kernel_cap_struct {
+   __u32 cap[2] ;
+};
+typedef struct kernel_cap_struct kernel_cap_t;
+struct user_namespace;
+struct user_namespace;
+struct prio_tree_node;
+struct raw_prio_tree_node {
+   struct prio_tree_node *left ;
+   struct prio_tree_node *right ;
+   struct prio_tree_node *parent ;
+};
+struct prio_tree_node {
+   struct prio_tree_node *left ;
+   struct prio_tree_node *right ;
+   struct prio_tree_node *parent ;
+   unsigned long start ;
+   unsigned long last ;
+};
+struct address_space;
+struct address_space;
+union __anonunion____missing_field_name_204 {
+   unsigned long index ;
+   void *freelist ;
+};
+struct __anonstruct____missing_field_name_208 {
+   unsigned int inuse : 16 ;
+   unsigned int objects : 15 ;
+   unsigned int frozen : 1 ;
+};
+union __anonunion____missing_field_name_207 {
+   atomic_t _mapcount ;
+   struct __anonstruct____missing_field_name_208 __annonCompField34 ;
+};
+struct __anonstruct____missing_field_name_206 {
+   union __anonunion____missing_field_name_207 __annonCompField35 ;
+   atomic_t _count ;
+};
+union __anonunion____missing_field_name_205 {
+   unsigned long counters ;
+   struct __anonstruct____missing_field_name_206 __annonCompField36 ;
+};
+struct __anonstruct____missing_field_name_203 {
+   union __anonunion____missing_field_name_204 __annonCompField33 ;
+   union __anonunion____missing_field_name_205 __annonCompField37 ;
+};
+struct __anonstruct____missing_field_name_210 {
+   struct page *next ;
+   int pages ;
+   int pobjects ;
+};
+union __anonunion____missing_field_name_209 {
+   struct list_head lru ;
+   struct __anonstruct____missing_field_name_210 __annonCompField39 ;
+};
+union __anonunion____missing_field_name_211 {
+   unsigned long private ;
+   struct kmem_cache *slab ;
+   struct page *first_page ;
+};
+struct page {
+   unsigned long flags ;
+   struct address_space *mapping ;
+   struct __anonstruct____missing_field_name_203 __annonCompField38 ;
+   union __anonunion____missing_field_name_209 __annonCompField40 ;
+   union __anonunion____missing_field_name_211 __annonCompField41 ;
+   unsigned long debug_flags ;
+} __attribute__((__aligned__((2) * (sizeof(unsigned long )) ))) ;
+struct __anonstruct_vm_set_213 {
+   struct list_head list ;
+   void *parent ;
+   struct vm_area_struct *head ;
+};
+union __anonunion_shared_212 {
+   struct __anonstruct_vm_set_213 vm_set ;
+   struct raw_prio_tree_node prio_tree_node ;
+};
+struct anon_vma;
+struct vm_operations_struct;
+struct mempolicy;
+struct vm_area_struct {
+   struct mm_struct *vm_mm ;
+   unsigned long vm_start ;
+   unsigned long vm_end ;
+   struct vm_area_struct *vm_next ;
+   struct vm_area_struct *vm_prev ;
+   pgprot_t vm_page_prot ;
+   unsigned long vm_flags ;
+   struct rb_node vm_rb ;
+   union __anonunion_shared_212 shared ;
+   struct list_head anon_vma_chain ;
+   struct anon_vma *anon_vma ;
+   struct vm_operations_struct const *vm_ops ;
+   unsigned long vm_pgoff ;
+   struct file *vm_file ;
+   void *vm_private_data ;
+   struct mempolicy *vm_policy ;
+};
+struct core_thread {
+   struct task_struct *task ;
+   struct core_thread *next ;
+};
+struct core_state {
+   atomic_t nr_threads ;
+   struct core_thread dumper ;
+   struct completion startup ;
+};
+struct mm_rss_stat {
+   atomic_long_t count[3] ;
+};
+struct linux_binfmt;
+struct mmu_notifier_mm;
+struct mm_struct {
+   struct vm_area_struct *mmap ;
+   struct rb_root mm_rb ;
+   struct vm_area_struct *mmap_cache ;
+   unsigned long (*get_unmapped_area)(struct file *filp , unsigned long addr , unsigned long len ,
+                                      unsigned long pgoff , unsigned long flags ) ;
+   void (*unmap_area)(struct mm_struct *mm , unsigned long addr ) ;
+   unsigned long mmap_base ;
+   unsigned long task_size ;
+   unsigned long cached_hole_size ;
+   unsigned long free_area_cache ;
+   pgd_t *pgd ;
+   atomic_t mm_users ;
+   atomic_t mm_count ;
+   int map_count ;
+   spinlock_t page_table_lock ;
+   struct rw_semaphore mmap_sem ;
+   struct list_head mmlist ;
+   unsigned long hiwater_rss ;
+   unsigned long hiwater_vm ;
+   unsigned long total_vm ;
+   unsigned long locked_vm ;
+   unsigned long pinned_vm ;
+   unsigned long shared_vm ;
+   unsigned long exec_vm ;
+   unsigned long stack_vm ;
+   unsigned long reserved_vm ;
+   unsigned long def_flags ;
+   unsigned long nr_ptes ;
+   unsigned long start_code ;
+   unsigned long end_code ;
+   unsigned long start_data ;
+   unsigned long end_data ;
+   unsigned long start_brk ;
+   unsigned long brk ;
+   unsigned long start_stack ;
+   unsigned long arg_start ;
+   unsigned long arg_end ;
+   unsigned long env_start ;
+   unsigned long env_end ;
+   unsigned long saved_auxv[44] ;
+   struct mm_rss_stat rss_stat ;
+   struct linux_binfmt *binfmt ;
+   cpumask_var_t cpu_vm_mask_var ;
+   mm_context_t context ;
+   unsigned int faultstamp ;
+   unsigned int token_priority ;
+   unsigned int last_interval ;
+   unsigned long flags ;
+   struct core_state *core_state ;
+   spinlock_t ioctx_lock ;
+   struct hlist_head ioctx_list ;
+   struct task_struct *owner ;
+   struct file *exe_file ;
+   unsigned long num_exe_file_vmas ;
+   struct mmu_notifier_mm *mmu_notifier_mm ;
+   pgtable_t pmd_huge_pte ;
+   struct cpumask cpumask_allocation ;
+};
+typedef unsigned long cputime_t;
+struct task_struct;
+struct sem_undo_list;
+struct sysv_sem {
+   struct sem_undo_list *undo_list ;
+};
+struct siginfo;
+struct siginfo;
+struct __anonstruct_sigset_t_215 {
+   unsigned long sig[1] ;
+};
+typedef struct __anonstruct_sigset_t_215 sigset_t;
+typedef void __signalfn_t(int );
+typedef __signalfn_t *__sighandler_t;
+typedef void __restorefn_t(void);
+typedef __restorefn_t *__sigrestore_t;
+struct sigaction {
+   __sighandler_t sa_handler ;
+   unsigned long sa_flags ;
+   __sigrestore_t sa_restorer ;
+   sigset_t sa_mask ;
+};
+struct k_sigaction {
+   struct sigaction sa ;
+};
+union sigval {
+   int sival_int ;
+   void *sival_ptr ;
+};
+typedef union sigval sigval_t;
+struct __anonstruct__kill_217 {
+   __kernel_pid_t _pid ;
+   __kernel_uid32_t _uid ;
+};
+struct __anonstruct__timer_218 {
+   __kernel_timer_t _tid ;
+   int _overrun ;
+   char _pad[sizeof(__kernel_uid32_t ) - sizeof(int )] ;
+   sigval_t _sigval ;
+   int _sys_private ;
+};
+struct __anonstruct__rt_219 {
+   __kernel_pid_t _pid ;
+   __kernel_uid32_t _uid ;
+   sigval_t _sigval ;
+};
+struct __anonstruct__sigchld_220 {
+   __kernel_pid_t _pid ;
+   __kernel_uid32_t _uid ;
+   int _status ;
+   __kernel_clock_t _utime ;
+   __kernel_clock_t _stime ;
+};
+struct __anonstruct__sigfault_221 {
+   void *_addr ;
+   short _addr_lsb ;
+};
+struct __anonstruct__sigpoll_222 {
+   long _band ;
+   int _fd ;
+};
+union __anonunion__sifields_216 {
+   int _pad[(128UL - 4UL * sizeof(int )) / sizeof(int )] ;
+   struct __anonstruct__kill_217 _kill ;
+   struct __anonstruct__timer_218 _timer ;
+   struct __anonstruct__rt_219 _rt ;
+   struct __anonstruct__sigchld_220 _sigchld ;
+   struct __anonstruct__sigfault_221 _sigfault ;
+   struct __anonstruct__sigpoll_222 _sigpoll ;
+};
+struct siginfo {
+   int si_signo ;
+   int si_errno ;
+   int si_code ;
+   union __anonunion__sifields_216 _sifields ;
+};
+typedef struct siginfo siginfo_t;
+struct siginfo;
+struct task_struct;
+struct user_struct;
+struct sigpending {
+   struct list_head list ;
+   sigset_t signal ;
+};
+struct timespec;
+struct pt_regs;
+struct pid_namespace;
+struct upid {
+   int nr ;
+   struct pid_namespace *ns ;
+   struct hlist_node pid_chain ;
+};
+struct pid {
+   atomic_t count ;
+   unsigned int level ;
+   struct hlist_head tasks[3] ;
+   struct rcu_head rcu ;
+   struct upid numbers[1] ;
+};
+struct pid_link {
+   struct hlist_node node ;
+   struct pid *pid ;
+};
+struct pid_namespace;
+struct __anonstruct_seccomp_t_225 {
+   int mode ;
+};
+typedef struct __anonstruct_seccomp_t_225 seccomp_t;
+struct plist_head {
+   struct list_head node_list ;
+};
+struct plist_node {
+   int prio ;
+   struct list_head prio_list ;
+   struct list_head node_list ;
+};
+struct rt_mutex_waiter;
+struct rt_mutex_waiter;
+struct rlimit {
+   unsigned long rlim_cur ;
+   unsigned long rlim_max ;
+};
+struct task_struct;
+struct timerqueue_node {
+   struct rb_node node ;
+   ktime_t expires ;
+};
+struct timerqueue_head {
+   struct rb_root head ;
+   struct timerqueue_node *next ;
+};
+struct hrtimer_clock_base;
+struct hrtimer_clock_base;
+struct hrtimer_cpu_base;
+struct hrtimer_cpu_base;
+enum hrtimer_restart {
+    HRTIMER_NORESTART = 0,
+    HRTIMER_RESTART = 1
+} ;
+struct hrtimer {
+   struct timerqueue_node node ;
+   ktime_t _softexpires ;
+   enum hrtimer_restart (*function)(struct hrtimer * ) ;
+   struct hrtimer_clock_base *base ;
+   unsigned long state ;
+   int start_pid ;
+   void *start_site ;
+   char start_comm[16] ;
+};
+struct hrtimer_clock_base {
+   struct hrtimer_cpu_base *cpu_base ;
+   int index ;
+   clockid_t clockid ;
+   struct timerqueue_head active ;
+   ktime_t resolution ;
+   ktime_t (*get_time)(void) ;
+   ktime_t softirq_time ;
+   ktime_t offset ;
+};
+struct hrtimer_cpu_base {
+   raw_spinlock_t lock ;
+   unsigned long active_bases ;
+   ktime_t expires_next ;
+   int hres_active ;
+   int hang_detected ;
+   unsigned long nr_events ;
+   unsigned long nr_retries ;
+   unsigned long nr_hangs ;
+   ktime_t max_hang_time ;
+   struct hrtimer_clock_base clock_base[3] ;
+};
+struct task_io_accounting {
+   u64 rchar ;
+   u64 wchar ;
+   u64 syscr ;
+   u64 syscw ;
+   u64 read_bytes ;
+   u64 write_bytes ;
+   u64 cancelled_write_bytes ;
+};
+struct task_struct;
+struct latency_record {
+   unsigned long backtrace[12] ;
+   unsigned int count ;
+   unsigned long time ;
+   unsigned long max ;
+};
+typedef int32_t key_serial_t;
+typedef uint32_t key_perm_t;
+struct key;
+struct key;
+struct user_struct;
+struct signal_struct;
+struct signal_struct;
+struct cred;
+struct key_type;
+struct key_type;
+struct keyring_list;
+struct keyring_list;
+struct key_user;
+union __anonunion____missing_field_name_226 {
+   time_t expiry ;
+   time_t revoked_at ;
+};
+union __anonunion_type_data_227 {
+   struct list_head link ;
+   unsigned long x[2] ;
+   void *p[2] ;
+   int reject_error ;
+};
+union __anonunion_payload_228 {
+   unsigned long value ;
+   void *rcudata ;
+   void *data ;
+   struct keyring_list *subscriptions ;
+};
+struct key {
+   atomic_t usage ;
+   key_serial_t serial ;
+   struct rb_node serial_node ;
+   struct key_type *type ;
+   struct rw_semaphore sem ;
+   struct key_user *user ;
+   void *security ;
+   union __anonunion____missing_field_name_226 __annonCompField42 ;
+   uid_t uid ;
+   gid_t gid ;
+   key_perm_t perm ;
+   unsigned short quotalen ;
+   unsigned short datalen ;
+   unsigned long flags ;
+   char *description ;
+   union __anonunion_type_data_227 type_data ;
+   union __anonunion_payload_228 payload ;
+};
+struct audit_context;
+struct audit_context;
+struct user_struct;
+struct cred;
+struct group_info {
+   atomic_t usage ;
+   int ngroups ;
+   int nblocks ;
+   gid_t small_block[32] ;
+   gid_t *blocks[0] ;
+};
+struct thread_group_cred {
+   atomic_t usage ;
+   pid_t tgid ;
+   spinlock_t lock ;
+   struct key *session_keyring ;
+   struct key *process_keyring ;
+   struct rcu_head rcu ;
+};
+struct cred {
+   atomic_t usage ;
+   atomic_t subscribers ;
+   void *put_addr ;
+   unsigned int magic ;
+   uid_t uid ;
+   gid_t gid ;
+   uid_t suid ;
+   gid_t sgid ;
+   uid_t euid ;
+   gid_t egid ;
+   uid_t fsuid ;
+   gid_t fsgid ;
+   unsigned int securebits ;
+   kernel_cap_t cap_inheritable ;
+   kernel_cap_t cap_permitted ;
+   kernel_cap_t cap_effective ;
+   kernel_cap_t cap_bset ;
+   unsigned char jit_keyring ;
+   struct key *thread_keyring ;
+   struct key *request_key_auth ;
+   struct thread_group_cred *tgcred ;
+   void *security ;
+   struct user_struct *user ;
+   struct user_namespace *user_ns ;
+   struct group_info *group_info ;
+   struct rcu_head rcu ;
+};
+struct llist_node;
+struct llist_node {
+   struct llist_node *next ;
+};
+struct futex_pi_state;
+struct futex_pi_state;
+struct robust_list_head;
+struct robust_list_head;
+struct bio_list;
+struct bio_list;
+struct fs_struct;
+struct fs_struct;
+struct perf_event_context;
+struct perf_event_context;
+struct blk_plug;
+struct blk_plug;
+struct cfs_rq;
+struct cfs_rq;
+struct task_struct;
+struct nsproxy;
+struct user_namespace;
+struct mm_struct;
+struct sighand_struct {
+   atomic_t count ;
+   struct k_sigaction action[64] ;
+   spinlock_t siglock ;
+   wait_queue_head_t signalfd_wqh ;
+};
+struct pacct_struct {
+   int ac_flag ;
+   long ac_exitcode ;
+   unsigned long ac_mem ;
+   cputime_t ac_utime ;
+   cputime_t ac_stime ;
+   unsigned long ac_minflt ;
+   unsigned long ac_majflt ;
+};
+struct cpu_itimer {
+   cputime_t expires ;
+   cputime_t incr ;
+   u32 error ;
+   u32 incr_error ;
+};
+struct task_cputime {
+   cputime_t utime ;
+   cputime_t stime ;
+   unsigned long long sum_exec_runtime ;
+};
+struct thread_group_cputimer {
+   struct task_cputime cputime ;
+   int running ;
+   raw_spinlock_t lock ;
+};
+struct autogroup;
+struct autogroup;
+struct tty_struct;
+struct taskstats;
+struct tty_audit_buf;
+struct signal_struct {
+   atomic_t sigcnt ;
+   atomic_t live ;
+   int nr_threads ;
+   wait_queue_head_t wait_chldexit ;
+   struct task_struct *curr_target ;
+   struct sigpending shared_pending ;
+   int group_exit_code ;
+   int notify_count ;
+   struct task_struct *group_exit_task ;
+   int group_stop_count ;
+   unsigned int flags ;
+   unsigned int is_child_subreaper : 1 ;
+   unsigned int has_child_subreaper : 1 ;
+   struct list_head posix_timers ;
+   struct hrtimer real_timer ;
+   struct pid *leader_pid ;
+   ktime_t it_real_incr ;
+   struct cpu_itimer it[2] ;
+   struct thread_group_cputimer cputimer ;
+   struct task_cputime cputime_expires ;
+   struct list_head cpu_timers[3] ;
+   struct pid *tty_old_pgrp ;
+   int leader ;
+   struct tty_struct *tty ;
+   struct autogroup *autogroup ;
+   cputime_t utime ;
+   cputime_t stime ;
+   cputime_t cutime ;
+   cputime_t cstime ;
+   cputime_t gtime ;
+   cputime_t cgtime ;
+   cputime_t prev_utime ;
+   cputime_t prev_stime ;
+   unsigned long nvcsw ;
+   unsigned long nivcsw ;
+   unsigned long cnvcsw ;
+   unsigned long cnivcsw ;
+   unsigned long min_flt ;
+   unsigned long maj_flt ;
+   unsigned long cmin_flt ;
+   unsigned long cmaj_flt ;
+   unsigned long inblock ;
+   unsigned long oublock ;
+   unsigned long cinblock ;
+   unsigned long coublock ;
+   unsigned long maxrss ;
+   unsigned long cmaxrss ;
+   struct task_io_accounting ioac ;
+   unsigned long long sum_sched_runtime ;
+   struct rlimit rlim[16] ;
+   struct pacct_struct pacct ;
+   struct taskstats *stats ;
+   unsigned int audit_tty ;
+   struct tty_audit_buf *tty_audit_buf ;
+   struct rw_semaphore group_rwsem ;
+   int oom_adj ;
+   int oom_score_adj ;
+   int oom_score_adj_min ;
+   struct mutex cred_guard_mutex ;
+};
+struct user_struct {
+   atomic_t __count ;
+   atomic_t processes ;
+   atomic_t files ;
+   atomic_t sigpending ;
+   atomic_t inotify_watches ;
+   atomic_t inotify_devs ;
+   atomic_t fanotify_listeners ;
+   atomic_long_t epoll_watches ;
+   unsigned long mq_bytes ;
+   unsigned long locked_shm ;
+   struct key *uid_keyring ;
+   struct key *session_keyring ;
+   struct hlist_node uidhash_node ;
+   uid_t uid ;
+   struct user_namespace *user_ns ;
+   atomic_long_t locked_vm ;
+};
+struct backing_dev_info;
+struct backing_dev_info;
+struct reclaim_state;
+struct reclaim_state;
+struct sched_info {
+   unsigned long pcount ;
+   unsigned long long run_delay ;
+   unsigned long long last_arrival ;
+   unsigned long long last_queued ;
+};
+struct task_delay_info {
+   spinlock_t lock ;
+   unsigned int flags ;
+   struct timespec blkio_start ;
+   struct timespec blkio_end ;
+   u64 blkio_delay ;
+   u64 swapin_delay ;
+   u32 blkio_count ;
+   u32 swapin_count ;
+   struct timespec freepages_start ;
+   struct timespec freepages_end ;
+   u64 freepages_delay ;
+   u32 freepages_count ;
+};
+struct io_context;
+struct io_context;
+struct audit_context;
+struct mempolicy;
+struct pipe_inode_info;
+struct pipe_inode_info;
+struct rq;
+struct rq;
+struct sched_class {
+   struct sched_class const *next ;
+   void (*enqueue_task)(struct rq *rq , struct task_struct *p , int flags ) ;
+   void (*dequeue_task)(struct rq *rq , struct task_struct *p , int flags ) ;
+   void (*yield_task)(struct rq *rq ) ;
+   bool (*yield_to_task)(struct rq *rq , struct task_struct *p , bool preempt ) ;
+   void (*check_preempt_curr)(struct rq *rq , struct task_struct *p , int flags ) ;
+   struct task_struct *(*pick_next_task)(struct rq *rq ) ;
+   void (*put_prev_task)(struct rq *rq , struct task_struct *p ) ;
+   int (*select_task_rq)(struct task_struct *p , int sd_flag , int flags ) ;
+   void (*pre_schedule)(struct rq *this_rq , struct task_struct *task ) ;
+   void (*post_schedule)(struct rq *this_rq ) ;
+   void (*task_waking)(struct task_struct *task ) ;
+   void (*task_woken)(struct rq *this_rq , struct task_struct *task ) ;
+   void (*set_cpus_allowed)(struct task_struct *p , struct cpumask const *newmask ) ;
+   void (*rq_online)(struct rq *rq ) ;
+   void (*rq_offline)(struct rq *rq ) ;
+   void (*set_curr_task)(struct rq *rq ) ;
+   void (*task_tick)(struct rq *rq , struct task_struct *p , int queued ) ;
+   void (*task_fork)(struct task_struct *p ) ;
+   void (*switched_from)(struct rq *this_rq , struct task_struct *task ) ;
+   void (*switched_to)(struct rq *this_rq , struct task_struct *task ) ;
+   void (*prio_changed)(struct rq *this_rq , struct task_struct *task , int oldprio ) ;
+   unsigned int (*get_rr_interval)(struct rq *rq , struct task_struct *task ) ;
+   void (*task_move_group)(struct task_struct *p , int on_rq ) ;
+};
+struct load_weight {
+   unsigned long weight ;
+   unsigned long inv_weight ;
+};
+struct sched_statistics {
+   u64 wait_start ;
+   u64 wait_max ;
+   u64 wait_count ;
+   u64 wait_sum ;
+   u64 iowait_count ;
+   u64 iowait_sum ;
+   u64 sleep_start ;
+   u64 sleep_max ;
+   s64 sum_sleep_runtime ;
+   u64 block_start ;
+   u64 block_max ;
+   u64 exec_max ;
+   u64 slice_max ;
+   u64 nr_migrations_cold ;
+   u64 nr_failed_migrations_affine ;
+   u64 nr_failed_migrations_running ;
+   u64 nr_failed_migrations_hot ;
+   u64 nr_forced_migrations ;
+   u64 nr_wakeups ;
+   u64 nr_wakeups_sync ;
+   u64 nr_wakeups_migrate ;
+   u64 nr_wakeups_local ;
+   u64 nr_wakeups_remote ;
+   u64 nr_wakeups_affine ;
+   u64 nr_wakeups_affine_attempts ;
+   u64 nr_wakeups_passive ;
+   u64 nr_wakeups_idle ;
+};
+struct sched_entity {
+   struct load_weight load ;
+   struct rb_node run_node ;
+   struct list_head group_node ;
+   unsigned int on_rq ;
+   u64 exec_start ;
+   u64 sum_exec_runtime ;
+   u64 vruntime ;
+   u64 prev_sum_exec_runtime ;
+   u64 nr_migrations ;
+   struct sched_statistics statistics ;
+   struct sched_entity *parent ;
+   struct cfs_rq *cfs_rq ;
+   struct cfs_rq *my_q ;
+};
+struct rt_rq;
+struct sched_rt_entity {
+   struct list_head run_list ;
+   unsigned long timeout ;
+   unsigned int time_slice ;
+   int nr_cpus_allowed ;
+   struct sched_rt_entity *back ;
+   struct sched_rt_entity *parent ;
+   struct rt_rq *rt_rq ;
+   struct rt_rq *my_q ;
+};
+struct files_struct;
+struct css_set;
+struct compat_robust_list_head;
+struct mem_cgroup;
+struct memcg_batch_info {
+   int do_batch ;
+   struct mem_cgroup *memcg ;
+   unsigned long nr_pages ;
+   unsigned long memsw_nr_pages ;
+};
+struct task_struct {
+   long volatile state ;
+   void *stack ;
+   atomic_t usage ;
+   unsigned int flags ;
+   unsigned int ptrace ;
+   struct llist_node wake_entry ;
+   int on_cpu ;
+   int on_rq ;
+   int prio ;
+   int static_prio ;
+   int normal_prio ;
+   unsigned int rt_priority ;
+   struct sched_class const *sched_class ;
+   struct sched_entity se ;
+   struct sched_rt_entity rt ;
+   struct hlist_head preempt_notifiers ;
+   unsigned char fpu_counter ;
+   unsigned int policy ;
+   cpumask_t cpus_allowed ;
+   struct sched_info sched_info ;
+   struct list_head tasks ;
+   struct plist_node pushable_tasks ;
+   struct mm_struct *mm ;
+   struct mm_struct *active_mm ;
+   unsigned int brk_randomized : 1 ;
+   int exit_state ;
+   int exit_code ;
+   int exit_signal ;
+   int pdeath_signal ;
+   unsigned int jobctl ;
+   unsigned int personality ;
+   unsigned int did_exec : 1 ;
+   unsigned int in_execve : 1 ;
+   unsigned int in_iowait : 1 ;
+   unsigned int sched_reset_on_fork : 1 ;
+   unsigned int sched_contributes_to_load : 1 ;
+   unsigned int irq_thread : 1 ;
+   pid_t pid ;
+   pid_t tgid ;
+   unsigned long stack_canary ;
+   struct task_struct *real_parent ;
+   struct task_struct *parent ;
+   struct list_head children ;
+   struct list_head sibling ;
+   struct task_struct *group_leader ;
+   struct list_head ptraced ;
+   struct list_head ptrace_entry ;
+   struct pid_link pids[3] ;
+   struct list_head thread_group ;
+   struct completion *vfork_done ;
+   int *set_child_tid ;
+   int *clear_child_tid ;
+   cputime_t utime ;
+   cputime_t stime ;
+   cputime_t utimescaled ;
+   cputime_t stimescaled ;
+   cputime_t gtime ;
+   cputime_t prev_utime ;
+   cputime_t prev_stime ;
+   unsigned long nvcsw ;
+   unsigned long nivcsw ;
+   struct timespec start_time ;
+   struct timespec real_start_time ;
+   unsigned long min_flt ;
+   unsigned long maj_flt ;
+   struct task_cputime cputime_expires ;
+   struct list_head cpu_timers[3] ;
+   struct cred const *real_cred ;
+   struct cred const *cred ;
+   struct cred *replacement_session_keyring ;
+   char comm[16] ;
+   int link_count ;
+   int total_link_count ;
+   struct sysv_sem sysvsem ;
+   unsigned long last_switch_count ;
+   struct thread_struct thread ;
+   struct fs_struct *fs ;
+   struct files_struct *files ;
+   struct nsproxy *nsproxy ;
+   struct signal_struct *signal ;
+   struct sighand_struct *sighand ;
+   sigset_t blocked ;
+   sigset_t real_blocked ;
+   sigset_t saved_sigmask ;
+   struct sigpending pending ;
+   unsigned long sas_ss_sp ;
+   size_t sas_ss_size ;
+   int (*notifier)(void *priv ) ;
+   void *notifier_data ;
+   sigset_t *notifier_mask ;
+   struct audit_context *audit_context ;
+   uid_t loginuid ;
+   unsigned int sessionid ;
+   seccomp_t seccomp ;
+   u32 parent_exec_id ;
+   u32 self_exec_id ;
+   spinlock_t alloc_lock ;
+   raw_spinlock_t pi_lock ;
+   struct plist_head pi_waiters ;
+   struct rt_mutex_waiter *pi_blocked_on ;
+   struct mutex_waiter *blocked_on ;
+   unsigned int irq_events ;
+   unsigned long hardirq_enable_ip ;
+   unsigned long hardirq_disable_ip ;
+   unsigned int hardirq_enable_event ;
+   unsigned int hardirq_disable_event ;
+   int hardirqs_enabled ;
+   int hardirq_context ;
+   unsigned long softirq_disable_ip ;
+   unsigned long softirq_enable_ip ;
+   unsigned int softirq_disable_event ;
+   unsigned int softirq_enable_event ;
+   int softirqs_enabled ;
+   int softirq_context ;
+   void *journal_info ;
+   struct bio_list *bio_list ;
+   struct blk_plug *plug ;
+   struct reclaim_state *reclaim_state ;
+   struct backing_dev_info *backing_dev_info ;
+   struct io_context *io_context ;
+   unsigned long ptrace_message ;
+   siginfo_t *last_siginfo ;
+   struct task_io_accounting ioac ;
+   u64 acct_rss_mem1 ;
+   u64 acct_vm_mem1 ;
+   cputime_t acct_timexpd ;
+   nodemask_t mems_allowed ;
+   seqcount_t mems_allowed_seq ;
+   int cpuset_mem_spread_rotor ;
+   int cpuset_slab_spread_rotor ;
+   struct css_set *cgroups ;
+   struct list_head cg_list ;
+   struct robust_list_head *robust_list ;
+   struct compat_robust_list_head *compat_robust_list ;
+   struct list_head pi_state_list ;
+   struct futex_pi_state *pi_state_cache ;
+   struct perf_event_context *perf_event_ctxp[2] ;
+   struct mutex perf_event_mutex ;
+   struct list_head perf_event_list ;
+   struct mempolicy *mempolicy ;
+   short il_next ;
+   short pref_node_fork ;
+   struct rcu_head rcu ;
+   struct pipe_inode_info *splice_pipe ;
+   struct task_delay_info *delays ;
+   int make_it_fail ;
+   int nr_dirtied ;
+   int nr_dirtied_pause ;
+   unsigned long dirty_paused_when ;
+   int latency_record_count ;
+   struct latency_record latency_record[32] ;
+   unsigned long timer_slack_ns ;
+   unsigned long default_timer_slack_ns ;
+   struct list_head *scm_work_list ;
+   unsigned long trace ;
+   unsigned long trace_recursion ;
+   struct memcg_batch_info memcg_batch ;
+   atomic_t ptrace_bp_refcnt ;
+};
+struct pid_namespace;
+struct kthread_work;
+struct kthread_work;
+struct kthread_worker {
+   spinlock_t lock ;
+   struct list_head work_list ;
+   struct task_struct *task ;
+};
+struct kthread_work {
+   struct list_head node ;
+   void (*func)(struct kthread_work *work ) ;
+   wait_queue_head_t done ;
+   atomic_t flushing ;
+   int queue_seq ;
+   int done_seq ;
+};
+struct spi_master;
+struct spi_device {
+   struct device dev ;
+   struct spi_master *master ;
+   u32 max_speed_hz ;
+   u8 chip_select ;
+   u8 mode ;
+   u8 bits_per_word ;
+   int irq ;
+   void *controller_state ;
+   void *controller_data ;
+   char modalias[32] ;
+};
+struct spi_message;
+struct spi_message;
+struct spi_driver {
+   struct spi_device_id const *id_table ;
+   int (*probe)(struct spi_device *spi ) ;
+   int (*remove)(struct spi_device *spi ) ;
+   void (*shutdown)(struct spi_device *spi ) ;
+   int (*suspend)(struct spi_device *spi , pm_message_t mesg ) ;
+   int (*resume)(struct spi_device *spi ) ;
+   struct device_driver driver ;
+};
+struct spi_master {
+   struct device dev ;
+   struct list_head list ;
+   s16 bus_num ;
+   u16 num_chipselect ;
+   u16 dma_alignment ;
+   u16 mode_bits ;
+   u16 flags ;
+   spinlock_t bus_lock_spinlock ;
+   struct mutex bus_lock_mutex ;
+   bool bus_lock_flag ;
+   int (*setup)(struct spi_device *spi ) ;
+   int (*transfer)(struct spi_device *spi , struct spi_message *mesg ) ;
+   void (*cleanup)(struct spi_device *spi ) ;
+   bool queued ;
+   struct kthread_worker kworker ;
+   struct task_struct *kworker_task ;
+   struct kthread_work pump_messages ;
+   spinlock_t queue_lock ;
+   struct list_head queue ;
+   struct spi_message *cur_msg ;
+   bool busy ;
+   bool running ;
+   bool rt ;
+   int (*prepare_transfer_hardware)(struct spi_master *master ) ;
+   int (*transfer_one_message)(struct spi_master *master , struct spi_message *mesg ) ;
+   int (*unprepare_transfer_hardware)(struct spi_master *master ) ;
+};
+struct spi_transfer {
+   void const *tx_buf ;
+   void *rx_buf ;
+   unsigned int len ;
+   dma_addr_t tx_dma ;
+   dma_addr_t rx_dma ;
+   unsigned int cs_change : 1 ;
+   u8 bits_per_word ;
+   u16 delay_usecs ;
+   u32 speed_hz ;
+   struct list_head transfer_list ;
+};
+struct spi_message {
+   struct list_head transfers ;
+   struct spi_device *spi ;
+   unsigned int is_dma_mapped : 1 ;
+   void (*complete)(void *context ) ;
+   void *context ;
+   unsigned int actual_length ;
+   int status ;
+   struct list_head queue ;
+   void *state ;
+};
+struct ks8995_pdata {
+};
+struct ks8995_switch {
+   struct spi_device *spi ;
+   struct mutex lock ;
+   struct ks8995_pdata *pdata ;
+};
+struct ks8995_data;
+long ldv__builtin_expect(long val , long res ) ;
+extern int ( printk)(char const *fmt , ...) ;
+__inline static void INIT_LIST_HEAD(struct list_head *list ) __attribute__((__no_instrument_function__)) ;
+__inline static void INIT_LIST_HEAD(struct list_head *list )
+{ unsigned long __cil_tmp2 ;
+  unsigned long __cil_tmp3 ;
+  {
+  *((struct list_head **)list) = list;
+  __cil_tmp2 = (unsigned long )list;
+  __cil_tmp3 = __cil_tmp2 + 8;
+  *((struct list_head **)__cil_tmp3) = list;
+  return;
+}
+}
+extern void __list_add(struct list_head *new , struct list_head *prev , struct list_head *next ) ;
+__inline static void list_add_tail(struct list_head *new , struct list_head *head ) __attribute__((__no_instrument_function__)) ;
+__inline static void list_add_tail(struct list_head *new , struct list_head *head )
+{ unsigned long __cil_tmp3 ;
+  unsigned long __cil_tmp4 ;
+  struct list_head *__cil_tmp5 ;
+  {
+  {
+  __cil_tmp3 = (unsigned long )head;
+  __cil_tmp4 = __cil_tmp3 + 8;
+  __cil_tmp5 = *((struct list_head **)__cil_tmp4);
+  __list_add(new, __cil_tmp5, head);
+  }
+  return;
+}
+}
+extern void *memset(void *s , int c , size_t n ) ;
+extern void __mutex_init(struct mutex *lock , char const *name , struct lock_class_key *key ) ;
+void mutex_lock(struct mutex *lock ) ;
+int __attribute__((__warn_unused_result__)) mutex_lock_interruptible(struct mutex *lock ) ;
+int __attribute__((__warn_unused_result__)) mutex_lock_killable(struct mutex *lock ) ;
+int mutex_trylock(struct mutex *lock ) ;
+void mutex_unlock(struct mutex *lock ) ;
+int atomic_dec_and_mutex_lock(atomic_t *cnt , struct mutex *lock ) ;
+extern int __attribute__((__warn_unused_result__)) sysfs_create_bin_file(struct kobject *kobj ,
+                                                                          struct bin_attribute const *attr ) ;
+extern void sysfs_remove_bin_file(struct kobject *kobj , struct bin_attribute const *attr ) ;
+extern struct module __this_module ;
+int init_module(void) ;
+void cleanup_module(void) ;
+extern void __const_udelay(unsigned long xloops ) ;
+extern void driver_unregister(struct device_driver *drv ) ;
+extern void *dev_get_drvdata(struct device const *dev ) ;
+extern int dev_set_drvdata(struct device *dev , void *data ) ;
+extern struct device *get_device(struct device *dev ) ;
+extern int ( dev_err)(struct device const *dev , char const *fmt
+                                              , ...) ;
+extern int ( _dev_info)(struct device const *dev , char const *fmt
+                                                , ...) ;
+extern void kfree(void const * ) ;
+extern int __VERIFIER_nondet_int(void);
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+extern void *malloc(size_t size);
+long ldv_is_err(const void *ptr)
+{
+  return ((unsigned long)ptr > ((unsigned long)-4095));
+}
+void *ldv_malloc(size_t size)
+{
+ if (__VERIFIER_nondet_int()) {
+  void *res = malloc(size);
+  assume_abort_if_not(!ldv_is_err(res));
+  return res;
+ } else {
+  return ((void *)0);
+ }
+}
+void *__kmalloc(size_t size, gfp_t t)
+{
+ return ldv_malloc(size);
+}
+__inline static void *( __attribute__((__always_inline__)) kmalloc)(size_t size ,
+                                                                    gfp_t flags ) __attribute__((__no_instrument_function__)) ;
+__inline static void *( __attribute__((__always_inline__)) kmalloc)(size_t size ,
+                                                                    gfp_t flags )
+{ void *tmp___2 ;
+  {
+  {
+  tmp___2 = __kmalloc(size, flags);
+  }
+  return (tmp___2);
+}
+}
+__inline static void *kzalloc(size_t size , gfp_t flags ) __attribute__((__no_instrument_function__)) ;
+void *ldv_zalloc(size_t size ) ;
+__inline static void *kzalloc(size_t size , gfp_t flags )
+{ void *tmp ;
+  unsigned int __cil_tmp4 ;
+  {
+  {
+  __cil_tmp4 = flags | 32768U;
+  tmp = kmalloc(size, __cil_tmp4);
+  }
+  return (tmp);
+}
+}
+extern struct bus_type spi_bus_type ;
+__inline static struct spi_device *spi_dev_get(struct spi_device *spi ) __attribute__((__no_instrument_function__)) ;
+__inline static struct spi_device *spi_dev_get(struct spi_device *spi )
+{ struct spi_device *tmp___8 ;
+  struct device *tmp___9 ;
+  struct device *__cil_tmp5 ;
+  void *__cil_tmp6 ;
+  void *__cil_tmp7 ;
+  {
+  if (spi) {
+    {
+    __cil_tmp5 = (struct device *)spi;
+    tmp___9 = get_device(__cil_tmp5);
+    }
+    if (tmp___9) {
+      tmp___8 = spi;
+    } else {
+      __cil_tmp6 = (void *)0;
+      tmp___8 = (struct spi_device *)__cil_tmp6;
+    }
+  } else {
+    __cil_tmp7 = (void *)0;
+    tmp___8 = (struct spi_device *)__cil_tmp7;
+  }
+  return (tmp___8);
+}
+}
+extern int spi_register_driver(struct spi_driver *sdrv ) ;
+__inline static void spi_unregister_driver(struct spi_driver *sdrv ) __attribute__((__no_instrument_function__)) ;
+__inline static void spi_unregister_driver(struct spi_driver *sdrv )
+{ unsigned long __cil_tmp2 ;
+  unsigned long __cil_tmp3 ;
+  struct device_driver *__cil_tmp4 ;
+  {
+  if (sdrv) {
+    {
+    __cil_tmp2 = (unsigned long )sdrv;
+    __cil_tmp3 = __cil_tmp2 + 48;
+    __cil_tmp4 = (struct device_driver *)__cil_tmp3;
+    driver_unregister(__cil_tmp4);
+    }
+  } else {
+  }
+  return;
+}
+}
+__inline static void spi_message_init(struct spi_message *m ) __attribute__((__no_instrument_function__)) ;
+__inline static void spi_message_init(struct spi_message *m )
+{ void *__cil_tmp2 ;
+  struct list_head *__cil_tmp3 ;
+  {
+  {
+  __cil_tmp2 = (void *)m;
+  memset(__cil_tmp2, 0, 80UL);
+  __cil_tmp3 = (struct list_head *)m;
+  INIT_LIST_HEAD(__cil_tmp3);
+  }
+  return;
+}
+}
+__inline static void spi_message_add_tail(struct spi_transfer *t , struct spi_message *m ) __attribute__((__no_instrument_function__)) ;
+__inline static void spi_message_add_tail(struct spi_transfer *t , struct spi_message *m )
+{ unsigned long __cil_tmp3 ;
+  unsigned long __cil_tmp4 ;
+  struct list_head *__cil_tmp5 ;
+  struct list_head *__cil_tmp6 ;
+  {
+  {
+  __cil_tmp3 = (unsigned long )t;
+  __cil_tmp4 = __cil_tmp3 + 48;
+  __cil_tmp5 = (struct list_head *)__cil_tmp4;
+  __cil_tmp6 = (struct list_head *)m;
+  list_add_tail(__cil_tmp5, __cil_tmp6);
+  }
+  return;
+}
+}
+extern int spi_setup(struct spi_device *spi ) ;
+extern int spi_sync(struct spi_device *spi , struct spi_message *message ) ;
+__inline static u8 get_chip_id(u8 val ) __attribute__((__no_instrument_function__)) ;
+__inline static u8 get_chip_id(u8 val )
+{ int __cil_tmp2 ;
+  int __cil_tmp3 ;
+  int __cil_tmp4 ;
+  {
+  {
+  __cil_tmp2 = (int )val;
+  __cil_tmp3 = __cil_tmp2 >> 4;
+  __cil_tmp4 = __cil_tmp3 & 15;
+  return ((u8 )__cil_tmp4);
+  }
+}
+}
+__inline static u8 get_chip_rev(u8 val ) __attribute__((__no_instrument_function__)) ;
+__inline static u8 get_chip_rev(u8 val )
+{ int __cil_tmp2 ;
+  int __cil_tmp3 ;
+  int __cil_tmp4 ;
+  {
+  {
+  __cil_tmp2 = (int )val;
+  __cil_tmp3 = __cil_tmp2 >> 1;
+  __cil_tmp4 = __cil_tmp3 & 7;
+  return ((u8 )__cil_tmp4);
+  }
+}
+}
+static int ks8995_read(struct ks8995_switch *ks , char *buf , unsigned int offset ,
+                       size_t count )
+{ u8 cmd[2] ;
+  struct spi_transfer t[2] ;
+  struct spi_message m ;
+  int err ;
+  size_t tmp___7 ;
+  void *__cil_tmp10 ;
+  unsigned long __cil_tmp11 ;
+  unsigned long __cil_tmp12 ;
+  unsigned long __cil_tmp13 ;
+  unsigned long __cil_tmp14 ;
+  u8 *__cil_tmp15 ;
+  unsigned long __cil_tmp16 ;
+  unsigned long __cil_tmp17 ;
+  unsigned long __cil_tmp18 ;
+  unsigned long __cil_tmp19 ;
+  unsigned long __cil_tmp20 ;
+  struct spi_transfer *__cil_tmp21 ;
+  unsigned long __cil_tmp22 ;
+  unsigned long __cil_tmp23 ;
+  unsigned long __cil_tmp24 ;
+  unsigned long __cil_tmp25 ;
+  unsigned long __cil_tmp26 ;
+  unsigned long __cil_tmp27 ;
+  unsigned long __cil_tmp28 ;
+  unsigned long __cil_tmp29 ;
+  struct spi_transfer *__cil_tmp30 ;
+  unsigned long __cil_tmp31 ;
+  unsigned long __cil_tmp32 ;
+  unsigned long __cil_tmp33 ;
+  unsigned long __cil_tmp34 ;
+  unsigned long __cil_tmp35 ;
+  unsigned long __cil_tmp36 ;
+  struct mutex *__cil_tmp37 ;
+  struct spi_device *__cil_tmp38 ;
+  unsigned long __cil_tmp39 ;
+  unsigned long __cil_tmp40 ;
+  struct mutex *__cil_tmp41 ;
+  {
+  {
+  spi_message_init(& m);
+  __cil_tmp10 = (void *)(& t);
+  memset(__cil_tmp10, 0, 128UL);
+  __cil_tmp11 = 0 * 64UL;
+  __cil_tmp12 = (unsigned long )(t) + __cil_tmp11;
+  __cil_tmp13 = 0 * 1UL;
+  __cil_tmp14 = (unsigned long )(cmd) + __cil_tmp13;
+  __cil_tmp15 = (u8 *)__cil_tmp14;
+  *((void const **)__cil_tmp12) = (void const *)__cil_tmp15;
+  __cil_tmp16 = 0 * 64UL;
+  __cil_tmp17 = __cil_tmp16 + 16;
+  __cil_tmp18 = (unsigned long )(t) + __cil_tmp17;
+  *((unsigned int *)__cil_tmp18) = (unsigned int )2UL;
+  __cil_tmp19 = 0 * 64UL;
+  __cil_tmp20 = (unsigned long )(t) + __cil_tmp19;
+  __cil_tmp21 = (struct spi_transfer *)__cil_tmp20;
+  spi_message_add_tail(__cil_tmp21, & m);
+  __cil_tmp22 = 1 * 64UL;
+  __cil_tmp23 = __cil_tmp22 + 8;
+  __cil_tmp24 = (unsigned long )(t) + __cil_tmp23;
+  *((void **)__cil_tmp24) = (void *)buf;
+  __cil_tmp25 = 1 * 64UL;
+  __cil_tmp26 = __cil_tmp25 + 16;
+  __cil_tmp27 = (unsigned long )(t) + __cil_tmp26;
+  *((unsigned int *)__cil_tmp27) = (unsigned int )count;
+  __cil_tmp28 = 1 * 64UL;
+  __cil_tmp29 = (unsigned long )(t) + __cil_tmp28;
+  __cil_tmp30 = (struct spi_transfer *)__cil_tmp29;
+  spi_message_add_tail(__cil_tmp30, & m);
+  __cil_tmp31 = 0 * 1UL;
+  __cil_tmp32 = (unsigned long )(cmd) + __cil_tmp31;
+  *((u8 *)__cil_tmp32) = (u8 )3U;
+  __cil_tmp33 = 1 * 1UL;
+  __cil_tmp34 = (unsigned long )(cmd) + __cil_tmp33;
+  *((u8 *)__cil_tmp34) = (u8 )offset;
+  __cil_tmp35 = (unsigned long )ks;
+  __cil_tmp36 = __cil_tmp35 + 8;
+  __cil_tmp37 = (struct mutex *)__cil_tmp36;
+  mutex_lock(__cil_tmp37);
+  __cil_tmp38 = *((struct spi_device **)ks);
+  err = spi_sync(__cil_tmp38, & m);
+  __cil_tmp39 = (unsigned long )ks;
+  __cil_tmp40 = __cil_tmp39 + 8;
+  __cil_tmp41 = (struct mutex *)__cil_tmp40;
+  mutex_unlock(__cil_tmp41);
+  }
+  if (err) {
+    tmp___7 = (size_t )err;
+  } else {
+    tmp___7 = count;
+  }
+  return ((int )tmp___7);
+}
+}
+static int ks8995_write(struct ks8995_switch *ks , char *buf , unsigned int offset ,
+                        size_t count )
+{ u8 cmd[2] ;
+  struct spi_transfer t[2] ;
+  struct spi_message m ;
+  int err ;
+  size_t tmp___7 ;
+  void *__cil_tmp10 ;
+  unsigned long __cil_tmp11 ;
+  unsigned long __cil_tmp12 ;
+  unsigned long __cil_tmp13 ;
+  unsigned long __cil_tmp14 ;
+  u8 *__cil_tmp15 ;
+  unsigned long __cil_tmp16 ;
+  unsigned long __cil_tmp17 ;
+  unsigned long __cil_tmp18 ;
+  unsigned long __cil_tmp19 ;
+  unsigned long __cil_tmp20 ;
+  struct spi_transfer *__cil_tmp21 ;
+  unsigned long __cil_tmp22 ;
+  unsigned long __cil_tmp23 ;
+  unsigned long __cil_tmp24 ;
+  unsigned long __cil_tmp25 ;
+  unsigned long __cil_tmp26 ;
+  unsigned long __cil_tmp27 ;
+  unsigned long __cil_tmp28 ;
+  struct spi_transfer *__cil_tmp29 ;
+  unsigned long __cil_tmp30 ;
+  unsigned long __cil_tmp31 ;
+  unsigned long __cil_tmp32 ;
+  unsigned long __cil_tmp33 ;
+  unsigned long __cil_tmp34 ;
+  unsigned long __cil_tmp35 ;
+  struct mutex *__cil_tmp36 ;
+  struct spi_device *__cil_tmp37 ;
+  unsigned long __cil_tmp38 ;
+  unsigned long __cil_tmp39 ;
+  struct mutex *__cil_tmp40 ;
+  {
+  {
+  spi_message_init(& m);
+  __cil_tmp10 = (void *)(& t);
+  memset(__cil_tmp10, 0, 128UL);
+  __cil_tmp11 = 0 * 64UL;
+  __cil_tmp12 = (unsigned long )(t) + __cil_tmp11;
+  __cil_tmp13 = 0 * 1UL;
+  __cil_tmp14 = (unsigned long )(cmd) + __cil_tmp13;
+  __cil_tmp15 = (u8 *)__cil_tmp14;
+  *((void const **)__cil_tmp12) = (void const *)__cil_tmp15;
+  __cil_tmp16 = 0 * 64UL;
+  __cil_tmp17 = __cil_tmp16 + 16;
+  __cil_tmp18 = (unsigned long )(t) + __cil_tmp17;
+  *((unsigned int *)__cil_tmp18) = (unsigned int )2UL;
+  __cil_tmp19 = 0 * 64UL;
+  __cil_tmp20 = (unsigned long )(t) + __cil_tmp19;
+  __cil_tmp21 = (struct spi_transfer *)__cil_tmp20;
+  spi_message_add_tail(__cil_tmp21, & m);
+  __cil_tmp22 = 1 * 64UL;
+  __cil_tmp23 = (unsigned long )(t) + __cil_tmp22;
+  *((void const **)__cil_tmp23) = (void const *)buf;
+  __cil_tmp24 = 1 * 64UL;
+  __cil_tmp25 = __cil_tmp24 + 16;
+  __cil_tmp26 = (unsigned long )(t) + __cil_tmp25;
+  *((unsigned int *)__cil_tmp26) = (unsigned int )count;
+  __cil_tmp27 = 1 * 64UL;
+  __cil_tmp28 = (unsigned long )(t) + __cil_tmp27;
+  __cil_tmp29 = (struct spi_transfer *)__cil_tmp28;
+  spi_message_add_tail(__cil_tmp29, & m);
+  __cil_tmp30 = 0 * 1UL;
+  __cil_tmp31 = (unsigned long )(cmd) + __cil_tmp30;
+  *((u8 *)__cil_tmp31) = (u8 )2U;
+  __cil_tmp32 = 1 * 1UL;
+  __cil_tmp33 = (unsigned long )(cmd) + __cil_tmp32;
+  *((u8 *)__cil_tmp33) = (u8 )offset;
+  __cil_tmp34 = (unsigned long )ks;
+  __cil_tmp35 = __cil_tmp34 + 8;
+  __cil_tmp36 = (struct mutex *)__cil_tmp35;
+  mutex_lock(__cil_tmp36);
+  __cil_tmp37 = *((struct spi_device **)ks);
+  err = spi_sync(__cil_tmp37, & m);
+  __cil_tmp38 = (unsigned long )ks;
+  __cil_tmp39 = __cil_tmp38 + 8;
+  __cil_tmp40 = (struct mutex *)__cil_tmp39;
+  mutex_unlock(__cil_tmp40);
+  }
+  if (err) {
+    tmp___7 = (size_t )err;
+  } else {
+    tmp___7 = count;
+  }
+  return ((int )tmp___7);
+}
+}
+__inline static int ks8995_write_reg(struct ks8995_switch *ks , u8 addr , u8 val ) __attribute__((__no_instrument_function__)) ;
+__inline static int ks8995_write_reg(struct ks8995_switch *ks , u8 addr , u8 val )
+{ char buf ;
+  int tmp___7 ;
+  char *__cil_tmp6 ;
+  unsigned int __cil_tmp7 ;
+  size_t __cil_tmp8 ;
+  {
+  {
+  __cil_tmp6 = & buf;
+  *__cil_tmp6 = (char )val;
+  __cil_tmp7 = (unsigned int )addr;
+  __cil_tmp8 = (size_t )1;
+  tmp___7 = ks8995_write(ks, & buf, __cil_tmp7, __cil_tmp8);
+  }
+  return (tmp___7 != 1);
+}
+}
+static int ks8995_stop(struct ks8995_switch *ks )
+{ int tmp___7 ;
+  u8 __cil_tmp3 ;
+  u8 __cil_tmp4 ;
+  {
+  {
+  __cil_tmp3 = (u8 )1;
+  __cil_tmp4 = (u8 )0;
+  tmp___7 = ks8995_write_reg(ks, __cil_tmp3, __cil_tmp4);
+  }
+  return (tmp___7);
+}
+}
+static int ks8995_start(struct ks8995_switch *ks )
+{ int tmp___7 ;
+  u8 __cil_tmp3 ;
+  u8 __cil_tmp4 ;
+  {
+  {
+  __cil_tmp3 = (u8 )1;
+  __cil_tmp4 = (u8 )1;
+  tmp___7 = ks8995_write_reg(ks, __cil_tmp3, __cil_tmp4);
+  }
+  return (tmp___7);
+}
+}
+static int ks8995_reset(struct ks8995_switch *ks )
+{ int err ;
+  int tmp___7 ;
+  {
+  {
+  err = ks8995_stop(ks);
+  }
+  if (err) {
+    return (err);
+  } else {
+  }
+  {
+  __const_udelay(42950UL);
+  tmp___7 = ks8995_start(ks);
+  }
+  return (tmp___7);
+}
+}
+static ssize_t ks8995_registers_read(struct file *filp , struct kobject *kobj , struct bin_attribute *bin_attr ,
+                                     char *buf , loff_t off , size_t count )
+{ struct device *dev ;
+  struct ks8995_switch *ks8995 ;
+  struct kobject const *__mptr ;
+  void *tmp___7 ;
+  long tmp___8 ;
+  long tmp___9 ;
+  int tmp___10 ;
+  struct device *__cil_tmp14 ;
+  unsigned long __cil_tmp15 ;
+  unsigned long __cil_tmp16 ;
+  struct kobject *__cil_tmp17 ;
+  unsigned int __cil_tmp18 ;
+  char *__cil_tmp19 ;
+  char *__cil_tmp20 ;
+  struct device const *__cil_tmp21 ;
+  int __cil_tmp22 ;
+  int __cil_tmp23 ;
+  int __cil_tmp24 ;
+  long __cil_tmp25 ;
+  loff_t __cil_tmp26 ;
+  loff_t __cil_tmp27 ;
+  loff_t __cil_tmp28 ;
+  int __cil_tmp29 ;
+  int __cil_tmp30 ;
+  int __cil_tmp31 ;
+  long __cil_tmp32 ;
+  unsigned int __cil_tmp33 ;
+  {
+  {
+  __mptr = (struct kobject const *)kobj;
+  __cil_tmp14 = (struct device *)0;
+  __cil_tmp15 = (unsigned long )__cil_tmp14;
+  __cil_tmp16 = __cil_tmp15 + 16;
+  __cil_tmp17 = (struct kobject *)__cil_tmp16;
+  __cil_tmp18 = (unsigned int )__cil_tmp17;
+  __cil_tmp19 = (char *)__mptr;
+  __cil_tmp20 = __cil_tmp19 - __cil_tmp18;
+  dev = (struct device *)__cil_tmp20;
+  __cil_tmp21 = (struct device const *)dev;
+  tmp___7 = dev_get_drvdata(__cil_tmp21);
+  ks8995 = (struct ks8995_switch *)tmp___7;
+  __cil_tmp22 = off > 128LL;
+  __cil_tmp23 = ! __cil_tmp22;
+  __cil_tmp24 = ! __cil_tmp23;
+  __cil_tmp25 = (long )__cil_tmp24;
+  tmp___8 = ldv__builtin_expect(__cil_tmp25, 0L);
+  }
+  if (tmp___8) {
+    return ((ssize_t )0);
+  } else {
+  }
+  {
+  __cil_tmp26 = (loff_t )count;
+  __cil_tmp27 = off + __cil_tmp26;
+  if (__cil_tmp27 > 128LL) {
+    __cil_tmp28 = 128LL - off;
+    count = (size_t )__cil_tmp28;
+  } else {
+  }
+  }
+  {
+  __cil_tmp29 = ! count;
+  __cil_tmp30 = ! __cil_tmp29;
+  __cil_tmp31 = ! __cil_tmp30;
+  __cil_tmp32 = (long )__cil_tmp31;
+  tmp___9 = ldv__builtin_expect(__cil_tmp32, 0L);
+  }
+  if (tmp___9) {
+    return ((ssize_t )count);
+  } else {
+  }
+  {
+  __cil_tmp33 = (unsigned int )off;
+  tmp___10 = ks8995_read(ks8995, buf, __cil_tmp33, count);
+  }
+  return ((ssize_t )tmp___10);
+}
+}
+static ssize_t ks8995_registers_write(struct file *filp , struct kobject *kobj , struct bin_attribute *bin_attr ,
+                                      char *buf , loff_t off , size_t count )
+{ struct device *dev ;
+  struct ks8995_switch *ks8995 ;
+  struct kobject const *__mptr ;
+  void *tmp___7 ;
+  long tmp___8 ;
+  long tmp___9 ;
+  int tmp___10 ;
+  struct device *__cil_tmp14 ;
+  unsigned long __cil_tmp15 ;
+  unsigned long __cil_tmp16 ;
+  struct kobject *__cil_tmp17 ;
+  unsigned int __cil_tmp18 ;
+  char *__cil_tmp19 ;
+  char *__cil_tmp20 ;
+  struct device const *__cil_tmp21 ;
+  int __cil_tmp22 ;
+  int __cil_tmp23 ;
+  int __cil_tmp24 ;
+  long __cil_tmp25 ;
+  loff_t __cil_tmp26 ;
+  loff_t __cil_tmp27 ;
+  loff_t __cil_tmp28 ;
+  int __cil_tmp29 ;
+  int __cil_tmp30 ;
+  int __cil_tmp31 ;
+  long __cil_tmp32 ;
+  unsigned int __cil_tmp33 ;
+  {
+  {
+  __mptr = (struct kobject const *)kobj;
+  __cil_tmp14 = (struct device *)0;
+  __cil_tmp15 = (unsigned long )__cil_tmp14;
+  __cil_tmp16 = __cil_tmp15 + 16;
+  __cil_tmp17 = (struct kobject *)__cil_tmp16;
+  __cil_tmp18 = (unsigned int )__cil_tmp17;
+  __cil_tmp19 = (char *)__mptr;
+  __cil_tmp20 = __cil_tmp19 - __cil_tmp18;
+  dev = (struct device *)__cil_tmp20;
+  __cil_tmp21 = (struct device const *)dev;
+  tmp___7 = dev_get_drvdata(__cil_tmp21);
+  ks8995 = (struct ks8995_switch *)tmp___7;
+  __cil_tmp22 = off >= 128LL;
+  __cil_tmp23 = ! __cil_tmp22;
+  __cil_tmp24 = ! __cil_tmp23;
+  __cil_tmp25 = (long )__cil_tmp24;
+  tmp___8 = ldv__builtin_expect(__cil_tmp25, 0L);
+  }
+  if (tmp___8) {
+    return ((ssize_t )-27);
+  } else {
+  }
+  {
+  __cil_tmp26 = (loff_t )count;
+  __cil_tmp27 = off + __cil_tmp26;
+  if (__cil_tmp27 > 128LL) {
+    __cil_tmp28 = 128LL - off;
+    count = (size_t )__cil_tmp28;
+  } else {
+  }
+  }
+  {
+  __cil_tmp29 = ! count;
+  __cil_tmp30 = ! __cil_tmp29;
+  __cil_tmp31 = ! __cil_tmp30;
+  __cil_tmp32 = (long )__cil_tmp31;
+  tmp___9 = ldv__builtin_expect(__cil_tmp32, 0L);
+  }
+  if (tmp___9) {
+    return ((ssize_t )count);
+  } else {
+  }
+  {
+  __cil_tmp33 = (unsigned int )off;
+  tmp___10 = ks8995_write(ks8995, buf, __cil_tmp33, count);
+  }
+  return ((ssize_t )tmp___10);
+}
+}
+static struct bin_attribute ks8995_registers_attr = {{"registers", (umode_t )384}, (size_t )128, (void *)0, & ks8995_registers_read,
+    & ks8995_registers_write, (int (*)(struct file * , struct kobject * , struct bin_attribute *attr ,
+                                       struct vm_area_struct *vma ))0};
+static struct lock_class_key __key___3 ;
+static int ks8995_probe(struct spi_device *spi ) __attribute__((__section__(".devinit.text"),
+__no_instrument_function__)) ;
+static int ks8995_probe(struct spi_device *spi )
+{ struct ks8995_switch *ks ;
+  struct ks8995_pdata *pdata ;
+  u8 ids[2] ;
+  int err ;
+  void *tmp___7 ;
+  u8 tmp___8 ;
+  u8 tmp___9 ;
+  unsigned long __cil_tmp9 ;
+  unsigned long __cil_tmp10 ;
+  unsigned long __cil_tmp11 ;
+  void *__cil_tmp12 ;
+  struct device *__cil_tmp13 ;
+  struct device const *__cil_tmp14 ;
+  unsigned long __cil_tmp15 ;
+  unsigned long __cil_tmp16 ;
+  struct mutex *__cil_tmp17 ;
+  unsigned long __cil_tmp18 ;
+  unsigned long __cil_tmp19 ;
+  struct device *__cil_tmp20 ;
+  void *__cil_tmp21 ;
+  unsigned long __cil_tmp22 ;
+  unsigned long __cil_tmp23 ;
+  unsigned long __cil_tmp24 ;
+  unsigned long __cil_tmp25 ;
+  struct device *__cil_tmp26 ;
+  struct device const *__cil_tmp27 ;
+  unsigned long __cil_tmp28 ;
+  unsigned long __cil_tmp29 ;
+  u8 *__cil_tmp30 ;
+  char *__cil_tmp31 ;
+  struct device *__cil_tmp32 ;
+  struct device const *__cil_tmp33 ;
+  unsigned long __cil_tmp34 ;
+  unsigned long __cil_tmp35 ;
+  u8 __cil_tmp36 ;
+  struct device *__cil_tmp37 ;
+  struct device const *__cil_tmp38 ;
+  unsigned long __cil_tmp39 ;
+  unsigned long __cil_tmp40 ;
+  u8 __cil_tmp41 ;
+  int __cil_tmp42 ;
+  unsigned long __cil_tmp43 ;
+  unsigned long __cil_tmp44 ;
+  unsigned long __cil_tmp45 ;
+  struct kobject *__cil_tmp46 ;
+  struct bin_attribute const *__cil_tmp47 ;
+  struct device *__cil_tmp48 ;
+  struct device const *__cil_tmp49 ;
+  unsigned long __cil_tmp50 ;
+  unsigned long __cil_tmp51 ;
+  u8 __cil_tmp52 ;
+  unsigned long __cil_tmp53 ;
+  unsigned long __cil_tmp54 ;
+  u8 __cil_tmp55 ;
+  struct device *__cil_tmp56 ;
+  struct device const *__cil_tmp57 ;
+  unsigned long __cil_tmp58 ;
+  unsigned long __cil_tmp59 ;
+  u8 __cil_tmp60 ;
+  int __cil_tmp61 ;
+  int __cil_tmp62 ;
+  int __cil_tmp63 ;
+  struct device *__cil_tmp64 ;
+  void *__cil_tmp65 ;
+  void const *__cil_tmp66 ;
+  {
+  {
+  __cil_tmp9 = 0 + 184;
+  __cil_tmp10 = (unsigned long )spi;
+  __cil_tmp11 = __cil_tmp10 + __cil_tmp9;
+  __cil_tmp12 = *((void **)__cil_tmp11);
+  pdata = (struct ks8995_pdata *)__cil_tmp12;
+  tmp___7 = kzalloc(88UL, 208U);
+  ks = (struct ks8995_switch *)tmp___7;
+  }
+  if (! ks) {
+    {
+    __cil_tmp13 = (struct device *)spi;
+    __cil_tmp14 = (struct device const *)__cil_tmp13;
+    dev_err(__cil_tmp14, "no memory for private data\n");
+    }
+    return (-12);
+  } else {
+  }
+  {
+  while (1) {
+    while_continue: ;
+    {
+    __cil_tmp15 = (unsigned long )ks;
+    __cil_tmp16 = __cil_tmp15 + 8;
+    __cil_tmp17 = (struct mutex *)__cil_tmp16;
+    __mutex_init(__cil_tmp17, "&ks->lock", & __key___3);
+    }
+    goto while_break;
+  }
+  while_break: ;
+  }
+  {
+  __cil_tmp18 = (unsigned long )ks;
+  __cil_tmp19 = __cil_tmp18 + 80;
+  *((struct ks8995_pdata **)__cil_tmp19) = pdata;
+  *((struct spi_device **)ks) = spi_dev_get(spi);
+  __cil_tmp20 = (struct device *)spi;
+  __cil_tmp21 = (void *)ks;
+  dev_set_drvdata(__cil_tmp20, __cil_tmp21);
+  __cil_tmp22 = (unsigned long )spi;
+  __cil_tmp23 = __cil_tmp22 + 781;
+  *((u8 *)__cil_tmp23) = (u8 )0;
+  __cil_tmp24 = (unsigned long )spi;
+  __cil_tmp25 = __cil_tmp24 + 782;
+  *((u8 *)__cil_tmp25) = (u8 )8;
+  err = spi_setup(spi);
+  }
+  if (err) {
+    {
+    __cil_tmp26 = (struct device *)spi;
+    __cil_tmp27 = (struct device const *)__cil_tmp26;
+    dev_err(__cil_tmp27, "spi_setup failed, err=%d\n", err);
+    }
+    goto err_drvdata;
+  } else {
+  }
+  {
+  __cil_tmp28 = 0 * 1UL;
+  __cil_tmp29 = (unsigned long )(ids) + __cil_tmp28;
+  __cil_tmp30 = (u8 *)__cil_tmp29;
+  __cil_tmp31 = (char *)__cil_tmp30;
+  err = ks8995_read(ks, __cil_tmp31, 0U, 2UL);
+  }
+  if (err < 0) {
+    {
+    __cil_tmp32 = (struct device *)spi;
+    __cil_tmp33 = (struct device const *)__cil_tmp32;
+    dev_err(__cil_tmp33, "unable to read id registers, err=%d\n", err);
+    }
+    goto err_drvdata;
+  } else {
+  }
+  {
+  __cil_tmp34 = 0 * 1UL;
+  __cil_tmp35 = (unsigned long )(ids) + __cil_tmp34;
+  __cil_tmp36 = *((u8 *)__cil_tmp35);
+  if ((int )__cil_tmp36 == 149) {
+    goto case_149;
+  } else {
+    {
+    goto switch_default;
+    if (0) {
+      case_149:
+      goto switch_break;
+      switch_default:
+      {
+      __cil_tmp37 = (struct device *)spi;
+      __cil_tmp38 = (struct device const *)__cil_tmp37;
+      __cil_tmp39 = 0 * 1UL;
+      __cil_tmp40 = (unsigned long )(ids) + __cil_tmp39;
+      __cil_tmp41 = *((u8 *)__cil_tmp40);
+      __cil_tmp42 = (int )__cil_tmp41;
+      dev_err(__cil_tmp38, "unknown family id:%02x\n", __cil_tmp42);
+      err = -19;
+      }
+      goto err_drvdata;
+    } else {
+      switch_break: ;
+    }
+    }
+  }
+  }
+  {
+  err = ks8995_reset(ks);
+  }
+  if (err) {
+    goto err_drvdata;
+  } else {
+  }
+  {
+  __cil_tmp43 = 0 + 16;
+  __cil_tmp44 = (unsigned long )spi;
+  __cil_tmp45 = __cil_tmp44 + __cil_tmp43;
+  __cil_tmp46 = (struct kobject *)__cil_tmp45;
+  __cil_tmp47 = (struct bin_attribute const *)(& ks8995_registers_attr);
+  err = (int )sysfs_create_bin_file(__cil_tmp46, __cil_tmp47);
+  }
+  if (err) {
+    {
+    __cil_tmp48 = (struct device *)spi;
+    __cil_tmp49 = (struct device const *)__cil_tmp48;
+    dev_err(__cil_tmp49, "unable to create sysfs file, err=%d\n", err);
+    }
+    goto err_drvdata;
+  } else {
+  }
+  {
+  __cil_tmp50 = 1 * 1UL;
+  __cil_tmp51 = (unsigned long )(ids) + __cil_tmp50;
+  __cil_tmp52 = *((u8 *)__cil_tmp51);
+  tmp___8 = get_chip_rev(__cil_tmp52);
+  __cil_tmp53 = 1 * 1UL;
+  __cil_tmp54 = (unsigned long )(ids) + __cil_tmp53;
+  __cil_tmp55 = *((u8 *)__cil_tmp54);
+  tmp___9 = get_chip_id(__cil_tmp55);
+  __cil_tmp56 = (struct device *)spi;
+  __cil_tmp57 = (struct device const *)__cil_tmp56;
+  __cil_tmp58 = 0 * 1UL;
+  __cil_tmp59 = (unsigned long )(ids) + __cil_tmp58;
+  __cil_tmp60 = *((u8 *)__cil_tmp59);
+  __cil_tmp61 = (int )__cil_tmp60;
+  __cil_tmp62 = (int )tmp___9;
+  __cil_tmp63 = (int )tmp___8;
+  _dev_info(__cil_tmp57, "KS89%02X device found, Chip ID:%01x, Revision:%01x\n", __cil_tmp61,
+            __cil_tmp62, __cil_tmp63);
+  }
+  return (0);
+  err_drvdata:
+  {
+  __cil_tmp64 = (struct device *)spi;
+  __cil_tmp65 = (void *)0;
+  dev_set_drvdata(__cil_tmp64, __cil_tmp65);
+  __cil_tmp66 = (void const *)ks;
+  kfree(__cil_tmp66);
+  }
+  return (err);
+}
+}
+static int ks8995_remove(struct spi_device *spi ) __attribute__((__section__(".devexit.text"),
+__no_instrument_function__)) ;
+static int ks8995_remove(struct spi_device *spi )
+{ struct ks8995_data *ks8995 ;
+  void *tmp___7 ;
+  struct device *__cil_tmp4 ;
+  struct device const *__cil_tmp5 ;
+  unsigned long __cil_tmp6 ;
+  unsigned long __cil_tmp7 ;
+  unsigned long __cil_tmp8 ;
+  struct kobject *__cil_tmp9 ;
+  struct bin_attribute const *__cil_tmp10 ;
+  struct device *__cil_tmp11 ;
+  void *__cil_tmp12 ;
+  void const *__cil_tmp13 ;
+  {
+  {
+  __cil_tmp4 = (struct device *)spi;
+  __cil_tmp5 = (struct device const *)__cil_tmp4;
+  tmp___7 = dev_get_drvdata(__cil_tmp5);
+  ks8995 = (struct ks8995_data *)tmp___7;
+  __cil_tmp6 = 0 + 16;
+  __cil_tmp7 = (unsigned long )spi;
+  __cil_tmp8 = __cil_tmp7 + __cil_tmp6;
+  __cil_tmp9 = (struct kobject *)__cil_tmp8;
+  __cil_tmp10 = (struct bin_attribute const *)(& ks8995_registers_attr);
+  sysfs_remove_bin_file(__cil_tmp9, __cil_tmp10);
+  __cil_tmp11 = (struct device *)spi;
+  __cil_tmp12 = (void *)0;
+  dev_set_drvdata(__cil_tmp11, __cil_tmp12);
+  __cil_tmp13 = (void const *)ks8995;
+  kfree(__cil_tmp13);
+  }
+  return (0);
+}
+}
+static struct spi_driver ks8995_driver = {(struct spi_device_id const *)0, & ks8995_probe, & ks8995_remove, (void (*)(struct spi_device *spi ))0,
+    (int (*)(struct spi_device *spi , pm_message_t mesg ))0, (int (*)(struct spi_device *spi ))0,
+    {"spi-ks8995", & spi_bus_type, & __this_module, (char const *)0, (_Bool)0, (struct of_device_id const *)0,
+     (int (*)(struct device *dev ))0, (int (*)(struct device *dev ))0, (void (*)(struct device *dev ))0,
+     (int (*)(struct device *dev , pm_message_t state ))0, (int (*)(struct device *dev ))0,
+     (struct attribute_group const **)0, (struct dev_pm_ops const *)0, (struct driver_private *)0}};
+static int ks8995_init(void) __attribute__((__section__(".init.text"), __no_instrument_function__)) ;
+static int ks8995_init(void)
+{ int tmp___7 ;
+  {
+  {
+  printk("<6>Micrel KS8995 Ethernet switch SPI driver version 0.1.1\n");
+  tmp___7 = spi_register_driver(& ks8995_driver);
+  }
+  return (tmp___7);
+}
+}
+int init_module(void)
+{ int tmp___7 ;
+  {
+  {
+  tmp___7 = ks8995_init();
+  }
+  return (tmp___7);
+}
+}
+static void ks8995_exit(void) __attribute__((__section__(".exit.text"), __no_instrument_function__)) ;
+static void ks8995_exit(void)
+{
+  {
+  {
+  spi_unregister_driver(& ks8995_driver);
+  }
+  return;
+}
+}
+void cleanup_module(void)
+{
+  {
+  {
+  ks8995_exit();
+  }
+  return;
+}
+}
+static char const __mod_description373[53] __attribute__((__used__, __unused__,
+__section__(".modinfo"), __aligned__(1))) =
+  { (char const )'d', (char const )'e', (char const )'s', (char const )'c',
+        (char const )'r', (char const )'i', (char const )'p', (char const )'t',
+        (char const )'i', (char const )'o', (char const )'n', (char const )'=',
+        (char const )'M', (char const )'i', (char const )'c', (char const )'r',
+        (char const )'e', (char const )'l', (char const )' ', (char const )'K',
+        (char const )'S', (char const )'8', (char const )'9', (char const )'9',
+        (char const )'5', (char const )' ', (char const )'E', (char const )'t',
+        (char const )'h', (char const )'e', (char const )'r', (char const )'n',
+        (char const )'e', (char const )'t', (char const )' ', (char const )'s',
+        (char const )'w', (char const )'i', (char const )'t', (char const )'c',
+        (char const )'h', (char const )' ', (char const )'S', (char const )'P',
+        (char const )'I', (char const )' ', (char const )'d', (char const )'r',
+        (char const )'i', (char const )'v', (char const )'e', (char const )'r',
+        (char const )'\000'};
+static char const __mod_version374[14] __attribute__((__used__, __unused__, __section__(".modinfo"),
+__aligned__(1))) =
+  { (char const )'v', (char const )'e', (char const )'r', (char const )'s',
+        (char const )'i', (char const )'o', (char const )'n', (char const )'=',
+        (char const )'0', (char const )'.', (char const )'1', (char const )'.',
+        (char const )'1', (char const )'\000'};
+static char const __mod_author375[43] __attribute__((__used__, __unused__, __section__(".modinfo"),
+__aligned__(1))) =
+  { (char const )'a', (char const )'u', (char const )'t', (char const )'h',
+        (char const )'o', (char const )'r', (char const )'=', (char const )'G',
+        (char const )'a', (char const )'b', (char const )'o', (char const )'r',
+        (char const )' ', (char const )'J', (char const )'u', (char const )'h',
+        (char const )'o', (char const )'s', (char const )' ', (char const )'<',
+        (char const )'j', (char const )'u', (char const )'h', (char const )'o',
+        (char const )'s', (char const )'g', (char const )' ', (char const )'a',
+        (char const )'t', (char const )' ', (char const )'o', (char const )'p',
+        (char const )'e', (char const )'n', (char const )'w', (char const )'r',
+        (char const )'t', (char const )'.', (char const )'o', (char const )'r',
+        (char const )'g', (char const )'>', (char const )'\000'};
+static char const __mod_license376[15] __attribute__((__used__, __unused__, __section__(".modinfo"),
+__aligned__(1))) =
+  { (char const )'l', (char const )'i', (char const )'c', (char const )'e',
+        (char const )'n', (char const )'s', (char const )'e', (char const )'=',
+        (char const )'G', (char const )'P', (char const )'L', (char const )' ',
+        (char const )'v', (char const )'2', (char const )'\000'};
+void ldv_check_final_state(void) ;
+extern void ldv_check_return_value(int res ) ;
+extern void ldv_initialize(void) ;
+extern int __VERIFIER_nondet_int(void) ;
+int LDV_IN_INTERRUPT ;
+static int res_ks8995_probe_11 ;
+void main(void)
+{ struct file *var_group1 ;
+  struct kobject *var_group2 ;
+  struct bin_attribute *var_ks8995_registers_read_9_p2 ;
+  char *var_ks8995_registers_read_9_p3 ;
+  loff_t var_ks8995_registers_read_9_p4 ;
+  size_t var_ks8995_registers_read_9_p5 ;
+  struct bin_attribute *var_ks8995_registers_write_10_p2 ;
+  char *var_ks8995_registers_write_10_p3 ;
+  loff_t var_ks8995_registers_write_10_p4 ;
+  size_t var_ks8995_registers_write_10_p5 ;
+  struct spi_device *var_group3 ;
+  int tmp___7 ;
+  int ldv_s_ks8995_driver_spi_driver ;
+  int tmp___8 ;
+  int tmp___9 ;
+  int __cil_tmp16 ;
+  {
+  {
+  LDV_IN_INTERRUPT = 1;
+  ldv_initialize();
+  tmp___7 = ks8995_init();
+  }
+  if (tmp___7) {
+    goto ldv_final;
+  } else {
+  }
+  ldv_s_ks8995_driver_spi_driver = 0;
+  {
+  while (1) {
+    while_continue: ;
+    {
+    tmp___9 = __VERIFIER_nondet_int();
+    }
+    if (tmp___9) {
+    } else {
+      {
+      __cil_tmp16 = ldv_s_ks8995_driver_spi_driver == 0;
+      if (! __cil_tmp16) {
+      } else {
+        goto while_break;
+      }
+      }
+    }
+    {
+    tmp___8 = __VERIFIER_nondet_int();
+    }
+    if (tmp___8 == 0) {
+      goto case_0;
+    } else
+    if (tmp___8 == 1) {
+      goto case_1;
+    } else
+    if (tmp___8 == 2) {
+      goto case_2;
+    } else {
+      {
+      goto switch_default;
+      if (0) {
+        case_0:
+        {
+        ks8995_registers_read(var_group1, var_group2, var_ks8995_registers_read_9_p2,
+                              var_ks8995_registers_read_9_p3, var_ks8995_registers_read_9_p4,
+                              var_ks8995_registers_read_9_p5);
+        }
+        goto switch_break;
+        case_1:
+        {
+        ks8995_registers_write(var_group1, var_group2, var_ks8995_registers_write_10_p2,
+                               var_ks8995_registers_write_10_p3, var_ks8995_registers_write_10_p4,
+                               var_ks8995_registers_write_10_p5);
+        }
+        goto switch_break;
+        case_2:
+        if (ldv_s_ks8995_driver_spi_driver == 0) {
+          {
+          res_ks8995_probe_11 = ks8995_probe(var_group3);
+          ldv_check_return_value(res_ks8995_probe_11);
+          }
+          if (res_ks8995_probe_11) {
+            goto ldv_module_exit;
+          } else {
+          }
+          ldv_s_ks8995_driver_spi_driver = 0;
+        } else {
+        }
+        goto switch_break;
+        switch_default:
+        goto switch_break;
+      } else {
+        switch_break: ;
+      }
+      }
+    }
+  }
+  while_break: ;
+  }
+  ldv_module_exit:
+  {
+  ks8995_exit();
+  }
+  ldv_final:
+  {
+  ldv_check_final_state();
+  }
+  return;
+}
+}
+void ldv_blast_assert(void)
+{
+  {
+  ERROR: {reach_error();abort();}
+}
+}
+extern int __VERIFIER_nondet_int(void) ;
+int ldv_mutex = 1;
+int __attribute__((__warn_unused_result__)) mutex_lock_interruptible(struct mutex *lock )
+{ int nondetermined ;
+  {
+  if (ldv_mutex == 1) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  {
+  nondetermined = __VERIFIER_nondet_int();
+  }
+  if (nondetermined) {
+    ldv_mutex = 2;
+    return (0);
+  } else {
+    return (-4);
+  }
+}
+}
+int __attribute__((__warn_unused_result__)) mutex_lock_killable(struct mutex *lock )
+{ int nondetermined ;
+  {
+  if (ldv_mutex == 1) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  {
+  nondetermined = __VERIFIER_nondet_int();
+  }
+  if (nondetermined) {
+    ldv_mutex = 2;
+    return (0);
+  } else {
+    return (-4);
+  }
+}
+}
+int atomic_dec_and_mutex_lock(atomic_t *cnt , struct mutex *lock )
+{ int atomic_value_after_dec ;
+  {
+  if (ldv_mutex == 1) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  {
+  atomic_value_after_dec = __VERIFIER_nondet_int();
+  }
+  if (atomic_value_after_dec == 0) {
+    ldv_mutex = 2;
+    return (1);
+  } else {
+  }
+  return (0);
+}
+}
+void mutex_lock(struct mutex *lock )
+{
+  {
+  if (ldv_mutex == 1) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  ldv_mutex = 2;
+  return;
+}
+}
+int mutex_trylock(struct mutex *lock )
+{ int nondetermined ;
+  {
+  if (ldv_mutex == 1) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  {
+  nondetermined = __VERIFIER_nondet_int();
+  }
+  if (nondetermined) {
+    ldv_mutex = 2;
+    return (1);
+  } else {
+    return (0);
+  }
+}
+}
+void mutex_unlock(struct mutex *lock )
+{
+  {
+  if (ldv_mutex == 2) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  ldv_mutex = 1;
+  return;
+}
+}
+void ldv_check_final_state(void)
+{
+  {
+  if (ldv_mutex == 1) {
+  } else {
+    {
+    ldv_blast_assert();
+    }
+  }
+  return;
+}
+}
+long ldv__builtin_expect(long val , long res )
+{
+  {
+  return (val);
+}
+}
+void __const_udelay(unsigned long arg0) {
+  return;
+}
+void __list_add(struct list_head *arg0, struct list_head *arg1, struct list_head *arg2) {
+  return;
+}
+void __mutex_init(struct mutex *arg0, const char *arg1, struct lock_class_key *arg2) {
+  return;
+}
+int __VERIFIER_nondet_int(void);
+int _dev_info(const struct device *arg0, const char *arg1, ...) {
+  return __VERIFIER_nondet_int();
+}
+int __VERIFIER_nondet_int(void);
+int dev_err(const struct device *arg0, const char *arg1, ...) {
+  return __VERIFIER_nondet_int();
+}
+void *dev_get_drvdata(const struct device *arg0) {
+  return ldv_malloc(0UL);
+}
+int __VERIFIER_nondet_int(void);
+int dev_set_drvdata(struct device *arg0, void *arg1) {
+  return __VERIFIER_nondet_int();
+}
+void driver_unregister(struct device_driver *arg0) {
+  return;
+}
+struct device *get_device(struct device *arg0) {
+  return ldv_malloc(sizeof(struct device));
+}
+void ldv_check_return_value(int arg0) {
+  return;
+}
+void ldv_initialize() {
+  return;
+}
+int __VERIFIER_nondet_int(void);
+int printk(const char *arg0, ...) {
+  return __VERIFIER_nondet_int();
+}
+int __VERIFIER_nondet_int(void);
+int spi_register_driver(struct spi_driver *arg0) {
+  return __VERIFIER_nondet_int();
+}
+int __VERIFIER_nondet_int(void);
+int spi_setup(struct spi_device *arg0) {
+  return __VERIFIER_nondet_int();
+}
+int __VERIFIER_nondet_int(void);
+int spi_sync(struct spi_device *arg0, struct spi_message *arg1) {
+  return __VERIFIER_nondet_int();
+}
+int __VERIFIER_nondet_int(void);
+int sysfs_create_bin_file(struct kobject *arg0, const struct bin_attribute *arg1) {
+  return __VERIFIER_nondet_int();
+}
+void sysfs_remove_bin_file(struct kobject *arg0, const struct bin_attribute *arg1) {
+  return;
+}
+void free(void *);
+void kfree(void const *p) {
+  free((void *)p);
+}

--- a/regression/esbmc-unix/github_1199-1/test.desc
+++ b/regression/esbmc-unix/github_1199-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i
+--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps -D'__builtin_unreachable()' --64  --no-pointer-check --no-bounds-check --interval-analysis --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -869,7 +869,7 @@ static inline expr2tc gen_byte_expression(
 {
   /**
    * The idea of this expression is to compute the object value
-   * in the case where every byte `value` was set set up until num_of_bytes
+   * in the case where every byte `value` was set up until num_of_bytes
    *
    * Note: this function assumes that all memory checks have been done!
    *
@@ -914,6 +914,10 @@ static inline expr2tc gen_byte_expression(
    * the computation of the object-value and initial mask representation
    *
    */
+
+  /* Can't set string constants */
+  if(is_string_type(type))
+    return expr2tc();
 
   if(is_pointer_type(type))
     return gen_byte_expression_byte_update(

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1486,7 +1486,7 @@ void value_sett::dump() const
 {
   std::ostringstream oss;
   output(oss);
-  log_debug("{}", oss.str());
+  log_status("{}", oss.str());
 }
 
 void value_sett::obj_numbering_ref(unsigned int num)


### PR DESCRIPTION
These are some fixes for unknown SV-COMP results that are all related to intrinsic_memset. The errors addressed are:

- segfaults due to nil-exprs caused by gen_value_by_byte(), e.g. in
  sv-benchmarks/c/ldv-linux-3.4-simple/32_1_cilled_ok_nondet_linux-3.4-32_1-drivers--net--phy--spi_ks8995.ko-ldv_main0_sequence_infinite_withcheck_stateful.cil.out.i

- dyn-sized array exceptions caused by type_byte_size() applied to VLAs, etc.
  e.g. in sv-benchmarks/c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-cisco-enic-enic.cil.i

- illegal application of gen_zero() to string-type, e.g. in c/ldv-linux-4.0-rc1-mav/linux-4.0-rc1---drivers--scsi--megaraid.ko.cil.i:10603