### PR TITLE
Optimize floats memset for zero initialization

### DIFF
--- a/regression/esbmc/github_1508_non_optimized-2/main.c
+++ b/regression/esbmc/github_1508_non_optimized-2/main.c
@@ -1,0 +1,9 @@
+float a;
+main() {
+  for (;;) {
+    memset(&a, 0, sizeof(a)-1);
+    reach_error();
+    for (;;)
+      ;
+  }
+}

--- a/regression/esbmc/github_1508_non_optimized-2/test.desc
+++ b/regression/esbmc/github_1508_non_optimized-2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_1508_non_optimized/main.c
+++ b/regression/esbmc/github_1508_non_optimized/main.c
@@ -1,0 +1,16 @@
+float a;
+
+void my_memset(char* ptr, int byte, int N)
+{
+  for(int i = 0; i < N; i++)
+	  ptr[i] = byte;
+}
+
+main() {
+  for (;;) {
+    my_memset(&a, 0, sizeof(a));
+    reach_error();
+    for (;;)
+      ;
+  }
+}

--- a/regression/esbmc/github_1508_non_optimized/test.desc
+++ b/regression/esbmc/github_1508_non_optimized/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_1508_optimized/main.c
+++ b/regression/esbmc/github_1508_optimized/main.c
@@ -1,0 +1,9 @@
+float a;
+main() {
+  for (;;) {
+    memset(&a, 0, sizeof(a));
+    reach_error();
+    for (;;)
+      ;
+  }
+}

--- a/regression/esbmc/github_1508_optimized/test.desc
+++ b/regression/esbmc/github_1508_optimized/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction
+^VERIFICATION FAILED$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1077,6 +1077,9 @@ static inline expr2tc gen_value_by_byte(
    *
    */
 
+  if(num_of_bytes == 0)
+    return value;
+
   /* TODO: Bitwise operations are valid for floats, but we don't have an
    * implementation, yet. Give up. */
   if(is_floatbv_type(type) || is_fixedbv_type(type))

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1078,7 +1078,7 @@ static inline expr2tc gen_value_by_byte(
    */
 
   if(num_of_bytes == 0)
-    return value;
+    return src;
 
   /* TODO: Bitwise operations are valid for floats, but we don't have an
    * implementation, yet. Give up. */

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1080,7 +1080,15 @@ static inline expr2tc gen_value_by_byte(
   /* TODO: Bitwise operations are valid for floats, but we don't have an
    * implementation, yet. Give up. */
   if(is_floatbv_type(type) || is_fixedbv_type(type))
+  {
+    unsigned int type_size = type_byte_size(type).to_uint64();
+    // HACK: this should fix the NN-benchmarks (see #1508)
+    if(
+      is_constant_int2t(value) && to_constant_int2t(value).value.is_zero() &&
+      num_of_bytes == type_size && offset == 0)
+      return gen_zero(type);
     return expr2tc();
+  }
 
   if(is_array_type(type))
   {


### PR DESCRIPTION
As shown in #1508 esbmc can't handle float memset properly as it breaks k-induction for some reason. This PR is just a workaround by enabling an extra simplification for the case of `float f; memset(&f, 0, sizeof(float));`