### PR TITLE
Guard simplification and a few random fixes

### DIFF
--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -222,22 +222,23 @@ static inline guardt merge_state_guards(
   // impossible. Therefore we only integrate it when to do so simplifies the
   // state guard.
 
-  // This function can trash either state's guards, since goto_state is dying
-  // and state's guard will shortly be overwritten.
+  // In CBMC this function can trash either state's guards, since goto_state is
+  // dying and state's guard will shortly be overwritten. However, we still use
+  // either state's guard, so keep them intact.
   if(
     (!goto_state.guard.is_false() && !state.guard.is_false()) ||
     state.guard.disjunction_may_simplify(goto_state.guard))
   {
     state.guard |= goto_state.guard;
-    return std::move(state.guard);
+    return state.guard;
   }
   else if(state.guard.is_false() && !goto_state.guard.is_false())
   {
-    return std::move(goto_state.guard);
+    return goto_state.guard;
   }
   else
   {
-    return std::move(state.guard);
+    return state.guard;
   }
 }
 

--- a/src/solvers/mathsat/CMakeLists.txt
+++ b/src/solvers/mathsat/CMakeLists.txt
@@ -32,7 +32,7 @@ if (ENABLE_MATHSAT)
     endif ()
 
     message(STATUS "Using MathSAT at: ${Mathsat_LIB}")
-    string(REGEX MATCH "version ([0-9].[0-9].[0-9]) " REGEX_OUTPUT ${Mathsat_VERSION})
+    string(REGEX MATCH "version ([0-9]+\.[0-9]+\.[0-9]+) " REGEX_OUTPUT ${Mathsat_VERSION})
     set(Mathsat_VERSION "${CMAKE_MATCH_1}")
     message(STATUS "MathSAT version: ${Mathsat_VERSION}")
     if (Mathsat_VERSION VERSION_LESS Mathsat_MIN_VERSION)

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -158,7 +158,7 @@ smt_convt::convert_pointer_arith(const expr2tc &expr, const type2tc &type)
     type2tc inttype = machine_ptr;
     type2tc difftype = get_int_type(config.ansi_c.address_width);
 
-    if(non_ptr_op->type->get_width() < config.ansi_c.pointer_width())
+    if(non_ptr_op->type->get_width() != config.ansi_c.pointer_width())
       non_ptr_op = typecast2tc(machine_ptr, non_ptr_op);
 
     expr2tc mul = mul2tc(inttype, non_ptr_op, pointee_size);

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -256,7 +256,7 @@ bool guardt::is_false() const
 
 void guardt::make_true()
 {
-  guard_list.clear();
+  clear();
 }
 
 void guardt::make_false()

--- a/src/util/guard.cpp
+++ b/src/util/guard.cpp
@@ -39,6 +39,7 @@ void guardt::add(const expr2tc &expr)
   // Easy case, there is no g_expr
   if(is_nil_expr(g_expr))
   {
+    assert(guard_list.size() == 1);
     g_expr = expr;
   }
   else
@@ -70,14 +71,21 @@ void guardt::build_guard_expr()
   // This method closely related to guardt::add and guardt::guard_expr
   // We need to build the chain of ands, to avoid memory bloat on as_expr
 
-  // if the guard is true, or a single symbol, we don't need to build it
-  if(is_true() || is_single_symbol())
-    return;
-
   // This method will only be used, when the guard is nil, for instance,
   // guardt &operator -= and guardt &operator |=, all other cases should
   // be handled by guardt::add
   assert(is_nil_expr(g_expr));
+
+  // if the guard is true, we don't need to build it
+  if(is_true())
+    return;
+
+  // the expression is the single symbol in case the list just has this one
+  if(is_single_symbol())
+  {
+    g_expr = *guard_list.begin();
+    return;
+  }
 
   // We can assume at least two operands
   auto it = guard_list.begin();

--- a/src/util/guard.h
+++ b/src/util/guard.h
@@ -10,7 +10,6 @@ class guardt
 public:
   // Default constructors
   guardt() = default;
-  guardt(const guardt &ref) = default;
 
   typedef std::vector<expr2tc> guard_listt;
 

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -322,10 +322,10 @@ expr2tc type_byte_size_bits_expr(const type2tc &type, const namespacet *ns)
 expr2tc type_byte_size_expr(const type2tc &type, const namespacet *ns)
 {
   expr2tc n = type_byte_size_bits_expr(type, ns);
-  if(is_constant_int2t(n))
-    return gen_ulong((to_constant_int2t(n).value + 7) / 8);
-  type2tc s = bitsize_type2();
   type2tc t = size_type2();
+  if(is_constant_int2t(n))
+    return gen_long(t, (to_constant_int2t(n).value + 7) / 8);
+  type2tc s = bitsize_type2();
   return typecast2tc(t, div2tc(s, add2tc(s, n, bitsize(7)), bitsize(8)));
 }
 


### PR DESCRIPTION
These changes came out of #1297. Unlike that one, this PR doesn't try to modify the implementation of guards because that one still has too much overhead. I will note again, though, that the current implementation of operators -= and |= is undefined and we should look into these.

Changes on guards are:
1. Remove std::move from `merge_state_guards()` because it is doing nothing: `guardt` defines the copy-constructor and therefore no move-constructor is implicitly being generated by the compiler. It just isn't available. This construction in the function uses the copy-ctor. It was backported from CBMC in ff829c0fd324e0f4322505450a56d68444ef203b and there still is unchanged. There guards don't have a move-ctor either.
2. Since now the definition of the copy-ctor of guards is unnecessary, remove it. This enables the implicit move-ctors, which are used elsewhere. To me this simplifies reasoning about the behaviour of guard objects.
3. Fix building the expr2tc: `build_guard_expr()` would only assign `g_expr` if the `guard_list` had strictly more than one symbol. However, `guardt::add()` assumes that `g_expr` would be valid also if `guard_list` had a single symbol.

Minor other changes:
- Support multi-digit MathSAT version numbers (like the current v5.6.10).
- Pointer arithmetic for --32 should be allowed operands of 64 bit size.

The following SV-COMP numbers are for this PR **except** the change in item 2. above. While to me it should only improve speed, C++ sometimes is hard to analyze, so please let me know if you would like me to run SV-COMP again with the change in item 2.

[Master](https://github.com/esbmc/esbmc/actions/runs/6240185504) (ce7742ec1fcd179c4b7f0818abe31e09151fd1ab):
```
Statistics:          23805 Files
  correct:           14161
    correct true:     7814
    correct false:    6347
  incorrect:            22
    incorrect true:      7
    incorrect false:    15
  unknown:            9622
  Score:             21511 (max: 38482)
```
[This PR except item 2.](https://github.com/esbmc/esbmc/actions/runs/6294055509) (dabde69490b95683dc7f5439a0a34ffee6502d02):
```
Statistics:          23805 Files
  correct:           14156
    correct true:     7811
    correct false:    6345
  incorrect:            21
    incorrect true:      6
    incorrect false:    15
  unknown:            9628
  Score:             21535 (max: 38482)
```
The one less incorrect in the stats is not actually solved by this PR, it is just a bit slower: c/pthread/triangular-longest-2.i in unreach-call (27s -> timeout).