### PR TITLE
Remove --memlimit 14000000 setting from test.desc for all regression tests

### DIFF
--- a/regression/cuda/COM_sanity_checks/call_kernel/test.desc
+++ b/regression/cuda/COM_sanity_checks/call_kernel/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/cuda/test.desc
+++ b/regression/cuda/COM_sanity_checks/cuda/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/cuda_device_runtime_api/test.desc
+++ b/regression/cuda/COM_sanity_checks/cuda_device_runtime_api/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/cuda_runtime_api/test.desc
+++ b/regression/cuda/COM_sanity_checks/cuda_runtime_api/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/curand/test.desc
+++ b/regression/cuda/COM_sanity_checks/curand/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/curand_kernel/test.desc
+++ b/regression/cuda/COM_sanity_checks/curand_kernel/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/device_launch_parameters/test.desc
+++ b/regression/cuda/COM_sanity_checks/device_launch_parameters/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/driver_types/test.desc
+++ b/regression/cuda/COM_sanity_checks/driver_types/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/host_defines/test.desc
+++ b/regression/cuda/COM_sanity_checks/host_defines/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/sm_atomic_functions/test.desc
+++ b/regression/cuda/COM_sanity_checks/sm_atomic_functions/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/COM_sanity_checks/vector_types/test.desc
+++ b/regression/cuda/COM_sanity_checks/vector_types/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
-  --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/algorithm/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/algorithm/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/bitset/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/bitset/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cassert/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cassert/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cctype/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cctype/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cerrno/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cerrno/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cfloat/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cfloat/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cisco646/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cisco646/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/climit/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/climit/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/clocale/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/clocale/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cmath/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cmath/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/complex/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/complex/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/csetjmp/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/csetjmp/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/csignal/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/csignal/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdarg/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdarg/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cstddef/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstddef/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdio/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdio/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cstdlib/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstdlib/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/cstring/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/cstring/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/ctime/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/ctime/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/definitions/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/definitions/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/deque/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/deque/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/exception/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/exception/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/float_h/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/float_h/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/fstream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/fstream/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/functional/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/functional/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/iomanip/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/iomanip/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/ios/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/ios/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/iostream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/iostream/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/istream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/istream/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/iterator/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/iterator/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/limits/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/limits/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/list/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/list/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/locale/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/locale/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/map/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/map/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/memory/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/memory/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/new/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/new/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/numeric/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/numeric/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/ostream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/ostream/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/pair/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/pair/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/queue/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/queue/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/set/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/set/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/sstream/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/sstream/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/stack/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/stack/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/stdexcept/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/stdexcept/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/stdio_h/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/stdio_h/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/stdlib_h/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/stdlib_h/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/streambuf/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/streambuf/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/string/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/string/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/string_h/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/string_h/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/typeinfo/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/typeinfo/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/unistd/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/unistd/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/utility/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/utility/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/valarray/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/valarray/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/OM_sanity_checks/vector/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/vector/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm10/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm100/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm100/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm100_stable_sort/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm100_stable_sort/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm101/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm101/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm101_partial_sort/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm101_partial_sort/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --z3 --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --z3 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm102/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm102/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm102_partial_sort_copy/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm102_partial_sort_copy/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm103/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm103/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm103_nth_element/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm103_nth_element/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm104/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm104/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm105/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm105/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm106/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm106/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm107/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm107/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm107_binary_search/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm107_binary_search/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm108/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm108/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm109/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm109/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm11/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm110/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm110/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm111/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm111/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm112/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm112/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm113/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm113/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm114/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm114/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm115/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm115/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm116/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm116/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm117/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm117/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm118/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm118/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm119/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm119/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm12/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm120/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm120/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm121/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm121/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm122/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm122/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm123/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm123/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm13/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm14/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm15/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm16/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm17/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm18/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm19/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm2/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm20/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm21/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm22/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm23/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm24/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm25/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm26/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm27/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm28/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm28/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm29/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm29/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm3/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm30/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm30/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm31/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm31/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm32/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm32/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm33/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm33/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm34/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm34/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm35/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm35/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm36/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm36/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm37/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm37/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm38/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm38/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm39/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm39/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm4/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm40/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm40/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm40_sort1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm40_sort1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm40_sort2/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm40_sort2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm41/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm41/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm41_stable_sort1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm41_stable_sort1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm42/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm42/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm42_partial_sort1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm42_partial_sort1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm43/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm43/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm43_partial_sort_copy1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm43_partial_sort_copy1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm44/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm44/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm45/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm45/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm46/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm46/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm47/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm47/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm48/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm48/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm48_binary_search1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm48_binary_search1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm49/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm49/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm5/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm50/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm50/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm51/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm51/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm52/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm52/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm53/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm53/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm54/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm54/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm55/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm55/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm56/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm56/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm57/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm57/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm58/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm58/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm59/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm59/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm6/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm60/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm60/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm61/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm61/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm62/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm62/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm63/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm63/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm64/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm64/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm65/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm65/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm66/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm66/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm67/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm67/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm68/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm68/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm69/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm69/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm69_adjacent_find1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm69_adjacent_find1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm7/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm70/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm70/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm71/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm71/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm72/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm72/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm73/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm73/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm74/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm74/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm75/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm75/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm76/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm76/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm77/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm77/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm78/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm78/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm79/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm79/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm8/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm80/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm80/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm81/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm81/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm81_transform/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm81_transform/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm82/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm82/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm83/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm83/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm84/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm84/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm85/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm85/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm86/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm86/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm86_fill/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm86_fill/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm87/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm87/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm87_fill_n/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm87_fill_n/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm88/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm88/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm89/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm89/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm9/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm90/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm90/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm90_unique/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm90_unique/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm91/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm91/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm91_unique_copy/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm91_unique_copy/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm92/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm92/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm93/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm93/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm94/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm94/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm95/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm95/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm96/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm96/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm97/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm97/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm98/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm98/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm99/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm99/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm_for_each/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm_for_each/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm_max/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm_max/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm_rotate/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm_rotate/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/algorithm/algorithm_swap/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm_swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/bug_fixes/1006_aggregate/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1006_aggregate/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1006_aggregate_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1006_aggregate_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/1032_POD_init/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1032_POD_init/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1032_POD_init_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1032_POD_init_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/1103_TC20/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC36/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC36/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/bug_fixes/1103_TC39/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1103_TC39/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/bug_fixes/1126_issue/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1126_issue/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1126_issue_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1126_issue_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
- --memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/1246_aggregate/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1246_aggregate/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/1246_aggregate_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/1246_aggregate_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/961_issue1/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/961_issue1/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/961_issue1_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/961_issue1_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/961_issue2/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/961_issue2/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/961_issue2_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/961_issue2_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/975_memberexpr_static/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/975_memberexpr_static/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/975_memberexpr_static_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/975_memberexpr_static_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/991_issue2/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/991_issue2/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/991_issue2_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/991_issue2_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/polymorphism_ns/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/polymorphism_ns/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/bug_fixes/polymorphism_ns_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/polymorphism_ns_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/bug_fixes/temporary/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/temporary/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/temporary_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/temporary_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cbmc/Templates1/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates10/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates11/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates12/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates13/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates14/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates15/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates16/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates17/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates18/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates19/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates2/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates20/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates21/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates22/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates23/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates24/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates25/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates26/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates27/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates28/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates28/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates29/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates29/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates3/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates30/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates30/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates31/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates31/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates32/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates32/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates33/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates33/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates34/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates34/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates35/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates35/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates36/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates36/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates37/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates37/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates38/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates38/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates39/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates39/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates4/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates5/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates6/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates7/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates8/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cbmc/Templates9/test.desc
+++ b/regression/esbmc-cpp/cbmc/Templates9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/06_trampoline_03/test.desc
+++ b/regression/esbmc-cpp/cpp/06_trampoline_03/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/Method_qualifier1/test.desc
+++ b/regression/esbmc-cpp/cpp/Method_qualifier1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/algorithm8_operator++_issue/test.desc
+++ b/regression/esbmc-cpp/cpp/algorithm8_operator++_issue/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/bicycle/test.desc
+++ b/regression/esbmc-cpp/cpp/bicycle/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Bicycle.cpp Display.cpp EmbeddedPC.cpp Thread.cpp --unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Bicycle.cpp Display.cpp EmbeddedPC.cpp Thread.cpp --unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cast_pointer_to_int/test.desc
+++ b/regression/esbmc-cpp/cpp/cast_pointer_to_int/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch10_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch10_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>circle.cpp point.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>circle.cpp point.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch10_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch10_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp circle.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp circle.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch10_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch10_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp circle.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp circle.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch10_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch10_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp circle.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp circle.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch11_0/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_0/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch11_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch11_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch11_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch11_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch12_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch12_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch13_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch13_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 100 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 100 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch13_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch13_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch13_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch13_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch13_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch13_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch14_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch14_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>clientData.cpp --unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>clientData.cpp --unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch15_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch15_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10  --no-unwinding-assertions --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10  --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch16_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch17_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch17_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch17_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch17_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch17_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_23/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_24/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_25/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_26/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_27/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_29/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_29/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_30/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_30/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_31/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_31/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch18_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch19_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch19_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_0/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_0/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch1_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch1_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch20_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch20_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_25/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_26/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_28/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_28/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_29/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_29/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_30/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_30/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_31/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_31/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_34/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_34/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_35/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_35/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_36/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_36/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_37/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_37/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_38/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_38/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_39/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_39/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_41/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_41/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_42/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_42/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_43/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_43/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --no-slice --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --no-slice --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch21_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Array.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Array.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>derived.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>derived.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch22_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch2_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch2_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_23/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_24/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_25/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch3_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch3_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch4_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch4_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_14/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_15/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_16/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_17/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_18/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_20/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_21/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_23/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_24/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch5_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch5_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Time4.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Time4.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Time1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Time1.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Time1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Time1.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Salesp.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Salesp.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Time2.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Time2.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Create.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Create.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch6_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Time3.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Time3.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>time5.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>time5.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_13/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>bell.cpp elevator.cpp light.cpp scheduler.cpp clock.cpp elevatorButton.cpp floor.cpp person.cpp building.cpp door.cpp floorButton.cpp --unwind 10 --no-unwinding-assertions  --depth 1000 --no-bounds-check --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>bell.cpp elevator.cpp light.cpp scheduler.cpp clock.cpp elevatorButton.cpp floor.cpp person.cpp building.cpp door.cpp floorButton.cpp --unwind 10 --no-unwinding-assertions  --depth 1000 --no-bounds-check --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Employee1.cpp Date1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Employee1.cpp Date1.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Time6.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Time6.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch7_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>employee2.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>employee2.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_10/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Date1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Date1.cpp --unwind 10 --no-unwinding-assertionsk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_11/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertionsk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_12/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>String1.cpp --unwind 2 --no-unwinding-assertions  --no-bounds-check --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>String1.cpp --unwind 2 --no-unwinding-assertions  --no-bounds-checkk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Array1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Array1.cpp --unwind 10 --no-unwinding-assertionsk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>String1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>String1.cpp --unwind 10 --no-unwinding-assertionsk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Date1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Date1.cpp --unwind 10 --no-unwinding-assertionsk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions  --memlimit 14000000k --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertionsk --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Complex1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Complex1.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Hugeint1.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Hugeint1.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch8_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Array1.cpp --unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Array1.cpp --unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>circle.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>circle.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>circle3.cpp point2.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>circle3.cpp point2.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>circle4.cpp point3.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>circle4.cpp point3.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>circle5.cpp point4.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>circle5.cpp point4.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>circle4.cpp cylinder.cpp point3.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>circle4.cpp cylinder.cpp point3.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_6/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>building.cpp elevator.cpp light.cpp person.cpp floor.cpp elevatorButton.cpp clock.cpp bell.cpp button.cpp door.cpp floorButton.cpp scheduler.cpp --unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>building.cpp elevator.cpp light.cpp person.cpp floor.cpp elevatorButton.cpp clock.cpp bell.cpp button.cpp door.cpp floorButton.cpp scheduler.cpp --unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/ch9_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch9_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/class-specialization/test.desc
+++ b/regression/esbmc-cpp/cpp/class-specialization/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cpp_with_pthread_01-no-lib/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_with_pthread_01-no-lib/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--no-library --unwind 10 --no-unwinding-assertions  --data-races-check --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--no-library --unwind 10 --no-unwinding-assertions  --data-races-check --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cpp_with_pthread_01/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_with_pthread_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --data-races-check --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --data-races-check --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cpp_with_pthread_02-no-lib/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_with_pthread_02-no-lib/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--no-library --unwind 10 --no-unwinding-assertions  --data-races-check --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--no-library --unwind 10 --no-unwinding-assertions  --data-races-check --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cpp_with_pthread_02/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_with_pthread_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --data-races-check --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --data-races-check --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring10_strpbrk/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring10_strpbrk/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring11_strtok/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring11_strtok/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring12_strrchr/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring12_strrchr/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring13_strstr/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring13_strstr/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring14_memcpy/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring14_memcpy/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring15_memmove/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring15_memmove/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring16_memcmp/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring16_memcmp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring17_memchr/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring17_memchr/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring18_memset/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring18_memset/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring19_strcpy/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring19_strcpy/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring1_strcpy/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring1_strcpy/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring20_strncmp_failed/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring20_strncmp_failed/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring2_strcat/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring2_strcat/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring3_strncat/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring3_strncat/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring4_strcmp/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring4_strcmp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring5_strncmp/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring5_strncmp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring6_strchr/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring6_strchr/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring7_strcspn/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring7_strcspn/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring8_strcpn/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring8_strcpn/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/cstring9_strlen/test.desc
+++ b/regression/esbmc-cpp/cpp/cstring9_strlen/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/double_free/test.desc
+++ b/regression/esbmc-cpp/cpp/double_free/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/if_declaration/test.desc
+++ b/regression/esbmc-cpp/cpp/if_declaration/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/inst_struct_class/test.desc
+++ b/regression/esbmc-cpp/cpp/inst_struct_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/list_reference-1/test.desc
+++ b/regression/esbmc-cpp/cpp/list_reference-1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/list_reference-2/test.desc
+++ b/regression/esbmc-cpp/cpp/list_reference-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/list_reference-3/test.desc
+++ b/regression/esbmc-cpp/cpp/list_reference-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_bitset-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_bitset-test/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_deque-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_deque-test/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_invalid_delete/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_invalid_delete/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_non_type_template/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_non_type_template/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_queue-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_queue-test/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_simple_inheritance/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_simple_inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_sort-test01/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_sort-test01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_sort-test02/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_sort-test02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_stack-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_stack-test/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_template_class/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_template_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_template_function_01/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_template_function_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_template_function_02/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_template_function_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_template_specialization/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_template_specialization/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_transform-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_transform-test/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_v-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_v-test/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/llbmc_virtual_function/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_virtual_function/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/memcpy/test.desc
+++ b/regression/esbmc-cpp/cpp/memcpy/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/new/test.desc
+++ b/regression/esbmc-cpp/cpp/new/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/new2/test.desc
+++ b/regression/esbmc-cpp/cpp/new2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/operator_new/test.desc
+++ b/regression/esbmc-cpp/cpp/operator_new/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/string_const/test.desc
+++ b/regression/esbmc-cpp/cpp/string_const/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/string_const_bug/test.desc
+++ b/regression/esbmc-cpp/cpp/string_const_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/switch_declaration/test.desc
+++ b/regression/esbmc-cpp/cpp/switch_declaration/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/switch_declaration_1/test.desc
+++ b/regression/esbmc-cpp/cpp/switch_declaration_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/switch_declaration_2/test.desc
+++ b/regression/esbmc-cpp/cpp/switch_declaration_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/template-specialization/test.desc
+++ b/regression/esbmc-cpp/cpp/template-specialization/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^ERROR: PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/template_function_specialization/test.desc
+++ b/regression/esbmc-cpp/cpp/template_function_specialization/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/try-catch_08/test.desc
+++ b/regression/esbmc-cpp/cpp/try-catch_08/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/cpp/while_declaration/test.desc
+++ b/regression/esbmc-cpp/cpp/while_declaration/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_assign/test.desc
+++ b/regression/esbmc-cpp/deque/deque_assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_assign_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_assign_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_at/test.desc
+++ b/regression/esbmc-cpp/deque/deque_at/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_at_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_at_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_back/test.desc
+++ b/regression/esbmc-cpp/deque/deque_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_back_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_back_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_begin/test.desc
+++ b/regression/esbmc-cpp/deque/deque_begin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_begin_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_begin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_clear/test.desc
+++ b/regression/esbmc-cpp/deque/deque_clear/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_clear_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_clear_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_constructor/test.desc
+++ b/regression/esbmc-cpp/deque/deque_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_empty/test.desc
+++ b/regression/esbmc-cpp/deque/deque_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_empty_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_end/test.desc
+++ b/regression/esbmc-cpp/deque/deque_end/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_end_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_end_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_erase/test.desc
+++ b/regression/esbmc-cpp/deque/deque_erase/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_erase_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_erase_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_front/test.desc
+++ b/regression/esbmc-cpp/deque/deque_front/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_front_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_front_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_insert/test.desc
+++ b/regression/esbmc-cpp/deque/deque_insert/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_insert_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_insert_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_operator_assign/test.desc
+++ b/regression/esbmc-cpp/deque/deque_operator_assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_operator_assign_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_operator_assign_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_operator_brackets/test.desc
+++ b/regression/esbmc-cpp/deque/deque_operator_brackets/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_operator_brackets_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_operator_brackets_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_overflow/test.desc
+++ b/regression/esbmc-cpp/deque/deque_overflow/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_pop_back/test.desc
+++ b/regression/esbmc-cpp/deque/deque_pop_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_pop_back_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_pop_back_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_pop_front/test.desc
+++ b/regression/esbmc-cpp/deque/deque_pop_front/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_pop_front_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_pop_front_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_push_back/test.desc
+++ b/regression/esbmc-cpp/deque/deque_push_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_push_back_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_push_back_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_rbegin/test.desc
+++ b/regression/esbmc-cpp/deque/deque_rbegin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_rbegin_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_rbegin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_rend/test.desc
+++ b/regression/esbmc-cpp/deque/deque_rend/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_rend_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_rend_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_resize/test.desc
+++ b/regression/esbmc-cpp/deque/deque_resize/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_resize_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_resize_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_size/test.desc
+++ b/regression/esbmc-cpp/deque/deque_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_size_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_swap/test.desc
+++ b/regression/esbmc-cpp/deque/deque_swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/deque/deque_swap_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_swap_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-deque</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-deque</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/ch13_25/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch13_25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp Employee.cpp HourlyEmployee.cpp SalariedEmployee.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp Employee.cpp HourlyEmployee.cpp SalariedEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/ch22_1/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch22_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/ch22_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch22_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/ch22_4/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch22_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>derived.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>derived.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast1/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast2_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast4/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast4_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast5/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast5_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast6/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple2/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple2_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple3_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_void/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_void/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance-cbmc/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance-cbmc/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance01/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance02/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance04/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance04/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance05/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance05/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance06/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance06/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance07/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance07/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance08/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance08/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance09/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance09/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance10/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance11/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance12/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance13/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance14/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/inheritance15/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/multiple_inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/multiple_inheritance_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/multiple_inheritance_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/multiple_inheritance_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/multiple_inheritance_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/paper_inheritance_example/test.desc
+++ b/regression/esbmc-cpp/inheritance/paper_inheritance_example/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/paper_inheritance_example_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/paper_inheritance_example_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_abstract_base_class/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_abstract_base_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_dynamic_allocation/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_dynamic_allocation/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_pointer_to_base_class/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_pointer_to_base_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/polymorphism_virtual_members/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_virtual_members/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/single_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/single_inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/single_inheritance_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/single_inheritance_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-inheritance</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast4_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_simple2_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/dynamic_cast_void_error/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance01/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance01/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance01_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance01_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance02/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance02/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance02_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance02_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance07_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/inheritance09_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance_bringup/single_member/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/single_member/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --verbosity 10
+--unwind 10 --no-unwinding-assertions --verbosity 10
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance_bringup/single_member_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance_bringup/single_member_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --verbosity 10
+--unwind 10 --no-unwinding-assertions --verbosity 10
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/list/list_assign/test.desc
+++ b/regression/esbmc-cpp/list/list_assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_assign_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_assign_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_back/test.desc
+++ b/regression/esbmc-cpp/list/list_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_back_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_back_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_begin/test.desc
+++ b/regression/esbmc-cpp/list/list_begin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_begin_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_begin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_class/test.desc
+++ b/regression/esbmc-cpp/list/list_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_class_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_class_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_clear/test.desc
+++ b/regression/esbmc-cpp/list/list_clear/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_clear_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_clear_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_constructor/test.desc
+++ b/regression/esbmc-cpp/list/list_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_empty/test.desc
+++ b/regression/esbmc-cpp/list/list_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_empty_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_end/test.desc
+++ b/regression/esbmc-cpp/list/list_end/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_end_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_end_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_erase/test.desc
+++ b/regression/esbmc-cpp/list/list_erase/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_erase_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_erase_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_front/test.desc
+++ b/regression/esbmc-cpp/list/list_front/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_front_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_front_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_insert/test.desc
+++ b/regression/esbmc-cpp/list/list_insert/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_insert_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_insert_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_maxsize/test.desc
+++ b/regression/esbmc-cpp/list/list_maxsize/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_merge-2/test.desc
+++ b/regression/esbmc-cpp/list/list_merge-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_merge/test.desc
+++ b/regression/esbmc-cpp/list/list_merge/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_merge_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_merge_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_merge_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_merge_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_operator_assign/test.desc
+++ b/regression/esbmc-cpp/list/list_operator_assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_operator_assign_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_operator_assign_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_pop_back/test.desc
+++ b/regression/esbmc-cpp/list/list_pop_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_pop_back_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_pop_back_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_pop_front/test.desc
+++ b/regression/esbmc-cpp/list/list_pop_front/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_pop_front_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_pop_front_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_push_back/test.desc
+++ b/regression/esbmc-cpp/list/list_push_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_push_front/test.desc
+++ b/regression/esbmc-cpp/list/list_push_front/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_push_front_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_push_front_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_rbegin/test.desc
+++ b/regression/esbmc-cpp/list/list_rbegin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_rbegin_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_rbegin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_remove/test.desc
+++ b/regression/esbmc-cpp/list/list_remove/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_remove_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_remove_if-2/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_if-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_remove_if/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_if/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_remove_if_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_if_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_remove_if_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_if_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_rend/test.desc
+++ b/regression/esbmc-cpp/list/list_rend/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_rend_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_rend_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_resize/test.desc
+++ b/regression/esbmc-cpp/list/list_resize/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 14 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 14 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_resize_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_resize_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_reverse/test.desc
+++ b/regression/esbmc-cpp/list/list_reverse/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_reverse_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_reverse_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_size/test.desc
+++ b/regression/esbmc-cpp/list/list_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_size_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_sort-2/test.desc
+++ b/regression/esbmc-cpp/list/list_sort-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_sort-3/test.desc
+++ b/regression/esbmc-cpp/list/list_sort-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_sort/test.desc
+++ b/regression/esbmc-cpp/list/list_sort/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_sort_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_sort_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_sort_bug-3/test.desc
+++ b/regression/esbmc-cpp/list/list_sort_bug-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_sort_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_sort_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_splice-2/test.desc
+++ b/regression/esbmc-cpp/list/list_splice-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_splice-3/test.desc
+++ b/regression/esbmc-cpp/list/list_splice-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_splice/test.desc
+++ b/regression/esbmc-cpp/list/list_splice/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_splice_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_splice_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_splice_bug-3/test.desc
+++ b/regression/esbmc-cpp/list/list_splice_bug-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_splice_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_splice_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_swap/test.desc
+++ b/regression/esbmc-cpp/list/list_swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_swap_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_swap_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_unique-2/test.desc
+++ b/regression/esbmc-cpp/list/list_unique-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_unique-3/test.desc
+++ b/regression/esbmc-cpp/list/list_unique-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_unique/test.desc
+++ b/regression/esbmc-cpp/list/list_unique/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_unique_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_unique_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_unique_bug-3/test.desc
+++ b/regression/esbmc-cpp/list/list_unique_bug-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/list/list_unique_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_unique_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 12 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_begin/test.desc
+++ b/regression/esbmc-cpp/map/map_begin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_begin_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_begin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_clear/test.desc
+++ b/regression/esbmc-cpp/map/map_clear/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_clear_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_clear_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_constructor/test.desc
+++ b/regression/esbmc-cpp/map/map_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_count/test.desc
+++ b/regression/esbmc-cpp/map/map_count/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_count_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_count_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_empty/test.desc
+++ b/regression/esbmc-cpp/map/map_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_empty_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_end/test.desc
+++ b/regression/esbmc-cpp/map/map_end/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_end_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_end_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_equal_range/test.desc
+++ b/regression/esbmc-cpp/map/map_equal_range/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_erase/test.desc
+++ b/regression/esbmc-cpp/map/map_erase/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_erase_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_erase_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_find/test.desc
+++ b/regression/esbmc-cpp/map/map_find/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_find_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_find_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_insert1/test.desc
+++ b/regression/esbmc-cpp/map/map_insert1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_insert1_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_insert1_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_insert2/test.desc
+++ b/regression/esbmc-cpp/map/map_insert2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_insert2_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_insert2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_insert3/test.desc
+++ b/regression/esbmc-cpp/map/map_insert3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_insert3_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_insert3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_key_comp/test.desc
+++ b/regression/esbmc-cpp/map/map_key_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_key_comp_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_key_comp_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_maxsize/test.desc
+++ b/regression/esbmc-cpp/map/map_maxsize/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_operator_assign/test.desc
+++ b/regression/esbmc-cpp/map/map_operator_assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_operator_assign_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_operator_assign_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_operator_brackets/test.desc
+++ b/regression/esbmc-cpp/map/map_operator_brackets/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_operator_brackets_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_operator_brackets_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --ir --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_rbegin/test.desc
+++ b/regression/esbmc-cpp/map/map_rbegin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_rbegin_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_rbegin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_rend/test.desc
+++ b/regression/esbmc-cpp/map/map_rend/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_rend_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_rend_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_size/test.desc
+++ b/regression/esbmc-cpp/map/map_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_size_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_string_class-2/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_string_class-2_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class-2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_string_class-3/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_string_class-3_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class-3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_string_class/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_swap/test.desc
+++ b/regression/esbmc-cpp/map/map_swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_swap_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_swap_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_upper_lower_bound/test.desc
+++ b/regression/esbmc-cpp/map/map_upper_lower_bound/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_upper_lower_bound_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_upper_lower_bound_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_value_comp/test.desc
+++ b/regression/esbmc-cpp/map/map_value_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/map/map_value_comp_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_value_comp_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_begin/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_begin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_begin_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_begin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_clear/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_clear/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_clear_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_clear_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_constructor/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_count/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_count/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_count_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_count_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_empty/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_empty_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_end/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_end/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_end_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_end_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_equal_range/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_equal_range/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_equal_range_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_equal_range_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_erase/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_erase/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_erase_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_erase_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 7 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_find/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_find/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_find_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_find_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_insert1/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_insert1_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert1_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_insert2/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_insert2_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_insert3/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_insert3_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_key_comp/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_key_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_key_comp_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_key_comp_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_maxsize/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_maxsize/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_operator_assign/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_operator_assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_operator_assign_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_operator_assign_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_rbegin/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_rbegin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_rbegin_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_rbegin_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_rend/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_rend/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_rend_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_rend_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_size/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_size_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_string_class-2/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_string_class-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_string_class-2_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_string_class-2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_string_class/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_string_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_string_class_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_string_class_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 3 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_swap/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_swap_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_swap_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_upper_lower_bound/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_upper_lower_bound/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_upper_lower_bound_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_upper_lower_bound_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_value_comp/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_value_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multimap/multimap_value_comp_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_value_comp_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 4 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-begin-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-begin-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-begin/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-begin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-clear-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-clear-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-clear/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-clear/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-construct-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-construct-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-construct/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-construct/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-count-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-count-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-count/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-count/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-destructor-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-destructor-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-destructor/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-destructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-empty-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-empty-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-empty/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-end-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-end-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-end/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-end/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-equal_range-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-equal_range-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-equal_range/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-equal_range/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-erase-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-erase-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-erase/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-erase/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-find-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-find-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-find/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-find/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-insert-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-insert-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-insert-with-iterators/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-insert-with-iterators/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-insert/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-insert/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-key_comp-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-key_comp-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-key_comp/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-key_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-lower_bound-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-lower_bound-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-lower_bound/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-lower_bound/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-max_size-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-max_size-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-max_size/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-max_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-operator-assign-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-operator-assign-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-operator-assign/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-operator-assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-rbegin-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-rbegin-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-rbegin/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-rbegin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-rend-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-rend-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-rend/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-rend/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-size-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-size-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-size/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-swap-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-swap-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-swap/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-upper_bound-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-upper_bound-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-upper_bound/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-upper_bound/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-value_comp-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-value_comp-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/multiset/multiset-value_comp/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-value_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/10_MI_Mlvl_ndiamond_mcol_2ndcolval/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/10_MI_Mlvl_ndiamond_mcol_2ndcolval/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/10_MI_Mlvl_ndiamond_mcol_2ndcolval_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/10_MI_Mlvl_ndiamond_mcol_2ndcolval_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/11_MI_Mlvl_ndiamond_scol_tpLvlPtr/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/11_MI_Mlvl_ndiamond_scol_tpLvlPtr/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/11_MI_Mlvl_ndiamond_scol_tpLvlPtr_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/11_MI_Mlvl_ndiamond_scol_tpLvlPtr_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/12_MI_Mlvl_ndiamond_scol_midLvlPtr/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/12_MI_Mlvl_ndiamond_scol_midLvlPtr/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/12_MI_Mlvl_ndiamond_scol_midLvlPtr_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/12_MI_Mlvl_ndiamond_scol_midLvlPtr_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/1_SI_virtual_ntvalCtor/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/1_SI_virtual_ntvalCtor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/1_SI_virtual_ntvalCtor_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/1_SI_virtual_ntvalCtor_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/2_SI_virtual_tvalCtor/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/2_SI_virtual_tvalCtor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/2_SI_virtual_tvalCtor_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/2_SI_virtual_tvalCtor_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/3_SI_virtual_ntvalDtor/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/3_SI_virtual_ntvalDtor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/3_SI_virtual_ntvalDtor_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/3_SI_virtual_ntvalDtor_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/4_SI_nvirtual/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/4_SI_nvirtual/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/4_SI_nvirtual_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/4_SI_nvirtual_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/5_MI_Slvl/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/5_MI_Slvl/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/5_MI_Slvl_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/5_MI_Slvl_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/6_MI_Slvl_abstract/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/6_MI_Slvl_abstract/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/6_MI_Slvl_abstract_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/6_MI_Slvl_abstract_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/7_MI_Mlvl_diamond_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/8_SI_virtual_ntvalCtor_MultiOvrd/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/8_SI_virtual_ntvalCtor_MultiOvrd/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/8_SI_virtual_ntvalCtor_MultiOvrd_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/8_SI_virtual_ntvalCtor_MultiOvrd_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/9_MI_Mlvl_ndiamond_mcol_2ndcolnval/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/9_MI_Mlvl_ndiamond_mcol_2ndcolnval/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/9_MI_Mlvl_ndiamond_mcol_2ndcolnval_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/9_MI_Mlvl_ndiamond_mcol_2ndcolnval_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast1/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast1/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast1_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast1_fail/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast5/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast5/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast5_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast5_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast_simple3/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast_simple3/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast_simple3_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast_simple3_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_multiple_inheritance/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance-wrong/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/llbmc_virtual_inheritance/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_1/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_2/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_3/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^ERROR: CONVERSION ERROR$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_4/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^ERROR: PARSING ERROR$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_5/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_common_error_5/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 is not a member of class 'File'$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_dynamic_allocation/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_dynamic_allocation/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/polymorphism_bringup/polymorphism_dynamic_allocation_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/polymorphism_dynamic_allocation_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_inside_class/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_inside_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_inside_class_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_inside_class_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/vmd_defined_outside_class_fail/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/ch21_12/test.desc
+++ b/regression/esbmc-cpp/priority_queue/ch21_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-cpp</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_constructor-2/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_constructor-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_constructor/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_constructor_bug-2/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_constructor_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_empty/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_empty_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_pop/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_pop/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_pop_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_pop_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_push/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_push/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_push_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_push_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_size/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_size_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_top/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_top/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/priority_queue/priority_queue_top_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_top_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_back/test.desc
+++ b/regression/esbmc-cpp/queue/queue_back/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_back_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_back_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_constructor/test.desc
+++ b/regression/esbmc-cpp/queue/queue_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_empty/test.desc
+++ b/regression/esbmc-cpp/queue/queue_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_empty_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_front/test.desc
+++ b/regression/esbmc-cpp/queue/queue_front/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_front_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_front_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_pop/test.desc
+++ b/regression/esbmc-cpp/queue/queue_pop/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_pop_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_pop_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_push/test.desc
+++ b/regression/esbmc-cpp/queue/queue_push/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_push_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_push_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_size/test.desc
+++ b/regression/esbmc-cpp/queue/queue_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/queue/queue_size_bug/test.desc
+++ b/regression/esbmc-cpp/queue/queue_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-begin-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-begin-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-begin/test.desc
+++ b/regression/esbmc-cpp/set/set-begin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-clear-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-clear-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-clear/test.desc
+++ b/regression/esbmc-cpp/set/set-clear/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-construct-2/test.desc
+++ b/regression/esbmc-cpp/set/set-construct-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-construct-3/test.desc
+++ b/regression/esbmc-cpp/set/set-construct-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-construct-4/test.desc
+++ b/regression/esbmc-cpp/set/set-construct-4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-construct-5/test.desc
+++ b/regression/esbmc-cpp/set/set-construct-5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-construct-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-construct-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-construct/test.desc
+++ b/regression/esbmc-cpp/set/set-construct/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-count-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-count-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-count/test.desc
+++ b/regression/esbmc-cpp/set/set-count/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-destructor-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-destructor-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-destructor/test.desc
+++ b/regression/esbmc-cpp/set/set-destructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-empty-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-empty-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-empty/test.desc
+++ b/regression/esbmc-cpp/set/set-empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-end-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-end-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-end/test.desc
+++ b/regression/esbmc-cpp/set/set-end/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-equal_range-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-equal_range-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-equal_range/test.desc
+++ b/regression/esbmc-cpp/set/set-equal_range/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-erase-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-erase-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-erase/test.desc
+++ b/regression/esbmc-cpp/set/set-erase/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-find-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-find-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-find/test.desc
+++ b/regression/esbmc-cpp/set/set-find/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-insert-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-insert-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-insert/test.desc
+++ b/regression/esbmc-cpp/set/set-insert/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-key_comp-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-key_comp-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-key_comp/test.desc
+++ b/regression/esbmc-cpp/set/set-key_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-loop-with-inserts-1-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-loop-with-inserts-1-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-lower_bound-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-lower_bound-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-lower_bound/test.desc
+++ b/regression/esbmc-cpp/set/set-lower_bound/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-max_size-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-max_size-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-max_size/test.desc
+++ b/regression/esbmc-cpp/set/set-max_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-operator-assign-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-operator-assign-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-operator-assign/test.desc
+++ b/regression/esbmc-cpp/set/set-operator-assign/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-rbegin-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-rbegin-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-rbegin/test.desc
+++ b/regression/esbmc-cpp/set/set-rbegin/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-rend-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-rend-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-rend/test.desc
+++ b/regression/esbmc-cpp/set/set-rend/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-size-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-size-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-size/test.desc
+++ b/regression/esbmc-cpp/set/set-size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-swap-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-swap-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-swap/test.desc
+++ b/regression/esbmc-cpp/set/set-swap/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-upper_bound-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-upper_bound-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-upper_bound/test.desc
+++ b/regression/esbmc-cpp/set/set-upper_bound/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-value_comp-bug/test.desc
+++ b/regression/esbmc-cpp/set/set-value_comp-bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-value_comp/test.desc
+++ b/regression/esbmc-cpp/set/set-value_comp/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/set/set-with-objects/test.desc
+++ b/regression/esbmc-cpp/set/set-with-objects/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_class/test.desc
+++ b/regression/esbmc-cpp/stack/stack_class/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_class_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_class_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_constructor/test.desc
+++ b/regression/esbmc-cpp/stack/stack_constructor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_constructor_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_empty/test.desc
+++ b/regression/esbmc-cpp/stack/stack_empty/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_empty_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_empty_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_pop/test.desc
+++ b/regression/esbmc-cpp/stack/stack_pop/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_pop_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_pop_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_push/test.desc
+++ b/regression/esbmc-cpp/stack/stack_push/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_push_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_push_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_size/test.desc
+++ b/regression/esbmc-cpp/stack/stack_size/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_size_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_size_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_top/test.desc
+++ b/regression/esbmc-cpp/stack/stack_top/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stack/stack_top_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_top_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/fstream_constructor_1/test.desc
+++ b/regression/esbmc-cpp/stream/fstream_constructor_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/fstream_is_open_1/test.desc
+++ b/regression/esbmc-cpp/stream/fstream_is_open_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/fstream_open_1/test.desc
+++ b/regression/esbmc-cpp/stream/fstream_open_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/fstream_rdbuf_1/test.desc
+++ b/regression/esbmc-cpp/stream/fstream_rdbuf_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ifstream_get_line_1/test.desc
+++ b/regression/esbmc-cpp/stream/ifstream_get_line_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>lista7paa.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>Solver.cpp Parser.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>Solver.cpp Parser.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_constructor_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_constructor_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_constructor_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_constructor_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_gcount_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_gcount_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_gcount_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_gcount_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_get_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_get_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_get_2/test.desc
+++ b/regression/esbmc-cpp/stream/istream_get_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_get_3/test.desc
+++ b/regression/esbmc-cpp/stream/istream_get_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_get_4/test.desc
+++ b/regression/esbmc-cpp/stream/istream_get_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_getline_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_getline_2/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_getline_3_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_getline_4_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_getline_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_ignore_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_ignore_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_ignore_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_ignore_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_bool/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_bool/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_char/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_char/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_double/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_double/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_float/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_float/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_int/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_int/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_long/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_long/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_short/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_short/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_operator_void/test.desc
+++ b/regression/esbmc-cpp/stream/istream_operator_void/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_peek_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_peek_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_peek_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_peek_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_putback_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_putback_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_putback_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_putback_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_read_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_read_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_read_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_read_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_readsome_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_readsome_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_readsome_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_readsome_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_unget_1/test.desc
+++ b/regression/esbmc-cpp/stream/istream_unget_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/istream_unget_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/istream_unget_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/line_break/test.desc
+++ b/regression/esbmc-cpp/stream/line_break/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_constructor_1/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_constructor_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_flush_1/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_flush_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_bool/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_bool/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_char/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_char/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_double/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_double/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_float/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_float/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_int/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_int/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_long/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_long/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_operator_short/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_operator_short/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_put_1/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_put_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_seekp_1/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_seekp_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_seekp_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_seekp_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_tellp_1/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_tellp_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_tellp_2_bug/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_tellp_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/ostream_write_1/test.desc
+++ b/regression/esbmc-cpp/stream/ostream_write_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_constructor_1/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_constructor_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_getline_1/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_getline_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_rdbuf_1/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_rdbuf_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_bool/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_bool/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_char/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_char/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_char_asterisk/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_char_asterisk/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_double/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_double/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_float/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_float/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_int/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_int/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_long/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_long/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_short/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_short/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_string/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_string/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/stream/sstream_str_void_asterisk/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_void_asterisk/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-stream</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-stream</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string-error-construct-2/test.desc
+++ b/regression/esbmc-cpp/string/string-error-construct-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string-error-construct/test.desc
+++ b/regression/esbmc-cpp/string/string-error-construct/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_1/test.desc
+++ b/regression/esbmc-cpp/string/string_append_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 9 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_10_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_10_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_11_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_11_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_12_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_12_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_13_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_13_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_14_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_14_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_2/test.desc
+++ b/regression/esbmc-cpp/string/string_append_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_3/test.desc
+++ b/regression/esbmc-cpp/string/string_append_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 14 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 14 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_4/test.desc
+++ b/regression/esbmc-cpp/string/string_append_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_5/test.desc
+++ b/regression/esbmc-cpp/string/string_append_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_6/test.desc
+++ b/regression/esbmc-cpp/string/string_append_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_7/test.desc
+++ b/regression/esbmc-cpp/string/string_append_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_9_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_9_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_final/test.desc
+++ b/regression/esbmc-cpp/string/string_append_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 55 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 55 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_append_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_1/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_10_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_10_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_11_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_11_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_12_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_12_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_2/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_3/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_4/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_5/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_6/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_7_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_7_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_9_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_9_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 60 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_final/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 45 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 45 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_assign_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 45 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 45 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_at_1/test.desc
+++ b/regression/esbmc-cpp/string/string_at_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_at_2/test.desc
+++ b/regression/esbmc-cpp/string/string_at_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_at_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_at_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_at_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_at_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_at_5/test.desc
+++ b/regression/esbmc-cpp/string/string_at_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_at_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_at_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_capacity_1/test.desc
+++ b/regression/esbmc-cpp/string/string_capacity_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_capacity_2/test.desc
+++ b/regression/esbmc-cpp/string/string_capacity_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_capacity_3/test.desc
+++ b/regression/esbmc-cpp/string/string_capacity_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_capacity_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_capacity_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_capacity_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_capacity_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_capacity_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_capacity_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_1/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_10_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_10_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_2/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_3/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_4/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_7_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_7_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_compare_9/test.desc
+++ b/regression/esbmc-cpp/string/string_compare_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_1/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_10/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_2/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_3/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_4/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_5/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_6/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_7/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_8/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_constructor_9/test.desc
+++ b/regression/esbmc-cpp/string/string_constructor_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_copy_1/test.desc
+++ b/regression/esbmc-cpp/string/string_copy_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_copy_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_copy_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_data_1/test.desc
+++ b/regression/esbmc-cpp/string/string_data_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_data_2/test.desc
+++ b/regression/esbmc-cpp/string/string_data_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_data_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_data_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_data_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_data_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_empty_1/test.desc
+++ b/regression/esbmc-cpp/string/string_empty_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_empty_2/test.desc
+++ b/regression/esbmc-cpp/string/string_empty_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_empty_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_empty_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_empty_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_empty_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_erase_1/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_erase_2/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_erase_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_erase_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_erase_final/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_erase_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_1/test.desc
+++ b/regression/esbmc-cpp/string/string_find_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_2/test.desc
+++ b/regression/esbmc-cpp/string/string_find_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 18 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 18 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_3/test.desc
+++ b/regression/esbmc-cpp/string/string_find_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_final/test.desc
+++ b/regression/esbmc-cpp/string/string_find_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_first_not_of_1/test.desc
+++ b/regression/esbmc-cpp/string/string_find_first_not_of_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_first_not_of_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_first_not_of_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_first_of_1/test.desc
+++ b/regression/esbmc-cpp/string/string_find_first_of_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_first_of_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_first_of_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_last_of_1/test.desc
+++ b/regression/esbmc-cpp/string/string_find_last_of_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_find_last_of_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_last_of_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_1/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_10_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_10_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_11_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_11_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_12_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_12_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_13_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_13_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_14_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_14_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_2/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_3/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_4/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_5/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_6/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_7/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_9_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_9_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_final/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_insert_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 50 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_length_1/test.desc
+++ b/regression/esbmc-cpp/string/string_length_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_length_2/test.desc
+++ b/regression/esbmc-cpp/string/string_length_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_length_3/test.desc
+++ b/regression/esbmc-cpp/string/string_length_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_length_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_length_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_length_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_length_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_length_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_length_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_assign_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_assign_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_5/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_brackets_7_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_brackets_7_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_eq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_eq_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_greater_eq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_greater_eq_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_less_eq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_less_eq_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 6 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_neq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_neq_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 26 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_1/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_2/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_3/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_5_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_5_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_6_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_6_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_7/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_operator_plus_eq_8_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_operator_plus_eq_8_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_1/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_10/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_11_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_11_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_12_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_12_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_13_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_13_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_14_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_14_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_15_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_15_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_16_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_16_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_17_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_17_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_18_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_18_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_19_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_19_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_2/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_20_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_20_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_3/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_4/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_5/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_6/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_7/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_8/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_9/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_final/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_replace_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 35 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_resize_1/test.desc
+++ b/regression/esbmc-cpp/string/string_resize_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_resize_2/test.desc
+++ b/regression/esbmc-cpp/string/string_resize_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_resize_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_resize_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_resize_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_resize_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_resize_final/test.desc
+++ b/regression/esbmc-cpp/string/string_resize_final/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_resize_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_resize_final_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_rfind_1/test.desc
+++ b/regression/esbmc-cpp/string/string_rfind_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_rfind_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_rfind_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_size_1/test.desc
+++ b/regression/esbmc-cpp/string/string_size_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_size_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_size_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_substr_1/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_substr_2/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 25 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_substr_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_substr_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_4_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 16 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 16 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_swap_1/test.desc
+++ b/regression/esbmc-cpp/string/string_swap_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/string/string_swap_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_swap_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-string</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-string</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 40 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/algorithm32/test.desc
+++ b/regression/esbmc-cpp/template/algorithm32/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-algorithm</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-algorithm</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/list_remove_if/test.desc
+++ b/regression/esbmc-cpp/template/list_remove_if/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/list_remove_if_bug/test.desc
+++ b/regression/esbmc-cpp/template/list_remove_if_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/list_sort/test.desc
+++ b/regression/esbmc-cpp/template/list_sort/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/list_sort_bug/test.desc
+++ b/regression/esbmc-cpp/template/list_sort_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/list_unique/test.desc
+++ b/regression/esbmc-cpp/template/list_unique/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/list_unique_bug/test.desc
+++ b/regression/esbmc-cpp/template/list_unique_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/nested_method_template/test.desc
+++ b/regression/esbmc-cpp/template/nested_method_template/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc> --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc> --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/priority_queue_constructor-2/test.desc
+++ b/regression/esbmc-cpp/template/priority_queue_constructor-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/priority_queue_constructor_bug-2/test.desc
+++ b/regression/esbmc-cpp/template/priority_queue_constructor_bug-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_1/test.desc
+++ b/regression/esbmc-cpp/template/template_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_1_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_1_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_2/test.desc
+++ b/regression/esbmc-cpp/template/template_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_2_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_2_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_3/test.desc
+++ b/regression/esbmc-cpp/template/template_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_3_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_3_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions -I /__w/esbmc/esbmc/src/cpp/library/ --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_array_to_ptr/test.desc
+++ b/regression/esbmc-cpp/template/template_array_to_ptr/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Covers the operate in bees</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc> --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc> --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_function_default/test.desc
+++ b/regression/esbmc-cpp/template/template_function_default/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-template</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_function_default_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_function_default_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-template</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_function_default_bug2/test.desc
+++ b/regression/esbmc-cpp/template/template_function_default_bug2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-template</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_list_struct-1/test.desc
+++ b/regression/esbmc-cpp/template/template_list_struct-1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_list_struct-2/test.desc
+++ b/regression/esbmc-cpp/template/template_list_struct-2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_list_struct-3/test.desc
+++ b/regression/esbmc-cpp/template/template_list_struct-3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_sort_string/test.desc
+++ b/regression/esbmc-cpp/template/template_sort_string/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/template/template_sort_string_bug/test.desc
+++ b/regression/esbmc-cpp/template/template_sort_string_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-list</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-list</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/ch13_1/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/ch13_2/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/ch13_3/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/ch13_5/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/ch13_8/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/ch13_9/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex1-bintree-duplicate/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex1-bintree-duplicate/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex10-io_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex10-io_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex10-io_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex10-io_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex11-new-badalloc/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex11-new-badalloc/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex12-template/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex12-template/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex13-nested-try-catch/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex13-nested-try-catch/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex14-loop-break-continue/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex14-loop-break-continue/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex15-nested-rethrow/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex15-nested-rethrow/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex16-multiple-live/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex16-multiple-live/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex2-list-baditerator/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex2-list-baditerator/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex3-delegation-dtor-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex3-delegation-dtor-throw/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex4-diamond-shared-inheritance/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex4-diamond-shared-inheritance/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --error-label ERROR --depth 200 --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions  --error-label ERROR --depth 200 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex6-std-uncaught-dtor/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex6-std-uncaught-dtor/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex7-ctor-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex7-ctor-throw/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex8-virtual-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex8-virtual-throw/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/nec_ex9-dynamic-cast/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex9-dynamic-cast/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 1 --no-unwinding-assertions  --error-label ERROR --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_01_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_03/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_03/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_04_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_04_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_05/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_05/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_06_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_06_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_07/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_07/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_08_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_08_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_09/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_09/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_10_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_10_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_11/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_order_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_order_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_order_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_order_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_order_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_order_03_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_pointer_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_pointer_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_pointer_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_pointer_02_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_rethrow_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_rethrow_01_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_rethrow_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_rethrow_02_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_03_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_04_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_04_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_05/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_05/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_06/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_06/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_07_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_07_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_08/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_08/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_09_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_09_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_10/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_11_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_11_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_12_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_12_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_13_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_13_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_14_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_14_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_15_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_15_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_16_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_16_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_17_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_17_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_terminate_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_terminate_01_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_terminate_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_terminate_02_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_01_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_03/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_03/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_04/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_04/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_05/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_05/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_06/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_06/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_07_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_07_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_08/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_08/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_09/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_09/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_typeid_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_typeid_01_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_02_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_03_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_05_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_05_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_06_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_06_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_value_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_value_01_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_value_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_value_02/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_vector_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_vector_01/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_vector_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_vector_02_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/try_catch/try-catch_vector_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_vector_03_bug/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-try_catch</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-try_catch</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm1/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm10/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm11/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm13/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm14/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm15/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm16/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm17/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm18/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm19/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm2/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm20/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm21/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm22/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm23/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm24/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm25/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm26/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm27/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm29/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm29/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm3/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm30/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm30/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm31/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm31/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm32/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm32/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm33/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm33/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm34/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm34/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm35/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm35/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm36/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm36/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm38/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm38/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm4/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 11 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm5/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm59/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm59/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm5_char/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm5_char/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm6/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm60/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm60/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm61/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm61/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm62/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm62/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm7/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/algorithm8/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch10_5/test.desc
+++ b/regression/esbmc-cpp/vector/ch10_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>point.cpp circle.cpp cylinder.cpp shape.cpp --unwind 1 --no-unwinding-assertions  --depth 500 --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>point.cpp circle.cpp cylinder.cpp shape.cpp --unwind 1 --no-unwinding-assertions  --depth 500 --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch10_6/test.desc
+++ b/regression/esbmc-cpp/vector/ch10_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>baseplus.cpp commission.cpp employee.cpp hourly.cpp salaried.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>baseplus.cpp commission.cpp employee.cpp hourly.cpp salaried.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch10_7/test.desc
+++ b/regression/esbmc-cpp/vector/ch10_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>baseplus.cpp commission.cpp employee.cpp hourly.cpp salaried.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>baseplus.cpp commission.cpp employee.cpp hourly.cpp salaried.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_10/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_11/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_12/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_13/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_14/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_15/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_16/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_17/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_18/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_19/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_20/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_21/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_22/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_23/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_24/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_25/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_26/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_27/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_28/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_28/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_5/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_6/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_7/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_8/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch11_9/test.desc
+++ b/regression/esbmc-cpp/vector/ch11_9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_10/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_13/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_14/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_15/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_16/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_17/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_18/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_2/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_20/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_21/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_23/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_24/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_27/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch21_3/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ch8_6/test.desc
+++ b/regression/esbmc-cpp/vector/ch8_6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/ifstream_get_line_2/test.desc
+++ b/regression/esbmc-cpp/vector/ifstream_get_line_2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector1/test.desc
+++ b/regression/esbmc-cpp/vector/vector1/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector10/test.desc
+++ b/regression/esbmc-cpp/vector/vector10/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector11/test.desc
+++ b/regression/esbmc-cpp/vector/vector11/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector12/test.desc
+++ b/regression/esbmc-cpp/vector/vector12/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector13/test.desc
+++ b/regression/esbmc-cpp/vector/vector13/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector14/test.desc
+++ b/regression/esbmc-cpp/vector/vector14/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector15/test.desc
+++ b/regression/esbmc-cpp/vector/vector15/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector16/test.desc
+++ b/regression/esbmc-cpp/vector/vector16/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector17/test.desc
+++ b/regression/esbmc-cpp/vector/vector17/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector18/test.desc
+++ b/regression/esbmc-cpp/vector/vector18/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector19/test.desc
+++ b/regression/esbmc-cpp/vector/vector19/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector2/test.desc
+++ b/regression/esbmc-cpp/vector/vector2/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector20/test.desc
+++ b/regression/esbmc-cpp/vector/vector20/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector21/test.desc
+++ b/regression/esbmc-cpp/vector/vector21/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector22/test.desc
+++ b/regression/esbmc-cpp/vector/vector22/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector23/test.desc
+++ b/regression/esbmc-cpp/vector/vector23/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector24/test.desc
+++ b/regression/esbmc-cpp/vector/vector24/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector25/test.desc
+++ b/regression/esbmc-cpp/vector/vector25/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector26/test.desc
+++ b/regression/esbmc-cpp/vector/vector26/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector27/test.desc
+++ b/regression/esbmc-cpp/vector/vector27/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 22 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 22 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector28/test.desc
+++ b/regression/esbmc-cpp/vector/vector28/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector29/test.desc
+++ b/regression/esbmc-cpp/vector/vector29/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector3/test.desc
+++ b/regression/esbmc-cpp/vector/vector3/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector30/test.desc
+++ b/regression/esbmc-cpp/vector/vector30/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector31/test.desc
+++ b/regression/esbmc-cpp/vector/vector31/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 30 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector32/test.desc
+++ b/regression/esbmc-cpp/vector/vector32/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector33/test.desc
+++ b/regression/esbmc-cpp/vector/vector33/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector34/test.desc
+++ b/regression/esbmc-cpp/vector/vector34/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector35/test.desc
+++ b/regression/esbmc-cpp/vector/vector35/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 8 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector36/test.desc
+++ b/regression/esbmc-cpp/vector/vector36/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector37/test.desc
+++ b/regression/esbmc-cpp/vector/vector37/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector38/test.desc
+++ b/regression/esbmc-cpp/vector/vector38/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector39/test.desc
+++ b/regression/esbmc-cpp/vector/vector39/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector4/test.desc
+++ b/regression/esbmc-cpp/vector/vector4/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector40/test.desc
+++ b/regression/esbmc-cpp/vector/vector40/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector41/test.desc
+++ b/regression/esbmc-cpp/vector/vector41/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector42/test.desc
+++ b/regression/esbmc-cpp/vector/vector42/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector43/test.desc
+++ b/regression/esbmc-cpp/vector/vector43/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector44/test.desc
+++ b/regression/esbmc-cpp/vector/vector44/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector45/test.desc
+++ b/regression/esbmc-cpp/vector/vector45/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector46/test.desc
+++ b/regression/esbmc-cpp/vector/vector46/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector47/test.desc
+++ b/regression/esbmc-cpp/vector/vector47/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 22 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 22 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector48/test.desc
+++ b/regression/esbmc-cpp/vector/vector48/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector49/test.desc
+++ b/regression/esbmc-cpp/vector/vector49/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector5/test.desc
+++ b/regression/esbmc-cpp/vector/vector5/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector50/test.desc
+++ b/regression/esbmc-cpp/vector/vector50/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector51/test.desc
+++ b/regression/esbmc-cpp/vector/vector51/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector52/test.desc
+++ b/regression/esbmc-cpp/vector/vector52/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector53/test.desc
+++ b/regression/esbmc-cpp/vector/vector53/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector54/test.desc
+++ b/regression/esbmc-cpp/vector/vector54/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector55/test.desc
+++ b/regression/esbmc-cpp/vector/vector55/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector55_insert/test.desc
+++ b/regression/esbmc-cpp/vector/vector55_insert/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector56/test.desc
+++ b/regression/esbmc-cpp/vector/vector56/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector57/test.desc
+++ b/regression/esbmc-cpp/vector/vector57/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector58/test.desc
+++ b/regression/esbmc-cpp/vector/vector58/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector59/test.desc
+++ b/regression/esbmc-cpp/vector/vector59/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector6/test.desc
+++ b/regression/esbmc-cpp/vector/vector6/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector60/test.desc
+++ b/regression/esbmc-cpp/vector/vector60/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector61/test.desc
+++ b/regression/esbmc-cpp/vector/vector61/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector62/test.desc
+++ b/regression/esbmc-cpp/vector/vector62/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 15 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector7/test.desc
+++ b/regression/esbmc-cpp/vector/vector7/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 20 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector8/test.desc
+++ b/regression/esbmc-cpp/vector/vector8/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^PARSING ERROR$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector9/test.desc
+++ b/regression/esbmc-cpp/vector/vector9/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp/vector/vector_operators/test.desc
+++ b/regression/esbmc-cpp/vector/vector_operators/test.desc
@@ -4,7 +4,7 @@
   <item_02_id>esbmc-vector</item_02_id>
   <item_03_summary>Aims to analyze the main function from module: esbmc-vector</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900</item_05_option_to_run_esbmc>
+  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
   <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>

--- a/regression/esbmc-cpp11/cpp/ch2_01/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch2_03/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_03/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch2_04/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch2_05/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_05/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch2_13/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch2_13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_01/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_03/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_03/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_05/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_05/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_07/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_07/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_09/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_09/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_11/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_11/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
-GradeBook.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+GradeBook.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch3_15/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch3_15/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
-GradeBook.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+GradeBook.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch4_08/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch4_08/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
-GradeBook.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+GradeBook.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch4_12/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch4_12/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
-GradeBook.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+GradeBook.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch4_16/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch4_16/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch4_16_2/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch4_16_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_01/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_02/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_02/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_05/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_05/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_06/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_06/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_07/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_07/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_09/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_09/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
-GradeBook.cpp --unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+GradeBook.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_13/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_14/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/ch5_18/test.desc
+++ b/regression/esbmc-cpp11/cpp/ch5_18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900
+--unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-old/github_839/test.desc
+++ b/regression/esbmc-old/github_839/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.cpp
---unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900 --old-frontend --goto-functions-only
+--unwind 10 --no-unwinding-assertions --timeout 900 --old-frontend --goto-functions-only
 END_FUNCTION$

--- a/regression/esbmc/github_956/test.desc
+++ b/regression/esbmc/github_956/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 main.cpp
---memlimit 14000000 --timeout 900
+ --timeout 900
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -171,7 +171,7 @@ class XMLTest1(ParseTest):
         self.assertEqual(self.test_case.test_mode, "CORE")
         self.assertEqual(self.test_case.test_file, "main.cpp")
         self.assertEqual(self.test_case.test_args,
-                         "--unwind 10 --no-unwinding-assertions  --memlimit 14000000 --timeout 900")
+                         "--unwind 10 --no-unwinding-assertions --timeout 900")
         self.assertEqual(self.test_case.test_regex, ["^VERIFICATION FAILED$"])
 
     def _argument_list_checks(self, test_obj: BaseTest):

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -430,7 +430,8 @@ const struct group_opt_templ all_cmd_options[] = {
   {"Miscellaneous options",
    {{"memlimit",
      boost::program_options::value<std::string>()->value_name("limit"),
-     "configure memory limit, of form \"100m\" or \"2g\""},
+     "configure memory limit, of form \"100m\" or \"2g\"; without suffix the "
+     "default unit is 'm'."},
     {"memstats", NULL, "print memory usage statistics"},
     {"timeout",
      boost::program_options::value<std::string>()->value_name("t"),


### PR DESCRIPTION
Closes #1381. I've also added a description of the default unit for the `--memlimit` option to ESBMC's help message. Hint: it's not bytes. The C++ tests still have the `--timeout 900` parameter, which, personally, I would remove as well. In particular since we can now pass such global constraints via `ESBMC_OPTS="--timeout 900" ctest ...`. In case they only apply to C++ for some reason, this PR doesn't touch them, though.