### PR TITLE
Allow more fine-grained control over debug log messages

### DIFF
--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -49,7 +49,7 @@ const struct group_opt_templ c2goto_options[] = {
      {"sysroot",
       boost::program_options::value<std::string>()->value_name("<path>"),
       "set the sysroot for the frontend"},
-     {"verbosity", boost::program_options::value<int>(), ""},
+     {"verbosity", boost::program_options::value<std::vector<std::string>>(), ""},
    }},
   {"end", {{"", NULL, "end of options"}}},
   {"Hidden Options", {{"", NULL, ""}}}};

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -49,7 +49,9 @@ const struct group_opt_templ c2goto_options[] = {
      {"sysroot",
       boost::program_options::value<std::string>()->value_name("<path>"),
       "set the sysroot for the frontend"},
-     {"verbosity", boost::program_options::value<std::vector<std::string>>(), ""},
+     {"verbosity",
+      boost::program_options::value<std::vector<std::string>>(),
+      ""},
    }},
   {"end", {{"", NULL, "end of options"}}},
   {"Hidden Options", {{"", NULL, ""}}}};

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -51,7 +51,9 @@ const struct group_opt_templ c2goto_options[] = {
       "set the sysroot for the frontend"},
      {"verbosity",
       boost::program_options::value<std::vector<std::string>>(),
-      ""},
+      "Verbosity of log output, can be given multiple times. Parameter is "
+      "either a decimal N or 'module:N' to set the log-level of debug messages "
+      "of the module to N; without module, it sets the global log-level"},
    }},
   {"end", {{"", NULL, "end of options"}}},
   {"Hidden Options", {{"", NULL, ""}}}};

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -30,7 +30,7 @@ clang_c_languaget::clang_c_languaget()
   // Build the compile arguments
   build_compiler_args(clang_headers_path());
 
-  if(FILE *f = messaget::state.target(VerbosityLevel::Debug))
+  if(FILE *f = messaget::state.target(nullptr, VerbosityLevel::Debug))
   {
     fprintf(f, "clang invocation:");
     for(const std::string &s : compiler_args)

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -30,7 +30,7 @@ clang_c_languaget::clang_c_languaget()
   // Build the compile arguments
   build_compiler_args(clang_headers_path());
 
-  if(FILE *f = messaget::state.target(nullptr, VerbosityLevel::Debug))
+  if(FILE *f = messaget::state.target("clang", VerbosityLevel::Debug))
   {
     fprintf(f, "clang invocation:");
     for(const std::string &s : compiler_args)
@@ -102,7 +102,7 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
   for(auto const &def : config.ansi_c.defines)
     compiler_args.push_back("-D" + def);
 
-  if(messaget::state.verbosity >= VerbosityLevel::Debug)
+  if(messaget::state.target("clang", VerbosityLevel::Debug))
     compiler_args.emplace_back("-v");
 
   compiler_args.emplace_back("-target");

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -849,6 +849,7 @@ bool clang_cpp_convertert::get_function_body(
     if(cxxcd.init_begin() != cxxcd.init_end())
     {
       log_debug(
+        "c++",
         "Class {} ctor {} has {} initializers",
         cxxcd.getParent()->getNameAsString(),
         cxxcd.getNameAsString(),

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -43,7 +43,7 @@ void clang_cpp_languaget::force_file_type()
     !config.options.get_bool_option("no-abstracted-cpp-includes") &&
     !config.options.get_bool_option("no-library"))
   {
-    log_debug("[CPP] Adding CPP includes: {}", esbmct::abstract_cpp_includes());
+    log_debug("c++", "Adding CPP includes: {}", esbmct::abstract_cpp_includes());
     //compiler_args.push_back("-cxx-isystem");
     //compiler_args.push_back(esbmct::abstract_cpp_includes());
     // Let the cpp include "overtake" others.

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -43,7 +43,8 @@ void clang_cpp_languaget::force_file_type()
     !config.options.get_bool_option("no-abstracted-cpp-includes") &&
     !config.options.get_bool_option("no-library"))
   {
-    log_debug("c++", "Adding CPP includes: {}", esbmct::abstract_cpp_includes());
+    log_debug(
+      "c++", "Adding CPP includes: {}", esbmct::abstract_cpp_includes());
     //compiler_args.push_back("-cxx-isystem");
     //compiler_args.push_back(esbmct::abstract_cpp_includes());
     // Let the cpp include "overtake" others.

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -751,7 +751,7 @@ smt_convt::resultt bmct::multi_property_check(
     // Just to confirm that things are in parallel
 #ifndef _WIN32
 #ifndef __APPLE__ // sched_getcpu not supported in OS X
-      log_debug("Thread running on Core {}", sched_getcpu());
+      log_debug("multi-property", "Thread running on Core {}", sched_getcpu());
 #endif
 #endif
       // Set up the current claim and slice it!
@@ -837,7 +837,7 @@ smt_convt::resultt bmct::multi_property_check(
       }
       catch(...)
       {
-        log_debug("Failing Fast");
+        log_debug("multi-property", "Failing Fast");
       }
     };
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -435,7 +435,7 @@ const struct group_opt_templ all_cmd_options[] = {
     // Abort if the program contains a recursion
     {"abort-on-recursion", NULL, ""},
     // Verbosity of message, probably does nothing
-    {"verbosity", boost::program_options::value<int>(), ""},
+    {"verbosity", boost::program_options::value<std::vector<std::string>>(), ""},
     // --break-at $insnnum will cause ESBMC to execute a trap
     // instruction when it executes the designated GOTO instruction number.
     {"break-at", boost::program_options::value<std::string>(), ""},

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -434,10 +434,13 @@ const struct group_opt_templ all_cmd_options[] = {
     {"double-assign-check", NULL, ""},
     // Abort if the program contains a recursion
     {"abort-on-recursion", NULL, ""},
-    // Verbosity of message, probably does nothing
+    /* see <https://github.com/esbmc/esbmc/pull/1281> for a list of supported
+     * modules; check "grep -rw 'log_debug(' src" for more up-to-date info. */
     {"verbosity",
      boost::program_options::value<std::vector<std::string>>(),
-     ""},
+     "Verbosity of log output, can be given multiple times. Parameter is "
+     "either a decimal N or 'module:N' to set the log-level of debug messages "
+     "of the module to N; without module, it sets the global log-level"},
     // --break-at $insnnum will cause ESBMC to execute a trap
     // instruction when it executes the designated GOTO instruction number.
     {"break-at", boost::program_options::value<std::string>(), ""},

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -435,7 +435,9 @@ const struct group_opt_templ all_cmd_options[] = {
     // Abort if the program contains a recursion
     {"abort-on-recursion", NULL, ""},
     // Verbosity of message, probably does nothing
-    {"verbosity", boost::program_options::value<std::vector<std::string>>(), ""},
+    {"verbosity",
+     boost::program_options::value<std::vector<std::string>>(),
+     ""},
     // --break-at $insnnum will cause ESBMC to execute a trap
     // instruction when it executes the designated GOTO instruction number.
     {"break-at", boost::program_options::value<std::string>(), ""},

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -383,7 +383,7 @@ T interval_domaint::get_interval(const expr2tc &e) const
       break;
     }
 
-    log_debug("Could not simplify: {}", *e);
+    log_debug("interval", "Could not simplify: {}", *e);
     break;
   }
 
@@ -528,11 +528,11 @@ T interval_domaint::get_interval(const expr2tc &e) const
 
   case expr2t::sideeffect_id:
     // This is probably a nondet
-    log_debug("[Interval] returning top for side effect {}", *e);
+    log_debug("interval", "returning top for side effect {}", *e);
     break;
 
   default:
-    log_debug("[Interval] Couldn't compute interval for expr: {}", *e);
+    log_debug("interval", "Couldn't compute interval for expr: {}", *e);
     break;
   }
 
@@ -1002,7 +1002,7 @@ void interval_domaint::havoc_rec(const expr2tc &expr)
       real_map.erase(identifier);
   }
   else
-    log_debug("[havoc_rec] Missing support: {}", *expr);
+    log_debug("interval", "[havoc_rec] Missing support: {}", *expr);
 }
 
 void interval_domaint::assume_rec(
@@ -1083,7 +1083,7 @@ void interval_domaint::assume(const expr2tc &cond)
     enable_eval_assumptions &&
     eval_boolean_expression(new_cond, *this).is_false())
   {
-    log_debug("The expr {} is always false. Returning bottom", *cond);
+    log_debug("interval", "The expr {} is always false. Returning bottom", *cond);
     make_bottom();
     return;
   }
@@ -1099,13 +1099,13 @@ tvt interval_domaint::eval_boolean_expression(
   // TODO: for now we will only support integer expressions (no mix!)
   if(enable_wrapped_intervals)
   {
-    log_debug("[eval_boolean_expression] Disabled for wrapped");
+    log_debug("interval", "[eval_boolean_expression] Disabled for wrapped");
     return tvt(tvt::TV_UNKNOWN);
   }
 
   if(contains_float(cond))
   {
-    log_debug("[eval_boolean_expression] No support for floats/mixing");
+    log_debug("interval", "[eval_boolean_expression] No support for floats/mixing");
     return tvt(tvt::TV_UNKNOWN);
   }
 
@@ -1174,7 +1174,7 @@ void interval_domaint::assume_rec(const expr2tc &cond, bool negation)
       cond->foreach_operand([this](const expr2tc &e) { assume_rec(e, true); });
   }
   else
-    log_debug("[assume_rec] Missing support: {}", *cond);
+    log_debug("interval", "[assume_rec] Missing support: {}", *cond);
 }
 
 void interval_domaint::dump() const

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1105,7 +1105,8 @@ tvt interval_domaint::eval_boolean_expression(
 
   if(contains_float(cond))
   {
-    log_debug("interval", "[eval_boolean_expression] No support for floats/mixing");
+    log_debug(
+      "interval", "[eval_boolean_expression] No support for floats/mixing");
     return tvt(tvt::TV_UNKNOWN);
   }
 

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -424,14 +424,14 @@ public:
   static interval_templatet<T>
   cast(const interval_templatet<T> &old, const type2tc &)
   {
-    log_debug("No support for typecasting");
+    log_debug("interval", "No support for typecasting");
     return old;
   }
 
   friend interval_templatet<T>
   operator%(const interval_templatet<T> &s, const interval_templatet<T> &)
   {
-    log_debug("No support for mod");
+    log_debug("interval", "No support for mod");
     return s;
   }
 
@@ -439,7 +439,7 @@ public:
     const interval_templatet<T> &,
     const interval_templatet<T> &) const
   {
-    log_debug("No support for bitand");
+    log_debug("interval", "No support for bitand");
     interval_templatet<T> result;
     return result;
   }
@@ -454,7 +454,7 @@ public:
     const interval_templatet<T> &,
     const interval_templatet<T> &) const
   {
-    log_debug("No support for bitor");
+    log_debug("interval", "No support for bitor");
     interval_templatet<T> result;
     return result;
   }
@@ -469,7 +469,7 @@ public:
     const interval_templatet<T> &,
     const interval_templatet<T> &) const
   {
-    log_debug("No support for bitxor");
+    log_debug("interval", "No support for bitxor");
     interval_templatet<T> result;
     return result;
   }
@@ -484,7 +484,7 @@ public:
     const interval_templatet<T> &,
     const interval_templatet<T> &) const
   {
-    log_debug("No support for lshr");
+    log_debug("interval", "No support for lshr");
     interval_templatet<T> result;
     return result;
   }
@@ -500,7 +500,7 @@ public:
     const interval_templatet<T> &,
     const interval_templatet<T> &) const
   {
-    log_debug("No support for shl");
+    log_debug("interval", "No support for shl");
     interval_templatet<T> result;
     return result;
   }

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -389,7 +389,7 @@ void goto_contractort::parse_error(const expr2tc &expr)
   std::ostringstream oss;
   oss << get_expr_id(expr);
   oss << " Expression is complex, skipping this assert.\n";
-  log_debug("{}", oss.str());
+  log_debug("contractor", "{}", oss.str());
 }
 
 bool goto_contractort::initialize_main_function_loops()

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -344,7 +344,8 @@ public:
     if(!function_loops.empty())
     {
       vars = new ibex::Variable(CspMap::MAX_VAR);
-      log_debug("contractor", "1/4 - Parsing asserts to create CSP Constraints.");
+      log_debug(
+        "contractor", "1/4 - Parsing asserts to create CSP Constraints.");
       get_contractors(_goto_functions);
       if(contractors.is_empty())
       {
@@ -354,7 +355,9 @@ public:
         return;
       }
       contractors.dump();
-      log_debug("contractor", "2/4 - Parsing assumes to set values for variables intervals.");
+      log_debug(
+        "contractor",
+        "2/4 - Parsing assumes to set values for variables intervals.");
       get_intervals(_goto_functions);
 
       log_debug("contractor", "3/4 - Applying contractor.");

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -125,7 +125,7 @@ private:
     }
     else
     {
-      log_debug("Contractors: Unsupported Ctc type");
+      log_debug("contractor", "Contractors: Unsupported Ctc type");
     }
     return nullptr;
   }
@@ -184,7 +184,7 @@ public:
       oss << "inner :" << to_oss(c->get_inner()).str() << "\n";
       oss << "location :" << c->get_location() << "\n";
     }
-    log_debug("{}", oss.str());
+    log_debug("contractor", "{}", oss.str());
   }
   std::ostringstream list_to_oss(ibex::Array<ibex::Ctc> *list, bool is_compo)
   {
@@ -344,7 +344,7 @@ public:
     if(!function_loops.empty())
     {
       vars = new ibex::Variable(CspMap::MAX_VAR);
-      log_debug("1/4 - Parsing asserts to create CSP Constraints.");
+      log_debug("contractor", "1/4 - Parsing asserts to create CSP Constraints.");
       get_contractors(_goto_functions);
       if(contractors.is_empty())
       {
@@ -354,13 +354,13 @@ public:
         return;
       }
       contractors.dump();
-      log_debug("2/4 - Parsing assumes to set values for variables intervals.");
+      log_debug("contractor", "2/4 - Parsing assumes to set values for variables intervals.");
       get_intervals(_goto_functions);
 
-      log_debug("3/4 - Applying contractor.");
+      log_debug("contractor", "3/4 - Applying contractor.");
       apply_contractor();
 
-      log_debug("4/4 - Inserting assumes.");
+      log_debug("contractor", "4/4 - Inserting assumes.");
       insert_assume(_goto_functions);
     }
   }

--- a/src/goto-programs/loop_numbers.cpp
+++ b/src/goto-programs/loop_numbers.cpp
@@ -13,7 +13,7 @@ void show_loop_numbers(const goto_programt &goto_program)
     {
       unsigned loop_id = instruction.loop_number;
 
-      log_debug("Loop {}:\n {}\n", loop_id, instruction.location);
+      log_debug("goto-loop", "Loop {}:\n {}\n", loop_id, instruction.location);
     }
   }
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1230,7 +1230,7 @@ void goto_symext::intrinsic_memset(
   {
     /* Not sure what to do here, let's rely
        * on the default implementation then */
-    log_debug("[memset] Couldn't optimize memset due to precondition");
+    log_debug("memset", "Couldn't optimize memset due to precondition");
     bump_call();
     return;
   }
@@ -1238,7 +1238,7 @@ void goto_symext::intrinsic_memset(
   simplify(arg2);
   if(!is_constant_int2t(arg2))
   {
-    log_debug("[memset] TODO: simplifier issues :/");
+    log_debug("memset", "TODO: simplifier issues :/");
     bump_call();
     return;
   }
@@ -1261,7 +1261,7 @@ void goto_symext::intrinsic_memset(
        * item_offset must be something! */
     if(!item_object || !item_offset)
     {
-      log_debug("[memset] Couldn't get item_object/item_offset");
+      log_debug("memset", "Couldn't get item_object/item_offset");
       bump_call();
       return;
     }
@@ -1270,9 +1270,10 @@ void goto_symext::intrinsic_memset(
     // We can't optimize symbolic offsets :/
     if(is_symbol2t(item_offset))
     {
-      log_debug(fmt::format(
-        "[memset] Item offset is symbolic: {}",
-        to_symbol2t(item_offset).get_symbol_name()));
+      log_debug(
+        "memset",
+        "Item offset is symbolic: {}",
+        to_symbol2t(item_offset).get_symbol_name());
       bump_call();
       return;
     }
@@ -1294,7 +1295,7 @@ void goto_symext::intrinsic_memset(
           // if side_1 of mult is a pointer_offset, then it is just zero
           if(is_pointer_offset2t(as_mul.side_1))
           {
-            log_debug("[memset] TODO: some simplifications are missing");
+            log_debug("memset", "TODO: some simplifications are missing");
             item_offset = constant_int2tc(get_uint64_type(), BigInt(0));
           }
         }
@@ -1309,7 +1310,7 @@ void goto_symext::intrinsic_memset(
        * For now bump_call, later we should expand our simplifier
        */
       log_debug(
-        "[memset] TODO: some simplifications are missing, bumping call");
+        "memset", "TODO: some simplifications are missing, bumping call");
       bump_call();
       return;
     }
@@ -1365,7 +1366,7 @@ void goto_symext::intrinsic_memset(
     // Were we able to optimize it? If not... bump call
     if(!new_object)
     {
-      log_debug("[memset] gen_value_by_byte failed");
+      log_debug("memset", "gen_value_by_byte failed");
       bump_call();
       return;
     }

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -21,7 +21,7 @@ void goto_trace_stept::dump() const
 {
   std::ostringstream oss;
   output(*migrate_namespace_lookup, oss);
-  log_debug("{}", oss.str());
+  log_debug("goto-trace", "{}", oss.str());
 }
 
 void goto_trace_stept::output(const namespacet &ns, std::ostream &out) const

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -287,7 +287,7 @@ void renaming::level2t::dump() const
 {
   std::ostringstream oss;
   print(oss);
-  log_debug("{}", oss.str());
+  log_debug("rename", "{}", oss.str());
 }
 
 void renaming::level2t::make_assignment(

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -51,10 +51,11 @@ void symex_slicet::run_on_assume(symex_target_equationt::SSA_stept &SSA_step)
     ++sliced;
     if(is_symbol2t(SSA_step.cond))
       log_debug(
+        "slice",
         "slice ignoring assume symbol {}",
         to_symbol2t(SSA_step.cond).get_symbol_name());
     else
-      log_debug("slide ignoring assume expression");
+      log_debug("slice", "slice ignoring assume expression");
   }
   else
   {
@@ -88,6 +89,7 @@ void symex_slicet::run_on_assignment(
     SSA_step.ignore = true;
     ++sliced;
     log_debug(
+      "slice",
       "slice ignoring assignment to symbol {}",
       to_symbol2t(SSA_step.lhs).get_symbol_name());
   }
@@ -112,6 +114,7 @@ void symex_slicet::run_on_renumber(symex_target_equationt::SSA_stept &SSA_step)
     SSA_step.ignore = true;
     ++sliced;
     log_debug(
+      "slice",
       "slice ignoring renumbering symbol {}",
       to_symbol2t(SSA_step.lhs).get_symbol_name());
   }

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -13,7 +13,7 @@ void symex_target_equationt::debug_print_step(const SSA_stept &step) const
 {
   std::ostringstream oss;
   step.output(ns, oss);
-  log_debug("{}", oss.str());
+  log_debug("ssa", "{}", oss.str());
 }
 
 void symex_target_equationt::assignment(

--- a/src/jimple-frontend/AST/jimple_ast.h
+++ b/src/jimple-frontend/AST/jimple_ast.h
@@ -22,7 +22,7 @@ public:
    */
   void dump() const
   {
-    log_debug("{}", this->to_string());
+    log_debug("jimple", "{}", this->to_string());
   }
 
   /**

--- a/src/jimple-frontend/AST/jimple_expr.cpp
+++ b/src/jimple-frontend/AST/jimple_expr.cpp
@@ -267,7 +267,7 @@ void jimple_expr_invoke::from_json(const json &j)
   // TODO: Move intrinsics to backend
   if(base_class == "java.lang.Integer" && method == "valueOf_1")
   {
-    log_debug("Got an intrinsic call to valueOf int");
+    log_debug("jimple", "Got an intrinsic call to valueOf int");
     is_intrinsic_method = true;
   }
 }

--- a/src/jimple-frontend/jimple-parser.cpp
+++ b/src/jimple-frontend/jimple-parser.cpp
@@ -9,7 +9,7 @@ void jimple_languaget::show_parse(std::ostream &out)
 
 bool jimple_languaget::parse(const std::string &path)
 {
-  log_debug("Parsing: {}", path);
+  log_debug("jimple", "Parsing: {}", path);
   try
   {
     root.load_file(path);

--- a/src/solidity-frontend/pattern_check.cpp
+++ b/src/solidity-frontend/pattern_check.cpp
@@ -48,7 +48,7 @@ void pattern_checker::check_authorization_through_tx_origin(
   const nlohmann::json &body_stmt = func["body"]["statements"];
   log_progress(
     "  - Pattern-based checking: SWC-115 Authorization through tx.origin");
-  log_debug("statements in function body array ... \n");
+  log_debug("solidity", "statements in function body array ... \n");
 
   unsigned index = 0;
 

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -112,6 +112,7 @@ bool solidity_convertert::convert_ast_nodes(const nlohmann::json &contract_def)
     std::string node_name = ast_node["name"].get<std::string>();
     std::string node_type = ast_node["nodeType"].get<std::string>();
     log_debug(
+      "solidity",
       "@@ Converting node[{}]: name={}, nodeType={} ...",
       index,
       node_name.c_str(),
@@ -173,6 +174,7 @@ bool solidity_convertert::get_var_decl_stmt(
   SolidityGrammar::VarDeclStmtT type =
     SolidityGrammar::get_var_decl_stmt_t(ast_node);
   log_debug(
+    "solidity",
     "	@@@ got Variable-declaration-statement: "
     "SolidityGrammar::VarDeclStmtT::{}",
     SolidityGrammar::var_decl_statement_to_str(type));
@@ -570,7 +572,7 @@ bool solidity_convertert::get_function_definition(
       type.arguments().push_back(param);
       ++num_param_decl;
     }
-    log_debug("  @@@ number of param decls: {}", num_param_decl);
+    log_debug("solidity", "  @@@ number of param decls: {}", num_param_decl);
   }
 
   added_symbol.type = type;
@@ -660,6 +662,7 @@ bool solidity_convertert::get_block(
 
   SolidityGrammar::BlockT type = SolidityGrammar::get_block_t(block);
   log_debug(
+    "solidity",
     "	@@@ got Block: SolidityGrammar::BlockT::{}",
     SolidityGrammar::block_to_str(type));
 
@@ -684,7 +687,7 @@ bool solidity_convertert::get_block(
       _block.operands().push_back(statement);
       ++ctr;
     }
-    log_debug(" \t@@@ CompoundStmt has {} statements", ctr);
+    log_debug("solidity", " \t@@@ CompoundStmt has {} statements", ctr);
 
     locationt location_end;
     get_final_location_from_stmt(block, location_end);
@@ -715,6 +718,7 @@ bool solidity_convertert::get_statement(
 
   SolidityGrammar::StatementT type = SolidityGrammar::get_statement_t(stmt);
   log_debug(
+    "solidity",
     "	@@@ got Stmt: SolidityGrammar::StatementT::{}",
     SolidityGrammar::statement_to_str(type));
 
@@ -761,7 +765,7 @@ bool solidity_convertert::get_statement(
       decls.operands().push_back(single_decl);
       ++ctr;
     }
-    log_debug(" \t@@@ DeclStmt group has {} decls", ctr);
+    log_debug("solidity", " \t@@@ DeclStmt group has {} decls", ctr);
 
     new_expr = decls;
     break;
@@ -976,6 +980,7 @@ bool solidity_convertert::get_expr(
 
   SolidityGrammar::ExpressionT type = SolidityGrammar::get_expression_t(expr);
   log_debug(
+    "solidity",
     "	@@@ got Expr: SolidityGrammar::ExpressionT::{}",
     SolidityGrammar::expression_to_str(type));
 
@@ -1059,6 +1064,7 @@ bool solidity_convertert::get_expr(
     SolidityGrammar::ElementaryTypeNameT type_name =
       SolidityGrammar::get_elementary_type_name_t(literal);
     log_debug(
+      "solidity",
       "	@@@ got Literal: SolidityGrammar::ElementaryTypeNameT::{}",
       SolidityGrammar::elementary_type_name_to_str(type_name));
 
@@ -1135,7 +1141,7 @@ bool solidity_convertert::get_expr(
       call.arguments().push_back(single_arg);
       ++num_args;
     }
-    log_debug("  @@ num_args={}", num_args);
+    log_debug("solidity", "  @@ num_args={}", num_args);
 
     // 4. Convert call arguments
     new_expr = call;
@@ -1260,7 +1266,7 @@ bool solidity_convertert::get_expr(
       call.arguments().push_back(single_arg);
       ++num_args;
     }
-    log_debug("  @@ num_args={}", num_args);
+    log_debug("solidity", "  @@ num_args={}", num_args);
 
     new_expr = call;
 
@@ -1341,6 +1347,7 @@ bool solidity_convertert::get_binary_operator_expr(
   SolidityGrammar::ExpressionT opcode =
     SolidityGrammar::get_expr_operator_t(expr);
   log_debug(
+    "solidity",
     "	@@@ got binop.getOpcode: SolidityGrammar::{}",
     SolidityGrammar::expression_to_str(opcode));
 
@@ -1588,6 +1595,7 @@ bool solidity_convertert::get_unary_operator_expr(
   SolidityGrammar::ExpressionT opcode =
     SolidityGrammar::get_unary_expr_operator_t(expr, expr["prefix"]);
   log_debug(
+    "solidity",
     "	@@@ got uniop.getOpcode: SolidityGrammar::{}",
     SolidityGrammar::expression_to_str(opcode));
 
@@ -1971,6 +1979,7 @@ bool solidity_convertert::get_type_description(
   default:
   {
     log_debug(
+      "solidity",
       "	@@@ got type name=SolidityGrammar::TypeNameT::{}",
       SolidityGrammar::type_name_to_str(type));
     assert(!"Unimplemented type in rule type-name");
@@ -2021,7 +2030,10 @@ bool solidity_convertert::get_func_decl_ref_type(
   }
   default:
   {
-    log_debug("	@@@ Got type={}", SolidityGrammar::func_decl_ref_to_str(type));
+    log_debug(
+      "solidity",
+      "	@@@ Got type={}",
+      SolidityGrammar::func_decl_ref_to_str(type));
     assert(!"Unimplemented type in auxiliary type to convert function call");
     return true;
   }
@@ -2103,7 +2115,9 @@ bool solidity_convertert::get_elementary_type_name(
     SolidityGrammar::get_elementary_type_name_t(type_name);
 
   log_debug(
-    "	@@@ got ElementaryType: SolidityGrammar::ElementaryTypeNameT::{}", type);
+    "solidity",
+    "	@@@ got ElementaryType: SolidityGrammar::ElementaryTypeNameT::{}",
+    type);
 
   switch(type)
   {
@@ -2211,6 +2225,7 @@ bool solidity_convertert::get_elementary_type_name(
   default:
   {
     log_debug(
+      "solidity",
       "	@@@ Got elementary-type-name={}",
       SolidityGrammar::elementary_type_name_to_str(type));
     assert(!"Unimplemented type in rule elementary-type-name");

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -1277,7 +1277,7 @@ void cvc_convt::dump_smt()
   auto const &assertions = smt.getAssertions();
   for(auto const &a : assertions)
     a.printAst(oss, 0);
-  log_debug("{}", oss.str());
+  log_debug("cvc4", "{}", oss.str());
 }
 
 void cvc_smt_ast::dump() const

--- a/src/solvers/mathsat/mathsat_conv.cpp
+++ b/src/solvers/mathsat/mathsat_conv.cpp
@@ -904,7 +904,7 @@ void mathsat_smt_ast::dump() const
   auto convt = dynamic_cast<const mathsat_convt *>(context);
   assert(convt != nullptr);
 
-  log_debug("{}", msat_to_smtlib2(convt->env, a));
+  log_debug("mathsat", "{}", msat_to_smtlib2(convt->env, a));
 }
 
 void mathsat_convt::dump_smt()

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.h
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.h
@@ -57,7 +57,7 @@ public:
 
   void dump() const override
   {
-    log_debug("name {}", name);
+    log_debug("tuple-node", "name {}", name);
     for(auto const &e : elements)
       e->dump();
   }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -919,7 +919,7 @@ smt_astt smtlib_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 
 smt_astt smtlib_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
 {
-  log_debug("[smt_ast] mk_zero_ext with {} width", topwidth);
+  log_debug("smtlib", "[smt_ast] mk_zero_ext with {} width", topwidth);
   smt_astt z = mk_smt_bv(0, mk_bv_sort(topwidth));
   return mk_concat(z, a);
 }

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -90,7 +90,7 @@ struct messaget
 
   public:
     VerbosityLevel verbosity;
-    std::unordered_map<std::string,VerbosityLevel> modules;
+    std::unordered_map<std::string, VerbosityLevel> modules;
     FILE *out;
     FILE *err;
 
@@ -100,9 +100,7 @@ struct messaget
       if(mod)
         if(auto it = modules.find(mod); it != modules.end())
           l = it->second;
-      return lvl > l                        ? nullptr
-             : lvl == VerbosityLevel::Error ? err
-                                            : out;
+      return lvl > l ? nullptr : lvl == VerbosityLevel::Error ? err : out;
     }
 
     void set_flushln() const
@@ -115,7 +113,12 @@ struct messaget
     }
 
     template <typename... Args>
-    bool logln(const char *mod, VerbosityLevel lvl, const char *file, int line, Args &&...args) const
+    bool logln(
+      const char *mod,
+      VerbosityLevel lvl,
+      const char *file,
+      int line,
+      Args &&...args) const
     {
       FILE *f = target(mod, lvl);
       if(!f)

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -155,9 +155,9 @@ print(VerbosityLevel lvl, std::string_view msg, const locationt &)
 #define log_status(fmt, ...)                                                   \
   messaget::state.logln(                                                       \
     nullptr, VerbosityLevel::Status, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
-#define log_debug(fmt, ...)                                                    \
+#define log_debug(mod, fmt, ...)                                               \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Debug, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    mod, VerbosityLevel::Debug, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
 // TODO: Eventually this will be removed
 #ifdef ENABLE_OLD_FRONTEND

--- a/src/util/parseoptions.cpp
+++ b/src/util/parseoptions.cpp
@@ -30,7 +30,7 @@ void parseoptions_baset::set_verbosity_msg(VerbosityLevel v)
       {
         mod = verb;
         *colon = '\0';
-        verb = colon+1;
+        verb = colon + 1;
       }
 
       VerbosityLevel w = (VerbosityLevel)atoi(verb);

--- a/src/util/parseoptions.cpp
+++ b/src/util/parseoptions.cpp
@@ -22,12 +22,31 @@ parseoptions_baset::parseoptions_baset(
 void parseoptions_baset::set_verbosity_msg(VerbosityLevel v)
 {
   if(cmdline.isset("verbosity"))
-    v = (VerbosityLevel)atoi(cmdline.getval("verbosity"));
+    for(std::string s : cmdline.get_values("verbosity")) // copy
+    {
+      char *mod = nullptr;
+      char *verb = s.data();
+      if(char *colon = strchr(verb, ':'))
+      {
+        mod = verb;
+        *colon = '\0';
+        verb = colon+1;
+      }
 
-  if(v < VerbosityLevel::None)
-    v = VerbosityLevel::None;
-  else if(v > VerbosityLevel::Debug)
-    v = VerbosityLevel::Debug;
+      VerbosityLevel w = (VerbosityLevel)atoi(verb);
+      if(w < VerbosityLevel::None)
+        w = VerbosityLevel::None;
+      else if(w > VerbosityLevel::Debug)
+        w = VerbosityLevel::Debug;
+
+      if(mod)
+        messaget::state.modules[mod] = w;
+      else
+        v = w;
+    }
+
+  assert(v >= VerbosityLevel::None);
+  assert(v <= VerbosityLevel::Debug);
 
   messaget::state.verbosity = v;
 }


### PR DESCRIPTION
This PR allows `--verbosity` to be specified multiple times, where later specifications overwrite earlier ones. In addition, to make this meaningful, instead of just a number N its parameter can optionally be a string of the form "module:N" where module is one of the strings specifying which "module" a log_debug() message belongs to. The following "modules" for these debug messages are introduced in this PR, based on the context the log_debug() calls are made in:
- clang
- c++
- multi-property
- interval
- contractor
- goto-loop
- memset
- goto-trace
- rename
- slice
- ssa
- jimple
- solidity
- cvc4
- mathsat
- tuple-node
- smtlib

Closed #1280. As an additional change, the log_*() things are now macros so they allow access to the correct `__FILE__` and `__LINE__`. This information is not printed, yet. The format of the log output also remains unchanged (modulo typos I found).

Example: `--verbosity slice:9` will now only print debug messages from the slicer and keep the normally output messages unchanged. In particular, it does not print the clang invocation params or debug messages from other "modules".