### PR TITLE
Interval Analysis assumptions now only uses local symbols

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -92,8 +92,6 @@ void instrument_intervals(
   const ait<interval_domaint> &interval_analysis,
   goto_functiont &goto_function)
 {
-  std::unordered_set<expr2tc, irep2_hash> symbols;
-
   // Inline optimizations
   Forall_goto_program_instructions(i_it, goto_function.body)
   {
@@ -103,115 +101,40 @@ void instrument_intervals(
     optimize_expression(i_it->code, d);
     optimize_expression(i_it->guard, d);
 
-    get_symbols(i_it->code, symbols);
-    get_symbols(i_it->guard, symbols);
+    // TODO: Move Guard Simplification to here
   }
 
   // Instrumentation of assumptions
   Forall_goto_program_instructions(i_it, goto_function.body)
   {
-    if(i_it == goto_function.body.instructions.begin())
-    {
-      // first instruction, we instrument
-    }
-    else
-    {
-      if(i_it->is_assume() || i_it->is_assert() || i_it->is_goto())
-      {
-        // We may be able to simplify here
-        const interval_domaint &d = interval_analysis[i_it];
+    if(!(i_it->is_goto() || i_it->is_assume() || i_it->is_assert()))
+      continue;
 
-        // Evaluate the simplified expression
-        tvt guard = interval_domaint::eval_boolean_expression(i_it->guard, d);
-        if(i_it->is_goto())
-          guard = !guard;
-        // If guard is always true... convert it into a skip!
-        if(guard.is_true() && interval_domaint::enable_assertion_simplification)
-          i_it->make_skip();
-        // If guard is always false... convert it to trivial!
-        if(
-          guard.is_false() && interval_domaint::enable_assertion_simplification)
-          i_it->guard = i_it->is_goto() ? gen_true_expr() : gen_false_expr();
+    // Let's instrument everything that affect the current instruction
+    std::unordered_set<expr2tc, irep2_hash> symbols;
+    get_symbols(i_it->code, symbols);
+    get_symbols(i_it->guard, symbols);
 
-        // Let's instrument an assumption with symbols that affect the guard
-        std::vector<expr2tc> assumption;
-        std::unordered_set<expr2tc, irep2_hash> guard_symbols;
-        get_symbols(i_it->guard, guard_symbols);
-        for(const auto &symbol_expr : guard_symbols)
-        {
-          expr2tc tmp = d.make_expression(symbol_expr);
-          if(!is_true(tmp))
-            assumption.push_back(tmp);
-        }
-
-        if(!assumption.empty())
-        {
-          goto_programt::targett t = goto_function.body.insert(i_it);
-          t->make_assumption(conjunction(assumption));
-          t->inductive_step_instruction = config.options.is_kind();
-        }
-
-        continue;
-      }
-
-      /**
-       * The instrumentation of the assume will happen in:
-       *
-       * 1. After IF (and)
-       *  IF !(a > 42) GOTO 5
-       *    +++ ASSUME (a > 42)
-       *
-       * 2. After a function call
-       *  FUCTION_CALL(FOO)
-       *    +++ ASSUME(state-after-foo)
-       *
-       * 3. Before a function call
-       *  +++ ASSUME(state-before-foo)
-       *  FUCNTION_CALL(FOO)
-       *
-       * 4. Before a target
-       *  +++ ASSUME(current-state)
-       *  1: ....
-      */
-      goto_programt::const_targett previous = i_it;
-      previous--;
-      if(previous->is_goto() && !is_true(previous->guard))
-      {
-        // we follow a branch, instrument
-      }
-      else if(previous->is_function_call() && !is_true(previous->guard))
-      {
-        // we follow a function call, instrument
-      }
-      else if(i_it->is_target() || i_it->is_function_call())
-      {
-        // we are a target or a function call, instrument
-      }
-      else
-        continue; // don't instrument
-    }
+    if(!symbols.size())
+      continue;
 
     const interval_domaint &d = interval_analysis[i_it];
-    std::vector<expr2tc> assertion;
+    std::vector<expr2tc> symbol_constraints;
     for(const auto &symbol_expr : symbols)
     {
       expr2tc tmp = d.make_expression(symbol_expr);
       if(!is_true(tmp))
-        assertion.push_back(tmp);
+        symbol_constraints.push_back(tmp);
     }
 
-    if(!assertion.empty())
+    if(!symbol_constraints.empty())
     {
-      goto_programt::targett t = goto_function.body.insert(i_it);
-      t->make_assumption(conjunction(assertion));
-      t->inductive_step_instruction = config.options.is_kind();
-#if 0
-      // TODO: This is crashing cases like
-      // email_spec11_productSimulator_false-unreach-call_true-termination.cil.c
-      i_it++; // goes to original instruction
-      t->location = i_it->location;
-      t->function = i_it->function;
-#endif
+      goto_programt::instructiont instruction;
+      instruction.make_assumption(conjunction(symbol_constraints));
+      instruction.inductive_step_instruction = config.options.is_kind();
+      instruction.location = i_it->location;
+      instruction.function = i_it->function;
+      goto_function.body.insert_swap(i_it++, instruction);
     }
   }
 }


### PR DESCRIPTION
Previously, the Interval Analysis assumptions contained all the symbols in the function. These assumptions were added using some heuristic. This PR:

1. Fixes an issue that assumptions were not instrumented correctly for loops. `1: IF X GOTO Y` used to be instrumented as `ASSUME state; 1:IF X GOTO Y;` while the correct instrumentation is `1: ASSUME state; IF X GOTO Y;` . This was making the invariant useless for the k-induction algorithm.
2. Now the assumption is only added before IFs, Asserts, and Assumes. The main difference is that previosly we also instrumented before/after function calls and after an IF.