### PR TITLE
Stop tracking global variables intervals

### DIFF
--- a/regression/esbmc/interval_can_handle_global/interval.i
+++ b/regression/esbmc/interval_can_handle_global/interval.i
@@ -1,0 +1,19 @@
+c, e = 1;
+a();
+void b();
+void d();
+main() {
+  c = 1;
+  if (c == 1) {
+    b();
+    (*a)();
+  }
+  d();
+}
+void b() { 
+int tmp = e;
+e = tmp + 1; }
+void d() {
+  if (e != 1)
+    reach_error();
+}

--- a/regression/esbmc/interval_can_handle_global/test.desc
+++ b/regression/esbmc/interval_can_handle_global/test.desc
@@ -1,0 +1,4 @@
+CORE
+interval.i
+--interval-analysis
+^VERIFICATION FAILED$

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -40,7 +40,11 @@ void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
   const integer_intervalt value)
 {
-  //  if(sym.thename)
+  // TODO: we can't handle globals
+  // as the analysis is not context-aware
+  //
+  if(has_prefix(sym.thename, "c:@"))
+     return;
   int_map[sym.thename] = value;
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -44,7 +44,7 @@ void interval_domaint::update_symbol_interval(
   // as the analysis is not context-aware
   //
   if(has_prefix(sym.thename, "c:@"))
-     return;
+    return;
   int_map[sym.thename] = value;
 }
 


### PR DESCRIPTION
Currently, our Abstract Interpretation framework is not context-aware making functions not aware of global state (and its parameters). This makes the intervals of non constant global variables completely wrong. 

~~I am opening this as a draft as it fixes a few wrong results of sv-benchmarks~~

I will leave as a TODO as it will not be solved any time soon.