### PR TITLE
Do not use #line directives for source locations in an sv-comp build

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3391,7 +3391,14 @@ void clang_c_convertert::get_presumed_location(
     return;
 
   clang::SourceLocation FileLoc = sm->getFileLoc(loc);
-  PLoc = sm->getPresumedLoc(FileLoc);
+  bool use_line_directives = true;
+#if ESBMC_SVCOMP
+  /* Do not use #line directives, because the GraphML witness format appearently
+   * wants to use the physical line in the pre-processed .i file; at least
+   * CPAchecker and UAutomizer do. */
+  use_line_directives = false;
+#endif
+  PLoc = sm->getPresumedLoc(FileLoc, use_line_directives);
 }
 
 void clang_c_convertert::set_location(


### PR DESCRIPTION
I've hard-coded the clang frontend to not interpret #line directives for generating `locationt`. We could also introduce an option, but as noone did request this functionality, yet, I thought it best to restrict it to sv-comp builds.