### PR TITLE
[Concurrency] optimise index races check

### DIFF
--- a/regression/esbmc-unix/github_1456/main.c
+++ b/regression/esbmc-unix/github_1456/main.c
@@ -1,0 +1,27 @@
+#include <pthread.h>
+
+int a[4];
+
+int index1 = 0;
+int index2 = 1;
+
+void* t1(void *arg) {
+    a[index1] = 1;    // a[0]             
+
+    return NULL;
+}
+
+void* t2(void *arg) {
+    a[index2] = 1;    // a[1]
+
+    return NULL;
+}
+
+int main() {
+    pthread_t id1, id2;
+
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+
+    return 0;
+}

--- a/regression/esbmc-unix/github_1456/test.desc
+++ b/regression/esbmc-unix/github_1456/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_1456_fail/main.c
+++ b/regression/esbmc-unix/github_1456_fail/main.c
@@ -1,0 +1,28 @@
+#include <pthread.h>
+
+int a[4];
+
+int index1 = 0;
+int index2 = 0;
+
+void* t1(void *arg) {
+    a[index1] = 1;     // a[0]            
+
+    return NULL;
+}
+
+void* t2(void *arg) {
+    a[index2] = 1;     // a[0], race here
+
+    return NULL;
+}
+
+int main() {
+    pthread_t id1, id2;
+
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_create(&id2, NULL, t2, NULL);
+
+    return 0;
+}
+

--- a/regression/esbmc-unix/github_1456_fail/test.desc
+++ b/regression/esbmc-unix/github_1456_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION FAILED$

--- a/src/goto-programs/rw_set.h
+++ b/src/goto-programs/rw_set.h
@@ -15,6 +15,7 @@ public:
     irep_idt object;
     bool r, w;
     exprt guard;
+    exprt original_expr;
 
     entryt() : r(false), w(false), guard(true_exprt())
     {
@@ -62,14 +63,14 @@ public:
     compute(code);
   }
 
-  void read(const exprt &expr)
+  void read_rec(const exprt &expr)
   {
-    read_write_rec(expr, true, false, "", guardt());
+    read_write_rec(expr, true, false, "", guardt(), exprt());
   }
 
-  void read(const exprt &expr, const guardt &guard)
+  void read_rec(const exprt &expr, const guardt &guard, const exprt &original_expr)
   {
-    read_write_rec(expr, true, false, "", guard);
+    read_write_rec(expr, true, false, "", guard, original_expr);
   }
 
 protected:
@@ -84,7 +85,8 @@ protected:
     bool r,
     bool w,
     const std::string &suffix,
-    const guardt &guard);
+    const guardt &guard,
+    const exprt &original_expr);
 };
 
 #define forall_rw_set_entries(it, rw_set)                                      \

--- a/src/goto-programs/rw_set.h
+++ b/src/goto-programs/rw_set.h
@@ -68,7 +68,8 @@ public:
     read_write_rec(expr, true, false, "", guardt(), exprt());
   }
 
-  void read_rec(const exprt &expr, const guardt &guard, const exprt &original_expr)
+  void
+  read_rec(const exprt &expr, const guardt &guard, const exprt &original_expr)
   {
     read_write_rec(expr, true, false, "", guard, original_expr);
   }


### PR DESCRIPTION
This PR will improve the case where index is symbol in data races check.

For example TC as follows:
```
#include <pthread.h>

int a[4];

void* t1(void *arg) {
    a[__ESBMC_get_thread_id()] = 1;                 

    return NULL;
}

void* t2(void *arg) {
    a[__ESBMC_get_thread_id()] = 1;

    return NULL;
}

int main() {
    pthread_t id1, id2;

    pthread_create(&id1, NULL, t1, NULL);
    pthread_create(&id2, NULL, t2, NULL);

    return 0;
}
```
goto functions as follow:

![8_FW8_3W_R{6QQIPU~))`)5](https://github.com/esbmc/esbmc/assets/115160284/863a4d25-3c5c-4d0a-bfb4-9bc79d9e1a1a)

![KI6FKV%`(Z S%Z0AZK_9D6Y](https://github.com/esbmc/esbmc/assets/115160284/38089f43-d658-4c9b-8adf-e8571370f6d9)

There is a problem with this PR, that is, the number of thread interleaving is increased greatly. I don't quite understand why the `array` has more thread interleaving in the verification. Can we improve this?


