### PR TITLE
Sanitize `(check-sat)` output

### DIFF
--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -164,7 +164,11 @@ void smtlib_convt::dump_smt()
 {
   auto path = config.options.get_option("output");
   if(path != "")
+  {
+    assert(emit_opt_output);
+    emit_opt_output.emit("%s\n", "(check-sat)");
     log_status("SMT formula written to output file {}", path);
+  }
 }
 
 smtlib_convt::file_emitter::file_emitter(const std::string &path)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1338,7 +1338,6 @@ void z3_convt::print_smt_formulae(std::ostream &dest)
   dest << "; Asserts from ESMBC starts\n";
   dest << smt_formula; // All VCC conditions in SMTLIB format.
   dest << "; Asserts from ESMBC ends\n";
-  dest << "(check-sat)\n";
   dest << "(get-model)\n";
   dest << "(exit)\n";
   log_status(


### PR DESCRIPTION
This PR repairs:
- `--smtlib --output FILE` hasn't been writing `(check-sat)` for the file output.
- `--z3 --smtlib-formula-only` has been writing `(check-sat)` twice.

Closes #1261.