### PR TITLE
esbmc-wrapper: handle no-data-race property

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -44,7 +44,7 @@ class Result:
       return True
     if res == Result.fail_memcleanup:
       return True
-    if res == result.fail_termination:
+    if res == result.fail_termination: # XXX fbrausse: shouldn't "result" be capitalized?
       return True
     if res == Result.fail_race:
       return True


### PR DESCRIPTION
I'm not sure about the `"FALSE_DATARACE"` string. Where are the possible result output strings listed for each (sub-)property?

An svcomp23 run of this PR just over the no-data-race RunSet is under way: https://github.com/esbmc/esbmc/actions/runs/6822429829