### PR TITLE
symex_input: use source location of intrinsic for assignments

### DIFF
--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -496,6 +496,8 @@ void goto_symext::symex_input(const code_function_call2t &func_call)
   else
     abort();
 
+  cur_state->source.pc--;
+
   if(func_call.ret)
     symex_assign(code_assign2tc(
       func_call.ret,
@@ -527,6 +529,8 @@ void goto_symext::symex_input(const code_function_call2t &func_call)
       symex_assign(code_assign2tc(item.object, val), false, cur_state->guard);
     }
   }
+
+  cur_state->source.pc++;
 }
 
 void goto_symext::symex_cpp_new(const expr2tc &lhs, const sideeffect2t &code)

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -283,7 +283,8 @@ void violation_graphml_goto_trace(
     case goto_trace_stept::ASSIGNMENT:
       if(
         step.pc->is_assign() || step.pc->is_return() ||
-        (step.pc->is_other() && is_nil_expr(step.lhs)))
+        (step.pc->is_other() && is_nil_expr(step.lhs)) ||
+        step.pc->is_function_call())
       {
         std::string assignment = get_formated_assignment(ns, step);
 
@@ -411,7 +412,8 @@ void show_goto_trace(
     case goto_trace_stept::ASSIGNMENT:
       if(
         step.pc->is_assign() || step.pc->is_return() ||
-        (step.pc->is_other() && is_nil_expr(step.lhs)))
+        (step.pc->is_other() && is_nil_expr(step.lhs)) ||
+        step.pc->is_function_call())
       {
         if(prev_step_nr != step.step_nr || first_step)
         {


### PR DESCRIPTION
In symex_step() the PC is incremented before executing the intrinsic, this leads to assignments made by intrinsics to have the wrong source location. Here we fix the symex_input() family of intrinsics to use the correct source location.

For counter-examples and witnesses to also print these assignments, additionally to the other conditions on goto-steps allow function call steps to be interpreted as assignments - if we do that internally.

This fixes a warning printed by CPAchecker about the assigned symbol not being on the source line indicated in the witness file for (at least) SV-COMP benchmarks no-overflow
1. c/Juliet_Test/CWE190_Integer_Overflow__int64_t_fscanf_square_21_bad_abs.i
2. c/Juliet_Test/CWE190_Integer_Overflow__int64_t_fscanf_add_08_bad.i

Unfortunately, CPAchecker still doesn't want to find the property violation, but with --compact-trace this now enables UAutomizer to validate the second one above.

Related: #1470, though we still can't mark it fixed because of --compact-trace. It's really unclear why --compact-trace makes a difference for item 2. above, I can't see anything in the larger counter-example that would be of help for validating the witness...