### PR TITLE
Fix some Clang warnings

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -18,6 +18,8 @@ template <class T>
 class interval_templatet
 {
 public:
+  virtual ~interval_templatet() = default;
+
   interval_templatet() : lower_set(false), upper_set(false)
   {
     // this is 'top'

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -415,6 +415,8 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
       idx = 2;
     }
   }
+  else
+    abort();
 
   // Now we pop the format
   for(size_t i = 0; i < idx; i++)
@@ -491,6 +493,8 @@ void goto_symext::symex_input(const code_function_call2t &func_call)
     fmt_idx = 1;
     number_of_format_args = func_call.operands.size() - 2;
   }
+  else
+    abort();
 
   if(func_call.ret)
     symex_assign(code_assign2tc(
@@ -1200,9 +1204,10 @@ static inline expr2tc gen_value_by_byte(
 
     uint64_t union_total_size = type_byte_size(type).to_uint64();
     // Let's find a member with the biggest size
-    int selected_member_index;
+    size_t n = to_union_type(type).members.size();
+    size_t selected_member_index = n;
 
-    for(unsigned i = 0; i < to_union_type(type).members.size(); i++)
+    for(size_t i = 0; i < n; i++)
     {
       if(
         type_byte_size(to_union_type(type).members[i]).to_uint64() ==
@@ -1212,6 +1217,8 @@ static inline expr2tc gen_value_by_byte(
         break;
       }
     }
+
+    assert(selected_member_index < n);
 
     const irep_idt &name =
       to_union_type(type).member_names[selected_member_index];

--- a/src/solvers/smt/tuple/smt_tuple_node.h
+++ b/src/solvers/smt/tuple/smt_tuple_node.h
@@ -29,8 +29,10 @@ public:
 
   expr2tc tuple_get_rec(tuple_node_smt_astt tuple);
 
-  expr2tc
-  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+  expr2tc tuple_get_array_elem(
+    smt_astt array,
+    uint64_t index,
+    const type2tc &subtype) override;
 
   smt_astt mk_tuple_array_symbol(const expr2tc &expr) override;
   smt_astt tuple_array_of(const expr2tc &init_value, unsigned long domain_width)

--- a/src/solvers/smt/tuple/smt_tuple_sym.h
+++ b/src/solvers/smt/tuple/smt_tuple_sym.h
@@ -27,8 +27,10 @@ public:
   expr2tc tuple_get(const expr2tc &expr) override;
   expr2tc tuple_get(const type2tc &type, smt_astt a) override;
 
-  expr2tc
-  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+  expr2tc tuple_get_array_elem(
+    smt_astt array,
+    uint64_t index,
+    const type2tc &subtype) override;
 
   expr2tc tuple_get_rec(tuple_sym_smt_astt tuple);
   smt_astt tuple_array_create(

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -171,8 +171,10 @@ public:
   expr2tc tuple_get(const expr2tc &expr) override;
   expr2tc tuple_get(const type2tc &type, smt_astt sym) override;
 
-  expr2tc
-  tuple_get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype);
+  expr2tc tuple_get_array_elem(
+    smt_astt array,
+    uint64_t index,
+    const type2tc &subtype) override;
 
   smt_astt tuple_array_create(
     const type2tc &array_type,

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -20,7 +20,7 @@ void base_type(type2tc &type, const namespacet &ns)
   {
     base_type(to_array_type(type).subtype, ns);
   }
-  else if(is_struct_type(type) | is_union_type(type))
+  else if(is_structure_type(type))
   {
     struct_union_data &data = static_cast<struct_union_data &>(*type.get());
 

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -441,7 +441,7 @@ expr2tc add2t::do_simplify() const
 
   // Attempt associative simplification
   std::function<expr2tc(const expr2tc &arg1, const expr2tc &arg2)> add_wrapper =
-    [this](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc {
+    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc {
     expr2tc a = arg1, b = arg2;
     type2tc t = common_arith_op2_type(a, b);
     return add2tc(t, a, b);


### PR DESCRIPTION
Just fix some warnings generated by Clang-16 on Linux. It's mostly:
- virtual dtor missing
- some else-cases shouldn't happen
- some override declarations missing

There are still more warnings left, in particular about unused functions, parameters and local variables. I've not touched those since I don't know the context off-hand and whether they could indeed be just removed.