### PR TITLE
migrate: do not strip typecasts from array sizes

### DIFF
--- a/regression/esbmc/github_1352/gh-1352.c
+++ b/regression/esbmc/github_1352/gh-1352.c
@@ -1,0 +1,62 @@
+//FormAI DATASET v1.0 Category: Fractal Generation ; Style: future-proof
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+/* function to get the user input */
+int getUserInput()
+{
+    int n;
+    printf("Enter the depth of the fractal: ");
+    scanf("%d", &n);
+    return n;
+}
+
+/* function to print fractal */
+void printFractal(char **fractal, int n)
+{
+    int i, j;
+    for(i=0; i<pow(2,n); i++)
+    {
+        for(j=0; j<pow(2,n); j++)
+        {
+            printf("%c", fractal[i][j]);
+        }
+        printf("\n");
+    }
+}
+
+/* function to generate fractal */
+void generateFractal(char **fractal, int n, int x, int y)
+{
+    int i, j;
+    if(n==0)
+        fractal[x][y] = '*';
+    else
+    {
+        int length = pow(2,n-1);
+        generateFractal(fractal, n-1, x, y);
+        generateFractal(fractal, n-1, x+length, y);
+        generateFractal(fractal, n-1, x, y+length);
+        generateFractal(fractal, n-1, x+length, y+length);
+    }
+}
+
+int main()
+{
+    int n = getUserInput();
+    char **fractal = (char **)malloc(pow(2,n) * sizeof(char *));
+    int i, j;
+    for(i=0; i<pow(2,n); i++)
+        fractal[i] = (char *)malloc(pow(2,n) * sizeof(char));
+    for(i=0; i<pow(2,n); i++)
+        for(j=0; j<pow(2,n); j++)
+            fractal[i][j] = ' ';
+    generateFractal(fractal, n, 0, 0);
+    printFractal(fractal, n);
+    for(i=0; i<pow(2,n); i++)
+        free(fractal[i]);
+    free(fractal);
+    return 0;
+}

--- a/regression/esbmc/github_1352/test.desc
+++ b/regression/esbmc/github_1352/test.desc
@@ -1,0 +1,4 @@
+CORE
+gh-1352.c
+--unwind 1 --no-unwinding-assertion --force-malloc-success
+^VERIFICATION SUCCESSFUL$

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -534,6 +534,9 @@ public:
     // the checking process should exist to eliminate this requirement.
     if(!is_nil_expr(size))
     {
+      assert(
+        size->type->type_id == signedbv_id ||
+        size->type->type_id == unsignedbv_id);
       expr2tc sz = size->simplify();
       if(!is_nil_expr(sz))
         array_size = sz;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -45,13 +45,13 @@ static expr2tc fixup_containerof_in_sizeof(const expr2tc &_expr)
 
   expr2tc expr = _expr;
 
-  // Blast through all typedefs
+  // Blast through all typecasts
   while(is_typecast2t(expr))
     expr = to_typecast2t(expr).from;
 
   // Base must be null; must start with an addressof.
   if(!is_address_of2t(expr))
-    return expr;
+    return _expr;
 
   const address_of2t &addrof = to_address_of2t(expr);
   return compute_pointer_offset(addrof.ptr_obj);


### PR DESCRIPTION
Fixes #1352. In case this passes our regression I would still like to double-check SV-COMP since this changes the type of array sizes and it might have adverse side effects.