### PR TITLE
Automatic commits for clang-format changes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,6 +65,10 @@ jobs:
   code-style:
     name: Check C/C++ code-style
     runs-on: ubuntu-20.04
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
     steps:
     - uses: actions/checkout@v2
     - name: Install Dependencies
@@ -77,8 +81,8 @@ jobs:
       run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | grep -v src/ansi-c/cpp | grep -v src/clang-c-frontend/headers/ | xargs ./clang/bin/clang-format -style=file -i -fallback-style=none
     - name: Run clang-format (tests)
       run: find unit -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh  | xargs ./clang/bin/clang-format -style=file -i -fallback-style=none
-    - name: Throws error if changes were made
-      run: git diff --exit-code --ignore-cr-at-eol
+    # Commit all changed files back to the repository
+    - uses: stefanzweifel/git-auto-commit-action@v5  
       
   cmake-lint:
     name: Check CMake modules

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -81,6 +81,8 @@ jobs:
       run: find src -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh | grep -v src/ansi-c/cpp | grep -v src/clang-c-frontend/headers/ | xargs ./clang/bin/clang-format -style=file -i -fallback-style=none
     - name: Run clang-format (tests)
       run: find unit -iname *.h -o -iname *.c -o -iname *.cpp -o -iname *.hpp -iname *.hh  | xargs ./clang/bin/clang-format -style=file -i -fallback-style=none
+    - name: Delete downloaded Clang 11
+      run: rm -rf clang*
     # Commit all changed files back to the repository
     - uses: stefanzweifel/git-auto-commit-action@v5  
       

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -237,7 +237,7 @@ static std::string format_target()
 // \param options - the options object created and updated by this method.
 void esbmc_parseoptionst::get_command_line_options(optionst &options)
 {
-  if(config.set(cmdline))
+  if (config.set(cmdline))
     exit(1);
 
   log_status("Target: {}", format_target());

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -237,7 +237,7 @@ static std::string format_target()
 // \param options - the options object created and updated by this method.
 void esbmc_parseoptionst::get_command_line_options(optionst &options)
 {
-  if (config.set(cmdline))
+  if(config.set(cmdline))
     exit(1);
 
   log_status("Target: {}", format_target());


### PR DESCRIPTION
This PR enables commits from the CI for clang-format changes. Closes #1526 

As an example: commit https://github.com/esbmc/esbmc/pull/1577/commits/d2cd7e32bce20c8090d64be9df113ea45e05b1f8  fixes the error introduced by https://github.com/esbmc/esbmc/pull/1577/commits/81a7d866faf68d9f3a90fc61502e04c4cc10c7e1

The main limitation is that the commit will [not trigger the workflow](https://github.com/marketplace/actions/git-auto-commit#commits-made-by-this-action-do-not-trigger-new-workflow-runs). This could be sorted in the future if we create a stub user for this purpose. 