### PR TITLE
Support shared builds against different Clang versions on Ubuntu

### DIFF
--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -1,5 +1,5 @@
 # For a quick check-up on dev branch pushes, giving early warning or good news.
-name: Build ESBMC - early warning on push
+name: Early warning on push
 
 on: [push]
 

--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -1,5 +1,4 @@
 # For a quick check-up on dev branch pushes, giving early warning or good news.
-# just a duplicate of build.yml with Linux job only
 name: Build ESBMC - early warning on push
 
 on: [push]
@@ -14,25 +13,10 @@ jobs:
     - name: Runs testing tool unit test
       run: cd regression && python3 testing_tool_test.py
 
-  # just keep the linux job
+  # just run the linux job
   build-unix:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    name: Build ESBMC (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build ESBMC
-      run: ./scripts/build.sh -b Debug
-    - uses: actions/upload-artifact@v1
-      with:
-        name: release-unix
-        path: ./release
-    - name: Run tests
-      run: cd build/ && ctest -j4 --output-on-failure --progress .
-    - uses: actions/upload-artifact@v2 # We shouldn't throw errors for now
-      with:
-        name: csmith-unix
-        path: ./build/csmith-error
-        if-no-files-found: ignore
+    uses: ./.github/workflows/build-unix.yml
+    with:
+      operating-system: ubuntu-latest
+      build-flags: '-b Debug'
+      testing: true

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -1,0 +1,32 @@
+
+on:
+  workflow_call:
+    inputs:
+      operating-system:
+        description: "Targeted OS (e.g. ubuntu-latest, windows-latest)"
+        required: true
+        type: string
+      build-flags:
+        description: "Flags to be passed to build.sh script"
+        required: true
+        type: string
+      testing:
+        description: "Whether to run tests (regression) for this build"
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    name: Build ESBMC (${{ inputs.operating-system }})
+    runs-on: ${{ inputs.operating-system }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build ESBMC
+      run: ./scripts/build.sh ${{ inputs.build-flags }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: release-${{ inputs.operating-system }}
+        path: ./release
+    - name: Run tests
+      if: ${{ inputs.testing == true }}
+      run: cd build/ && ctest -j4 --output-on-failure --progress .

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    name: Build ESBMC (Windows)
+    name: Build ESBMC (${{ inputs.operating-system }})
     runs-on: ${{ inputs.operating-system }}
     steps:
     - name: Set up Python

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,50 @@
+
+on:
+  workflow_call:
+    inputs:
+      operating-system:
+        description: "Targeted OS (e.g. ubuntu-latest, windows-latest)"
+        required: true
+        type: string
+      build-flags:
+        description: "Flags to be passed to build.sh script"
+        required: true
+        type: string
+      testing:
+        description: "Whether to run tests (regression) for this build"
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    name: Build ESBMC (Windows)
+    runs-on: ${{ inputs.operating-system }}
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: check python
+      run: python --version
+    - name: Update vcpkg
+      run: |
+        vcpkg.exe update
+        cd C:/vcpkg
+        git.exe pull
+        .\bootstrap-vcpkg.bat
+    - name: Make git use LF only
+      run: |
+        git config --system core.autocrlf false
+        git config --system core.eol lf
+    - uses: actions/checkout@v2
+    - name: Configure ESBMC
+      run: ./scripts/build.ps1
+    - uses: actions/upload-artifact@v2
+      with:
+        name: release-windows-latest
+        path: C:/deps/esbmc
+    - name: Run Tests
+      if: ${{ inputs.testing == true }}
+      run: |
+        cd build
+        ctest -j4 --output-on-failure --progress . -C RelWithDebInfo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,53 +32,18 @@ on:
             type: boolean
 
 jobs:
-    build-unix:
-        name: Build ESBMC (${{ inputs.operating-system }})
-        if: ${{ inputs.operating-system != 'windows-latest' }}
-        runs-on: ${{ inputs.operating-system }}
-        steps:
-        - uses: actions/checkout@v2
-        - name: Build ESBMC
-          run: ./scripts/build.sh ${{ inputs.build-flags }}
-        - uses: actions/upload-artifact@v1
-          with:
-            name: release-${{ inputs.operating-system }}
-            path: ./release
-        - name: Run tests
-          if: ${{ inputs.testing == true }}
-          run: cd build/ && ctest -j4 --output-on-failure --progress .
+  build-unix:
+    if: ${{ !startsWith(inputs.operating-system, 'windows-') }}
+    uses: ./.github/workflows/build-unix.yml
+    with:
+      operating-system: ${{ inputs.operating-system }}
+      build-flags: ${{ inputs.build-flags }}
+      testing: ${{ inputs.testing }}
 
-    build-windows:
-        name: Build ESBMC (Windows)
-        if: ${{ inputs.operating-system == 'windows-latest' }}
-        runs-on: windows-latest
-        steps:
-        - name: Set up Python
-          uses: actions/setup-python@v2
-          with:
-            python-version: 3.8
-        - name: check python
-          run: python --version
-        - name: Update vcpkg
-          run: |
-            vcpkg.exe update
-            cd C:/vcpkg
-            git.exe pull
-            .\bootstrap-vcpkg.bat
-        - name: Make git use LF only
-          run: |
-            git config --system core.autocrlf false
-            git config --system core.eol lf
-        - uses: actions/checkout@v2
-        - name: Configure ESBMC
-          run: ./scripts/build.ps1
-        - uses: actions/upload-artifact@v2
-          with:
-            name: release-windows-latest
-            path: C:/deps/esbmc
-        - name: Run Tests
-          if: ${{ inputs.testing == true }}
-          run: |
-            cd build
-            ctest -j4 --output-on-failure --progress . -C RelWithDebInfo
-        
+  build-windows:
+    if: ${{ startsWith(inputs.operating-system, 'windows-') }}
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      operating-system: ${{ inputs.operating-system }}
+      build-flags: ${{ inputs.build-flags }}
+      testing: ${{ inputs.testing }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,23 +28,29 @@ jobs:
         name: Developer-Manual
         path: manual.pdf    
 
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    uses: ./.github/workflows/build.yml
+  build-ubuntu:
+    uses: ./.github/workflows/build-unix.yml
+    name: build (ubuntu-latest)
     with:
-      operating-system: ${{ matrix.os }}
+      operating-system: ubuntu-latest
+      build-flags: '-b DebugOpt -e On'
+      testing: true
+
+  build-windows:
+    uses: ./.github/workflows/build-windows.yml
+    name: build (windows-latest)
+    with:
+      operating-system: windows-latest
       build-flags: '-b DebugOpt -e On'
       testing: true
 
   # Also run a build with frontend linked shared against Ubuntu's clang-13
   build-shared:
     name: dyn. llvm-13
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build-unix.yml
     with:
       operating-system: ubuntu-latest
-      build-flags: -b DebugOpt -e On -S OFF -c 13
+      build-flags: '-b DebugOpt -e On -S OFF -c 13'
       testing: true
 
     # Check project with clang-format

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,7 +30,7 @@ jobs:
 
   build-ubuntu:
     uses: ./.github/workflows/build-unix.yml
-    name: build (ubuntu-latest)
+    name: static llvm-11 DebugOpt
     with:
       operating-system: ubuntu-latest
       build-flags: '-b DebugOpt -e On'
@@ -38,7 +38,7 @@ jobs:
 
   build-windows:
     uses: ./.github/workflows/build-windows.yml
-    name: build (windows-latest)
+    name: static llvm-11 DebugOpt
     with:
       operating-system: windows-latest
       build-flags: '-b DebugOpt -e On'
@@ -46,7 +46,7 @@ jobs:
 
   # Also run a build with frontend linked shared against Ubuntu's clang-13
   build-shared:
-    name: dyn. llvm-13
+    name: dyn. llvm-13 DebugOpt
     uses: ./.github/workflows/build-unix.yml
     with:
       operating-system: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,10 +32,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        build-flags: [-b DebugOpt -e On]
+        include:
+          # Also run a build with frontend linked shared against Ubuntu's clang-13
+          - os: ubuntu-latest
+            build-flags: -b DebugOpt -e On -S OFF -c 13
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ${{ matrix.os }}
-      build-flags: '-b DebugOpt -e On'
+      build-flags: ${{ matrix.build-flags }}
       testing: true
       
     # Check project with clang-format

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-    name: Build shared against Clang-13
+    name: Dyn. clang-13 build
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ${{ matrix.os }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,17 +32,24 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        build-flags: [-b DebugOpt -e On]
-        include:
-          # Also run a build with frontend linked shared against Ubuntu's clang-13
-          - os: ubuntu-latest
-            build-flags: -b DebugOpt -e On -S OFF -c 13
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ${{ matrix.os }}
-      build-flags: ${{ matrix.build-flags }}
+      build-flags: '-b DebugOpt -e On'
       testing: true
-      
+
+  # Also run a build with frontend linked shared against Ubuntu's clang-13
+  build-shared:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    name: Build shared against Clang-13
+    uses: ./.github/workflows/build.yml
+    with:
+      operating-system: ${{ matrix.os }}
+      build-flags: -b DebugOpt -e On -S OFF -c 13
+      testing: true
+
     # Check project with clang-format
   code-style:
     name: Check C/C++ code-style

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: PR Checks
+name: PR
 
 on: [pull_request]
 
@@ -40,13 +40,10 @@ jobs:
 
   # Also run a build with frontend linked shared against Ubuntu's clang-13
   build-shared:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    name: Dyn. clang-13 build
+    name: dyn. llvm-13
     uses: ./.github/workflows/build.yml
     with:
-      operating-system: ${{ matrix.os }}
+      operating-system: ubuntu-latest
       build-flags: -b DebugOpt -e On -S OFF -c 13
       testing: true
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Pull Request Checks
+name: PR Checks
 
 on: [pull_request]
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,48 +1,127 @@
 #!/bin/sh
 
-# Create build directory
-mkdir build && cd build || exit $?
-
 # Set arguments that should be available for every OS
-BASE_ARGS="-DDOWNLOAD_DEPENDENCIES=On -GNinja -DENABLE_CSMITH=On -DBUILD_TESTING=On -DENABLE_REGRESSION=On -DENABLE_SOLIDITY_FRONTEND=On -DENABLE_JIMPLE_FRONTEND=On -DCMAKE_INSTALL_PREFIX:PATH=$PWD/../release"
-SOLVER_FLAGS="-DENABLE_BOOLECTOR=On -DENABLE_YICES=Off -DENABLE_CVC4=OFF  -DENABLE_BITWUZLA=On -DENABLE_GOTO_CONTRACTOR=OFF"
+BASE_ARGS="\
+    -DDOWNLOAD_DEPENDENCIES=On \
+    -GNinja \
+    -DENABLE_CSMITH=On \
+    -DBUILD_TESTING=On \
+    -DENABLE_REGRESSION=On \
+    -DENABLE_SOLIDITY_FRONTEND=On \
+    -DENABLE_JIMPLE_FRONTEND=On \
+    -DCMAKE_INSTALL_PREFIX:PATH=$PWD/release \
+"
+SOLVER_FLAGS="\
+    -DENABLE_BOOLECTOR=On \
+    -DENABLE_YICES=Off \
+    -DENABLE_CVC4=OFF \
+    -DENABLE_BITWUZLA=On \
+    -DENABLE_GOTO_CONTRACTOR=OFF \
+"
 COMPILER_ARGS=''
+
+STATIC=
+
+error() {
+    echo "$*" >&2
+    exit 1
+}
+
 # Ubuntu setup (pre-config)
 ubuntu_setup () {
     # Tested on ubuntu 22.04
-    echo "Configuring Ubuntu build" &&
-    sudo apt-get update &&
-    sudo apt-get install -y \
-        clang clang-tidy python-is-python3 csmith python3 \
+    PKGS="\
+        clang-11 clang-tidy-11 python-is-python3 csmith python3 \
         git ccache unzip wget curl libcsmith-dev gperf \
         libgmp-dev cmake bison flex g++-multilib linux-libc-dev \
         libboost-all-dev ninja-build python3-setuptools \
         libtinfo-dev pkg-config python3-pip python3-toml \
-        python-is-python3 openjdk-11-jdk &&
+        python-is-python3 openjdk-11-jdk \
+    "
+    if [ -z "$STATIC" ]; then STATIC=ON; fi
+    if [ $STATIC = OFF ]; then
+        PKGS="$PKGS \
+            llvm-11-dev libclang-11-dev libclang-cpp11-dev libz3-dev \
+        "
+        BASE_ARGS="$BASE_ARGS \
+            -DClang_DIR=/usr/lib/cmake/clang-11 \
+            -DLLVM_DIR=/usr/lib/llvm-11/lib/cmake/llvm \
+            -DZ3_DIR=/usr \
+        "
+        echo "Configuring shared Ubuntu build"
+    else
+        echo "Configuring static Ubuntu build"
+    fi
+    sudo apt-get update &&
+    sudo apt-get install -y $PKGS &&
     echo "Installing Python dependencies" &&
     pip3 install --user meson ast2json &&
     meson --version &&
-    BASE_ARGS="$BASE_ARGS -DENABLE_OLD_FRONTEND=On -DENABLE_PYTHON_FRONTEND=On -DDOWNLOAD_DEPENDENCIES=On -DBUILD_STATIC=On" &&
-    SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_Z3=ON" &&
+    BASE_ARGS="$BASE_ARGS \
+        -DENABLE_OLD_FRONTEND=On \
+        -DENABLE_PYTHON_FRONTEND=On \
+        -DBUILD_STATIC=$STATIC \
+    " &&
+    SOLVER_FLAGS="$SOLVER_FLAGS \
+        -DENABLE_Z3=ON \
+    " &&
     # Hack: Boolector might fail to download some dependencies using curl (maybe we should patch it?)
     # curl: (60) SSL: no alternative certificate subject name matches target host name 'codeload.github.com'
     # As a unsafe workaround... we can just tell curl to be unsafe
     echo "insecure" > $HOME/.curlrc
 }
 
+ubuntu_post_setup () {
+  echo "No further steps needed for ubuntu"
+}
+
 # macOS setup (pre-config)
 macos_setup () {
     echo "Configuring macOS build"
-    brew install z3 gmp csmith cmake boost ninja python3 automake bison flex && pip3 install PySMT toml ast2json &&
+    if [ -z "$STATIC" ]; then STATIC=OFF; fi
+    if [ $STATIC = ON ]; then
+        error "static macOS build is currently not supported"
+    fi
+    brew install z3 gmp csmith cmake boost ninja python3 automake bison flex &&
+    pip3 install PySMT toml ast2json &&
     wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz &&
-    tar xf clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz && mv clang+llvm-11.0.0-x86_64-apple-darwin ../clang &&
-    BASE_ARGS="$BASE_ARGS -DENABLE_WERROR=Off -DBUILD_STATIC=Off -DClang_DIR=$PWD/../clang -DLLVM_DIR=$PWD/../clang -DC2GOTO_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+    tar xf clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz &&
+    mv clang+llvm-11.0.0-x86_64-apple-darwin ../clang &&
+    BASE_ARGS="$BASE_ARGS \
+        -DENABLE_WERROR=Off \
+        -DBUILD_STATIC=$STATIC \
+        -DClang_DIR=$PWD/../clang \
+        -DLLVM_DIR=$PWD/../clang \
+        -DC2GOTO_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
+    "
 }
 
+# macOS needs an extra step before testing
+macos_post_setup () {
+  chmod +x build/macos-wrapper.sh
+}
+
+# Create build directory
+mkdir build && cd build || exit $?
 
 # Detect the platform ($OSTYPE was not working on github actions for ubuntu)
 # Note: Linux here means Ubuntu, this will mostly not work anywhere else.
-OS="`uname`"
+OS=`uname`
+
+# Setup build flags (release, debug, sanitizer, ...)
+while getopts b:s:e:r:dS: flag
+do
+    case "${flag}" in
+        b) BASE_ARGS="$BASE_ARGS -DCMAKE_BUILD_TYPE=${OPTARG}";;
+        s) BASE_ARGS="$BASE_ARGS -DSANITIZER_TYPE=${OPTARG}"
+           COMPILER_ARGS="$COMPILER_ARGS CC=clang CXX=clang++";;
+        e) BASE_ARGS="$BASE_ARGS -DENABLE_WERROR=${OPTARG}";;
+        r) BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=${OPTARG}" ;;
+        d) set -x; export ESBMC_OPTS='--verbosity 9' ;;
+        S) STATIC=$OPTARG ;; # should be capital ON or OFF
+    esac
+done
+
 case $OS in
   'Linux')
     ubuntu_setup
@@ -53,19 +132,6 @@ case $OS in
   *) echo "Unsupported OS $OSTYPE" ; exit 1; ;;
 esac || exit $?
 
-# Setup build flags (release, debug, sanitizer, ...)
-while getopts b:s:e:r:d flag
-do
-    case "${flag}" in
-        b) BASE_ARGS="$BASE_ARGS -DCMAKE_BUILD_TYPE=${OPTARG}";;
-        s) BASE_ARGS="$BASE_ARGS -DSANITIZER_TYPE=${OPTARG}"
-           COMPILER_ARGS="$COMPILER_ARGS CC=clang CXX=clang++";;
-        e) BASE_ARGS="$BASE_ARGS -DENABLE_WERROR=${OPTARG}";;
-        r) BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=${OPTARG}" ;;
-        d) set -x; export ESBMC_OPTS='--verbosity 9' ;;
-    esac
-done
-
 # Configure ESBMC
 printf "Running CMake:"
 printf " '%s'" $COMPILER_ARGS cmake .. $BASE_ARGS $SOLVER_FLAGS
@@ -73,15 +139,6 @@ echo
 $COMPILER_ARGS cmake .. $BASE_ARGS $SOLVER_FLAGS &&
 # Compile ESBMC
 cmake --build . && ninja install || exit $?
-
-ubuntu_post_setup () {
-  echo "No further steps needed for ubuntu"
-}
-
-# macOS needs an extra step before testing
-macos_post_setup () {
-  chmod +x build/macos-wrapper.sh
-}
 
 case $OS in
   'Linux')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,6 +21,7 @@ SOLVER_FLAGS="\
 COMPILER_ARGS=''
 
 STATIC=
+CLANG_VERSION=11
 
 error() {
     echo "$*" >&2
@@ -31,24 +32,28 @@ error() {
 ubuntu_setup () {
     # Tested on ubuntu 22.04
     PKGS="\
-        clang-11 clang-tidy-11 python-is-python3 csmith python3 \
+        clang-$CLANG_VERSION clang-tidy-$CLANG_VERSION \
+        python-is-python3 csmith python3 \
         git ccache unzip wget curl libcsmith-dev gperf \
         libgmp-dev cmake bison flex g++-multilib linux-libc-dev \
         libboost-all-dev ninja-build python3-setuptools \
         libtinfo-dev pkg-config python3-pip python3-toml \
-        python-is-python3 openjdk-11-jdk \
+        openjdk-11-jdk \
     "
     if [ -z "$STATIC" ]; then STATIC=ON; fi
     if [ $STATIC = OFF ]; then
         PKGS="$PKGS \
-            llvm-11-dev libclang-11-dev libclang-cpp11-dev libz3-dev \
+            llvm-$CLANG_VERSION-dev \
+            libclang-$CLANG_VERSION-dev \
+            libclang-cpp$CLANG_VERSION-dev \
+            libz3-dev \
         "
         BASE_ARGS="$BASE_ARGS \
-            -DClang_DIR=/usr/lib/cmake/clang-11 \
-            -DLLVM_DIR=/usr/lib/llvm-11/lib/cmake/llvm \
+            -DClang_DIR=/usr/lib/cmake/clang-$CLANG_VERSION \
+            -DLLVM_DIR=/usr/lib/llvm-$CLANG_VERSION/lib/cmake/llvm \
             -DZ3_DIR=/usr \
         "
-        echo "Configuring shared Ubuntu build"
+        echo "Configuring shared Ubuntu build with Clang v$CLANG_VERSION"
     else
         echo "Configuring static Ubuntu build"
     fi
@@ -109,7 +114,7 @@ mkdir build && cd build || exit $?
 OS=`uname`
 
 # Setup build flags (release, debug, sanitizer, ...)
-while getopts b:s:e:r:dS: flag
+while getopts b:s:e:r:dS:c: flag
 do
     case "${flag}" in
         b) BASE_ARGS="$BASE_ARGS -DCMAKE_BUILD_TYPE=${OPTARG}";;
@@ -119,6 +124,7 @@ do
         r) BASE_ARGS="$BASE_ARGS -DBENCHBRINGUP=${OPTARG}" ;;
         d) set -x; export ESBMC_OPTS='--verbosity 9' ;;
         S) STATIC=$OPTARG ;; # should be capital ON or OFF
+        c) CLANG_VERSION=$OPTARG ;; # LLVM/Clang major version
     esac
 done
 


### PR DESCRIPTION
This PR generalizes the build.sh script to allow for shared builds (new parameter `-S OFF`) and to select which Ubuntu-22.04-packaged Clang version to build the frontend against (new parameter `-c MAJOR` where I've tested builds with MAJOR being one of 11, 12, 13, 14, 15). Shared builds now also link against the system's Z3.

Reasons for this change: We're slowly moving away from Clang-11 as the default. Binary builds of newer versions are not distributed by upstream anymore. So we should look into building against one provided by the distribution. Additionally, it is worth noting that the C++ ABI is not stable across compiler versions, that means pre-built binaries are not guaranteed to link correctly.

@rafaelsamenezes Do you think it would be worth to extend the CI to additionally run a shared build against one of the newer Clangs?