### PR TITLE
Propagation of Boolean Intervals

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -624,14 +624,16 @@ public:
     const interval_templatet<T> &lhs,
     const interval_templatet<T> &rhs)
   {
-    return less_than(rhs, lhs);
+    // a >= b <==> b <= a
+    return less_than_equal(rhs, lhs);
   }
 
   static interval_templatet<T> greater_than(
     const interval_templatet<T> &lhs,
     const interval_templatet<T> &rhs)
   {
-    return less_than_equal(rhs, lhs);
+    // a > b <==> b < a
+    return less_than(rhs, lhs);
   }
 
   /// This is just to check if a value has changed. This is not the same as an interval comparation!


### PR DESCRIPTION
This enables propagating boolean intervals that are always true (do not contain zero) or always false (only contains zero).

This way, a program such as:

```c
int main() {
  int a;
  __ESBMC_assume(a > 10 && a < 100);
  __ESBMC_assert(a > 0, "error"); 
}
```

Could be simplified to:

```c
int main() {
  int a;
  __ESBMC_assume(a > 10 && a < 100);
  __ESBMC_assert(1, "error"); 
}
```