### PR TITLE
Unify simplification of modulus2t with div2t

### DIFF
--- a/regression/esbmc/github_1172-1/gh-1172-1.c
+++ b/regression/esbmc/github_1172-1/gh-1172-1.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int main()
+{
+	unsigned n = nondet_uint() % 1024;
+	char *fmt = malloc(n+1);
+	uint16_t *data = malloc((n+1) * sizeof(*data));
+	if (fmt && data)
+	{
+		unsigned i = nondet_uint() % n;
+		fmt[n] = '\0';
+		printf(fmt, data[i]);
+	}
+}

--- a/regression/esbmc/github_1172-1/test.desc
+++ b/regression/esbmc/github_1172-1/test.desc
@@ -1,0 +1,5 @@
+CORE
+gh-1172-1.c
+
+^VERIFICATION FAILED$
+\bdivision by zero\b

--- a/regression/esbmc/github_1172-2/gh-1172-2.c
+++ b/regression/esbmc/github_1172-2/gh-1172-2.c
@@ -1,0 +1,70 @@
+//FormAI DATASET v1.0 Category: Public-Key Algorithm Implementation ; Style: energetic
+#include<stdio.h>
+#include<stdlib.h>
+#include<time.h>
+#include<math.h>
+
+int isPrime(int n){
+    int i;
+    for(i = 2; i <= n/2; ++i){
+        if(n % i == 0){
+            return 0;
+        }
+    }
+    return 1;
+}
+
+int gcd(int a, int b){
+    int temp;
+    while (b != 0){
+        temp = b;
+        b = a % b;
+        a = temp;
+    }
+    return a;
+}
+
+int main(){
+    srand(time(0));
+    int p, q, n, phi, e, d, plaintext, ciphertext;
+    
+    //Generating two prime numbers
+    while(!isPrime(p)){
+        p = rand()%100 + 1;
+    }
+    while(!isPrime(q)){
+        q = rand()%100 + 1;
+    }
+    n = p * q;
+    phi = (p-1) * (q-1);
+
+    //Choosing a public key
+    do{
+        e = rand()%phi;
+    }while(gcd(e, phi) != 1);
+
+    //Calculating private key
+    int k = 1;
+    while(1){
+        k = k + phi;
+        if(k % e == 0){
+            d = k/e;
+            break;
+        }
+    }
+
+    printf("Public Key: (%d, %d)\n", e, n);
+    printf("Private Key: (%d, %d)\n", d, n);
+
+    //Encryption
+    printf("Enter the plaintext (a single letter): ");
+    scanf("%d", &plaintext);
+    ciphertext = fmod(pow(plaintext, e), n);
+    printf("The ciphertext is: %d\n", ciphertext);
+
+    //Decryption
+    plaintext = fmod(pow(ciphertext, d), n);
+    printf("The plaintext is: %d\n", plaintext);
+
+    return 0;
+}

--- a/regression/esbmc/github_1172-2/test.desc
+++ b/regression/esbmc/github_1172-2/test.desc
@@ -1,0 +1,5 @@
+CORE
+gh-1172-2.c
+--unwind 1 --overflow --no-unwinding-assertions
+^VERIFICATION FAILED$
+\bdivision by zero\b

--- a/src/util/fixedbv.cpp
+++ b/src/util/fixedbv.cpp
@@ -140,6 +140,19 @@ fixedbvt &fixedbvt::operator/=(const fixedbvt &o)
   return *this;
 }
 
+fixedbvt &fixedbvt::operator%=(const fixedbvt &y)
+{
+  fixedbvt z = *this;
+  z /= y;
+  z.from_integer(z.to_integer());
+  z *= y;
+  // ensure z has the same sign as *this
+  if(v.is_negative() != z.v.is_negative())
+    z.v.negate();
+  *this -= z;
+  return *this;
+}
+
 bool fixedbvt::operator==(int i) const
 {
   return v == power(2, spec.get_fraction_bits()) * i;

--- a/src/util/fixedbv.h
+++ b/src/util/fixedbv.h
@@ -100,6 +100,7 @@ public:
   void negate();
 
   fixedbvt &operator/=(const fixedbvt &other);
+  fixedbvt &operator%=(const fixedbvt &other);
   fixedbvt &operator*=(const fixedbvt &other);
   fixedbvt &operator+=(const fixedbvt &other);
   fixedbvt &operator-=(const fixedbvt &other);


### PR DESCRIPTION
This PR unifies the simplification algorithms for div2t and modulus2t, thereby it avoids the div-by-zero and fixes #1172. For that generic algorithm to work, I had to implement `operator%=` for `fixedbvt`. I've basically followed [fmod(3)](https://linux.die.net/man/3/fmod) for that.