### PR TITLE
Do not overwrite location of first instruction during goto-conversion

### DIFF
--- a/regression/esbmc/switch-line-no/main.c
+++ b/regression/esbmc/switch-line-no/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int main()
+{
+	int data = 0;
+	switch (42) {
+	case 42: { // line 7
+		data = nondet_int(); // line 8
+		break;
+	}
+	default:
+		break;
+	}
+	assert(!data);
+}

--- a/regression/esbmc/switch-line-no/test.desc
+++ b/regression/esbmc/switch-line-no/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+main.c line 8.*\n.*\n\s*data = 

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -188,7 +188,8 @@ void goto_convertt::convert_switch_case(
   goto_programt tmp;
   convert(code.code(), tmp);
 
-  goto_programt::targett target = tmp.instructions.begin();
+  goto_programt::targett target = tmp.insert(tmp.instructions.begin());
+  target->make_skip();
   target->location = code.code().location();
   dest.destructive_append(tmp);
 


### PR DESCRIPTION
During goto-conversion of switch-case code, the location of the first instruction is being overwritten with that of the label of case. This PR fixes the counter-example produced for no-overflow
- c/Juliet_Test/CWE190_Integer_Overflow__int64_t_fscanf_postinc_15_bad.i

(maybe other tasks as well) such that UAutomizer now can validate ESBMC's witness.