### PR TITLE
Remove string_typet and string_type2t for good

### DIFF
--- a/regression/esbmc/memset-const-2/memset-const.c
+++ b/regression/esbmc/memset-const-2/memset-const.c
@@ -1,0 +1,10 @@
+#include <string.h>
+
+const char b[] = "abc";
+
+int main(int argc, char **argv)
+{
+	char a[2];
+	char *c = argc == 1 ? a : b;
+	memset(c, 0, 1);
+}

--- a/regression/esbmc/memset-const-2/test.desc
+++ b/regression/esbmc/memset-const-2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+memset-const.c
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/memset-const-no-simpl/memset-const.c
+++ b/regression/esbmc/memset-const-no-simpl/memset-const.c
@@ -1,0 +1,11 @@
+#include <string.h>
+
+const char b[] = "abc";
+const char *d = "xyz";
+
+int main(int argc, char **argv)
+{
+	char a[2];
+	char *c = argc == 1 ? a : argc == 2 ? b : d;
+	memset(c, 0, 1);
+}

--- a/regression/esbmc/memset-const-no-simpl/test.desc
+++ b/regression/esbmc/memset-const-no-simpl/test.desc
@@ -1,0 +1,4 @@
+CORE
+memset-const.c
+--no-simplify --unwind 8
+^VERIFICATION FAILED$

--- a/regression/esbmc/memset-const/memset-const.c
+++ b/regression/esbmc/memset-const/memset-const.c
@@ -1,0 +1,11 @@
+#include <string.h>
+
+const char b[] = "abc";
+const char *d = "xyz";
+
+int main(int argc, char **argv)
+{
+	char a[2];
+	char *c = argc == 1 ? a : argc == 2 ? b : d;
+	memset(c, 0, 1);
+}

--- a/regression/esbmc/memset-const/test.desc
+++ b/regression/esbmc/memset-const/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+memset-const.c
+
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -637,13 +637,10 @@ void goto_checkt::bounds_check(
   expr2tc lower = greaterthanequal2tc(the_index, zero);
   add_guarded_claim(lower, name + " lower bound", "array bounds", loc, guard);
 
-  assert(is_array_type(t) || is_string_type(t) || is_vector_type(t));
+  assert(is_array_type(t) || is_vector_type(t));
 
-  const expr2tc &array_size =
-    is_array_type(t) ? to_array_type(t).array_size
-    : is_vector_type(t)
-      ? to_vector_type(t).array_size
-      : constant_int2tc(get_uint32_type(), to_string_type(t).get_length());
+  const expr2tc &array_size = is_array_type(t) ? to_array_type(t).array_size
+                                               : to_vector_type(t).array_size;
 
   // Cast size to index type
   expr2tc casted_size = typecast2tc(the_index->type, array_size);

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -447,11 +447,11 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     // this is due to printf_formatter does not handle the char array.
     for (auto &arg : args)
     {
-      if (is_array_type(get_base_object(arg)))
+      const expr2tc &base_expr = get_base_object(arg);
+      if (!is_constant_string2t(base_expr) && is_array_type(base_expr))
       {
         // the current expression "arg" does not hold the value info (might be a bug)
         // thus we need to look it up from the symbol table
-        const expr2tc &base_expr = get_base_object(arg);
         assert(is_symbol2t(base_expr));
         symbolt s = *ns.lookup(to_symbol2t(base_expr).thename);
         exprt dest;
@@ -1015,13 +1015,10 @@ static inline expr2tc gen_byte_expression(
    *
    */
 
-  /* Can't set string constants */
-  if (is_string_type(type))
-    return expr2tc();
-
   if (is_pointer_type(type))
     return gen_byte_expression_byte_update(
       type, src, value, num_of_bytes, offset);
+
   expr2tc result = gen_zero(type);
   auto value_downcast = typecast2tc(get_uint8_type(), value);
   auto value_upcast = typecast2tc(

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -421,7 +421,7 @@ void goto_symext::symex_assign_typecast(
           new_rhs,
           constant_string2tc(
             array_type2tc(
-              get_uint8_type(), gen_ulong(from_name[i].size()), false),
+              get_uint8_type(), gen_ulong(from_name[i].size() + 1), false),
             from_name[i],
             constant_string2t::DEFAULT),
           typecast2tc(from_type[i], member2tc(lhs_type[i], rhs, lhs_name[i])));
@@ -527,7 +527,7 @@ void goto_symext::symex_assign_member(
   //   a'==a WITH [c:=e]
 
   type2tc str_type = array_type2tc(
-    get_uint8_type(), gen_ulong(component_name.as_string().size()), false);
+    get_uint8_type(), gen_ulong(component_name.as_string().size() + 1), false);
   expr2tc new_rhs = with2tc(
     real_lhs->type,
     real_lhs,

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -420,7 +420,8 @@ void goto_symext::symex_assign_typecast(
           from->type,
           new_rhs,
           constant_string2tc(
-            string_type2tc(get_uint8_type(), from_name[i].size()),
+            array_type2tc(
+              get_uint8_type(), gen_ulong(from_name[i].size()), false),
             from_name[i],
             constant_string2t::DEFAULT),
           typecast2tc(from_type[i], member2tc(lhs_type[i], rhs, lhs_name[i])));
@@ -465,8 +466,7 @@ void goto_symext::symex_assign_array(
   const index2t &index = to_index2t(lhs);
 
   assert(
-    is_array_type(index.source_value) || is_string_type(index.source_value) ||
-    is_vector_type(index.source_value));
+    is_array_type(index.source_value) || is_vector_type(index.source_value));
 
   // turn
   //   a[i]=e
@@ -526,8 +526,8 @@ void goto_symext::symex_assign_member(
   // into
   //   a'==a WITH [c:=e]
 
-  type2tc str_type =
-    string_type2tc(get_uint8_type(), component_name.as_string().size());
+  type2tc str_type = array_type2tc(
+    get_uint8_type(), gen_ulong(component_name.as_string().size()), false);
   expr2tc new_rhs = with2tc(
     real_lhs->type,
     real_lhs,

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -423,7 +423,6 @@ public:
     signedbv_id,
     fixedbv_id,
     floatbv_id,
-    string_id,
     cpp_name_id,
     end_type_id
   };

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -288,7 +288,7 @@ expr2tc constant_string2t::to_array() const
   std::vector<expr2tc> contents;
   unsigned int length = value.as_string().size(), i;
 
-  type2tc type = to_string_type(constant_string2t::type).subtype;
+  type2tc type = to_array_type(constant_string2t::type).subtype;
 
   for (i = 0; i < length; i++)
     contents.push_back(constant_int2tc(type, BigInt(value.as_string()[i])));
@@ -351,12 +351,6 @@ void with2t::assert_consistency() const
     assert(is_bv_type(update_field->type));
     assert_type_compat_for_with(
       to_vector_type(source_value->type).subtype, update_value->type);
-  }
-  else if (is_string_type(source_value))
-  {
-    assert(is_bv_type(update_field->type));
-    assert(is_bv_type(update_value->type));
-    assert(update_value->type->get_width() == config.ansi_c.char_width);
   }
   else
   {

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1629,7 +1629,7 @@ class constant_string2t : public constant_string_expr_methods
 {
 public:
   /** Primary constructor.
-   *  @param type Type of this string; presumably a string_type2t.
+   *  @param type Type of this string; presumably an array_type2t.
    *  @param stringref String pool'd string we're dealing with
    *  @param kind The kind of string literal:
    *              - DEFAULT: `""`
@@ -2884,9 +2884,7 @@ public:
   index2t(const type2tc &type, const expr2tc &source, const expr2tc &index)
     : index_expr_methods(type, index_id, source, index)
   {
-    assert(
-      is_array_type(source) || is_string_type(source) ||
-      is_vector_type(source));
+    assert(is_array_type(source) || is_vector_type(source));
 #if 0
     assert(
       is_array_type(source)

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -27,7 +27,6 @@ static const char *type_names[] = {
   "signedbv",
   "fixedbv",
   "floatbv",
-  "string",
   "cpp_name"};
 // If this fires, you've added/removed a type id, and need to update the list
 // above (which is ordered according to the enum list)
@@ -228,16 +227,6 @@ unsigned int floatbv_type2t::get_width() const
 unsigned int code_data::get_width() const
 {
   throw symbolic_type_excp();
-}
-
-unsigned int string_type2t::get_width() const
-{
-  return width * 8;
-}
-
-unsigned int string_type2t::get_length() const
-{
-  return width;
 }
 
 const std::vector<type2tc> &struct_union_data::get_structure_members() const

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -20,7 +20,6 @@ class vector_type2t;
 class pointer_type2t;
 class fixedbv_type2t;
 class floatbv_type2t;
-class string_type2t;
 class cpp_name_type2t;
 
 // We also require in advance, the actual classes that store type data.
@@ -261,26 +260,6 @@ public:
   typedef esbmct::type2t_traits<fraction_field, exponent_field> traits;
 };
 
-class string_data : public type2t
-{
-public:
-  string_data(type2t::type_ids id, const type2tc &subtype, unsigned int w)
-    : type2t(id), subtype(subtype), width(w)
-  {
-  }
-  string_data(const string_data &ref) = default;
-
-  type2tc subtype;
-  unsigned int width;
-
-  // Type mangling:
-  typedef esbmct::field_traits<type2tc, string_data, &string_data::subtype>
-    subtype_field;
-  typedef esbmct::field_traits<unsigned int, string_data, &string_data::width>
-    width_field;
-  typedef esbmct::type2t_traits<subtype_field, width_field> traits;
-};
-
 class cpp_name_data : public type2t
 {
 public:
@@ -334,7 +313,6 @@ irep_typedefs(array, array_data);
 irep_typedefs(pointer, pointer_data);
 irep_typedefs(fixedbv, fixedbv_data);
 irep_typedefs(floatbv, floatbv_data);
-irep_typedefs(string, string_data);
 irep_typedefs(cpp_name, cpp_name_data);
 irep_typedefs(vector, array_data);
 #undef irep_typedefs
@@ -678,29 +656,6 @@ public:
   static std::string field_names[esbmct::num_type_fields];
 };
 
-/** String type class.
- *  Slightly artificial as original irep had no type for this; Represents the
- *  type of a string constant. Because it needs a bit width, we also store the
- *  size of the constant string in elements.
- *  @extends string_data
- */
-class string_type2t : public string_type_methods
-{
-public:
-  /** Primary constructor.
-   *  @param elements Number of 8-bit characters in string constant.
-   */
-  string_type2t(type2tc subtype, unsigned int elements)
-    : string_type_methods(string_id, subtype, elements)
-  {
-  }
-  string_type2t(const string_type2t &ref) = default;
-  unsigned int get_width() const override;
-  virtual unsigned int get_length() const;
-
-  static std::string field_names[esbmct::num_type_fields];
-};
-
 /** C++ Name type.
  *  Contains a type name, but also a vector of template parameters.
  *  Something in the C++ frontend uses this; it's precise purpose is unclear.
@@ -769,7 +724,6 @@ type_macros(unsignedbv);
 type_macros(signedbv);
 type_macros(fixedbv);
 type_macros(floatbv);
-type_macros(string);
 type_macros(cpp_name);
 #undef type_macros
 #ifdef dynamic_cast

--- a/src/irep2/templates/irep2_template_utils.cpp
+++ b/src/irep2/templates/irep2_template_utils.cpp
@@ -35,7 +35,7 @@ std::string type_to_string(const constant_string_data::kindt &theval, int)
   case constant_string_data::UNICODE:
     return "unicode";
   }
-  assert(0 && "Unrecognized string_data::kindt enum value");
+  assert(0 && "Unrecognized constant_string_data::kindt enum value");
   abort();
 }
 

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -31,8 +31,6 @@ std::string fixedbv_type2t::field_names[esbmct::num_type_fields] =
   {"width", "integer_bits", "", "", ""};
 std::string floatbv_type2t::field_names[esbmct::num_type_fields] =
   {"fraction", "exponent", "", "", ""};
-std::string string_type2t::field_names[esbmct::num_type_fields] =
-  {"subtype", "width", "", "", ""};
 std::string cpp_name_type2t::field_names[esbmct::num_type_fields] =
   {"name", "template args", "", "", ""};
 

--- a/src/irep2/templates/irep2_templates_type.cpp
+++ b/src/irep2/templates/irep2_templates_type.cpp
@@ -13,5 +13,4 @@ type_typedefs3(vector_type, array_data);
 type_typedefs1(pointer_type, pointer_data);
 type_typedefs2(fixedbv_type, fixedbv_data);
 type_typedefs2(floatbv_type, floatbv_data);
-type_typedefs2(string_type, string_data);
 type_typedefs2(cpp_name_type, cpp_name_data);

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -913,7 +913,7 @@ void dereferencet::build_reference_rec(
     flags |= flag_dst_union;
   else if (is_scalar_type(type))
     flags |= flag_dst_scalar;
-  else if (is_array_type(type) || is_string_type(type))
+  else if (is_array_type(type))
   {
     log_error(
       "Can't construct rvalue reference to array type during dereference\n"
@@ -932,7 +932,7 @@ void dereferencet::build_reference_rec(
     flags |= flag_src_union;
   else if (is_scalar_type(value))
     flags |= flag_src_scalar;
-  else if (is_array_type(value) || is_string_type(value))
+  else if (is_array_type(value))
     flags |= flag_src_array;
   else
   {
@@ -1077,7 +1077,7 @@ void dereferencet::construct_from_array(
   modet mode,
   unsigned long alignment)
 {
-  assert(is_array_type(value) || is_string_type(value));
+  assert(is_array_type(value));
 
   const array_type2t arr_type = get_arr_type(value);
   type2tc arr_subtype = arr_type.subtype;
@@ -1516,7 +1516,7 @@ void dereferencet::construct_from_multidir_array(
   unsigned long alignment,
   modet mode)
 {
-  assert(is_array_type(value) || is_string_type(value));
+  assert(is_array_type(value));
   const array_type2t arr_type = get_arr_type(value);
 
   // Right: any access across the boundary of the outer dimension of this array
@@ -1934,8 +1934,6 @@ std::vector<expr2tc> dereferencet::extract_bytes(
       base = to_array_type(base).subtype;
     else if (is_vector_type(base))
       base = to_vector_type(base).subtype;
-    else if (is_string_type(base))
-      base = bytetype;
     else
       break;
 
@@ -2140,7 +2138,7 @@ void dereferencet::bounds_check(
   if (options.get_bool_option("no-bounds-check"))
     return;
 
-  assert(is_array_type(expr) || is_string_type(expr));
+  assert(is_array_type(expr));
   const array_type2t arr_type = get_arr_type(expr);
 
   if (!arr_type.array_size)
@@ -2163,7 +2161,7 @@ void dereferencet::bounds_check(
 
   expr2tc arrsize;
   if (
-    !is_constant_array2t(expr) &&
+    !is_constant_expr(expr) &&
     has_prefix(
       ns.lookup(to_symbol2t(expr).thename)->id.as_string(), "symex_dynamic::"))
   {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -25,13 +25,6 @@
 // global data, horrible
 unsigned int dereferencet::invalid_counter = 0;
 
-static inline const array_type2t get_arr_type(const expr2tc &expr)
-{
-  return (is_array_type(expr))
-           ? to_array_type(expr->type)
-           : to_array_type(to_constant_string2t(expr).to_array()->type);
-}
-
 // Look for the base of an expression such as &a->b[1];, where all we're doing
 // is performing some pointer arithmetic, rather than actually performing some
 // dereference operation.
@@ -1079,7 +1072,7 @@ void dereferencet::construct_from_array(
 {
   assert(is_array_type(value));
 
-  const array_type2t arr_type = get_arr_type(value);
+  const array_type2t arr_type = to_array_type(value->type);
   type2tc arr_subtype = arr_type.subtype;
 
   if (is_array_type(arr_subtype))
@@ -1517,7 +1510,7 @@ void dereferencet::construct_from_multidir_array(
   modet mode)
 {
   assert(is_array_type(value));
-  const array_type2t arr_type = get_arr_type(value);
+  const array_type2t arr_type = to_array_type(value->type);
 
   // Right: any access across the boundary of the outer dimension of this array
   // is an alignment violation as that can possess extra padding.
@@ -2139,7 +2132,7 @@ void dereferencet::bounds_check(
     return;
 
   assert(is_array_type(expr));
-  const array_type2t arr_type = get_arr_type(expr);
+  const array_type2t arr_type = to_array_type(expr->type);
 
   if (!arr_type.array_size)
   {

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -224,7 +224,7 @@ void value_sett::get_value_set_rec(
 
 #ifndef NDEBUG
     const type2tc &source_type = idx.source_value->type;
-    assert(is_array_type(source_type) || is_string_type(source_type));
+    assert(is_array_type(source_type));
 #endif
 
     // Attach '[]' to the suffix, identifying the variable tracking all the
@@ -807,8 +807,7 @@ void value_sett::get_reference_set_rec(const expr2tc &expr, object_mapt &dest)
     // the source value, and store a reference to all those things.
     const index2t &index = to_index2t(expr);
 
-    assert(
-      is_array_type(index.source_value) || is_string_type(index.source_value));
+    assert(is_array_type(index.source_value));
 
     // Compute the offset introduced by this index.
     BigInt index_offset;
@@ -1255,7 +1254,6 @@ void value_sett::assign_rec(
   {
     assert(
       is_array_type(to_index2t(lhs).source_value) ||
-      is_string_type(to_index2t(lhs).source_value) ||
       is_dynamic_object2t(to_index2t(lhs).source_value));
 
     assign_rec(to_index2t(lhs).source_value, values_rhs, "[]" + suffix, true);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1263,16 +1263,6 @@ smt_sortt smt_convt::convert_sort(const type2tc &type)
     break;
   }
 
-  case type2t::string_id:
-  {
-    const string_type2t &str_type = to_string_type(type);
-    expr2tc width = constant_int2tc(
-      get_uint_type(config.ansi_c.int_width), BigInt(str_type.width));
-    type2tc new_type = array_type2tc(get_uint8_type(), width, false);
-    result = convert_sort(new_type);
-    break;
-  }
-
   case type2t::vector_id:
   case type2t::array_id:
   {
@@ -2014,7 +2004,7 @@ smt_astt smt_convt::convert_array_index(const expr2tc &expr)
   }
 
   // Firstly, if it's a string, shortcircuit.
-  if (is_string_type(index.source_value))
+  if (is_constant_string2t(index.source_value))
   {
     smt_astt tmp = convert_ast(src_value);
     return tmp->select(this, newidx);

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -127,28 +127,6 @@ bool base_type_eqt::base_type_eq_rec(const type2tc &type1, const type2tc &type2)
     return base_type_eq_rec(type1, tmp);
   }
 
-  if (type1->type_id == type2t::string_id)
-  {
-    if (is_array_type(type2) && is_bv_type(to_array_type(type2).subtype))
-    {
-      const array_type2t &ref = to_array_type(type2);
-      if (static_cast<const bv_data &>(*ref.subtype.get()).width == 8)
-        // Both are strings, technically
-        return true;
-    }
-  }
-
-  if (type2->type_id == type2t::string_id)
-  {
-    if (is_array_type(type1) && is_bv_type(to_array_type(type1).subtype))
-    {
-      const array_type2t &ref = to_array_type(type1);
-      if (static_cast<const bv_data &>(*ref.subtype.get()).width == 8)
-        // Both are strings, technically
-        return true;
-    }
-  }
-
   if (type1->type_id != type2->type_id)
     return false;
 

--- a/src/util/format_constant.cpp
+++ b/src/util/format_constant.cpp
@@ -20,7 +20,7 @@ std::string format_constantt::operator()(const expr2tc &expr)
     if (is_floatbv_type(expr))
       return ieee_floatt(to_constant_floatbv2t(expr).value).format(*this);
 
-    if (is_string_type(expr))
+    if (is_constant_string2t(expr))
       return to_constant_string2t(expr).value.as_string();
   }
 

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -707,8 +707,7 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     irep_idt thestring = expr.value();
     typet thetype = expr.type();
     assert(thetype.add(typet::a_size).id() == irept::id_constant);
-    exprt &face = (exprt &)thetype.add(typet::a_size);
-    BigInt val = binary2bigint(face.value(), false);
+    type2tc t = migrate_type(thetype);
 
     const irep_idt &kind1 = expr.get("kind");
 
@@ -716,9 +715,6 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
                  : kind1 == string_constantt::k_unicode
                    ? constant_string2t::UNICODE
                    : constant_string2t::DEFAULT;
-
-    type2tc s = migrate_type(thetype.subtype());
-    type2tc t = array_type2tc(s, gen_ulong(val), false);
 
     new_expr_ref = constant_string2tc(t, thestring, kind2);
   }
@@ -1289,10 +1285,10 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
     if (expr.op1().id() == "member_name")
     {
+      const irep_idt &name = expr.op1().get_string("component_name");
       idx = constant_string2tc(
-        array_type2tc(
-          get_uint8_type(), gen_ulong(sizeof("component_name")), false),
-        expr.op1().get_string("component_name"),
+        array_type2tc(get_uint8_type(), gen_ulong(name.size() + 1), false),
+        name,
         constant_string2t::DEFAULT);
     }
     else

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -625,22 +625,6 @@ public:
 
 const floatbv_typet &to_floatbv_type(const typet &type);
 
-class string_typet : public typet
-{
-public:
-  string_typet() : typet(t_string)
-  {
-  }
-
-  friend const string_typet &to_string_type(const typet &type)
-  {
-    assert(type.id() == t_string);
-    return static_cast<const string_typet &>(type);
-  }
-};
-
-const string_typet &to_string_type(const typet &type);
-
 /**
  * @brief This type maps the vectors
  *

--- a/src/util/type.cpp
+++ b/src/util/type.cpp
@@ -35,7 +35,6 @@ irep_idt typet::t_array = dstring("array");
 irep_idt typet::t_pointer = dstring("pointer");
 irep_idt typet::t_reference = dstring("#reference");
 irep_idt typet::t_bv = dstring("bv");
-irep_idt typet::t_string = dstring("string");
 irep_idt typet::t_vector = dstring("vector");
 
 irep_idt typet::t_intcap = dstring("intcap");

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -99,7 +99,6 @@ public:
   static irep_idt t_pointer;
   static irep_idt t_reference;
   static irep_idt t_bv;
-  static irep_idt t_string;
   static irep_idt t_vector;
 
   static irep_idt t_intcap;

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -112,10 +112,6 @@ BigInt type_sizet::size_bits(const type2tc &type) const
   case type2t::pointer_id:
     return type->get_width();
 
-  case type2t::string_id:
-    // TODO: Strings of wchar will return the wrong result here
-    return to_string_type(type).width * config.ansi_c.char_width;
-
   case type2t::vector_id:
   case type2t::array_id:
   {
@@ -219,10 +215,6 @@ expr2tc type_sizet::size_bits_expr(const type2tc &type) const
   case type2t::floatbv_id:
   case type2t::pointer_id:
     return bitsize(type->get_width());
-
-  case type2t::string_id:
-    // TODO: Strings of wchar will return the wrong result here
-    return bitsize(to_string_type(type).width * config.ansi_c.char_width);
 
   case type2t::array_id:
   case type2t::vector_id:
@@ -343,10 +335,6 @@ expr2tc type_sizet::pointer_offset_bits(const expr2tc &expr) const
     {
       const array_type2t &arr_type = to_array_type(index.source_value->type);
       sub_size = size_bits_expr(arr_type.subtype);
-    }
-    else if (is_string_type(index.source_value))
-    {
-      sub_size = gen_ulong(64);
     }
     else
     {


### PR DESCRIPTION
These 2 types are only used for constant-string expressions (string literals in the given source code). In C/C++ they have (const) array type, nothing special. Removing the special-casing of string types simplifies the code and doesn't lead to any obvious regressions.

Master:
```
Statistics:          23805 Files
  correct:           14435
    correct true:     8012
    correct false:    6423
  incorrect:            25
    incorrect true:     15
    incorrect false:    10
  unknown:            9345
  Score:             21807 (max: 38482)

https://github.com/esbmc/esbmc/actions/runs/7249259396
```
This PR:
```
Statistics:          23805 Files
  correct:           14461
    correct true:     8025
    correct false:    6436
  incorrect:            28
    incorrect true:     16
    incorrect false:    12
  unknown:            9316
  Score:             21782 (max: 38482)

https://github.com/esbmc/esbmc/actions/runs/7250081086
```
I've checked the 3x new timeout -> incorrect: they're already incorrect on master:
- no-data-race: c/pthread-driver-races/char_pc8736x_gpio_pc8736x_gpio_change_pc8736x_gpio_current.i
- unreach-call:
  - c/ldv-linux-3.14/linux-3.14_linux-kernel-locking-spinlock_drivers-net-ethernet-myricom-myri10ge-myri10ge.cil.i
  - c/pthread/triangular-longest-2.i

The rest is timeout noise.