### PR TITLE
strerror: fix integer overflow

### DIFF
--- a/regression/esbmc/strerror-no-overflow/main.c
+++ b/regression/esbmc/strerror-no-overflow/main.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include <assert.h>
+
+int main()
+{
+	int no = __VERIFIER_nondet_int();
+	const char *err = strerror(no);
+	assert(err); // C99 says this must not be NULL
+}

--- a/regression/esbmc/strerror-no-overflow/test.desc
+++ b/regression/esbmc/strerror-no-overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/headers/string.h
+++ b/src/c2goto/headers/string.h
@@ -22,6 +22,7 @@ char *strpbrk(const char *s, const char *accept);
 char *strstr(const char *str1, const char *str2);
 char *strtok(char *__ESBMC_restrict str, const char *__ESBMC_restrict delim);
 char *strdup(const char *str);
+char *strerror(int errnum);
 void *memcpy(void *__ESBMC_restrict dst, const void *__ESBMC_restrict src, size_t n);
 void *memset(void *s, int c, size_t n);
 void *memmove(void *dest, const void *src, size_t n);

--- a/src/c2goto/library/syserr.c
+++ b/src/c2goto/library/syserr.c
@@ -1,8 +1,5 @@
 char *strerror(int errnum)
 {
-  if(errnum < 0)
-    errnum = -errnum;
-
   char *sys_errlist[] = {
     /*  0                 */ "No error",
     /*  1 EPERM           */ "Operation not permitted",
@@ -102,7 +99,7 @@ char *strerror(int errnum)
 
   int sys_nerr = sizeof(sys_errlist) / sizeof(sys_errlist[0]);
 
-  if(errnum >= sys_nerr)
+  if(errnum < 0 || errnum >= sys_nerr)
     return "Unknown error";
 
   return sys_errlist[errnum];


### PR DESCRIPTION
This was causing an incorrect result for the no-overflow property of the sv-comp'24 pre-run in (at least)
- c/busybox-1.22.0/logname-1.yml

