### PR TITLE
Set benchexec job with 30 threads

### DIFF
--- a/scripts/benchexec.sh
+++ b/scripts/benchexec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 BENCHEXEC_BIN=/usr/bin/benchexec
-BENCHEXEC_COMMON_FLAGS="-o ../esbmc-output/ -N 9 ./esbmc.xml --read-only-dir / --overlay-dir /home  -T $TIMEOUT --container"
+BENCHEXEC_COMMON_FLAGS="-o ../esbmc-output/ -N 30 ./esbmc.xml --read-only-dir / --overlay-dir /home  -T $TIMEOUT --container"
 
 # Prepare Environment to run benchexec
 setup_folder () {

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-2.3.dtd">
-<benchmark tool="esbmc" timelimit="15 min" memlimit="6 GB" cpuCores="2">
+<benchmark tool="esbmc" timelimit="15 min" memlimit="6 GB" cpuCores="1">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
 


### PR DESCRIPTION
The VMs config were updated to have more power. With this setup 30s reachability now takes 2h (it was 6h before). The main downside is that it may add more noise now, this shall be handled in another PR that will consider a "benchmarking" configuration.