### PR TITLE
Interval expression generation for floats

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -633,12 +633,18 @@ expr2tc interval_domaint::make_expression_value<real_intervalt>(
   const type2tc &type,
   bool upper) const
 {
-  expr2tc value = constant_floatbv2tc(ieee_floatt(ieee_float_spect(
-    to_floatbv_type(type).fraction, to_floatbv_type(type).exponent)));
+  expr2tc value = gen_zero(type);
   constant_floatbv2t &v = to_constant_floatbv2t(value);
 
   const auto d = (upper ? interval.upper : interval.lower).convert_to<double>();
   v.value.from_double(d);
+
+  // 'from_double' changes the original spec. This makes solvers complain that we are comparing
+  // 'orange' floats to 'apple' floats. To fix this, we need to convert the spec back.
+  const ieee_float_spect original_spec(
+    to_floatbv_type(type).fraction, to_floatbv_type(type).exponent);
+  v.value.change_spec(original_spec);
+
   assert(!v.value.is_NaN() && !v.value.is_infinity());
   if(upper)
     v.value.increment(true);


### PR DESCRIPTION
When generating floats from doubles, the float spec is changed. This causes esbmc to crash later due to solver encondings. 
Now the float is converted back to the previous spec.