### PR TITLE
[interval-analysis] --interval-anaylsis-csv-dump now produce compressed files

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -5,6 +5,9 @@
 #include <goto-programs/abstract-interpretation/interval_domain.h>
 #include <unordered_set>
 #include <util/prefix.h>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
 
 static inline void get_symbols(
   const expr2tc &expr,
@@ -195,8 +198,15 @@ void interval_analysis(
     Forall_goto_functions(f_it, goto_functions)
       dump_intervals(oss, f_it->second, interval_analysis);
 
-    std::ofstream csv(csv_file);
-    csv << oss.str();
+    // to decompress:
+    // zlib-flate -uncompress intervals.csv.z interval.unz
+    std::stringstream ss{oss.str()};
+    std::ofstream file(
+      csv_file + ".z", std::ios_base::out | std::ios_base::binary);
+    boost::iostreams::filtering_streambuf<boost::iostreams::output> out;
+    out.push(boost::iostreams::zlib_compressor());
+    out.push(file);
+    boost::iostreams::copy(ss, out);
   }
 
   Forall_goto_functions(f_it, goto_functions)


### PR DESCRIPTION
Using the option --interval-analysis-csv-dump will produce compressed files. This is due to how large the file can become. 