### PR TITLE
Fix comments of assertion instructions generated from wide/non-char string literals

### DIFF
--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -46,14 +46,8 @@ bool clang_c_convertert::convert_string_literal(
   }
   else
   {
-    /* TODO: need to take the encoding into account, for that we should examine
-     * string_literal.getKind() to interpret the strings in the correct source
-     * and execution character sets.
-     *
-     * For now we assume all strings are Unicode, in particular char * and
-     * wchar_t * are also Unicode (which isn't true in China: they use GB18030).
-     */
-    string_constantt string(string_literal.getBytes().str(), type);
+    string_constantt string(
+      string_literal.getBytes().str(), type, string_literal.isWide());
     dest.swap(string);
   }
 

--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -46,6 +46,13 @@ bool clang_c_convertert::convert_string_literal(
   }
   else
   {
+    /* TODO: need to take the encoding into account, for that we should examine
+     * string_literal.getKind() to interpret the strings in the correct source
+     * and execution character sets.
+     *
+     * For now we assume all strings are Unicode, in particular char * and
+     * wchar_t * are also Unicode (which isn't true in China: they use GB18030).
+     */
     string_constantt string(string_literal.getBytes().str(), type);
     dest.swap(string);
   }

--- a/src/clang-c-frontend/clang_c_convert_literals.cpp
+++ b/src/clang-c-frontend/clang_c_convert_literals.cpp
@@ -46,8 +46,14 @@ bool clang_c_convertert::convert_string_literal(
   }
   else
   {
-    string_constantt string(
-      string_literal.getBytes().str(), type, string_literal.isWide());
+    irep_idt kind = string_constantt::k_default;
+    if (string_literal.isWide())
+      kind = string_constantt::k_wide;
+    else if (
+      string_literal.isUTF8() || string_literal.isUTF16() ||
+      string_literal.isUTF32())
+      kind = string_constantt::k_unicode;
+    string_constantt string(string_literal.getBytes().str(), type, kind);
     dest.swap(string);
   }
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -33,16 +33,17 @@ static const std::string &get_string_constant(const exprt &expr)
   }
 
   const exprt &string = expr.op0().op0();
-  irep_idt v;
-  try
-  {
-    v = to_string_constant(string).mb_value();
-  }
-  catch (const string_constantt::mb_conversion_error &e)
-  {
-    log_warning("{}", e.what());
-    v = string.value();
-  }
+  irep_idt v = string.value();
+  if (string.id() == "string-constant")
+    try
+    {
+      v = to_string_constant(string).mb_value();
+    }
+    catch (const string_constantt::mb_conversion_error &e)
+    {
+      log_warning("{}", e.what());
+    }
+
   return v.as_string();
 }
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -16,6 +16,7 @@
 #include <util/simplify_expr.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
+#include <util/string_constant.h>
 #include <util/type_byte_size.h>
 
 static const std::string &get_string_constant(const exprt &expr)
@@ -31,7 +32,18 @@ static const std::string &get_string_constant(const exprt &expr)
     abort();
   }
 
-  return expr.op0().op0().value().as_string();
+  const exprt &string = expr.op0().op0();
+  irep_idt v;
+  try
+  {
+    v = to_string_constant(string).mb_value();
+  }
+  catch (const string_constantt::mb_conversion_error &e)
+  {
+    log_warning("{}", e.what());
+    v = string.value();
+  }
+  return v.as_string();
 }
 
 static void get_alloc_type_rec(const exprt &src, typet &type, exprt &size)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -419,7 +419,10 @@ void goto_symext::symex_assign_typecast(
         new_rhs = with2tc(
           from->type,
           new_rhs,
-          constant_string2tc(string_type2tc(from_name[i].size()), from_name[i]),
+          constant_string2tc(
+            string_type2tc(get_uint8_type(), from_name[i].size()),
+            from_name[i],
+            constant_string2t::DEFAULT),
           typecast2tc(from_type[i], member2tc(lhs_type[i], rhs, lhs_name[i])));
       }
 
@@ -523,11 +526,12 @@ void goto_symext::symex_assign_member(
   // into
   //   a'==a WITH [c:=e]
 
-  type2tc str_type = string_type2tc(component_name.as_string().size());
+  type2tc str_type =
+    string_type2tc(get_uint8_type(), component_name.as_string().size());
   expr2tc new_rhs = with2tc(
     real_lhs->type,
     real_lhs,
-    constant_string2tc(str_type, component_name),
+    constant_string2tc(str_type, component_name, constant_string2t::DEFAULT),
     rhs);
 
   symex_assign_rec(

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -288,7 +288,7 @@ expr2tc constant_string2t::to_array() const
   std::vector<expr2tc> contents;
   unsigned int length = value.as_string().size(), i;
 
-  type2tc type = get_uint8_type();
+  type2tc type = to_string_type(constant_string2t::type).subtype;
 
   for (i = 0; i < length; i++)
     contents.push_back(constant_int2tc(type, BigInt(value.as_string()[i])));

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -184,19 +184,34 @@ public:
 class constant_string_data : public constant2t
 {
 public:
-  constant_string_data(const type2tc &t, expr2t::expr_ids id, const irep_idt &v)
-    : constant2t(t, id), value(v)
+  enum kindt
+  {
+    DEFAULT, /* "" */
+    WIDE,    /* L"" */
+    UNICODE, /* u8"", u"" and U"" */
+  };
+
+  constant_string_data(
+    const type2tc &t,
+    expr2t::expr_ids id,
+    const irep_idt &v,
+    kindt kind)
+    : constant2t(t, id), value(v), kind(kind)
   {
   }
   constant_string_data(const constant_string_data &ref) = default;
 
   irep_idt value;
+  kindt kind;
 
   // Type mangling:
   typedef esbmct::
     field_traits<irep_idt, constant_string_data, &constant_string_data::value>
       value_field;
-  typedef esbmct::expr2t_traits<value_field> traits;
+  typedef esbmct::
+    field_traits<kindt, constant_string_data, &constant_string_data::kind>
+      kind_field;
+  typedef esbmct::expr2t_traits<value_field, kind_field> traits;
 };
 
 class symbol_data : public expr2t
@@ -1616,9 +1631,13 @@ public:
   /** Primary constructor.
    *  @param type Type of this string; presumably a string_type2t.
    *  @param stringref String pool'd string we're dealing with
+   *  @param kind The kind of string literal:
+   *              - DEFAULT: `""`
+   *              - WIDE   : `L""`
+   *              - UNICODE: `u8""`, `u""` and `U""`
    */
-  constant_string2t(const type2tc &type, const irep_idt &stringref)
-    : constant_string_expr_methods(type, constant_string_id, stringref)
+  constant_string2t(const type2tc &type, const irep_idt &stringref, kindt kind)
+    : constant_string_expr_methods(type, constant_string_id, stringref, kind)
   {
   }
   constant_string2t(const constant_string2t &ref) = default;

--- a/src/irep2/irep2_template_utils.h
+++ b/src/irep2/irep2_template_utils.h
@@ -16,6 +16,8 @@ std::string type_to_string(const sideeffect_data::allockind &data, int);
 
 std::string type_to_string(const unsigned int &theval, int);
 
+std::string type_to_string(const constant_string_data::kindt &theval, int);
+
 std::string type_to_string(const symbol_data::renaming_level &theval, int);
 
 std::string type_to_string(const BigInt &theint, int);
@@ -43,6 +45,10 @@ bool do_type_cmp(const unsigned int &side1, const unsigned int &side2);
 bool do_type_cmp(
   const sideeffect_data::allockind &side1,
   const sideeffect_data::allockind &side2);
+
+bool do_type_cmp(
+  const constant_string_data::kindt &side1,
+  const constant_string_data::kindt &side2);
 
 bool do_type_cmp(
   const symbol_data::renaming_level &side1,
@@ -83,6 +89,10 @@ int do_type_lt(const unsigned int &side1, const unsigned int &side2);
 int do_type_lt(
   const sideeffect_data::allockind &side1,
   const sideeffect_data::allockind &side2);
+
+int do_type_lt(
+  const constant_string_data::kindt &side1,
+  const constant_string_data::kindt &side2);
 
 int do_type_lt(
   const symbol_data::renaming_level &side1,
@@ -126,6 +136,10 @@ void do_type_hash(const unsigned int &theval, crypto_hash &hash);
 size_t do_type_crc(const sideeffect_data::allockind &theval);
 
 void do_type_hash(const sideeffect_data::allockind &theval, crypto_hash &hash);
+
+size_t do_type_crc(const constant_string_data::kindt &theval);
+
+void do_type_hash(const constant_string_data::kindt &theval, crypto_hash &hash);
 
 size_t do_type_crc(const symbol_data::renaming_level &theval);
 

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -264,17 +264,21 @@ public:
 class string_data : public type2t
 {
 public:
-  string_data(type2t::type_ids id, unsigned int w) : type2t(id), width(w)
+  string_data(type2t::type_ids id, const type2tc &subtype, unsigned int w)
+    : type2t(id), subtype(subtype), width(w)
   {
   }
   string_data(const string_data &ref) = default;
 
+  type2tc subtype;
   unsigned int width;
 
   // Type mangling:
+  typedef esbmct::field_traits<type2tc, string_data, &string_data::subtype>
+    subtype_field;
   typedef esbmct::field_traits<unsigned int, string_data, &string_data::width>
     width_field;
-  typedef esbmct::type2t_traits<width_field> traits;
+  typedef esbmct::type2t_traits<subtype_field, width_field> traits;
 };
 
 class cpp_name_data : public type2t
@@ -686,8 +690,8 @@ public:
   /** Primary constructor.
    *  @param elements Number of 8-bit characters in string constant.
    */
-  string_type2t(unsigned int elements)
-    : string_type_methods(string_id, elements)
+  string_type2t(type2tc subtype, unsigned int elements)
+    : string_type_methods(string_id, subtype, elements)
   {
   }
   string_type2t(const string_type2t &ref) = default;

--- a/src/irep2/templates/irep2_template_utils.cpp
+++ b/src/irep2/templates/irep2_template_utils.cpp
@@ -24,6 +24,21 @@ std::string type_to_string(const unsigned int &theval, int)
   return std::string(buffer);
 }
 
+std::string type_to_string(const constant_string_data::kindt &theval, int)
+{
+  switch (theval)
+  {
+  case constant_string_data::DEFAULT:
+    return "default";
+  case constant_string_data::WIDE:
+    return "wide";
+  case constant_string_data::UNICODE:
+    return "unicode";
+  }
+  assert(0 && "Unrecognized string_data::kindt enum value");
+  abort();
+}
+
 std::string type_to_string(const symbol_data::renaming_level &theval, int)
 {
   switch (theval)
@@ -157,6 +172,13 @@ bool do_type_cmp(
 }
 
 bool do_type_cmp(
+  const constant_string_data::kindt &side1,
+  const constant_string_data::kindt &side2)
+{
+  return side1 == side2;
+}
+
+bool do_type_cmp(
   const symbol_data::renaming_level &side1,
   const symbol_data::renaming_level &side2)
 {
@@ -257,6 +279,18 @@ int do_type_lt(const unsigned int &side1, const unsigned int &side2)
 int do_type_lt(
   const sideeffect_data::allockind &side1,
   const sideeffect_data::allockind &side2)
+{
+  if (side1 < side2)
+    return -1;
+  else if (side2 < side1)
+    return 1;
+  else
+    return 0;
+}
+
+int do_type_lt(
+  const constant_string_data::kindt &side1,
+  const constant_string_data::kindt &side2)
 {
   if (side1 < side2)
     return -1;
@@ -428,6 +462,16 @@ size_t do_type_crc(const sideeffect_data::allockind &theval)
 }
 
 void do_type_hash(const sideeffect_data::allockind &theval, crypto_hash &hash)
+{
+  hash.ingest((void *)&theval, sizeof(theval));
+}
+
+size_t do_type_crc(const constant_string_data::kindt &theval)
+{
+  return boost::hash<uint8_t>()(theval);
+}
+
+void do_type_hash(const constant_string_data::kindt &theval, crypto_hash &hash)
 {
   hash.ingest((void *)&theval, sizeof(theval));
 }

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -32,7 +32,7 @@ std::string fixedbv_type2t::field_names[esbmct::num_type_fields] =
 std::string floatbv_type2t::field_names[esbmct::num_type_fields] =
   {"fraction", "exponent", "", "", ""};
 std::string string_type2t::field_names[esbmct::num_type_fields] =
-  {"width", "", "", "", ""};
+  {"subtype", "width", "", "", ""};
 std::string cpp_name_type2t::field_names[esbmct::num_type_fields] =
   {"name", "template args", "", "", ""};
 
@@ -55,7 +55,7 @@ std::string constant_array2t::field_names[esbmct::num_type_fields] =
 std::string constant_array_of2t::field_names[esbmct::num_type_fields] =
   {"initializer", "", "", "", ""};
 std::string constant_string2t::field_names[esbmct::num_type_fields] =
-  {"value", "", "", "", ""};
+  {"value", "kind", "", "", ""};
 std::string constant_vector2t::field_names[esbmct::num_type_fields] =
   {"members", "", "", "", ""};
 std::string symbol2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates_expr_data.cpp
+++ b/src/irep2/templates/irep2_templates_expr_data.cpp
@@ -9,7 +9,7 @@ expr_typedefs1(constant_array, constant_datatype_data);
 expr_typedefs1(constant_vector, constant_datatype_data);
 expr_typedefs1(constant_bool, constant_bool_data);
 expr_typedefs1(constant_array_of, constant_array_of_data);
-expr_typedefs1(constant_string, constant_string_data);
+expr_typedefs2(constant_string, constant_string_data);
 expr_typedefs6(symbol, symbol_data);
 expr_typedefs2(nearbyint, typecast_data);
 expr_typedefs2(typecast, typecast_data);

--- a/src/irep2/templates/irep2_templates_type.cpp
+++ b/src/irep2/templates/irep2_templates_type.cpp
@@ -13,5 +13,5 @@ type_typedefs3(vector_type, array_data);
 type_typedefs1(pointer_type, pointer_data);
 type_typedefs2(fixedbv_type, fixedbv_data);
 type_typedefs2(floatbv_type, floatbv_data);
-type_typedefs1(string_type, string_data);
+type_typedefs2(string_type, string_data);
 type_typedefs2(cpp_name_type, cpp_name_data);

--- a/src/solidity-frontend/solidity_convert_literals.cpp
+++ b/src/solidity-frontend/solidity_convert_literals.cpp
@@ -76,7 +76,7 @@ bool solidity_convertert::convert_string_literal(
       integer2string(string_size),
       int_type()));
   // TODO: Handle null terminator byte
-  string_constantt string(the_value, type);
+  string_constantt string(the_value, type, false);
   dest.swap(string);
 
   return false;

--- a/src/solidity-frontend/solidity_convert_literals.cpp
+++ b/src/solidity-frontend/solidity_convert_literals.cpp
@@ -76,7 +76,7 @@ bool solidity_convertert::convert_string_literal(
       integer2string(string_size),
       int_type()));
   // TODO: Handle null terminator byte
-  string_constantt string(the_value, type, false);
+  string_constantt string(the_value, type, string_constantt::k_default);
   dest.swap(string);
 
   return false;

--- a/src/util/c_types.cpp
+++ b/src/util/c_types.cpp
@@ -210,12 +210,12 @@ typet char32_type()
 
 typet wchar_type()
 {
-  return signedbv_typet(config.ansi_c.int_width);
+  return signedbv_typet(config.ansi_c.wchar_t_width);
 }
 
 typet unsigned_wchar_type()
 {
-  return unsignedbv_typet(config.ansi_c.int_width);
+  return unsignedbv_typet(config.ansi_c.wchar_t_width);
 }
 
 type2tc char_type2()

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -102,6 +102,15 @@ public:
 
     triple target;
 
+    /* TODO: make this configurable.
+     *
+     * While it is not, the empty string means that we assume that the given
+     * program uses the same locale as we do ourselves. This is used for
+     * setlocale() in order to interpret string literals, see
+     * string_constantt::mb_value(). Therefore, this gives both, the source and
+     * execution character set. */
+    std::string locale_name;
+
     std::list<std::string> defines;
     std::list<std::string> include_paths;
     std::list<std::string> idirafter_paths;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -710,15 +710,18 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
   }
   else if (expr.id() == "string-constant")
   {
-    std::string thestring = expr.value().as_string();
+    irep_idt thestring = expr.value();
     typet thetype = expr.type();
     assert(thetype.add(typet::a_size).id() == irept::id_constant);
     exprt &face = (exprt &)thetype.add(typet::a_size);
     BigInt val = binary2bigint(face.value(), false);
 
+    // TODO: move this to irep2
+    bool is_wide [[maybe_unused]] = expr.get_bool("wide");
+
     type2tc t = string_type2tc(val.to_int64());
 
-    new_expr_ref = constant_string2tc(t, irep_idt(thestring));
+    new_expr_ref = constant_string2tc(t, thestring);
   }
   else if (
     (expr.id() == irept::id_constant && expr.type().id() == typet::t_array) ||

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -6,6 +6,7 @@
 #include <util/namespace.h>
 #include <util/prefix.h>
 #include <util/simplify_expr.h>
+#include <util/string_constant.h>
 #include <util/type_byte_size.h>
 
 // File for old irep -> new irep conversions.
@@ -319,7 +320,10 @@ static type2tc migrate_type0(const typet &type)
   {
     irep_idt width = type.width();
     unsigned int iwidth = strtol(width.as_string().c_str(), nullptr, 10);
-    return string_type2tc(iwidth);
+    type2tc subtype = get_uint8_type();
+    if (type.subtype().is_not_nil())
+      subtype = migrate_type(type.subtype());
+    return string_type2tc(subtype, iwidth);
   }
 
   log_error("{}", type);
@@ -716,12 +720,17 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     exprt &face = (exprt &)thetype.add(typet::a_size);
     BigInt val = binary2bigint(face.value(), false);
 
-    // TODO: move this to irep2
-    bool is_wide [[maybe_unused]] = expr.get_bool("wide");
+    const irep_idt &kind1 = expr.get("kind");
 
-    type2tc t = string_type2tc(val.to_int64());
+    auto kind2 = kind1 == string_constantt::k_wide ? constant_string2t::WIDE
+                 : kind1 == string_constantt::k_unicode
+                   ? constant_string2t::UNICODE
+                   : constant_string2t::DEFAULT;
 
-    new_expr_ref = constant_string2tc(t, thestring);
+    type2tc s = migrate_type(thetype.subtype());
+    type2tc t = string_type2tc(s, val.to_int64());
+
+    new_expr_ref = constant_string2tc(t, thestring, kind2);
   }
   else if (
     (expr.id() == irept::id_constant && expr.type().id() == typet::t_array) ||
@@ -1291,7 +1300,9 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     if (expr.op1().id() == "member_name")
     {
       idx = constant_string2tc(
-        string_type2tc(1), expr.op1().get_string("component_name"));
+        string_type2tc(get_uint8_type(), 1),
+        expr.op1().get_string("component_name"),
+        constant_string2t::DEFAULT);
     }
     else
     {
@@ -2059,6 +2070,23 @@ exprt migrate_expr_back(const expr2tc &ref)
 
     thestring.type() = thetype;
     thestring.set("value", irep_idt(ref2.value));
+
+    irep_idt kind;
+    switch (ref2.kind)
+    {
+    case constant_string2t::DEFAULT:
+      kind = string_constantt::k_default;
+      break;
+    case constant_string2t::WIDE:
+      kind = string_constantt::k_wide;
+      break;
+    case constant_string2t::UNICODE:
+      kind = string_constantt::k_unicode;
+      break;
+    }
+    assert(!kind.empty());
+    thestring.set("kind", kind);
+
     return thestring;
   }
   case expr2t::constant_struct_id:

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2,7 +2,9 @@
 #define CPROVER_STD_EXPR_H
 
 #include <cassert>
+#include <util/bitvector.h>
 #include <util/expr.h>
+#include <util/mp_arith.h>
 
 class transt : public exprt
 {
@@ -1047,6 +1049,14 @@ public:
   {
     set("#cformat", _cformat);
     set_value(_value);
+  }
+
+  constant_exprt(const BigInt &value, const typet &type)
+    : constant_exprt(
+        integer2binary(value, bv_width(type)),
+        integer2string(value),
+        type)
+  {
   }
 
   inline const irep_idt &get_value() const

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -2,9 +2,13 @@
 #include <util/bitvector.h>
 #include <util/config.h>
 #include <util/c_types.h>
+#include <util/message.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 #include <util/string_constant.h>
+
+#include <cuchar>
+#include <cwchar>
 
 string_constantt::string_constantt(const irep_idt &value)
   : string_constantt(value, array_typet(char_type()))
@@ -20,4 +24,90 @@ string_constantt::string_constantt(const irep_idt &value, const typet &type)
 void string_constantt::set_value(const irep_idt &value)
 {
   exprt::value(value);
+}
+
+namespace
+{
+struct convert_mb
+{
+  const std::string &v;
+  int w;
+  bool le;
+
+  std::vector<char> res;
+
+  convert_mb(const std::string &v, int w)
+    : v(v),
+      w(w),
+      le(
+        config.ansi_c.endianess ==
+        configt::ansi_ct::endianesst::IS_LITTLE_ENDIAN)
+  {
+    assert(v.length() % w == 0);
+    if (config.ansi_c.endianess == configt::ansi_ct::endianesst::NO_ENDIANESS)
+      throw string_constantt::mb_conversion_error(fmt::format(
+        "impossible to interpret char{}_t string literal without endianness",
+        8 * w));
+
+    char buffer[MB_CUR_MAX];
+    mbstate_t ps;
+    memset(&ps, 0, sizeof(ps));
+    size_t n = v.length() / w; // number of code units
+    size_t i;
+
+    /* need to set the locale for c*rtomb() to work; we'll restore it later */
+    char *loc = setlocale(LC_CTYPE, config.ansi_c.locale_name.c_str());
+    assert(loc);
+    for (i = 0; i < n; i++)
+    {
+      uint32_t c = decode(i);
+      size_t r = w == 2 ? c16rtomb(buffer, c, &ps) : c32rtomb(buffer, c, &ps);
+      if (r == (size_t)-1)
+        break;
+      res.insert(res.end(), buffer, buffer + r);
+    }
+    setlocale(LC_CTYPE, loc); // restore locale
+
+    if (i < n)
+      throw string_constantt::mb_conversion_error(fmt::format(
+        "error interpreting char{}_t string literal at {}: {}",
+        8 * w,
+        i,
+        strerror(errno)));
+  }
+
+  uint32_t decode(size_t k) const
+  {
+    const char *p = v.data() + k * w;
+    uint32_t r = 0;
+    for (int i = 0; i < w; i++)
+    {
+      uint8_t c = p[i];
+      r |= (uint32_t)c << 8 * (le ? i : w - 1 - i);
+    }
+    return r;
+  }
+
+  std::string result() const
+  {
+    return std::string(res.begin(), res.end());
+  }
+};
+
+} // namespace
+
+irep_idt string_constantt::mb_value() const
+{
+  /* Assume wchar_t is either char16_t or char32_t. */
+  int elem_width = atoi(type().subtype().width().c_str());
+  switch (elem_width) {
+  case 8:
+    return get_value();
+
+  case 16:
+  case 32:
+    return convert_mb(get_value().as_string(), elem_width / 8).result();
+  }
+  log_error("illegal character width {} of string literal", elem_width);
+  abort();
 }

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -101,7 +101,8 @@ irep_idt string_constantt::mb_value() const
 {
   /* Assume wchar_t is either char16_t or char32_t. */
   int elem_width = atoi(type().subtype().width().c_str());
-  switch (elem_width) {
+  switch (elem_width)
+  {
   case 8:
     return get_value();
 

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -74,6 +74,11 @@ struct convert_mb
         8 * w,
         i,
         strerror(errno)));
+    if (!mbsinit(&ps))
+      throw string_constantt::mb_conversion_error(fmt::format(
+        "error interpreting char{}_t string literal: terminates with "
+        "incomplete sequence",
+        8 * w));
   }
 
   uint32_t decode(size_t k) const

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -11,17 +11,14 @@
 #include <cwchar>
 
 string_constantt::string_constantt(const irep_idt &value)
-  : string_constantt(value, array_typet(char_type()))
+  : string_constantt(
+      value,
+      array_typet(char_type(), constant_exprt(value.size() + 1, size_type())))
 {
 }
 
 string_constantt::string_constantt(const irep_idt &value, const typet &type)
   : exprt("string-constant", type)
-{
-  set_value(value);
-}
-
-void string_constantt::set_value(const irep_idt &value)
 {
   exprt::value(value);
 }
@@ -104,11 +101,11 @@ irep_idt string_constantt::mb_value() const
   switch (elem_width)
   {
   case 8:
-    return get_value();
+    return value();
 
   case 16:
   case 32:
-    return convert_mb(get_value().as_string(), elem_width / 8).result;
+    return convert_mb(value().as_string(), elem_width / 8).result;
   }
   log_error("illegal character width {} of string literal", elem_width);
   abort();

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -51,8 +51,8 @@ struct convert_mb
     assert(v.length() % w == 0);
     if (config.ansi_c.endianess == configt::ansi_ct::endianesst::NO_ENDIANESS)
       throw string_constantt::mb_conversion_error(fmt::format(
-        "impossible to interpret char{}_t string literal without endianness",
-        8 * w));
+        "impossible to interpret {} string literal without endianness",
+        desc()));
 
     memset(&ps, 0, sizeof(ps));
     size_t n = v.length() / w; // number of code units
@@ -75,15 +75,20 @@ struct convert_mb
 
     if (i < n)
       throw string_constantt::mb_conversion_error(fmt::format(
-        "error interpreting char{}_t string literal at {}: {}",
-        8 * w,
+        "error interpreting {} string literal at {}: {}",
+        desc(),
         i,
         strerror(errno)));
     if (!mbsinit(&ps))
       throw string_constantt::mb_conversion_error(fmt::format(
-        "error interpreting char{}_t string literal: terminates with "
+        "error interpreting {} string literal: terminates with "
         "incomplete sequence",
-        8 * w));
+        desc()));
+  }
+
+  std::string desc() const
+  {
+    return wide ? std::string("wchar_t") : fmt::format("char{}_t", 8 * w);
   }
 
   uint32_t decode(size_t k) const

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -19,14 +19,5 @@ string_constantt::string_constantt(const irep_idt &value, const typet &type)
 
 void string_constantt::set_value(const irep_idt &value)
 {
-  /* Fails for L"" and other large character types, because the below
-   * computation is buggy for those. See also #1165. */
-  assert(bv_width(type().subtype()) == config.ansi_c.char_width);
-
-  exprt size_expr = constant_exprt(
-    integer2binary(value.size() + 1, bv_width(size_type())),
-    integer2string(value.size() + 1),
-    size_type());
-  type().size(size_expr);
   exprt::value(value);
 }

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -27,6 +27,13 @@ public:
   {
     return value();
   }
+
+  irep_idt mb_value() const;
+
+  class mb_conversion_error : public std::runtime_error
+  {
+    using std::runtime_error::runtime_error;
+  };
 };
 
 const string_constantt &to_string_constant(const exprt &expr);

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -21,13 +21,6 @@ public:
     return static_cast<string_constantt &>(expr);
   }
 
-  void set_value(const irep_idt &value);
-
-  const irep_idt &get_value() const
-  {
-    return value();
-  }
-
   irep_idt mb_value() const;
 
   class mb_conversion_error : public std::runtime_error

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -6,11 +6,15 @@
 class string_constantt : public exprt
 {
 public:
+  static const irep_idt k_default;
+  static const irep_idt k_wide;
+  static const irep_idt k_unicode;
+
   explicit string_constantt(const irep_idt &value);
   explicit string_constantt(
     const irep_idt &value,
     const typet &type,
-    bool is_wide);
+    const irep_idt &kind);
 
   friend inline const string_constantt &to_string_constant(const exprt &expr)
   {

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -7,7 +7,10 @@ class string_constantt : public exprt
 {
 public:
   explicit string_constantt(const irep_idt &value);
-  explicit string_constantt(const irep_idt &value, const typet &type);
+  explicit string_constantt(
+    const irep_idt &value,
+    const typet &type,
+    bool is_wide);
 
   friend inline const string_constantt &to_string_constant(const exprt &expr)
   {


### PR DESCRIPTION
This PR tries to address #1540 and also removes a buggy type computation from the `string_constantt` class (related: #1165). Background: ESBMC prints the contents of string literals from the source code into the counter example, e.g. comments of assertions. On Windows (at least), there is `_wassert()` taking a wide character string, which (usually?) is UTF-16 there. Printing that out resulted in the garbage seen in #1540.

This PR extends the irep1 and irep2 string constants to also include a "kind", that is one of:
- default: for `""` literals
- wide: for `L""` literals
- unicode: for `u8""`, `u""` and `U""` literals.

This information is used when computing the comment to put on a user-assertion. The string-literal (unfortunately) has to be converted to the multi-byte representation ESBMC's message system uses (aka narrow strings). The problem here is that we don't know the source / target encodings. For now, the assumption is that the host encoding (given by the locale `""`) will also be used for the target program. I've added a variable `locale_name` (for now always the empty string) to the config. The idea is that we / the user can set this to the default locale name of the target platform. I'm not doing that, yet, so it is always empty (meaning: host platform's locale).

Besides all this locale-handling, there is another potential problem for cross-platform verification: `wchar_t` on Windows is either UTF-16 or GB18030 (as far as I know) and has 2 bytes, everywhere else it is whatever the locale says (usually UTF-32) and has 4 bytes. Cross-platform verification between both, using the above assumption that the host's locale matches the target's cannot work. I don't have a good solution to this problem, so the code catches this case and falls back to printing the garbage from #1540 then.

I've also touched the `string_type2t` to add the correct subtype.