### PR TITLE
Interpret __builtin_unreachable() as no-op for sv-comp

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -227,8 +227,6 @@ esbmc_path = "./esbmc "
 # ESBMC default commands: this is the same for every submission
 esbmc_dargs = "--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets "
 esbmc_dargs += "--no-align-check --k-step 2 --floatbv --unlimited-k-steps "
-# <https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/issues/1296>
-esbmc_dargs += "-D'__builtin_unreachable()' "
 
 # <https://github.com/esbmc/esbmc/pull/1190#issuecomment-1637047028>
 esbmc_dargs += "--no-vla-size-check "

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -227,27 +227,20 @@ esbmc_path = "./esbmc "
 # ESBMC default commands: this is the same for every submission
 esbmc_dargs = "--no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets "
 esbmc_dargs += "--no-align-check --k-step 2 --floatbv --unlimited-k-steps "
+# <https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/issues/1296>
+esbmc_dargs += "-D'__builtin_unreachable()' "
 
 # <https://github.com/esbmc/esbmc/pull/1190#issuecomment-1637047028>
 esbmc_dargs += "--no-vla-size-check "
 
-USAGE_PTHREAD = 0
-USAGE_BUILTIN_UNREACHABLE_DEF = 1
 
 import re
-def check_benchmark_usage(benchmark):
-  r = set()
-  pats = {}
-  for (p,v) in (("pthread_create", USAGE_PTHREAD),
-                ("\\bvoid\\s+__builtin_unreachable\\(", USAGE_BUILTIN_UNREACHABLE_DEF)):
-    pats[v] = re.compile(p)
+def check_if_benchmark_contains_pthread(benchmark):
   with open(benchmark, "r") as f:
     for line in f:
-      line = line.strip()
-      for (v,p) in pats.items():
-        if re.search(p, line):
-          r.add(v)
-  return r
+      if re.search("pthread_create", line.strip()):
+        return True
+  return False
 
 def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci):
   command_line = esbmc_path + dargs
@@ -261,14 +254,8 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
   else:
     command_line += "--64 "
 
-  usage = check_benchmark_usage(benchmark)
-
   concurrency = ((prop in (Property.reach, Property.datarace)) and
-                 USAGE_PTHREAD in usage)
-
-  if USAGE_BUILTIN_UNREACHABLE_DEF not in usage:
-    # <https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/issues/1296>
-    command_line += "-D'__builtin_unreachable()' "
+                 check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
     command_line += " --no-por --context-bound 2 "

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -238,7 +238,7 @@ import re
 def check_benchmark_usage(benchmark):
   r = set()
   pats = {}
-  for (p,v) in (("\\bpthread_create\\b", USAGE_PTHREAD),
+  for (p,v) in (("pthread_create", USAGE_PTHREAD),
                 ("\\bvoid\\s+__builtin_unreachable\\(", USAGE_BUILTIN_UNREACHABLE_DEF)):
     pats[v] = re.compile(p)
   with open(benchmark, "r") as f:

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -238,7 +238,7 @@ import re
 def check_benchmark_usage(benchmark):
   r = set()
   pats = {}
-  for (p,v) in (("pthread_create", USAGE_PTHREAD),
+  for (p,v) in (("\\bpthread_create\\b", USAGE_PTHREAD),
                 ("\\bvoid\\s+__builtin_unreachable\\(", USAGE_BUILTIN_UNREACHABLE_DEF)):
     pats[v] = re.compile(p)
   with open(benchmark, "r") as f:

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -1,3 +1,6 @@
+
+#include <ac_config.h>
+
 #include <cassert>
 #include <goto-programs/goto_convert_class.h>
 #include <regex>

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -578,6 +578,12 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
 
+#if ESBMC_SVCOMP
+    /* <https://gitlab.com/sosy-lab/benchmarking/sv-benchmarks/-/issues/1296> */
+    if(base_name == "__builtin_unreachable")
+      return;
+#endif
+
     goto_programt::targett t = dest.add_instruction(ASSERT);
     t->guard = gen_false_expr();
     t->location = function.location();


### PR DESCRIPTION
Fixes a part of #1494:

	Parsing ../../sv-benchmarks/c/coreutils-v8.31/env_3args_ok.c
	../../sv-benchmarks/c/coreutils-v8.31/env_3args_ok.c:48729:6: error: expected identifier or '('
	void __builtin_unreachable();
	     ^
	<command line>:5:33: note: expanded from here
	#define __builtin_unreachable() 1

I'll keep this a draft until an sv-comp run has confirmed I'm not breaking anything.