### PR TITLE
Added a default table style for benchexec

### DIFF
--- a/scripts/competitions/svcomp/table.xml
+++ b/scripts/competitions/svcomp/table.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<!DOCTYPE table PUBLIC "+//IDN sosy-lab.org//DTD BenchExec table 1.10//EN" "https://www.sosy-lab.org/benchexec/table-1.10.dtd">
+<table>
+
+  <column title="status"/>
+  <column title="cputime" displayTitle="CPU Time"/>
+  <column title="walltime" displayTitle="Wall Time"/>
+  <column title="memory" displayTitle="Memory" sourceUnit="B" displayUnit="MB"/>
+  <column displayTitle="Bound" sourceUnit="i" title="k">.*\(k = (\d+)\)</column>
+  <column displayTitle="GOTO Generation Time" sourceUnit="s" title="goto-generation">GOTO program creation time: (.*)s</column>
+  <column displayTitle="GOTO Preprocessing Time" sourceUnit="s" title="goto-preprocessing">GOTO program processing time: (.*)s</column>
+  <column displayTitle="Total Symex Time" sourceUnit="s" title="symex-total">Symex completed in: (.*)s .*</column>
+  <column displayTitle="Total Solving Time" sourceUnit="s" title="decision-total">Runtime decision procedure: (.*)s</column>
+</table>


### PR DESCRIPTION
This PR adds support for using custom columns when using table-generator. This will enable us to start looking for patterns and points to improve. With the current table the output will contain:

- The bound where the violation/proof was found
- The time that it took to generate the GOTO program
- The time that it took to preprocess the GOTO program
- The total (sum) time of Symex
- The total (sum) time of Solving

Example:

![Screenshot 2023-10-25 170248](https://github.com/esbmc/esbmc/assets/8601807/2c47108c-8e8a-48c2-ba8c-fd915bba91e8)



It depends on https://github.com/sosy-lab/benchexec/pull/929 being merged though.