### PR TITLE
[benchexec] fixed results path for RunSet runs

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -129,7 +129,7 @@ jobs:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
       - name: Show summary
-        run: tail $HOME/esbmc-output/*results.txt
+        run: tail $HOME/esbmc-output/*results*.txt
       - name: Save logs
         if: ${{ inputs.output != '' }}
         run: cp $HOME/output.zip $HOME/${{ inputs.output }}


### PR DESCRIPTION
Some benchexec actions are crashing due to the file name generated at the end: https://github.com/esbmc/esbmc/actions/runs/6328373588

This PR fixes it (see: https://github.com/esbmc/esbmc/actions/runs/6335012463)