### PR TITLE
Empty loops are now converted to assume 0

### DIFF
--- a/regression/esbmc/github_1411_false/main.c
+++ b/regression/esbmc/github_1411_false/main.c
@@ -1,0 +1,13 @@
+int my_assume(int n)
+{
+_EXIT: goto _EXIT;
+}
+
+int main() {
+        int c = __VERIFIER_nondet_int();
+        if(!c) my_assume(c);
+
+        for(int i = 0; i < 5; i++);
+
+        __ESBMC_assert(0, "");
+}

--- a/regression/esbmc/github_1411_false/test.desc
+++ b/regression/esbmc/github_1411_false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$


### PR DESCRIPTION
Empty goto loops were not added into the `function_loops`, this creates a whole chain of misinterpretation as the `k_induction` methods needs the loop for the convertion to work. 

These loops are also used historically in TACAS to describe an `assume(0)` in an "automata" way, so I just did the convetion back.

Fixes #1411 
