### PR TITLE
[Concurrency] Do not produce interleavings after __ESBMC_main ends

### DIFF
--- a/regression/esbmc-unix/01_malloc_17/main.c
+++ b/regression/esbmc-unix/01_malloc_17/main.c
@@ -1,0 +1,37 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t *mutex;
+
+void *thread1(void *arg)
+{
+  pthread_mutex_lock(mutex); 
+  pthread_mutex_unlock(mutex);
+
+  return NULL;
+}
+
+
+void *thread2(void *arg)
+{
+  pthread_mutex_lock(mutex); 
+  pthread_mutex_unlock(mutex);
+
+  return NULL;
+}
+
+
+int main(void)
+{
+  pthread_t id1, id2;
+
+  mutex = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+  if (mutex==NULL)
+    exit(0);
+  pthread_mutex_init(mutex, NULL);
+
+  pthread_create(&id1, NULL, thread1, NULL);
+  pthread_create(&id2, NULL, thread2, NULL);
+
+  return 0;
+}

--- a/regression/esbmc-unix/01_malloc_17/test.desc
+++ b/regression/esbmc-unix/01_malloc_17/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/01_malloc_18/main.c
+++ b/regression/esbmc-unix/01_malloc_18/main.c
@@ -1,0 +1,41 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t *mutex;
+
+void *thread1(void *arg)
+{
+  pthread_mutex_lock(mutex); 
+  pthread_mutex_unlock(mutex);
+
+  return NULL;
+}
+
+
+void *thread2(void *arg)
+{
+  pthread_mutex_lock(mutex); 
+  pthread_mutex_unlock(mutex);
+
+  return NULL;
+}
+
+
+int main(void)
+{
+  pthread_t id1, id2;
+
+  mutex = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+
+  if (mutex==NULL)
+    exit(0);
+
+  pthread_mutex_init(mutex, NULL);
+
+  pthread_create(&id1, NULL, thread1, NULL);
+  pthread_create(&id2, NULL, thread2, NULL);
+
+  free(mutex);
+
+  return 0;
+}

--- a/regression/esbmc-unix/01_malloc_18/test.desc
+++ b/regression/esbmc-unix/01_malloc_18/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/01_malloc_19/main.c
+++ b/regression/esbmc-unix/01_malloc_19/main.c
@@ -1,0 +1,44 @@
+#include <pthread.h>
+#include <stdlib.h>
+
+pthread_mutex_t *mutex;
+
+void *thread1(void *arg)
+{
+  pthread_mutex_lock(mutex); 
+  pthread_mutex_unlock(mutex);
+
+  return NULL;
+}
+
+
+void *thread2(void *arg)
+{
+  pthread_mutex_lock(mutex); 
+  pthread_mutex_unlock(mutex);
+
+  return NULL;
+}
+
+
+int main(void)
+{
+  pthread_t id1, id2;
+
+  mutex = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+
+  if (mutex==NULL)
+    exit(0);
+
+  pthread_mutex_init(mutex, NULL);
+
+  pthread_create(&id1, NULL, thread1, NULL);
+  pthread_create(&id2, NULL, thread2, NULL);
+
+  pthread_join(id1, NULL);
+  pthread_join(id2, NULL);
+
+  free(mutex);
+
+  return 0;
+}

--- a/regression/esbmc-unix/01_malloc_19/test.desc
+++ b/regression/esbmc-unix/01_malloc_19/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/01_malloc_20/main.c
+++ b/regression/esbmc-unix/01_malloc_20/main.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#define N 2
+
+int  num;
+pthread_mutex_t *m;
+pthread_cond_t *empty, *full;
+
+void *thread1(void * arg)
+{
+  int i;
+
+  i = 0;
+  while (i < N){
+    pthread_mutex_lock(m);
+    while (num > 0) 
+      pthread_cond_wait(empty, m);
+    
+    num++;
+
+    printf ("produce ....%d\n", i);
+    pthread_mutex_unlock(m);
+
+    pthread_cond_signal(full);
+
+    i++;
+  }
+}
+
+
+void *thread2(void *arg)
+{
+  int j;
+
+  j = 0;
+  while (j < N){
+    pthread_mutex_lock(m);
+    while (num == 0) 
+      pthread_cond_wait(full, m);
+
+    num--;
+    printf("consume ....%d\n",j);
+    pthread_mutex_unlock(m);
+    
+    pthread_cond_signal(empty);
+    j++;    
+  }
+}
+
+
+int main()
+{
+  pthread_t  t1, t2;
+
+  num = 0;
+
+  m = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+  empty = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
+  full = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
+
+  if (m==NULL || empty==NULL || full==NULL)
+    exit(0);
+
+  pthread_mutex_init(m, 0);
+  pthread_cond_init(empty, 0);
+  pthread_cond_init(full, 0);
+  
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  free(m);
+  free(empty);
+  free(full);
+
+  return 0;
+  
+}

--- a/regression/esbmc-unix/01_malloc_20/test.desc
+++ b/regression/esbmc-unix/01_malloc_20/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-unwinding-assertions --unwind 3 --context-bound 2 --force-malloc-success --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/01_malloc_21/main.c
+++ b/regression/esbmc-unix/01_malloc_21/main.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#define N 2
+
+int  num;
+pthread_mutex_t *m;
+pthread_cond_t *empty, *full;
+
+void *thread1(void * arg)
+{
+  int i;
+
+  i = 0;
+  while (i < N){
+    pthread_mutex_lock(m);
+    while (num > 0) 
+      pthread_cond_wait(empty, m);
+    
+    num++;
+
+    printf ("produce ....%d\n", i);
+    pthread_mutex_unlock(m);
+
+    pthread_cond_signal(full);
+
+    i++;
+  }
+}
+
+
+void *thread2(void *arg)
+{
+  int j;
+
+  j = 0;
+  while (j < N){
+    pthread_mutex_lock(m);
+    while (num == 0) 
+      pthread_cond_wait(full, m);
+
+    num--;
+    printf("consume ....%d\n",j);
+    pthread_mutex_unlock(m);
+    
+    pthread_cond_signal(empty);
+    j++;    
+  }
+}
+
+
+int main()
+{
+  pthread_t  t1, t2;
+
+  num = 0;
+
+  m = (pthread_mutex_t *) malloc(sizeof(pthread_mutex_t));
+  empty = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
+  full = (pthread_cond_t *) malloc(sizeof(pthread_cond_t));
+
+  if (m==NULL || empty==NULL || full==NULL)
+    exit(0);
+
+  pthread_mutex_init(m, 0);
+  pthread_cond_init(empty, 0);
+  pthread_cond_init(full, 0);
+  
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  free(m);
+  free(empty);
+  free(full);
+
+  return 0;
+  
+}

--- a/regression/esbmc-unix/01_malloc_21/test.desc
+++ b/regression/esbmc-unix/01_malloc_21/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-unwinding-assertions --unwind 3 --context-bound 2 --memory-leak-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/28_memory_leak_01/main.c
+++ b/regression/esbmc-unix2/28_memory_leak_01/main.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <pthread.h>
+
+int *shared;
+
+void *t1(void *arg)
+{
+  return NULL;
+}
+
+int main()
+{
+  shared = (int *)malloc(sizeof(int));
+  pthread_t id1;
+  pthread_join(id1, NULL);
+  free(shared);
+  return 0;
+}

--- a/regression/esbmc-unix2/28_memory_leak_01/test.desc
+++ b/regression/esbmc-unix2/28_memory_leak_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-slice --memory-leak-check --show-stacktrace
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/28_memory_leak_02/main.c
+++ b/regression/esbmc-unix2/28_memory_leak_02/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <pthread.h>
+
+int *shared;
+
+void *t1(void *arg)
+{
+  return NULL;
+}
+
+int main()
+{
+  shared = (int *)malloc(sizeof(int));
+  pthread_t id1;
+  pthread_create(&id1, NULL, t1, NULL);
+  pthread_join(id1, NULL);
+  free(shared);
+  return 0;
+}

--- a/regression/esbmc-unix2/28_memory_leak_02/test.desc
+++ b/regression/esbmc-unix2/28_memory_leak_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-slice --memory-leak-check --show-stacktrace
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix2/28_memory_leak_03/main.c
+++ b/regression/esbmc-unix2/28_memory_leak_03/main.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <pthread.h>
+
+int *shared;
+
+void *t1(void *arg)
+{
+  return NULL;
+}
+
+int main()
+{
+  shared = (int *)malloc(sizeof(int));
+  pthread_t id1;
+  pthread_create(&id1, NULL, t1, NULL);
+  pthread_join(id1, NULL);
+  return 0;
+}

--- a/regression/esbmc-unix2/28_memory_leak_03/test.desc
+++ b/regression/esbmc-unix2/28_memory_leak_03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-slice --memory-leak-check --show-stacktrace
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/28_memory_leak_04/main.c
+++ b/regression/esbmc-unix2/28_memory_leak_04/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <pthread.h>
+
+int *shared;
+
+void *t1(void *arg)
+{
+  free(shared);
+  return NULL;
+}
+
+int main()
+{
+  shared = (int *)malloc(sizeof(int));
+  pthread_t id1;
+  pthread_create(&id1, NULL, t1, NULL);
+  pthread_join(id1, NULL);
+  return 0;
+}

--- a/regression/esbmc-unix2/28_memory_leak_04/test.desc
+++ b/regression/esbmc-unix2/28_memory_leak_04/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-slice --memory-leak-check --show-stacktrace
+^VERIFICATION SUCCESSFUL$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -240,7 +240,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
   concurrency = (prop == Property.reach) and check_if_benchmark_contains_pthread(benchmark)
 
   if concurrency:
-    command_line += " --no-por --context-bound 2 "
+    command_line += " --no-por --context-bound 3 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -240,7 +240,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
   concurrency = (prop == Property.reach) and check_if_benchmark_contains_pthread(benchmark)
 
   if concurrency:
-    command_line += " --no-por --context-bound 3 "
+    command_line += " --no-por --context-bound 2 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -179,6 +179,9 @@ __ESBMC_HIDE:;
   pthread_exec_key_destructors();
   __ESBMC_terminate_thread();
   __ESBMC_atomic_end(); // Never reached; doesn't matter.
+
+  // Ensure that we cut all subsequent execution paths.
+  __ESBMC_assume(0);
   return;
 }
 
@@ -223,6 +226,9 @@ __ESBMC_HIDE:;
   __ESBMC_assume(__ESBMC_blocked_threads_count == 0);
   __ESBMC_terminate_thread();
   __ESBMC_atomic_end();
+
+  // Ensure that there is no subsequent execution path
+  __ESBMC_assume(0);
 }
 
 pthread_t pthread_self(void)

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -48,9 +48,9 @@ void(
 /* TODO: these should be 'static', right? */
 pthread_key_t __ESBMC_next_thread_key = 0;
 
-unsigned int __ESBMC_num_total_threads = 0;
-unsigned int __ESBMC_num_threads_running = 0;
-unsigned int __ESBMC_blocked_threads_count = 0;
+unsigned short int __ESBMC_num_total_threads = 0;
+unsigned short int __ESBMC_num_threads_running = 0;
+unsigned short int __ESBMC_blocked_threads_count = 0;
 
 pthread_t __ESBMC_get_thread_id(void);
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -426,7 +426,10 @@ bool execution_statet::check_if_ileaves_blocked()
     // and to what thread.
     return true;
 
-  if(owning_rt->main_thread_ended && memory_leak_check)
+  if(
+    owning_rt->main_thread_ended &&
+    !options.get_bool_option("deadlock-check") &&
+    !options.get_bool_option("data-races-check"))
     // Don't generate further interleavings since __ESBMC_main thread has ended.
     return true;
 
@@ -897,9 +900,8 @@ void execution_statet::get_expr_globals(
     }
   }
 
-  expr->foreach_operand([this, &globals_list, &ns](const expr2tc &e) {
-    get_expr_globals(ns, e, globals_list);
-  });
+  expr->foreach_operand([this, &globals_list, &ns](const expr2tc &e)
+                        { get_expr_globals(ns, e, globals_list); });
 }
 
 bool execution_statet::check_mpor_dependancy(unsigned int j, unsigned int l)

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -248,6 +248,7 @@ void execution_statet::symex_step(reachability_treet &art)
     if(instruction.function == "__ESBMC_main")
     {
       end_thread();
+      owning_rt->main_thread_ended = true;
     }
     else if(
       instruction.function == "c:@F@main" &&
@@ -423,6 +424,10 @@ bool execution_statet::check_if_ileaves_blocked()
     // Don't generate interleavings automatically - instead, the user will
     // inserts intrinsics identifying where they want interleavings to occur,
     // and to what thread.
+    return true;
+
+  if(owning_rt->main_thread_ended && memory_leak_check)
+    // Don't generate further interleavings since __ESBMC_main thread has ended.
     return true;
 
   if(threads_state.size() < 2)

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -900,8 +900,9 @@ void execution_statet::get_expr_globals(
     }
   }
 
-  expr->foreach_operand([this, &globals_list, &ns](const expr2tc &e)
-                        { get_expr_globals(ns, e, globals_list); });
+  expr->foreach_operand([this, &globals_list, &ns](const expr2tc &e) {
+    get_expr_globals(ns, e, globals_list);
+  });
 }
 
 bool execution_statet::check_mpor_dependancy(unsigned int j, unsigned int l)

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -41,7 +41,7 @@ reachability_treet::reachability_treet(
   interactive_ileaves = options.get_bool_option("interactive-ileaves");
   schedule = options.get_bool_option("schedule");
   por = !options.get_bool_option("no-por");
-
+  main_thread_ended = false;
   target_template = std::move(target);
 }
 

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -318,6 +318,8 @@ public:
   const namespacet &ns;
   /** Options that are enabled */
   optionst &options;
+  /** __ESBMC_main thread has ended */
+  bool main_thread_ended;
 
 protected:
   /** Stack of execution states representing current interleaving.


### PR DESCRIPTION
This approach to stop producing interleavings after __ESBMC_main, when checking memory leaks, keeps our SV-COMP regression:

This PR:
````
 Statistics:            689 Files
   correct:             434
     correct true:      146
    correct false:     288
   incorrect:             9
     incorrect true:      9
     incorrect false:     0
   unknown:             246
   Score:               292 (max: 1036)
````
GitHub actions: https://github.com/esbmc/esbmc/actions/runs/5807542502

Master:

````
 Statistics:            689 Files
   correct:             434
     correct true:      146
     correct false:     288
   incorrect:             9
     incorrect true:      9
     incorrect false:     0
   unknown:             246
   Score:               292 (max: 1036)
````

GitHub actions: https://github.com/esbmc/esbmc/actions/runs/5789501214
