### PR TITLE
[Concurrency] support "printf" for data races check

### DIFF
--- a/regression/esbmc-unix/SV_COMP_01/main.c
+++ b/regression/esbmc-unix/SV_COMP_01/main.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdio.h>
+
+int *x;
+int *y;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m);
+  *x = 3; // NORACE
+  *y = 8; // RACE!
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+
+  x = malloc(sizeof(int));
+  y = malloc(sizeof(int));
+
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m);
+  printf("%d\n",*x); // NORACE
+  pthread_mutex_unlock(&m);
+  printf("%d\n",*y); // RACE!
+
+  return 0;
+}

--- a/regression/esbmc-unix/SV_COMP_01/test.desc
+++ b/regression/esbmc-unix/SV_COMP_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --data-races-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/SV_COMP_01_success/main.c
+++ b/regression/esbmc-unix/SV_COMP_01_success/main.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdio.h>
+
+int *x;
+int *y;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void *t_fun(void *arg) {
+  pthread_mutex_lock(&m);
+  *x = 3; // NORACE
+  *y = 8; // NORACE
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+int main() {
+  pthread_t id;
+
+  x = malloc(sizeof(int));
+  y = malloc(sizeof(int));
+
+  pthread_create(&id, NULL, t_fun, NULL);
+
+  pthread_mutex_lock(&m);
+  printf("%d\n",*x); // NORACE
+  printf("%d\n",*y); // NORACE
+  pthread_mutex_unlock(&m);
+
+  return 0;
+}

--- a/regression/esbmc-unix/SV_COMP_01_success/test.desc
+++ b/regression/esbmc-unix/SV_COMP_01_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/SV_COMP_02/main.c
+++ b/regression/esbmc-unix/SV_COMP_02/main.c
@@ -1,0 +1,21 @@
+#include <pthread.h>
+
+int a;
+
+void* t1(void *arg) {
+    a = 1;                 
+    return NULL;
+}
+
+int t2(void) {
+    return a;
+}
+
+int main() {
+    pthread_t id1, id2;
+
+    pthread_create(&id1, NULL, t1, NULL);
+    t2();
+
+    return 0;
+}

--- a/regression/esbmc-unix/SV_COMP_02/test.desc
+++ b/regression/esbmc-unix/SV_COMP_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix/SV_COMP_02_success/main.c
+++ b/regression/esbmc-unix/SV_COMP_02_success/main.c
@@ -1,0 +1,22 @@
+#include <pthread.h>
+
+int a;
+
+void* t1(void *arg) {
+    a = 1;                 
+    return NULL;
+}
+
+int t2(void) {
+    return a;
+}
+
+int main() {
+    pthread_t id1, id2;
+
+    pthread_create(&id1, NULL, t1, NULL);
+    pthread_join(id1, NULL);
+    t2();
+
+    return 0;
+}

--- a/regression/esbmc-unix/SV_COMP_02_success/test.desc
+++ b/regression/esbmc-unix/SV_COMP_02_success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -125,7 +125,7 @@ void add_race_assertions(
     if(instruction.is_atomic_begin())
       is_atomic = true;
 
-    if(instruction.is_assign() && !is_atomic)
+    if((instruction.is_assign() || instruction.is_other()) && !is_atomic)
     {
       exprt tmp_expr = migrate_expr_back(instruction.code);
       rw_sett rw_set(ns, value_sets, i_it, to_code(tmp_expr));

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -121,11 +121,14 @@ void add_race_assertions(
   Forall_goto_program_instructions(i_it, goto_program)
   {
     goto_programt::instructiont &instruction = *i_it;
-    
+
     if(instruction.is_atomic_begin())
       is_atomic = true;
 
-    if((instruction.is_assign() || instruction.is_other() || instruction.is_return()) && !is_atomic)
+    if(
+      (instruction.is_assign() || instruction.is_other() ||
+       instruction.is_return()) &&
+      !is_atomic)
     {
       exprt tmp_expr = migrate_expr_back(instruction.code);
       rw_sett rw_set(ns, value_sets, i_it, to_code(tmp_expr));

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -20,6 +20,11 @@ void rw_sett::compute(const codet &code)
     Forall_operands(it, expr)
       read_rec(*it);
   }
+  else if(statement == "return")
+  {
+    assert(code.operands().size() == 1);
+    read_rec(code.op0());
+  }
 }
 
 void rw_sett::assign(const exprt &lhs, const exprt &rhs)

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -14,6 +14,12 @@ void rw_sett::compute(const codet &code)
     assert(code.operands().size() == 2);
     assign(code.op0(), code.op1());
   }
+  else if(statement == "printf")
+  {
+    exprt expr = code;
+    Forall_operands(it, expr)
+      read_rec(*it);
+  }
 }
 
 void rw_sett::assign(const exprt &lhs, const exprt &rhs)

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -58,7 +58,8 @@ void rw_sett::read_write_rec(
         symbol->name == "__ESBMC_alloc" ||
         symbol->name == "__ESBMC_alloc_size" || symbol->name == "stdin" ||
         symbol->name == "stdout" || symbol->name == "stderr" ||
-        symbol->name == "sys_nerr")
+        symbol->name == "sys_nerr" || symbol->name == "operator=::ref" ||
+        symbol->name == "this")
       {
         return; // ignore for now
       }


### PR DESCRIPTION
This PR improves the strategy for data race detection. |

Now identify "printf" as a `read` operation.

![JBSOD_28 CQN}O5Z9)M)MLP](https://github.com/esbmc/esbmc/assets/115160284/7f1bb5f3-3207-4937-8a9d-5c4a216b0cc6)

