### PR TITLE
Python frontend: Add support for recursion

### DIFF
--- a/regression/python/recursion-fail/main.py
+++ b/regression/python/recursion-fail/main.py
@@ -1,0 +1,11 @@
+def factorial(n:int) -> int:
+    if n == 0 or n == 1:
+        return 1
+    else:
+        return n * factorial(n - 1)
+
+result:int = factorial(5)
+assert(result == 120)
+
+result = factorial(4)
+assert(result == 20) # result == 24

--- a/regression/python/recursion-fail/test.desc
+++ b/regression/python/recursion-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/recursion/main.py
+++ b/regression/python/recursion/main.py
@@ -1,6 +1,10 @@
-def zero(n:int) -> int:
-    if (n>0):
-        return zero(n-1)
-    return n
+def fib(n:int) -> int:
+  if n <= 0:
+    return 0
+  elif n == 1:
+    return 1
+  else:
+    return fib(n - 1) + fib(n - 2)
 
-result:int = zero(5)
+n:int = 6
+result:int = fib(n)

--- a/regression/python/recursion/main.py
+++ b/regression/python/recursion/main.py
@@ -1,0 +1,6 @@
+def zero(n:int) -> int:
+    if (n>0):
+        return zero(n-1)
+    return n
+
+result:int = zero(5)

--- a/regression/python/recursion/test.desc
+++ b/regression/python/recursion/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion/test.desc
+++ b/regression/python/recursion/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
+--k-induction
 
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -254,7 +254,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     code_function_callt call;
     call.location() = location;
     call.function() = symbol_expr(*func_symbol);
-    call.type() = func_symbol->type;
+    const typet &return_type = to_code_type(func_symbol->type).return_type();
+    call.type() = return_type;
 
     for(const auto &arg_node : element["args"])
     {
@@ -416,7 +417,7 @@ void python_converter::get_var_assign(
    */
   if(rhs.is_code() && rhs.get("statement") == "function_call")
   {
-    // op0() references the left-hand side (lhs) of the function call
+    // op0() refers to the left-hand side (lhs) of the function call
     rhs.op0() = lhs;
     target_block.copy_to_operands(rhs);
     return;
@@ -590,8 +591,8 @@ void python_converter::get_function_definition(
   }
 
   // Create symbol
-  symbolt symbol = create_symbol(
-    module_name, current_func_name, id, location, type);
+  symbolt symbol =
+    create_symbol(module_name, current_func_name, id, location, type);
   symbol.lvalue = true;
   symbol.is_extern = false;
   symbol.file_local = false;

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -1094,6 +1094,10 @@ public:
   {
     return id() == id_code;
   }
+  inline bool is_function_call() const
+  {
+    return is_code() && statement() == "function_call";
+  }
   inline bool is_constant() const
   {
     return id() == id_constant;


### PR DESCRIPTION
This PR:
- Adds support for recursion by inserting the function symbol into the context before converting the function body. This addresses the "symbol not found" issue that may occur if the body contains a recursive call.
- Converts function calls to side effects when handling expressions, as "required" by the goto conversion layer.