### PR TITLE
Python frontend: Class definition and instantiation

### DIFF
--- a/regression/python/classes-fail/main.py
+++ b/regression/python/classes-fail/main.py
@@ -1,0 +1,6 @@
+class Foo:
+    def __init__(self, value: int):
+        self.blah:int = value
+        x:int = 1/self.blah
+
+f:Foo = Foo(0)

--- a/regression/python/classes-fail/main.py
+++ b/regression/python/classes-fail/main.py
@@ -3,4 +3,4 @@ class Foo:
         self.blah:int = value
         x:int = 1/self.blah
 
-f:Foo = Foo(0)
+f = Foo(0)

--- a/regression/python/classes-fail/test.desc
+++ b/regression/python/classes-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -4,13 +4,13 @@ class MyClass:
 
 
 obj1 = MyClass(5)
-#assert(obj1.data == 5)
+assert(obj1.data == 5)
 obj1.data = 10
 assert(obj1.data == 10)
 obj1.data = 20
 assert(obj1.data == 20)
 
 obj2 = MyClass(30)
-# assert(obj2.data == 30)
+assert(obj2.data == 30)
 obj2.data = 40
 assert(obj2.data == 40)

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -1,0 +1,16 @@
+class MyClass:
+    def __init__(self, value: int):
+        self.data:int = value
+
+
+obj1 = MyClass(5)
+#assert(obj1.data == 5)
+obj1.data = 10
+assert(obj1.data == 10)
+obj1.data = 20
+assert(obj1.data == 20)
+
+obj2 = MyClass(30)
+# assert(obj2.data == 30)
+obj2.data = 40
+assert(obj2.data == 40)

--- a/regression/python/classes/test.desc
+++ b/regression/python/classes/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -24,8 +24,8 @@ bool clang_c_adjust::adjust()
   // warning! hash-table iterators are not stable
 
   symbol_listt symbol_list;
-  context.Foreach_operand_in_order(
-    [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
+  context.Foreach_operand_in_order([&symbol_list](symbolt &s)
+                                   { symbol_list.push_back(&s); });
 
   // Adjust types first, so that symbolic-type resolution always receives
   // fixed up types.
@@ -236,6 +236,8 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
     }
     else if (statement == "nondet")
     {
+      /* Bypassing side effects with `nondet` as a statement since
+       * the goto layer can handle it. */
     }
     else
     {

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -24,8 +24,8 @@ bool clang_c_adjust::adjust()
   // warning! hash-table iterators are not stable
 
   symbol_listt symbol_list;
-  context.Foreach_operand_in_order([&symbol_list](symbolt &s)
-                                   { symbol_list.push_back(&s); });
+  context.Foreach_operand_in_order(
+    [&symbol_list](symbolt &s) { symbol_list.push_back(&s); });
 
   // Adjust types first, so that symbolic-type resolution always receives
   // fixed up types.

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -234,6 +234,9 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
     else if (statement == "gcc_conditional_expression")
     {
     }
+    else if (statement == "nondet")
+    {
+    }
     else
     {
       log_error("unknown side effect: {} at {}", statement, expr.location());

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -2,7 +2,6 @@
 
 namespace json_utils
 {
-
 template <typename JsonType>
 bool is_class(const std::string &name, const JsonType &json)
 {

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace json_utils
+{
+
+template <typename JsonType>
+bool is_class(const std::string &name, const JsonType &json)
+{
+  for (const auto &elem : json)
+  {
+    if (elem["_type"] == "ClassDef" && elem["name"] == name)
+      return true;
+  }
+  return false;
+}
+
+} // namespace json_utils

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -132,8 +132,17 @@ private:
 
         // lhs
         auto target = element["targets"][0];
-        int col_offset = target["col_offset"].template get<int>() +
-                         target["id"].template get<std::string>().size() + 1;
+        std::string id;
+        if (target.contains("id"))
+          id = target["id"];
+        else if (target["_type"] == "Attribute")
+          id = target["value"]["id"].template get<std::string>() + "." +
+               target["attr"].template get<std::string>(); // e.g. f.blah
+
+        assert(!id.empty());
+
+        int col_offset =
+          target["col_offset"].template get<int>() + id.size() + 1;
 
         // Add annotation field
         element["annotation"] = {

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -115,6 +115,13 @@ private:
             }
           }
         }
+        // Get type from constructor call
+        else if (
+          element["value"]["_type"] == "Call" &&
+          is_class(element["value"]["func"]["id"]))
+        {
+          type = element["value"]["func"]["id"];
+        }
         else
           continue;
 
@@ -156,6 +163,26 @@ private:
         element["value"]["end_col_offset"] =
           element["value"]["end_col_offset"].template get<int>() + type.size() +
           1;
+
+        if (element["value"].contains("args"))
+        {
+          for (auto &arg : element["value"]["args"])
+          {
+            arg["col_offset"] =
+              arg["col_offset"].template get<int>() + type.size() + 1;
+            arg["end_col_offset"] =
+              arg["end_col_offset"].template get<int>() + type.size() + 1;
+          }
+        }
+        if (element["value"].contains("func"))
+        {
+          element["value"]["func"]["col_offset"] =
+            element["value"]["func"]["col_offset"].template get<int>() +
+            type.size() + 1;
+          element["value"]["func"]["end_col_offset"] =
+            element["value"]["func"]["end_col_offset"].template get<int>() +
+            type.size() + 1;
+        }
       }
     }
   }
@@ -187,6 +214,16 @@ private:
       }
     }
     return Json();
+  }
+
+  bool is_class(const std::string &classname) const
+  {
+    for (const auto &elem : ast_["body"])
+    {
+      if (elem["_type"] == "ClassDef" && elem["name"] == classname)
+        return true;
+    }
+    return false;
   }
 
   Json &ast_;

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <python-frontend/json_utils.h>
 #include <util/message.h>
 #include <string>
 
@@ -118,7 +119,8 @@ private:
         // Get type from constructor call
         else if (
           element["value"]["_type"] == "Call" &&
-          is_class(element["value"]["func"]["id"]))
+          json_utils::is_class<Json>(
+            element["value"]["func"]["id"], ast_["body"]))
         {
           type = element["value"]["func"]["id"];
         }
@@ -223,16 +225,6 @@ private:
       }
     }
     return Json();
-  }
-
-  bool is_class(const std::string &classname) const
-  {
-    for (const auto &elem : ast_["body"])
-    {
-      if (elem["_type"] == "ClassDef" && elem["name"] == classname)
-        return true;
-    }
-    return false;
   }
 
   Json &ast_;

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -132,14 +132,15 @@ private:
         // Update type field
         element["_type"] = "AnnAssign";
 
-        // lhs
         auto target = element["targets"][0];
         std::string id;
+        // Get lhs from simple variables on assignments.
         if (target.contains("id"))
           id = target["id"];
+        // Get lhs from members access on assignments. e.g.: x.data = 10
         else if (target["_type"] == "Attribute")
           id = target["value"]["id"].template get<std::string>() + "." +
-               target["attr"].template get<std::string>(); // e.g. f.blah
+               target["attr"].template get<std::string>();
 
         assert(!id.empty());
 
@@ -175,6 +176,8 @@ private:
           element["value"]["end_col_offset"].template get<int>() + type.size() +
           1;
 
+        /* Adjust column offset node on lines involving function
+         * calls with arguments */
         if (element["value"].contains("args"))
         {
           for (auto &arg : element["value"]["args"])
@@ -185,6 +188,7 @@ private:
               arg["end_col_offset"].template get<int>() + type.size() + 1;
           }
         }
+        // Adjust column offset in function call node
         if (element["value"].contains("func"))
         {
           element["value"]["func"]["col_offset"] =

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -387,9 +387,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     if (is_constructor_call(element))
     {
       // Insert class name in the symbol id
-      std::size_t pos = symbol_id.rfind("@F");
+      std::size_t pos = symbol_id.rfind("@F@");
       if (pos != std::string::npos)
-        symbol_id.insert(pos - 2, "@C@" + func_name);
+        symbol_id.insert(pos, "@C@" + func_name);
     }
 
     const symbolt *func_symbol = context.find_symbol(symbol_id.c_str());

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -488,7 +488,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
 
       // Get object type name from symbol. e.g.: tag-MyClass
       std::string obj_type_name;
-      for (const auto &it : symbol->type.get_named_sub())
+      const typet &symbol_type =
+        (symbol->type.is_pointer()) ? symbol->type.subtype() : symbol->type;
+      for (const auto &it : symbol_type.get_named_sub())
       {
         if (it.first == "identifier")
           obj_type_name = it.second.id_string();
@@ -923,6 +925,7 @@ void python_converter::get_class_definition(const nlohmann::json &class_node)
     if (class_member["_type"] == "FunctionDef")
     {
       get_attributes_from_self(class_member["body"], clazz);
+      added_symbol->type = clazz;
 
       std::string method_name = class_member["name"].get<std::string>();
       if (method_name == "__init__")

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -127,7 +127,7 @@ static ExpressionType get_expression_type(const nlohmann::json &element)
   {
     return ExpressionType::LITERAL;
   }
-  if (type == "Name")
+  if (type == "Name" || type == "Attribute")
   {
     return ExpressionType::VARIABLE_REF;
   }
@@ -454,8 +454,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
   }
   case ExpressionType::VARIABLE_REF:
   {
-    // Find the variable declaration in the current function
-    std::string var_name = element["id"].get<std::string>();
+    std::string var_name;
+    if (element["_type"] == "Name")
+      var_name = element["id"].get<std::string>();
+    else if (element["_type"] == "Attribute")
+      var_name = element["attr"].get<std::string>();
+
+    assert(!var_name.empty());
+
     std::string symbol_id = create_symbol_id() + std::string("@") + var_name;
     symbolt *symbol = context.find_symbol(symbol_id);
     if (!symbol)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -466,7 +466,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     symbolt *symbol = context.find_symbol(symbol_id);
     if (!symbol)
     {
-      log_error("Symbol not found\n");
+      log_error("Symbol not found: {}\n", symbol_id.c_str());
       abort();
     }
     expr = symbol_expr(*symbol);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -33,6 +33,8 @@ private:
   void adjust_statement_types(exprt &lhs, exprt &rhs) const;
   std::string create_symbol_id() const;
   bool is_constructor_call(const nlohmann::json &json);
+  typet get_typet(const std::string &ast_type);
+  typet get_typet(const nlohmann::json &elem);
 
   contextt &context;
   typet current_element_type;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -46,4 +46,5 @@ private:
   const nlohmann::json &ast_json;
   std::string current_func_name;
   std::string current_class_name;
+  exprt* ref_instance;
 };

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -46,5 +46,5 @@ private:
   const nlohmann::json &ast_json;
   std::string current_func_name;
   std::string current_class_name;
-  exprt* ref_instance;
+  exprt *ref_instance;
 };

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -30,8 +30,8 @@ private:
 
   const nlohmann::json
   find_var_decl(const std::string &var_name, const nlohmann::json &json);
-
   void adjust_statement_types(exprt &lhs, exprt &rhs) const;
+  std::string create_symbol_id() const;
 
   contextt &context;
   typet current_element_type;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -8,10 +8,7 @@ class codet;
 class python_converter
 {
 public:
-  python_converter(contextt &_context, const nlohmann::json &ast)
-    : context(_context), ast_json(ast), current_func_name("")
-  {
-  }
+  python_converter(contextt &_context, const nlohmann::json &ast);
   bool convert();
 
 private:
@@ -20,6 +17,7 @@ private:
   void
   get_return_statements(const nlohmann::json &ast_node, codet &target_block);
   void get_function_definition(const nlohmann::json &function_node);
+  void get_class_definition(const nlohmann::json &class_node);
 
   locationt get_location_from_decl(const nlohmann::json &ast_node);
   exprt get_expr(const nlohmann::json &element);
@@ -40,4 +38,5 @@ private:
   std::string python_filename;
   const nlohmann::json &ast_json;
   std::string current_func_name;
+  std::string current_class_name;
 };

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -32,6 +32,7 @@ private:
   find_var_decl(const std::string &var_name, const nlohmann::json &json);
   void adjust_statement_types(exprt &lhs, exprt &rhs) const;
   std::string create_symbol_id() const;
+  bool is_constructor_call(const nlohmann::json &json);
 
   contextt &context;
   typet current_element_type;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 
 class codet;
+class struct_typet;
 
 class python_converter
 {
@@ -35,6 +36,9 @@ private:
   bool is_constructor_call(const nlohmann::json &json);
   typet get_typet(const std::string &ast_type);
   typet get_typet(const nlohmann::json &elem);
+  void get_attributes_from_self(
+    const nlohmann::json &method_body,
+    struct_typet &clazz);
 
   contextt &context;
   typet current_element_type;

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -10,6 +10,7 @@ enum class StatementType
   EXPR,
   RETURN,
   ASSERT,
+  CLASS_DEFINITION,
   UNKNOWN,
 };
 

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -1,6 +1,7 @@
 #include <python-frontend/python_language.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_annotation.h>
+#include <clang-cpp-frontend/clang_cpp_adjust.h>
 #include <util/message.h>
 #include <util/filesystem.h>
 #include <util/c_expr2string.h>
@@ -94,7 +95,14 @@ bool python_languaget::typecheck(
   const std::string & /*module*/)
 {
   python_converter converter(context, ast);
-  return converter.convert();
+  if (converter.convert())
+    return true;
+
+  clang_cpp_adjust adjuster(context);
+  if (adjuster.adjust())
+    return true;
+
+  return false;
 }
 
 void python_languaget::show_parse(std::ostream &out)

--- a/unit/python-frontend/python_annotation_test.cpp
+++ b/unit/python-frontend/python_annotation_test.cpp
@@ -665,4 +665,387 @@ TEST_CASE("Add type annotation")
 
     REQUIRE(input_json == expected_output);
   }
+
+  SECTION("Get LHS type from constructor call")
+  {
+    std::istringstream input_data(R"json({
+    "_type": "Module",
+    "body": [
+        {
+            "_type": "ClassDef",
+            "bases": [],
+            "body": [
+                {
+                    "_type": "FunctionDef",
+                    "args": {
+                        "_type": "arguments",
+                        "args": [
+                            {
+                                "_type": "arg",
+                                "annotation": null,
+                                "arg": "self",
+                                "col_offset": 17,
+                                "end_col_offset": 21,
+                                "end_lineno": 2,
+                                "lineno": 2,
+                                "type_comment": null
+                            },
+                            {
+                                "_type": "arg",
+                                "annotation": {
+                                    "_type": "Name",
+                                    "col_offset": 30,
+                                    "ctx": {
+                                        "_type": "Load"
+                                    },
+                                    "end_col_offset": 33,
+                                    "end_lineno": 2,
+                                    "id": "int",
+                                    "lineno": 2
+                                },
+                                "arg": "value",
+                                "col_offset": 23,
+                                "end_col_offset": 33,
+                                "end_lineno": 2,
+                                "lineno": 2,
+                                "type_comment": null
+                            }
+                        ],
+                        "defaults": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "kwonlyargs": [],
+                        "posonlyargs": [],
+                        "vararg": null
+                    },
+                    "body": [
+                        {
+                            "_type": "AnnAssign",
+                            "annotation": {
+                                "_type": "Name",
+                                "col_offset": 18,
+                                "ctx": {
+                                    "_type": "Load"
+                                },
+                                "end_col_offset": 21,
+                                "end_lineno": 3,
+                                "id": "int",
+                                "lineno": 3
+                            },
+                            "col_offset": 8,
+                            "end_col_offset": 29,
+                            "end_lineno": 3,
+                            "lineno": 3,
+                            "simple": 0,
+                            "target": {
+                                "_type": "Attribute",
+                                "attr": "blah",
+                                "col_offset": 8,
+                                "ctx": {
+                                    "_type": "Store"
+                                },
+                                "end_col_offset": 17,
+                                "end_lineno": 3,
+                                "lineno": 3,
+                                "value": {
+                                    "_type": "Name",
+                                    "col_offset": 8,
+                                    "ctx": {
+                                        "_type": "Load"
+                                    },
+                                    "end_col_offset": 12,
+                                    "end_lineno": 3,
+                                    "id": "self",
+                                    "lineno": 3
+                                }
+                            },
+                            "value": {
+                                "_type": "Name",
+                                "col_offset": 24,
+                                "ctx": {
+                                    "_type": "Load"
+                                },
+                                "end_col_offset": 29,
+                                "end_lineno": 3,
+                                "id": "value",
+                                "lineno": 3
+                            }
+                        }
+                    ],
+                    "col_offset": 4,
+                    "decorator_list": [],
+                    "end_col_offset": 29,
+                    "end_lineno": 3,
+                    "lineno": 2,
+                    "name": "__init__",
+                    "returns": null,
+                    "type_comment": null
+                }
+            ],
+            "col_offset": 0,
+            "decorator_list": [],
+            "end_col_offset": 29,
+            "end_lineno": 3,
+            "keywords": [],
+            "lineno": 1,
+            "name": "Foo"
+        },
+        {
+            "_type": "Assign",
+            "col_offset": 0,
+            "end_col_offset": 10,
+            "end_lineno": 6,
+            "lineno": 6,
+            "targets": [
+                {
+                    "_type": "Name",
+                    "col_offset": 0,
+                    "ctx": {
+                        "_type": "Store"
+                    },
+                    "end_col_offset": 1,
+                    "end_lineno": 6,
+                    "id": "f",
+                    "lineno": 6
+                }
+            ],
+            "type_comment": null,
+            "value": {
+                "_type": "Call",
+                "args": [
+                    {
+                        "_type": "Constant",
+                        "col_offset": 8,
+                        "end_col_offset": 9,
+                        "end_lineno": 6,
+                        "kind": null,
+                        "lineno": 6,
+                        "n": 0,
+                        "s": 0,
+                        "value": 0
+                    }
+                ],
+                "col_offset": 4,
+                "end_col_offset": 10,
+                "end_lineno": 6,
+                "func": {
+                    "_type": "Name",
+                    "col_offset": 4,
+                    "ctx": {
+                        "_type": "Load"
+                    },
+                    "end_col_offset": 7,
+                    "end_lineno": 6,
+                    "id": "Foo",
+                    "lineno": 6
+                },
+                "keywords": [],
+                "lineno": 6
+            }
+        }
+    ],
+    "filename": "main.py",
+    "type_ignores": []
+    })json");
+
+    nlohmann::json input_json;
+    input_data >> input_json;
+
+    std::istringstream output_data(R"json({
+    "_type": "Module",
+    "body": [
+        {
+            "_type": "ClassDef",
+            "bases": [],
+            "body": [
+                {
+                    "_type": "FunctionDef",
+                    "args": {
+                        "_type": "arguments",
+                        "args": [
+                            {
+                                "_type": "arg",
+                                "annotation": null,
+                                "arg": "self",
+                                "col_offset": 17,
+                                "end_col_offset": 21,
+                                "end_lineno": 2,
+                                "lineno": 2,
+                                "type_comment": null
+                            },
+                            {
+                                "_type": "arg",
+                                "annotation": {
+                                    "_type": "Name",
+                                    "col_offset": 30,
+                                    "ctx": {
+                                        "_type": "Load"
+                                    },
+                                    "end_col_offset": 33,
+                                    "end_lineno": 2,
+                                    "id": "int",
+                                    "lineno": 2
+                                },
+                                "arg": "value",
+                                "col_offset": 23,
+                                "end_col_offset": 33,
+                                "end_lineno": 2,
+                                "lineno": 2,
+                                "type_comment": null
+                            }
+                        ],
+                        "defaults": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "kwonlyargs": [],
+                        "posonlyargs": [],
+                        "vararg": null
+                    },
+                    "body": [
+                        {
+                            "_type": "AnnAssign",
+                            "annotation": {
+                                "_type": "Name",
+                                "col_offset": 18,
+                                "ctx": {
+                                    "_type": "Load"
+                                },
+                                "end_col_offset": 21,
+                                "end_lineno": 3,
+                                "id": "int",
+                                "lineno": 3
+                            },
+                            "col_offset": 8,
+                            "end_col_offset": 29,
+                            "end_lineno": 3,
+                            "lineno": 3,
+                            "simple": 0,
+                            "target": {
+                                "_type": "Attribute",
+                                "attr": "blah",
+                                "col_offset": 8,
+                                "ctx": {
+                                    "_type": "Store"
+                                },
+                                "end_col_offset": 17,
+                                "end_lineno": 3,
+                                "lineno": 3,
+                                "value": {
+                                    "_type": "Name",
+                                    "col_offset": 8,
+                                    "ctx": {
+                                        "_type": "Load"
+                                    },
+                                    "end_col_offset": 12,
+                                    "end_lineno": 3,
+                                    "id": "self",
+                                    "lineno": 3
+                                }
+                            },
+                            "value": {
+                                "_type": "Name",
+                                "col_offset": 24,
+                                "ctx": {
+                                    "_type": "Load"
+                                },
+                                "end_col_offset": 29,
+                                "end_lineno": 3,
+                                "id": "value",
+                                "lineno": 3
+                            }
+                        }
+                    ],
+                    "col_offset": 4,
+                    "decorator_list": [],
+                    "end_col_offset": 29,
+                    "end_lineno": 3,
+                    "lineno": 2,
+                    "name": "__init__",
+                    "returns": null,
+                    "type_comment": null
+                }
+            ],
+            "col_offset": 0,
+            "decorator_list": [],
+            "end_col_offset": 29,
+            "end_lineno": 3,
+            "keywords": [],
+            "lineno": 1,
+            "name": "Foo"
+        },
+        {
+            "_type": "AnnAssign",
+            "annotation": {
+                "_type": "Name",
+                "col_offset": 2,
+                "ctx": {
+                    "_type": "Load"
+                },
+                "end_col_offset": 5,
+                "end_lineno": 6,
+                "id": "Foo",
+                "lineno": 6
+            },
+            "col_offset": 0,
+            "end_col_offset": 14,
+            "end_lineno": 6,
+            "lineno": 6,
+            "simple": 1,
+            "target": {
+                "_type": "Name",
+                "col_offset": 0,
+                "ctx": {
+                    "_type": "Store"
+                },
+                "end_col_offset": 1,
+                "end_lineno": 6,
+                "id": "f",
+                "lineno": 6
+            },
+            "value": {
+                "_type": "Call",
+                "args": [
+                    {
+                        "_type": "Constant",
+                        "col_offset": 12,
+                        "end_col_offset": 13,
+                        "end_lineno": 6,
+                        "kind": null,
+                        "lineno": 6,
+                        "n": 0,
+                        "s": 0,
+                        "value": 0
+                    }
+                ],
+                "col_offset": 8,
+                "end_col_offset": 14,
+                "end_lineno": 6,
+                "func": {
+                    "_type": "Name",
+                    "col_offset": 8,
+                    "ctx": {
+                        "_type": "Load"
+                    },
+                    "end_col_offset": 11,
+                    "end_lineno": 6,
+                    "id": "Foo",
+                    "lineno": 6
+                },
+                "keywords": [],
+                "lineno": 6
+            }
+        }
+    ],
+    "filename": "main.py",
+    "type_ignores": []
+    })json");
+
+    nlohmann::json expected_output;
+    output_data >> expected_output;
+
+    python_annotation<nlohmann::json> ann(input_json);
+    ann.add_type_annotation();
+
+    REQUIRE(input_json.dump(2) == expected_output.dump(2));
+  }
 }


### PR DESCRIPTION
This pull request adds support for class definition and instantiation.
Some relevant details:

- The __init__() method is treated as class constructor.
- In constructor calls like `obj1 = MyClass(..)`, `obj1` is passed as the first argument to the constructor.
- In Python, "Variables defined in the class definition are **class attributes**; they are shared by instances. **Instance attributes** can be set in a method with self.name = value. Both class and instance attributes are accessible through the notation “self.name”, and an instance attribute hides a class attribute with the same name when accessed in this way."(https://docs.python.org/3/reference/compound_stmts.html#class).
- This pull request specifically addresses __instance attributes__. When an attribute is referred by "self" it is added as a field to the corresponding self type. __Class attributes__ will be addressed in a future (perhaps the next) PR.
- The current implementation does not yet consider default inheritance from "object" class. This feature will also be addressed in a subsequent update.