### PR TITLE
Changed default sv-benchmarks tag to svcomp23

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -17,7 +17,7 @@ on:
       svbenchmarks:
         description: 'Git branch, tag, or commit of SV-Benchmarks to use'
         required: true
-        default: 'svcomp23-rc.1'      	
+        default: 'svcomp23'      	
       mode:
         type: choice
         description: Benchecex run mode

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -75,10 +75,6 @@
     <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-ReachSafety.set</includesfile>
     <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
-  <tasks name="SoftwareSystems-coreutils-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils-ReachSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
     <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <excludesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</excludesfile>

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -130,10 +130,6 @@
     <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
     <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
-  <tasks name="SoftwareSystems-coreutils-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils-MemSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
   <tasks name="SoftwareSystems-DeviceDriversLinux64-MemSafety">
     <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-MemSafety.set</includesfile>
     <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
@@ -165,10 +161,6 @@
 
   <tasks name="SoftwareSystems-BusyBox-NoOverflows">
     <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-coreutils-NoOverflows">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils-NoOverflows.set</includesfile>
     <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
   </tasks>
   <tasks name="SoftwareSystems-uthash-NoOverflows">


### PR DESCRIPTION
As disscussed at https://github.com/esbmc/esbmc/issues/1315#issuecomment-1715272865

I also started a full 5s run just to double check.