### PR TITLE
Work around macOS libc limitation for string-constant charset conversion

### DIFF
--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -32,32 +32,6 @@ string_constantt::string_constantt(
   set("kind", kind);
 }
 
-namespace
-{
-/* RAII-like type to temporarily switch the locale */
-struct switch_locale
-{
-  std::string orig;
-  int cat;
-
-  switch_locale(int cat, const char *loc)
-    : orig(setlocale(cat, nullptr)), cat(cat)
-  {
-    const char *n = setlocale(cat, loc);
-    if (!n)
-      throw fmt::format("locale '{}' not found", loc);
-    log_debug(
-      "convert_mb", "switching from locale '{}' to '{}' -> '{}'", orig, loc, n);
-  }
-
-  ~switch_locale() noexcept
-  {
-    const char *n = setlocale(cat, orig.c_str()); // restore locale
-    assert(n);
-    assert(n == orig);
-  }
-};
-
 #if __APPLE__ && __MACH__
 /* Apple enjoys their users suffering to write platform-independent code, that's
  * why they chose to *not* provide the c(16|32)rtomb functions. */
@@ -120,6 +94,32 @@ static size_t c16rtomb(char *buf, char16_t c, mbstate_t *ps)
 }
 #endif
 
+namespace
+{
+/* RAII-like type to temporarily switch the locale */
+struct switch_locale
+{
+  std::string orig;
+  int cat;
+
+  switch_locale(int cat, const char *loc)
+    : orig(setlocale(cat, nullptr)), cat(cat)
+  {
+    const char *n = setlocale(cat, loc);
+    if (!n)
+      throw fmt::format("locale '{}' not found", loc);
+    log_debug(
+      "convert_mb", "switching from locale '{}' to '{}' -> '{}'", orig, loc, n);
+  }
+
+  ~switch_locale() noexcept
+  {
+    const char *n = setlocale(cat, orig.c_str()); // restore locale
+    assert(n);
+    assert(n == orig);
+  }
+};
+
 struct convert_mb
 {
   const std::string &v;
@@ -134,9 +134,7 @@ struct convert_mb
     : v(v),
       w(w),
       wide(wide),
-      le(
-        config.ansi_c.endianess ==
-        configt::ansi_ct::endianesst::IS_LITTLE_ENDIAN)
+      le(config.ansi_c.endianess == configt::ansi_ct::IS_LITTLE_ENDIAN)
   {
     assert(v.length() % w == 0);
     if (wide && sizeof(wchar_t) * 8 != config.ansi_c.wchar_t_width)
@@ -146,53 +144,41 @@ struct convert_mb
         desc(),
         sizeof(wchar_t) * 8,
         config.ansi_c.wchar_t_width));
-    if (config.ansi_c.endianess == configt::ansi_ct::endianesst::NO_ENDIANESS)
+    if (config.ansi_c.endianess == configt::ansi_ct::NO_ENDIANESS)
       throw string_constantt::mb_conversion_error(fmt::format(
         "impossible to interpret {} string literal without endianness",
         desc()));
 
     memset(&ps, 0, sizeof(ps));
-    size_t n = v.length() / w; // number of code units
-    size_t i;
 
-    /* need to set the locale for (wc|c16|c32)rtomb() to work outside of ASCII;
-     * we'll restore it later */
-    std::string orig_loc = setlocale(LC_CTYPE, nullptr);
-    char *loc = setlocale(LC_CTYPE, config.ansi_c.locale_name.c_str());
-    if (!loc)
-      throw string_constantt::mb_conversion_error(fmt::format(
-        "error interpreting {} string literal: locale '{}' not found",
-        desc(),
-        config.ansi_c.locale_name));
-    log_debug(
-      "convert_mb",
-      "switching from locale '{}' to '{}' -> '{}'",
-      orig_loc,
-      config.ansi_c.locale_name,
-      loc);
-
-    /* do not throw errors  inside this block - need to restore the locale! */
-    std::vector<char> buffer(MB_CUR_MAX);
-    char *buf = buffer.data();
-    for (i = 0; i < n; i++)
+    try
     {
-      uint32_t c = decode(i);
-      size_t r = encode(buf, c);
-      if (r == (size_t)-1)
-        break;
-      result.insert(result.end(), buf, buf + r);
+      /* need to set the locale for (wc|c16|c32)rtomb() to work outside of
+       * ASCII; it'll be restored by the destructor at the end of this block */
+      switch_locale nloc(LC_CTYPE, config.ansi_c.locale_name.c_str());
+      size_t n = v.length() / w; // number of code units
+
+      std::vector<char> buffer(MB_CUR_MAX);
+      char *buf = buffer.data();
+      for (size_t i = 0; i < n; i++)
+      {
+        uint32_t c = decode(i);
+        size_t r = encode(buf, c);
+        if (r == (size_t)-1)
+          throw string_constantt::mb_conversion_error(fmt::format(
+            "error interpreting {} string literal at {}: {}",
+            desc(),
+            i,
+            strerror(errno)));
+        result.insert(result.end(), buf, buf + r);
+      }
+    }
+    catch (const std::string &ex)
+    {
+      throw string_constantt::mb_conversion_error(
+        fmt::format("error interpreting {} string literal: {}", desc(), ex));
     }
 
-    loc = setlocale(LC_CTYPE, orig_loc.c_str()); // restore locale
-    assert(loc);
-    assert(loc == orig_loc);
-
-    if (i < n)
-      throw string_constantt::mb_conversion_error(fmt::format(
-        "error interpreting {} string literal at {}: {}",
-        desc(),
-        i,
-        strerror(errno)));
     if (!mbsinit(&ps))
       throw string_constantt::mb_conversion_error(fmt::format(
         "error interpreting {} string literal: terminates with "
@@ -219,6 +205,7 @@ struct convert_mb
 
   size_t encode(char *buf, uint32_t c)
   {
+    assert(c || mbsinit(&ps));
     return wide     ? wcrtomb(buf, c, &ps)
            : w == 2 ? c16rtomb(buf, c, &ps)
                     : c32rtomb(buf, c, &ps);
@@ -236,8 +223,7 @@ static std::string convert_utf8(const std::string &v)
   const uint8_t *p0 = reinterpret_cast<const uint8_t *>(v.data());
   const uint8_t *p = p0;
   const uint8_t *e = p0 + v.length();
-  bool le =
-    config.ansi_c.endianess == configt::ansi_ct::endianesst::IS_LITTLE_ENDIAN;
+  bool le = config.ansi_c.endianess == configt::ansi_ct::IS_LITTLE_ENDIAN;
   while (p != e)
   {
     const uint8_t *p1 = p;
@@ -251,19 +237,7 @@ static std::string convert_utf8(const std::string &v)
       throw string_constantt::mb_conversion_error(fmt::format(
         "error interpreting UTF-8 string literal: invalid sequence at {}",
         p1 - p0));
-    uint32_t c = *p++;
-    switch (n)
-    {
-    case 2:
-      c &= ~0xc0U;
-      break;
-    case 3:
-      c &= ~0xe0U;
-      break;
-    case 4:
-      c &= ~0xf0U;
-      break;
-    }
+    uint32_t c = *p++ & (0xff >> n);
     for (int i = 1; i < n; i++, p++)
     {
       if (*p < 0x80 || *p >= 0xc0)
@@ -282,7 +256,7 @@ static std::string convert_utf8(const std::string &v)
 
 irep_idt string_constantt::mb_value() const
 {
-  int elem_width = atoi(type().subtype().width().c_str());
+  int elem_width = bv_width(type().subtype());
   irep_idt kind = get("kind");
   bool is_wide = kind == k_wide;
   bool is_default = kind == k_default;

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -36,9 +36,6 @@ string_constantt::string_constantt(
 /* Apple enjoys their users suffering to write platform-independent code, that's
  * why they chose to *not* provide the c(16|32)rtomb functions. */
 
-typedef uint16_t char16_t;
-typedef uint32_t char32_t;
-
 static_assert(sizeof(wchar_t) == sizeof(char32_t));
 static_assert(sizeof(mbstate_t) >= sizeof(uint32_t));
 
@@ -58,11 +55,14 @@ static_assert(sizeof(mbstate_t) >= sizeof(uint32_t));
  * them in their libc, we'll be notified and have to see about the version... */
 static size_t c32rtomb(char *buf, char32_t c, mbstate_t *ps)
 {
+  /* Assumption: wchar_t is UTF-32, same as char32_t */
   return wcrtomb(buf, static_cast<wchar_t>(c), ps);
 }
 
 static size_t c16rtomb(char *buf, char16_t c, mbstate_t *ps)
 {
+  /* Convert from UTF-16 to UTF-32 and use c32rtomb() */
+
   /* Initial state     <-> low surrogate not allowed
    * Not initial state <-> low surrogate expected */
   bool init = mbsinit(ps);


### PR DESCRIPTION
Fixes #1570 by assuming `char *` is UTF-8, `char16_t *` is UTF-16 and `char32_t *` is UTF-32 same as `wchar_t *`, universally, on macOS. Fallback implementations for the missing functions are provided, guarded by `#if __APPLE__ && __MACH__`.