### PR TITLE
Fixed crash caused by invalid id in value set

### DIFF
--- a/regression/esbmc-unix/github_1498/main.c
+++ b/regression/esbmc-unix/github_1498/main.c
@@ -1,0 +1,8 @@
+typedef struct {
+  int a;
+} b;
+
+int main()
+{
+  ((b *)60000)->a = 0;
+}

--- a/regression/esbmc-unix/github_1498/test.desc
+++ b/regression/esbmc-unix/github_1498/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check
+^VERIFICATION SUCCESSFUL$

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1247,7 +1247,7 @@ void value_sett::assign_rec(
     {
       const expr2tc obj = object_numbering[it.first];
 
-      if(!is_unknown2t(obj))
+      if(!is_unknown2t(obj) && !is_invalid2t(obj))
         assign_rec(obj, values_rhs, suffix, add_to_sets);
     }
   }


### PR DESCRIPTION
ESBMC should not crash for program.

```
typedef struct {
  int a;
} b;

int main()
{
  ((b *)60000)->a = 0;
}
```
For some code that directly manipulated memory, this would cause our static analysis module to crash.