### PR TITLE
<fenv.h> only use own definitions on FreeBSD

### DIFF
--- a/src/c2goto/headers/fenv.h
+++ b/src/c2goto/headers/fenv.h
@@ -1,4 +1,7 @@
 
+/* their <fenv.h> contains inline function definitions incompatible with ours */
+#ifdef __FreeBSD__
+
 /* partially taken from FreeBSD-14 */
 
 #pragma once
@@ -48,3 +51,10 @@ int feholdexcept(fenv_t *envp);
 int fesetenv(const fenv_t *envp);
 int feupdateenv(const fenv_t *envp);
 
+#else /* !defined __FreeBSD__ */
+
+/* For SV-COMP's pre-processed sources we need the system's definitions of
+ * (at least) the constants for the rounding modes. */
+#include_next <fenv.h>
+
+#endif


### PR DESCRIPTION
PR #1397 added an own version of <fenv.h>. However, that resulted in new incorrect SV-COMP results: https://github.com/esbmc/esbmc/commit/f9a93907c084fd839bdd94b261100c98b8cabb57 

For SV-COMP we still need the system's definitions, because of their preprocessing hard-coding the constants for rounding modes.

So this PR only uses the own definitions on FreeBSD (because there the system's header defines inline functions which ESBMC can't override if they're present) and goes to the system's <fenv.h> otherwise. I've started an SV-COMP run in <https://github.com/esbmc/esbmc/actions/runs/6626419104>.