### PR TITLE
Support bit-casting to multi-dimensional arrays

### DIFF
--- a/regression/esbmc/github_1288/gh-1288.c
+++ b/regression/esbmc/github_1288/gh-1288.c
@@ -1,0 +1,92 @@
+//FormAI DATASET v1.0 Category: Online Examination System ; Style: careful
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Define maximum number of questions and options
+#define MAX_QUESTIONS 10
+#define MAX_OPTIONS 4
+
+// Struct for each question and its options
+typedef struct {
+    char question[100];
+    char options[MAX_OPTIONS][50];
+    int answer;
+} Question;
+
+// Struct for the exam
+typedef struct {
+    char title[50];
+    int totalQuestions;
+    Question questions[MAX_QUESTIONS];
+    int correctAnswers;
+} Exam;
+
+// Function to display the exam questions and choices
+void displayExam(Exam exam) {
+    printf("**********\n");
+    printf("%s\n\n", exam.title);
+    for(int i=0; i<exam.totalQuestions; i++) {
+        printf("%d) %s\n", i+1, exam.questions[i].question);
+        for(int j=0; j<MAX_OPTIONS; j++) {
+            printf("%c) %s\n", 'A'+j, exam.questions[i].options[j]);
+        }
+        printf("\n");
+    }
+    printf("**********\n");
+}
+
+// Function to grade the exam and print the results
+void gradeExam(Exam exam, char answers[]) {
+    exam.correctAnswers = 0;
+    for(int i=0; i<exam.totalQuestions; i++) {
+        if(answers[i] == exam.questions[i].answer + 'A') {
+            exam.correctAnswers++;
+        }
+    }
+    printf("**********\n");
+    printf("You answered %d questions correctly out of %d.\n", exam.correctAnswers, exam.totalQuestions);
+    printf("**********\n");
+}
+
+int main() {
+    // Initialize the exam
+    Exam exam;
+    strcpy(exam.title, "C Online Exam");
+    exam.totalQuestions = 3;
+
+    // Enter the exam questions and options
+    strcpy(exam.questions[0].question, "What is the output of the following code?\nint x=10; printf(\"%d\", x++); printf(\"%d\", x);");
+    strcpy(exam.questions[0].options[0], "A) 1011");
+    strcpy(exam.questions[0].options[1], "B) 1111");
+    strcpy(exam.questions[0].options[2], "C) 1110");
+    strcpy(exam.questions[0].options[3], "D) 1010");
+    exam.questions[0].answer = 1;
+
+    strcpy(exam.questions[1].question, "What is the size of int data type in bytes?");
+    strcpy(exam.questions[1].options[0], "A) 2");
+    strcpy(exam.questions[1].options[1], "B) 4");
+    strcpy(exam.questions[1].options[2], "C) 8");
+    strcpy(exam.questions[1].options[3], "D) Depends on the system architecture");
+    exam.questions[1].answer = 1;
+
+    strcpy(exam.questions[2].question, "What is the output of the following code?\nint a=5, b=10; a += (b++)+(++a); printf(\"%d %d\", a, b);");
+    strcpy(exam.questions[2].options[0], "A) 27 11");
+    strcpy(exam.questions[2].options[1], "B) 26 10");
+    strcpy(exam.questions[2].options[2], "C) 24 12");
+    strcpy(exam.questions[2].options[3], "D) Compiler error");
+    exam.questions[2].answer = 0;
+
+    // Display the exam and get user answers
+    displayExam(exam);
+    char userAnswers[exam.totalQuestions];
+    for(int i=0; i<exam.totalQuestions; i++) {
+        printf("Enter your answer for question %d: ", i+1);
+        scanf(" %c", &userAnswers[i]);
+    }
+
+    // Grade the exam and print results
+    gradeExam(exam, userAnswers);
+
+    return 0;
+}

--- a/regression/esbmc/github_1288/test.desc
+++ b/regression/esbmc/github_1288/test.desc
@@ -1,0 +1,5 @@
+CORE
+gh-1288.c
+--unwind 1
+^VERIFICATION FAILED$
+\bunwinding assertion loop\b

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -211,18 +211,18 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
       array_type2t arr_type = to_array_type(to_type);
       type2tc subtype = arr_type.subtype;
 
-      // We shouldn't have any bit left behind
       unsigned int sz = subtype->get_width();
+      // We shouldn't have any bit left behind
       assert(new_from->type->get_width() % sz == 0);
-      unsigned int num_el = new_from->type->get_width() / subtype->get_width();
+      unsigned int num_el = new_from->type->get_width() / sz;
 
-      std::vector<expr2tc> elems;
+      std::vector<expr2tc> elems(num_el);
+      type2tc uint_subtype = get_uint_type(sz);
       for(unsigned int i = 0; i < num_el; ++i)
       {
         unsigned int offset = i * sz;
-        expr2tc tmp =
-          extract2tc(get_uint_type(sz), new_from, offset + sz - 1, offset);
-        elems.push_back(bitcast2tc(subtype, tmp));
+        elems[i] = bitcast2tc(
+          subtype, extract2tc(uint_subtype, new_from, offset + sz - 1, offset));
       }
 
       /* In case to_type is a multi-dimensional array type, the constant_array2t

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -208,31 +208,25 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
 
     if(is_bv_type(new_from) || is_union_type(new_from))
     {
-      // TODO: handle multidimensional arrays
-      assert(
-        !is_multi_dimensional_array(to_type) &&
-        "Bitcasting to multidimensional arrays is not supported for now\n");
-
       array_type2t arr_type = to_array_type(to_type);
       type2tc subtype = arr_type.subtype;
 
       // We shouldn't have any bit left behind
-      assert(new_from->type->get_width() % subtype->get_width() == 0);
+      unsigned int sz = subtype->get_width();
+      assert(new_from->type->get_width() % sz == 0);
       unsigned int num_el = new_from->type->get_width() / subtype->get_width();
 
       std::vector<expr2tc> elems;
       for(unsigned int i = 0; i < num_el; ++i)
       {
-        unsigned int sz = subtype->get_width();
         unsigned int offset = i * sz;
-        expr2tc tmp = extract2tc(
-          get_uint_type(subtype->get_width()),
-          new_from,
-          offset + sz - 1,
-          offset);
+        expr2tc tmp =
+          extract2tc(get_uint_type(sz), new_from, offset + sz - 1, offset);
         elems.push_back(bitcast2tc(subtype, tmp));
       }
 
+      /* In case to_type is a multi-dimensional array type, the constant_array2t
+       * expression will get flattened by convert_ast(). */
       return convert_ast(constant_array2tc(to_type, elems));
     }
   }


### PR DESCRIPTION
Fixes #1288 by relaxing the conditions for `flatten_array_body()` a bit: it will now also flatten a constant_array2t expr of multi-dimensional array type which does itself *not* contain constant_array2t expressions. These kinds of expressions are now allowed to be produced when bitcasting for instance a long bitvector to this type.

In order to be able to document concisely how the new flatten_array_body() works, I had to allow producing index2t expressions into arrays, which was not done before. This shouldn't happen for any of the cases we originally supported since there one of the assertions removed by this PR would have triggered. Still, it wouldn't hurt to double-check, I guess.