### PR TITLE
Fix stack-use-after-scope reported by ASAN

### DIFF
--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -758,7 +758,8 @@ bool clang_cpp_convertert::get_constructor_call(
   call.type() = type;
 
   // Try to get the object that this constructor is constructing
-  auto it = ASTContext->getParents(constructor_call).begin();
+  auto parents = ASTContext->getParents(constructor_call);
+  auto it = parents.begin();
   const clang::Decl *objectDecl = it->get<clang::Decl>();
 
   if(!objectDecl && need_new_object(it->get<clang::Stmt>(), constructor_call))


### PR DESCRIPTION
This reduces the number of failed regressions from 573 to 44 for a Sanitizer build under #1381. Just a simple API usage mistake: getParents() returns a temporary. Basically, the C++ and CUDA stack-use-after-scope ones are all fixed.