### PR TITLE
[NFC] Fix warnings and enable Werror on github actions

### DIFF
--- a/regression/esbmc-solidity/constructor_3/test.desc
+++ b/regression/esbmc-solidity/constructor_3/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 contract.solast
 --function Derive --sol contract.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/constructor_3/test.desc
+++ b/regression/esbmc-solidity/constructor_3/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+KNOWNBUG
 contract.solast
 --function Derive --sol contract.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/constructor_6/test.desc
+++ b/regression/esbmc-solidity/constructor_6/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 contract.solast
 --function DD --sol contract.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/constructor_6/test.desc
+++ b/regression/esbmc-solidity/constructor_6/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+KNOWNBUG
 contract.solast
 --function DD --sol contract.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/multiple_contracts_2/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_2/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 mul.solast
 --function empty --sol mul.sol
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/multiple_contracts_2/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_2/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+KNOWNBUG
 mul.solast
 --function empty --sol mul.sol
 ^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -177,8 +177,7 @@ void add_cprover_library(contextt &context, const languaget *c_language)
   {
   case 16:
     log_warning(
-      "Warning: this version of ESBMC does not have a C library "
-      "for 16 bit machines");
+      "this version of ESBMC does not have a C library for 16 bit machines");
     return;
   case 32:
   case 64:
@@ -195,7 +194,7 @@ void add_cprover_library(contextt &context, const languaget *c_language)
   {
     if(c_language)
       return add_bundled_library_sources(context, *c_language);
-    log_error("error: Zero-lengthed internal C library");
+    log_error("Zero-lengthed internal C library");
     abort();
   }
 

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -207,7 +207,8 @@ __ESBMC_HIDE:;
   return 0; // We never fail
 }
 
-void abort();
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-noreturn"
 void pthread_exit(void *retval)
 {
 __ESBMC_HIDE:;
@@ -227,6 +228,7 @@ __ESBMC_HIDE:;
   // Ensure that there is no subsequent execution path
   abort();
 }
+#pragma clang diagnostic pop
 
 pthread_t pthread_self(void)
 {

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -207,6 +207,7 @@ __ESBMC_HIDE:;
   return 0; // We never fail
 }
 
+void abort();
 void pthread_exit(void *retval)
 {
 __ESBMC_HIDE:;
@@ -224,7 +225,7 @@ __ESBMC_HIDE:;
   __ESBMC_atomic_end();
 
   // Ensure that there is no subsequent execution path
-  __ESBMC_assume(0);
+  abort();
 }
 
 pthread_t pthread_self(void)

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -226,7 +226,7 @@ __ESBMC_HIDE:;
   __ESBMC_atomic_end();
 
   // Ensure that there is no subsequent execution path
-  abort();
+  __ESBMC_assume(0);
 }
 #pragma clang diagnostic pop
 

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -92,13 +92,8 @@ bool clang_c_maint::clang_main()
 
   if(matches.size() >= 2)
   {
-    if(matches.size() == 2)
-      log_error("warning: main symbol `{}' is ambiguous", main);
-    else
-    {
-      log_error("main symbol `{}' is ambiguous", main);
-      return true;
-    }
+    log_error("main symbol `{}' is ambiguous", main);
+    return true;
   }
 
   main_symbol = matches.front();

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -140,10 +140,9 @@ void clang_cpp_adjust::adjust_side_effect_assign(side_effect_exprt &expr)
     // where bleh has been declared and there exists a corresponding symbol
     side_effect_expr_function_callt &rhs_func_call =
       to_side_effect_expr_function_call(rhs);
-    exprt &f_op = rhs_func_call.function();
 
     // callee must be a constructor
-    assert(f_op.type().return_type().id() == "constructor");
+    assert(rhs_func_call.function().type().return_type().id() == "constructor");
 
     // just populate rhs' argument and replace the entire expression
     exprt &lhs = expr.op0();

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1401,6 +1401,7 @@ void clang_cpp_convertert::get_base_map(
       continue;
 
     auto status = map.insert({class_id, base_cxxrd});
+    (void)status;
     assert(status.second);
   }
 }

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -621,6 +621,7 @@ void clang_cpp_convertert::get_overriden_methods(
       continue;
 
     auto status = map.insert({method_id, *md_overriden});
+    (void)status;
     assert(status.second);
   }
 }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -326,6 +326,10 @@ void bmct::report_multi_property_trace(
 
 void bmct::report_result(smt_convt::resultt &res)
 {
+  // k-induction prints its own messages
+  if(options.get_bool_option("k-induction-parallel"))
+    return;
+
   bool bs = options.get_bool_option("base-case");
   bool fc = options.get_bool_option("forward-condition");
   bool is = options.get_bool_option("inductive-step");

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -735,9 +735,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         break;
 
       default:
-        log_error(
-          "Message from unrecognized k-induction child "
-          "process");
+        log_error("Message from unrecognized k-induction child process");
         abort();
       }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -891,7 +891,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        log_status("BASE CASE PROCESS FINISHED.\n");
+        log_status("Base case process finished (bug found).\n");
         return true;
       }
 
@@ -942,7 +942,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    log_status("BASE CASE PROCESS FINISHED.\n");
+    log_status("Base case process finished (no bug found).\n");
     return false;
   }
 
@@ -998,7 +998,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        log_status("FORWARD CONDITION PROCESS FINISHED.");
+        log_status("Forward condition process finished (safety proven).");
         return false;
       }
     }
@@ -1010,7 +1010,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    log_status("FORWARD CONDITION PROCESS FINISHED.");
+    log_status("Forward condition process finished (safety not proven).");
     return true;
   }
 
@@ -1066,7 +1066,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
         assert(len == sizeof(r) && "short write");
         (void)len; //ndebug
 
-        log_status("INDUCTIVE STEP PROCESS FINISHED.");
+        log_status("Inductive process finished (safety proven).");
         return false;
       }
     }
@@ -1078,7 +1078,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     assert(len == sizeof(r) && "short write");
     (void)len; //ndebug
 
-    log_status("INDUCTIVE STEP PROCESS FINISHED.");
+    log_status("Inductive process finished (safety not proven).");
     return true;
   }
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -471,15 +471,14 @@ void goto_convertt::do_function_call_symbol(
   const symbolt *symbol = ns.lookup(identifier);
   if(!symbol)
   {
-    log_error("error: function `{}' not found", id2string(identifier));
+    log_error("Function `{}' not found", id2string(identifier));
     abort();
   }
 
   if(!symbol->type.is_code())
   {
     log_error(
-      "error: function `{}' type mismatch: expected code",
-      id2string(identifier));
+      "Function `{}' type mismatch: expected code", id2string(identifier));
   }
 
   // If the symbol is not nil, i.e., the user defined the expected behaviour of

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -351,7 +351,7 @@ ibex::Function *goto_contractort::create_function_from_expr2t(expr2tc expr)
     }
     else
     {
-      log_error("ERROR: MAX VAR SIZE REACHED");
+      log_error("MAX VAR SIZE REACHED");
       return nullptr;
     }
     break;

--- a/src/goto-programs/goto_program_irep.cpp
+++ b/src/goto-programs/goto_program_irep.cpp
@@ -114,8 +114,8 @@ void convert(const irept &irep, goto_programt &program)
       if(fit == program.instructions.end())
       {
         log_error(
-          "Warning: could not resolve target link "
-          "during irep->goto_program translation.");
+          "could not resolve target link during irep->goto_program "
+          "translation.");
         abort();
       }
     }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -710,8 +710,7 @@ void goto_symext::intrinsic_spawn_thread(
     !options.get_bool_option("disable-inductive-step"))
   {
     log_warning(
-      "WARNING: k-induction does not support concurrency yet. "
-      "Disabling inductive step");
+      "k-induction does not support concurrency yet. Disabling inductive step");
 
     // Disable inductive step on multi threaded code
     options.set_option("disable-inductive-step", true);

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -188,7 +188,7 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   {
     if(has_prefix(identifier.as_string(), "symex::invalid_object"))
     {
-      log_warning("WARNING: function ptr call with no target, ");
+      log_warning("function ptr call with no target, ");
       cur_state->source.pc++;
       return;
     }

--- a/src/goto2c/goto2c_check.cpp
+++ b/src/goto2c/goto2c_check.cpp
@@ -134,33 +134,39 @@ void goto2ct::check_goto(goto_programt::instructiont instruction)
   assert(instruction.targets.size() == 1);
 }
 
-void goto2ct::check_function_call(goto_programt::instructiont instruction)
+void goto2ct::check_function_call(goto_programt::instructiont instruction
+                                  [[maybe_unused]])
 {
   assert(is_code_function_call2t(instruction.code));
 }
 
-void goto2ct::check_return(goto_programt::instructiont instruction)
+void goto2ct::check_return(goto_programt::instructiont instruction
+                           [[maybe_unused]])
 {
   assert(is_code_return2t(instruction.code));
 }
 
-void goto2ct::check_end_function(goto_programt::instructiont instruction)
+void goto2ct::check_end_function(goto_programt::instructiont instruction
+                                 [[maybe_unused]])
 {
   assert(is_nil_expr(instruction.code));
   assert(is_true(instruction.guard));
 }
 
-void goto2ct::check_decl(goto_programt::instructiont instruction)
+void goto2ct::check_decl(goto_programt::instructiont instruction
+                         [[maybe_unused]])
 {
   assert(is_code_decl2t(instruction.code));
 }
 
-void goto2ct::check_dead(goto_programt::instructiont instruction)
+void goto2ct::check_dead(goto_programt::instructiont instruction
+                         [[maybe_unused]])
 {
   assert(is_code_dead2t(instruction.code));
 }
 
-void goto2ct::check_assign(goto_programt::instructiont instruction)
+void goto2ct::check_assign(goto_programt::instructiont instruction
+                           [[maybe_unused]])
 {
   assert(is_code_assign2t(instruction.code));
 }
@@ -179,12 +185,14 @@ void goto2ct::check_skip(goto_programt::instructiont instruction
   // or something else
 }
 
-void goto2ct::check_throw(goto_programt::instructiont instruction)
+void goto2ct::check_throw(goto_programt::instructiont instruction
+                          [[maybe_unused]])
 {
   assert(is_code_cpp_throw2t(instruction.code));
 }
 
-void goto2ct::check_catch(goto_programt::instructiont instruction)
+void goto2ct::check_catch(goto_programt::instructiont instruction
+                          [[maybe_unused]])
 {
   assert(is_code_cpp_catch2t(instruction.code));
 }
@@ -199,12 +207,14 @@ void goto2ct::check_atomic_end(goto_programt::instructiont instruction
 {
 }
 
-void goto2ct::check_throw_decl(goto_programt::instructiont instruction)
+void goto2ct::check_throw_decl(goto_programt::instructiont instruction
+                               [[maybe_unused]])
 {
   assert(is_code_cpp_throw_decl2t(instruction.code));
 }
 
-void goto2ct::check_throw_decl_end(goto_programt::instructiont instruction)
+void goto2ct::check_throw_decl_end(goto_programt::instructiont instruction
+                                   [[maybe_unused]])
 {
   assert(is_code_cpp_throw_decl_end2t(instruction.code));
 }
@@ -214,7 +224,7 @@ void goto2ct::check_other(goto_programt::instructiont instruction
 {
 }
 
-void check_if_sideeffect_or_assign_expr(expr2tc expr)
+void check_if_sideeffect_or_assign_expr(expr2tc expr [[maybe_unused]])
 {
   assert(!is_code_assign2t(expr));
   assert(!is_sideeffect2t(expr));

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -415,7 +415,7 @@ expr2tc dereferencet::dereference_expr_nonscalar(
     {
       auto *t = static_cast<const struct_union_data *>(structure->type.get());
       log_warning(
-        "WARNING: not checking alignment for access to packed {} {}",
+        "not checking alignment for access to packed {} {}",
         get_type_id(*structure->type),
         t->name.as_string());
       mode.unaligned = true;

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -252,8 +252,8 @@ bool solidity_convertert::get_var_decl(
   }
   else
   {
-    assert(
-      !"Error: ESBMC could not find the parent scope for this local variable");
+    log_error("ESBMC could not find the parent scope for this local variable");
+    return true;
   }
 
   // 3. populate location
@@ -810,7 +810,12 @@ bool solidity_convertert::get_statement(
   case SolidityGrammar::StatementT::ReturnStatement:
   {
     if(!current_functionDecl)
-      assert(!"Error: ESBMC could not find the parent scope for this ReturnStatement");
+    {
+      log_error(
+        "Error: ESBMC could not find the parent scope for this "
+        "ReturnStatement");
+      return true;
+    }
 
     // 1. get return type
     // TODO: Fix me! Assumptions:

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -609,7 +609,7 @@ smt_convt::resultt smtlib_convt::dec_solve()
   }
   else if(smtlib_output->token == TOK_KW_ERROR)
   {
-    log_error("SMTLIB solver returned error: \"{}\"", smtlib_output->data);
+    log_error("SMTLIB solver returned: \"{}\"", smtlib_output->data);
     return smt_convt::P_ERROR;
   }
   else
@@ -968,7 +968,7 @@ smt_astt smtlib_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 
 int smtliberror(int startsym [[maybe_unused]], const std::string &error)
 {
-  log_error("SMTLIB response parsing error: \"{}\"", error);
+  log_error("SMTLIB response parsing: \"{}\"", error);
   abort();
 }
 

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -169,7 +169,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
   if(is_code_in_context != is_code_new_symbol)
   {
     log_error(
-      "error: conflicting definition for symbol \"{}\"\n"
+      "conflicting definition for symbol \"{}\"\n"
       "old definition: {}\n"
       "Module: {}\n"
       "new definition: {}\n"
@@ -206,8 +206,8 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       {
         // keep the one in in_context -- libraries come last!
         log_warning(
-          "warning: function `{}' in module `{}' "
-          "is shadowed by a definition in module `{}'",
+          "function `{}' in module `{}' is shadowed by a definition in module "
+          "`{}'",
           in_context.name,
           new_symbol.module,
           in_context.module);
@@ -215,7 +215,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       else
       {
         log_error(
-          "error: duplicate definition of function `{}'\n"
+          "duplicate definition of function `{}'\n"
           "In module `{}' and module `{}'\n"
           "Location: {}",
           in_context.name,
@@ -275,7 +275,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       else
       {
         log_error(
-          "error: conflicting definition for variable `{}'\n"
+          "conflicting definition for variable `{}'\n"
           "old definition: {}\n"
           "Module: {}\n"
           "new definition: {}\n"
@@ -301,7 +301,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       else if(!base_type_eq(in_context.value, new_symbol.value, ns))
       {
         log_error(
-          "error: conflicting initializers for variable `{}'\n"
+          "conflicting initializers for variable `{}'\n"
           "old value: {}\n"
           "Module: {}\n"
           "new value: {}\n"

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -210,7 +210,7 @@ bool cmdlinet::parse(
   }
   catch(std::exception &e)
   {
-    log_error("ESBMC error: {}", e.what());
+    log_error("{}", e.what());
     return true;
   }
 

--- a/src/util/compiler_defs.h
+++ b/src/util/compiler_defs.h
@@ -21,8 +21,8 @@
 
 #define CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()                                     \
   DO_PRAGMA(GCC diagnostic ignored "-Wstrict-aliasing")                        \
-  DO_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")
-
+  DO_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")                       \
+  DO_PRAGMA(GCC diagnostic ignored "-Wnonnull")
 #endif
 
 #ifndef GNUC_PREREQ

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -162,7 +162,7 @@ bool configt::set(const cmdlinet &cmdline)
     else if(mode != "off")
     {
       log_error(
-        "error: only 'hybrid' and 'purecap' modes supported for --cheri, "
+        "only 'hybrid' and 'purecap' modes supported for --cheri, "
         "argument was: {}",
         mode);
       abort();

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -41,6 +41,8 @@ void messaget::statet::println(
   {
     if(lvl == VerbosityLevel::Error)
       fmt::print(f, "ERROR: ");
+    if(lvl == VerbosityLevel::Warning)
+      fmt::print(f, "WARNING: ");
     fmt::vprint(f, format, args);
   }
 


### PR DESCRIPTION
This PR is part of a series of PRs derived from #876: although that PR was accepted, it's been a nightmare to rebase, so I decided to split it.

This first PR fixes all warnings on esbmc (except for one in smtlib) and enables werror in the build.sh script (for linux only, as I don't have macos to test this PR).