### PR TITLE
replace pow() recursion with loop

### DIFF
--- a/src/c2goto/library/libm/pow.c
+++ b/src/c2goto/library/libm/pow.c
@@ -5,18 +5,30 @@
 double pow(double base, double exponent)
 {
 __ESBMC_HIDE:;
-  int result = 1;
+  double result = 1.0;
   if(exponent == 0)
     return result;
 
   if(exponent < 0)
-    return 1 / pow(base, -exponent);
+  {
+    base = 1.0 / base;
+    exponent = -exponent;
+  }
 
-  float temp = pow(base, exponent / 2);
-  if((int)exponent % 2 == 0)
-    return temp * temp;
-
-  return (base * temp * temp);
+  while (exponent > 0)
+  {
+    if((int)exponent % 2 == 0)
+    {
+      base *= base;
+      exponent /= 2;
+    }
+    else
+    {
+      result *= base;
+      exponent--;
+    }
+  }
+  return result;
 }
 
 double __pow(double base, double exponent)


### PR DESCRIPTION
esbmc cannot finish unrolling the recursion in `pow()` function, and also doesn't work with `--unwindset` because it doesn't have a loopid.
```
int main() {
  int res = pow(2, 4);
  assert(res == 16);
}
```
Shall we replace the recursion with the loop?