### PR TITLE
Benchexec action now prints run summary

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -128,6 +128,8 @@ jobs:
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
+      - name: Show summary
+        run: tail $HOME/esbmc-output/*results.txt
       - name: Save logs
         if: ${{ inputs.output != '' }}
         run: cp $HOME/output.zip $HOME/${{ inputs.output }}


### PR DESCRIPTION
GitHub is having trouble showing the logs for the full run. Also, sometimes it is nice just to check the summary at the phone. 


![Screenshot 2023-09-25 at 11 09 27](https://github.com/esbmc/esbmc/assets/8601807/dd7f6cc0-139b-4c8c-b32b-9ed92c86d1aa)
