### PR TITLE
Interval Analysis unit tests now deletes migration reference

### DIFF
--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -1,3 +1,4 @@
+#include "migrate.h"
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
 
 #define CATCH_CONFIG_MAIN
@@ -98,6 +99,7 @@ public:
       ait<interval_domaint> baseline;
       run_test<interval_domaint::wrap_mapt>(baseline, true);
     }
+    delete(migrate_namespace_lookup);
   }
 
   static void set_baseline_config()

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -98,6 +98,8 @@ public:
       ait<interval_domaint> baseline;
       run_test<interval_domaint::wrap_mapt>(baseline, true);
     }
+    // A namespace is instatiated at goto_factory::get_goto_functions
+    // and it needs to be released now
     delete(migrate_namespace_lookup);
   }
 

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -1,4 +1,3 @@
-#include "migrate.h"
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
 
 #define CATCH_CONFIG_MAIN


### PR DESCRIPTION
As described in https://github.com/esbmc/esbmc/issues/1383. Interval Analysis unit tests were causing issues on Address Sanitizer.