### PR TITLE
[SMT backend] Added Bitwuzla v0.1.1

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -187,11 +187,8 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
-Linux:
-git clone --depth=1 --branch=0.1.1 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
-
-macOS:
-git clone --depth=1 --branch=0.1.1 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+Linux/macOS:
+git clone --depth=1 --branch=0.1.1 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -188,10 +188,10 @@ We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
 Linux:
-git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+git clone --depth=1 --branch=0.1.1 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DGMP_INCLUDE_DIR=$PWD/../../gmp/include -DGMP_LIBRARIES=$PWD/../../gmp/lib/libgmp.a -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
 
 macOS:
-git clone --depth=1 --branch=smtcomp-2021 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
+git clone --depth=1 --branch=0.1.1 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./contrib/setup-lingeling.sh && ./contrib/setup-btor2tools.sh && ./contrib/setup-symfpu.sh && ./configure.sh --prefix $PWD/../bitwuzla-release && cd build && cmake -DONLY_LINGELING=ON ../ && make -j8 && make install && cd .. && cd ..
 ```
 
 If you need more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.1           |
 | Z3        | no       | 4.8.9           |
-| Bitwuzla  | no       | smtcomp-2021    |
+| Bitwuzla  | no       | 0.1.1           |
 
 The version requirements are usually pretty stable, but can change between releases.
 

--- a/regression/bitwuzla/memset-good/test.desc
+++ b/regression/bitwuzla/memset-good/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+KNOWNBUG
 memset-good.c
 --bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,13 +5,16 @@ mkdir build && cd build || exit $?
 
 # Set arguments that should be available for every OS
 BASE_ARGS="-DDOWNLOAD_DEPENDENCIES=On -GNinja -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DENABLE_SOLIDITY_FRONTEND=On -DENABLE_JIMPLE_FRONTEND=On -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release"
-SOLVER_FLAGS="-DENABLE_BOOLECTOR=On -DENABLE_YICES=Off -DENABLE_CVC4=OFF  -DENABLE_BITWUZLA=OFF -DENABLE_GOTO_CONTRACTOR=OFF"
+SOLVER_FLAGS="-DENABLE_BOOLECTOR=On -DENABLE_YICES=Off -DENABLE_CVC4=OFF  -DENABLE_BITWUZLA=On -DENABLE_GOTO_CONTRACTOR=OFF"
 COMPILER_ARGS=''
 # Ubuntu setup (pre-config)
 ubuntu_setup () {
     # Tested on ubuntu 22.04
     echo "Configuring Ubuntu build"
     sudo apt-get update && sudo apt-get install -y clang clang-tidy python-is-python3 csmith python3 git ccache unzip wget curl libcsmith-dev gperf libgmp-dev cmake bison flex gcc-multilib linux-libc-dev libboost-all-dev ninja-build python3-setuptools libtinfo-dev pkg-config python3-pip python3-toml python-is-python3 openjdk-11-jdk &&
+    echo "Installing Python dependencies"
+    pip3 install --user meson &&
+    meson --version &&
     BASE_ARGS="$BASE_ARGS -DENABLE_OLD_FRONTEND=On  -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
     SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_Z3=ON"
     # Hack: Boolector might fail to download some dependencies using curl (maybe we should patch it?)

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -1,35 +1,57 @@
-set (ESBMC_ENABLE_z3 0)
-set (ESBMC_ENABLE_minisat 0)
-set (ESBMC_ENABLE_boolector 0)
-set (ESBMC_ENABLE_cvc4 0)
-set (ESBMC_ENABLE_mathsat 0)
-set (ESBMC_ENABLE_yices 0)
-set (ESBMC_ENABLE_bitwuzla 0)
+set(Bitwuzla_MIN_VERSION "0.1")
 
-add_subdirectory(prop)
-add_subdirectory(smt)
-add_subdirectory(smtlib)
+if(DEFINED Bitwuzla_DIR)
+    set(ENABLE_BITWUZLA ON)
+else()
+    if(ENABLE_BITWUZLA AND DOWNLOAD_DEPENDENCIES)
+        # See Boolector configurations for more details about this
 
-add_library(solve solve.cpp)
-target_link_libraries(solve fmt::fmt)
-target_include_directories(solve
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-    PRIVATE ${Boost_INCLUDE_DIRS}
-)
+        CPMAddPackage(
+            NAME bitwuzla
+            DOWNLOAD_ONLY YES
+            GITHUB_REPOSITORY bitwuzla/bitwuzla
+            GIT_TAG 0.1.1)
+	  
+	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
+        message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")
+        execute_process(COMMAND python3 ./configure.py --prefix ${bitwuzla_BINARY_DIR}
+          WORKING_DIRECTORY "${bitwuzla_SOURCE_DIR}")
 
-add_library(solvers INTERFACE)
-target_link_libraries(solvers INTERFACE solve smtlib smttuple smtfp smt prop)
+	
+        message("[bitwuzla] Building...")
+        execute_process(COMMAND meson install
+          WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR}/build
+	  COMMAND_ECHO STDOUT)
 
-# Logic for each of these are duplicated -- cmake doesn't have indirect function
-# calling, so it's hard to structure it how I want
-add_subdirectory(z3)
-add_subdirectory(boolector)
-add_subdirectory(cvc4)
-add_subdirectory(mathsat)
-add_subdirectory(yices)
-add_subdirectory(bitwuzla)
+        set(Bitwuzla_DIR ${bitwuzla_BINARY_DIR})
+	# We need to tell cmake where to look for the .pc file exported by bitwuzla
+	set(CMAKE_PREFIX_PATH "${bitwuzla_BINARY_DIR}")
+    endif()
 
-set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS}" PARENT_SCOPE)
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/solver_config.h.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/solver_config.h")
+endif()
+
+if(EXISTS $ENV{HOME}/bitwuzla)
+    set(ENABLE_BITWUZLA ON)
+endif()
+
+if(ENABLE_BITWUZLA)
+  include(FindPkgConfig)
+  pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
+
+    message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")
+    message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
+    if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
+        message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
+    endif()
+
+    add_library(solverbitw bitwuzla_conv.cpp)
+    target_include_directories(solverbitw
+            PRIVATE ${Boost_INCLUDE_DIRS}
+            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(solverbitw fmt::fmt PkgConfig::Bitwuzla)
+
+    target_link_libraries(solvers INTERFACE solverbitw)
+
+    set(ESBMC_ENABLE_bitwuzla 1 PARENT_SCOPE)
+    set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS} bitwuzla" PARENT_SCOPE)
+endif()

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -1,57 +1,35 @@
-set(Bitwuzla_MIN_VERSION "0.1")
+set (ESBMC_ENABLE_z3 0)
+set (ESBMC_ENABLE_minisat 0)
+set (ESBMC_ENABLE_boolector 0)
+set (ESBMC_ENABLE_cvc4 0)
+set (ESBMC_ENABLE_mathsat 0)
+set (ESBMC_ENABLE_yices 0)
+set (ESBMC_ENABLE_bitwuzla 0)
 
-if(DEFINED Bitwuzla_DIR)
-    set(ENABLE_BITWUZLA ON)
-else()
-    if(ENABLE_BITWUZLA AND DOWNLOAD_DEPENDENCIES)
-        # See Boolector configurations for more details about this
+add_subdirectory(prop)
+add_subdirectory(smt)
+add_subdirectory(smtlib)
 
-        CPMAddPackage(
-            NAME bitwuzla
-            DOWNLOAD_ONLY YES
-            GITHUB_REPOSITORY bitwuzla/bitwuzla
-            GIT_TAG 0.1.1)
-	  
-	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
-        message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")
-        execute_process(COMMAND python3 ./configure.py --prefix ${bitwuzla_BINARY_DIR}
-          WORKING_DIRECTORY "${bitwuzla_SOURCE_DIR}")
+add_library(solve solve.cpp)
+target_link_libraries(solve fmt::fmt)
+target_include_directories(solve
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${Boost_INCLUDE_DIRS}
+)
 
-	
-        message("[bitwuzla] Building...")
-        execute_process(COMMAND meson install
-          WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR}/build
-	  COMMAND_ECHO STDOUT)
+add_library(solvers INTERFACE)
+target_link_libraries(solvers INTERFACE solve smtlib smttuple smtfp smt prop)
 
-        set(Bitwuzla_DIR ${bitwuzla_BINARY_DIR})
-	# We need to tell cmake where to look for the .pc file exported by bitwuzla
-	set(CMAKE_PREFIX_PATH "${bitwuzla_BINARY_DIR}")
-    endif()
+# Logic for each of these are duplicated -- cmake doesn't have indirect function
+# calling, so it's hard to structure it how I want
+add_subdirectory(z3)
+add_subdirectory(boolector)
+add_subdirectory(cvc4)
+add_subdirectory(mathsat)
+add_subdirectory(yices)
+add_subdirectory(bitwuzla)
 
-endif()
-
-if(EXISTS $ENV{HOME}/bitwuzla)
-    set(ENABLE_BITWUZLA ON)
-endif()
-
-if(ENABLE_BITWUZLA)
-  include(FindPkgConfig)
-  pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
-
-    message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")
-    message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
-    if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
-        message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
-    endif()
-
-    add_library(solverbitw bitwuzla_conv.cpp)
-    target_include_directories(solverbitw
-            PRIVATE ${Boost_INCLUDE_DIRS}
-            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    target_link_libraries(solverbitw fmt::fmt PkgConfig::Bitwuzla)
-
-    target_link_libraries(solvers INTERFACE solverbitw)
-
-    set(ESBMC_ENABLE_bitwuzla 1 PARENT_SCOPE)
-    set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS} bitwuzla" PARENT_SCOPE)
-endif()
+set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS}" PARENT_SCOPE)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/solver_config.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/solver_config.h")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
             NAME bitwuzla
             DOWNLOAD_ONLY YES
             GITHUB_REPOSITORY bitwuzla/bitwuzla
-            GIT_TAG smtcomp-2021)
+            GIT_TAG 0.1.1)
 
         message("[bitwuzla] Setting up lingeling")
         execute_process(COMMAND "./contrib/setup-lingeling.sh"

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 if(ENABLE_BITWUZLA)
   include(FindPkgConfig)
-  set(ENV{PKG_CONFIG_PATH} "${Bitwuzla_DIR}/lib/pkgconfig")
+  # export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/home/lucas/ESBMC_Project/bitwuzla/bitwuzla-release/lib/x86_64-linux-gnu/pkgconfig/
   pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -42,8 +42,9 @@ if(EXISTS $ENV{HOME}/bitwuzla)
 endif()
 
 if(ENABLE_BITWUZLA)
-    include(FindPkgConfig)
-    pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
+  include(FindPkgConfig)
+  set(ENV{PKG_CONFIG_PATH} "${Bitwuzla_DIR}/lib/pkgconfig")
+  pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")
     message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -24,8 +24,6 @@ else()
 	  COMMAND_ECHO STDOUT)
 
         set(Bitwuzla_DIR ${bitwuzla_BINARY_DIR})
-	# We need to tell cmake where to look for the .pc file exported by bitwuzla
-	set(CMAKE_PREFIX_PATH "${bitwuzla_BINARY_DIR}")
     endif()
 
 endif()
@@ -35,8 +33,18 @@ if(EXISTS $ENV{HOME}/bitwuzla)
 endif()
 
 if(ENABLE_BITWUZLA)
+  
+  if(Bitwuzla_DIR)
+    # We need to tell cmake where to look for the .pc file exported by bitwuzla
+    list(APPEND CMAKE_PREFIX_PATH "${Bitwuzla_DIR}")
+  endif()
+
   include(FindPkgConfig)
   pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
+
+  if(NOT Bitwuzla_FOUND)
+    message(ERROR "Could not find Bitwuzla in '${Bitwuzla_DIR}'")
+  endif()
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")
     message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -11,28 +11,21 @@ else()
             DOWNLOAD_ONLY YES
             GITHUB_REPOSITORY bitwuzla/bitwuzla
             GIT_TAG 0.1.1)
+	  
+	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
+        message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")
+        execute_process(COMMAND python3 ./configure.py --prefix ${bitwuzla_BINARY_DIR}
+          WORKING_DIRECTORY "${bitwuzla_SOURCE_DIR}")
 
-        message("[bitwuzla] Setting up lingeling")
-        execute_process(COMMAND "./contrib/setup-lingeling.sh"
-            WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR})
-
-        message("[bitwuzla] Setting up btor2tools")
-        execute_process(COMMAND "./contrib/setup-btor2tools.sh"
-            WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR})
-
-        message("[bitwuzla] Setting up symfpu")
-        execute_process(COMMAND "./contrib/setup-symfpu.sh"
-            WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR})
-
-        message("[bitwuzla] Configuring build")
-        execute_process(COMMAND ${bitwuzla_SOURCE_DIR}/configure.sh --prefix ${bitwuzla_BINARY_DIR}
-            WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR})
-
+	
         message("[bitwuzla] Building...")
-        execute_process(COMMAND make -j4 install
-            WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR}/build)
+        execute_process(COMMAND meson install
+          WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR}/build
+	  COMMAND_ECHO STDOUT)
 
         set(Bitwuzla_DIR ${bitwuzla_BINARY_DIR})
+	# We need to tell cmake where to look for the .pc file exported by bitwuzla
+	set(CMAKE_PREFIX_PATH "${bitwuzla_BINARY_DIR}")
     endif()
 
 endif()
@@ -43,7 +36,6 @@ endif()
 
 if(ENABLE_BITWUZLA)
   include(FindPkgConfig)
-  # export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/home/lucas/ESBMC_Project/bitwuzla/bitwuzla-release/lib/x86_64-linux-gnu/pkgconfig/
   pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
 
     message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -42,10 +42,10 @@ if(EXISTS $ENV{HOME}/bitwuzla)
 endif()
 
 if(ENABLE_BITWUZLA)
-    find_package(Bitwuzla REQUIRED
-            HINTS ${Bitwuzla_DIR}/lib/cmake $ENV{HOME}/bitwuzla)
+    include(FindPkgConfig)
+    pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
 
-    message(STATUS "Found Bitwuzla at: ${Bitwuzla_DIR}")
+    message(STATUS "Found Bitwuzla at: ${Bitwuzla_PREFIX}")
     message(STATUS "Bitwuzla version: ${Bitwuzla_VERSION}")
     if(Bitwuzla_VERSION VERSION_LESS Bitwuzla_MIN_VERSION)
         message(FATAL_ERROR "Expected version ${Bitwuzla_MIN_VERSION} or greater")
@@ -55,7 +55,7 @@ if(ENABLE_BITWUZLA)
     target_include_directories(solverbitw
             PRIVATE ${Boost_INCLUDE_DIRS}
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    target_link_libraries(solverbitw fmt::fmt Bitwuzla::bitwuzla)
+    target_link_libraries(solverbitw fmt::fmt PkgConfig::Bitwuzla)
 
     target_link_libraries(solvers INTERFACE solverbitw)
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -525,7 +525,7 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   return new_ast(
     bitwuzla_mk_bv_value(
-      to_solver_smt_sort<BitwuzlaSort *>(s)->s,
+      to_solver_smt_sort<BitwuzlaSort>(s)->s,
       integer2binary(theint, s->get_data_width()).c_str(),
       2),
     s);

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -35,7 +35,7 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
 bitwuzla_convt::~bitwuzla_convt()
 {
   bitwuzla_delete(bitw);
-  delete bitw_options;
+  bitwuzla_options_delete(bitw_options);
   bitw = nullptr;
   bitw_options = nullptr;
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -29,9 +29,7 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
 
   bitwuzla_set_option(bitw_options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
-
-  if(options.get_bool_option("smt-during-symex"))
-    bitw = bitwuzla_new(bitw_options);
+  bitw = bitwuzla_new(bitw_options);
 }
 
 bitwuzla_convt::~bitwuzla_convt()
@@ -645,10 +643,10 @@ bool bitwuzla_convt::get_bool(smt_astt a)
   bool res;
   switch(*result)
   {
-  case '1':
+  case 'true':
     res = true;
     break;
-  case '0':
+  case 'false':
     res = false;
     break;
   default:

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -25,11 +25,13 @@ smt_convt *create_new_bitwuzla_solver(
 bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
   : smt_convt(ns, options), array_iface(true, true), fp_convt(this)
 {
-  bitw = bitwuzla_new();
-  bitwuzla_set_option(bitw, BITWUZLA_OPT_PRODUCE_MODELS, 1);
+  bitw_options = bitwuzla_options_new(); 
+
+  bitwuzla_set_option(bitw_options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
+  
   if(options.get_bool_option("smt-during-symex"))
-    bitwuzla_set_option(bitw, BITWUZLA_OPT_INCREMENTAL, 1);
+    bitw = bitwuzla_new(bitw_options);
 }
 
 bitwuzla_convt::~bitwuzla_convt()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -635,24 +635,23 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 bool bitwuzla_convt::get_bool(smt_astt a)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
+
   const char *result =
     bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
 
   assert(result != NULL && "Bitwuzla returned null bv value string");
 
   bool res;
-  switch(*result)
-  {
-  case 'true':
+  if(!strcmp(result, "true"))
     res = true;
-    break;
-  case 'false':
+  else if(!strcmp(result, "false"))
     res = false;
-    break;
-  default:
-    log_error("Can't get boolean value from Bitwuzla");
+  else
+  {
+    log_error("Can't get boolean value from Bitwuzla: {}", result);
     abort();
   }
+
   return res;
 }
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -672,7 +672,7 @@ expr2tc bitwuzla_convt::get_array_elem(
   const type2tc &subtype)
 {
   const bitw_smt_ast *za = to_solver_smt_ast<bitw_smt_ast>(array);
-  unsigned long array_bound = array->sort->get_domain_width();
+  size_t array_bound = array->sort->get_domain_width();
   const bitw_smt_ast *idx;
   if(int_encoding)
     idx = to_solver_smt_ast<bitw_smt_ast>(mk_smt_int(BigInt(index)));

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -671,7 +671,8 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 bool bitwuzla_convt::get_bool(smt_astt a)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  const char *result = bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
+  const char *result =
+    bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
 
   assert(result != NULL && "Bitwuzla returned null bv value string");
 
@@ -694,7 +695,8 @@ bool bitwuzla_convt::get_bool(smt_astt a)
 BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  const char *result = bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
+  const char *result =
+    bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
   BigInt val = binary2integer(result, is_signed);
   return val;
 }
@@ -714,7 +716,8 @@ expr2tc bitwuzla_convt::get_array_elem(
   if(size > 0)
     for(size_t i = 0; i < size; i++)
     {
-      const char *index_str = bitwuzla_term_to_string(bitwuzla_get_value(bitw, indicies[i]));
+      const char *index_str =
+        bitwuzla_term_to_string(bitwuzla_get_value(bitw, indicies[i]));
       auto idx = string2integer(index_str, 2);
       if(idx == index)
         return get_by_ast(subtype, new_ast(values[i], convert_sort(subtype)));

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -675,7 +675,7 @@ expr2tc bitwuzla_convt::get_array_elem(
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(array);
 
   size_t size;
-  BitwuzlaTerm **indicies, **values, *default_value;
+  BitwuzlaTerm *indicies, *values, *default_value;
   bitwuzla_get_array_value(
     bitw, ast->a, &indicies, &values, &size, &default_value);
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -29,7 +29,7 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
 
   bitwuzla_set_option(bitw_options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
-  
+
   if(options.get_bool_option("smt-during-symex"))
     bitw = bitwuzla_new(bitw_options);
 }
@@ -70,7 +70,7 @@ smt_convt::resultt bitwuzla_convt::dec_solve()
 const std::string bitwuzla_convt::solver_text()
 {
   std::string ss = "Bitwuzla ";
-  ss += bitwuzla_version(bitw);
+  ss += bitwuzla_version();
   return ss;
 }
 

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -707,7 +707,7 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
   bool is_signed =
     (is_signedbv_type(opers.side_1) || is_signedbv_type(opers.side_2));
 
-  BitwuzlaTerm *res;
+  BitwuzlaTerm res;
   if(is_add2t(overflow.operand))
   {
     if(is_signed)
@@ -769,8 +769,7 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
   return new_ast(
     bitwuzla_mk_const_array(
-      bitw,
-      to_solver_smt_sort<BitwuzlaSort *>(arrsort)->s,
+      to_solver_smt_sort<BitwuzlaSort>(arrsort)->s,
       to_solver_smt_ast<bitw_smt_ast>(init_val)->a),
     arrsort);
 }
@@ -782,7 +781,8 @@ void bitwuzla_convt::dump_smt()
 
 void bitw_smt_ast::dump() const
 {
-  bitwuzla_print_term(a, "smt2", messaget::state.out);
+  //@TODO: find a replacement
+  //bitwuzla_print_term(a, "smt2", messaget::state.out);
 }
 
 void bitwuzla_convt::print_model()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -811,22 +811,22 @@ smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 
 smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 {
-  auto domain_sort = to_solver_smt_sort<BitwuzlaSort *>(domain);
-  auto range_sort = to_solver_smt_sort<BitwuzlaSort *>(range);
+  auto domain_sort = to_solver_smt_sort<BitwuzlaSort>(domain);
+  auto range_sort = to_solver_smt_sort<BitwuzlaSort>(range);
 
-  auto t = bitwuzla_mk_array_sort(bitw, domain_sort->s, range_sort->s);
+  auto t = bitwuzla_mk_array_sort(domain_sort->s, range_sort->s);
   return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
-  return new solver_smt_sort<BitwuzlaSort *>(
+  return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_BVFP, bitwuzla_mk_bv_sort(ew + sw + 1), ew + sw + 1, sw + 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort *>(
+  return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(3), 3);
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -671,7 +671,7 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 bool bitwuzla_convt::get_bool(smt_astt a)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  const char *result = bitwuzla_get_bv_value(bitw, ast->a);
+  const char *result = bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
 
   assert(result != NULL && "Bitwuzla returned null bv value string");
 
@@ -694,7 +694,7 @@ bool bitwuzla_convt::get_bool(smt_astt a)
 BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  const char *result = bitwuzla_get_bv_value(bitw, ast->a);
+  const char *result = bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
   BigInt val = binary2integer(result, is_signed);
   return val;
 }
@@ -714,7 +714,7 @@ expr2tc bitwuzla_convt::get_array_elem(
   if(size > 0)
     for(size_t i = 0; i < size; i++)
     {
-      const char *index_str = bitwuzla_get_bv_value(bitw, indicies[i]);
+      const char *index_str = bitwuzla_term_to_string(bitwuzla_get_value(bitw, indicies[i]));
       auto idx = string2integer(index_str, 2);
       if(idx == index)
         return get_by_ast(subtype, new_ast(values[i], convert_sort(subtype)));
@@ -807,17 +807,18 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
 void bitwuzla_convt::dump_smt()
 {
-  bitwuzla_dump_formula(bitw, "smt2", messaget::state.out);
+  bitwuzla_print_formula(bitw, "smt2", messaget::state.out);
 }
 
 void bitw_smt_ast::dump() const
 {
-  bitwuzla_term_dump(a, "smt2", messaget::state.out);
+  bitwuzla_print_term(a, "smt2", messaget::state.out);
 }
 
 void bitwuzla_convt::print_model()
 {
-  bitwuzla_print_model(bitw, "smt2", messaget::state.out);
+  // TODO: requires more work! See porting manual!
+  //bitwuzla_print_model(bitw, "smt2", messaget::state.out);
 }
 
 smt_sortt bitwuzla_convt::mk_bool_sort()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -799,14 +799,14 @@ smt_sortt bitwuzla_convt::mk_bool_sort()
 
 smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BitwuzlaSort *>(
-    SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw, width), width);
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_BV, bitwuzla_mk_bv_sort(width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BitwuzlaSort *>(
-    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw, width), width);
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
@@ -815,18 +815,18 @@ smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
   auto range_sort = to_solver_smt_sort<BitwuzlaSort *>(range);
 
   auto t = bitwuzla_mk_array_sort(bitw, domain_sort->s, range_sort->s);
-  return new solver_smt_sort<BitwuzlaSort *>(
+  return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
   return new solver_smt_sort<BitwuzlaSort *>(
-    SMT_SORT_BVFP, bitwuzla_mk_bv_sort(bitw, ew + sw + 1), ew + sw + 1, sw + 1);
+    SMT_SORT_BVFP, bitwuzla_mk_bv_sort(ew + sw + 1), ew + sw + 1, sw + 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
   return new solver_smt_sort<BitwuzlaSort *>(
-    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw, 3), 3);
+    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(3), 3);
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -35,7 +35,9 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
 bitwuzla_convt::~bitwuzla_convt()
 {
   bitwuzla_delete(bitw);
+  delete bitw_options;
   bitw = nullptr;
+  bitw_options = nullptr;
 }
 
 void bitwuzla_convt::push_ctx()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -25,7 +25,7 @@ smt_convt *create_new_bitwuzla_solver(
 bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
   : smt_convt(ns, options), array_iface(true, true), fp_convt(this)
 {
-  bitw_options = bitwuzla_options_new(); 
+  bitw_options = bitwuzla_options_new();
 
   bitwuzla_set_option(bitw_options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
@@ -352,8 +352,7 @@ smt_astt bitwuzla_convt::mk_not(smt_astt a)
 {
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    bitwuzla_mk_term1(
-      BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+    bitwuzla_mk_term1(BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     boolean_sort);
 }
 
@@ -528,7 +527,7 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
     bitwuzla_mk_bv_value(
       to_solver_smt_sort<BitwuzlaSort *>(s)->s,
       integer2binary(theint, s->get_data_width()).c_str(),
-      BITWUZLA_BV_BASE_BIN),
+      2),
     s);
 }
 
@@ -564,8 +563,8 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_BVFP_RM:
   case SMT_SORT_BOOL:
   case SMT_SORT_ARRAY:
-    node = bitwuzla_mk_const(
-      to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
+    node =
+      bitwuzla_mk_const(to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   default:
@@ -585,8 +584,8 @@ bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
 {
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm b = bitwuzla_mk_term1_indexed2(
-    BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
+  BitwuzlaTerm b =
+    bitwuzla_mk_term1_indexed2(BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
 
@@ -594,8 +593,8 @@ smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
-    BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
+  BitwuzlaTerm b =
+    bitwuzla_mk_term1_indexed1(BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -603,8 +602,8 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
-    BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
+  BitwuzlaTerm b =
+    bitwuzla_mk_term1_indexed1(BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -712,45 +711,44 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
   {
     if(is_signed)
     {
-      res = bitwuzla_mk_term2(
-        BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
+      res =
+        bitwuzla_mk_term2(BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = bitwuzla_mk_term2(
-        BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
+      res =
+        bitwuzla_mk_term2(BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_sub2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = bitwuzla_mk_term2(
-        BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
+      res =
+        bitwuzla_mk_term2(BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = bitwuzla_mk_term2(
-        BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
+      res =
+        bitwuzla_mk_term2(BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_mul2t(overflow.operand))
   {
     if(is_signed)
     {
-      res = bitwuzla_mk_term2(
-        BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
+      res =
+        bitwuzla_mk_term2(BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res = bitwuzla_mk_term2(
-        BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
+      res =
+        bitwuzla_mk_term2(BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
-    res = bitwuzla_mk_term2(
-      BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
+    res = bitwuzla_mk_term2(BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -793,8 +793,8 @@ void bitwuzla_convt::print_model()
 
 smt_sortt bitwuzla_convt::mk_bool_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort *>(
-    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw), 1);
+  return new solver_smt_sort<BitwuzlaSort>(
+    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(), 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -85,7 +85,6 @@ smt_astt bitwuzla_convt::mk_bvadd(smt_astt a, smt_astt b)
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_ADD,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -99,7 +98,6 @@ smt_astt bitwuzla_convt::mk_bvsub(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SUB,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -113,7 +111,6 @@ smt_astt bitwuzla_convt::mk_bvmul(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_MUL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -127,7 +124,6 @@ smt_astt bitwuzla_convt::mk_bvsmod(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SREM,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -141,7 +137,6 @@ smt_astt bitwuzla_convt::mk_bvumod(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_UREM,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -155,7 +150,6 @@ smt_astt bitwuzla_convt::mk_bvsdiv(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SDIV,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -169,7 +163,6 @@ smt_astt bitwuzla_convt::mk_bvudiv(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_UDIV,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -183,7 +176,6 @@ smt_astt bitwuzla_convt::mk_bvshl(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SHL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -197,7 +189,6 @@ smt_astt bitwuzla_convt::mk_bvashr(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_ASHR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -211,7 +202,6 @@ smt_astt bitwuzla_convt::mk_bvlshr(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SHR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -223,7 +213,7 @@ smt_astt bitwuzla_convt::mk_bvneg(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw, BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
 }
 
@@ -232,7 +222,7 @@ smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw, BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
 }
 
@@ -243,7 +233,6 @@ smt_astt bitwuzla_convt::mk_bvnxor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_XNOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -257,7 +246,6 @@ smt_astt bitwuzla_convt::mk_bvnor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_NOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -271,7 +259,6 @@ smt_astt bitwuzla_convt::mk_bvnand(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_NAND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -285,7 +272,6 @@ smt_astt bitwuzla_convt::mk_bvxor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_XOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -299,7 +285,6 @@ smt_astt bitwuzla_convt::mk_bvor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_OR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -313,7 +298,6 @@ smt_astt bitwuzla_convt::mk_bvand(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_AND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -325,7 +309,6 @@ smt_astt bitwuzla_convt::mk_implies(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_IMPLIES,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -337,7 +320,6 @@ smt_astt bitwuzla_convt::mk_xor(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_XOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -349,7 +331,6 @@ smt_astt bitwuzla_convt::mk_or(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_OR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -361,7 +342,6 @@ smt_astt bitwuzla_convt::mk_and(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_AND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -373,7 +353,7 @@ smt_astt bitwuzla_convt::mk_not(smt_astt a)
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw, BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     boolean_sort);
 }
 
@@ -384,7 +364,6 @@ smt_astt bitwuzla_convt::mk_bvult(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_ULT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -398,7 +377,6 @@ smt_astt bitwuzla_convt::mk_bvslt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SLT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -412,7 +390,6 @@ smt_astt bitwuzla_convt::mk_bvugt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_UGT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -426,7 +403,6 @@ smt_astt bitwuzla_convt::mk_bvsgt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SGT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -440,7 +416,6 @@ smt_astt bitwuzla_convt::mk_bvule(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_ULE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -454,7 +429,6 @@ smt_astt bitwuzla_convt::mk_bvsle(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SLE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -468,7 +442,6 @@ smt_astt bitwuzla_convt::mk_bvuge(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_UGE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -482,7 +455,6 @@ smt_astt bitwuzla_convt::mk_bvsge(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_SGE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -494,7 +466,6 @@ smt_astt bitwuzla_convt::mk_eq(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_EQUAL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -506,7 +477,6 @@ smt_astt bitwuzla_convt::mk_neq(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_DISTINCT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -521,7 +491,6 @@ smt_astt bitwuzla_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
     a->sort->get_range_sort()->get_data_width() == c->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term3(
-      bitw,
       BITWUZLA_KIND_ARRAY_STORE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a,
@@ -535,7 +504,6 @@ smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
   assert(a->sort->get_domain_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_ARRAY_SELECT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -558,7 +526,6 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   return new_ast(
     bitwuzla_mk_bv_value(
-      bitw,
       to_solver_smt_sort<BitwuzlaSort *>(s)->s,
       integer2binary(theint, s->get_data_width()).c_str(),
       BITWUZLA_BV_BASE_BIN),
@@ -598,7 +565,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_BOOL:
   case SMT_SORT_ARRAY:
     node = bitwuzla_mk_const(
-      bitw, to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
+      to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
     break;
 
   default:
@@ -619,7 +586,7 @@ bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm *b = bitwuzla_mk_term1_indexed2(
-    bitw, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
+    BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
 
@@ -628,7 +595,7 @@ smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(
-    bitw, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
+    BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -637,7 +604,7 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(
-    bitw, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
+    BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -648,7 +615,6 @@ smt_astt bitwuzla_convt::mk_concat(smt_astt a, smt_astt b)
 
   return new_ast(
     bitwuzla_mk_term2(
-      bitw,
       BITWUZLA_KIND_BV_CONCAT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -662,7 +628,6 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 
   return new_ast(
     bitwuzla_mk_term3(
-      bitw,
       BITWUZLA_KIND_ITE,
       to_solver_smt_ast<bitw_smt_ast>(cond)->a,
       to_solver_smt_ast<bitw_smt_ast>(t)->a,
@@ -748,12 +713,12 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if(is_signed)
     {
       res = bitwuzla_mk_term2(
-        bitw, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
+        BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res = bitwuzla_mk_term2(
-        bitw, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
+        BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_sub2t(overflow.operand))
@@ -761,12 +726,12 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if(is_signed)
     {
       res = bitwuzla_mk_term2(
-        bitw, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
+        BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res = bitwuzla_mk_term2(
-        bitw, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
+        BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_mul2t(overflow.operand))
@@ -774,18 +739,18 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if(is_signed)
     {
       res = bitwuzla_mk_term2(
-        bitw, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
+        BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res = bitwuzla_mk_term2(
-        bitw, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
+        BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if(is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
     res = bitwuzla_mk_term2(
-      bitw, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
+      BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -554,7 +554,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   if(it != symtable.end())
     return it->second;
 
-  BitwuzlaTerm *node;
+  BitwuzlaTerm node;
 
   switch(s->id)
   {
@@ -565,7 +565,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_BOOL:
   case SMT_SORT_ARRAY:
     node = bitwuzla_mk_const(
-      to_solver_smt_sort<BitwuzlaSort *>(s)->s, name.c_str());
+      to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   default:
@@ -585,7 +585,7 @@ bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
 {
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed2(
+  BitwuzlaTerm b = bitwuzla_mk_term1_indexed2(
     BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
@@ -594,7 +594,7 @@ smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(
+  BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
     BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
@@ -603,7 +603,7 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm *b = bitwuzla_mk_term1_indexed1(
+  BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
     BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -534,7 +534,7 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 
 smt_astt bitwuzla_convt::mk_smt_bool(bool val)
 {
-  BitwuzlaTerm *node = (val) ? bitwuzla_mk_true(bitw) : bitwuzla_mk_false(bitw);
+  BitwuzlaTerm node = (val) ? bitwuzla_mk_true() : bitwuzla_mk_false();
   const smt_sort *sort = boolean_sort;
   return new_ast(node, sort);
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -11,10 +11,10 @@ extern "C"
 #include <bitwuzla/c/bitwuzla.h>
 }
 
-class bitw_smt_ast : public solver_smt_ast<BitwuzlaTerm *>
+class bitw_smt_ast : public solver_smt_ast<BitwuzlaTerm>
 {
 public:
-  using solver_smt_ast<BitwuzlaTerm *>::solver_smt_ast;
+  using solver_smt_ast<BitwuzlaTerm>::solver_smt_ast;
   ~bitw_smt_ast() override = default;
 
   void dump() const override;

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -8,7 +8,7 @@
 
 extern "C"
 {
-#include <bitwuzla/bitwuzla.h>
+#include <bitwuzla/c/bitwuzla.h>
 }
 
 class bitw_smt_ast : public solver_smt_ast<BitwuzlaTerm *>

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -106,6 +106,7 @@ public:
 
   // Members
   Bitwuzla *bitw;
+  BitwuzlaOptions *bitw_options;
 
   typedef std::unordered_map<std::string, smt_astt> symtable_type;
   symtable_type symtable;


### PR DESCRIPTION
Bitwuzla version 0.1.1 has just been released. It outperforms other solvers in some categories in SMT-COMP, as described in the CAV 2023 paper.

Release: https://github.com/bitwuzla/bitwuzla/releases/tag/0.1.1

Paper: https://link.springer.com/chapter/10.1007/978-3-031-37703-7_1