### PR TITLE
Optimise the efficiency of data race detection

### DIFF
--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -155,7 +155,10 @@ void add_race_assertions(
         i_it = ++t;
       }
 
-      // Avoid adding too much thread interleaving
+      // Avoid adding too much thread interleaving by using atomic block
+      // tmp_A = 0;
+      // atomic {A = n; Assert tmp_A == 0; tmp_A = 1;}
+      // See https://github.com/esbmc/esbmc/pull/1544
       goto_programt::targett t = goto_program.insert(i_it);
       *t = ATOMIC_BEGIN;
       i_it = ++t;

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -69,7 +69,6 @@ public:
 
   const exprt get_w_guard_expr(const rw_sett::entryt &entry)
   {
-    assert(entry.w || entry.deref);
     return get_guard_symbol_expr(
       entry.object, entry.original_expr, entry.deref);
   }
@@ -143,8 +142,7 @@ void add_race_assertions(
       i_it++;
 
       // now add assignments for what is written -- reset
-      forall_rw_set_entries(
-        e_it, rw_set) if (e_it->second.w || e_it->second.deref)
+      forall_rw_set_entries(e_it, rw_set)
       {
         goto_programt::targett t = goto_program.insert(i_it);
 

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -142,6 +142,21 @@ void add_race_assertions(
       instruction.make_skip();
       i_it++;
 
+      // now add assignments for what is written -- reset
+      forall_rw_set_entries(
+        e_it, rw_set) if (e_it->second.w || e_it->second.deref)
+      {
+        goto_programt::targett t = goto_program.insert(i_it);
+
+        t->type = ASSIGN;
+        code_assignt theassign(
+          w_guards.get_w_guard_expr(e_it->second), false_exprt());
+        migrate_expr(theassign, t->code);
+
+        t->location = original_instruction.location;
+        i_it = ++t;
+      }
+
       // Avoid adding too much thread interleaving
       goto_programt::targett t = goto_program.insert(i_it);
       *t = ATOMIC_BEGIN;
@@ -187,21 +202,10 @@ void add_race_assertions(
         i_it = ++t;
       }
 
-      *t = ATOMIC_END;
-      i_it = ++t;
-
-      // now add assignments for what is written -- reset
-      forall_rw_set_entries(
-        e_it, rw_set) if (e_it->second.w || e_it->second.deref)
       {
         goto_programt::targett t = goto_program.insert(i_it);
 
-        t->type = ASSIGN;
-        code_assignt theassign(
-          w_guards.get_w_guard_expr(e_it->second), false_exprt());
-        migrate_expr(theassign, t->code);
-
-        t->location = original_instruction.location;
+        *t = ATOMIC_END;
         i_it = ++t;
       }
 


### PR DESCRIPTION
I found a paper that proposed a way to make race detection in ESBMC significantly reduce thread interleaving.
https://www.academia.edu/download/43202005/TRANSYT_A_Tool_for_the_Verification_of_A20160229-25351-14feb9w.pdf#page=96

![image](https://github.com/esbmc/esbmc/assets/115160284/23ccf27b-c06c-4599-a25b-c61295e62adb)
We can reduce unnecessary thread interleaving by using atomic. At the same time, we can guarantee the correctness of the verification.
```
#include <pthread.h>

int a[4];

void* t1(void *arg) {
    a[__ESBMC_get_thread_id()] = 1;                 

    return NULL;
}

void* t2(void *arg) {
    a[__ESBMC_get_thread_id()] = 1;

    return NULL;
}

int main() {
    pthread_t id1, id2;

    pthread_create(&id1, NULL, t1, NULL);
    pthread_create(&id2, NULL, t2, NULL);

    return 0;
}
```
For example, the above code: `esbmc main.c --data-races-check`
Master:
![image](https://github.com/esbmc/esbmc/assets/115160284/a717bf69-2611-4a2a-976b-1b4b5c7992f6)
This PR:
![image](https://github.com/esbmc/esbmc/assets/115160284/957a192c-67d7-4ff0-863d-406ccdcec84c)

6000->1000, That's a big improvement.


