### PR TITLE
Fix gcc-13 warnings

### DIFF
--- a/scripts/cmake/ExternalDependencies.cmake
+++ b/scripts/cmake/ExternalDependencies.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 # FMT
 FetchContent_Declare(fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 9.1.0)
+  GIT_TAG 10.2.0)
 FetchContent_MakeAvailable(fmt)
 
 #nlohmann json

--- a/src/c2goto/c2goto.cpp
+++ b/src/c2goto/c2goto.cpp
@@ -73,7 +73,7 @@ public:
     if (config.set(cmdline))
       return 1;
     config.options.cmdline(cmdline);
-    set_verbosity_msg(VerbosityLevel::Debug);
+    set_verbosity_msg(VerbosityLevel::Result);
 
     if (!cmdline.isset("output"))
     {

--- a/src/c2goto/library/setjmp.c
+++ b/src/c2goto/library/setjmp.c
@@ -5,12 +5,13 @@
 int setjmp(jmp_buf __env)
 {
   __ESBMC_unreachable();
+  return nondet_int();
 }
 
 // Due to some macro expansion some programs may have the _setjmp instead
 int _setjmp(jmp_buf __env)
 {
-  setjmp(__env);
+  return setjmp(__env);
 }
 
 void longjmp(jmp_buf env, int status)

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -1462,7 +1462,7 @@ exprt cpp_typecheck_resolvet::resolve(
       result.type() = pointer_typet();
       result.type().subtype() = empty_typet();
       result.location() = location;
-      return std::move(result);
+      return result;
     }
     else if (
       base_name == "__func__" || base_name == "__FUNCTION__" ||
@@ -1472,7 +1472,7 @@ exprt cpp_typecheck_resolvet::resolve(
       // __FUNCTION__ and __PRETTY_FUNCTION__ are GCC-specific
       string_constantt s(location.get_function());
       s.location() = location;
-      return std::move(s);
+      return s;
     }
   }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -63,6 +63,14 @@ extern "C"
 #include <goto-programs/goto_contractor.h>
 #endif
 
+extern "C" const char buildidstring_buf[];
+extern "C" const unsigned int buildidstring_buf_size;
+
+static std::string_view esbmc_version_string()
+{
+  return {buildidstring_buf, buildidstring_buf_size};
+}
+
 enum PROCESS_TYPE
 {
   BASE_CASE,
@@ -88,8 +96,6 @@ void timeout_handler(int)
   _exit(1);
 }
 #endif
-
-extern "C" const char *const esbmc_version_string;
 
 // This transforms a string representation of a time interval
 // written in the form <number><suffix> into seconds.
@@ -242,7 +248,7 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
 
   if (cmdline.isset("git-hash"))
   {
-    log_result("{}", esbmc_version_string);
+    log_result("{}", esbmc_version_string());
     exit(0);
   }
 

--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -1,4 +1,5 @@
 #include <langapi/mode.h>
+#include <cstdint>
 
 const mode_table_et mode_table[] = {
   LANGAPI_MODE_CLANG_C,

--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -1,5 +1,4 @@
 #include <langapi/mode.h>
-#include <cstdint>
 
 const mode_table_et mode_table[] = {
   LANGAPI_MODE_CLANG_C,
@@ -20,6 +19,3 @@ const mode_table_et mode_table[] = {
   LANGAPI_MODE_PYTHON,
 #endif
   LANGAPI_MODE_END};
-
-extern "C" const uint8_t buildidstring_buf[];
-extern "C" const uint8_t *const esbmc_version_string = buildidstring_buf;

--- a/src/jimple-frontend/AST/jimple_method_body.cpp
+++ b/src/jimple-frontend/AST/jimple_method_body.cpp
@@ -49,14 +49,20 @@ void jimple_full_method_body::from_json(const json &stmts)
      * To solve this, we threat the location as a Statement.
      */
   int inner_location = -1;
-  for (auto &stmt : stmts)
+  for (const json &stmt : stmts)
   {
     std::shared_ptr<jimple_method_field> to_add;
 
     auto mode = stmt.at("object").get<std::string>();
     // I think that this is the best way without
     // adding some crazy function pointer.
-    switch (from_map[mode])
+    auto it = from_map.find(mode);
+    if (it == from_map.end())
+    {
+      log_error("Unknown type {}", stmt.dump(2));
+      abort();
+    }
+    switch (it->second)
     {
     case statement::Declaration:
     {
@@ -149,7 +155,10 @@ void jimple_full_method_body::from_json(const json &stmts)
       break;
     }
     default:
-      log_error("Unknown type {}", stmt);
+      log_error(
+        "unsupported jimple statement id {} for key '{}'",
+        static_cast<std::underlying_type_t<statement>>(it->second),
+        it->first);
       abort();
     }
 

--- a/src/util/c_types.cpp
+++ b/src/util/c_types.cpp
@@ -10,7 +10,7 @@ typet build_float_type(unsigned width)
     fixedbv_typet result;
     result.set_width(width);
     result.set_integer_bits(width / 2);
-    return std::move(result);
+    return result;
   }
   floatbv_typet result;
   result.set_width(width);
@@ -36,7 +36,7 @@ typet build_float_type(unsigned width)
     assert(false);
   }
 
-  return std::move(result);
+  return result;
 }
 
 type2tc build_float_type2(unsigned width)

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1855,7 +1855,7 @@ typet migrate_type_back(const type2tc &ref)
     thetype.set("tag", irep_idt(ref2.name));
     if (ref2.packed)
       thetype.set("packed", true);
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::union_id:
   {
@@ -1878,7 +1878,7 @@ typet migrate_type_back(const type2tc &ref)
 
     thetype.components() = comps;
     thetype.set("tag", irep_idt(ref2.name));
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::code_id:
   {
@@ -1903,7 +1903,7 @@ typet migrate_type_back(const type2tc &ref)
     if (ref2.ellipsis)
       code.make_ellipsis();
 
-    return std::move(code);
+    return code;
   }
   case type2t::array_id:
   {
@@ -1920,7 +1920,7 @@ typet migrate_type_back(const type2tc &ref)
       thetype.size() = migrate_expr_back(ref2.array_size);
     }
 
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::vector_id:
   {
@@ -1931,7 +1931,7 @@ typet migrate_type_back(const type2tc &ref)
     assert(!ref2.size_is_infinite);
     thetype.size() = migrate_expr_back(ref2.array_size);
 
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::pointer_id:
   {
@@ -1939,7 +1939,7 @@ typet migrate_type_back(const type2tc &ref)
 
     typet subtype = migrate_type_back(ref2.subtype);
     pointer_typet thetype(subtype);
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::unsignedbv_id:
   {
@@ -1960,7 +1960,7 @@ typet migrate_type_back(const type2tc &ref)
     fixedbv_typet thetype;
     thetype.set_integer_bits(ref2.integer_bits);
     thetype.set_width(ref2.width);
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::floatbv_id:
   {
@@ -1969,7 +1969,7 @@ typet migrate_type_back(const type2tc &ref)
     floatbv_typet thetype;
     thetype.set_f(ref2.fraction);
     thetype.set_width(ref2.get_width());
-    return std::move(thetype);
+    return thetype;
   }
   case type2t::cpp_name_id:
   {
@@ -2019,7 +2019,7 @@ exprt migrate_expr_back(const expr2tc &ref)
     constant_exprt theexpr(thetype);
     unsigned int width = atoi(thetype.width().as_string().c_str());
     theexpr.set_value(integer2binary(ref2.value, width));
-    return std::move(theexpr);
+    return theexpr;
   }
   case expr2t::constant_fixedbv_id:
   {
@@ -2127,7 +2127,7 @@ exprt migrate_expr_back(const expr2tc &ref)
       // Special case.
       constant_exprt const_expr(migrate_type_back(ref2.type));
       const_expr.set_value(ref2.get_symbol_name());
-      return std::move(const_expr);
+      return const_expr;
     }
     else if (ref2.thename == "INVALID")
     {
@@ -2146,7 +2146,7 @@ exprt migrate_expr_back(const expr2tc &ref)
 
     typecast_exprt new_expr(migrate_expr_back(ref2.from), thetype);
     new_expr.set("rounding_mode", migrate_expr_back(ref2.rounding_mode));
-    return std::move(new_expr);
+    return new_expr;
   }
   case expr2t::nearbyint_id:
   {
@@ -2167,7 +2167,7 @@ exprt migrate_expr_back(const expr2tc &ref)
       migrate_expr_back(ref2.true_value),
       migrate_expr_back(ref2.false_value));
     theif.type() = thetype;
-    return std::move(theif);
+    return theif;
   }
   case expr2t::equality_id:
   {


### PR DESCRIPTION
Even if it's not spring, yet, this PR does a bit of spring-cleaning:

Fixes a bunch of compiler warnings new in GCC-13 (compared to v12):
- unnecessary std::move in return statements
- Jimple frontend: suspicious handling of error cases + fmt-lib usage
- update fmt-lib to v10.2.0 due to use of possibly dangling references (for expr2t parameters) fixed in v10.1.1

Besides that:
- reset c2goto verbosity to Result for a cleaner build log
- setjmp() OM: return nondet value to avoid Clang warning
- change esbmc_version_string to function and move it (and fixed dependencies) out of globals.cpp