### PR TITLE
Add option to build an SV-COMP version of ESBMC

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -118,7 +118,7 @@ usage() {
     echo "  -d         enable debug output for this script and c2goto"
     echo "  -S ON|OFF  enable/disable static build [ON for Ubuntu, OFF for macOS]"
     echo "  -c VERS    use packaged clang-VERS in a shared build on Ubuntu [11]"
-    echo "  -C YEAR    build an SV-COMP'YEAR version (YEAR has two digits) []"
+    echo "  -C         build an SV-COMP version [disabled]"
     echo
     echo "This script prepares the environment, downloads dependencies, configures"
     echo "the ESBMC build and runs the commands to compile and install ESBMC into"
@@ -130,7 +130,7 @@ usage() {
 }
 
 # Setup build flags (release, debug, sanitizer, ...)
-while getopts hb:s:e:r:dS:c:C: flag
+while getopts hb:s:e:r:dS:c:C flag
 do
     case "${flag}" in
     h) usage; exit 0 ;;
@@ -142,7 +142,7 @@ do
     d) set -x; export ESBMC_OPTS='--verbosity 9' ;;
     S) STATIC=$OPTARG ;; # should be capital ON or OFF
     c) CLANG_VERSION=$OPTARG ;; # LLVM/Clang major version
-    C) BASE_ARGS="$BASE_ARGS -DESBMC_SVCOMP=${OPTARG}" ;;
+    C) BASE_ARGS="$BASE_ARGS -DESBMC_SVCOMP=ON" ;;
     *) exit 1 ;;
     esac
 done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -118,6 +118,7 @@ usage() {
     echo "  -d         enable debug output for this script and c2goto"
     echo "  -S ON|OFF  enable/disable static build [ON for Ubuntu, OFF for macOS]"
     echo "  -c VERS    use packaged clang-VERS in a shared build on Ubuntu [11]"
+    echo "  -C YEAR    build an SV-COMP'YEAR version (YEAR has two digits) []"
     echo
     echo "This script prepares the environment, downloads dependencies, configures"
     echo "the ESBMC build and runs the commands to compile and install ESBMC into"
@@ -129,7 +130,7 @@ usage() {
 }
 
 # Setup build flags (release, debug, sanitizer, ...)
-while getopts hb:s:e:r:dS:c: flag
+while getopts hb:s:e:r:dS:c:C: flag
 do
     case "${flag}" in
     h) usage; exit 0 ;;
@@ -141,6 +142,7 @@ do
     d) set -x; export ESBMC_OPTS='--verbosity 9' ;;
     S) STATIC=$OPTARG ;; # should be capital ON or OFF
     c) CLANG_VERSION=$OPTARG ;; # LLVM/Clang major version
+    C) BASE_ARGS="$BASE_ARGS -DESBMC_SVCOMP=${OPTARG}" ;;
     *) exit 1 ;;
     esac
 done

--- a/scripts/cmake/Options.cmake
+++ b/scripts/cmake/Options.cmake
@@ -49,6 +49,7 @@ option(ENABLE_CSMITH "Add csmith Tests (default: OFF) (depends: ENABLE_REGRESSIO
 option(BENCHBRINGUP "Run a user-specified benchmark in Github workflow" OFF)
 option(DOWNLOAD_DEPENDENCIES "Download and build dpendencies if needed (default: OFF)" OFF)
 option(ACADEMIC_BUILD "Check and Enable libs that available only in Academic builds (default: OFF)" OFF)
+option(ESBMC_SVCOMP "Enable an SV-COMP build of ESBMC (default: OFF)" OFF)
 
 #############################
 # PRE-BUILT DEPENDENCIES

--- a/scripts/cmake/cmake_config.in
+++ b/scripts/cmake/cmake_config.in
@@ -26,7 +26,7 @@
 #cmakedefine ESBMC_CHERI_HYBRID_SYSROOT "@ESBMC_CHERI_HYBRID_SYSROOT@"
 #cmakedefine ESBMC_CHERI_PURECAP_SYSROOT "@ESBMC_CHERI_PURECAP_SYSROOT@"
 
-#cmakedefine ESBMC_SVCOMP @ESBMC_SVCOMP@
+#cmakedefine ESBMC_SVCOMP 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD 1

--- a/scripts/cmake/cmake_config.in
+++ b/scripts/cmake/cmake_config.in
@@ -26,5 +26,7 @@
 #cmakedefine ESBMC_CHERI_HYBRID_SYSROOT "@ESBMC_CHERI_HYBRID_SYSROOT@"
 #cmakedefine ESBMC_CHERI_PURECAP_SYSROOT "@ESBMC_CHERI_PURECAP_SYSROOT@"
 
+#cmakedefine ESBMC_SVCOMP @ESBMC_SVCOMP@
+
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD 1

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -84,14 +84,21 @@ __ESBMC_HIDE:;
 FILE *fopen(const char *filename, const char *m)
 {
 __ESBMC_HIDE:;
+#if __ESBMC_SVCOMP >= 24
+  FILE *f = (void *)1;
+#else
   FILE *f = malloc(sizeof(FILE));
+#endif
   return f;
 }
 
 int fclose(FILE *stream)
 {
 __ESBMC_HIDE:;
+#if __ESBMC_SVCOMP >= 24
+#else
   free(stream);
+#endif
   return nondet_int();
 }
 

--- a/src/c2goto/library/io.c
+++ b/src/c2goto/library/io.c
@@ -84,7 +84,7 @@ __ESBMC_HIDE:;
 FILE *fopen(const char *filename, const char *m)
 {
 __ESBMC_HIDE:;
-#if __ESBMC_SVCOMP >= 24
+#if __ESBMC_SVCOMP
   FILE *f = (void *)1;
 #else
   FILE *f = malloc(sizeof(FILE));
@@ -95,7 +95,7 @@ __ESBMC_HIDE:;
 int fclose(FILE *stream)
 {
 __ESBMC_HIDE:;
-#if __ESBMC_SVCOMP >= 24
+#if __ESBMC_SVCOMP
 #else
   free(stream);
 #endif

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -282,11 +282,7 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
   }
 
 #if ESBMC_SVCOMP
-#define STR(x) #x
-#define XSTR(x) STR(x)
-  compiler_args.push_back("-D__ESBMC_SVCOMP=" XSTR(ESBMC_SVCOMP));
-#undef XSTR
-#undef STR
+  compiler_args.push_back("-D__ESBMC_SVCOMP");
 #endif
 
   // Increase maximum bracket depth

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -281,6 +281,14 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
     compiler_args.push_back("-D_USE_MATH_DEFINES");
   }
 
+#if ESBMC_SVCOMP
+#define STR(x) #x
+#define XSTR(x) STR(x)
+  compiler_args.push_back("-D__ESBMC_SVCOMP=" XSTR(ESBMC_SVCOMP));
+#undef XSTR
+#undef STR
+#endif
+
   // Increase maximum bracket depth
   compiler_args.push_back("-fbracket-depth=1024");
 


### PR DESCRIPTION
This PR doesn't change defaults, but adds:
- option "ESBMC_SVCOMP" to cmake, causing a #define of the same name to be available during the build
- option "-C" to scripts/build.sh enabling cmake's ESMBC_SVCOMP variable
- if the ESBMC_SVCOMP #define is set, pass it as __ESBMC_SVCOMP on to the C/C++ frontends; this is to make the c2goto models take advantage of it.
- in case it is set, let our `fopen()` model return `(void *)1` and `fclose()` be a no-op.

These are "internal" options in the sense that a user of ESBMC doesn't need to know. The intention is to enable this option for the SV-COMP build, obviously, in order to switch to different OM implementations, if necessary.

*Edit:* If enabled, fixes sv-comp memsafety
- c/loop-industry-pattern/aiob_4.c.v+cfa-reducer.yml
- c/loop-industry-pattern/aiob_4.c.v+lh-reducer.yml
- c/loop-industry-pattern/aiob_4.c.v+lhb-reducer.yml
- c/loop-industry-pattern/aiob_4.c.v+nlh-reducer.yml