### PR TITLE
Don't abort when we can't find a string constant

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -19,7 +19,7 @@
 #include <util/string_constant.h>
 #include <util/type_byte_size.h>
 
-static const std::string &get_string_constant(const exprt &expr)
+static const std::string get_string_constant(const exprt &expr)
 {
   if (expr.id() == "typecast" && expr.operands().size() == 1)
     return get_string_constant(expr.op0());
@@ -28,8 +28,7 @@ static const std::string &get_string_constant(const exprt &expr)
     !expr.is_address_of() || expr.operands().size() != 1 ||
     !expr.op0().is_index() || expr.op0().operands().size() != 2)
   {
-    log_error("expected string constant, but got:\n{}", expr);
-    abort();
+    return {};
   }
 
   const exprt &string = expr.op0().op0();

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -19,7 +19,7 @@
 #include <util/string_constant.h>
 #include <util/type_byte_size.h>
 
-static const std::string get_string_constant(const exprt &expr)
+static const std::string &get_string_constant(const exprt &expr)
 {
   if (expr.id() == "typecast" && expr.operands().size() == 1)
     return get_string_constant(expr.op0());
@@ -28,6 +28,7 @@ static const std::string get_string_constant(const exprt &expr)
     !expr.is_address_of() || expr.operands().size() != 1 ||
     !expr.op0().is_index() || expr.op0().operands().size() != 2)
   {
+    log_warning("expected string constant, but got:\n{}", expr);
     return {};
   }
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -19,17 +19,20 @@
 #include <util/string_constant.h>
 #include <util/type_byte_size.h>
 
-static const std::string &get_string_constant(const exprt &expr)
+static void get_string_constant(const exprt &expr, std::string &the_string)
 {
   if (expr.id() == "typecast" && expr.operands().size() == 1)
-    return get_string_constant(expr.op0());
+  {
+    get_string_constant(expr.op0(), the_string);
+    return;
+  }
 
   if (
     !expr.is_address_of() || expr.operands().size() != 1 ||
     !expr.op0().is_index() || expr.op0().operands().size() != 2)
   {
     log_warning("expected string constant, but got:\n{}", expr);
-    return {};
+    return;
   }
 
   const exprt &string = expr.op0().op0();
@@ -44,7 +47,7 @@ static const std::string &get_string_constant(const exprt &expr)
       log_warning("{}", e.what());
     }
 
-  return v.as_string();
+  the_string.append(v.as_string());
 }
 
 static void get_alloc_type_rec(const exprt &src, typet &type, exprt &size)
@@ -563,9 +566,10 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add_instruction(ASSERT);
     migrate_expr(arguments[0], t->guard);
 
-    const std::string &description = arguments.size() == 1
-                                       ? "ESBMC assertion"
-                                       : get_string_constant(arguments[1]);
+    std::string description = "ESBMC assertion";
+    if (arguments.size() != 1)
+      get_string_constant(arguments[1], description);
+
     t->location = function.location();
     t->location.user_provided(true);
     t->location.property("assertion");
@@ -678,8 +682,8 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
 
-    const irep_idt description =
-      "assertion " + id2string(get_string_constant(arguments[0]));
+    std::string description = "assertion ";
+    get_string_constant(arguments[0], description);
 
     if (options.get_bool_option("no-assertions"))
       return;
@@ -702,8 +706,8 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
 
-    const irep_idt description =
-      "assertion " + id2string(get_string_constant(arguments[3]));
+    std::string description = "assertion ";
+    get_string_constant(arguments[3], description);
 
     if (options.get_bool_option("no-assertions"))
       return;
@@ -726,8 +730,8 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
 
-    const std::string description =
-      "assertion " + get_string_constant(arguments[0]);
+    std::string description = "assertion ";
+    get_string_constant(arguments[0], description);
 
     if (options.get_bool_option("no-assertions"))
       return;

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -566,8 +566,10 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add_instruction(ASSERT);
     migrate_expr(arguments[0], t->guard);
 
-    std::string description = "ESBMC assertion";
-    if (arguments.size() != 1)
+    std::string description;
+    if (arguments.size() == 1)
+      description = "ESBMC assertion";
+    else
       get_string_constant(arguments[1], description);
 
     t->location = function.location();


### PR DESCRIPTION
Fixes #2146