### PR TITLE
Remove some migrations

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ ubuntu_setup () {
     # Tested on ubuntu 22.04
     echo "Configuring Ubuntu build"
     sudo apt-get update && sudo apt-get install -y clang clang-tidy python-is-python3 csmith python3 git ccache unzip wget curl libcsmith-dev gperf libgmp-dev cmake bison flex gcc-multilib linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev pkg-config python3-pip python3-toml python-is-python3 openjdk-11-jdk &&
-    BASE_ARGS="$BASE_ARGS -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
+    BASE_ARGS="$BASE_ARGS -DENABLE_OLD_FRONTEND=On -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
     SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_Z3=ON"
     # Hack: Boolector might fail to download some dependencies using curl (maybe we should patch it?)
     # curl: (60) SSL: no alternative certificate subject name matches target host name 'codeload.github.com'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,7 @@ ubuntu_setup () {
     # Tested on ubuntu 22.04
     echo "Configuring Ubuntu build"
     sudo apt-get update && sudo apt-get install -y clang clang-tidy python-is-python3 csmith python3 git ccache unzip wget curl libcsmith-dev gperf libgmp-dev cmake bison flex gcc-multilib linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev pkg-config python3-pip python3-toml python-is-python3 openjdk-11-jdk &&
-    BASE_ARGS="$BASE_ARGS -DENABLE_OLD_FRONTEND=On  -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
+    BASE_ARGS="$BASE_ARGS -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
     SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_Z3=ON"
     # Hack: Boolector might fail to download some dependencies using curl (maybe we should patch it?)
     # curl: (60) SSL: no alternative certificate subject name matches target host name 'codeload.github.com'

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_types.h>
 #include <util/string_constant.h>
 #include <iostream>
+#include <ansi-c/compat.h>
 
 void c_typecheck_baset::typecheck_expr(exprt &expr)
 {
@@ -791,7 +792,7 @@ void c_typecheck_baset::typecheck_expr_member(exprt &expr)
 
   typet type = op0.type();
 
-  follow_symbol(type);
+  follow_symbol(type, *this);
 
   if(type.id() == "incomplete_struct")
   {

--- a/src/ansi-c/compat.h
+++ b/src/ansi-c/compat.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <util/irep.h>
+#include <util/namespace.h>
+
+// Magic functions that we need because... we want to keep the old frontend
+inline void follow_symbol(irept &irep, const namespacet &ns)
+{
+  while(irep.id() == "symbol")
+  {
+    const symbolt *symbol = ns.lookup(irep.identifier());
+    assert(symbol);
+
+    if(symbol->is_type)
+    {
+      if(symbol->type.is_nil())
+        return;
+
+      irep = symbol->type;
+    }
+    else
+    {
+      if(symbol->value.is_nil())
+        return;
+
+      irep = symbol->value;
+    }
+  }
+}

--- a/src/clang-c-frontend/expr2c.cpp
+++ b/src/clang-c-frontend/expr2c.cpp
@@ -10,8 +10,6 @@
 #include <util/std_code.h>
 #include <util/std_types.h>
 
-
-
 std::string expr2ct::id_shorthand(const exprt &expr) const
 {
   const irep_idt &identifier = expr.identifier();
@@ -67,7 +65,6 @@ std::string expr2ct::convert(const type2tc &src)
 {
   return convert(migrate_type_back(src));
 }
-
 
 std::string expr2ct::convert_rec(
   const typet &src,
@@ -2065,7 +2062,8 @@ static bool is_pointer_arithmetic(const exprt &e, const exprt *&ptr, exprt &idx)
   {
     assert(e.operands().size() == 2);
     const exprt *p = nullptr, *i = nullptr;
-    auto categorize = [&p, &i](const exprt &e) {
+    auto categorize = [&p, &i](const exprt &e)
+    {
       const irep_idt &tid = e.type().id();
       if(tid == "pointer")
         p = &e;
@@ -2081,9 +2079,8 @@ static bool is_pointer_arithmetic(const exprt &e, const exprt *&ptr, exprt &idx)
       exprt j;
       if(is_pointer_arithmetic(*p, p, j))
       {
-        auto is_unsigned = [](const exprt &e) {
-          return e.type().id() == "unsignedbv";
-        };
+        auto is_unsigned = [](const exprt &e)
+        { return e.type().id() == "unsignedbv"; };
         const char *type =
           is_unsigned(j) || is_unsigned(*i) ? "unsignedbv" : "signedbv";
         idx = exprt(e.id(), typet(type));

--- a/src/clang-c-frontend/expr2c.cpp
+++ b/src/clang-c-frontend/expr2c.cpp
@@ -10,6 +10,8 @@
 #include <util/std_code.h>
 #include <util/std_types.h>
 
+
+
 std::string expr2ct::id_shorthand(const exprt &expr) const
 {
   const irep_idt &identifier = expr.identifier();
@@ -60,6 +62,12 @@ std::string expr2ct::convert(const typet &src)
 {
   return convert_rec(src, c_qualifierst(), "");
 }
+
+std::string expr2ct::convert(const type2tc &src)
+{
+  return convert(migrate_type_back(src));
+}
+
 
 std::string expr2ct::convert_rec(
   const typet &src,
@@ -2096,6 +2104,11 @@ static bool is_pointer_arithmetic(const exprt &e, const exprt *&ptr, exprt &idx)
   return false;
 }
 
+std::string expr2ct::convert(const expr2tc &src, unsigned &precedence)
+{
+  return convert(migrate_expr_back(src), precedence);
+}
+
 std::string expr2ct::convert(const exprt &src, unsigned &precedence)
 {
   precedence = 16;
@@ -2560,6 +2573,11 @@ std::string expr2ct::convert(const exprt &src)
 {
   unsigned precedence;
   return convert(src, precedence);
+}
+
+std::string expr2ct::convert(const expr2tc &src)
+{
+  return convert(migrate_expr_back(src));
 }
 
 std::string expr2c(const exprt &expr, const namespacet &ns, bool fullname)

--- a/src/clang-c-frontend/expr2c.h
+++ b/src/clang-c-frontend/expr2c.h
@@ -24,6 +24,9 @@ public:
 
   virtual std::string convert(const typet &src);
   virtual std::string convert(const exprt &src);
+  virtual std::string convert(const type2tc &src);
+  virtual std::string convert(const expr2tc &src);
+
 
   void get_shorthands(const exprt &expr);
 
@@ -150,6 +153,7 @@ protected:
   virtual std::string convert_code_printf(const codet &src, unsigned indent);
 
   virtual std::string convert(const exprt &src, unsigned &precedence);
+  virtual std::string convert(const expr2tc &src, unsigned &precedence);
 
   std::string convert_function_call(const exprt &src, unsigned &precedence);
   virtual std::string convert_malloc(const exprt &src, unsigned &precedence);

--- a/src/clang-c-frontend/expr2ccode.cpp
+++ b/src/clang-c-frontend/expr2ccode.cpp
@@ -53,9 +53,8 @@ bool expr2ccodet::is_typedef_struct_union(std::string tag)
 
 std::string expr2ccode(const expr2tc &expr, const namespacet &ns, bool fullname)
 {
-  return expr2ccode(migrate_expr_back(expr),ns,fullname);
+  return expr2ccode(migrate_expr_back(expr), ns, fullname);
 }
-
 
 std::string expr2ccode(const exprt &expr, const namespacet &ns, bool fullname)
 {
@@ -969,6 +968,12 @@ std::string expr2ccodet::convert(const exprt &src, unsigned &precedence)
   return convert_norep(src, precedence);
 }
 
+std::string expr2ccodet::convert(const expr2tc &src, unsigned &precedence)
+{
+  return convert(migrate_expr_back(src), precedence);
+}
+
+
 std::string
 expr2ccodet::convert_typecast(const exprt &src, unsigned &precedence)
 {
@@ -1355,12 +1360,12 @@ expr2ccodet::convert_same_object(const exprt &src, unsigned &precedence)
         add2tc(arr_type->subtype, addr->ptr_obj, arr_size));
       or2tc in_bounds(gt, gt2);
       simplify(in_bounds);
-      return convert(migrate_expr_back(in_bounds), precedence);
+      return convert(in_bounds, precedence);
     }
   }
 
   equality2tc eq(same->side_1, same->side_2);
-  return convert(migrate_expr_back(not2tc(eq)), precedence);
+  return convert(not2tc(eq), precedence);
 }
 
 std::string expr2ccodet::convert_pointer_offset(

--- a/src/clang-c-frontend/expr2ccode.cpp
+++ b/src/clang-c-frontend/expr2ccode.cpp
@@ -973,7 +973,6 @@ std::string expr2ccodet::convert(const expr2tc &src, unsigned &precedence)
   return convert(migrate_expr_back(src), precedence);
 }
 
-
 std::string
 expr2ccodet::convert_typecast(const exprt &src, unsigned &precedence)
 {

--- a/src/clang-c-frontend/expr2ccode.cpp
+++ b/src/clang-c-frontend/expr2ccode.cpp
@@ -51,6 +51,12 @@ bool expr2ccodet::is_typedef_struct_union(std::string tag)
     std::regex_search(id2string(tag), m, std::regex("struct[[:space:]]+.*")));
 }
 
+std::string expr2ccode(const expr2tc &expr, const namespacet &ns, bool fullname)
+{
+  return expr2ccode(migrate_expr_back(expr),ns,fullname);
+}
+
+
 std::string expr2ccode(const exprt &expr, const namespacet &ns, bool fullname)
 {
   expr2ccodet expr2ccode(ns, fullname);

--- a/src/clang-c-frontend/expr2ccode.h
+++ b/src/clang-c-frontend/expr2ccode.h
@@ -8,6 +8,10 @@
 #include <util/namespace.h>
 #include <util/std_code.h>
 #include <clang-c-frontend/expr2c.h>
+#include <irep2/irep2.h>
+
+std::string
+expr2ccode(const expr2tc &expr, const namespacet &ns, bool fullname = false);
 
 std::string
 expr2ccode(const exprt &expr, const namespacet &ns, bool fullname = false);

--- a/src/clang-c-frontend/expr2ccode.h
+++ b/src/clang-c-frontend/expr2ccode.h
@@ -73,7 +73,7 @@ protected:
 
   std::string convert_code_decl(const codet &src, unsigned indent) override;
   std::string convert(const exprt &src, unsigned &precedence) override;
-
+  std::string convert(const expr2tc &src, unsigned &precedence) override;
   std::string convert_same_object(const exprt &src, unsigned &precedence);
   std::string convert_pointer_offset(
     const exprt &src,

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -11,7 +11,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/std_types.h>
-
+#include <ansi-c/compat.h>
 codet cpp_typecheckt::cpp_constructor(
   const locationt &location,
   const exprt &object,
@@ -22,7 +22,7 @@ codet cpp_typecheckt::cpp_constructor(
   typecheck_expr(object_tc);
 
   typet tmp_type(object_tc.type());
-  follow_symbol(tmp_type);
+  follow_symbol(tmp_type, *this);
 
   assert(!is_reference(tmp_type));
   if(tmp_type.id() == "array")

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -9,7 +9,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <cpp/cpp_typecheck.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
-
+#include <ansi-c/compat.h>
 codet cpp_typecheckt::cpp_destructor(
   const locationt &location,
   const typet &type,
@@ -19,7 +19,7 @@ codet cpp_typecheckt::cpp_destructor(
   new_code.location() = location;
 
   typet tmp_type(type);
-  follow_symbol(tmp_type);
+  follow_symbol(tmp_type, *this);
 
   assert(!is_reference(tmp_type));
 

--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -35,7 +35,7 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
       throw 0;
     }
 
-    const symbolt &base_symbol = *lookup(base_symbol_expr.type());
+    const symbolt &base_symbol = *lookup(base_symbol_expr.type().identifier());
 
     if(
       base_symbol.type.id() == "incomplete_struct" ||

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -23,7 +23,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
-
+#include <ansi-c/compat.h>
 bool cpp_typecheckt::find_parent(
   const symbolt &symb,
   const irep_idt &base_name,
@@ -83,8 +83,8 @@ void cpp_typecheckt::typecheck_expr_main(exprt &expr)
     typecheck_type(base);
     typecheck_type(deriv);
 
-    follow_symbol(base);
-    follow_symbol(deriv);
+    follow_symbol(base, *this);
+    follow_symbol(deriv, *this);
 
     if(base.id() != "struct" || deriv.id() != "struct")
       expr.make_false();
@@ -1558,7 +1558,7 @@ void cpp_typecheckt::typecheck_side_effect_function_call(
 
   // look at type of function
 
-  follow_symbol(expr.function().type());
+  follow_symbol(expr.function().type(), *this);
 
   if(expr.function().type().id() == "pointer")
   {

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -20,7 +20,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/std_types.h>
 #include <util/string_constant.h>
 #include <utility>
-
+#include <ansi-c/compat.h>
 cpp_typecheck_resolvet::cpp_typecheck_resolvet(cpp_typecheckt &_cpp_typecheck)
   : cpp_typecheck(_cpp_typecheck)
 {
@@ -448,7 +448,7 @@ exprt cpp_typecheck_resolvet::convert_identifier(
 
       while(followed_type.id() == "symbol")
       {
-        typet tmp = cpp_typecheck.lookup(followed_type)->type;
+        typet tmp = cpp_typecheck.lookup(followed_type.identifier())->type;
         followed_type = tmp;
         constant |= followed_type.cmt_constant();
       }
@@ -1233,7 +1233,8 @@ const symbolt &cpp_typecheck_resolvet::disambiguate_template_classes(
     auto new_end = std::remove_if(
       zero_distance_matches.begin(),
       zero_distance_matches.end(),
-      [&full_template_args_tc](matcht const &match) {
+      [&full_template_args_tc](matcht const &match)
+      {
         // This should be replaced by a clean std::remove_if...
         for(unsigned i = 0; i < full_template_args_tc.arguments().size(); ++i)
         {
@@ -1355,7 +1356,7 @@ void cpp_typecheck_resolvet::show_identifiers(
 
       if(id_expr.type().get_bool("is_template"))
       {
-        out << cpp_typecheck.lookup(to_symbol_expr(id_expr))->name;
+        out << cpp_typecheck.lookup(to_symbol_expr(id_expr).identifier())->name;
       }
       else if(id_expr.type().id() == "code")
       {
@@ -1391,7 +1392,8 @@ void cpp_typecheck_resolvet::show_identifiers(
 
       if(id_expr.id() == "symbol")
       {
-        const symbolt &symbol = *cpp_typecheck.lookup(to_symbol_expr(id_expr));
+        const symbolt &symbol =
+          *cpp_typecheck.lookup(to_symbol_expr(id_expr).identifier());
         out << " (" << symbol.location << ")";
       }
       else if(id_expr.id() == "member")
@@ -2100,7 +2102,7 @@ exprt cpp_typecheck_resolvet::guess_function_template_args(
   const cpp_typecheck_fargst &fargs)
 {
   typet tmp = expr.type();
-  cpp_typecheck.follow_symbol(tmp);
+  follow_symbol(tmp, cpp_typecheck);
 
   // XXX -- Spec allows for partial template argument specification, currently
   // not handled.

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -237,7 +237,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
     oss << "\n/* " << count << " */ ";
 
     std::string string_value;
-    languages.from_expr(migrate_expr_back(it.cond), string_value);
+    languages.from_expr(it.cond, string_value);
 
     if(it.is_assignment())
     {
@@ -258,7 +258,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
 
     if(!migrate_expr_back(it.guard).is_true())
     {
-      languages.from_expr(migrate_expr_back(it.guard), string_value);
+      languages.from_expr(it.guard, string_value);
       oss << std::string(i2string(count).size() + 3, ' ');
       oss << "guard: " << string_value << "\n";
     }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -256,7 +256,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
       oss << "renumber: " << from_expr(ns, "", it.lhs) << "\n";
     }
 
-    if(!migrate_expr_back(it.guard).is_true())
+    if(!is_true(it.guard))
     {
       languages.from_expr(it.guard, string_value);
       oss << std::string(i2string(count).size() + 3, ' ');

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -36,7 +36,7 @@ void bmct::show_vcc(
         if(!p_it->ignore)
         {
           std::string string_value;
-          languages.from_expr(migrate_expr_back(p_it->cond), string_value);
+          languages.from_expr(p_it->cond, string_value);
           out << "{-" << count << "} " << string_value << "\n";
           count++;
         }
@@ -45,7 +45,7 @@ void bmct::show_vcc(
         << "\n";
 
     std::string string_value;
-    languages.from_expr(migrate_expr_back(it->cond), string_value);
+    languages.from_expr(it->cond, string_value);
     out << "{" << 1 << "} " << string_value << "\n";
 
     out << "\n";

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -71,8 +71,7 @@ void goto_programt::instructiont::output_instruction(
     break;
 
   case FUNCTION_CALL:
-    out << "FUNCTION_CALL:  " << from_expr(ns, "", code)
-        << "\n";
+    out << "FUNCTION_CALL:  " << from_expr(ns, "", code) << "\n";
     break;
 
   case RETURN:

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -71,7 +71,7 @@ void goto_programt::instructiont::output_instruction(
     break;
 
   case FUNCTION_CALL:
-    out << "FUNCTION_CALL:  " << from_expr(ns, "", migrate_expr_back(code))
+    out << "FUNCTION_CALL:  " << from_expr(ns, "", code)
         << "\n";
     break;
 

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -125,11 +125,8 @@ void printf_formattert::process_format(std::ostream &out)
     // 2. address_of2t -> index2taddress_of2t -> constant_string2t
     const expr2tc &op = *(next_operand++);
     const expr2tc symbol2 = get_base_object(op);
-    exprt char_array = migrate_expr_back(symbol2);
-
-    // string
-    if(char_array.id() == "string-constant")
-      out << char_array.value().as_string();
+    if(is_constant_string2t(symbol2))
+       out << to_constant_string2t(symbol2).value.as_string();
   }
   break;
 

--- a/src/goto-symex/printf_formatter.cpp
+++ b/src/goto-symex/printf_formatter.cpp
@@ -126,7 +126,7 @@ void printf_formattert::process_format(std::ostream &out)
     const expr2tc &op = *(next_operand++);
     const expr2tc symbol2 = get_base_object(op);
     if(is_constant_string2t(symbol2))
-       out << to_constant_string2t(symbol2).value.as_string();
+      out << to_constant_string2t(symbol2).value.as_string();
   }
   break;
 

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -293,13 +293,13 @@ void symex_target_equationt::SSA_stept::output(
   }
 
   if(is_assert() || is_assume() || is_assignment())
-    out << from_expr(ns, "", migrate_expr_back(cond)) << "\n";
+    out << from_expr(ns, "", cond) << "\n";
 
   if(is_assert())
     out << comment << "\n";
 
   if(config.options.get_bool_option("ssa-guards"))
-    out << "Guard: " << from_expr(ns, "", migrate_expr_back(guard)) << "\n";
+    out << "Guard: " << from_expr(ns, "", guard) << "\n";
 }
 
 void symex_target_equationt::SSA_stept::short_output(

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -734,7 +734,7 @@ bool is_valid_witness_step(const namespacet &ns, const goto_trace_stept &step)
 {
   languagest languages(ns, language_idt::C);
   std::string lhsexpr;
-  languages.from_expr(migrate_expr_back(step.lhs), lhsexpr);
+  languages.from_expr(step.lhs, lhsexpr);
   std::string location = step.pc->location.to_string();
   return (
     (location.find("built-in") & location.find("library") &
@@ -749,7 +749,7 @@ bool is_valid_witness_expr(
 {
   languagest languages(ns, language_idt::C);
   std::string value;
-  languages.from_expr(migrate_expr_back(exp), value);
+  languages.from_expr(exp, value);
   return (value.find("__ESBMC") & value.find("stdin") & value.find("stdout") &
           value.find("stderr") & value.find("sys_")) == std::string::npos;
 }

--- a/src/goto-symex/xml_goto_trace.cpp
+++ b/src/goto-symex/xml_goto_trace.cpp
@@ -60,7 +60,7 @@ void convert(const namespacet &ns, const goto_tracet &goto_trace, xmlt &xml)
       {
         value_string = from_expr(ns, identifier, step.value);
         type_string =
-          from_type(ns, identifier, migrate_type_back(step.value->type));
+          from_type(ns, identifier, step.value->type);
       }
 
       const symbolt *symbol = ns.lookup(identifier);

--- a/src/goto-symex/xml_goto_trace.cpp
+++ b/src/goto-symex/xml_goto_trace.cpp
@@ -58,7 +58,7 @@ void convert(const namespacet &ns, const goto_tracet &goto_trace, xmlt &xml)
 
       if(!is_nil_expr(step.value))
       {
-        value_string = from_expr(ns, identifier, migrate_expr_back(step.value));
+        value_string = from_expr(ns, identifier, step.value);
         type_string =
           from_type(ns, identifier, migrate_type_back(step.value->type));
       }

--- a/src/goto-symex/xml_goto_trace.cpp
+++ b/src/goto-symex/xml_goto_trace.cpp
@@ -59,8 +59,7 @@ void convert(const namespacet &ns, const goto_tracet &goto_trace, xmlt &xml)
       if(!is_nil_expr(step.value))
       {
         value_string = from_expr(ns, identifier, step.value);
-        type_string =
-          from_type(ns, identifier, step.value->type);
+        type_string = from_type(ns, identifier, step.value->type);
       }
 
       const symbolt *symbol = ns.lookup(identifier);

--- a/src/goto2c/goto2c_translate.cpp
+++ b/src/goto2c/goto2c_translate.cpp
@@ -192,7 +192,7 @@ std::string goto2ct::translate(goto_programt::instructiont &instruction)
   case GOTO:
     // If we know that the guard is TRUE, then just skip the "if" part
     if(!is_true(instruction.guard))
-      out << "if(" << expr2ccode(migrate_expr_back(instruction.guard), ns)
+      out << "if(" << expr2ccode(instruction.guard, ns)
           << ") ";
     // It is guaranteed that every GOTO instruction has only one target
     out << "goto __ESBMC_goto_label_"
@@ -204,7 +204,7 @@ std::string goto2ct::translate(goto_programt::instructiont &instruction)
   case DECL:
   case ASSIGN:
   case OTHER:
-    out << expr2ccode(migrate_expr_back(instruction.code), ns);
+    out << expr2ccode(instruction.code, ns);
     break;
   // "Silent" instructions. They cannot be translated directly into C.
   // So we just keep them for debugging purposes.
@@ -212,7 +212,7 @@ std::string goto2ct::translate(goto_programt::instructiont &instruction)
     out << "// " << instruction.location.function();
     break;
   case DEAD:
-    out << "// " << expr2ccode(migrate_expr_back(instruction.code), ns);
+    out << "// " << expr2ccode(instruction.code, ns);
     break;
   case LOCATION:
     out << "// " << instruction.location;

--- a/src/goto2c/goto2c_translate.cpp
+++ b/src/goto2c/goto2c_translate.cpp
@@ -192,8 +192,7 @@ std::string goto2ct::translate(goto_programt::instructiont &instruction)
   case GOTO:
     // If we know that the guard is TRUE, then just skip the "if" part
     if(!is_true(instruction.guard))
-      out << "if(" << expr2ccode(instruction.guard, ns)
-          << ") ";
+      out << "if(" << expr2ccode(instruction.guard, ns) << ") ";
     // It is guaranteed that every GOTO instruction has only one target
     out << "goto __ESBMC_goto_label_"
         << instruction.targets.front()->target_number;

--- a/src/langapi/languages.h
+++ b/src/langapi/languages.h
@@ -3,7 +3,7 @@
 
 #include <langapi/mode.h>
 #include <util/language.h>
-
+#include <util/migrate.h>
 class languagest
 {
 public:
@@ -12,6 +12,11 @@ public:
   bool from_expr(const exprt &expr, std::string &code)
   {
     return language->from_expr(expr, code, ns);
+  }
+
+  bool from_expr(const expr2tc &expr, std::string &code)
+  {
+    return language->from_expr(migrate_expr_back(expr), code, ns);
   }
 
   bool from_type(const typet &type, std::string &code)

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -22,7 +22,7 @@ bool goto_program_dereferencet::has_failed_symbol(
       to_symbol2t(expr).thename == "INVALID")
       return false;
 
-    const symbolt &ptr_symbol = *ns.lookup(migrate_expr_back(expr));
+    const symbolt &ptr_symbol = *ns.lookup(expr);
 
     const irep_idt &failed_symbol = ptr_symbol.type.failed_symbol();
 

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -22,7 +22,7 @@ bool goto_program_dereferencet::has_failed_symbol(
       to_symbol2t(expr).thename == "INVALID")
       return false;
 
-    const symbolt &ptr_symbol = *ns.lookup(expr);
+    const symbolt &ptr_symbol = *ns.lookup(to_symbol2t(expr).thename);
 
     const irep_idt &failed_symbol = ptr_symbol.type.failed_symbol();
 

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -153,8 +153,7 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
 
     // Actually perform some pointer arith
     const pointer_type2t &ptr_type = to_pointer_type(ptr_op->type);
-    typet followed_type_old = ns.follow(migrate_type_back(ptr_type.subtype));
-    type2tc followed_type = migrate_type(followed_type_old);
+    type2tc followed_type = ns.follow(ptr_type.subtype);
     expr2tc pointee_size = type_byte_size_expr(followed_type);
     type2tc inttype = machine_ptr;
     type2tc difftype = get_int_type(config.ansi_c.address_width);

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -20,6 +20,11 @@ const symbolt *namespacet::lookup(const irep_idt &name) const
   return context->find_symbol(name);
 }
 
+const symbolt *namespacet::lookup(const expr2tc &name) const
+{
+  return lookup(migrate_expr_back(name));
+}
+
 void namespacet::follow_symbol(irept &irep) const
 {
   while(irep.id() == "symbol")

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <util/namespace.h>
 #include <util/message.h>
+#include <irep2/irep2_utils.h>
 
 unsigned namespacet::get_max(const std::string &prefix) const
 {
@@ -20,41 +21,13 @@ const symbolt *namespacet::lookup(const irep_idt &name) const
   return context->find_symbol(name);
 }
 
-const symbolt *namespacet::lookup(const expr2tc &name) const
-{
-  return lookup(migrate_expr_back(name));
-}
-
-void namespacet::follow_symbol(irept &irep) const
-{
-  while(irep.id() == "symbol")
-  {
-    const symbolt *symbol = lookup(irep);
-    assert(symbol);
-
-    if(symbol->is_type)
-    {
-      if(symbol->type.is_nil())
-        return;
-
-      irep = symbol->type;
-    }
-    else
-    {
-      if(symbol->value.is_nil())
-        return;
-
-      irep = symbol->value;
-    }
-  }
-}
 
 const typet &namespacet::follow(const typet &src) const
 {
   if(!src.is_symbol())
     return src;
 
-  const symbolt *symbol = lookup(src);
+  const symbolt *symbol = lookup(src.identifier());
 
   /* If its cyclic it means we don't actually have a definition of this type.
    * In that case we can do nothing and shouldn't even have been called. */
@@ -66,7 +39,7 @@ const typet &namespacet::follow(const typet &src) const
     assert(symbol->is_type);
     if(!symbol->type.is_symbol())
       return symbol->type;
-    const symbolt *next = lookup(symbol->type);
+    const symbolt *next = lookup(symbol->type.identifier());
     assert(next != symbol && "cycle of length 1 in ns.follow()");
     symbol = next;
   }

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -10,7 +10,6 @@ class namespacet
 public:
   virtual const symbolt *lookup(const irep_idt &name) const;
 
-
   const typet &follow(const typet &src) const;
   const type2tc follow(const type2tc &src) const
   {

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -9,13 +9,7 @@ class namespacet
 {
 public:
   virtual const symbolt *lookup(const irep_idt &name) const;
-  virtual const symbolt *lookup(const expr2tc &name) const;
-  const symbolt *lookup(const irept &irep) const
-  {
-    return lookup(irep.identifier());
-  }
 
-  void follow_symbol(irept &irep) const;
 
   const typet &follow(const typet &src) const;
   const type2tc follow(const type2tc &src) const

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -9,6 +9,7 @@ class namespacet
 {
 public:
   virtual const symbolt *lookup(const irep_idt &name) const;
+  virtual const symbolt *lookup(const expr2tc &name) const;
   const symbolt *lookup(const irept &irep) const
   {
     return lookup(irep.identifier());

--- a/src/util/type_eq.cpp
+++ b/src/util/type_eq.cpp
@@ -8,7 +8,7 @@ bool type_eq(const typet &type1, const typet &type2, const namespacet &ns)
 
   if(type1.id() == "symbol")
   {
-    const symbolt *symbol = ns.lookup(type1);
+    const symbolt *symbol = ns.lookup(type1.identifier());
     assert(symbol);
     if(!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
@@ -18,7 +18,7 @@ bool type_eq(const typet &type1, const typet &type2, const namespacet &ns)
 
   if(type2.id() == "symbol")
   {
-    const symbolt *symbol = ns.lookup(type2);
+    const symbolt *symbol = ns.lookup(type2.identifier());
     assert(symbol);
     if(!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";


### PR DESCRIPTION
As we discussed in https://github.com/esbmc/esbmc/issues/888 there are a couple of steps that are needed to get rid of irep1.

In this PR I will be focusing in:

- trivial cases that migrate back is not needed and is easily replace
- remove some irep functions that aren't used.

Usages of irep1 left: namespacet (symbolt is still the default), serialization, and string representations (all goto2c and outputs). These will be done in other PRs.