### PR TITLE
Wrapper: adapt for sv-benchmark's MR 1470

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -364,7 +364,9 @@ f = open(property_file, 'r')
 property_file_content = f.read()
 
 category_property = 0
-if "CHECK( init(main()), LTL(G valid-free) )" in property_file_content:
+if "CHECK( init(main()), LTL(G valid-memcleanup) )" in property_file_content:
+  category_property = Property.memcleanup
+elif "CHECK( init(main()), LTL(G valid-free) )" in property_file_content:
   category_property = Property.memory
 elif "CHECK( init(main()), LTL(G ! overflow) )" in property_file_content:
   category_property = Property.overflow
@@ -372,8 +374,6 @@ elif "CHECK( init(main()), LTL(G ! call(reach_error())) )" in property_file_cont
   category_property = Property.reach
 elif "CHECK( init(main()), LTL(F end) )" in property_file_content:
   category_property = Property.termination
-elif "CHECK( init(main()), LTL(G valid-memcleanup) )" in property_file_content:
-  category_property = Property.memcleanup
 else:
   print("Unsupported Property")
   exit(1)


### PR DESCRIPTION
This change should take care of <https://github.com/esbmc/esbmc/issues/1440#issuecomment-1790507782>, which is about SV-COMP's [MR 1470](https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/merge_requests/1470). We should really start considering parsing the strings according to some (adhoc? which?) grammar...

I'm [running](https://github.com/esbmc/esbmc/actions/runs/6731716856) it over the 2023 benchmarks to be sure.