### PR TITLE
[Multi-property] Show decision runtime for each claim

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -789,7 +789,7 @@ smt_convt::resultt bmct::multi_property_check(
     smt_convt::resultt result = runtime_solver->dec_solve();
     fine_timet sat_stop = current_time();
     log_status(
-        "Runtime decision procedure: {}s", time2string(sat_stop - sat_start));
+      "Runtime decision procedure: {}s", time2string(sat_stop - sat_start));
     // This try-catch is mainly for fail-fast.
 
     if (result == smt_convt::P_SATISFIABLE)

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -785,8 +785,11 @@ smt_convt::resultt bmct::multi_property_check(
       runtime_solver->solver_text());
     total_instance++;
 
+    fine_timet sat_start = current_time();
     smt_convt::resultt result = runtime_solver->dec_solve();
-
+    fine_timet sat_stop = current_time();
+    log_status(
+        "Runtime decision procedure: {}s", time2string(sat_stop - sat_start));
     // This try-catch is mainly for fail-fast.
 
     if (result == smt_convt::P_SATISFIABLE)


### PR DESCRIPTION
This is a tiny PR to print the smt solving time for each claim in multi-property mode, should be useful for analyzing.

A log example:

```
Encoding to solver time: 1.806s
Solving claim 'prop_success_realm_state_cons' with solver Boolector 3.2.1
Runtime decision procedure: 6.368s
Slicing for Claim prop_result_cons (0.001s)
Slicing time: 0.017s (removed 3720 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 1.976s
Solving claim 'prop_result_cons' with solver Boolector 3.2.1
Runtime decision procedure: 6.517s
Slicing for Claim prop_failure_realm_state_cons (0.001s)
Slicing time: 0.017s (removed 3720 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 2.036s
Solving claim 'prop_failure_realm_state_cons' with solver Boolector 3.2.1
Runtime decision procedure: 6.660s
```