### PR TITLE
Increase precision of floatbv constants in cex/witness

### DIFF
--- a/src/util/format_spec.h
+++ b/src/util/format_spec.h
@@ -16,12 +16,12 @@ public:
   stylet style;
 
   format_spect()
-    : min_width(0), precision(6), zero_padding(false), style(AUTOMATIC)
+    : min_width(0), precision(16), zero_padding(false), style(AUTOMATIC)
   {
   }
 
   explicit format_spect(stylet _style)
-    : min_width(0), precision(6), zero_padding(false), style(_style)
+    : min_width(0), precision(16), zero_padding(false), style(_style)
   {
   }
 


### PR DESCRIPTION
This is to ensure that the bit pattern provided by cex is actually the one C would interpret for the decimal representation of the floating point literals.

It's less nice for users to see these enlarged fractional parts, but the previous 6 decimal digits aren't even enough for `float`.

Related: #1492