### PR TITLE
`migrate_namespace_lookup` now managed by language_uit

### DIFF
--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -62,7 +62,7 @@ class c2goto_parseopt : public parseoptions_baset, public language_uit
 {
 public:
   c2goto_parseopt(int argc, const char **argv)
-    : parseoptions_baset(c2goto_options, argc, argv), language_uit(cmdline)
+    : parseoptions_baset(c2goto_options, argc, argv)
   {
   }
 
@@ -81,7 +81,7 @@ public:
       return 1;
     }
 
-    if (parse())
+    if (parse(cmdline))
       return 1;
     if (typecheck())
       return 1;

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1533,7 +1533,7 @@ bool esbmc_parseoptionst::create_goto_program(
 bool esbmc_parseoptionst::read_goto_binary(goto_functionst &goto_functions)
 {
   log_progress("Reading GOTO program from file");
-  for (const auto &arg : _cmdline.args)
+  for (const auto &arg : cmdline.args)
   {
     if (::read_goto_binary(arg, context, goto_functions))
     {
@@ -1555,7 +1555,7 @@ bool esbmc_parseoptionst::parse_goto_program(
 {
   try
   {
-    if (parse())
+    if (parse(cmdline))
       return true;
 
     if (cmdline.isset("parse-tree-too") || cmdline.isset("parse-tree-only"))

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1493,9 +1493,6 @@ bool esbmc_parseoptionst::create_goto_program(
       return true;
     }
 
-    // Ahem
-    migrate_namespace_lookup = new namespacet(context);
-
     // If the user is providing the GOTO functions, we don't need to parse
     if (cmdline.isset("binary"))
     {

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -19,7 +19,7 @@ public:
   void help() override;
 
   esbmc_parseoptionst(int argc, const char **argv)
-    : parseoptions_baset(all_cmd_options, argc, argv), language_uit(cmdline)
+    : parseoptions_baset(all_cmd_options, argc, argv)
   {
   }
 

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -6,8 +6,7 @@
 #include <util/message.h>
 #include <util/show_symbol_table.h>
 
-language_uit::language_uit(const cmdlinet &__cmdline)
-  : ns(context), _cmdline(__cmdline)
+language_uit::language_uit() : ns(context)
 {
   // Ahem
   migrate_namespace_lookup = &ns;
@@ -20,8 +19,7 @@ language_uit::~language_uit() noexcept
 language_uit::language_uit(language_uit &&o) noexcept
   : language_files(std::move(o.language_files)),
     context(std::move(o.context)),
-    ns(context),
-    _cmdline(o._cmdline)
+    ns(context)
 {
   // Ahem
   migrate_namespace_lookup = &ns;
@@ -32,7 +30,6 @@ language_uit &language_uit::operator=(language_uit &&o) noexcept
   language_files = std::move(o.language_files);
   context = std::move(o.context);
   ns = namespacet(context);
-  assert(&_cmdline == &o._cmdline);
 
   // Ahem
   migrate_namespace_lookup = &ns;
@@ -40,9 +37,9 @@ language_uit &language_uit::operator=(language_uit &&o) noexcept
   return *this;
 }
 
-bool language_uit::parse()
+bool language_uit::parse(const cmdlinet &cmdline)
 {
-  for (const auto &arg : _cmdline.args)
+  for (const auto &arg : cmdline.args)
   {
     if (parse(arg))
       return true;
@@ -99,8 +96,9 @@ bool language_uit::parse(const std::string &filename)
 #ifdef ENABLE_SOLIDITY_FRONTEND
   if (mode == get_mode(language_idt::SOLIDITY))
   {
-    if (!config.options.get_option("function").empty())
-      language.set_func_name(_cmdline.vm["function"].as<std::string>());
+    std::string fun = config.options.get_option("function");
+    if (!fun.empty())
+      language.set_func_name(fun);
 
     if (config.options.get_option("sol") == "")
     {

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -12,10 +12,6 @@ language_uit::language_uit() : ns(context)
   migrate_namespace_lookup = &ns;
 }
 
-language_uit::~language_uit() noexcept
-{
-}
-
 language_uit::language_uit(language_uit &&o) noexcept
   : language_files(std::move(o.language_files)),
     context(std::move(o.context)),

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -6,8 +6,38 @@
 #include <util/message.h>
 #include <util/show_symbol_table.h>
 
-language_uit::language_uit(const cmdlinet &__cmdline) : _cmdline(__cmdline)
+language_uit::language_uit(const cmdlinet &__cmdline)
+  : ns(context), _cmdline(__cmdline)
 {
+  // Ahem
+  migrate_namespace_lookup = &ns;
+}
+
+language_uit::~language_uit() noexcept
+{
+}
+
+language_uit::language_uit(language_uit &&o) noexcept
+  : language_files(std::move(o.language_files)),
+    context(std::move(o.context)),
+    ns(context),
+    _cmdline(o._cmdline)
+{
+  // Ahem
+  migrate_namespace_lookup = &ns;
+}
+
+language_uit &language_uit::operator=(language_uit &&o) noexcept
+{
+  language_files = std::move(o.language_files);
+  context = std::move(o.context);
+  ns = namespacet(context);
+  assert(&_cmdline == &o._cmdline);
+
+  // Ahem
+  migrate_namespace_lookup = &ns;
+
+  return *this;
 }
 
 bool language_uit::parse()
@@ -130,5 +160,5 @@ void language_uit::show_symbol_table_xml_ui()
 
 void language_uit::show_symbol_table_plain(std::ostream &out)
 {
-  ::show_symbol_table_plain(namespacet(context), out);
+  ::show_symbol_table_plain(ns, out);
 }

--- a/src/langapi/language_ui.h
+++ b/src/langapi/language_ui.h
@@ -10,9 +10,15 @@ class language_uit
 public:
   language_filest language_files;
   contextt context;
+  namespacet ns;
 
   language_uit(const cmdlinet &__cmdline);
-  virtual ~language_uit() = default;
+  virtual ~language_uit() noexcept;
+
+  /* The instance of this class manages the global migrate_namespace_lookup,
+   * thus it cannot be copied. */
+  language_uit(language_uit &&) noexcept;
+  language_uit &operator=(language_uit &&) noexcept;
 
   virtual bool parse();
   virtual bool parse(const std::string &filename);

--- a/src/langapi/language_ui.h
+++ b/src/langapi/language_ui.h
@@ -13,7 +13,7 @@ public:
   namespacet ns;
 
   language_uit();
-  virtual ~language_uit() noexcept;
+  virtual ~language_uit() noexcept = default;
 
   /* The instance of this class manages the global migrate_namespace_lookup,
    * thus it cannot be copied. */

--- a/src/langapi/language_ui.h
+++ b/src/langapi/language_ui.h
@@ -12,7 +12,7 @@ public:
   contextt context;
   namespacet ns;
 
-  language_uit(const cmdlinet &__cmdline);
+  language_uit();
   virtual ~language_uit() noexcept;
 
   /* The instance of this class manages the global migrate_namespace_lookup,
@@ -20,7 +20,7 @@ public:
   language_uit(language_uit &&) noexcept;
   language_uit &operator=(language_uit &&) noexcept;
 
-  virtual bool parse();
+  virtual bool parse(const cmdlinet &cmdline);
   virtual bool parse(const std::string &filename);
   virtual bool typecheck();
   virtual bool final();
@@ -33,9 +33,6 @@ public:
   virtual void show_symbol_table();
   virtual void show_symbol_table_plain(std::ostream &out);
   virtual void show_symbol_table_xml_ui();
-
-protected:
-  const cmdlinet &_cmdline;
 };
 
 #endif

--- a/src/util/context.h
+++ b/src/util/context.h
@@ -36,6 +36,7 @@ public:
   }
   ~contextt() = default;
   contextt(const contextt &obj) = delete;
+  contextt(contextt &&) noexcept = default;
 
 #ifdef ENABLE_OLD_FRONTEND
   contextt &operator=(const contextt &rhs)
@@ -56,6 +57,8 @@ public:
 #else
   contextt &operator=(const contextt &rhs) = delete;
 #endif
+
+  contextt &operator=(contextt &&) noexcept = default;
 
   symbol_base_mapt symbol_base_map;
 

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -98,9 +98,6 @@ public:
       ait<interval_domaint> baseline;
       run_test<interval_domaint::wrap_mapt>(baseline, true);
     }
-    // A namespace is instatiated at goto_factory::get_goto_functions
-    // and it needs to be released now
-    delete (migrate_namespace_lookup);
   }
 
   static void set_baseline_config()

--- a/unit/goto-programs/loop_unroll.test.cpp
+++ b/unit/goto-programs/loop_unroll.test.cpp
@@ -22,7 +22,8 @@ SCENARIO("the loop unroller detects bounded loops", "[algorithms]")
   GIVEN("An empty goto-functions")
   {
     std::istringstream empty("");
-    auto goto_function = goto_factory::get_goto_functions(empty).functions;
+    program P = goto_factory::get_goto_functions(empty);
+    auto &goto_function = P.functions;
     unsigned functions = 0;
     Forall_goto_functions (it, goto_function)
     {
@@ -32,12 +33,13 @@ SCENARIO("the loop unroller detects bounded loops", "[algorithms]")
   }
   GIVEN("A loopless goto-functions")
   {
-    std::istringstream program(
+    std::istringstream src(
       "int main() {"
       "int a = nondet_int();"
       "return a;"
       "}");
-    auto goto_functions = goto_factory::get_goto_functions(program).functions;
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
 
     bounded_loop_unroller unwind_loops;
     unwind_loops.run(goto_functions);
@@ -47,12 +49,13 @@ SCENARIO("the loop unroller detects bounded loops", "[algorithms]")
   }
   GIVEN("An unbounded loop")
   {
-    std::istringstream program(
+    std::istringstream src(
       "int main() {"
       "while(1) __ESBMC_assert(1,\"\");"
       "return 0;"
       "}");
-    auto goto_functions = goto_factory::get_goto_functions(program).functions;
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
     bounded_loop_unroller unwind_loops;
     unwind_loops.run(goto_functions);
 
@@ -62,13 +65,14 @@ SCENARIO("the loop unroller detects bounded loops", "[algorithms]")
   }
   GIVEN("A bounded crescent-for loop without control-flow")
   {
-    std::istringstream program(
+    std::istringstream src(
       "int main() { "
       "  int a; "
       "  for(int i = 0; i < 5; i++) a = i; "
       "  return 0; "
       "}");
-    auto goto_functions = goto_factory::get_goto_functions(program).functions;
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
     bounded_loop_unroller unwind_loops;
     unwind_loops.run(goto_functions);
 
@@ -78,14 +82,15 @@ SCENARIO("the loop unroller detects bounded loops", "[algorithms]")
   }
   GIVEN("A bounded incremental-for loop with control-flow")
   {
-    std::istringstream program(
+    std::istringstream src(
       "int main() { "
       "  int a; "
       "  for(int i = 0; i < 5; i++) "
       "    if(i == 2) a = 3;"
       "  return 0; "
       "}");
-    auto goto_functions = goto_factory::get_goto_functions(program).functions;
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
     bounded_loop_unroller unwind_loops;
     unwind_loops.run(goto_functions);
 
@@ -95,14 +100,15 @@ SCENARIO("the loop unroller detects bounded loops", "[algorithms]")
   }
   GIVEN("A bounded incremental-for loop with inner-loop")
   {
-    std::istringstream program(
+    std::istringstream src(
       "int main() { "
       "  int a; "
       "  for(int i = 0; i < 5; i++) "
       "    for(int j = 0; j < 4; j++) a = 4;"
       "  return 0; "
       "}");
-    auto goto_functions = goto_factory::get_goto_functions(program).functions;
+    program P = goto_factory::get_goto_functions(src);
+    auto &goto_functions = P.functions;
     bounded_loop_unroller unwind_loops;
     unwind_loops.run(goto_functions);
 

--- a/unit/testing-utils/goto_factory.cpp
+++ b/unit/testing-utils/goto_factory.cpp
@@ -184,28 +184,27 @@ bool goto_factory::parse(language_uit &l)
 
 program goto_factory::get_goto_functions(cmdlinet &cmd, optionst &opts)
 {
-  goto_functionst goto_functions;
-  language_uit lui(cmd);
-  migrate_namespace_lookup = new namespacet(lui.context);
-  if (!goto_factory::parse(lui))
+  program P(cmd);
+
+  if (goto_factory::parse(P))
   {
-    return program(lui.context, goto_functions);
+    goto_functionst &goto_functions = P.functions;
+    goto_convert(P.context, opts, goto_functions);
+
+    namespacet &ns = P.ns;
+    goto_check(ns, opts, goto_functions);
+    // remove no-op's
+    remove_no_op(goto_functions);
+
+    // Remove unreachable code
+    remove_unreachable(goto_functions);
+
+    // recalculate numbers, etc.
+    goto_functions.update();
+
+    // add loop ids
+    goto_functions.compute_loop_numbers();
   }
 
-  goto_convert(lui.context, opts, goto_functions);
-
-  namespacet ns(lui.context);
-  goto_check(ns, opts, goto_functions);
-  // remove no-op's
-  remove_no_op(goto_functions);
-
-  // Remove unreachable code
-  remove_unreachable(goto_functions);
-
-  // recalculate numbers, etc.
-  goto_functions.update();
-
-  // add loop ids
-  goto_functions.compute_loop_numbers();
-  return program(ns, goto_functions);
+  return P;
 }

--- a/unit/testing-utils/goto_factory.cpp
+++ b/unit/testing-utils/goto_factory.cpp
@@ -169,10 +169,10 @@ optionst goto_factory::get_default_options(cmdlinet cmd)
   return options;
 }
 
-bool goto_factory::parse(language_uit &l)
+bool goto_factory::parse(const cmdlinet &cmdline, language_uit &l)
 {
   l.context.clear();
-  if (l.parse())
+  if (l.parse(cmdline))
     return false; // TODO: This can be used to add testcases for frontend
   if (l.typecheck())
     return false;
@@ -184,9 +184,9 @@ bool goto_factory::parse(language_uit &l)
 
 program goto_factory::get_goto_functions(cmdlinet &cmd, optionst &opts)
 {
-  program P(cmd);
+  program P;
 
-  if (goto_factory::parse(P))
+  if (goto_factory::parse(cmd, P))
   {
     goto_functionst &goto_functions = P.functions;
     goto_convert(P.context, opts, goto_functions);

--- a/unit/testing-utils/goto_factory.h
+++ b/unit/testing-utils/goto_factory.h
@@ -4,13 +4,13 @@
 #include <goto-programs/goto_functions.h>
 #include <langapi/language_ui.h>
 
-class program
+class program : public language_uit
 {
 public:
-  namespacet ns;
   goto_functionst functions;
-  program(namespacet ns, goto_functionst &functions)
-    : ns(ns), functions(functions)
+
+  explicit program(const cmdlinet &cmdline)
+    : language_uit(cmdline)
   {
   }
 };
@@ -31,11 +31,11 @@ public:
   };
 
   /**
-     * @brief Get the goto functions object
-     * 
-     * @param c_inputstream input stream containing the C program
-     * @return goto_functionst of the parsed object
-     */
+   * @brief Get the goto functions object
+   *
+   * @param c_inputstream input stream containing the C program
+   * @return goto_functionst of the parsed object
+   */
   static program get_goto_functions(
     std::istream &c_inputstream,
     goto_factory::Architecture arch = goto_factory::Architecture::BIT_16);

--- a/unit/testing-utils/goto_factory.h
+++ b/unit/testing-utils/goto_factory.h
@@ -8,11 +8,6 @@ class program : public language_uit
 {
 public:
   goto_functionst functions;
-
-  explicit program(const cmdlinet &cmdline)
-    : language_uit(cmdline)
-  {
-  }
 };
 
 /**
@@ -54,7 +49,7 @@ public:
   static optionst get_default_options(cmdlinet cmd);
 
 private:
-  static bool parse(language_uit &l);
+  static bool parse(const cmdlinet &cmdline, language_uit &l);
   static void
   create_file_from_istream(std::istream &c_inputstream, std::string filename);
   static void create_file_from_string(std::string &str, std::string filename);


### PR DESCRIPTION
This PR moves the initialization and management of the global `migrate_namespace_lookup` from the various entry routines to the `language_uit` class, which also holds the context that ends up being used throughout goto and symex. This change should fix #1567 by keeping the context alive after goto_factory::get_goto_functions() ends.

For this to work it was necessary to introduce move-constructors for `contextt` and `language_uit`. The copy/move ctors weren't being used before, so this change just adds a way to move objects of those two types. Each has different reasons why copy construction isn't supported.