### PR TITLE
Keep benchmark definition file inside esbmc repo

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -17,7 +17,7 @@ on:
       svbenchmarks:
         description: 'Git branch, tag, or commit of SV-Benchmarks to use'
         required: true
-        default: 'svcomp23'      	
+        default: 'svcomp23-rc.1'      	
       mode:
         type: choice
         description: Benchecex run mode

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -100,7 +100,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all && git checkout ${{ inputs.svbenchmarks }}
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }}
       - name: Download Linux Build
         uses: actions/download-artifact@v1
         with:

--- a/scripts/benchexec.sh
+++ b/scripts/benchexec.sh
@@ -7,6 +7,7 @@ BENCHEXEC_COMMON_FLAGS="-o ../esbmc-output/ -N 9 ./esbmc.xml --read-only-dir / -
 setup_folder () {
     echo "Setting up machine folder..."
     cp esbmc-src/scripts/competitions/svcomp/esbmc-wrapper.py $HOME/esbmc-wrapper.py
+    cp esbmc-src/scripts/competitions/svcomp/esbmc.xml $HOME/esbmc.xml
     rm -rf $HOME/output-action $HOME/esbmc-output esbmc-src $HOME/run-output.zip
     mkdir $HOME/output-action
     cp ./bin/esbmc $HOME/output-action

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.18//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.18.dtd">
+<benchmark tool="esbmc" displayName="ESBMC-bkind" timelimit="15 min" memlimit="6 GB" cpuCores="2">
+
+  <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
+
+  <resultfiles>**/test-suite</resultfiles>
+
+  <option name="-s">kinduction</option>
+
+  <rundefinition name="Test-Comp23_coverage-error-call">
+    <propertyfile>$HOME/sv-benchmarks/c/properties/coverage-error-call.prp</propertyfile>
+  </rundefinition>
+
+  <tasks name="ReachSafety-Arrays">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-BitVectors">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-ControlFlow">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-ECA">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
+    <excludesfile>excludes/ReachSafety-ECA-excludes.set</excludesfile>
+  </tasks>
+  <tasks name="ReachSafety-Floats">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-Heap">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-Loops">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-ProductLines">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-Sequentialized">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-XCSP">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-XCSP.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-Combinations">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Combinations.set</includesfile>
+  </tasks>
+  <tasks name="ReachSafety-Hardware">
+    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Hardware.set</includesfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
+    <excludesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</excludesfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-SQLite-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-SQLite-MemSafety.set</includesfile>
+  </tasks>
+
+  <tasks name="Termination-MainHeap">
+    <includesfile>$HOME/sv-benchmarks/c/Termination-MainHeap.set</includesfile>
+  </tasks>
+
+</benchmark>

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-2.3.dtd">
-<benchmark tool="esbmc" timelimit="15 min" memlimit="15 GB" cpuCores="8">
+<benchmark tool="esbmc" timelimit="15 min" memlimit="6 GB" cpuCores="2">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
 

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -1,73 +1,208 @@
 <?xml version="1.0"?>
-<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.18//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.18.dtd">
-<benchmark tool="esbmc" displayName="ESBMC-bkind" timelimit="15 min" memlimit="6 GB" cpuCores="2">
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-2.3.dtd">
+<benchmark tool="esbmc" timelimit="15 min" memlimit="15 GB" cpuCores="8">
 
-  <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
 
-  <resultfiles>**/test-suite</resultfiles>
-
+  <resultfiles>**/*.graphml</resultfiles>
+  
   <option name="-s">kinduction</option>
 
-  <rundefinition name="Test-Comp23_coverage-error-call">
-    <propertyfile>$HOME/sv-benchmarks/c/properties/coverage-error-call.prp</propertyfile>
-  </rundefinition>
-
+<rundefinition name="SV-COMP23_unreach-call">
   <tasks name="ReachSafety-Arrays">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ECA">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
-    <excludesfile>excludes/ReachSafety-ECA-excludes.set</excludesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Floats">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Heap">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Loops">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Recursive">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-XCSP">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-XCSP.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Combinations">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Combinations.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Hardware">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Hardware.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+
+  <tasks name="ConcurrencySafety-Main">
+    <includesfile>$HOME/sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-AWS-C-Common-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-AWS-C-Common-ReachSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-BusyBox-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-ReachSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-coreutils-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils-ReachSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
+    <excludesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</excludesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-DeviceDriversLinux64Large-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-uthash-ReachSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash-ReachSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="SV-COMP23_no-data-race">
+  <tasks name="NoDataRace-Main">
+    <includesfile>$HOME/sv-benchmarks/c/NoDataRace-Main.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="SV-COMP23_valid-memcleanup">
+  <tasks name="MemSafety-MemCleanup">
+    <includesfile>$HOME/sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="SV-COMP23_valid-memsafety">
+  <tasks name="MemSafety-Arrays">
+    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Heap">
+    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Heap.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-LinkedLists">
+    <includesfile>$HOME/sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Other">
+    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Other.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-Juliet">
+    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Juliet.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-MemSafety">
     <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-coreutils-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils-MemSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-DeviceDriversLinux64-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-MemSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-OpenBSD-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-OpenBSD-MemSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-uthash-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash-MemSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
 
-  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
-    <excludesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</excludesfile>
+  <tasks name="ConcurrencySafety-MemSafety">
+    <includesfile>$HOME/sv-benchmarks/c/ConcurrencySafety-MemSafety.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="SV-COMP23_no-overflow">
+  <tasks name="NoOverflows-Main">
+    <includesfile>$HOME/sv-benchmarks/c/NoOverflows-Main.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+  <tasks name="NoOverflows-Juliet">
+    <includesfile>$HOME/sv-benchmarks/c/NoOverflows-Juliet.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
   </tasks>
 
-  <tasks name="SoftwareSystems-SQLite-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-SQLite-MemSafety.set</includesfile>
+  <tasks name="SoftwareSystems-BusyBox-NoOverflows">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-coreutils-NoOverflows">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils-NoOverflows.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-uthash-NoOverflows">
+    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash-NoOverflows.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
   </tasks>
 
+  <tasks name="ConcurrencySafety-NoOverflows">
+    <includesfile>$HOME/sv-benchmarks/c/ConcurrencySafety-NoOverflows.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="SV-COMP23_termination">
+  <tasks name="Termination-BitVectors">
+    <includesfile>$HOME/sv-benchmarks/c/Termination-BitVectors.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
+  <tasks name="Termination-MainControlFlow">
+    <includesfile>$HOME/sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
   <tasks name="Termination-MainHeap">
     <includesfile>$HOME/sv-benchmarks/c/Termination-MainHeap.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
   </tasks>
+  <tasks name="Termination-Other">
+    <includesfile>$HOME/sv-benchmarks/c/Termination-Other.set</includesfile>
+    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+  </tasks>
+</rundefinition>
 
 </benchmark>


### PR DESCRIPTION
I mistakenly pushed some patches into ESBMC master that adds a field to set the git commit/tag of sv-benchmarks to be executed. However, the benchmark definition file might change based on the version of the benchmarks. Here I am adding the default one that we used during the competition.