### PR TITLE
Support for symbol expressions during interval analysis

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -71,10 +71,15 @@ void interval_domaint::apply_assume_symbol_truth(
     interval.set_lower(0);
   }
   // [1, infinity]
-  else if(
-    sym.type->type_id == type2t::unsignedbv_id ||
-    sym.type->type_id == type2t::bool_id)
+  else if(is_unsignedbv_type(sym.type) || is_bool_type(sym.type))
     interval.make_ge_than(1);
+  else if(is_signedbv_type(sym.type))
+  {
+    if(interval.lower_set && interval.get_lower() == 0)
+      interval.make_ge_than(1);
+    else if(interval.upper_set && interval.get_upper() == 0)
+      interval.make_le_than(-1);
+  }
 
   update_symbol_interval(sym, interval);
 }

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -76,8 +76,6 @@ void interval_domaint::apply_assume_symbol_truth(
     sym.type->type_id == type2t::bool_id)
     interval.make_ge_than(1);
 
-  sym.dump();
-  interval.dump();
   update_symbol_interval(sym, interval);
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -178,8 +178,6 @@ public:
    */
   void assume(const expr2tc &);
 
-  void assume_symbol_is_true(const expr2tc &);
-
   /**
    * @brief Uses the abstract state to simplify a given expression using context-
    * specific information.

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -178,6 +178,8 @@ public:
    */
   void assume(const expr2tc &);
 
+  void assume_symbol_is_true(const expr2tc &);
+
   /**
    * @brief Uses the abstract state to simplify a given expression using context-
    * specific information.
@@ -300,6 +302,16 @@ protected:
    */
   template <class Interval>
   void apply_assume_less(const expr2tc &lhs, const expr2tc &rhs);
+
+  /**
+   * @brief Applies symbol = truth
+   *
+   * @tparam Interval interval template specialization (Integers, Reals)
+   * @param symbol
+   * @param negation
+   */
+  template <class Interval>
+  void apply_assume_symbol_truth(const symbol2t &sym, bool is_false);
 
   /**
    * @brief Generates interval with [min, max] using symbol type


### PR DESCRIPTION
During interval analysis, the process only works by *trying* to generate an CNF of less than equal operations. This means that something like `a && b < 0` would add a restriction over `b` but not over `a`. This PR adds supports for this. Closes #1325