### PR TITLE
Simplify BigInt power2 API

### DIFF
--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -309,12 +309,10 @@ public:
   unsigned floorPow2() const;
 
   // Not part of original BigInt.
-  static BigInt power2(unsigned n, bool negated = false)
+  static BigInt power2(unsigned n)
   {
     BigInt b;
     b.setPower2(n);
-    if (negated)
-      b.negate();
     return b;
   }
 

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -245,9 +245,11 @@ public:
       positive = !positive;
     return *this;
   }
-  BigInt operator-() const
+
+  friend BigInt operator-(BigInt b)
   {
-    return BigInt(*this).negate();
+    b.negate();
+    return b;
   }
 
 #define IN_PLACE_OPERATOR(TYPE)                                                \

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -317,13 +317,10 @@ public:
   }
 
   // Not part of original BigInt.
-  static BigInt power2m1(unsigned n, bool negated = false)
+  static BigInt power2m1(unsigned n)
   {
-    BigInt b;
-    b.setPower2(n);
+    BigInt b = power2(n);
     --b;
-    if (negated)
-      b.negate();
     return b;
   }
 

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -310,6 +310,27 @@ public:
   // Not part of original BigInt.
   void setPower2(unsigned exponent);
 
+  // Not part of original BigInt.
+  static BigInt power2(unsigned n, bool negated = false)
+  {
+    BigInt b;
+    b.setPower2(n);
+    if (negated)
+      b.negate();
+    return b;
+  }
+
+  // Not part of original BigInt.
+  static BigInt power2m1(unsigned n, bool negated = false)
+  {
+    BigInt b;
+    b.setPower2(n);
+    --b;
+    if (negated)
+      b.negate();
+    return b;
+  }
+
   void swap(BigInt &other)
   {
     std::swap(other.size, size);

--- a/src/big-int/bigint.hh
+++ b/src/big-int/bigint.hh
@@ -306,10 +306,6 @@ public:
   // Not part of original BigInt.
   unsigned floorPow2() const;
 
-  // Sets the number to the power of two given by the exponent
-  // Not part of original BigInt.
-  void setPower2(unsigned exponent);
-
   // Not part of original BigInt.
   static BigInt power2(unsigned n, bool negated = false)
   {
@@ -338,6 +334,11 @@ public:
     std::swap(other.digit, digit);
     std::swap(other.positive, positive);
   }
+
+private:
+  // Sets the number to the power of two given by the exponent
+  // Not part of original BigInt.
+  void setPower2(unsigned exponent);
 };
 
 // Binary arithmetic operators

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -165,20 +165,17 @@ interval_domaint::generate_modular_interval<integer_intervalt>(
   const symbol2t sym) const
 {
   auto t = sym.type;
-  BigInt b;
   integer_intervalt result;
   if (is_unsignedbv_type(t))
   {
-    b.setPower2(t->get_width());
-    result.make_le_than(b - 1);
+    result.make_le_than(BigInt::power2m1(t->get_width()));
     result.make_ge_than(0);
   }
   else if (is_signedbv_type(t))
   {
-    b.setPower2(t->get_width() - 1);
+    BigInt b = BigInt::power2(t->get_width() - 1);
     result.make_ge_than(-b);
-    b = b - 1;
-    result.make_le_than(b);
+    result.make_le_than(b - 1);
   }
   else
   {

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -1442,6 +1442,7 @@ private:
   // For bitwise intervals approximations (Warren 2002)
   static uint64_t compute_m(unsigned width)
   {
+    assert(width - 1 < 64);
     uint64_t m = (uint64_t)1 << (width - 1);
     if (width == 32)
       assert(m == 0x80000000);

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -753,10 +753,7 @@ public:
   static BigInt trunc(const BigInt &b, unsigned k)
   {
     // TODO: and operation for bigint
-    BigInt r = 1;
-    r.setPower2(k);
-
-    return b.to_uint64() & (r.to_uint64() - 1);
+    return b % BigInt::power2(k);
   }
 
   static wrapped_interval
@@ -818,9 +815,7 @@ public:
     else
     {
       result.lower = 0;
-      BigInt m(1);
-      m.setPower2(k);
-      result.upper = (get_upper_bound() - 1) - (m - 1);
+      result.upper = (get_upper_bound() - 1) - BigInt::power2m1(k);
     }
     return result;
   }
@@ -847,9 +842,7 @@ public:
     if (south_pole(t).is_included(*this))
     {
       result.lower = 0;
-      BigInt m(1);
-      m.setPower2(t->get_width() - k);
-      result.upper = (m - 1);
+      result.upper = BigInt::power2m1(t->get_width() - k);
     }
     else
     {
@@ -880,11 +873,9 @@ public:
     wrapped_interval result(t);
     if (north_pole(t).is_included(*this))
     {
-      BigInt m(1);
-      m.setPower2(t->get_width() - k);
-      result.lower = (get_upper_bound() - 1) - (m - 1);
-
-      result.upper = (m - 1);
+      BigInt m = BigInt::power2m1(t->get_width() - k);
+      result.lower = (get_upper_bound() - 1) - m;
+      result.upper = m;
     }
     else
     {
@@ -1434,9 +1425,7 @@ protected:
 private:
   static BigInt compute_upper_bound(const type2tc &t)
   {
-    BigInt r(1);
-    r.setPower2(t->get_width());
-    return r;
+    return BigInt::power2(t->get_width());
   }
 
   // For bitwise intervals approximations (Warren 2002)

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -3515,9 +3515,8 @@ public:
   concat2t(const type2tc &type, const expr2tc &forward, const expr2tc &aft)
     : concat_expr_methods(type, concat_id, forward, aft)
   {
-    /* TODO: what are the semantics of a signed-bv concatenation? */
-    assert(is_unsignedbv_type(forward) || is_signedbv_type(forward));
-    assert(is_unsignedbv_type(aft) || is_signedbv_type(aft));
+    assert(is_unsignedbv_type(forward));
+    assert(is_unsignedbv_type(aft));
   }
   concat2t(const concat2t &ref) = default;
 

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1963,6 +1963,8 @@ std::vector<expr2tc> dereferencet::extract_bytes(
     assert(src->type == base);
     if (!base_is_byte) // Don't produce a byte update of a byte.
       src = byte_extract2tc(bytetype, src, off, is_big_endian);
+    else if (!is_unsignedbv_type(base))
+      src = bitcast2tc(bytetype, src);
 
     bytes.emplace_back(src);
   }

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -879,11 +879,11 @@ smt_astt fp_convt::mk_smt_typecast_from_fpbv_to_fpbv(
     // check whether exponent is within roundable (to_ebits+2) range.
     BigInt z = BigInt::power2(to_ebits + 1, true);
     smt_astt max_exp = ctx->mk_concat(
-      ctx->mk_smt_bv(BigInt::power2m1(to_ebits, false), to_ebits + 1),
+      ctx->mk_smt_bv(BigInt::power2m1(to_ebits), to_ebits + 1),
       ctx->mk_smt_bv(BigInt(0), 1));
     smt_astt min_exp = ctx->mk_smt_bv(BigInt(z + 2), to_ebits + 2);
 
-    BigInt ovft = BigInt::power2m1(to_ebits + 1, false);
+    BigInt ovft = BigInt::power2m1(to_ebits + 1);
     smt_astt first_ovf_exp = ctx->mk_smt_bv(BigInt(ovft), from_ebits + 2);
     smt_astt first_udf_exp = ctx->mk_concat(
       ctx->mk_bvneg(ctx->mk_smt_bv(BigInt(1), ebits_diff + 3)),
@@ -1685,7 +1685,7 @@ smt_astt fp_convt::mk_smt_fpbv_is_normal(smt_astt op)
   smt_astt is_zero = mk_smt_fpbv_is_zero(op);
 
   unsigned ebits = exp->sort->get_data_width();
-  smt_astt p = ctx->mk_smt_bv(BigInt::power2m1(ebits, false), ebits);
+  smt_astt p = ctx->mk_smt_bv(BigInt::power2m1(ebits), ebits);
 
   smt_astt is_special = ctx->mk_eq(exp, p);
 
@@ -1990,7 +1990,7 @@ void fp_convt::round(
   smt_astt exp_redand = ctx->mk_bvredand(biased_exp);
   smt_astt preOVF2 = ctx->mk_eq(exp_redand, one_1);
   smt_astt OVF2 = ctx->mk_and(SIGovf, preOVF2);
-  smt_astt pem2m1 = ctx->mk_smt_bv(BigInt::power2m1(ebits - 2, false), ebits);
+  smt_astt pem2m1 = ctx->mk_smt_bv(BigInt::power2m1(ebits - 2), ebits);
   biased_exp = ctx->mk_ite(OVF2, pem2m1, biased_exp);
   smt_astt OVF = ctx->mk_or(OVF1, OVF2);
 
@@ -2012,10 +2012,9 @@ void fp_convt::round(
   smt_astt zero1 = ctx->mk_smt_bv(BigInt(0), 1);
   smt_astt sgn_is_zero = ctx->mk_eq(sgn, zero1);
 
-  smt_astt max_sig =
-    ctx->mk_smt_bv(BigInt::power2m1(sbits - 1, false), sbits - 1);
+  smt_astt max_sig = ctx->mk_smt_bv(BigInt::power2m1(sbits - 1), sbits - 1);
   smt_astt max_exp = ctx->mk_concat(
-    ctx->mk_smt_bv(BigInt::power2m1(ebits - 1, false), ebits - 1),
+    ctx->mk_smt_bv(BigInt::power2m1(ebits - 1), ebits - 1),
     ctx->mk_smt_bv(BigInt(0), 1));
   smt_astt inf_sig = ctx->mk_smt_bv(BigInt(0), sbits - 1);
   smt_astt inf_exp = top_exp;
@@ -2047,19 +2046,19 @@ void fp_convt::round(
 
 smt_astt fp_convt::mk_min_exp(std::size_t ebits)
 {
-  BigInt z = BigInt::power2m1(ebits - 1, true) + 1;
+  BigInt z = -BigInt::power2m1(ebits - 1) + 1;
   return ctx->mk_smt_bv(z, ebits);
 }
 
 smt_astt fp_convt::mk_max_exp(std::size_t ebits)
 {
-  BigInt z = BigInt::power2m1(ebits - 1, false);
+  BigInt z = BigInt::power2m1(ebits - 1);
   return ctx->mk_smt_bv(z, ebits);
 }
 
 smt_astt fp_convt::mk_top_exp(std::size_t sz)
 {
-  return ctx->mk_smt_bv(BigInt::power2m1(sz, false), sz);
+  return ctx->mk_smt_bv(BigInt::power2m1(sz), sz);
 }
 
 smt_astt fp_convt::mk_bot_exp(std::size_t sz)
@@ -2137,7 +2136,7 @@ smt_astt fp_convt::mk_bias(smt_astt e)
 {
   std::size_t ebits = e->sort->get_data_width();
 
-  smt_astt bias = ctx->mk_smt_bv(BigInt::power2m1(ebits - 1, false), ebits);
+  smt_astt bias = ctx->mk_smt_bv(BigInt::power2m1(ebits - 1), ebits);
   return ctx->mk_bvadd(e, bias);
 }
 
@@ -2167,7 +2166,7 @@ smt_astt fp_convt::mk_one(smt_astt sgn, unsigned ew, unsigned sw)
     ctx->mk_concat(
       sgn,
       ctx->mk_concat(
-        ctx->mk_smt_bv(BigInt::power2m1(ew - 1, false), ew),
+        ctx->mk_smt_bv(BigInt::power2m1(ew - 1), ew),
         ctx->mk_smt_bv(BigInt(0), sw - 1))),
     mk_fpbv_sort(ew, sw - 1));
 }

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -117,8 +117,7 @@ smt_astt fp_convt::mk_smt_nearbyint_from_float(smt_astt x, smt_astt rm)
   smt_astt none = mk_one(one_1, ebits, sbits);
   smt_astt xone = ctx->mk_ite(sgn_eq_1, none, pone);
 
-  smt_astt pow_2_sbitsm1 =
-    ctx->mk_smt_bv(BigInt::power2(sbits - 1, false), sbits);
+  smt_astt pow_2_sbitsm1 = ctx->mk_smt_bv(BigInt::power2(sbits - 1), sbits);
   smt_astt m1 = ctx->mk_bvneg(ctx->mk_smt_bv(BigInt(1), ebits));
   smt_astt t1 = ctx->mk_eq(a_sig, pow_2_sbitsm1);
   smt_astt t2 = ctx->mk_eq(a_exp, m1);
@@ -298,7 +297,7 @@ smt_astt fp_convt::mk_smt_fpbv_sqrt(smt_astt x, smt_astt rm)
   assert(sig_prime->sort->get_data_width() == sbits + 1);
 
   // This is algorithm 10.2 in the Handbook of Floating-Point Arithmetic
-  BigInt p2 = BigInt::power2(sbits + 3, false);
+  BigInt p2 = BigInt::power2(sbits + 3);
   smt_astt Q = ctx->mk_smt_bv(p2, sbits + 5);
   smt_astt R =
     ctx->mk_bvsub(ctx->mk_concat(sig_prime, ctx->mk_smt_bv(BigInt(0), 4)), Q);
@@ -877,7 +876,7 @@ smt_astt fp_convt::mk_smt_typecast_from_fpbv_to_fpbv(
       ctx->mk_bvsub(ctx->mk_sign_ext(exp, 2), ctx->mk_sign_ext(lz, 2));
 
     // check whether exponent is within roundable (to_ebits+2) range.
-    BigInt z = BigInt::power2(to_ebits + 1, true);
+    BigInt z = -BigInt::power2(to_ebits + 1);
     smt_astt max_exp = ctx->mk_concat(
       ctx->mk_smt_bv(BigInt::power2m1(to_ebits), to_ebits + 1),
       ctx->mk_smt_bv(BigInt(0), 1));
@@ -2046,7 +2045,7 @@ void fp_convt::round(
 
 smt_astt fp_convt::mk_min_exp(std::size_t ebits)
 {
-  BigInt z = BigInt::power2(ebits - 1, true) + 2;
+  BigInt z = -BigInt::power2(ebits - 1) + 2;
   return ctx->mk_smt_bv(z, ebits);
 }
 

--- a/src/solvers/smt/fp/fp_conv.cpp
+++ b/src/solvers/smt/fp/fp_conv.cpp
@@ -2046,7 +2046,7 @@ void fp_convt::round(
 
 smt_astt fp_convt::mk_min_exp(std::size_t ebits)
 {
-  BigInt z = -BigInt::power2m1(ebits - 1) + 1;
+  BigInt z = BigInt::power2(ebits - 1, true) + 2;
   return ctx->mk_smt_bv(z, ebits);
 }
 

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -51,7 +51,7 @@ static expr2tc flatten_to_bitvector(const expr2tc &new_expr)
   // Easy cases, no need to concat anything
 
   /* keep this condition in sync with concat2t's assumptions */
-  if (is_bv_type(new_expr))
+  if (is_unsignedbv_type(new_expr))
     return new_expr;
 
   if (is_number_type(new_expr) || is_pointer_type(new_expr))

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1878,9 +1878,7 @@ type2tc make_array_domain_type(const array_type2t &arr)
 expr2tc smt_convt::array_domain_to_width(const type2tc &type)
 {
   const unsignedbv_type2t &uint = to_unsignedbv_type(type);
-  BigInt sz;
-  sz.setPower2(uint.width);
-  return constant_int2tc(index_type2(), sz);
+  return constant_int2tc(index_type2(), BigInt::power2(uint.width));
 }
 
 static expr2tc gen_additions(const type2tc &type, std::vector<expr2tc> &exprs)

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1878,8 +1878,9 @@ type2tc make_array_domain_type(const array_type2t &arr)
 expr2tc smt_convt::array_domain_to_width(const type2tc &type)
 {
   const unsignedbv_type2t &uint = to_unsignedbv_type(type);
-  uint64_t sz = 1ULL << uint.width;
-  return constant_int2tc(index_type2(), BigInt(sz));
+  BigInt sz;
+  sz.setPower2(uint.width);
+  return constant_int2tc(index_type2(), sz);
 }
 
 static expr2tc gen_additions(const type2tc &type, std::vector<expr2tc> &exprs)
@@ -2494,7 +2495,7 @@ expr2tc smt_convt::get_array(const type2tc &type, smt_astt array)
     w = 10;
 
   array_type2t ar = to_array_type(flatten_array_type(type));
-  expr2tc arr_size = constant_int2tc(index_type2(), BigInt(1 << w));
+  expr2tc arr_size = constant_int2tc(index_type2(), BigInt(1ULL << w));
   type2tc arr_type = array_type2tc(ar.subtype, arr_size, false);
   std::vector<expr2tc> fields;
 
@@ -2674,11 +2675,9 @@ smt_astt array_iface::default_convert_array_of(
   smt_astt newsym_ast =
     ctx->mk_fresh(arrsort, "default_array_of::", init_val->sort);
 
-  unsigned long sz = 1ULL << array_size;
-  for (unsigned long i = 0; i < sz; i++)
-  {
+  unsigned long long sz = 1ULL << array_size;
+  for (unsigned long long i = 0; i < sz; i++)
     newsym_ast = newsym_ast->update(ctx, init_val, i);
-  }
 
   return newsym_ast;
 }

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -877,9 +877,7 @@ inline smt_ast::smt_ast(smt_convt *ctx, smt_sortt s) : sort(s), context(ctx)
 
 inline BigInt ones(unsigned n_bits)
 {
-  BigInt r;
-  r.setPower2(n_bits);
-  return r -= 1;
+  return BigInt::power2m1(n_bits);
 }
 
 #endif /* _ESBMC_PROP_SMT_SMT_CONV_H_ */

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -875,9 +875,4 @@ inline smt_ast::smt_ast(smt_convt *ctx, smt_sortt s) : sort(s), context(ctx)
   ctx->live_asts.push_back(this);
 }
 
-inline BigInt ones(unsigned n_bits)
-{
-  return BigInt::power2m1(n_bits);
-}
-
 #endif /* _ESBMC_PROP_SMT_SMT_CONV_H_ */

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -528,7 +528,7 @@ void smt_convt::init_addr_space_array()
   expr2tc zero_ptr_int = constant_int2tc(ptr_int_type, BigInt(0));
   expr2tc one_ptr_int = constant_int2tc(ptr_int_type, BigInt(1));
   expr2tc obj1_end_const =
-    constant_int2tc(ptr_int_type, ones(ptr_int_type->get_width()));
+    constant_int2tc(ptr_int_type, BigInt::power2m1(ptr_int_type->get_width()));
 
   expr2tc obj0_start = symbol2tc(ptr_int_type, "__ESBMC_ptr_obj_start_0");
   expr2tc obj0_end = symbol2tc(ptr_int_type, "__ESBMC_ptr_obj_end_0");

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -59,7 +59,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
 
       // Corner case: subtracting MIN_INT from many things overflows. The result
       // should always be positive.
-      BigInt topbit = BigInt::power2(opers.side_1->type->get_width() - 1, true);
+      BigInt topbit = -BigInt::power2(opers.side_1->type->get_width() - 1);
       expr2tc min_int = constant_int2tc(opers.side_1->type, topbit);
       expr2tc is_min_int = equality2tc(min_int, opers.side_2);
       return convert_ast(or2tc(add_overflows, is_min_int));
@@ -79,7 +79,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       // We can't divide -MIN_INT/-1
-      BigInt topbit = BigInt::power2(opers.side_1->type->get_width() - 1, true);
+      BigInt topbit = -BigInt::power2(opers.side_1->type->get_width() - 1);
       expr2tc min_int = constant_int2tc(opers.side_1->type, topbit);
       expr2tc is_min_int = equality2tc(min_int, opers.side_1);
       expr2tc imp =
@@ -212,7 +212,7 @@ smt_astt smt_convt::overflow_neg(const expr2tc &expr)
   unsigned int width = neg.operand->type->get_width();
 
   expr2tc min_int =
-    constant_int2tc(neg.operand->type, BigInt::power2(width - 1, true));
+    constant_int2tc(neg.operand->type, -BigInt::power2(width - 1));
   expr2tc val = equality2tc(neg.operand, min_int);
   return convert_ast(val);
 }

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -59,9 +59,8 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
 
       // Corner case: subtracting MIN_INT from many things overflows. The result
       // should always be positive.
-      BigInt topbit;
-      topbit.setPower2(opers.side_1->type->get_width() - 1);
-      expr2tc min_int = constant_int2tc(opers.side_1->type, -topbit);
+      BigInt topbit = BigInt::power2(opers.side_1->type->get_width() - 1, true);
+      expr2tc min_int = constant_int2tc(opers.side_1->type, topbit);
       expr2tc is_min_int = equality2tc(min_int, opers.side_2);
       return convert_ast(or2tc(add_overflows, is_min_int));
     }
@@ -80,9 +79,8 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       // We can't divide -MIN_INT/-1
-      BigInt topbit;
-      topbit.setPower2(opers.side_1->type->get_width() - 1);
-      expr2tc min_int = constant_int2tc(opers.side_1->type, -topbit);
+      BigInt topbit = BigInt::power2(opers.side_1->type->get_width() - 1, true);
+      expr2tc min_int = constant_int2tc(opers.side_1->type, topbit);
       expr2tc is_min_int = equality2tc(min_int, opers.side_1);
       expr2tc imp =
         implies2tc(is_min_int, greaterthan2tc(overflow.operand, zero));
@@ -185,12 +183,8 @@ smt_astt smt_convt::overflow_cast(const expr2tc &expr)
   unsigned int pos_zero_bits = width - bits;
   unsigned int neg_one_bits = (width - bits) + 1;
 
-  BigInt ones;
-  ones.setPower2(neg_one_bits);
-  --ones;
-
   smt_astt pos_bits = mk_smt_bv(BigInt(0), pos_zero_bits);
-  smt_astt neg_bits = mk_smt_bv(ones, neg_one_bits);
+  smt_astt neg_bits = mk_smt_bv(ones(neg_one_bits), neg_one_bits);
 
   smt_astt pos_sel = mk_extract(orig_val, width - 1, width - pos_zero_bits);
   smt_astt neg_sel = mk_extract(orig_val, width - 1, width - neg_one_bits);
@@ -217,9 +211,8 @@ smt_astt smt_convt::overflow_neg(const expr2tc &expr)
   const overflow_neg2t &neg = to_overflow_neg2t(expr);
   unsigned int width = neg.operand->type->get_width();
 
-  BigInt M;
-  M.setPower2(width - 1);
-  expr2tc min_int = constant_int2tc(neg.operand->type, -M);
+  expr2tc min_int =
+    constant_int2tc(neg.operand->type, BigInt::power2(width - 1, true));
   expr2tc val = equality2tc(neg.operand, min_int);
   return convert_ast(val);
 }

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -126,7 +126,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       type2tc newtype = unsignedbv_type2tc(sz + 1);
 
       // All one bit vector is tricky, might be 64 bits wide for all we know.
-      expr2tc allonesexpr = constant_int2tc(newtype, ones(sz + 1));
+      expr2tc allonesexpr = constant_int2tc(newtype, BigInt::power2m1(sz + 1));
       smt_astt allonesvector = convert_ast(allonesexpr);
 
       // It should either be zero or all one's;
@@ -184,7 +184,7 @@ smt_astt smt_convt::overflow_cast(const expr2tc &expr)
   unsigned int neg_one_bits = (width - bits) + 1;
 
   smt_astt pos_bits = mk_smt_bv(BigInt(0), pos_zero_bits);
-  smt_astt neg_bits = mk_smt_bv(ones(neg_one_bits), neg_one_bits);
+  smt_astt neg_bits = mk_smt_bv(BigInt::power2m1(neg_one_bits), neg_one_bits);
 
   smt_astt pos_sel = mk_extract(orig_val, width - 1, width - pos_zero_bits);
   smt_astt neg_sel = mk_extract(orig_val, width - 1, width - neg_one_bits);

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -1158,8 +1158,7 @@ c_expr2stringt::convert_constant(const exprt &src, unsigned &precedence)
   else if (type.id() == "unsignedbv" || type.id() == "signedbv")
   {
     BigInt int_value = binary2integer(value, type.id() == "signedbv");
-    BigInt llong_ub;
-    llong_ub.setPower2(config.ansi_c.long_long_int_width - 1);
+    BigInt llong_ub = BigInt::power2(config.ansi_c.long_long_int_width - 1);
     if (int_value == -llong_ub)
     {
       dest = integer2string(int_value + 1);

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -2389,9 +2389,8 @@ expr2tc concat2t::do_simplify() const
   const BigInt &value2 = to_constant_int2t(side_2).value;
 
   // k; Take the values, and concatenate. Side 1 has higher end bits.
-  BigInt accuml;
-  accuml.setPower2(side_2->type->get_width());
-  accuml *= value1;
+  BigInt accuml = value1;
+  accuml *= BigInt::power2(side_2->type->get_width());
   accuml += value2;
 
   return constant_int2tc(type, accuml);

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -2389,8 +2389,9 @@ expr2tc concat2t::do_simplify() const
   const BigInt &value2 = to_constant_int2t(side_2).value;
 
   // k; Take the values, and concatenate. Side 1 has higher end bits.
-  BigInt accuml = value1;
-  accuml *= (1ULL << side_2->type->get_width());
+  BigInt accuml;
+  accuml.setPower2(side_2->type->get_width());
+  accuml *= value1;
   accuml += value2;
 
   return constant_int2tc(type, accuml);
@@ -2407,15 +2408,17 @@ expr2tc extract2t::do_simplify() const
   // generating extracts, and you have to consider performing extracts on
   // negative numbers.
   assert(is_unsignedbv_type(from->type));
-  const constant_int2t &cint = to_constant_int2t(from);
-  const BigInt &theint = cint.value;
-  assert(theint.is_positive());
+  const BigInt &theint = to_constant_int2t(from).value;
+  assert(!theint.is_negative());
+  if (!theint.is_uint64())
+    return expr2tc();
 
   // Take the value, mask and shift.
   uint64_t theval = theint.to_uint64();
   theval >>= lower;
-  theval &= (2 << upper) - 1;
-  bool isneg = (1 << (upper)) & theval;
+  if (upper + 1 < 64)
+    theval &= ~(~0ULL << (upper + 1));
+  bool isneg = (theval >> upper) & 1;
 
   if (is_signedbv_type(type) && isneg)
   {

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -2388,6 +2388,9 @@ expr2tc concat2t::do_simplify() const
   const BigInt &value1 = to_constant_int2t(side_1).value;
   const BigInt &value2 = to_constant_int2t(side_2).value;
 
+  assert(!value1.is_negative());
+  assert(!value2.is_negative());
+
   // k; Take the values, and concatenate. Side 1 has higher end bits.
   BigInt accuml = value1;
   accuml *= BigInt::power2(side_2->type->get_width());


### PR DESCRIPTION
This PR:
- Replaces potentially unbounded left-shifts `1 << n` by BigInt arithmetic, and
- simplifies the usage of powers of two via BigInt. I've hidden the `setPower2()` function and replaced it with `power2()` and `power2m1()`. Additionally, the unary `operator-` on BigInt now takes its argument by-value, thereby preventing additional copies for things like `-BigInt::power2(n)`.

I've also added a few assertions in code that was using the power2 API, mainly related to concat2t. This one used to take signedbvs, but the expr2 simplification code assumed unsigned (or at least the same sign). As it's not entirely clear what signedbv concatenation is supposed to be (sign bits extend arbitrarily far), I've tightened the assumptions here: only unsignedbv concatenations are supported now.

For this last change a few new bitcasts are inserted. I'll run this over the benchmarks to be sure nothing breaks. Locally, this already affected a few regression tests:
- regression/esbmc/github_60: wrong verdict? How can there be an overflow detected when `--overflow-check` is not passed?
- regression/cbmc/01_cbmc_String_Abstraction7: wrong verdict? `fgets` stores zero-terminated strings.
- regression/cstd/strerror: was KNOWNBUG.
- regression/esbmc-cpp/cpp/cpp_priority_queue_size_bug: was KNOWNBUG
- regression/esbmc-cpp/cpp/cpp_queue_front_bug: was KNOWNBUG

*Edit:* Sorry, the above regression test changes are only for a `-DESBMC_SVCOMP=ON` build. Without that (the default) they're unchanged. We should look into these though.