### PR TITLE
Wrapper now parses stderr

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -77,10 +77,9 @@ def run(cmd_line):
   p = subprocess.Popen(the_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   (stdout, stderr) = p.communicate()
 
-  print(stdout.decode())
   print(stderr.decode())
 
-  return stdout
+  return stderr
 
 def parse_result(the_output, prop):
 


### PR DESCRIPTION
PR #1284 made ESBMC log messages be handled through stderr by default. This was causing wrapper to not detect
our output correctly.