### PR TITLE
[CUDA verification] Support for more TCS

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -159,6 +159,7 @@ else()
                     csmith
                     k-induction-parallel
                     cuda/benchmarks
+                    cuda/Supported_long_time
                     nonz3
                     ${REGRESSIONS_BITWUZLA}
                     ${REGRESSIONS_CVC}
@@ -171,7 +172,6 @@ else()
                     ${REGRESSIONS_JIMPLE}
                     extensions
                     cuda/COM_sanity_checks
-		    cuda/Supported_long_time
                     linux
                     ${REGRESSIONS_CHERI}
        )

--- a/regression/cuda/Supported_long_time/075_reduced_strength_blockwise/main.cu
+++ b/regression/cuda/Supported_long_time/075_reduced_strength_blockwise/main.cu
@@ -1,0 +1,51 @@
+//pass
+//--blockDim=256 --gridDim=2 -DWIDTH=2064 --no-inline
+#include <cuda_runtime_api.h>
+#include <stdio.h>
+
+#define GRIDDIM 1
+#define BLOCKDIM 2//256
+#define WIDTH 2//2048
+#define N WIDTH
+/*
+ * This kernel demonstrates a blockwise strength-reduction loop.
+ * Each block is given a disjoint partition (of length WIDTH) of A.
+ * Then each thread writes multiple elements in the partition.
+ * It is not necessarily the case that WIDTH%blockDim.x == 0
+ */
+
+__global__ void k(int *A) {
+
+  for (int i=threadIdx.x; i<WIDTH; i+=blockDim.x) {
+
+    A[blockIdx.x*WIDTH+i] = i;
+  }
+}
+
+int main (){
+	int *a;
+	int *dev_a;
+	int size = N*sizeof(int);
+
+	cudaMalloc((void**)&dev_a, size);
+
+	a = (int*)malloc(size);
+
+	for (int i = 0; i < N; i++)
+		a[i] = 0;
+
+	cudaMemcpy(dev_a,a,size,cudaMemcpyHostToDevice);
+
+	//k <<<GRIDDIM, BLOCKDIM>>>(dev_a);
+	ESBMC_verify_kernel(k,GRIDDIM,BLOCKDIM,dev_a);
+
+	cudaMemcpy(a,dev_a,size,cudaMemcpyDeviceToHost);
+
+	for (int i = 0; i < N; i++){
+		assert(a[i]== i);
+	}
+
+	free(a);
+	cudaFree(dev_a);
+	return 0;
+}

--- a/regression/cuda/Supported_long_time/075_reduced_strength_blockwise/test.desc
+++ b/regression/cuda/Supported_long_time/075_reduced_strength_blockwise/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--force-malloc-success --unwind 9 --state-hashing --context-bound 2
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/Supported_long_time/105_pass/main.cu
+++ b/regression/cuda/Supported_long_time/105_pass/main.cu
@@ -1,0 +1,73 @@
+//pass
+//--blockDim=1024 --gridDim=1
+#include <cuda_runtime_api.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#define N 4//1024
+
+//swap the strings
+__device__ void swap(char *in, char *out) {
+	char tmp[N];
+	tmp[threadIdx.x]= in[threadIdx.x];
+	__syncthreads();
+	in[threadIdx.x] = out[threadIdx.x];
+	__syncthreads();
+	out[threadIdx.x]= tmp[threadIdx.x];
+}
+
+__global__ void foo(char *A, char *B, char* c)
+{
+  char *choice1 = A;	//It Makes choice1 receives A
+  char *choice2 = B;	//It Makes choice2 receives B
+  swap(choice1, choice2);		//This function swaps choice1 and choice2
+	assert(strcmp(choice1,choice2) == 0);
+}
+
+int main() {
+
+	char *a;
+	char *b;
+	
+	char *dev_a;
+	char *dev_b;
+	char* dev_c;
+
+	int size = N*sizeof(char);
+
+	cudaMalloc((void**)&dev_a, size);
+	cudaMalloc((void**)&dev_b, size);
+	cudaMalloc((void**)&dev_c, sizeof(char));
+
+	a = (char*)malloc(size);
+	b = (char*)malloc(size);
+
+	strcpy(a, "123");
+	strcpy(b, "123");
+
+	assert(strcmp(a,b) == 0);
+
+	cudaMemcpy(dev_a,a,size, cudaMemcpyHostToDevice);
+	cudaMemcpy(dev_b,b,size, cudaMemcpyHostToDevice);
+
+	//foo<<<1,N>>>(dev_a, dev_b, dev_c);
+	ESBMC_verify_kernel_c(foo, 1, 2, dev_a, dev_b, dev_c);
+
+	char *d;
+	char *e;
+	d = (char*)malloc(size);
+	e = (char*)malloc(size);
+
+	cudaMemcpy(d,dev_a,size,cudaMemcpyDeviceToHost);
+	cudaMemcpy(e,dev_b,size,cudaMemcpyDeviceToHost);
+
+	free(a); free(b); free(d); free(e);
+
+	cudaFree(dev_a);
+	cudaFree(dev_b);
+	cudaFree(dev_c);
+
+	return 0;
+}

--- a/regression/cuda/Supported_long_time/105_pass/test.desc
+++ b/regression/cuda/Supported_long_time/105_pass/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--force-malloc-success --context-bound 2 --state-hashing --unwind 5
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/benchmarks/006_unhandled_varval/main.cu
+++ b/regression/cuda/benchmarks/006_unhandled_varval/main.cu
@@ -1,0 +1,57 @@
+//xfail:BUGLE_ERROR
+//--gridDim=1 --blockDim=32 --no-inline
+
+//This kernel is not-racy: memset is called with variable value.
+
+//#define memset(dst,val,len) __builtin_memset(dst,val,len)
+
+#define N 2//32
+
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+
+__device__ int bar(void){
+	int value;
+	return value;
+}
+
+__global__ void kernel(uint4 *out) {
+  uint4 vector;
+  int val = bar();
+   memset(&vector, val, 16);
+  out[threadIdx.x] = vector;
+}
+
+int main(){
+	uint4 *a;
+	uint4 *dev_a;
+	int size = N*sizeof(uint4);
+
+	a = (uint4*)malloc(size);
+
+	/* initialization of a */
+	for (int i = 0; i < N; i++) {
+		a[i].x = i; a[i].y = i; a[i].z = i, a[i].w = i;
+	}
+
+	cudaMalloc((void**)&dev_a, size);
+
+	cudaMemcpy(dev_a,a,size, cudaMemcpyHostToDevice);
+
+	//kernel<<<1,N>>>(dev_a);
+	ESBMC_verify_kernel_u(kernel,1,N,dev_a);
+
+	cudaMemcpy(a,dev_a,size,cudaMemcpyDeviceToHost);
+
+	printf("new a:\n");
+	for (int i = 0; i < N; i++) {
+		assert(a[i].x == 0);			
+		assert(a[i].y == 0);
+		assert(a[i].z == 0);			
+		assert(a[i].w == 0);
+    }
+
+	cudaFree(dev_a);
+	free(a);
+	return 0;
+}

--- a/regression/cuda/benchmarks/006_unhandled_varval/test.desc
+++ b/regression/cuda/benchmarks/006_unhandled_varval/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--unwind 33 --force-malloc-success --state-hashing --context-bound 2 
+
+^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/018_testbasicaliasing/main.cu
+++ b/regression/cuda/benchmarks/018_testbasicaliasing/main.cu
@@ -1,0 +1,52 @@
+//fail: data race
+#include <stdio.h>
+#include <stdlib.h>
+#include "cuda_runtime_api.h"
+#include <assert.h>
+
+#define N 2//64
+
+__global__ void foo (int* p, int* q){
+
+    p[2] = q[2] + 1;
+
+}
+
+int main() {
+	int *a;
+	int *dev_a;
+	int *b;
+	int *dev_b;
+
+	a = (int*)malloc(N*sizeof(int));
+	b = (int*)malloc(N*sizeof(int));
+
+	for (int i=0; i<N; i++){
+		a[i]=i;
+		b[i]=2*i;
+	}
+
+	cudaMalloc((void**)&dev_a, N*sizeof(int));
+	cudaMalloc((void**)&dev_b, N*sizeof(int));
+
+	cudaMemcpy(dev_a, a, N*sizeof(int), cudaMemcpyHostToDevice);
+	cudaMemcpy(dev_b, b, N*sizeof(int), cudaMemcpyHostToDevice);
+
+	//foo<<<N, N>>>(dev_a, dev_b);
+	ESBMC_verify_kernel(foo, 1, N, dev_a, dev_b);
+
+	cudaMemcpy(a, dev_a, N*sizeof(int), cudaMemcpyDeviceToHost);
+	cudaMemcpy(b, dev_b, N*sizeof(int), cudaMemcpyDeviceToHost);
+
+	for (int i=0; i<N; i++){
+		printf ("a[%d]= %d; b[%d]=%d;\n", i, a[i], i, b[i]);
+	}
+
+	assert(a[2]==(b[2]+1));
+
+	free(a); free(b);
+	cudaFree(dev_a);
+	cudaFree(dev_b);
+
+	return 0;
+}

--- a/regression/cuda/benchmarks/018_testbasicaliasing/test.desc
+++ b/regression/cuda/benchmarks/018_testbasicaliasing/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--unwind 9 --force-malloc-success --state-hashing --context-bound 3 --data-races-check --no-bounds-check
+
+^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/041_test_copy_between_memory_spaces/main.cu
+++ b/regression/cuda/benchmarks/041_test_copy_between_memory_spaces/main.cu
@@ -1,0 +1,47 @@
+//--blockDim=64 --gridDim=1 --equality-abstraction --no-inline
+#include "cuda_runtime_api.h"
+#include <stdio.h>
+#include <assert.h>
+#define N 2
+
+__global__ void foo(int* p) {
+
+	__shared__  int A[10];
+
+	A[0] = 1;
+
+	p[0] = A[0];
+
+}
+
+int main(){
+
+	int *b;
+	int *dev_b;
+
+	b = (int*)malloc(N*sizeof(int));
+
+	for (int i = 0; i < N; ++i){
+		b[i] = i+1;
+		printf(" %d; ", b[i]);
+	}
+	printf("\n");
+
+	cudaMalloc((void**)&dev_b, N*sizeof(int));
+
+	cudaMemcpy(dev_b, b, N*sizeof(int), cudaMemcpyHostToDevice);
+
+    // foo<<<1,N>>>(dev_b);
+	ESBMC_verify_kernel(foo,1,N,dev_b);
+
+	cudaMemcpy(b, dev_b, N*sizeof(int), cudaMemcpyDeviceToHost);
+
+	for (int i = 0; i < N; ++i){
+		printf(" %d; ", b[i]);
+		assert(b[0]==1);
+	}
+
+	free(b);
+	cudaFree(dev_b);
+
+}

--- a/regression/cuda/benchmarks/041_test_copy_between_memory_spaces/test.desc
+++ b/regression/cuda/benchmarks/041_test_copy_between_memory_spaces/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--unwind 9 --force-malloc-success --state-hashing --context-bound 3 --data-races-check
+
+^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/042_test_copy_between_pointers/main.cu
+++ b/regression/cuda/benchmarks/042_test_copy_between_pointers/main.cu
@@ -1,0 +1,57 @@
+//--blockDim=64 --gridDim=64 --equality-abstraction --no-inline
+
+#include "cuda_runtime_api.h"
+#include <stdio.h>
+#include <assert.h>
+
+#define N 2
+
+__global__ void foo(int* p) {
+
+  __shared__ int A[10];
+
+  int* x;
+
+  x = p;
+
+  	assert(*p <2);
+
+  x[0] = 0;
+	
+  x = A;
+
+  x[0] = 0;
+
+}
+
+int main(){
+	int *b;
+	int *dev_b;
+
+	b = (int*)malloc(N*sizeof(int));
+
+	for (int i = 0; i < N; ++i){
+		b[i] = i+1;
+		printf("%d; ", b[i]);
+	}
+
+	printf("\n");
+
+	cudaMalloc((void**)&dev_b, N*sizeof(int));
+
+	cudaMemcpy(dev_b, b, N*sizeof(int), cudaMemcpyHostToDevice);
+
+	//foo<<<1,N>>>(dev_b);
+	ESBMC_verify_kernel(foo,1,N,dev_b);
+
+	cudaMemcpy(b, dev_b, N*sizeof(int), cudaMemcpyDeviceToHost);
+
+	for (int i = 0; i < N; ++i){
+		printf("%d; ", b[i]);
+	}
+
+	assert(b[0]==0);
+
+	free(b);
+	cudaFree(dev_b);
+}

--- a/regression/cuda/benchmarks/042_test_copy_between_pointers/test.desc
+++ b/regression/cuda/benchmarks/042_test_copy_between_pointers/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--context-bound 3 --force-malloc-success --state-hashing --unwind 9 --data-races-check
+
+^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/093_bronken_shuffle/main.cu
+++ b/regression/cuda/benchmarks/093_bronken_shuffle/main.cu
@@ -1,0 +1,52 @@
+//xfail:BOOGIE_ERROR
+//--blockDim=1024 --gridDim=1 --warp-sync=16 --no-inline
+//It should show only the values from B[0] to B[31], but it exceeds.
+
+#include <cuda_runtime_api.h>
+#include <stdio.h>
+
+#define N 2//32//1024
+
+__global__ void shuffle (int* A)
+{
+	int tid = threadIdx.x;
+	int warp = tid / 32;
+	int* B = A + (warp*32);
+	A[tid] = B[(tid + 1)%32];
+}
+
+int main() {
+	int *a;
+	int *dev_a;
+	int size = N*sizeof(int);
+
+	cudaMalloc((void**)&dev_a, size);
+
+	a = (int*)malloc(N*size);
+
+	for (int i = 0; i < N; i++)
+		a[i] = i;
+
+	cudaMemcpy(dev_a,a,size, cudaMemcpyHostToDevice);
+
+	printf("a:  ");
+
+	for (int i = 0; i < N; i++)
+		printf("%d        ", a[i]);
+
+    // shuffle<<<1,N>>>(dev_a);
+	ESBMC_verify_kernel(shuffle, 1, N, dev_a);
+
+	cudaMemcpy(a,dev_a,size,cudaMemcpyDeviceToHost);
+
+	printf("\nFunction Results:\n   ");
+
+	for (int i = 0; i < N; i++)
+		printf("%d        ", a[i]);
+
+	free(a);
+
+	cudaFree(dev_a);
+
+	return 0;
+}

--- a/regression/cuda/benchmarks/093_bronken_shuffle/test.desc
+++ b/regression/cuda/benchmarks/093_bronken_shuffle/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cu
+--unwind 9 --force-malloc-success --state-hashing --context-bound 2 --data-races-check --no-bounds-check
+
+^VERIFICATION FAILED$
+

--- a/regression/cuda/benchmarks/099_test8/main.cu
+++ b/regression/cuda/benchmarks/099_test8/main.cu
@@ -1,0 +1,43 @@
+// data-racer
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include <assert.h>
+
+#define N 2
+
+__global__ void foo(int	*p, int *ptr_a) {
+
+	ptr_a = p + threadIdx.x;
+
+}
+
+int main() {
+	int *c;
+	int *dev_c;
+	int *a;
+	int *dev_a;
+
+
+	c = (int*)malloc(N*sizeof(int));
+	a = (int*)malloc(N*sizeof(int));
+
+	for (int i = 0; i < N; ++i)
+		c[i] = 2;
+
+	cudaMalloc((void**)&dev_c, N*sizeof(int));
+	cudaMalloc((void**)&dev_a, N*sizeof(int));
+
+	cudaMemcpy(dev_c, c, N*sizeof(int), cudaMemcpyHostToDevice);
+
+    //foo<<<1, N>>>(dev_c, dev_a);
+	ESBMC_verify_kernel(foo,1,N,dev_c, dev_a);
+
+	cudaMemcpy(a, dev_a, N*sizeof(int), cudaMemcpyDeviceToHost);
+
+	free(a);
+	free(c);
+	cudaFree(dev_a);
+	cudaFree(dev_c);
+
+	return 0;
+}

--- a/regression/cuda/benchmarks/099_test8/test.desc
+++ b/regression/cuda/benchmarks/099_test8/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cu
+--context-bound 3 --force-malloc-success --state-hashing --unwind 9 --data-races-check
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/00_race15/test.desc
+++ b/regression/esbmc-unix/00_race15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --data-races-check
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -36,7 +36,7 @@ void rw_sett::read_write_rec(
     const symbolt *symbol = ns.lookup(symbol_expr.get_identifier());
     if(symbol)
     {
-      if(!symbol->static_lifetime /*&& expr.type().id()=="pointer"*/)
+      if(!symbol->static_lifetime && !expr.type().is_pointer())
       {
         return; // ignore for now
       }
@@ -50,7 +50,11 @@ void rw_sett::read_write_rec(
         return; // ignore for now
       }
 
-      // TODO improvements for CUDA features
+      // Improvements for CUDA features
+      if(symbol->name == "indexOfThread" || symbol->name == "indexOfBlock")
+      {
+        return; // ignore for now
+      }
     }
 
     irep_idt object = id2string(symbol_expr.get_identifier()) + suffix;


### PR DESCRIPTION
1. Data races checks for Pointers are enabled.

2. Correct the verification result of [00_race15](https://github.com/esbmc/esbmc/tree/master/regression/esbmc-unix/00_race15).

3. More supported CUDA TCs are enabled.

So far, the varification accuracy of CUDA is 130/154 = 84.4%