### PR TITLE
[concurrency] analyze global variables for goto instructions during symex

### DIFF
--- a/regression/esbmc-unix2/github_1270/main.c
+++ b/regression/esbmc-unix2/github_1270/main.c
@@ -1,0 +1,96 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://github.com/sosy-lab/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2011-2020 The SV-Benchmarks community
+// SPDX-FileCopyrightText: The ESBMC project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern void abort(void);
+#include <assert.h>
+void reach_error() { assert(0); }
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#define USAGE "./reorder <param1> <param2>\n"
+
+static int iSet = 2;
+static int iCheck = 2;
+
+static int a = 0;
+static int b = 0;
+
+void *setThread(void *param);
+void *checkThread(void *param);
+void set();
+int check();
+
+int main(int argc, char *argv[]) {
+    int i, err;
+
+    if (argc != 1) {
+        if (argc != 3) {
+            fprintf(stderr, USAGE);
+            exit(-1);
+        } else {
+            sscanf(argv[1], "%d", &iSet);
+            sscanf(argv[2], "%d", &iCheck);
+        }
+    }
+
+    //printf("iSet = %d\niCheck = %d\n", iSet, iCheck);
+
+    pthread_t setPool[iSet];
+    pthread_t checkPool[iCheck];
+
+    for (i = 0; i < iSet; i++) {
+        if (0 != (err = pthread_create(&setPool[i], NULL, &setThread, NULL))) {
+            fprintf(stderr, "Error [%d] found creating set thread.\n", err);
+            exit(-1);
+        }
+    }
+
+    for (i = 0; i < iCheck; i++) {
+        if (0 != (err = pthread_create(&checkPool[i], NULL, &checkThread,
+                                       NULL))) {
+            fprintf(stderr, "Error [%d] found creating check thread.\n", err);
+            exit(-1);
+        }
+    }
+
+    for (i = 0; i < iSet; i++) {
+        if (0 != (err = pthread_join(setPool[i], NULL))) {
+            fprintf(stderr, "pthread join error: %d\n", err);
+            exit(-1);
+        }
+    }
+
+    for (i = 0; i < iCheck; i++) {
+        if (0 != (err = pthread_join(checkPool[i], NULL))) {
+            fprintf(stderr, "pthread join error: %d\n", err);
+            exit(-1);
+        }
+    }
+
+    return 0;
+}
+        
+void *setThread(void *param) {
+    a = 1;
+    b = -1;
+
+    return NULL;
+}
+
+void *checkThread(void *param) {
+    if (! ((a == 0 && b == 0) || (a == 1 && b == -1))) {
+        fprintf(stderr, "Bug found!\n");
+    	ERROR: {reach_error();abort();}
+    }
+
+    return NULL;
+}
+
+

--- a/regression/esbmc-unix2/github_1270/test.desc
+++ b/regression/esbmc-unix2/github_1270/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--context-bound 2
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/github_1270_1/main.c
+++ b/regression/esbmc-unix2/github_1270_1/main.c
@@ -1,0 +1,104 @@
+// This file is part of the SV-Benchmarks collection of verification tasks:
+// https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks
+//
+// SPDX-FileCopyrightText: 2021 F. Schuessele <schuessf@informatik.uni-freiburg.de>
+// SPDX-FileCopyrightText: 2021 D. Klumpp <klumpp@informatik.uni-freiburg.de>
+//
+// SPDX-License-Identifier: LicenseRef-BSD-3-Clause-Attribution-Vandikas
+
+typedef unsigned long int pthread_t;
+
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+
+extern void __assert_fail(const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "unroll-2.wvr.c", 21, __extension__ __PRETTY_FUNCTION__); }
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+
+typedef unsigned int size_t;
+extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
+
+extern int  __VERIFIER_nondet_int(void);
+extern unsigned int  __VERIFIER_nondet_uint(void);
+extern void __VERIFIER_atomic_begin(void);
+extern void __VERIFIER_atomic_end(void);
+
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+
+int *f;
+int x1, x2, size;
+unsigned int n;
+
+int *create_fresh_int_array(int size);
+
+void* thread1() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x1 >= 0 && x1 < size);
+    x1 = f[x1];
+    i++;
+  }
+  return 0;
+}
+
+void* thread2() {
+  unsigned int i = 0;
+  while (i < 2 * n) {
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+    assume_abort_if_not(x2 >= 0 && x2 < size);
+    x2 = f[x2];
+    i++;
+  }
+  return 0;
+}
+
+int main() {
+  pthread_t t1, t2;
+
+  // initialize global variables
+  n = __VERIFIER_nondet_uint();
+  size = __VERIFIER_nondet_int();
+  assume_abort_if_not(size > 0);
+  f = create_fresh_int_array(size);
+  
+  assume_abort_if_not(n < 4294967296 / 2);
+
+  // main method
+  pthread_create(&t1, 0, thread1, 0);
+  pthread_create(&t2, 0, thread2, 0);
+  pthread_join(t1, 0);
+  pthread_join(t2, 0);
+
+  assume_abort_if_not(x1 != x2);
+  reach_error();
+
+  return 0;
+}
+
+int *create_fresh_int_array(int size) {
+  assume_abort_if_not(size >= 0);
+  assume_abort_if_not(size <= (((size_t) 4294967295) / sizeof(int)));
+
+  int* arr = (int*)malloc(sizeof(int) * (size_t)size);
+  for (int i = 0; i < size; i++) {
+    arr[i] = __VERIFIER_nondet_int();
+  }
+  return arr;
+}
+
+

--- a/regression/esbmc-unix2/github_1270_1/test.desc
+++ b/regression/esbmc-unix2/github_1270_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+ --force-malloc-success --unwind 10 --no-unwinding-assertions --context-bound 2 --memory-leak-check --no-abnormal-memory-leak
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -324,13 +324,8 @@ void execution_statet::symex_goto(const expr2tc &old_guard)
 
   goto_symext::symex_goto(old_guard);
 
-  if(!pre_goto_guard.is_false())
-  {
-    if(threads_state.size() >= thread_cswitch_threshold)
-    {
-      analyze_read(old_guard);
-    }
-  }
+  if(threads_state.size() >= thread_cswitch_threshold)
+    analyze_read(old_guard);
 }
 
 void execution_statet::assume(const expr2tc &assumption)


### PR DESCRIPTION
This PR should fix the issue reported in https://github.com/esbmc/esbmc/pull/1270 by @fbrausse.