### PR TITLE
Remove TACAS nondet declarations for svcomp builds

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -447,6 +447,9 @@ float nondet_float();
 double nondet_double();
 
 // TACAS definitions,
+#ifndef __ESBMC_SVCOMP
+// Some TACAS benchmarks use the wrong signature for nondet
+// e.g. uthash_SFH_nondet_test4-2.i  contains `extern int __VERIFIER_nondet_uint(void);`
 int __VERIFIER_nondet_int();
 unsigned int __VERIFIER_nondet_uint();
 long __VERIFIER_nondet_long();
@@ -459,6 +462,7 @@ signed char __VERIFIER_nondet_schar();
 _Bool __VERIFIER_nondet_bool();
 float __VERIFIER_nondet_float();
 double __VERIFIER_nondet_double();
+#endif
 
 void __VERIFIER_error();
 void __VERIFIER_assume(int);


### PR DESCRIPTION
Some benchmarks use some weird signature. Since it is unreasonable for us to fix all... let's just assume the return type is the nondet type.

Results: https://github.com/esbmc/esbmc/actions/runs/6905490581