### PR TITLE
wrapper: handle deref failure from memset() intrinsic

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -103,6 +103,7 @@ def parse_result(the_output, prop):
   # Error messages:
   memory_leak = "dereference failure: forgotten memory"
   invalid_pointer = "dereference failure: invalid pointer"
+  memset_access_oob = "dereference failure: memset of memory segment of size"
   access_out = "dereference failure: Access to object out of bounds"
   dereference_null = "dereference failure: NULL pointer"
   expired_variable = "dereference failure: accessed expired variable pointer"
@@ -147,7 +148,7 @@ def parse_result(the_output, prop):
       if free_error in the_output:
         return Result.fail_free
 
-      if access_out in the_output:
+      if access_out in the_output or memset_access_oob in the_output:
         return Result.fail_deref
 
       if invalid_object in the_output:


### PR DESCRIPTION
For valid-memsafety c/uthash-2.0.2/uthash_SFH_test9-2.i ESBMC's memset intrinsic produces
```
Violated property:
  file string.c line 282 column 3 function memset
  dereference failure: memset of memory segment of size 40 with 44 bytes
```
But the wrapper doesn't recognize this as FALSE_DEREF, yet. With this PR it does.