### PR TITLE
Log output

### DIFF
--- a/scripts/cmake/ExternalDependencies.cmake
+++ b/scripts/cmake/ExternalDependencies.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 # FMT
 FetchContent_Declare(fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 7.1.3)
+  GIT_TAG 9.1.0)
 FetchContent_MakeAvailable(fmt)
 
 #nlohmann json

--- a/src/ansi-c/ansi_c_convert.cpp
+++ b/src/ansi-c/ansi_c_convert.cpp
@@ -383,13 +383,13 @@ bool ansi_c_convert(
 
   catch(const char *e)
   {
-    log_error(e);
+    log_error("{}", e);
     abort();
   }
 
   catch(const std::string &e)
   {
-    log_error(e);
+    log_error("{}", e);
     abort();
   }
 
@@ -412,13 +412,13 @@ bool ansi_c_convert(exprt &expr, const std::string &module)
 
   catch(const char *e)
   {
-    log_error(e);
+    log_error("{}", e);
     abort();
   }
 
   catch(const std::string &e)
   {
-    log_error(e);
+    log_error("{}", e);
     abort();
   }
 

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -123,7 +123,7 @@ void ansi_c_parsert::convert_declarator(
     }
     if(t.id() == "")
     {
-      log_status("D: " + declarator.pretty());
+      log_status("D: {}", declarator.pretty());
       assert(0);
     }
     else if(t.is_nil())

--- a/src/ansi-c/c_final.cpp
+++ b/src/ansi-c/c_final.cpp
@@ -21,7 +21,7 @@ void c_finalize_expression(const contextt &context, exprt &expr)
       if(s == nullptr)
       {
         str << "failed to find symbol " << expr.identifier();
-        log_error(str.str());
+        log_error("{}", str.str());
         throw 0;
       }
 
@@ -33,14 +33,14 @@ void c_finalize_expression(const contextt &context, exprt &expr)
       {
         symbol.location.dump();
         str << "symbol `" << symbol.name << "' has incomplete type";
-        log_error(str.str());
+        log_error("{}", str.str());
         throw 0;
       }
       else
       {
         symbol.location.dump();
         str << "symbol `" << symbol.name << "' has unexpected type";
-        log_error(str.str());
+        log_error("{}", str.str());
         throw 0;
       }
     }

--- a/src/ansi-c/c_main.cpp
+++ b/src/ansi-c/c_main.cpp
@@ -78,17 +78,17 @@ bool c_main(contextt &context, const std::string &standard_main)
 
   if(matches.empty())
   {
-    log_error("main symbol `" + themain + "' not found");
+    log_error("main symbol `{}' not found", themain);
     return true; // give up
   }
 
   if(matches.size() >= 2)
   {
     if(matches.size() == 2)
-      log_error("warning: main symbol `" + themain + "' is ambiguous");
+      log_error("warning: main symbol `{}' is ambiguous", themain);
     else
     {
-      log_error("main symbol `" + themain + " is ambiguous");
+      log_error("main symbol `{} is ambiguous", themain);
       return true;
     }
   }

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -224,7 +224,7 @@ bool c_preprocess(const std::string &path, std::ostream &outstream, bool is_cpp)
 
     std::ifstream stderr_input(stderr_file_buf);
     str << stderr_input.rdbuf();
-    log_status(str.str());
+    log_status("{}", str.str());
 
     std::ifstream output_input(out_file_buf);
     outstream << output_input.rdbuf();

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -328,7 +328,7 @@ void c_typecheck_baset::typecheck_symbol_redefinition(
         {
           err_location(new_symbol.location);
           str << "function `" << new_symbol.name << "' defined twice";
-          log_error(str.str());
+          log_error("{}", str.str());
           abort();
         }
         else
@@ -382,7 +382,7 @@ void c_typecheck_baset::typecheck_symbol_redefinition(
               err_location(new_symbol.value);
               str << "symbol `" << new_symbol.name
                   << "' already has an initial value";
-              log_warning(str.str());
+              log_warning("{}", str.str());
             }
           }
         }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1081,8 +1081,7 @@ void c_typecheck_baset::typecheck_expr_side_effect(side_effect_exprt &expr)
     if(type0.cmt_constant())
     {
       err_location(op0);
-      std::string msg = "warning: `" + to_string(op0) + "' is constant";
-      log_warning(msg);
+      log_warning("warning: `{}' is constant", to_string(op0));
     }
 
     if(
@@ -1158,7 +1157,7 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
 
       err_location(f_op);
       str << "function `" << identifier << "' is not declared";
-      log_warning(str.str());
+      log_warning("{}", str.str());
     }
   }
 
@@ -1922,8 +1921,7 @@ void c_typecheck_baset::typecheck_side_effect_assignment(exprt &expr)
   if(o_type0.cmt_constant())
   {
     err_location(expr);
-    std::string msg = "warning: `" + to_string(op0) + "' is constant";
-    log_warning(msg);
+    log_warning("warning: `{}' is constant", to_string(op0));
   }
 
   if(statement == "assign")

--- a/src/ansi-c/c_typecheck_typecast.cpp
+++ b/src/ansi-c/c_typecheck_typecast.cpp
@@ -26,7 +26,7 @@ void c_typecheck_baset::implicit_typecast(exprt &expr, const typet &type)
     err_location(expr);
     str << "conversion from `" << to_string(original_expr_type) << "' to `"
         << to_string(type) << "': " << *it;
-    log_error(str.str());
+    log_error("{}", str.str());
     abort();
   }
 
@@ -40,7 +40,7 @@ void c_typecheck_baset::implicit_typecast(exprt &expr, const typet &type)
     err_location(expr);
     str << "warning: conversion from `" << to_string(original_expr_type)
         << "' to `" << to_string(type) << "': " << *it;
-    log_warning(str.str());
+    log_warning("{}", str.str());
   }
 }
 

--- a/src/c2goto/cprover_libc_sources.cpp
+++ b/src/c2goto/cprover_libc_sources.cpp
@@ -122,10 +122,10 @@ void add_bundled_library_sources(contextt &context, const languaget &c_language)
       if(skip_fenv && get_filename_from_path(path) == "fenv.c")
         return;
       languaget *l = c_language.new_language();
-      log_status("file " + path + ": Parsing");
+      log_status("file {}: Parsing", path);
       if(l->parse(path) || l->typecheck(context, path))
       {
-        log_error("error processing internal libc source " + path);
+        log_error("error processing internal libc source {}", path);
         abort();
       }
       delete l;

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -79,17 +79,17 @@ bool clang_c_maint::clang_main()
 
   if(matches.empty())
   {
-    log_error("main symbol `" + main + "' not found");
+    log_error("main symbol `{}' not found", main);
     return true; // give up
   }
 
   if(matches.size() >= 2)
   {
     if(matches.size() == 2)
-      log_error("warning: main symbol `" + main + "' is ambiguous");
+      log_error("warning: main symbol `{}' is ambiguous", main);
     else
     {
-      log_error("main symbol `" + main + "' is ambiguous");
+      log_error("main symbol `{}' is ambiguous", main);
       return true;
     }
   }

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -110,7 +110,7 @@ symbolt &cpp_declarator_convertert::convert(
         err_location(declarator.name());
         str << "member `" << base_name << "' not found in scope `"
             << scope->identifier << "'";
-        log_error(str.str());
+        log_error("{}", str.str());
         abort();
       }
     }
@@ -135,7 +135,7 @@ symbolt &cpp_declarator_convertert::convert(
       {
         err_location(name.location());
         str << "error: expected type";
-        log_error(str.str());
+        log_error("{}", str.str());
         abort();
       }
 

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -286,7 +286,7 @@ exprt cpp_typecheck_resolvet::convert_template_argument(
       location.dump();
       str << "internal error: template parameter without instance:" << std::endl
           << identifier << std::endl;
-      log_error(str.str());
+      log_error("{}", str.str());
       throw 0;
     }
 
@@ -882,13 +882,13 @@ exprt cpp_typecheck_resolvet::do_builtin(
     dest = exprt("constant", typet("empty"));
     str << "Scopes in location " << location << std::endl;
     cpp_typecheck.cpp_scopes.get_root_scope().print(str);
-    log_warning(str.str());
+    log_warning("{}", str.str());
   }
   else if(base_name == "current_scope")
   {
     dest = exprt("constant", typet("empty"));
     str << "Scope in location " << location << ": " << original_scope->prefix;
-    log_warning(str.str());
+    log_warning("{}", str.str());
   }
   else if(base_name == "context")
   {

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -294,9 +294,9 @@ bool Parser::SyntaxError()
         message += t[i].text;
       }
 
-    message += "'\nLocation{}";
+    message += "'\nLocation: " + location.to_string();
 
-    log_error(message, location.to_string());
+    log_error("{}", message);
   }
 
   return bool(++number_of_errors < MaxErrors);
@@ -6111,15 +6111,14 @@ bool Parser::rTryStatement(codet &statement)
       // catch(...) must always be the last catch
       if(has_catch_ellipsis)
       {
-        std::string message =
-          "‘...’ handler must be the last handler for its try block\nLocation: "
-          "{}";
-
         locationt location;
         location.set_file(op.filename);
         location.set_line(i2string(op.line_no));
 
-        log_error(message, location.to_string());
+        log_error(
+          "‘...’ handler must be the last handler for its try block\nLocation: "
+          "{}",
+          location);
         return false;
       }
 

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -384,10 +384,8 @@ void bmct::report_result(smt_convt::resultt &res)
 
   if((interleaving_number > 0) && options.get_bool_option("all-runs"))
   {
-    log_status(
-      "Number of generated interleavings: {}", interleaving_number);
-    log_status(
-      "Number of failed interleavings: {}", interleaving_failed);
+    log_status("Number of generated interleavings: {}", interleaving_number);
+    log_status("Number of failed interleavings: {}", interleaving_failed);
   }
 }
 

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -385,11 +385,9 @@ void bmct::report_result(smt_convt::resultt &res)
   if((interleaving_number > 0) && options.get_bool_option("all-runs"))
   {
     log_status(
-      "Number of generated interleavings: " +
-      integer2string((interleaving_number)));
+      "Number of generated interleavings: {}", interleaving_number);
     log_status(
-      "Number of failed interleavings: " +
-      integer2string((interleaving_failed)));
+      "Number of failed interleavings: {}", interleaving_failed);
   }
 }
 
@@ -652,7 +650,7 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     {
       std::ostringstream oss;
       document_subgoals(*eq.get(), oss);
-      log_status(oss.str());
+      log_status("{}", oss.str());
       return smt_convt::P_SMTLIB;
     }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -89,7 +89,7 @@ void timeout_handler(int)
 }
 #endif
 
-extern "C" const uint8_t *const esbmc_version_string;
+extern "C" const char *const esbmc_version_string;
 
 uint64_t esbmc_parseoptionst::read_time_spec(const char *str)
 {

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1384,13 +1384,13 @@ bool esbmc_parseoptionst::set_claims(goto_functionst &goto_functions)
 
   catch(const char *e)
   {
-    log_error(e);
+    log_error("{}", e);
     return true;
   }
 
   catch(const std::string &e)
   {
-    log_error(e);
+    log_error("{}", e);
     return true;
   }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -416,9 +416,8 @@ int esbmc_parseoptionst::doit()
   if(cmdline.isset("file-output"))
   {
     FILE *f = fopen(cmdline.getval("file-output"), "w+");
+    /* TODO: handle failure */
     out = f;
-    err = f;
-    messaget::state.err = f;
     messaget::state.out = f;
   }
   //

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -25,8 +25,6 @@ public:
   ~esbmc_parseoptionst()
   {
     close_file(out);
-    if(out != err)
-      close_file(err);
   }
 
 protected:
@@ -81,8 +79,7 @@ protected:
 
   void print_ileave_points(namespacet &ns, goto_functionst &goto_functions);
 
-  FILE *out = stdout;
-  FILE *err = stderr;
+  FILE *out = stderr;
 
   std::vector<std::unique_ptr<goto_functions_algorithm>>
     goto_preprocess_algorithms;

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -208,7 +208,7 @@ void interval_analysis(
   {
     std::ostringstream oss;
     interval_analysis.output(goto_functions, oss);
-    log_status(oss.str());
+    log_status("{}", oss.str());
   }
 
   std::string csv_file = options.get_option("interval-analysis-csv-dump");

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -101,7 +101,7 @@ public:
       else
         oss << "+inf)";
     }
-    log_status(oss.str());
+    log_status("{}", oss.str());
   }
 
   virtual bool is_le_than(const T &a, const T &b) const

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -370,10 +370,8 @@ void goto_convertt::remove_assignment(
   {
     if(expr.operands().size() != 2)
     {
-      std::ostringstream str;
-      str << statement << " takes two arguments\n";
-      str << "Location: " << expr.location();
-      log_error(str.str());
+      log_error(
+        "{} takes two arguments\nLocation: {}", statement, expr.location());
       abort();
     }
 
@@ -552,10 +550,10 @@ void goto_convertt::remove_pre(
       constant_type = op_type;
     else
     {
-      std::ostringstream str;
-      str << "no constant one of type " + op_type.to_string() << "\n";
-      str << "Location: " << expr.location();
-      log_error(str.str());
+      log_error(
+        "no constant one of type {}\nLocation: {}",
+        op_type.to_string(),
+        expr.location());
       abort();
     }
 
@@ -643,10 +641,10 @@ void goto_convertt::remove_post(
       constant_type = op_type;
     else
     {
-      std::ostringstream str;
-      str << "no constant one of type " + op_type.to_string();
-      str << "Location: " << expr.location();
-      log_error(str.str());
+      log_error(
+        "no constant one of type {}\nLocation: {}",
+        op_type.to_string(),
+        expr.location());
       abort();
     }
 

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -244,7 +244,7 @@ void renaming::renaming_levelt::get_original_name(
     return;
 
   default:
-    log_error("get_original_nameing to invalid level {}", lev);
+    log_error("get_original_nameing to invalid level {}", fmt::underlying(lev));
     abort();
   }
 }

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -382,12 +382,16 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
       if(guard.is_true())
       {
         log_error(
-          "non-code call target '{}' generated at {}", sym.thename.as_string());
+          "non-code call target '{}' generated at {}",
+          sym.thename.as_string(),
+          cur_state->source.pc->location);
         return false;
       }
 
       log_status(
-        "non-code call target '{}' generated at {}", sym.thename.as_string());
+        "non-code call target '{}' generated at {}",
+        sym.thename.as_string(),
+        cur_state->source.pc->location);
     }
     return true;
   };

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -444,15 +444,14 @@ bool goto_symext::get_unwind(
     this_loop_max_unwind != 0 && unwind >= this_loop_max_unwind;
   if(!options.get_bool_option("quiet"))
   {
-    log_status(
-      stop_unwind ? "Not unwinding "
-                  : "Unwinding "
-                    "loop {} {} {} {} {}",
-      i2string(cur_state->source.pc->loop_number),
-      " iteration ",
-      integer2string(unwind),
-      " ",
-      cur_state->source.pc->location.as_string());
+    if(stop_unwind)
+      log_status("Not unwinding");
+    else
+      log_status(
+        "Unwinding loop {} iteration {}   {}",
+        i2string(cur_state->source.pc->loop_number),
+        integer2string(unwind),
+        cur_state->source.pc->location);
   }
 
   return stop_unwind;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -340,7 +340,7 @@ void goto_symext::symex_step(reachability_treet &art)
   default:
     log_error(
       "GOTO instruction type {} not handled in goto_symext::symex_step",
-      instruction.type);
+      fmt::underlying(instruction.type));
     abort();
   }
 }

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -2117,7 +2117,7 @@ bool solidity_convertert::get_elementary_type_name(
   log_debug(
     "solidity",
     "	@@@ got ElementaryType: SolidityGrammar::ElementaryTypeNameT::{}",
-    type);
+    fmt::underlying(type));
 
   switch(type)
   {

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -705,7 +705,7 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
     if(base_type_eq(cast.type, cast.from->type, ns))
       return convert_ast(cast.from); // No additional conversion required
 
-    log_error("Can't typecast between unions\n{}");
+    log_error("Can't typecast between unions\n{}", *expr);
     abort();
   }
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2376,14 +2376,15 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
     if(!options.get_bool_option("non-supported-models-as-zero"))
     {
       log_error(
-        "Unimplemented type'd expression ({}) in smt get", type->type_id);
+        "Unimplemented type'd expression ({}) in smt get",
+        fmt::underlying(type->type_id));
       abort();
     }
     else
     {
       log_warning(
         "Unimplemented type'd expression ({}) in smt get. Returning zero!",
-        type->type_id);
+        fmt::underlying(type->type_id));
       return gen_zero(type);
     }
   }
@@ -2412,14 +2413,15 @@ expr2tc smt_convt::get_by_type(const expr2tc &expr)
     if(!options.get_bool_option("non-supported-models-as-zero"))
     {
       log_error(
-        "Unimplemented type'd expression ({}) in smt get", expr->type->type_id);
+        "Unimplemented type'd expression ({}) in smt get",
+        fmt::underlying(expr->type->type_id));
       abort();
     }
     else
     {
       log_warning(
         "Unimplemented type'd expression ({}) in smt get. Returning zero!",
-        expr->type->type_id);
+        fmt::underlying(expr->type->type_id));
       return gen_zero(expr->type);
     }
   }

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -661,7 +661,9 @@ static BigInt interp_numeric(const sexpr &respval, bool is_signed)
   case TOK_BINNUM:
     return binary2integer(respval.data.substr(2), is_signed);
   default:
-    log_error("interpreting S-expr of token type {} as an integer", tok);
+    log_error(
+      "interpreting S-expr of token type {} as an integer",
+      fmt::underlying(tok));
     abort();
   }
 }

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -64,7 +64,7 @@ void yices_convt::push_ctx()
 
   if(res != 0)
   {
-    yices_print_error(messaget::state.err);
+    yices_print_error(messaget::state.out);
     log_error("Error pushing yices context");
     abort();
   }
@@ -76,7 +76,7 @@ void yices_convt::pop_ctx()
 
   if(res != 0)
   {
-    yices_print_error(messaget::state.err);
+    yices_print_error(messaget::state.out);
     log_error("Error poping yices context");
     abort();
   }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(util_esbmc xml_irep.cpp xml.cpp
         string_constant.cpp c_types.cpp ieee_float.cpp c_qualifiers.cpp
         c_sizeof.cpp c_link.cpp c_typecast.cpp fix_symbol.cpp destructor.cpp
         c_expr2string.cpp cpp_expr2string.cpp
+        message.cpp
         )
 # Boost is needed by anything that touches irep2
 target_include_directories(util_esbmc

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -99,7 +99,7 @@ simple_shell_unescape(const char *s, const char *var)
       log_warning(
         "cannot parse environment variable {}: unfinished {}, ignoring...",
         var,
-        mode);
+        fmt::underlying(mode));
       return {};
     }
     split.emplace_back(std::move(arg));

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -157,7 +157,7 @@ bool configt::set(const cmdlinet &cmdline)
     {
       log_error(
         "error: only 'hybrid' and 'purecap' modes supported for --cheri, "
-        "argument was: " +
+        "argument was: {}",
         mode);
       abort();
     }
@@ -225,7 +225,7 @@ bool configt::set(const cmdlinet &cmdline)
     {
       if(!flavor.empty() && flavor != "purecap")
         log_warning(
-          "overriding flavor '" + flavor + "' by 'purecap' due to --cheri");
+          "overriding flavor '{}' by 'purecap' due to --cheri", flavor);
       flavor = "purecap";
     }
     req_target++;
@@ -235,7 +235,7 @@ bool configt::set(const cmdlinet &cmdline)
   {
     log_error(
       "only at most one target can be specified via "
-      "--i386-{win32,macos,linux}, --ppc-macos, --cheri and --no-arch");
+      "--i386-{{win32,macos,linux}}, --ppc-macos, --cheri and --no-arch");
     return true;
   }
 

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -1,0 +1,65 @@
+
+#include <util/config.h>
+#include <util/message.h>
+
+void messaget::statet::println(
+  FILE *f,
+  VerbosityLevel lvl,
+  fmt::string_view format,
+  fmt::format_args args)
+{
+  if(config.options.get_bool_option("color"))
+  {
+    switch(lvl)
+    {
+    case VerbosityLevel::Error:
+      fmt::print(f, fmt::fg(fmt::color::red) | fmt::emphasis::bold, "[ERROR] ");
+      fmt::vprint(f, format, args);
+      break;
+    case VerbosityLevel::Warning:
+      fmt::print(
+        f, fmt::fg(fmt::color::yellow) | fmt::emphasis::bold, "[WARNING] ");
+      fmt::vprint(f, format, args);
+      break;
+    case VerbosityLevel::Progress:
+      fmt::print(
+        f, fmt::fg(fmt::color::blue) | fmt::emphasis::bold, "[PROGRESS] ");
+      fmt::vprint(f, format, args);
+      break;
+    case VerbosityLevel::Fail:
+      fmt::vprint(f, fmt::fg(fmt::color::red), format, args);
+      break;
+    case VerbosityLevel::Success:
+      fmt::vprint(f, fmt::fg(fmt::color::green), format, args);
+      break;
+    default:
+      fmt::vprint(f, format, args);
+      break;
+    }
+  }
+  else
+  {
+    if(lvl == VerbosityLevel::Error)
+      fmt::print(f, "ERROR: ");
+    fmt::vprint(f, format, args);
+  }
+
+  fmt::print(f, "\n");
+}
+
+FILE *messaget::statet::target(const char *mod, VerbosityLevel lvl) const
+{
+  VerbosityLevel l = verbosity;
+  if(mod)
+    if(auto it = modules.find(mod); it != modules.end())
+      l = it->second;
+  return lvl > l ? nullptr : out;
+}
+
+void messaget::statet::set_flushln() const
+{
+/* Win32 interprets _IOLBF as _IOFBF (and then chokes on size=0) */
+#if !defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
+  setvbuf(out, NULL, _IOLBF, 0);
+#endif
+}

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -41,73 +41,19 @@ enum class VerbosityLevel : char
 
 struct messaget
 {
-  static inline class
+  static inline class statet
   {
     static void println(FILE *f, VerbosityLevel lvl, fmt::string_view format,
-                        fmt::format_args args)
-    {
-      if(config.options.get_bool_option("color"))
-      {
-        switch(lvl)
-        {
-        case VerbosityLevel::Error:
-          fmt::print(
-            f, fmt::fg(fmt::color::red) | fmt::emphasis::bold, "[ERROR] ");
-          fmt::vprint(f, format, args);
-          break;
-        case VerbosityLevel::Warning:
-          fmt::print(
-            f, fmt::fg(fmt::color::yellow) | fmt::emphasis::bold, "[WARNING] ");
-          fmt::vprint(f, format, args);
-          break;
-        case VerbosityLevel::Progress:
-          fmt::print(
-            f, fmt::fg(fmt::color::blue) | fmt::emphasis::bold, "[PROGRESS] ");
-          fmt::vprint(f, format, args);
-          break;
-        case VerbosityLevel::Fail:
-          fmt::vprint(f, fmt::fg(fmt::color::red), format, args);
-          break;
-        case VerbosityLevel::Success:
-          fmt::vprint(
-            f, fmt::fg(fmt::color::green), format, args);
-          break;
-        default:
-          fmt::vprint(f, format, args);
-          break;
-        }
-      }
-      else
-      {
-        if(lvl == VerbosityLevel::Error)
-          fmt::print(f, "ERROR: ");
-        fmt::vprint(f, format, args);
-      }
-
-      fmt::print(f, "\n");
-    }
+                        fmt::format_args args);
 
   public:
     VerbosityLevel verbosity;
     std::unordered_map<std::string, VerbosityLevel> modules;
     FILE *out;
 
-    FILE *target(const char *mod, VerbosityLevel lvl) const
-    {
-      VerbosityLevel l = verbosity;
-      if(mod)
-        if(auto it = modules.find(mod); it != modules.end())
-          l = it->second;
-      return lvl > l ? nullptr : out;
-    }
+    FILE *target(const char *mod, VerbosityLevel lvl) const;
 
-    void set_flushln() const
-    {
-/* Win32 interprets _IOLBF as _IOFBF (and then chokes on size=0) */
-#if !defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
-      setvbuf(out, NULL, _IOLBF, 0);
-#endif
-    }
+    void set_flushln() const;
 
     template <typename... Args>
     bool logln(

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -92,7 +92,6 @@ struct messaget
     VerbosityLevel verbosity;
     std::unordered_map<std::string, VerbosityLevel> modules;
     FILE *out;
-    FILE *err;
 
     FILE *target(const char *mod, VerbosityLevel lvl) const
     {
@@ -100,7 +99,7 @@ struct messaget
       if(mod)
         if(auto it = modules.find(mod); it != modules.end())
           l = it->second;
-      return lvl > l ? nullptr : lvl == VerbosityLevel::Error ? err : out;
+      return lvl > l ? nullptr : out;
     }
 
     void set_flushln() const
@@ -108,7 +107,6 @@ struct messaget
 /* Win32 interprets _IOLBF as _IOFBF (and then chokes on size=0) */
 #if !defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
       setvbuf(out, NULL, _IOLBF, 0);
-      setvbuf(err, NULL, _IOLBF, 0);
 #endif
     }
 
@@ -128,7 +126,7 @@ struct messaget
       (void)file;
       (void)line;
     }
-  } state = {VerbosityLevel::Status, {}, stdout, stderr};
+  } state = {VerbosityLevel::Status, {}, stderr};
 };
 
 static inline void

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -14,7 +14,6 @@ Maintainers:
 #include <fmt/format.h>
 #include <fmt/color.h>
 #include <util/message/format.h>
-#include <util/location.h>
 
 /**
  * @brief Verbosity refers to the max level
@@ -128,12 +127,6 @@ struct messaget
     }
   } state = {VerbosityLevel::Status, {}, stderr};
 };
-
-static inline void
-print(VerbosityLevel lvl, std::string_view msg, const locationt &)
-{
-  messaget::state.logln(nullptr, lvl, nullptr, 0, "{}", msg);
-}
 
 #define log_error(fmt, ...)                                                    \
   messaget::state.logln(                                                       \

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -43,8 +43,8 @@ struct messaget
 {
   static inline class
   {
-    template <typename... Args>
-    static void println(FILE *f, VerbosityLevel lvl, Args &&...args)
+    static void println(FILE *f, VerbosityLevel lvl, fmt::string_view format,
+                        fmt::format_args args)
     {
       if(config.options.get_bool_option("color"))
       {
@@ -53,27 +53,27 @@ struct messaget
         case VerbosityLevel::Error:
           fmt::print(
             f, fmt::fg(fmt::color::red) | fmt::emphasis::bold, "[ERROR] ");
-          fmt::print(f, std::forward<Args>(args)...);
+          fmt::vprint(f, format, args);
           break;
         case VerbosityLevel::Warning:
           fmt::print(
             f, fmt::fg(fmt::color::yellow) | fmt::emphasis::bold, "[WARNING] ");
-          fmt::print(f, std::forward<Args>(args)...);
+          fmt::vprint(f, format, args);
           break;
         case VerbosityLevel::Progress:
           fmt::print(
             f, fmt::fg(fmt::color::blue) | fmt::emphasis::bold, "[PROGRESS] ");
-          fmt::print(f, std::forward<Args>(args)...);
+          fmt::vprint(f, format, args);
           break;
         case VerbosityLevel::Fail:
-          fmt::print(f, fmt::fg(fmt::color::red), std::forward<Args>(args)...);
+          fmt::vprint(f, fmt::fg(fmt::color::red), format, args);
           break;
         case VerbosityLevel::Success:
-          fmt::print(
-            f, fmt::fg(fmt::color::green), std::forward<Args>(args)...);
+          fmt::vprint(
+            f, fmt::fg(fmt::color::green), format, args);
           break;
         default:
-          fmt::print(f, std::forward<Args>(args)...);
+          fmt::vprint(f, format, args);
           break;
         }
       }
@@ -81,7 +81,7 @@ struct messaget
       {
         if(lvl == VerbosityLevel::Error)
           fmt::print(f, "ERROR: ");
-        fmt::print(f, std::forward<Args>(args)...);
+        fmt::vprint(f, format, args);
       }
 
       fmt::print(f, "\n");
@@ -115,12 +115,13 @@ struct messaget
       VerbosityLevel lvl,
       const char *file,
       int line,
+      fmt::format_string<Args...> format,
       Args &&...args) const
     {
       FILE *f = target(mod, lvl);
       if(!f)
         return false;
-      println(f, lvl, std::forward<Args>(args)...);
+      println(f, lvl, format, fmt::make_format_args(args...));
       return true;
       (void)file;
       (void)line;

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -77,28 +77,68 @@ struct messaget
 
 #define log_error(fmt, ...)                                                    \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Error, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Error,                                                     \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_result(fmt, ...)                                                   \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Result, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Result,                                                    \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_warning(fmt, ...)                                                  \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Warning, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Warning,                                                   \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_progress(fmt, ...)                                                 \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Progress, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Progress,                                                  \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_success(fmt, ...)                                                  \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Success, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Success,                                                   \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_fail(fmt, ...)                                                     \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Fail, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Fail,                                                      \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_status(fmt, ...)                                                   \
   messaget::state.logln(                                                       \
-    nullptr, VerbosityLevel::Status, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    nullptr,                                                                   \
+    VerbosityLevel::Status,                                                    \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 #define log_debug(mod, fmt, ...)                                               \
   messaget::state.logln(                                                       \
-    mod, VerbosityLevel::Debug, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
+    mod,                                                                       \
+    VerbosityLevel::Debug,                                                     \
+    __FILE__,                                                                  \
+    __LINE__,                                                                  \
+    FMT_STRING(fmt),                                                           \
+    ##__VA_ARGS__)
 
 // TODO: Eventually this will be removed
 #ifdef ENABLE_OLD_FRONTEND

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -43,8 +43,11 @@ struct messaget
 {
   static inline class statet
   {
-    static void println(FILE *f, VerbosityLevel lvl, fmt::string_view format,
-                        fmt::format_args args);
+    static void println(
+      FILE *f,
+      VerbosityLevel lvl,
+      fmt::string_view format,
+      fmt::format_args args);
 
   public:
     VerbosityLevel verbosity;

--- a/src/util/parser.cpp
+++ b/src/util/parser.cpp
@@ -28,5 +28,5 @@ void parsert::parse_error(const std::string &message, const std::string &before)
   std::string tmp = message;
   if(before != "")
     tmp += " before `" + before + "'";
-  print(VerbosityLevel::Error, tmp, location);
+  log_error("at {}: {}", location, tmp);
 }


### PR DESCRIPTION
This PR does 3 things:
- update the `fmt` library from 7.1.3 to 9.1.0,
- perform compile-time checks of all the format strings going to log_*() + fixing some bugs related to that, and
- as discussed in <https://github.com/esbmc/esbmc/discussions/678> the output is to `stderr` only.

As particularly the last item might change the user experience if using ESBMC in a scripted context, I'd like to know whether anyone sees problems with printing to `stderr` only by default. This can of course be changed via `--file-output`, see <https://github.com/esbmc/esbmc/pull/655>.