### PR TITLE
Fix overflows

### DIFF
--- a/regression/esbmc/overflow-long/ovfl3.c
+++ b/regression/esbmc/overflow-long/ovfl3.c
@@ -1,0 +1,7 @@
+
+int main()
+{
+int a = -136;
+int v = 32;
+int dl = (long)v * (long)a;
+}

--- a/regression/esbmc/overflow-long/test.desc
+++ b/regression/esbmc/overflow-long/test.desc
@@ -1,0 +1,4 @@
+CORE
+ovfl3.c
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -656,7 +656,7 @@ public:
  *  Contains a spec for a floating point number -- this is the equivalent of a
  *  ieee_float_spect in the old irep situation. Stores how bits are distributed
  *  over fraction bits and exponent bits.
- *  @extend floatbv_type_methods
+ *  @extend floatbv_data
  */
 class floatbv_type2t : public floatbv_type_methods
 {

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -1098,9 +1098,12 @@ smt_astt cvc_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   std::size_t w = s->get_data_width();
 
-  // Seems we can't make negative bitvectors; so just pull the value out and
-  // assume CVC is going to cut the top off correctly.
-  CVC4::BitVector bv = CVC4::BitVector(w, theint.to_uint64());
+  CVC4::BitVector bv;
+  if(theint.is_negative() || !theint.is_uint64())
+    bv = CVC4::BitVector(integer2binary(theint, w), 2);
+  else
+    bv = CVC4::BitVector(w, theint.to_uint64());
+
   CVC4::Expr e = em.mkConst(bv);
   return new_ast(e, s);
 }

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -875,4 +875,11 @@ inline smt_ast::smt_ast(smt_convt *ctx, smt_sortt s) : sort(s), context(ctx)
   ctx->live_asts.push_back(this);
 }
 
+inline BigInt ones(unsigned n_bits)
+{
+  BigInt r;
+  r.setPower2(n_bits);
+  return r -= 1;
+}
+
 #endif /* _ESBMC_PROP_SMT_SMT_CONV_H_ */

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -514,13 +514,6 @@ smt_astt smt_convt::convert_addr_of(const expr2tc &expr)
   abort();
 }
 
-static BigInt ones(unsigned n_bits)
-{
-  BigInt r;
-  r.setPower2(n_bits);
-  return r -= 1;
-}
-
 void smt_convt::init_addr_space_array()
 {
   addr_space_sym_num.back() = 1;

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -125,7 +125,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       unsignedbv_type2tc newtype(sz + 1);
 
       // All one bit vector is tricky, might be 64 bits wide for all we know.
-      constant_int2tc allonesexpr(newtype, BigInt((1ULL << (sz + 1)) - 1));
+      constant_int2tc allonesexpr(newtype, ones(sz + 1));
       smt_astt allonesvector = convert_ast(allonesexpr);
 
       // It should either be zero or all one's;

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -681,7 +681,18 @@ smt_astt yices_convt::mk_smt_real(const std::string &str)
 smt_astt yices_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   std::size_t w = s->get_data_width();
-  term_t term = yices_bvconst_uint64(w, theint.to_int64());
+  term_t term;
+
+  if(theint.is_int64())
+    term = yices_bvconst_int64(w, theint.to_int64());
+  else if(theint.is_uint64())
+    term = yices_bvconst_uint64(w, theint.to_uint64());
+  else
+  {
+    std::string bits = integer2binary(theint, w);
+    term = yices_parse_bvbin(bits.c_str());
+  }
+
   return new_ast(term, s);
 }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -819,11 +819,19 @@ smt_astt z3_convt::mk_smt_real(const std::string &str)
 smt_astt z3_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   std::size_t w = s->get_data_width();
+  z3::expr e(z3_ctx);
 
-  if(theint.is_negative())
-    return new_ast(z3_ctx.bv_val(theint.to_int64(), w), s);
+  if(theint.is_int64())
+    e = z3_ctx.bv_val(theint.to_int64(), w);
+  else if(theint.is_uint64())
+    e = z3_ctx.bv_val(theint.to_uint64(), w);
+  else
+  {
+    std::string dec = integer2string(theint, 10);
+    e = z3_ctx.bv_val(dec.c_str(), w);
+  }
 
-  return new_ast(z3_ctx.bv_val(theint.to_uint64(), w), s);
+  return new_ast(e, s);
 }
 
 smt_astt z3_convt::mk_smt_fpbv(const ieee_floatt &thereal)


### PR DESCRIPTION
This PR fixes issues related to overflows, both checking them and actual overflows in the backends:
- smt_overflow: `1ULL << n` where `n` has no bounds is never a good idea
- z3: creating BVs of widths > 64
- cvc, yices: creating BVs from constants of widths > 63

Fixes #1238 for all backends. I've added a reduced regression test for that issue.