### PR TITLE
Add and default to `DebugOpt` build type for faster PRs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ${{ matrix.os }}
-      build-flags: '-b Debug -e On'
+      build-flags: '-b DebugOpt -e On'
       testing: true
       
     # Check project with clang-format
@@ -71,4 +71,4 @@ jobs:
       run: pip install cmakelint
     - name: Run CMake Lint
       run: find . -iname *.cmake -o -iname CMakeLists.txt | grep -v build | xargs cmakelint || echo "failure"
-      
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,21 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
   set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
       STRING "Choose the type of build." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Sanitizer")
 endif()
+
+# Set the possible values of build type for cmake-gui
+set(CMAKE_CXX_FLAGS_DEBUGOPT "-O2 -g" CACHE STRING "C++ compiler flags for DebugOpt build" FORCE)
+set(CMAKE_C_FLAGS_DEBUGOPT "-O2 -g" CACHE STRING "C compiler flags for DebugOpt build" FORCE)
+#set(CMAKE_EXE_LINKER_FLAGS_DEBUGOPT "")
+#set(CMAKE_SHARED_LINKER_FLAGS_DEBUGOPT "")
+mark_as_advanced(
+  CMAKE_CXX_FLAGS_DEBUGOPT
+  CMAKE_C_FLAGS_DEBUGOPT
+  #CMAKE_EXE_LINKER_FLAGS_DEBUGOPT
+  #CMAKE_SHARED_LINKER_FLAGS_DEBUGOPT
+)
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+             "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Sanitizer" "DebugOpt")
 
 set(ESBMC_CXX_Clang_DEFAULTS -Wall -Wextra -pipe)
 set(ESBMC_CXX_GNU_DEFAULTS -Wall -Wextra -pipe)

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3446,8 +3446,9 @@ void clang_c_convertert::convert_expression_to_code(exprt &expr)
 const clang::Decl *
 clang_c_convertert::get_DeclContext_from_Stmt(const clang::Stmt &stmt)
 {
-  auto it = ASTContext->getParents(stmt).begin();
-  if(it == ASTContext->getParents(stmt).end())
+  auto parents = ASTContext->getParents(stmt);
+  auto it = parents.begin();
+  if(it == parents.end())
     return nullptr;
 
   const clang::Decl *aDecl = it->get<clang::Decl>();


### PR DESCRIPTION
This PR adds the new value `DebugOpt` for the CMAKE_BUILD_TYPE variable. It contains the flags "-O2 -g". The difference to the existing `RelWithDebInfo` is that `-DNDEBUG` is *not* part of `DebugOpt`. It thus keeps all internal assertions, but compiles with -O2. Also switch the default from `Debug` to `DebugOpt` for the CI.

Locally, I go from Debug:
```
time ninja -j16
real	4m22,021s
user	51m27,560s
sys	2m55,290s

time ctest -j15
real	19m36,899s
user	257m17,031s
sys	5m50,710s
```
to DebugOpt:
```
time ninja -j16
real	5m48,021s
user	74m6,785s
sys	3m25,686s

time ctest -j15
real	9m49,003s
user	122m58,941s
sys	5m4,590s
```
My hope is that the CI will be faster. It might also result in some -Werrors since optimization enables more of the compiler's checks and/or in some failed test cases. I would like to ask for help in fixing those in code I'm not too familiar with.