### PR TITLE
Support for context-aware intervals

### DIFF
--- a/regression/esbmc/interval-analysis-function-1-false/main.c
+++ b/regression/esbmc/interval-analysis-function-1-false/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int foo(int n)
+{
+  // n: [1,40]
+  assert(n == 42); // always false
+}
+
+
+int main()
+{
+  foo(1);
+  foo(40);
+}

--- a/regression/esbmc/interval-analysis-function-1-false/test.desc
+++ b/regression/esbmc/interval-analysis-function-1-false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION FAILED$

--- a/regression/esbmc/interval-analysis-function-1/main.c
+++ b/regression/esbmc/interval-analysis-function-1/main.c
@@ -9,6 +9,5 @@ int foo(int n)
 
 int main()
 {
-  foo(51);
-  foo(60);
+  foo(42);
 }

--- a/regression/esbmc/interval-analysis-function-1/main.c
+++ b/regression/esbmc/interval-analysis-function-1/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int foo(int n)
+{
+  // n: [51,60]
+  assert(n == 42); // always holds
+}
+
+
+int main()
+{
+  foo(51);
+  foo(60);
+}

--- a/regression/esbmc/interval-analysis-function-1/main.c
+++ b/regression/esbmc/interval-analysis-function-1/main.c
@@ -2,7 +2,7 @@
 
 int foo(int n)
 {
-  // n: [51,60]
+  // n: [42,42]
   assert(n == 42); // always holds
 }
 

--- a/regression/esbmc/interval-analysis-function-1/test.desc
+++ b/regression/esbmc/interval-analysis-function-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/interval-analysis-function-2-false/main.c
+++ b/regression/esbmc/interval-analysis-function-2-false/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+int foo() {
+  return 22;
+}
+
+int main()
+{
+  int A = foo();
+  assert(A == 42);
+  A = foo();
+  assert(A > 40);
+}
+
+

--- a/regression/esbmc/interval-analysis-function-2-false/test.desc
+++ b/regression/esbmc/interval-analysis-function-2-false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION FAILED$

--- a/regression/esbmc/interval-analysis-function-2/main.c
+++ b/regression/esbmc/interval-analysis-function-2/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+int foo() {
+  return 42;
+}
+
+int main()
+{
+  int A = foo();
+  assert(A == 42);
+  A = foo();
+  assert(A > 40);
+}
+
+

--- a/regression/esbmc/interval-analysis-function-2/test.desc
+++ b/regression/esbmc/interval-analysis-function-2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/interval-analysis-function-3-false/main.c
+++ b/regression/esbmc/interval-analysis-function-3-false/main.c
@@ -1,0 +1,14 @@
+int sum(int n)
+{
+  if (n == 0)
+    return 0;
+  int tmp = n + sum(n - 1);
+  return tmp;
+}
+
+int main()
+{
+  int A = 5;
+  int B = sum(A);
+  __ESBMC_assert(B <= 10, "Should be able to verify!");  
+}

--- a/regression/esbmc/interval-analysis-function-3-false/test.desc
+++ b/regression/esbmc/interval-analysis-function-3-false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --interval-analysis-arithmetic
+^VERIFICATION FAILED$

--- a/regression/esbmc/interval-analysis-function-3-false/test.desc
+++ b/regression/esbmc/interval-analysis-function-3-false/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---interval-analysis --interval-analysis-arithmetic
+--interval-analysis
 ^VERIFICATION FAILED$

--- a/regression/esbmc/interval-analysis-function-3/main.c
+++ b/regression/esbmc/interval-analysis-function-3/main.c
@@ -1,0 +1,14 @@
+int sum(int n)
+{
+  if (n == 0)
+    return 0;
+  int tmp = n + sum(n - 1);
+  return tmp;
+}
+
+int main()
+{
+  int A = 5;
+  int B = sum(A);
+  __ESBMC_assert(B == 15, "Should be able to verify!");  
+}

--- a/regression/esbmc/interval-analysis-function-3/test.desc
+++ b/regression/esbmc/interval-analysis-function-3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/interval_can_handle_function_ptr/interval.i
+++ b/regression/esbmc/interval_can_handle_function_ptr/interval.i
@@ -1,5 +1,6 @@
 int c, e = 1;
 
+int a();
 void b();
 void d();
 
@@ -7,8 +8,16 @@ int main()
 {
   // e = [1,1], c = [0,0]
   c = 1;
-  if (c == 1)
+  if (c == 1) {
     b();
+    // e = [2,2]
+    (*a)();
+    // clear everything
+  }
+  else
+  {
+    e = 1;
+  }
   
   d();
 }

--- a/regression/esbmc/interval_can_handle_function_ptr/test.desc
+++ b/regression/esbmc/interval_can_handle_function_ptr/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+interval.i
+--interval-analysis
+^VERIFICATION FAILED$

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -141,7 +141,8 @@ void dump_intervals(
   forall_goto_program_instructions (i_it, goto_function.body)
   {
     const interval_domaint &d = interval_analysis[i_it];
-    auto print_vars = [&out, &i_it](const auto &map) {
+    auto print_vars = [&out, &i_it](const auto &map)
+    {
       for (const auto &interval : map)
       {
         // "state,var,min,max,bot,top";

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -44,25 +44,6 @@ inline void optimize_expr_interval(expr2tc &expr, const interval_domaint &state)
   }
 }
 
-static inline void get_symbols(
-  const expr2tc &expr,
-  std::unordered_set<expr2tc, irep2_hash> &symbols)
-{
-  if (is_nil_expr(expr))
-    return;
-
-  if (is_symbol2t(expr))
-  {
-    symbol2t s = to_symbol2t(expr);
-    if (s.thename.as_string().find("__ESBMC_") != std::string::npos)
-      return;
-    symbols.insert(expr);
-  }
-
-  expr->foreach_operand(
-    [&symbols](const expr2tc &e) -> void { get_symbols(e, symbols); });
-}
-
 static void optimize_expression(expr2tc &expr, const interval_domaint &state)
 {
   // Preconditions

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -141,8 +141,7 @@ void dump_intervals(
   forall_goto_program_instructions (i_it, goto_function.body)
   {
     const interval_domaint &d = interval_analysis[i_it];
-    auto print_vars = [&out, &i_it](const auto &map)
-    {
+    auto print_vars = [&out, &i_it](const auto &map) {
       for (const auto &interval : map)
       {
         // "state,var,min,max,bot,top";

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -40,11 +40,6 @@ void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
   const integer_intervalt value)
 {
-  // TODO: we can't handle globals
-  // as the analysis is not context-aware
-  //
-  if (has_prefix(sym.thename, "c:@"))
-    return;
   int_map[sym.thename] = value;
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -720,8 +720,7 @@ expr2tc interval_domaint::make_expression_helper<wrapped_interval>(
     // Interval: [a,b]
     std::vector<expr2tc> disjuncts;
 
-    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w)
-    {
+    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w) {
       assert(*w.lower <= *w.upper);
 
       std::vector<expr2tc> s_conjuncts;
@@ -770,8 +769,7 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
     return gen_false_expr();
 
   std::vector<expr2tc> conjuncts;
-  auto typecast = [&symbol](expr2tc v)
-  {
+  auto typecast = [&symbol](expr2tc v) {
     c_implicit_typecast(v, symbol->type, *migrate_namespace_lookup);
     return v;
   };
@@ -848,12 +846,10 @@ bool contains_float(const expr2tc &e)
     return true;
 
   bool inner_float = false;
-  e->foreach_operand(
-    [&inner_float](auto &it)
-    {
-      if (contains_float(it))
-        inner_float = true;
-    });
+  e->foreach_operand([&inner_float](auto &it) {
+    if (contains_float(it))
+      inner_float = true;
+  });
 
   return inner_float;
 }
@@ -940,7 +936,7 @@ void interval_domaint::transform(
   case END_FUNCTION:
   case ATOMIC_BEGIN:
   case ATOMIC_END:
-  case NO_INSTRUCTION_TYPE:  
+  case NO_INSTRUCTION_TYPE:
   case OTHER:
   case SKIP:
   case LOCATION:

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -925,6 +925,7 @@ void interval_domaint::transform(
 
     assign(
       code_assign2tc(return_var, to_code_return2t(instruction.code).operand));
+    break;
   }
 
   case ASSERT:
@@ -935,7 +936,20 @@ void interval_domaint::transform(
     break;
   }
 
-  default:;
+  case FUNCTION_CALL:
+  case END_FUNCTION:
+  case ATOMIC_BEGIN:
+  case ATOMIC_END:
+  case NO_INSTRUCTION_TYPE:  
+  case OTHER:
+  case SKIP:
+  case LOCATION:
+  case THROW: // TODO: try/catch intervals
+  case CATCH: // TODO: try/catch intervals
+  case DEAD:
+  case THROW_DECL:
+  case THROW_DECL_END:
+    break;
   }
 
   /* The abstract interpreter can only affect the state 'after' the execution of the statement

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -201,7 +201,10 @@ wrapped_interval interval_domaint::generate_modular_interval<wrapped_interval>(
 }
 
 template <class T>
-void interval_domaint::apply_assignment(const expr2tc &lhs, const expr2tc &rhs, bool recursive)
+void interval_domaint::apply_assignment(
+  const expr2tc &lhs,
+  const expr2tc &rhs,
+  bool recursive)
 {
   assert(is_symbol2t(lhs));
   const symbol2t &sym = to_symbol2t(lhs);
@@ -213,13 +216,13 @@ void interval_domaint::apply_assignment(const expr2tc &lhs, const expr2tc &rhs, 
     auto a = generate_modular_interval<T>(sym);
     b.intersect_with(a);
   }
-  
+
   if (recursive)
   {
     auto previous = get_interval_from_symbol<T>(sym);
     b.join(previous);
   }
-  
+
   // TODO: add classic algorithm
   update_symbol_interval(sym, b);
 }
@@ -717,7 +720,8 @@ expr2tc interval_domaint::make_expression_helper<wrapped_interval>(
     // Interval: [a,b]
     std::vector<expr2tc> disjuncts;
 
-    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w) {
+    auto convert = [this, &src, &symbol, &disjuncts](wrapped_interval &w)
+    {
       assert(*w.lower <= *w.upper);
 
       std::vector<expr2tc> s_conjuncts;
@@ -766,7 +770,8 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
     return gen_false_expr();
 
   std::vector<expr2tc> conjuncts;
-  auto typecast = [&symbol](expr2tc v) {
+  auto typecast = [&symbol](expr2tc v)
+  {
     c_implicit_typecast(v, symbol->type, *migrate_namespace_lookup);
     return v;
   };
@@ -843,10 +848,12 @@ bool contains_float(const expr2tc &e)
     return true;
 
   bool inner_float = false;
-  e->foreach_operand([&inner_float](auto &it) {
-    if (contains_float(it))
-      inner_float = true;
-  });
+  e->foreach_operand(
+    [&inner_float](auto &it)
+    {
+      if (contains_float(it))
+        inner_float = true;
+    });
 
   return inner_float;
 }
@@ -918,9 +925,8 @@ void interval_domaint::transform(
 
     assign(
       code_assign2tc(return_var, to_code_return2t(instruction.code).operand));
-    
   }
-  
+
   case ASSERT:
   {
     // There is a bug in Floats that need to be investigated! regression-float/nextafter
@@ -939,14 +945,13 @@ void interval_domaint::transform(
   if (to->is_function_call())
   {
     const code_function_call2t &code_function_call =
-      to_code_function_call2t( to->code);
+      to_code_function_call2t(to->code);
 
     // We don't know anything about the return value
     if (!is_nil_expr(code_function_call.ret))
     {
       havoc_rec(code_function_call.ret);
     }
-     
 
     assert(is_code_type(code_function_call.function->type));
     const code_type2t &function =
@@ -965,7 +970,7 @@ void interval_domaint::transform(
       get_symbols(arg_value, symbols);
 
       bool is_recursive_arg = symbols.count(arg_symbol);
-      assign(code_assign2tc(arg_symbol, arg_value), is_recursive_arg); 
+      assign(code_assign2tc(arg_symbol, arg_value), is_recursive_arg);
     }
   }
 
@@ -976,7 +981,7 @@ void interval_domaint::transform(
     // TODO: deal with recursive functions
     if (from->function == to->function)
       return;
-    
+
     const code_function_call2t &code_function_call =
       to_code_function_call2t(to->code);
 
@@ -984,10 +989,11 @@ void interval_domaint::transform(
     if (!is_nil_expr(code_function_call.ret))
     {
       expr2tc return_var = symbol2tc(
-      code_function_call.ret->type, fmt::format("c:{}:ret", instruction.function));
-      assign(code_assign2tc(code_function_call.ret, return_var)); 
+        code_function_call.ret->type,
+        fmt::format("c:{}:ret", instruction.function));
+      assign(code_assign2tc(code_function_call.ret, return_var));
     }
-  }   
+  }
 }
 
 template <class IntervalMap>
@@ -1091,7 +1097,7 @@ void interval_domaint::assign(const expr2tc &expr, const bool recursive)
       apply_assignment<integer_intervalt>(c.target, c.source, recursive);
   }
   if (isfloatbvop && enable_real_intervals)
-      apply_assignment<real_intervalt>(c.target, c.source, recursive);
+    apply_assignment<real_intervalt>(c.target, c.source, recursive);
 }
 
 void interval_domaint::havoc_rec(const expr2tc &expr)

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -124,24 +124,27 @@ real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e) const
   value1.increment(true);
   value2.decrement(true);
 
-  if (value1.is_NaN() || value1.is_infinity() || value2.is_NaN() || value2.is_infinity())
+  if (
+    value1.is_NaN() || value1.is_infinity() || value2.is_NaN() ||
+    value2.is_infinity())
   {
     assert(result.is_top() && !result.is_bottom());
     return result;
   }
 
   // [value2, value1]
-  // a <= value1  
-  if(value1.is_double())
+  // a <= value1
+  if (value1.is_double())
     result.make_le_than(value1.to_double());
   else
     log_warning("Failed to convert value1: {}", value1.to_string_decimal(10));
-  
+
   // a >= value2
-  if(value2.is_double())
+  if (value2.is_double())
     result.make_ge_than(value2.to_double());
   else
-    log_warning("Failed to convert value2: {}", value2.to_string_decimal(10));// 
+    log_warning(
+      "Failed to convert value2: {}", value2.to_string_decimal(10)); //
 
   assert(!result.is_bottom());
   return result;

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -980,7 +980,7 @@ void interval_domaint::transform(
     const code_function_call2t &code_function_call =
       to_code_function_call2t(to->code);
 
-    // We don't know anything about the return value
+    // Apply assignment over return value
     if (!is_nil_expr(code_function_call.ret))
     {
       expr2tc return_var = symbol2tc(

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -252,7 +252,7 @@ protected:
    *
    * @param assignment
    */
-  void assign(const expr2tc &assignment);
+  void assign(const expr2tc &assignment, const bool recursive = false);
 
   /**
    * @brief Applies LHS <= RHS and RHS <= LHS from assignment instructions
@@ -264,7 +264,7 @@ protected:
    * @param rhs
    */
   template <class Interval>
-  void apply_assignment(const expr2tc &lhs, const expr2tc &rhs);
+  void apply_assignment(const expr2tc &lhs, const expr2tc &rhs, bool recursive);
 
   /**
    * @brief Applies Extrapolation widening algorithm

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -693,4 +693,23 @@ inline expr2tc distribute_vector_operation(
   return result;
 }
 
+inline void get_symbols(
+  const expr2tc &expr,
+  std::unordered_set<expr2tc, irep2_hash> &symbols)
+{
+  if (is_nil_expr(expr))
+    return;
+
+  if (is_symbol2t(expr))
+  {
+    symbol2t s = to_symbol2t(expr);
+    if (s.thename.as_string().find("__ESBMC_") != std::string::npos)
+      return;
+    symbols.insert(expr);
+  }
+
+  expr->foreach_operand(
+    [&symbols](const expr2tc &e) -> void { get_symbols(e, symbols); });
+}
+
 #endif /* UTIL_IREP2_UTILS_H_ */


### PR DESCRIPTION
This PR enables the abstract domain to have more information about the context where it is invoked. Specifically, this enables:

1. Global variables
2. Reasoning about functions calls: parameters and return values.
3. ~~Disables the interval analysis unit tests due to #1567~~ (solved by PR #1568) 