### PR TITLE
Interval expressions are now limited to type limits

### DIFF
--- a/regression/esbmc/github_1363_invalid_interval_expression_fail/main.c
+++ b/regression/esbmc/github_1363_invalid_interval_expression_fail/main.c
@@ -1,0 +1,11 @@
+extern void __VERIFIER_error(void);
+extern unsigned short __VERIFIER_nondet_ushort(void);
+int main(){
+	unsigned short T2_460 = __VERIFIER_nondet_ushort();
+	if((unsigned int) ((unsigned int) (((unsigned short)(T2_460)) + ((unsigned int) 0))) <= (unsigned int) ((unsigned int) 65536)){
+		if(!((unsigned int) (((unsigned int) 112) - ((unsigned int) (((unsigned short)(T2_460)) + ((unsigned int) 72)))) < (unsigned int) ((unsigned int) 63))){
+			__VERIFIER_error();
+		}
+	}    
+       return 0;
+}

--- a/regression/esbmc/github_1363_invalid_interval_expression_fail/test.desc
+++ b/regression/esbmc/github_1363_invalid_interval_expression_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION FAILED$

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -752,7 +752,16 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
 
   if(!is_mapped<T>(src))
     return gen_true_expr();
-  const auto interval = get_interval_from_symbol<T>(src);
+  T interval = get_interval_from_symbol<T>(src);
+
+  // Some intervals can be beyond what the type can hold
+  // e.g., [-infinity,256] for an unsigned char.
+  // Althugh this is expected (when modular intervals are off)
+  // We still need to deal with the out-of-bounds when generating
+  // the expressions, as 256 would be converted to 0.
+  T type_interval = generate_modular_interval<T>(src);
+  interval.intersect_with(type_interval);
+
   if(interval.is_top())
     return gen_true_expr();
 


### PR DESCRIPTION
This fixes #1363 

The main issue was that when generating an expression we have to do a cast for the symbol type. This means that if an unsigned char "a" has an interval of `(-inf, 256]` will generate the following `ASSUME a <= (unsigned char) 256` which is an overlap... resulting in `ASSUME a <= 0`.