### PR TITLE
Allow not checking for memory leaks on abnormal termination

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -217,6 +217,11 @@ esbmc_dargs += "-D'__builtin_unreachable()' "
 # <https://github.com/esbmc/esbmc/pull/1190#issuecomment-1637047028>
 esbmc_dargs += "--no-vla-size-check "
 
+memleak_check_args = "--memory-leak-check "
+# It seems SV-COMP doesn't want to check for memleaks on abort(), etc.
+# see also <https://github.com/esbmc/esbmc/issues/1259>
+memleak_check_args += "-D__ESBMC_NO_MEMLEAK_CHECK_ON_ABNORMAL_TERMINATION "
+
 import re
 def check_if_benchmark_contains_pthread(benchmark):
   with open(benchmark, "r") as f:
@@ -255,10 +260,10 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
   if prop == Property.overflow:
     command_line += "--no-pointer-check --no-bounds-check --overflow-check --no-assertions "
   elif prop == Property.memory:
-    command_line += "--memory-leak-check --no-assertions "
+    command_line += memleak_check_args + "--no-assertions "
     strat = "incr"
   elif prop == Property.memcleanup:
-    command_line += "--no-pointer-check --no-bounds-check --memory-leak-check --memory-cleanup-check --no-assertions "
+    command_line += "--no-pointer-check --no-bounds-check " + memleak_check_args + "--memory-cleanup-check --no-assertions "
     strat = "incr"
   elif prop == Property.reach:
     if concurrency:

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -68,14 +68,18 @@ __ESBMC_HIDE:;
 void abort(void)
 {
 __ESBMC_HIDE:;
+#ifndef __ESBMC_NO_MEMLEAK_CHECK_ON_ABNORMAL_TERMINATION
   __ESBMC_memory_leak_checks();
+#endif
   __ESBMC_assume(0);
 }
 
 void _Exit(int status)
 {
 __ESBMC_HIDE:;
+#ifndef __ESBMC_NO_MEMLEAK_CHECK_ON_ABNORMAL_TERMINATION
   __ESBMC_memory_leak_checks();
+#endif
   __ESBMC_assume(0);
 }
 #pragma clang diagnostic pop


### PR DESCRIPTION
This PR adds a new #define passed by the esbmc-wrapper.py and which is interpreted in c2goto/stdlib.c by our OMs for `abort()` and `_Exit()`. Addresses part of #1259.