### PR TITLE
[Concurrency]Guard fix

### DIFF
--- a/regression/esbmc-unix2/11_burckhardt-fig2/main.c
+++ b/regression/esbmc-unix2/11_burckhardt-fig2/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <pthread.h> 
+
+int X = 0;
+int Y = 0;
+
+void* thread() {
+  if(Y)
+    Y = 1;
+}
+
+int main() {
+  pthread_t t1;
+  pthread_create(&t1, NULL, thread, NULL);
+  X = 1;
+  assert(X==1);
+  return 0;
+}
+

--- a/regression/esbmc-unix2/11_burckhardt-fig2/test.desc
+++ b/regression/esbmc-unix2/11_burckhardt-fig2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 10 --no-por
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -660,7 +660,7 @@ bool execution_statet::is_cur_state_guard_false(const expr2tc &guard)
     }
   }
 
-  return false;
+  return is_false(guard);
 }
 
 void execution_statet::execute_guard()


### PR DESCRIPTION
There is a bug in executing guards, and can be exposed by `--no-por` in this regression test.

In the function` is_cur_state_guard_false()` in `src/goto-symex/execution_state.cpp`, when not using `smt_thread_guard`, it should return if the guard is false, but not the false value. 

This should be the root cause of this issue #1213 