### PR TITLE
phi_function: avoid copying the current l2 names

### DIFF
--- a/src/goto-symex/renaming.h
+++ b/src/goto-symex/renaming.h
@@ -256,14 +256,6 @@ public:
     }
   };
 
-  void get_variables(std::set<name_record> &vars) const
-  {
-    for(const auto &current_name : current_names)
-    {
-      vars.insert(current_name.first);
-    }
-  }
-
   unsigned current_number(const expr2tc &sym) const;
   unsigned current_number(const name_record &rec) const;
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -314,11 +314,9 @@ void goto_symext::phi_function(const statet::goto_statet &goto_state)
     return;
 
   // go over all variables to see what changed
-  std::set<renaming::level2t::name_record> variables;
-  cur_state->level2.get_variables(variables);
+  const auto &variables = cur_state->level2.current_names;
 
-  std::set<renaming::level2t::name_record> goto_variables;
-  goto_state.level2.get_variables(goto_variables);
+  const auto &goto_variables = goto_state.level2.current_names;
 
   guardt tmp_guard;
   if(
@@ -331,7 +329,7 @@ void goto_symext::phi_function(const statet::goto_statet &goto_state)
     tmp_guard -= cur_state->guard;
   }
 
-  for(const auto &variable : variables)
+  for(const auto &[variable, _] : variables)
   {
     if(
       goto_state.level2.current_number(variable) ==


### PR DESCRIPTION
While this patch doesn't address struct members specifically, it brings down symex time for the two examples in #1344 from

1. Symex completed in: 23.550s (44311 assignments)
2. Symex completed in: 2.005s (24311 assignments)

to

1. Symex completed in: 6.422s (44311 assignments)
2. Symex completed in: 0.871s (24311 assignments)

on my machine for a release build.

*Edit:* Corrected order of examples.