### PR TITLE
Add option to avoid checking memory-leaks on abort()

### DIFF
--- a/regression/esbmc/github_1259_unroll-2-v1-fail/test.desc
+++ b/regression/esbmc/github_1259_unroll-2-v1-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+unroll-2-v1.wvr.c
+--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps -D'__builtin_unreachable()' --no-vla-size-check --32  --memory-leak-check --no-assertions --incremental-bmc
+^VERIFICATION FAILED$
+\bforgotten memory\b

--- a/regression/esbmc/github_1259_unroll-2-v1-fail/unroll-2-v1.wvr.c
+++ b/regression/esbmc/github_1259_unroll-2-v1-fail/unroll-2-v1.wvr.c
@@ -1,0 +1,106 @@
+/* modified version of c/weaver/unroll-2.wvr.yml from SV-COMP 2023 */
+
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "unroll-2.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+typedef unsigned int size_t;
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int  __VERIFIER_nondet_int(void);
+extern unsigned int  __VERIFIER_nondet_uint(void);
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int *f;
+int x1, x2, size;
+unsigned int n;
+
+int *create_fresh_int_array(int size);
+
+void* thread1() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x1 >= 0 && x1 < size);
+    x1 = f[x1];
+    i++;
+  }
+  return 0;
+}
+
+void* thread2() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+  }
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  n = __VERIFIER_nondet_uint();
+  size = __VERIFIER_nondet_int();
+  assume_abort_if_not(size > 0);
+  f = create_fresh_int_array(size);
+  
+  assume_abort_if_not(n < 4294967296 / 2);
+#if 0 /* let's ignore the finite state manipulation done here */
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+#endif
+  assume_abort_if_not(x1 != x2);
+  reach_error();
+
+  return 0;
+}
+
+int *create_fresh_int_array(int size) {
+  assume_abort_if_not(size >= 0);
+  assume_abort_if_not(size <= (((size_t) 4294967295) / sizeof(int)));
+
+  int* arr = (int*)malloc(sizeof(int) * (size_t)size);
+#if 0 /* this is what ESBMC does anyway, only takes time */
+  for (int i = 0; i < size; i++) {
+    arr[i] = __VERIFIER_nondet_int();
+  }
+#endif
+  return arr;
+}

--- a/regression/esbmc/github_1259_unroll-2-v1-success/test.desc
+++ b/regression/esbmc/github_1259_unroll-2-v1-success/test.desc
@@ -1,0 +1,4 @@
+CORE
+unroll-2-v1.wvr.c
+--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps -D'__builtin_unreachable()' --no-vla-size-check --32  --memory-leak-check --no-assertions --incremental-bmc --no-abnormal-memory-leak
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_1259_unroll-2-v1-success/unroll-2-v1.wvr.c
+++ b/regression/esbmc/github_1259_unroll-2-v1-success/unroll-2-v1.wvr.c
@@ -1,0 +1,106 @@
+/* modified version of c/weaver/unroll-2.wvr.yml from SV-COMP 2023 */
+
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "unroll-2.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+typedef unsigned int size_t;
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int  __VERIFIER_nondet_int(void);
+extern unsigned int  __VERIFIER_nondet_uint(void);
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int *f;
+int x1, x2, size;
+unsigned int n;
+
+int *create_fresh_int_array(int size);
+
+void* thread1() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x1 >= 0 && x1 < size);
+    x1 = f[x1];
+    i++;
+  }
+  return 0;
+}
+
+void* thread2() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+  }
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  n = __VERIFIER_nondet_uint();
+  size = __VERIFIER_nondet_int();
+  assume_abort_if_not(size > 0);
+  f = create_fresh_int_array(size);
+  
+  assume_abort_if_not(n < 4294967296 / 2);
+#if 0 /* let's ignore the finite state manipulation done here */
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+#endif
+  assume_abort_if_not(x1 != x2);
+  reach_error();
+
+  return 0;
+}
+
+int *create_fresh_int_array(int size) {
+  assume_abort_if_not(size >= 0);
+  assume_abort_if_not(size <= (((size_t) 4294967295) / sizeof(int)));
+
+  int* arr = (int*)malloc(sizeof(int) * (size_t)size);
+#if 0 /* this is what ESBMC does anyway, only takes time */
+  for (int i = 0; i < size; i++) {
+    arr[i] = __VERIFIER_nondet_int();
+  }
+#endif
+  return arr;
+}

--- a/regression/esbmc/github_1259_unroll-2-v2-fail/test.desc
+++ b/regression/esbmc/github_1259_unroll-2-v2-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+unroll-2-v2.wvr.c
+--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps -D'__builtin_unreachable()' --no-vla-size-check --32  --memory-leak-check --no-assertions --incremental-bmc
+^VERIFICATION FAILED$
+\bforgotten memory\b

--- a/regression/esbmc/github_1259_unroll-2-v2-fail/unroll-2-v2.wvr.c
+++ b/regression/esbmc/github_1259_unroll-2-v2-fail/unroll-2-v2.wvr.c
@@ -1,0 +1,110 @@
+/* modified version of c/weaver/unroll-2.wvr.yml from SV-COMP 2023 */
+
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "unroll-2.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+typedef unsigned int size_t;
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int  __VERIFIER_nondet_int(void);
+extern unsigned int  __VERIFIER_nondet_uint(void);
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int *f;
+int x1, x2, size;
+unsigned int n;
+
+int *create_fresh_int_array(int size);
+
+void* thread1() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x1 >= 0 && x1 < size);
+    x1 = f[x1];
+    i++;
+  }
+  return 0;
+}
+
+void* thread2() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+  }
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  n = __VERIFIER_nondet_uint();
+  size = __VERIFIER_nondet_int();
+  assume_abort_if_not(size > 0);
+  f = create_fresh_int_array(size);
+  
+  assume_abort_if_not(n < 4294967296 / 2);
+
+  n = 0;
+#if 1 /* change to 0 for VERIFICATION SUCCESSFUL */
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  // pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  // pthread_join(t2, 0);
+#else
+  thread1(0);
+#endif
+  assume_abort_if_not(x1 != x2);
+  reach_error();
+
+  return 0;
+}
+
+int *create_fresh_int_array(int size) {
+  assume_abort_if_not(size >= 0);
+  assume_abort_if_not(size <= (((size_t) 4294967295) / sizeof(int)));
+
+  int* arr = (int*)malloc(sizeof(int) * (size_t)size);
+#if 0
+  for (int i = 0; i < size; i++) {
+    arr[i] = __VERIFIER_nondet_int();
+  }
+#endif
+  return arr;
+}

--- a/regression/esbmc/github_1259_unroll-2-v2-success/test.desc
+++ b/regression/esbmc/github_1259_unroll-2-v2-success/test.desc
@@ -1,0 +1,4 @@
+CORE
+unroll-2-v2.wvr.c
+--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps -D'__builtin_unreachable()' --no-vla-size-check --32  --memory-leak-check --no-assertions --incremental-bmc --no-abnormal-memory-leak
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_1259_unroll-2-v2-success/unroll-2-v2.wvr.c
+++ b/regression/esbmc/github_1259_unroll-2-v2-success/unroll-2-v2.wvr.c
@@ -1,0 +1,110 @@
+/* modified version of c/weaver/unroll-2.wvr.yml from SV-COMP 2023 */
+
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "unroll-2.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+typedef unsigned int size_t;
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int  __VERIFIER_nondet_int(void);
+extern unsigned int  __VERIFIER_nondet_uint(void);
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int *f;
+int x1, x2, size;
+unsigned int n;
+
+int *create_fresh_int_array(int size);
+
+void* thread1() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x1 >= 0 && x1 < size);
+    x1 = f[x1];
+    i++;
+  }
+  return 0;
+}
+
+void* thread2() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+  }
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  n = __VERIFIER_nondet_uint();
+  size = __VERIFIER_nondet_int();
+  assume_abort_if_not(size > 0);
+  f = create_fresh_int_array(size);
+  
+  assume_abort_if_not(n < 4294967296 / 2);
+
+  n = 0;
+#if 1 /* change to 0 for VERIFICATION SUCCESSFUL */
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  // pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  // pthread_join(t2, 0);
+#else
+  thread1(0);
+#endif
+  assume_abort_if_not(x1 != x2);
+  reach_error();
+
+  return 0;
+}
+
+int *create_fresh_int_array(int size) {
+  assume_abort_if_not(size >= 0);
+  assume_abort_if_not(size <= (((size_t) 4294967295) / sizeof(int)));
+
+  int* arr = (int*)malloc(sizeof(int) * (size_t)size);
+#if 0
+  for (int i = 0; i < size; i++) {
+    arr[i] = __VERIFIER_nondet_int();
+  }
+#endif
+  return arr;
+}

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -217,6 +217,11 @@ esbmc_dargs += "-D'__builtin_unreachable()' "
 # <https://github.com/esbmc/esbmc/pull/1190#issuecomment-1637047028>
 esbmc_dargs += "--no-vla-size-check "
 
+memleak_args = "--memory-leak-check "
+# It seems SV-COMP doesn't want to check for memleaks on abort()
+# see also <https://github.com/esbmc/esbmc/issues/1259>
+memleak_args += "--no-abnormal-memory-leak "
+
 import re
 def check_if_benchmark_contains_pthread(benchmark):
   with open(benchmark, "r") as f:
@@ -255,10 +260,10 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs):
   if prop == Property.overflow:
     command_line += "--no-pointer-check --no-bounds-check --overflow-check --no-assertions "
   elif prop == Property.memory:
-    command_line += "--memory-leak-check --no-assertions "
+    command_line += memleak_args + " --no-assertions "
     strat = "incr"
   elif prop == Property.memcleanup:
-    command_line += "--no-pointer-check --no-bounds-check --memory-leak-check --memory-cleanup-check --no-assertions "
+    command_line += "--no-pointer-check --no-bounds-check " + memleak_args + "--memory-cleanup-check --no-assertions "
     strat = "incr"
   elif prop == Property.reach:
     if concurrency:

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -65,10 +65,13 @@ __ESBMC_HIDE:;
   __ESBMC_assume(0);
 }
 
+_Bool __ESBMC_no_abnormal_memory_leak(void);
+
 void abort(void)
 {
 __ESBMC_HIDE:;
-  __ESBMC_memory_leak_checks();
+  if(!__ESBMC_no_abnormal_memory_leak())
+    __ESBMC_memory_leak_checks();
   __ESBMC_assume(0);
 }
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -284,6 +284,11 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "do not check whether the size of VLAs overflows the available address "
      "space"},
+    {"no-abnormal-memory-leak",
+     NULL,
+     "affects --memory-leak-check; if both are enabled, the check for memory "
+     "leaks is only performed for normal termination, that is, not for "
+     "abort()"},
     {"nan-check", NULL, "check floating-point for NaN"},
     {"memory-leak-check", NULL, "enable memory leak check"},
     {"overflow-check", NULL, "enable arithmetic over- and underflow check"},

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -608,6 +608,14 @@ void goto_symext::run_intrinsic(
         : gen_false_expr();
     symex_assign(code_assign2tc(func_call.ret, is_little_endian));
   }
+  else if(symname == "c:@F@__ESBMC_no_abnormal_memory_leak")
+  {
+    expr2tc no_abnormal_memleak =
+      config.options.get_bool_option("no-abnormal-memory-leak")
+        ? gen_true_expr()
+        : gen_false_expr();
+    symex_assign(code_assign2tc(func_call.ret, no_abnormal_memleak));
+  }
   else if(symname == "c:@F@__ESBMC_builtin_constant_p")
   {
     assert(


### PR DESCRIPTION
This PR adds the cmdline option `--no-abnormal-memory-leak` that alters the operational model of `abort()` to avoid performing the memleak check. Based on #1265, it fixes the examples from <https://github.com/esbmc/esbmc/issues/1259#issuecomment-1666817732> and <https://github.com/esbmc/esbmc/issues/1259#issuecomment-1666975645>, both of which are modified versions of the SV-COMP 2023 benchmark `c/weaver/unroll-2.wvr.yml`. That one now timeouts locally instead of giving the wrong result. My guess is that we're trying all 2^31 possible runs with all interleavings of the 2 threads it creates...

*Edit:* I've put the test into symex instead of following Lucas' suggestion in <https://github.com/esbmc/esbmc/pull/1267#issuecomment-1671994859> because we might want to be able to use `abort()` calls in other OMs and these calls shouldn't be given a concrete semantics in the precompiled c2goto, yet. In case there is no reason to be that defensive or because the additional runtime cost is prohibitive, I'm happy to move this implementation to where Lucas suggested.