### PR TITLE
counter-example: only recurse if generating a sub-expr has been possible

### DIFF
--- a/regression/esbmc/github_1408-1/gh-1408-1.c
+++ b/regression/esbmc/github_1408-1/gh-1408-1.c
@@ -1,0 +1,12 @@
+struct InnerStruct
+{
+   char innerValue[10];
+};
+
+int main()
+{
+   struct InnerStruct array[2];
+   strcpy(array[0].innerValue, "20");
+   char *ptr;
+   assert(strtol(array[0].innerValue, ptr, 10) == 40);
+}

--- a/regression/esbmc/github_1408-1/test.desc
+++ b/regression/esbmc/github_1408-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+gh-1408-1.c
+--unwind 3 --no-pointer-check --no-bound --no-div-by-zero-check --no-slice
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_1408/gh-1408.c
+++ b/regression/esbmc/github_1408/gh-1408.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+struct InnerStruct {
+    char innerValue[10];
+};
+
+int main() {
+    struct InnerStruct array[2];
+
+    strcpy(array[0].innerValue, "20");
+    strcpy(array[1].innerValue, "40");
+
+    for (int i = 0; i < 2; i++) {
+        int innerValue = atoi(array[i].innerValue);
+        assert(innerValue == 40);
+    }
+
+    return 0;
+}

--- a/regression/esbmc/github_1408/test.desc
+++ b/regression/esbmc/github_1408/test.desc
@@ -1,0 +1,4 @@
+CORE
+gh-1408.c
+--multi-property --unwind 3
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2363,7 +2363,9 @@ expr2tc smt_convt::get(const expr2tc &expr)
   // Recurse on operands
   bool have_all = true;
   res->Foreach_operand([this, &have_all](expr2tc &e) {
-    expr2tc new_e = get(e);
+    expr2tc new_e;
+    if(e)
+      new_e = get(e);
     e = new_e;
     if(!e)
       have_all = false;


### PR DESCRIPTION
The tuple-node-flattener does not support getting arrays inside tuples right now, so it generates a nil expr for the cases tested by the 2 new regression tests. Recursing into nil exprs however leads to segfaults.

Fixes #1408. But it does not fix the underlying issue: When the structures/arrays are nested deeper, this will come back to bite us.

A proper fix could be to return the "have_all" boolean from get() (and also from the *-flatteners' versions of it) and properly use that information.