### PR TITLE
Added cstdint include for globals.cpp

### DIFF
--- a/src/esbmc/globals.cpp
+++ b/src/esbmc/globals.cpp
@@ -1,4 +1,5 @@
 #include <langapi/mode.h>
+#include <cstdint>
 
 const mode_table_et mode_table[] = {
   LANGAPI_MODE_CLANG_C,


### PR DESCRIPTION
Building ESBMC in Fedora Linux causes the error:

```
/home/esbmc/repos/esbmc/src/esbmc/globals.cpp:23:18: error: unknown type name 'uint8_t'
   23 | extern "C" const uint8_t buildidstring_buf[];
```

This PR fixes it.