### PR TITLE
Python frontend: Support for // operator

### DIFF
--- a/regression/python/annotate-function/main.py
+++ b/regression/python/annotate-function/main.py
@@ -1,0 +1,5 @@
+def error() -> None:
+    a = b  ## Python annotation will fail here if esbmc is invoked without --function foo
+
+def foo() -> int:
+    return 1

--- a/regression/python/annotate-function/test.desc
+++ b/regression/python/annotate-function/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--function foo
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert-arith/main.py
+++ b/regression/python/assert-arith/main.py
@@ -1,2 +1,5 @@
-x : int = 1
+x: int = 1
 assert(x == x+0)
+
+y: int = -1
+assert(y == -1)

--- a/regression/python/binary-ops/main.py
+++ b/regression/python/binary-ops/main.py
@@ -2,6 +2,10 @@ add: int = 1 + 0
 sub: int = 1 - 0
 mul: int = 1 * 0
 div: int = 1 / 1
+idiv:int = -5 // 2
+assert(idiv == -3)
+idiv = 5//2
+assert(idiv == 2)
 mod: int = 2 % 2
 bitor: int = 1 | 1
 bitand: int = 1 & 0

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -27,6 +27,20 @@ public:
     }
   }
 
+  // Add annotation in a specific function
+  void add_type_annotation(const std::string &func_name)
+  {
+    for(Json &elem : ast_["body"])
+    {
+      if(elem["_type"] == "FunctionDef" && elem["name"] == func_name)
+      {
+        add_annotation(elem);
+        update_end_col_offset(elem);
+        return;
+      }
+    }
+  }
+
 private:
   void update_end_col_offset(Json &ast)
   {
@@ -140,11 +154,11 @@ private:
     for(const Json &elem : body)
     {
       if(
-        (elem.contains("_type") && elem["_type"] == "AnnAssign" &&
-         elem.contains("target") && elem["target"].contains("id") &&
-         elem["target"]["id"].template get<std::string>() == node_name) ||
-        (elem.contains("_type") && elem["_type"] == "arg" &&
-         elem["arg"] == node_name))
+        elem.contains("_type") &&
+        ((elem["_type"] == "AnnAssign" && elem.contains("target") &&
+          elem["target"].contains("id") &&
+          elem["target"]["id"].template get<std::string>() == node_name) ||
+         (elem["_type"] == "arg" && elem["arg"] == node_name)))
       {
         return elem;
       }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -72,6 +72,19 @@ static typet get_typet(const std::string &ast_type)
   return empty_typet();
 }
 
+static typet get_typet(const nlohmann::json &elem)
+{
+  if(elem.is_number_integer() || elem.is_number_unsigned())
+    return int_type();
+  else if(elem.is_boolean())
+    return bool_type();
+  else if(elem.is_number_float())
+    return float_type();
+
+  log_error("Invalid type\n");
+  abort();
+}
+
 static symbolt create_symbol(
   const std::string &module,
   const std::string &name,
@@ -189,8 +202,11 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
 exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
 {
-  exprt unary_expr(
-    get_op(element["op"]["_type"].get<std::string>()), current_element_type);
+  typet type = current_element_type;
+  if(element["operand"].contains("value"))
+    type = get_typet(element["operand"]["value"]);
+
+  exprt unary_expr(get_op(element["op"]["_type"].get<std::string>()), type);
 
   // get subexpr
   exprt unary_sub = get_expr(element["operand"]);

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -11,13 +11,14 @@
 #include <unordered_map>
 
 static const std::unordered_map<std::string, std::string> operator_map = {
-  {"Add", "+"},          {"Sub", "-"},         {"Mult", "*"},
-  {"Div", "/"},          {"Mod", "mod"},       {"BitOr", "bitor"},
-  {"BitAnd", "bitand"},  {"BitXor", "bitxor"}, {"Invert", "bitnot"},
-  {"LShift", "shl"},     {"RShift", "ashr"},   {"USub", "unary-"},
-  {"Eq", "="},           {"Lt", "<"},          {"LtE", "<="},
-  {"NotEq", "notequal"}, {"Gt", ">"},          {"GtE", ">="},
-  {"And", "and"},        {"Or", "or"},         {"Not", "not"},
+  {"Add", "+"},         {"Sub", "-"},          {"Mult", "*"},
+  {"Div", "/"},         {"Mod", "mod"},        {"BitOr", "bitor"},
+  {"FloorDiv", "/"},    {"BitAnd", "bitand"},  {"BitXor", "bitxor"},
+  {"Invert", "bitnot"}, {"LShift", "shl"},     {"RShift", "ashr"},
+  {"USub", "unary-"},   {"Eq", "="},           {"Lt", "<"},
+  {"LtE", "<="},        {"NotEq", "notequal"}, {"Gt", ">"},
+  {"GtE", ">="},        {"And", "and"},        {"Or", "or"},
+  {"Not", "not"},
 };
 
 static const std::unordered_map<std::string, StatementType> statement_map = {
@@ -195,8 +196,44 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
   typet type = (is_relational_op(op)) ? bool_type() : lhs.type();
   exprt bin_expr(get_op(op), type);
-
   bin_expr.copy_to_operands(lhs, rhs);
+
+  // floor division (//) operation corresponds to an int division with floor rounding
+  // So we need to emulate this behaviour here:
+  // int result = (num/div) - (num%div != 0 && ((num < 0) ^ (den<0)) ? 1 : 0)
+  // e.g.: -5//2 equals to -3, and 5//2 equals to 2
+  if(op == "FloorDiv")
+  {
+    // remainder = num%den;
+    exprt remainder("mod", int_type());
+    remainder.copy_to_operands(lhs, rhs);
+
+    // Get num signal
+    exprt is_num_neg("<", bool_type());
+    is_num_neg.copy_to_operands(lhs, gen_zero(int_type()));
+    // Get den signal
+    exprt is_den_neg("<", bool_type());
+    is_den_neg.copy_to_operands(rhs, gen_zero(int_type()));
+
+    // remainder != 0
+    exprt pos_remainder("notequal", bool_type());
+    pos_remainder.copy_to_operands(remainder, gen_zero(int_type()));
+
+    // diff_signals = is_num_neg ^ is_den_neg;
+    exprt diff_signals("bitxor", bool_type());
+    diff_signals.copy_to_operands(is_num_neg, is_den_neg);
+
+    exprt cond("and", bool_type());
+    cond.copy_to_operands(pos_remainder, diff_signals);
+    exprt if_expr("if", int_type());
+    if_expr.copy_to_operands(cond, gen_one(int_type()), gen_zero(int_type()));
+
+    // floor_div = (lhs / rhs) - (1 if (lhs % rhs != 0) and (lhs < 0) ^ (rhs < 0) else 0)
+    exprt floor_div("-", int_type());
+    floor_div.copy_to_operands(bin_expr, if_expr); //bin_expr contains lhs/rhs
+    return floor_div;
+  }
+
   return bin_expr;
 }
 

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -68,11 +68,17 @@ bool python_languaget::parse(const std::string &path)
     return true;
   }
 
+  // Parse and generate AST
   std::ifstream ast_json(ast_output_dir + "/ast.json");
   ast = nlohmann::json::parse(ast_json);
 
+  // Add annotation
   python_annotation<nlohmann::json> ann(ast);
-  ann.add_type_annotation();
+  const std::string function = config.options.get_option("function");
+  if(!function.empty())
+    ann.add_type_annotation(function);
+  else
+    ann.add_type_annotation();
 
   return false;
 }


### PR DESCRIPTION
This PR:
- Adds support for the floor division (//) operator
- Fixes asserts with negative numbers
- Limits annotation to a specific function when `--function` is used