### PR TITLE
Add OM for pthread_rwlock_rdlock

### DIFF
--- a/regression/esbmc-unix/00_read_write/test.c
+++ b/regression/esbmc-unix/00_read_write/test.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+#include <assert.h>
+int x, y;
+pthread_rwlock_t rwlock;
+void *writer(void *arg) {
+  pthread_rwlock_wrlock(&rwlock);
+  x = 3;
+  pthread_rwlock_unlock(&rwlock);
+  return 0;
+}
+void *reader(void *arg) {
+  int l;
+  pthread_rwlock_rdlock(&rwlock);
+  l = x;
+  y = l;
+  if (y != x)
+    assert(0);
+  pthread_rwlock_unlock(&rwlock);
+  return 0;
+}
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, writer, 0);
+  pthread_create(&t2, 0, reader, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/00_read_write/test.desc
+++ b/regression/esbmc-unix/00_read_write/test.desc
@@ -1,0 +1,4 @@
+CORE
+test.c
+--context-bound 2 --no-por
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/01_read_write/test.c
+++ b/regression/esbmc-unix/01_read_write/test.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+#include <assert.h>
+int x, y;
+pthread_rwlock_t rwlock;
+void *writer(void *arg) {
+  pthread_rwlock_wrlock(&rwlock);
+  x = 3;
+  pthread_rwlock_unlock(&rwlock);
+  return 0;
+}
+void *reader(void *arg) {
+  int l;
+  pthread_rwlock_rdlock(&rwlock);
+  l = x;
+  y = l;
+  if (x != 3 && y == x)
+    assert(0);
+  pthread_rwlock_unlock(&rwlock);
+  return 0;
+}
+int main() {
+  pthread_t t1, t2;
+  pthread_create(&t1, 0, writer, 0);
+  pthread_create(&t2, 0, reader, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/01_read_write/test.desc
+++ b/regression/esbmc-unix/01_read_write/test.desc
@@ -1,0 +1,4 @@
+CORE
+test.c
+--context-bound 2 --no-por
+^VERIFICATION FAILED$

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -470,6 +470,11 @@ __ESBMC_HIDE:;
 
 int pthread_rwlock_rdlock(pthread_rwlock_t *lock)
 {
+__ESBMC_HIDE:;
+  __ESBMC_atomic_begin();
+  __ESBMC_assume(!__ESBMC_rwlock_field(*lock));
+  __ESBMC_rwlock_field(*lock) = 1;
+  __ESBMC_atomic_end();
   return 0;
 }
 


### PR DESCRIPTION
The regression testcase is a reduced version from the incorrect false of `read_write_lock-1-pthread` in SVCOMP.

From the pthread document: 

The calling thread acquires the write lock if no other thread (reader or writer) holds the read-write lock rwlock.  
The calling thread acquires the read lock if a writer does not hold the lock and there are no writers blocked on the lock.