### PR TITLE
Interval now uses std::optional to keep the bounds

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -158,8 +158,8 @@ void dump_intervals(
           i_it->location.column().as_string(),
           i_it->location.function().as_string(),
           interval.first,
-          (interval.second.lower_set ? interval.second.lower : "-inf"),
-          (interval.second.upper_set ? interval.second.upper : "inf"),
+          (interval.second.lower ? *interval.second.lower : "-inf"),
+          (interval.second.upper ? *interval.second.upper : "inf"),
           interval.second.is_bottom(),
           interval.second.is_top());
       }

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -75,9 +75,9 @@ void interval_domaint::apply_assume_symbol_truth(
     interval.make_ge_than(1);
   else if(is_signedbv_type(sym.type))
   {
-    if(interval.lower_set && interval.get_lower() == 0)
+    if(interval.lower && interval.get_lower() == 0)
       interval.make_ge_than(1);
-    else if(interval.upper_set && interval.get_upper() == 0)
+    else if(interval.upper && interval.get_upper() == 0)
       interval.make_le_than(-1);
   }
 
@@ -222,13 +222,10 @@ template <class T>
 T interval_domaint::extrapolate_intervals(const T &before, const T &after)
 {
   T result; // Full extrapolation
-
-  bool lower_decreased =
-    !after.lower_set ||
-    (before.lower_set && after.lower_set && after.lower < before.lower);
-  bool upper_increased =
-    !after.upper_set ||
-    (before.upper_set && after.upper_set && after.upper > before.upper);
+  bool lower_decreased = !after.lower || (before.lower && after.lower &&
+                                          *after.lower < *before.lower);
+  bool upper_increased = !after.upper || (before.upper && after.upper &&
+                                          *after.upper > *before.upper);
 
   if((lower_decreased || upper_increased) && !widening_under_approximate_bound)
     return result;
@@ -236,17 +233,20 @@ T interval_domaint::extrapolate_intervals(const T &before, const T &after)
   // Set lower bound: if we didn't decrease then just update the interval
   if(!lower_decreased)
   {
-    result.lower_set = before.lower_set;
-    result.lower = before.lower;
+    if(!before.lower)
+      result.lower.reset();
+    else
+      result.lower = *before.lower;
   }
 
   // Set upper bound:
   if(!upper_increased)
   {
-    result.upper_set = before.upper_set;
-    result.upper = before.upper;
+    if(!before.upper)
+      result.upper.reset();
+    else
+      result.upper = *before.upper;
   }
-
   return result;
 }
 
@@ -278,15 +278,15 @@ T interval_domaint::interpolate_intervals(const T &before, const T &after)
 {
   T result;
 
-  bool lower_increased = !before.lower_set;
-  bool upper_decreased = !before.upper_set;
+  // before: [-infinity, +infinity], after: [a,b] ==> [a,b]
+  bool lower_increased = !before.lower && after.lower;
+  bool upper_decreased = !before.upper && after.upper;
 
-  result.lower_set = lower_increased ? after.lower_set : before.lower_set;
-  result.lower = lower_increased ? after.lower : before.lower;
+  if(lower_increased)
+    result.lower = *after.lower;
 
-  result.upper_set = upper_decreased ? after.upper_set : before.upper_set;
-  result.upper = upper_decreased ? after.upper : before.upper;
-
+  if(upper_decreased)
+    result.upper = *after.upper;
   return result;
 }
 
@@ -582,10 +582,10 @@ void interval_domaint::apply_assume_less(const expr2tc &a, const expr2tc &b)
       lhs.make_sound_le(rhs);
     else
     {
-      if(rhs.upper_set)
+      if(rhs.upper)
         lhs.make_le_than(rhs.get_upper());
 
-      if(lhs.lower_set)
+      if(lhs.lower)
         rhs.make_ge_than(lhs.get_lower());
     }
   }
@@ -648,9 +648,9 @@ template <>
 expr2tc interval_domaint::make_expression_value<integer_intervalt>(
   const integer_intervalt &interval,
   const type2tc &type,
-  bool upper) const
+  bool is_upper) const
 {
-  return from_integer(upper ? interval.upper : interval.lower, type);
+  return from_integer(is_upper ? *interval.upper : *interval.lower, type);
 }
 
 template <>
@@ -662,7 +662,8 @@ expr2tc interval_domaint::make_expression_value<real_intervalt>(
   expr2tc value = gen_zero(type);
   constant_floatbv2t &v = to_constant_floatbv2t(value);
 
-  const auto d = (upper ? interval.upper : interval.lower).convert_to<double>();
+  const auto d =
+    (upper ? *interval.upper : *interval.lower).convert_to<double>();
   v.value.from_double(d);
 
   // 'from_double' changes the original spec. This makes solvers complain that we are comparing
@@ -716,12 +717,12 @@ expr2tc interval_domaint::make_expression_helper<wrapped_interval>(
   }
   else
   {
-    assert(interval.upper_set && interval.lower_set);
+    assert(interval.upper && interval.lower);
     // Interval: [a,b]
     std::vector<expr2tc> disjuncts;
 
     auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w) {
-      assert(w.lower <= w.upper);
+      assert(*w.lower <= *w.upper);
 
       std::vector<expr2tc> s_conjuncts;
       expr2tc value1 = make_expression_value(w, src.type, true);
@@ -780,13 +781,13 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
   }
   else
   {
-    if(interval.upper_set)
+    if(interval.upper)
     {
       expr2tc value = make_expression_value(interval, src.type, true);
       conjuncts.push_back(lessthanequal2tc(symbol, typecast(value)));
     }
 
-    if(interval.lower_set)
+    if(interval.lower)
     {
       expr2tc value = make_expression_value(interval, src.type, false);
       conjuncts.push_back(lessthanequal2tc(typecast(value), symbol));
@@ -810,11 +811,11 @@ void interval_domaint::output(std::ostream &out) const
   {
     if(interval.second.is_top())
       continue;
-    if(interval.second.lower_set)
-      out << interval.second.lower << " <= ";
+    if(interval.second.lower)
+      out << *interval.second.lower << " <= ";
     out << interval.first;
-    if(interval.second.upper_set)
-      out << " <= " << interval.second.upper;
+    if(interval.second.upper)
+      out << " <= " << *interval.second.upper;
     out << "\n";
   }
 
@@ -831,11 +832,11 @@ void interval_domaint::output(std::ostream &out) const
   {
     if(interval.second.is_top())
       continue;
-    if(interval.second.lower_set)
-      out << interval.second.lower << " <= ";
+    if(interval.second.lower)
+      out << *interval.second.lower << " <= ";
     out << interval.first;
-    if(interval.second.upper_set)
-      out << " <= " << interval.second.upper;
+    if(interval.second.upper)
+      out << " <= " << *interval.second.upper;
     out << "\n";
   }
 }

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -236,7 +236,7 @@ T interval_domaint::extrapolate_intervals(const T &before, const T &after)
     if(!before.lower)
       result.lower.reset();
     else
-      result.lower = *before.lower;
+      result.lower = before.lower;
   }
 
   // Set upper bound:
@@ -245,7 +245,7 @@ T interval_domaint::extrapolate_intervals(const T &before, const T &after)
     if(!before.upper)
       result.upper.reset();
     else
-      result.upper = *before.upper;
+      result.upper = before.upper;
   }
   return result;
 }
@@ -283,10 +283,10 @@ T interval_domaint::interpolate_intervals(const T &before, const T &after)
   bool upper_decreased = !before.upper && after.upper;
 
   if(lower_increased)
-    result.lower = *after.lower;
+    result.lower = after.lower;
 
   if(upper_decreased)
-    result.upper = *after.upper;
+    result.upper = after.upper;
   return result;
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -232,21 +232,11 @@ T interval_domaint::extrapolate_intervals(const T &before, const T &after)
 
   // Set lower bound: if we didn't decrease then just update the interval
   if(!lower_decreased)
-  {
-    if(!before.lower)
-      result.lower.reset();
-    else
-      result.lower = before.lower;
-  }
+    result.lower = before.lower;
 
   // Set upper bound:
   if(!upper_increased)
-  {
-    if(!before.upper)
-      result.upper.reset();
-    else
-      result.upper = before.upper;
-  }
+    result.upper = before.upper;
   return result;
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -268,6 +268,25 @@ protected:
    * @brief Applies Extrapolation widening algorithm
    *
    * Given two intervals: (a0, b0) (before the computation) and (a1, b1) (after the computation):
+   * The objective of the extrapolation is to accelerate the convergence at the cost of precision
+   *
+   * Example:
+   * int i = 0;
+   * while(i < 10)
+   *  i++;  <--- what is the interval for i before the increment?
+   *
+   * Computing the interval of sum would need 11 iterations to arrive to [0,9],
+   * it 1 = [0,0]
+   * it 2 = [0,1]
+   * it 3 = [0,2]
+   * ...
+   * it 10 = [0,9]
+   * it 11 = [0,9] fixpoint
+   *
+   * By extrapolating, we can arrive at [0, +inf] in two iterations.
+   * it 1 = [0,0]
+   * it 2 = [0,1] => [0, inf]
+   * it 3 = [0,inf] fixpoint
    *
    * Widening((a0,b0), (a1,b1)) = (a1 < a0 ? -infinity : a0, b1 > b0 ? infinity : b0 )
    * @tparam Interval interval template specialization (Integers, Reals)
@@ -279,10 +298,22 @@ protected:
 
   /**
    * @brief Applies Interpolation narrowing algorithm
+   * 
    *
    * Given two intervals: (a0, b0) (before the computation) and (a1, b1) (after the computation):
+   * The objective of the interpolation is to bring back some of the precision lost from an extrapolation.
    *
-   * Narrowing((a0,b0), (a1,b1)) = (a1 > a0 ? a0 : a1, b1 < b0 ? b0 : b1 )
+   * Example:
+   * int i = 0;
+   * while(i < 10)
+   *  i++;  <--- what is the interval for i before the increment?
+   * 
+   * Coming back from an extrapolation [0, +inf] (which is a fixpoint)
+   * we can narrow the interval by checking the interval post the loop condition (i < 10)
+   * it 4 = narrowing([0, inf], [0, 9]) => [0,9]
+   * it 5 = [0,9]  
+   *
+   * Narrowing((a0,b0), (a1,b1)) = (a0 == -inf ? a1 : a0, b0 = +inf ? b1 : b0)
    * @tparam Interval interval template specialization (Integers, Reals)
    * @param lhs
    * @param rhs

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -21,23 +21,16 @@ class interval_templatet
 public:
   virtual ~interval_templatet() = default;
 
-  interval_templatet()
-  {
-    // this is 'top'
-  }
+  interval_templatet() = default;
 
   explicit interval_templatet(const T &x) : lower(x), upper(x)
   {
   }
 
-  explicit interval_templatet(const T &l, const T &u) : lower(l), upper(u)
+  interval_templatet(const T &l, const T &u) : lower(l), upper(u)
   {
   }
 
-  /* TODO: There is a clear dependency between the lower/upper and
-  *        and lower_set/upper_set variable. Shouldn't we convert the
-  *        the uses into the constraints functions?
-  */
   /// Bound value
   std::optional<T> lower, upper;
 
@@ -113,7 +106,7 @@ public:
  */
   virtual bool empty() const
   {
-    return !is_top() && (lower && upper && *lower > *upper);
+    return lower && upper && *lower > *upper;
   }
 
   bool is_bottom() const // equivalent to 'false'
@@ -171,9 +164,9 @@ public:
               : upper          ? *upper
                                : *v.upper;
     if(lower || v.lower)
-      lower = lower && v.lower ? std::max(*lower, *v.lower)
-              : lower          ? *lower
-                               : *v.lower;
+      v.lower = lower && v.lower ? std::max(*lower, *v.lower)
+                : lower          ? *lower
+                                 : *v.lower;
   }
 
   virtual void make_ge_than(const T &v) // add lower bound
@@ -635,12 +628,6 @@ public:
       return false;
 
     if((lower != i.lower) || (upper != i.upper))
-      return true;
-
-    if(lower && *lower != *i.lower)
-      return true;
-
-    if(upper && *upper != *i.upper)
       return true;
 
     return false;

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -7,6 +7,7 @@
 #include <util/message.h>
 #include <sstream>
 #include <util/ieee_float.h>
+#include <optional>
 /**
  * @brief This class is used to store intervals
  * in the form of lower <= upper. It also has support
@@ -20,18 +21,16 @@ class interval_templatet
 public:
   virtual ~interval_templatet() = default;
 
-  interval_templatet() : lower_set(false), upper_set(false)
+  interval_templatet()
   {
     // this is 'top'
   }
 
-  explicit interval_templatet(const T &x)
-    : lower_set(true), upper_set(true), lower(x), upper(x)
+  explicit interval_templatet(const T &x) : lower(x), upper(x)
   {
   }
 
-  explicit interval_templatet(const T &l, const T &u)
-    : lower_set(true), upper_set(true), lower(l), upper(u)
+  explicit interval_templatet(const T &l, const T &u) : lower(l), upper(u)
   {
   }
 
@@ -39,10 +38,8 @@ public:
   *        and lower_set/upper_set variable. Shouldn't we convert the
   *        the uses into the constraints functions?
   */
-  /// If the `_set` variables are false, then the bound is infinity
-  bool lower_set, upper_set;
   /// Bound value
-  T lower, upper;
+  std::optional<T> lower, upper;
 
   T get_lower() const
   {
@@ -70,17 +67,15 @@ public:
 
   virtual T get(bool is_upper) const
   {
-    return is_upper ? upper : lower;
+    return is_upper ? *upper : *lower;
   }
 
   void set_upper(const T &b)
   {
-    upper_set = true;
     set(true, b);
   }
   void set_lower(const T &b)
   {
-    lower_set = true;
     set(false, b);
   }
 
@@ -92,13 +87,14 @@ public:
       oss << "EMPTY";
     else
     {
-      if(lower_set)
+      if(lower)
+
         oss << "[" << get_lower();
       else
         oss << "(-inf";
 
       oss << ",";
-      if(upper_set)
+      if(upper)
         oss << get_upper() << "]";
       else
         oss << "+inf)";
@@ -117,7 +113,7 @@ public:
  */
   virtual bool empty() const
   {
-    return !is_top() && (upper_set && lower_set && lower > upper);
+    return !is_top() && (lower && upper && *lower > *upper);
   }
 
   bool is_bottom() const // equivalent to 'false'
@@ -127,27 +123,26 @@ public:
 
   virtual bool is_top() const // equivalent to 'true'
   {
-    return !lower_set && !upper_set;
+    return !lower && !upper;
   }
 
   /// There is only one value that satisfies
   bool singleton() const
   {
-    return upper_set && lower_set && lower == upper;
+    return upper && lower && *lower == *upper;
   }
 
   // constraints
   virtual void make_le_than(const T &v) // add upper bound
   {
     auto value = adjust(v);
-    if(upper_set)
+    if(upper)
     {
       if(is_le_than(value, get_upper()))
         set_upper(value);
     }
     else
     {
-      upper_set = true;
       set_upper(value);
     }
   }
@@ -157,10 +152,10 @@ public:
     if(is_top())
       return true;
 
-    if(lower_set && e < get_lower())
+    if(lower && e < get_lower())
       return false;
 
-    if(upper_set && e > get_upper())
+    if(upper && e > get_upper())
       return false;
 
     return true;
@@ -169,23 +164,28 @@ public:
   // Sound version (considering over approximations)
   void make_sound_le(interval_templatet<T> &v)
   {
-    upper_set = upper_set || v.upper_set;
-    upper = std::min(upper, v.upper);
-    v.lower_set = lower_set && v.lower_set;
-    v.lower = std::max(lower, v.lower);
+    // [lower, upper] <= [v.lower,v.upper] <==> [lower, min(upper,v.upper)] <= [max(lower, v.lower)]
+
+    if(upper || v.upper)
+      upper = upper && v.upper ? std::min(*upper, *v.upper)
+              : upper          ? *upper
+                               : *v.upper;
+    if(lower || v.lower)
+      lower = lower && v.lower ? std::max(*lower, *v.lower)
+              : lower          ? *lower
+                               : *v.lower;
   }
 
   virtual void make_ge_than(const T &v) // add lower bound
   {
     auto value = adjust(v);
-    if(lower_set)
+    if(lower)
     {
       if(is_le_than(get_lower(), value))
         set_lower(value);
     }
     else
     {
-      lower_set = true;
       set_lower(value);
     }
   }
@@ -204,44 +204,42 @@ public:
 
   void intersect_with(const interval_templatet &i)
   {
-    if(i.lower_set)
+    if(i.lower)
     {
-      if(lower_set)
+      if(lower)
       {
-        lower = std::max(lower, i.lower);
+        lower = std::max(*lower, *i.lower);
       }
       else
       {
-        lower_set = true;
-        lower = i.lower;
+        lower = *i.lower;
       }
     }
 
-    if(i.upper_set)
+    if(i.upper)
     {
-      if(upper_set)
+      if(upper)
       {
-        upper = std::min(upper, i.upper);
+        upper = std::min(*upper, *i.upper);
       }
       else
       {
-        upper_set = true;
-        upper = i.upper;
+        upper = *i.upper;
       }
     }
   }
 
   virtual void approx_union_with(const interval_templatet &i)
   {
-    if(i.lower_set && lower_set)
-      lower = std::min(lower, i.lower);
-    else if(!i.lower_set && lower_set)
-      lower_set = false;
+    if(i.lower && lower)
+      lower = std::min(*lower, *i.lower);
+    else if(!i.lower)
+      lower.reset();
 
-    if(i.upper_set && upper_set)
-      upper = std::max(upper, i.upper);
-    else if(!i.upper_set && upper_set)
-      upper_set = false;
+    if(i.upper && upper)
+      upper = std::max(*upper, *i.upper);
+    else if(!i.upper)
+      upper.reset();
   }
 
   /* INTERVAL ARITHMETICS 
@@ -278,15 +276,15 @@ public:
     if(result.empty())
       return result;
 
-    if(!lhs.lower_set || !rhs.lower_set)
-      result.lower_set = false;
+    if(!lhs.lower || !rhs.lower)
+      result.lower.reset();
     else
-      result.lower = lhs.lower + rhs.lower;
+      result.lower = *lhs.lower + *rhs.lower;
 
-    if(!lhs.upper_set || !rhs.upper_set)
-      result.upper_set = false;
+    if(!lhs.upper || !rhs.upper)
+      result.upper.reset();
     else
-      result.upper = lhs.upper + rhs.upper;
+      result.upper = *lhs.upper + *rhs.upper;
 
     return result;
   }
@@ -295,22 +293,20 @@ public:
   {
     // -[a_0, a_1] = [-a_1, -a_0]
     auto result = lhs;
-    if(!lhs.upper_set)
-      result.lower_set = false;
+    if(!lhs.upper)
+      result.lower.reset();
     else
     {
-      result.lower = -lhs.upper;
-      result.lower_set = true;
+      result.lower = -(*lhs.upper);
     }
 
-    if(!lhs.lower_set)
+    if(!lhs.lower)
     {
-      result.upper_set = false;
+      result.upper.reset();
     }
     else
     {
-      result.upper = -lhs.lower;
-      result.upper_set = true;
+      result.upper = -(*lhs.lower);
     }
     return result;
   }
@@ -323,15 +319,15 @@ public:
     if(result.empty())
       return result;
 
-    if(!lhs.lower_set || !rhs.upper_set)
-      result.lower_set = false;
+    if(!lhs.lower || !rhs.upper)
+      result.lower.reset();
     else
-      result.lower = lhs.lower - rhs.upper;
+      result.lower = *lhs.lower - *rhs.upper;
 
-    if(!lhs.upper_set || !rhs.lower_set)
-      result.upper_set = false;
+    if(!lhs.upper || !rhs.lower)
+      result.upper.reset();
     else
-      result.upper = lhs.upper - rhs.lower;
+      result.upper = *lhs.upper - *rhs.lower;
 
     return result;
   }
@@ -345,25 +341,22 @@ public:
       return rhs.empty() ? rhs : lhs;
 
     // Let's deal with infinities first
-    if(!lhs.lower_set || !rhs.lower_set || !lhs.upper_set || !rhs.upper_set)
+    if(!lhs.lower || !rhs.lower || !lhs.upper || !rhs.upper)
       return result;
 
-    result.lower_set = true;
-    result.upper_set = true;
-
     // Initialize with a0 * b0
-    auto a0_b0 = lhs.lower * rhs.lower;
+    auto a0_b0 = *lhs.lower * *rhs.lower;
     result.lower = a0_b0;
     result.upper = a0_b0;
 
     auto update_value = [&result](T value) {
-      result.lower = std::min(value, result.lower);
-      result.upper = std::max(value, result.upper);
+      result.lower = std::min(value, *result.lower);
+      result.upper = std::max(value, *result.upper);
     };
 
-    update_value(lhs.lower * rhs.upper); // a0 * b1
-    update_value(lhs.upper * rhs.lower); // a1 * b0
-    update_value(lhs.upper * rhs.upper); // a1 * b1
+    update_value(*lhs.lower * *rhs.upper); // a0 * b1
+    update_value(*lhs.upper * *rhs.lower); // a1 * b0
+    update_value(*lhs.upper * *rhs.upper); // a1 * b1
 
     return result;
   }
@@ -383,26 +376,23 @@ public:
 
     // Let's (not) deal with infinities first and division by 0.
     if(
-      !lhs.lower_set || !rhs.lower_set || !lhs.upper_set || !rhs.upper_set ||
-      rhs.lower == 0 || rhs.upper == 0)
+      !lhs.lower || !rhs.lower || !lhs.upper || !rhs.upper || *rhs.lower == 0 ||
+      *rhs.upper == 0)
       return result;
 
-    result.lower_set = true;
-    result.upper_set = true;
-
     // Initialize with a0 * b0
-    auto a0_b0 = lhs.lower / rhs.lower;
+    T a0_b0 = *lhs.lower / *rhs.lower;
     result.lower = a0_b0;
     result.upper = a0_b0;
 
     auto update_value = [&result](T value) {
-      result.lower = std::min(value, result.lower);
-      result.upper = std::max(value, result.upper);
+      result.lower = std::min(value, *result.lower);
+      result.upper = std::max(value, *result.upper);
     };
 
-    update_value(lhs.lower / rhs.upper); // a0 / b1
-    update_value(lhs.upper / rhs.lower); // a1 / b0
-    update_value(lhs.upper / rhs.upper); // a1 / b1
+    update_value(*lhs.lower / *rhs.upper); // a0 / b1
+    update_value(*lhs.upper / *rhs.lower); // a1 / b0
+    update_value(*lhs.upper / *rhs.upper); // a1 / b1
 
     return result;
   }
@@ -579,14 +569,14 @@ public:
     result.set_upper(1);
 
     // MAX LHS < MIN RHS => TRUE
-    if(lhs.upper_set && rhs.lower_set && lhs.get_upper() < rhs.get_lower())
+    if(lhs.upper && rhs.lower && lhs.get_upper() < rhs.get_lower())
     {
       result.set_lower(1);
       return result;
     }
 
     // MIN LHS >= MAX RHS => FALSE
-    if(lhs.lower_set && rhs.upper_set && lhs.get_lower() >= rhs.get_upper())
+    if(lhs.lower && rhs.upper && lhs.get_lower() >= rhs.get_upper())
     {
       result.set_upper(0);
       return result;
@@ -605,14 +595,14 @@ public:
     result.set_upper(1);
 
     // MAX LHS <= MIN RHS => TRUE
-    if(lhs.upper_set && rhs.lower_set && lhs.get_upper() <= rhs.get_lower())
+    if(lhs.upper && rhs.lower && lhs.get_upper() <= rhs.get_lower())
     {
       result.set_lower(1);
       return result;
     }
 
     // MIN LHS > MAX RHS => FALSE
-    if(lhs.lower_set && rhs.upper_set && lhs.get_lower() > rhs.get_upper())
+    if(lhs.lower && rhs.upper && lhs.get_lower() > rhs.get_upper())
     {
       result.set_upper(0);
       return result;
@@ -643,20 +633,15 @@ public:
   {
     if(empty())
       return false;
-    auto lower_equal = lower == i.lower;
-    auto upper_equal = upper == i.upper;
-    auto lower_set_equal = lower_set == i.lower_set;
-    auto upper_set_equal = upper_set == i.upper_set;
 
-    if(lower_set && upper_set)
-      return !(
-        lower_set_equal && upper_set_equal && lower_equal && upper_equal);
+    if((lower != i.lower) || (upper != i.upper))
+      return true;
 
-    if(lower_set)
-      return !(upper_set_equal && upper_equal);
+    if(lower && *lower != *i.lower)
+      return true;
 
-    if(upper_set)
-      return !(lower_set_equal && lower_equal);
+    if(upper && *upper != *i.upper)
+      return true;
 
     return false;
   }
@@ -707,9 +692,9 @@ public:
 template <class T>
 tvt operator<=(const interval_templatet<T> &a, const interval_templatet<T> &b)
 {
-  if(a.upper_set && b.lower_set && a.upper <= b.lower)
+  if(a.upper && b.lower && *a.upper <= *b.lower)
     return tvt(true);
-  if(a.lower_set && b.upper_set && a.lower > b.upper)
+  if(a.lower && b.upper && *a.lower > *b.upper)
     return tvt(false);
 
   return tvt(tvt::TV_UNKNOWN);
@@ -736,14 +721,14 @@ tvt operator>(const interval_templatet<T> &a, const interval_templatet<T> &b)
 template <class T>
 bool operator==(const interval_templatet<T> &a, const interval_templatet<T> &b)
 {
-  if(a.lower_set != b.lower_set)
+  if(a.lower.has_value() != b.lower.has_value())
     return false;
-  if(a.upper_set != b.upper_set)
+  if(a.upper.has_value() != b.upper.has_value())
     return false;
 
-  if(a.lower_set && a.lower != b.lower)
+  if(a.lower && *a.lower != *b.lower)
     return false;
-  if(a.upper_set && a.upper != b.upper)
+  if(a.upper && *a.upper != *b.upper)
     return false;
 
   return true;
@@ -759,7 +744,6 @@ template <class T>
 interval_templatet<T> upper_interval(const T &u)
 {
   interval_templatet<T> i;
-  i.upper_set = true;
   i.upper = u;
   return i;
 }
@@ -768,7 +752,6 @@ template <class T>
 interval_templatet<T> lower_interval(const T &l)
 {
   interval_templatet<T> i;
-  i.lower_set = true;
   i.lower = l;
   return i;
 }
@@ -776,15 +759,15 @@ interval_templatet<T> lower_interval(const T &l)
 template <class T>
 std::ostream &operator<<(std::ostream &out, const interval_templatet<T> &i)
 {
-  if(i.lower_set)
-    out << '[' << i.lower;
+  if(i.lower)
+    out << '[' << *i.lower;
   else
     out << ")-INF";
 
   out << ',';
 
-  if(i.upper_set)
-    out << i.upper << ']';
+  if(i.upper)
+    out << *i.upper << ']';
   else
     out << "+INF(";
 

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -157,7 +157,7 @@ public:
   // Sound version (considering over approximations)
   void make_sound_le(interval_templatet<T> &v)
   {
-    // [lower, upper] <= [v.lower,v.upper] <==> [lower, min(upper,v.upper)] <= [max(lower, v.lower)]
+    // [lower, upper] <= [v.lower,v.upper] <==> [lower, min(upper,v.upper)] <= [max(lower, v.lower), v.upper]
 
     if(upper || v.upper)
       upper = upper && v.upper ? std::min(*upper, *v.upper)

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -49,7 +49,7 @@ public:
     {
       auto middle = get_upper_bound() / 2; // [128] 256
       if(*value >= middle)
-        value = *value - middle * 2;
+        *value -= middle * 2;
     }
 
     return *value;
@@ -79,7 +79,7 @@ public:
       result.lower = (*w.upper + 1) % mod;
       result.upper = (*w.lower - 1) % mod;
       if(result.upper < 0)
-        result.upper = *result.upper + mod;
+        *result.upper += mod;
     }
     return result;
   }
@@ -608,9 +608,9 @@ public:
       result.lower = (*lhs.lower - *rhs.upper) % mod;
       result.upper = (*lhs.upper - *rhs.lower) % mod;
       if(*result.lower < 0)
-        result.lower = *result.lower + mod;
+        *result.lower += mod;
       if(*result.upper < 0)
-        result.upper = *result.upper + mod;
+        *result.upper += mod;
       assert(*result.lower >= 0);
       assert(*result.upper >= 0);
     }

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -461,10 +461,10 @@ public:
     if(t.is_included(s))
       return t;
 
-    const BigInt a = *s.lower;
-    const BigInt b = *s.upper;
-    const BigInt c = *t.lower;
-    const BigInt d = *t.upper;
+    const BigInt &a = *s.lower;
+    const BigInt &b = *s.upper;
+    const BigInt &c = *t.lower;
+    const BigInt &d = *t.upper;
 
     wrapped_interval result(s.t);
 

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -302,10 +302,10 @@ public:
     if(t.is_included(s))
       return s;
 
-    const BigInt a = s.lower;
-    const BigInt b = s.upper;
-    const BigInt c = t.lower;
-    const BigInt d = t.upper;
+    const BigInt &a = s.lower;
+    const BigInt &b = s.upper;
+    const BigInt &c = t.lower;
+    const BigInt &d = t.upper;
 
     wrapped_interval result(s.t);
 
@@ -394,10 +394,10 @@ public:
       return result;
     }
 
-    const BigInt a = *s.lower;
-    const BigInt b = *s.upper;
-    const BigInt c = *t.lower;
-    const BigInt d = *t.upper;
+    const BigInt &a = *s.lower;
+    const BigInt &b = *s.upper;
+    const BigInt &c = *t.lower;
+    const BigInt &d = *t.upper;
 
     if(t.contains(a) && t.contains(b) && s.contains(c) && s.contains(d))
     {

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -180,14 +180,9 @@ public:
               // Hack to get values!
               auto cpy = interval->second;
               cpy.set_lower(value);
-              CAPTURE(
-                interval->second.get_lower(),
-                interval->second.get_upper(),
-                cpy.get_lower(),
-                property_it->var,
-                i_it->location.get_line().as_string());
+              assert(cpy.lower);
               REQUIRE(
-                interval->second.contains(cpy.lower) ==
+                interval->second.contains(*cpy.lower) ==
                 property_it->should_contain);
             }
           }
@@ -511,7 +506,6 @@ TEST_CASE(
 
   T.run_configs();
 }
-
 TEST_CASE("Interval Analysis - While Statement", "[ai][interval-analysis]")
 {
   // Setup global options here

--- a/unit/goto-programs/interval_template.test.cpp
+++ b/unit/goto-programs/interval_template.test.cpp
@@ -164,10 +164,10 @@ TEST_CASE(
     B.make_le_than(10);
 
     auto result = A + B;
-    REQUIRE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.lower == 6);
-    REQUIRE(result.upper == 20);
+    REQUIRE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.lower == 6);
+    REQUIRE(*result.upper == 20);
   }
 
   SECTION("Add test 2")
@@ -179,9 +179,9 @@ TEST_CASE(
     B.make_le_than(10);
 
     auto result = A + B;
-    REQUIRE_FALSE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.upper == 20);
+    REQUIRE_FALSE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.upper == 20);
   }
 
   SECTION("Add test 3")
@@ -192,8 +192,8 @@ TEST_CASE(
     B.make_ge_than(5);
 
     auto result = A + B;
-    REQUIRE_FALSE(result.lower_set);
-    REQUIRE_FALSE(result.upper_set);
+    REQUIRE_FALSE(result.lower);
+    REQUIRE_FALSE(result.upper);
   }
 
   SECTION("Sub test 1")
@@ -206,10 +206,10 @@ TEST_CASE(
     B.make_le_than(10);
 
     auto result = A - B;
-    REQUIRE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.lower == -9);
-    REQUIRE(result.upper == 5);
+    REQUIRE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.lower == -9);
+    REQUIRE(*result.upper == 5);
   }
 
   SECTION("Sub test 2")
@@ -221,9 +221,9 @@ TEST_CASE(
     B.make_le_than(10);
 
     auto result = A - B;
-    REQUIRE_FALSE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.upper == 5);
+    REQUIRE_FALSE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.upper == 5);
   }
 
   SECTION("Sub test 3")
@@ -234,9 +234,9 @@ TEST_CASE(
     B.make_ge_than(5);
 
     auto result = A - B;
-    REQUIRE_FALSE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.upper == 5);
+    REQUIRE_FALSE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.upper == 5);
   }
 
   SECTION("Mul test 1")
@@ -248,10 +248,10 @@ TEST_CASE(
     B.make_le_than(1);
 
     auto result = A * B;
-    REQUIRE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.lower == -10);
-    REQUIRE(result.upper == 10);
+    REQUIRE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.lower == -10);
+    REQUIRE(*result.upper == 10);
   }
 
   SECTION("Mul test 2")
@@ -263,10 +263,10 @@ TEST_CASE(
     B.make_le_than(2);
 
     auto result = A * B;
-    REQUIRE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.lower == -30);
-    REQUIRE(result.upper == 20);
+    REQUIRE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.lower == -30);
+    REQUIRE(*result.upper == 20);
   }
 
   SECTION("Div test 1")
@@ -278,10 +278,10 @@ TEST_CASE(
     B.make_le_than(2);
 
     auto result = A / B;
-    REQUIRE(result.lower_set);
-    REQUIRE(result.upper_set);
-    REQUIRE(result.lower == 2);
-    REQUIRE(result.upper == 10);
+    REQUIRE(result.lower);
+    REQUIRE(result.upper);
+    REQUIRE(*result.lower == 2);
+    REQUIRE(*result.upper == 10);
   }
 
   SECTION("Copy constructor")
@@ -289,8 +289,8 @@ TEST_CASE(
     // Just to be sure
     auto tmp_a = A;
     A.make_ge_than(0);
-    REQUIRE(!tmp_a.lower_set);
-    REQUIRE(A.lower_set);
+    REQUIRE(!tmp_a.lower);
+    REQUIRE(A.lower);
   }
   SECTION("Contractor")
   {
@@ -305,15 +305,15 @@ TEST_CASE(
     B.make_ge_than(0);
 
     interval_templatet<int>::contract_interval_le(B, A);
-    REQUIRE(A.lower_set);
-    REQUIRE(A.upper_set);
-    REQUIRE(A.lower == 0);
-    REQUIRE(A.upper == 20);
+    REQUIRE(A.lower);
+    REQUIRE(A.upper);
+    REQUIRE(*A.lower == 0);
+    REQUIRE(*A.upper == 20);
 
-    REQUIRE(B.lower_set);
-    REQUIRE(B.upper_set);
-    REQUIRE(B.lower == 0);
-    REQUIRE(B.upper == 20);
+    REQUIRE(B.lower);
+    REQUIRE(B.upper);
+    REQUIRE(*B.lower == 0);
+    REQUIRE(*B.upper == 20);
   }
 }
 
@@ -363,14 +363,14 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
     wrapped_interval A(t1_unsigned);
     wrapped_interval C(t2_unsigned);
 
-    REQUIRE(A.lower == 0);
-    REQUIRE(A.upper.to_uint64() == pow(2, N1) - 1);
+    REQUIRE(*A.lower == 0);
+    REQUIRE((*A.upper).to_uint64() == pow(2, N1) - 1);
     REQUIRE(!A.is_bottom());
     CAPTURE(A.cardinality());
     REQUIRE(A.is_top());
 
-    REQUIRE(C.lower == 0);
-    REQUIRE(C.upper.to_uint64() == pow(2, N2) - 1);
+    REQUIRE(*C.lower == 0);
+    REQUIRE((*C.upper).to_uint64() == pow(2, N2) - 1);
     REQUIRE(!C.is_bottom());
     REQUIRE(C.is_top());
 
@@ -379,8 +379,8 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
     {
       A.set_lower(c);
       A.set_upper(c);
-      REQUIRE(A.lower >= 0);
-      REQUIRE(A.upper >= 0);
+      REQUIRE(*A.lower >= 0);
+      REQUIRE(*A.upper >= 0);
       REQUIRE(A.get_lower() == c);
       REQUIRE(A.get_upper() == c);
     }
@@ -389,9 +389,9 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
   SECTION("Init Signed")
   {
     wrapped_interval A(t1_signed);
-    CAPTURE(A.lower.to_int64(), A.upper.to_uint64());
-    REQUIRE(A.lower == 0);
-    REQUIRE(A.upper.to_uint64() == pow(2, N1) - 1);
+    CAPTURE((*A.lower).to_int64(), (*A.upper).to_uint64());
+    REQUIRE(*A.lower == 0);
+    REQUIRE((*A.upper).to_uint64() == pow(2, N1) - 1);
     REQUIRE(!A.is_bottom());
     REQUIRE(A.is_top());
 
@@ -400,8 +400,8 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
     {
       A.set_lower(c);
       A.set_upper(c);
-      REQUIRE(A.lower >= 0);
-      REQUIRE(A.upper >= 0);
+      REQUIRE(*A.lower >= 0);
+      REQUIRE(*A.upper >= 0);
       REQUIRE(A.get_lower() == c);
       REQUIRE(A.get_upper() == c);
     }
@@ -495,8 +495,8 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
     B.approx_union_with(A);
     CAPTURE(B.lower, B.upper);
     REQUIRE(!B.is_bottom());
-    REQUIRE(B.lower == 51);
-    REQUIRE(B.upper == 52);
+    REQUIRE(*B.lower == 51);
+    REQUIRE(*B.upper == 52);
   }
 
   SECTION("Join/Meet from bug")
@@ -578,8 +578,8 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
 
   SECTION("Addition Unsigned")
   {
-    REQUIRE(A.lower == 0);
-    REQUIRE(A.upper.to_uint64() == pow(2, N1) - 1);
+    REQUIRE(*A.lower == 0);
+    REQUIRE((*A.upper).to_uint64() == pow(2, N1) - 1);
     REQUIRE(!A.is_bottom());
     REQUIRE(A.is_top());
 
@@ -609,7 +609,7 @@ TEST_CASE("Wrapped Intervals tests", "[ai][interval-analysis]")
   SECTION("Addition Unsigned wrap")
   {
     REQUIRE(A.lower == 0);
-    REQUIRE(A.upper.to_uint64() == pow(2, N1) - 1);
+    REQUIRE((*A.upper).to_uint64() == pow(2, N1) - 1);
     REQUIRE(!A.is_bottom());
     REQUIRE(A.is_top());
 
@@ -662,13 +662,13 @@ TEST_CASE("Interval templates arithmetic operations", "[ai][interval-analysis]")
   SECTION("North Pole")
   {
     auto np = wrapped_interval::north_pole(t1_signed);
-    REQUIRE((np.lower == 127 && np.upper == 128));
+    REQUIRE((*np.lower == 127 && *np.upper == 128));
   }
 
   SECTION("South Pole")
   {
     auto np = wrapped_interval::south_pole(t1_signed);
-    REQUIRE((np.upper == 0 && np.lower == 255));
+    REQUIRE((*np.upper == 0 && *np.lower == 255));
   }
 
   SECTION("North Split")
@@ -687,10 +687,10 @@ TEST_CASE("Interval templates arithmetic operations", "[ai][interval-analysis]")
     REQUIRE(w1_split.size() == 2);
 
     // The right part is returned as first element! (not a rule though)
-    REQUIRE(w1_split[0].lower == 128);
-    REQUIRE(w1_split[0].upper == 150);
-    REQUIRE(w1_split[1].lower == 100);
-    REQUIRE(w1_split[1].upper == 127);
+    REQUIRE(*w1_split[0].lower == 128);
+    REQUIRE(*w1_split[0].upper == 150);
+    REQUIRE(*w1_split[1].lower == 100);
+    REQUIRE(*w1_split[1].upper == 127);
   }
 
   SECTION("South Split")
@@ -711,10 +711,10 @@ TEST_CASE("Interval templates arithmetic operations", "[ai][interval-analysis]")
     REQUIRE(w1_split.size() == 2);
 
     // The left part is returned as first element! (not a rule though)
-    REQUIRE(w1_split[0].lower == 0);
-    REQUIRE(w1_split[0].upper == 150);
-    REQUIRE(w1_split[1].lower == 200);
-    REQUIRE(w1_split[1].upper == 255);
+    REQUIRE(*w1_split[0].lower == 0);
+    REQUIRE(*w1_split[0].upper == 150);
+    REQUIRE(*w1_split[1].lower == 200);
+    REQUIRE(*w1_split[1].upper == 255);
   }
 
   SECTION("Cut")
@@ -761,14 +761,14 @@ TEST_CASE("Interval templates arithmetic operations", "[ai][interval-analysis]")
     w.lower = 255;
     w.upper = 127;
 
-    REQUIRE(w.most_significant_bit(w.lower));
-    REQUIRE(!w.most_significant_bit(w.upper));
+    REQUIRE(w.most_significant_bit(*w.lower));
+    REQUIRE(!w.most_significant_bit(*w.upper));
 
     w.lower = 25;
     w.upper = 130;
 
-    REQUIRE(!w.most_significant_bit(w.lower));
-    REQUIRE(w.most_significant_bit(w.upper));
+    REQUIRE(!w.most_significant_bit(*w.lower));
+    REQUIRE(w.most_significant_bit(*w.upper));
   }
 
   SECTION("Difference")
@@ -783,8 +783,8 @@ TEST_CASE("Interval templates arithmetic operations", "[ai][interval-analysis]")
 
     auto result = w1.difference(w1, w2);
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 111);
-    REQUIRE(result.upper == 120);
+    REQUIRE(*result.lower == 111);
+    REQUIRE(*result.upper == 120);
   }
 }
 
@@ -808,8 +808,8 @@ TEST_CASE("Interval templates multiplication", "[ai][interval-analysis]")
     auto w3 = w1 * w2;
 
     CAPTURE(w3.lower, w3.upper);
-    REQUIRE(w3.lower == 10);
-    REQUIRE(w3.upper == 100);
+    REQUIRE(*w3.lower == 10);
+    REQUIRE(*w3.upper == 100);
 
     w1.lower = 1;
     w1.upper = 2;
@@ -819,8 +819,8 @@ TEST_CASE("Interval templates multiplication", "[ai][interval-analysis]")
 
     w3 = w1 * w2;
     CAPTURE(w3.lower, w3.upper);
-    REQUIRE(w3.lower == 0);
-    REQUIRE(w3.upper == 254);
+    REQUIRE(*w3.lower == 0);
+    REQUIRE(*w3.upper == 254);
   }
 
   SECTION("Multiply signed")
@@ -836,8 +836,8 @@ TEST_CASE("Interval templates multiplication", "[ai][interval-analysis]")
     auto w3 = w1 * w2;
 
     CAPTURE(w3.lower, w3.upper);
-    REQUIRE(w3.lower == 246);
-    REQUIRE(w3.upper == 255);
+    REQUIRE(*w3.lower == 246);
+    REQUIRE(*w3.upper == 255);
   }
 }
 
@@ -861,8 +861,8 @@ TEST_CASE("Interval templates division", "[ai][interval-analysis]")
     auto w3 = w1 / w2;
 
     CAPTURE(w3.lower, w3.upper);
-    REQUIRE(w3.lower == 0);
-    REQUIRE(w3.upper == 10);
+    REQUIRE(*w3.lower == 0);
+    REQUIRE(*w3.upper == 10);
 
     w1.lower = 10;
     w1.upper = 20;
@@ -872,8 +872,8 @@ TEST_CASE("Interval templates division", "[ai][interval-analysis]")
 
     w3 = w1 / w2;
     CAPTURE(w3.lower, w3.upper);
-    REQUIRE(w3.lower == 1);
-    REQUIRE(w3.upper == 10);
+    REQUIRE(*w3.lower == 1);
+    REQUIRE(*w3.upper == 10);
   }
 
   SECTION("Division signed")
@@ -889,8 +889,8 @@ TEST_CASE("Interval templates division", "[ai][interval-analysis]")
     auto w3 = w1 / w2;
 
     CAPTURE(w3.lower, w3.upper);
-    REQUIRE(w3.lower == 236);
-    REQUIRE(w3.upper == 251);
+    REQUIRE(*w3.lower == 236);
+    REQUIRE(*w3.upper == 251);
   }
 }
 
@@ -919,8 +919,8 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     result1 = w1.trunc(t1_unsigned);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.lower == 0);
-    REQUIRE(result1.upper == 4);
+    REQUIRE(*result1.lower == 0);
+    REQUIRE(*result1.upper == 4);
   }
 
   SECTION("Truncation (signed)")
@@ -931,16 +931,16 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = w1.trunc(t1_signed);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.lower == 30);
-    REQUIRE(result1.upper == 128);
+    REQUIRE(*result1.lower == 30);
+    REQUIRE(*result1.upper == 128);
 
     w1.lower = 30;
     w1.upper = 257;
 
     result1 = w1.trunc(t1_signed);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.lower == 30);
-    REQUIRE(result1.upper == 1);
+    REQUIRE(*result1.lower == 30);
+    REQUIRE(*result1.upper == 1);
   }
 
   SECTION("Unsigned to unsigned")
@@ -951,7 +951,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, t2_unsigned);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.upper == 255);
+    REQUIRE(*result1.upper == 255);
   }
 
   SECTION("Signed to Signed 1")
@@ -962,7 +962,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, t2_signed);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.upper == 0xffff);
+    REQUIRE(*result1.upper == 0xffff);
   }
 
   SECTION("Signed to Signed 2")
@@ -973,7 +973,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, t2_signed);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.upper == 20);
+    REQUIRE(*result1.upper == 20);
   }
 
   SECTION("Unsigned to signed")
@@ -984,7 +984,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, t2_signed);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.upper == 255);
+    REQUIRE(*result1.upper == 255);
   }
 
   SECTION("Signed to Unsigned")
@@ -995,7 +995,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, t2_unsigned);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.upper == 0xffff);
+    REQUIRE(*result1.upper == 0xffff);
   }
 
   SECTION("Unsigned to BOOL")
@@ -1007,7 +1007,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, get_bool_type());
     CAPTURE(result1.lower, 1);
-    REQUIRE(result1.upper == 1);
+    REQUIRE(*result1.upper == 1);
   }
 
   SECTION("Unsigned to BOOL 2")
@@ -1019,7 +1019,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, get_bool_type());
     CAPTURE(result1.lower, 0);
-    REQUIRE(result1.upper == 0);
+    REQUIRE(*result1.upper == 0);
   }
 
   SECTION("Unsigned to BOOL 3")
@@ -1031,7 +1031,7 @@ TEST_CASE("Wrapped Interval Typecast", "[ai][interval-analysis]")
 
     auto result1 = wrapped_interval::cast(w1, get_bool_type());
     CAPTURE(result1.lower, 0);
-    REQUIRE(result1.upper == 1);
+    REQUIRE(*result1.upper == 1);
   }
 }
 
@@ -1049,16 +1049,16 @@ TEST_CASE("Wrapped Interval Left Shift", "[ai][interval-analysis]")
 
     auto result1 = w.left_shift(1);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.lower == 60);
-    REQUIRE(result1.upper == 160);
+    REQUIRE(*result1.lower == 60);
+    REQUIRE(*result1.upper == 160);
 
     w.lower = 50;
     w.upper = 100;
 
     auto result2 = w.left_shift(3);
     CAPTURE(result2.lower, result2.upper);
-    REQUIRE(result2.lower == 0);
-    REQUIRE(result2.upper == 248);
+    REQUIRE(*result2.lower == 0);
+    REQUIRE(*result2.upper == 248);
   }
 
   SECTION("Left shift signed")
@@ -1069,8 +1069,8 @@ TEST_CASE("Wrapped Interval Left Shift", "[ai][interval-analysis]")
 
     auto result1 = w.left_shift(1);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.lower == 0);
-    REQUIRE(result1.upper == 254);
+    REQUIRE(*result1.lower == 0);
+    REQUIRE(*result1.upper == 254);
   }
 
   SECTION("Logical right shift")
@@ -1081,16 +1081,16 @@ TEST_CASE("Wrapped Interval Left Shift", "[ai][interval-analysis]")
 
     auto result1 = w.logical_right_shift(1);
     CAPTURE(result1.lower, result1.upper);
-    REQUIRE(result1.lower == 15);
-    REQUIRE(result1.upper == 40);
+    REQUIRE(*result1.lower == 15);
+    REQUIRE(*result1.upper == 40);
 
     w.lower = 250;
     w.upper = 20; // [0, 127]
 
     auto result2 = w.logical_right_shift(1);
     CAPTURE(result2.lower, result2.upper);
-    REQUIRE(result2.lower == 0);
-    REQUIRE(result2.upper == 127);
+    REQUIRE(*result2.lower == 0);
+    REQUIRE(*result2.upper == 127);
   }
 
   SECTION("Arithmetic right shift")
@@ -1109,8 +1109,8 @@ TEST_CASE("Wrapped Interval Left Shift", "[ai][interval-analysis]")
 
     auto result2 = w.arithmetic_right_shift(1);
     CAPTURE(result2.lower, result2.upper);
-    REQUIRE(result2.lower == 254);
-    REQUIRE(result2.upper == 255);
+    REQUIRE(*result2.lower == 254);
+    REQUIRE(*result2.upper == 255);
   }
 }
 
@@ -1133,22 +1133,22 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w2.upper = 10;
 
     auto result1 = w1 % w2;
-    REQUIRE(result1.lower == 0);
-    REQUIRE(result1.upper == 0);
+    REQUIRE(*result1.lower == 0);
+    REQUIRE(*result1.upper == 0);
 
     w2.lower = 9;
     w2.upper = 9;
 
     auto result2 = w1 % w2;
-    REQUIRE(result2.lower == 1);
-    REQUIRE(result2.upper == 1);
+    REQUIRE(*result2.lower == 1);
+    REQUIRE(*result2.upper == 1);
 
     w2.lower = 11;
     w2.upper = 11;
 
     auto result3 = w1 % w2;
-    REQUIRE(result3.lower == 10);
-    REQUIRE(result3.upper == 10);
+    REQUIRE(*result3.lower == 10);
+    REQUIRE(*result3.upper == 10);
 
     wrapped_interval w3(t1_signed);
     wrapped_interval w4(t1_signed);
@@ -1160,22 +1160,22 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w4.upper = 10;
 
     auto result4 = w3 % w4;
-    REQUIRE(result4.lower == 0);
-    REQUIRE(result4.upper == 0);
+    REQUIRE(*result4.lower == 0);
+    REQUIRE(*result4.upper == 0);
 
     w4.lower = 9;
     w4.upper = 9;
 
     auto result5 = w3 % w4;
-    REQUIRE(result5.lower == 1);
-    REQUIRE(result5.upper == 1);
+    REQUIRE(*result5.lower == 1);
+    REQUIRE(*result5.upper == 1);
 
     w4.lower = 11;
     w4.upper = 11;
 
     auto result6 = w3 % w4;
-    REQUIRE(result6.lower == 10);
-    REQUIRE(result6.upper == 10);
+    REQUIRE(*result6.lower == 10);
+    REQUIRE(*result6.upper == 10);
 
     w3.set_lower(-10);
     w3.set_upper(-10);
@@ -1184,8 +1184,8 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w4.upper = 10;
 
     auto result7 = w3 % w4;
-    REQUIRE(result7.lower == 0);
-    REQUIRE(result7.upper == 0);
+    REQUIRE(*result7.lower == 0);
+    REQUIRE(*result7.upper == 0);
 
     w4.lower = 9;
     w4.upper = 9;
@@ -1214,15 +1214,15 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w2.upper = 5;
 
     auto result1 = w1 % w2;
-    REQUIRE(result1.lower == 0);
-    REQUIRE(result1.upper == 4);
+    REQUIRE(*result1.lower == 0);
+    REQUIRE(*result1.upper == 4);
 
     w1.lower = 10;
     w1.upper = 8;
 
     auto result2 = w1 % w2;
-    REQUIRE(result2.lower == 0);
-    REQUIRE(result2.upper == 4);
+    REQUIRE(*result2.lower == 0);
+    REQUIRE(*result2.upper == 4);
 
     w1.lower = 10;
     w1.upper = 10;
@@ -1231,16 +1231,16 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w2.upper = 5;
 
     auto result3 = w1 % w2;
-    REQUIRE(result3.lower == 0);
-    REQUIRE(result3.upper == 2);
+    REQUIRE(*result3.lower == 0);
+    REQUIRE(*result3.upper == 2);
 
     w2.lower = 5;
     w2.upper = 1;
 
     // TODO: we can probably optimize this!
     auto result4 = w1 % w2;
-    REQUIRE(result4.lower == 0);
-    REQUIRE(result4.upper == 254);
+    REQUIRE(*result4.lower == 0);
+    REQUIRE(*result4.upper == 254);
   }
 
   SECTION("Non singletons (signed)")
@@ -1255,16 +1255,16 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w2.upper = 5;
 
     auto result1 = w1 % w2;
-    REQUIRE(result1.lower == 0);
-    REQUIRE(result1.upper == 4);
+    REQUIRE(*result1.lower == 0);
+    REQUIRE(*result1.upper == 4);
 
     w1.lower = 10;
     w1.upper = 8;
 
     auto result2 = w1 % w2;
     CAPTURE(result2.upper, result2.lower);
-    REQUIRE(result2.lower == 252); // -4
-    REQUIRE(result2.upper == 4);   // 4
+    REQUIRE(*result2.lower == 252); // -4
+    REQUIRE(*result2.upper == 4);   // 4
 
     w1.lower = 200;
     w1.upper = 250;
@@ -1273,8 +1273,8 @@ TEST_CASE("Remainder Operations", "[ai][interval-analysis]")
     w2.upper = 4;
 
     auto result3 = w1 % w2;
-    REQUIRE(result3.lower == 253);
-    REQUIRE(result3.upper == 0);
+    REQUIRE(*result3.lower == 253);
+    REQUIRE(*result3.upper == 0);
   }
 }
 
@@ -1295,8 +1295,8 @@ TEST_CASE("Bitor Operations", "[ai][interval-analysis]")
 
     auto result = w1 | w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 170); // 0xAA
-    REQUIRE(result.upper == 170); // 0xAA
+    REQUIRE(*result.lower == 170); // 0xAA
+    REQUIRE(*result.upper == 170); // 0xAA
   }
 
   SECTION("Intervals")
@@ -1308,8 +1308,8 @@ TEST_CASE("Bitor Operations", "[ai][interval-analysis]")
 
     auto result = w1 | w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 170);
-    REQUIRE(result.upper == 174);
+    REQUIRE(*result.lower == 170);
+    REQUIRE(*result.upper == 174);
   }
   /*
   SECTION("Intervals Overlap")
@@ -1347,8 +1347,8 @@ TEST_CASE("Bitand Operations", "[ai][interval-analysis]")
 
     auto result = w1 & w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 0); // 0x00
-    REQUIRE(result.upper == 0); // 0x00
+    REQUIRE(*result.lower == 0); // 0x00
+    REQUIRE(*result.upper == 0); // 0x00
   }
 
   SECTION("Singletons")
@@ -1360,8 +1360,8 @@ TEST_CASE("Bitand Operations", "[ai][interval-analysis]")
 
     auto result = w1 & w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 1); // 0x01
-    REQUIRE(result.upper == 1); // 0x01
+    REQUIRE(*result.lower == 1); // 0x01
+    REQUIRE(*result.upper == 1); // 0x01
   }
 
   SECTION("Intervals")
@@ -1373,8 +1373,8 @@ TEST_CASE("Bitand Operations", "[ai][interval-analysis]")
 
     auto result = w1 & w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 0);
-    REQUIRE(result.upper == 2);
+    REQUIRE(*result.lower == 0);
+    REQUIRE(*result.upper == 2);
   }
 
   SECTION("Hardware issue")
@@ -1386,8 +1386,8 @@ TEST_CASE("Bitand Operations", "[ai][interval-analysis]")
 
     auto result = w1 & w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 0);
-    REQUIRE(result.upper == 1);
+    REQUIRE(*result.lower == 0);
+    REQUIRE(*result.upper == 1);
   }
 
   SECTION("Hardware issue 2")
@@ -1399,8 +1399,8 @@ TEST_CASE("Bitand Operations", "[ai][interval-analysis]")
 
     auto result = w1 & w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 0);
-    REQUIRE(result.upper == 1);
+    REQUIRE(*result.lower == 0);
+    REQUIRE(*result.upper == 1);
   }
 }
 
@@ -1421,8 +1421,8 @@ TEST_CASE("Bitxor Operations", "[ai][interval-analysis]")
 
     auto result = w1 ^ w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 170); // 0xAA
-    REQUIRE(result.upper == 170); // 0xAA
+    REQUIRE(*result.lower == 170); // 0xAA
+    REQUIRE(*result.upper == 170); // 0xAA
   }
 
   SECTION("Singletons")
@@ -1434,8 +1434,8 @@ TEST_CASE("Bitxor Operations", "[ai][interval-analysis]")
 
     auto result = w1 ^ w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 160); // 0xA0
-    REQUIRE(result.upper == 160); // 0xA0
+    REQUIRE(*result.lower == 160); // 0xA0
+    REQUIRE(*result.upper == 160); // 0xA0
   }
 
   SECTION("Intervals")
@@ -1447,8 +1447,8 @@ TEST_CASE("Bitxor Operations", "[ai][interval-analysis]")
 
     auto result = w1 ^ w2;
     CAPTURE(result.lower, result.upper);
-    REQUIRE(result.lower == 168); // 1010 1100
-    REQUIRE(result.upper == 174); // 1010 1110
+    REQUIRE(*result.lower == 168); // 1010 1100
+    REQUIRE(*result.upper == 174); // 1010 1110
   }
 }
 
@@ -1465,16 +1465,16 @@ TEST_CASE("Bitnot Operations", "[ai][interval-analysis]")
 
     auto r = wrapped_interval::bitnot(w);
     CAPTURE(r.lower, r.upper);
-    REQUIRE(r.lower == 254);
-    REQUIRE(r.upper == 254);
+    REQUIRE(*r.lower == 254);
+    REQUIRE(*r.upper == 254);
 
     w.lower = 250; // 0xFA
     w.upper = 250; // 0xFA
 
     r = wrapped_interval::bitnot(w);
     CAPTURE(r.lower, r.upper);
-    REQUIRE(r.lower == 5); // 0x05
-    REQUIRE(r.upper == 5); // 0x05
+    REQUIRE(*r.lower == 5); // 0x05
+    REQUIRE(*r.upper == 5); // 0x05
   }
 
   SECTION("Intervals")
@@ -1484,7 +1484,7 @@ TEST_CASE("Bitnot Operations", "[ai][interval-analysis]")
 
     auto r = wrapped_interval::bitnot(w);
     CAPTURE(r.lower, r.upper);
-    REQUIRE(r.lower == 254); // 0xFE
-    REQUIRE(r.upper == 255); // 0xFF
+    REQUIRE(*r.lower == 254); // 0xFE
+    REQUIRE(*r.upper == 255); // 0xFF
   }
 }


### PR DESCRIPTION
As reported in https://github.com/esbmc/esbmc/pull/1403, the `lower/upper` and `lower_set/upper_set` had an unhealthy relation that could lead to some unitialized uses. This PR removes the `_set` variables and replaces all `lower/upper` uses into an `std::optional`. Besides... during the refactoring I found some issues that are now fixed:

- the `has_changed` function used to check the upper bound incorrectly;
- the interpolation function was not using infinity on the previous interval as a precondition.

I will also start a reachability run.