### PR TITLE
Wrapper now defaults as witness.graphml for naming

### DIFF
--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -7,6 +7,7 @@
   <resultfiles>**/*.graphml</resultfiles>
   
   <option name="-s">kinduction</option>
+  <option name="--ci"/>
 
 <rundefinition name="SV-COMP23_unreach-call">
   <tasks name="ReachSafety-Arrays">


### PR DESCRIPTION
This PR:

1. Sets witness.graphml as the default name
2. Adds the --ci option to keep compatibility with our current CI

I will also do a quick run on reachsafety-arrays just to double check