### PR TITLE
Cleanup langapi, remove need for external handling of "mode" index

### DIFF
--- a/src/langapi/CMakeLists.txt
+++ b/src/langapi/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(langapi mode.cpp language_ui.cpp languages.cpp language_util.cpp)
+add_library(langapi mode.cpp language_ui.cpp language_util.cpp)
 target_include_directories(langapi
     PRIVATE ${Boost_INCLUDE_DIRS}
 )

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -63,6 +63,8 @@ bool language_uit::parse(const std::string &filename)
     return true;
   }
 
+  log_progress("Parsing {}", filename);
+
   std::pair<language_filest::filemapt::iterator, bool> result =
     language_files.filemap.emplace(
       std::piecewise_construct,
@@ -82,27 +84,6 @@ bool language_uit::parse(const std::string &filename)
     return true;
   }
   languaget &language = *lf.language;
-
-  log_progress("Parsing {}", filename);
-
-#ifdef ENABLE_SOLIDITY_FRONTEND
-  if (lang == language_idt::SOLIDITY)
-  {
-    std::string fun = config.options.get_option("function");
-    if (!fun.empty())
-      language.set_func_name(fun);
-
-    if (config.options.get_option("sol") == "")
-    {
-      log_error("Please set the smart contract source file.");
-      return true;
-    }
-    else
-    {
-      language.set_smart_contract_source(config.options.get_option("sol"));
-    }
-  }
-#endif
 
   if (language.parse(filename))
   {

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -78,7 +78,7 @@ bool language_uit::parse(const std::string &filename)
     log_error(
       "{}frontend for {} was not built on this version of ESBMC",
       config.options.get_bool_option("old-frontend") ? "old-" : "",
-      language_desc(lang)->name);
+      language_name(lang));
     return true;
   }
   languaget &language = *lf.language;

--- a/src/langapi/language_ui.h
+++ b/src/langapi/language_ui.h
@@ -15,11 +15,6 @@ public:
   language_uit();
   virtual ~language_uit() noexcept = default;
 
-  /* The instance of this class manages the global migrate_namespace_lookup,
-   * thus it cannot be copied. */
-  language_uit(language_uit &&) noexcept;
-  language_uit &operator=(language_uit &&) noexcept;
-
   virtual bool parse(const cmdlinet &cmdline);
   virtual bool parse(const std::string &filename);
   virtual bool typecheck();
@@ -33,6 +28,13 @@ public:
   virtual void show_symbol_table();
   virtual void show_symbol_table_plain(std::ostream &out);
   virtual void show_symbol_table_xml_ui();
+
+protected:
+  /* The instance of this class manages the global migrate_namespace_lookup,
+   * thus it cannot be copied. These functions are protected in order for
+   * derived classes to opt-into move support. */
+  language_uit(language_uit &&) noexcept;
+  language_uit &operator=(language_uit &&) noexcept;
 };
 
 #endif

--- a/src/langapi/language_util.cpp
+++ b/src/langapi/language_util.cpp
@@ -3,26 +3,29 @@
 #include <memory>
 #include <util/message.h>
 
-static int mode_from_symbol(const symbolt *symbol)
+std::unique_ptr<languaget> language_from_symbol(const symbolt &symbol)
 {
-  if (!symbol)
-    return 0;
+  language_idt lang = language_idt::C;
+  if (symbol.mode != "")
+    lang = language_id_by_name(id2string(symbol.mode));
 
-  if (symbol->mode == "")
-    return 0;
+  if (lang != language_idt::NONE)
+    return std::unique_ptr<languaget>(new_language(lang));
 
-  if (int mode = get_mode(id2string(symbol->mode)); mode >= 0)
-    return mode;
-
-  log_error("symbol '{}' has unknown mode '{}'", symbol->name, symbol->mode);
+  log_error("symbol '{}' has unknown mode '{}'", symbol.name, symbol.mode);
   abort();
 }
 
 static std::unique_ptr<languaget>
 language_from_symbol_id(const namespacet &ns, const irep_idt &id)
 {
-  int mode = id == "" ? 0 : mode_from_symbol(ns.lookup(id));
-  return std::unique_ptr<languaget>(mode_table[mode].new_language());
+  if (id != "")
+  {
+    const symbolt *s = ns.lookup(id);
+    if (s)
+      return language_from_symbol(*s);
+  }
+  return std::unique_ptr<languaget>(new_language(language_idt::C));
 }
 
 std::string from_expr(

--- a/src/langapi/language_util.cpp
+++ b/src/langapi/language_util.cpp
@@ -1,6 +1,6 @@
 #include <langapi/language_util.h>
+#include <langapi/languages.h>
 #include <langapi/mode.h>
-#include <memory>
 #include <util/message.h>
 
 static language_idt language_id_from_mode(irep_idt mode)
@@ -18,17 +18,14 @@ std::unique_ptr<languaget> language_from_symbol(const symbolt &symbol)
   abort();
 }
 
-static std::unique_ptr<languaget>
-language_from_symbol_id(const namespacet &ns, const irep_idt &id)
+static languagest
+languages_from_symbol_id(const namespacet &ns, const irep_idt &id)
 {
   language_idt lang = language_idt::C;
   if (!id.empty())
     if (const symbolt *s = ns.lookup(id))
       lang = language_id_from_mode(s->mode);
-
-  std::unique_ptr<languaget> l = new_language(lang);
-  assert(l);
-  return l;
+  return languagest(ns, lang);
 }
 
 std::string from_expr(
@@ -37,9 +34,9 @@ std::string from_expr(
   const exprt &expr,
   presentationt target)
 {
-  std::unique_ptr<languaget> p = language_from_symbol_id(ns, identifier);
+  languagest langs = languages_from_symbol_id(ns, identifier);
   std::string result;
-  p->from_expr(expr, result, ns, target);
+  langs.from_expr(expr, result, target);
   return result;
 }
 
@@ -49,9 +46,9 @@ std::string from_type(
   const typet &type,
   presentationt target)
 {
-  std::unique_ptr<languaget> p = language_from_symbol_id(ns, identifier);
+  languagest langs = languages_from_symbol_id(ns, identifier);
   std::string result;
-  p->from_type(type, result, ns, target);
+  langs.from_type(type, result, target);
   return result;
 }
 

--- a/src/langapi/language_util.h
+++ b/src/langapi/language_util.h
@@ -5,6 +5,9 @@
 #include <util/language.h>
 #include <util/migrate.h>
 #include <util/namespace.h>
+#include <util/symbol.h>
+
+std::unique_ptr<languaget> language_from_symbol(const symbolt &symbol);
 
 std::string from_expr(
   const namespacet &ns,

--- a/src/langapi/languages.cpp
+++ b/src/langapi/languages.cpp
@@ -1,12 +1,7 @@
 #include <langapi/languages.h>
 #include <langapi/mode.h>
 
-languagest::languagest(const namespacet &_ns, language_idt lang) : ns(_ns)
+languagest::languagest(const namespacet &_ns, language_idt lang)
+  : ns(_ns), language(new_language(lang))
 {
-  language = new_language(lang);
-}
-
-languagest::~languagest()
-{
-  delete language;
 }

--- a/src/langapi/languages.cpp
+++ b/src/langapi/languages.cpp
@@ -1,7 +1,0 @@
-#include <langapi/languages.h>
-#include <langapi/mode.h>
-
-languagest::languagest(const namespacet &_ns, language_idt lang)
-  : ns(_ns), language(new_language(lang))
-{
-}

--- a/src/langapi/languages.h
+++ b/src/langapi/languages.h
@@ -28,11 +28,11 @@ public:
   // constructor / destructor
 
   languagest(const namespacet &_ns, language_idt lang);
-  virtual ~languagest();
+  virtual ~languagest() = default;
 
 protected:
   const namespacet &ns;
-  languaget *language;
+  std::unique_ptr<languaget> language;
 };
 
 #endif

--- a/src/langapi/languages.h
+++ b/src/langapi/languages.h
@@ -4,9 +4,17 @@
 #include <langapi/mode.h>
 #include <util/language.h>
 
-class languagest
+class languagest final
 {
+  const namespacet &ns;
+  std::unique_ptr<languaget> language;
+
 public:
+  languagest(const namespacet &_ns, language_idt lang)
+    : ns(_ns), language(new_language(lang))
+  {
+  }
+
   // conversion of expressions
 
   bool from_expr(
@@ -24,15 +32,6 @@ public:
   {
     return language->from_type(type, code, ns, target);
   }
-
-  // constructor / destructor
-
-  languagest(const namespacet &_ns, language_idt lang);
-  virtual ~languagest() = default;
-
-protected:
-  const namespacet &ns;
-  std::unique_ptr<languaget> language;
 };
 
 #endif

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <langapi/mode.h>
 #include <util/config.h>
+#include <util/language.h>
 
 static const char *const extensions_ansi_c[] = {"c", "i", nullptr};
 
@@ -113,15 +114,16 @@ static int get_old_frontend_mode(int current_mode)
   return -1;
 }
 
-languaget *new_language(language_idt lang)
+std::unique_ptr<languaget> new_language(language_idt lang)
 {
   int mode = get_mode(lang);
 
   if (mode >= 0 && config.options.get_bool_option("old-frontend"))
     mode = get_old_frontend_mode(mode);
 
-  if (mode < 0)
-    return nullptr;
+  languaget *l = nullptr;
+  if (mode >= 0)
+    l = mode_table[mode].new_language();
 
-  return mode_table[mode].new_language();
+  return std::unique_ptr<languaget>(l);
 }

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -92,7 +92,7 @@ language_idt language_id_by_path(const std::string &path)
   return language_id_by_ext(extension);
 }
 
-int get_mode(language_idt lang)
+static int get_mode(language_idt lang)
 {
   assert(language_desc(lang));
 
@@ -101,15 +101,6 @@ int get_mode(language_idt lang)
       return i;
 
   return -1;
-}
-
-int get_mode(const std::string &str)
-{
-  language_idt id = language_id_by_name(str);
-  if (id == language_idt::NONE)
-    return -1;
-
-  return get_mode(id);
 }
 
 static int get_old_frontend_mode(int current_mode)

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -122,15 +122,6 @@ static int get_old_frontend_mode(int current_mode)
   return -1;
 }
 
-int get_mode_filename(const std::string &filename)
-{
-  language_idt id = language_id_by_path(filename);
-  if (id == language_idt::NONE)
-    return -1;
-
-  return get_mode(id);
-}
-
 languaget *new_language(language_idt lang)
 {
   int mode = get_mode(lang);

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -79,8 +79,15 @@ language_idt language_id_by_name(const std::string &name)
   }
 }
 
-static language_idt language_id_by_ext(const std::string_view &ext)
+language_idt language_id_by_path(const std::string &path)
 {
+  const char *dot = strrchr(path.c_str(), '.');
+
+  if (dot == nullptr)
+    return language_idt::NONE;
+
+  std::string_view ext(dot + 1);
+
   for (int i = 0;; i++)
   {
     language_idt lid = static_cast<language_idt>(i);
@@ -91,16 +98,6 @@ static language_idt language_id_by_ext(const std::string_view &ext)
       if (*e == ext)
         return lid;
   }
-}
-
-language_idt language_id_by_path(const std::string &path)
-{
-  const char *ext = strrchr(path.c_str(), '.');
-
-  if (ext == nullptr)
-    return language_idt::NONE;
-
-  return language_id_by_ext(ext + 1);
 }
 
 static int get_mode(language_idt lang)

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -64,7 +64,7 @@ language_idt language_id_by_name(const std::string &name)
   }
 }
 
-language_idt language_id_by_ext(const std::string &ext)
+static language_idt language_id_by_ext(const std::string_view &ext)
 {
   for (int i = 0;; i++)
   {
@@ -85,12 +85,7 @@ language_idt language_id_by_path(const std::string &path)
   if (ext == nullptr)
     return language_idt::NONE;
 
-  std::string extension = ext + 1;
-
-  if (extension == "")
-    return language_idt::NONE;
-
-  return language_id_by_ext(extension);
+  return language_id_by_ext(ext + 1);
 }
 
 static int get_mode(language_idt lang)

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <cstring>
 #include <langapi/mode.h>
+#include <util/config.h>
 
 static const char *const extensions_ansi_c[] = {"c", "i", nullptr};
 
@@ -111,7 +112,7 @@ int get_mode(const std::string &str)
   return get_mode(id);
 }
 
-int get_old_frontend_mode(int current_mode)
+static int get_old_frontend_mode(int current_mode)
 {
   language_idt expected = mode_table[current_mode].language_id;
   for (int i = current_mode + 1; mode_table[i].new_language; i++)
@@ -132,5 +133,13 @@ int get_mode_filename(const std::string &filename)
 
 languaget *new_language(language_idt lang)
 {
-  return mode_table[get_mode(lang)].new_language();
+  int mode = get_mode(lang);
+
+  if (mode >= 0 && config.options.get_bool_option("old-frontend"))
+    mode = get_old_frontend_mode(mode);
+
+  if (mode < 0)
+    return nullptr;
+
+  return mode_table[mode].new_language();
 }

--- a/src/langapi/mode.cpp
+++ b/src/langapi/mode.cpp
@@ -4,6 +4,15 @@
 #include <util/config.h>
 #include <util/language.h>
 
+namespace
+{
+struct language_desct
+{
+  const char *name;
+  const char *const *filename_extensions;
+};
+} // namespace
+
 static const char *const extensions_ansi_c[] = {"c", "i", nullptr};
 
 #ifdef _WIN32
@@ -31,7 +40,7 @@ static const language_desct language_desc_python = {
   "Python",
   extensions_python};
 
-const struct language_desct *language_desc(language_idt id)
+static const language_desct *language_desc(language_idt id)
 {
   switch (id)
   {
@@ -49,6 +58,12 @@ const struct language_desct *language_desc(language_idt id)
     return &language_desc_python;
   }
   return nullptr;
+}
+
+const char *language_name(language_idt lang)
+{
+  const language_desct *desc = language_desc(lang);
+  return desc ? desc->name : nullptr;
 }
 
 language_idt language_id_by_name(const std::string &name)

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -30,7 +30,7 @@ struct mode_table_et
 };
 
 // List of language modes that are going to be supported in the final tool.
-// Must be declared by user of langapi, must end with HAVE_MODE_NULL.
+// Must be declared by user of langapi, must end with LANGAPI_MODE_END.
 
 extern const mode_table_et mode_table[];
 

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -17,13 +17,7 @@ enum class language_idt : int
   PYTHON,
 };
 
-struct language_desct
-{
-  const char *name;
-  const char *const *filename_extensions;
-};
-
-const language_desct *language_desc(language_idt id);
+const char *language_name(language_idt id);
 language_idt language_id_by_name(const std::string &name);
 language_idt language_id_by_path(const std::string &path);
 

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -85,7 +85,6 @@ languaget *new_python_language();
 
 int get_mode(language_idt lang);
 int get_mode(const std::string &str);
-int get_mode_filename(const std::string &filename);
 
 languaget *new_language(language_idt lang);
 

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -86,7 +86,6 @@ languaget *new_python_language();
 int get_mode(language_idt lang);
 int get_mode(const std::string &str);
 int get_mode_filename(const std::string &filename);
-int get_old_frontend_mode(int current_mode);
 
 languaget *new_language(language_idt lang);
 

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -25,7 +25,6 @@ struct language_desct
 
 const language_desct *language_desc(language_idt id);
 language_idt language_id_by_name(const std::string &name);
-language_idt language_id_by_ext(const std::string &ext);
 language_idt language_id_by_path(const std::string &path);
 
 // Table recording details about language modes

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -2,6 +2,7 @@
 #define CPROVER_MODE_H
 
 #include <string>
+#include <memory> /* std::unique_ptr */
 
 /* forward declarations */
 class languaget;
@@ -83,6 +84,6 @@ languaget *new_python_language();
     language_idt::NONE, NULL                                                   \
   }
 
-languaget *new_language(language_idt lang);
+std::unique_ptr<languaget> new_language(language_idt lang);
 
 #endif

--- a/src/langapi/mode.h
+++ b/src/langapi/mode.h
@@ -83,9 +83,6 @@ languaget *new_python_language();
     language_idt::NONE, NULL                                                   \
   }
 
-int get_mode(language_idt lang);
-int get_mode(const std::string &str);
-
 languaget *new_language(language_idt lang);
 
 #endif

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -19,6 +19,21 @@ languaget *new_solidity_language()
   return new solidity_languaget;
 }
 
+solidity_languaget::solidity_languaget()
+{
+  std::string fun = config.options.get_option("function");
+  if (!fun.empty())
+    func_name = fun;
+
+  std::string sol = config.options.get_option("sol");
+  if (sol.empty())
+  {
+    log_error("Please set the smart contract source file via --sol");
+    abort();
+  }
+  smart_contract = sol;
+}
+
 std::string solidity_languaget::get_temp_file()
 {
   // Create a temp file for clang-tool

--- a/src/solidity-frontend/solidity_language.h
+++ b/src/solidity-frontend/solidity_language.h
@@ -11,6 +11,8 @@
 class solidity_languaget : public clang_c_languaget
 {
 public:
+  solidity_languaget();
+
   bool parse(const std::string &path) override;
 
   bool final(contextt &context) override;
@@ -37,6 +39,12 @@ public:
   }
 
   bool convert_intrinsics(contextt &context);
+
+  // function name for verification that requires this information before GOTO conversion phase.
+  std::string func_name;
+
+  // smart contract source
+  std::string smart_contract;
 
   // store AST json in nlohmann::json data structure
   nlohmann::json ast_json;

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -85,27 +85,7 @@ public:
 
   virtual ~languaget() = default;
 
-  inline void set_func_name(const std::string _path)
-  {
-    func_name = _path;
-  };
-
-#ifdef ENABLE_SOLIDITY_FRONTEND
-  inline void set_smart_contract_source(const std::string _path)
-  {
-    smart_contract = _path;
-  };
-#endif
-
 protected:
-  // function name for verification that requires this information before GOTO conversion phase.
-  std::string func_name = "";
-
-#ifdef ENABLE_SOLIDITY_FRONTEND
-  // smart contract source
-  std::string smart_contract = "";
-#endif
-
   virtual bool from_expr(
     const exprt &expr,
     std::string &code,

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -43,7 +43,9 @@ public:
   // type check a module in the currently parsed file
   virtual bool typecheck(contextt &context, const std::string &module) = 0;
 
-  // language id / description
+  // language id
+  /* This is used by language_filest::final() to call languaget::final() only
+   * once for each concrete languaget in case of multiple source files. */
   virtual std::string id() const
   {
     return "";

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -48,10 +48,6 @@ public:
   {
     return "";
   }
-  virtual std::string description() const
-  {
-    return "";
-  }
 
   // show parse tree
 

--- a/src/util/language_file.cpp
+++ b/src/util/language_file.cpp
@@ -4,12 +4,6 @@
 #include <util/message.h>
 #include <util/std_types.h>
 
-language_filet::~language_filet()
-{
-  if (language != nullptr)
-    delete language;
-}
-
 void language_filet::get_modules()
 {
   language->modules_provided(modules);

--- a/src/util/language_file.h
+++ b/src/util/language_file.h
@@ -22,16 +22,10 @@ class language_filet
 public:
   std::set<std::string> modules;
 
-  class languaget *language;
+  std::unique_ptr<languaget> language;
   std::string filename;
 
   void get_modules();
-
-  language_filet()
-  {
-    language = nullptr;
-  }
-  ~language_filet();
 };
 
 class language_filest

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -2,6 +2,7 @@
 
 #include <util/language.h>
 #include <langapi/mode.h>
+#include <langapi/language_util.h>
 
 #include "show_symbol_table.h"
 
@@ -18,18 +19,7 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
   out << "\n";
 
   ns.get_context().foreach_operand_in_order([&out, &ns](const symbolt &s) {
-    int mode;
-
-    if (s.mode == "")
-      mode = 0;
-    else
-    {
-      mode = get_mode(id2string(s.mode));
-      if (mode < 0)
-        throw "symbol " + id2string(s.name) + " has unknown mode";
-    }
-
-    std::unique_ptr<languaget> p(mode_table[mode].new_language());
+    std::unique_ptr<languaget> p = language_from_symbol(s);
     std::string type_str, value_str;
 
     if (s.type.is_not_nil())
@@ -41,8 +31,7 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";
     out << "Base name...: " << s.name << "\n";
-    out << "Mode........: " << s.mode << " (" << mode << ")"
-        << "\n";
+    out << "Mode........: " << s.mode << "\n";
     out << "Type........: " << type_str << "\n";
     out << "Value.......: " << value_str << "\n";
     out << "Flags.......:";

--- a/unit/testing-utils/goto_factory.h
+++ b/unit/testing-utils/goto_factory.h
@@ -8,6 +8,10 @@ class program : public language_uit
 {
 public:
   goto_functionst functions;
+
+  program() = default;
+  program(program &&) = default;
+  program &operator=(program &&) = default;
 };
 
 /**


### PR DESCRIPTION
Summary:
- avoid direct access to the `mode_table` and handling the associated `int mode` -- instead use the language_idt
- move from raw `languaget *` to unique-ptrs
- move Solidity-specific information from base to derived class