### PR TITLE
Python frontend: Class attributes

### DIFF
--- a/regression/python/class-attributes/main.py
+++ b/regression/python/class-attributes/main.py
@@ -1,0 +1,42 @@
+class MyClass:
+    # Class attribute
+    class_attr:int = 1
+
+    def __init__(self, value: int):
+        self.data:int = value
+
+
+# Checking if the class attribute has the expected value
+assert MyClass.class_attr == 1
+
+
+# Creating an instance of MyClass
+obj1 = MyClass(10)
+
+# Instance attributes can be set with self.name = value
+obj1.class_attr = 2
+
+# Verifying that the instance attribute now hides the class attribute with the same name
+assert obj1.class_attr == 2
+
+# Confirming that the class attribute still retains its original value
+assert MyClass.class_attr == 1
+
+# Creating another instance of MyClass
+obj2 = MyClass(15)
+
+# Verifying that obj2 refers to the class attribute as it doesn't have an instance attribute with the same name
+assert obj2.class_attr == 1
+
+
+# Updating the class attribute, affecting all instances of MyClass
+MyClass.class_attr = 3
+
+# Checking that the class attribute has been successfully updated
+assert MyClass.class_attr == 3
+
+# Verifying that the instance attribute of obj1 remains the same
+assert obj1.class_attr == 2
+
+# Checking that obj2 now refers to the updated class attribute
+assert obj2.class_attr == 3

--- a/regression/python/class-attributes/test.desc
+++ b/regression/python/class-attributes/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -1,6 +1,6 @@
 class MyClass:
     # Class attribute
-    class_attr:int = 50
+    class_attr:int = 25
 
     def __init__(self, value: int):
         self.data:int = value
@@ -10,19 +10,21 @@ obj1 = MyClass(5)
 assert(obj1.data == 5)
 obj1.data = 10
 assert(obj1.data == 10)
-obj1.data = 20
-assert(obj1.data == 20)
 
-obj2 = MyClass(30)
-assert(obj2.data == 30)
-obj2.data = 40
-assert(obj2.data == 40)
+obj2 = MyClass(15)
+obj2.data = 20
+assert(obj2.data == 20)
 
+assert(MyClass.class_attr == 25)
+
+obj3 = MyClass(30)
+obj3.class_attr = 35 # Instance attributes can be set in a method with self.name = value
+assert(obj3.class_attr == 35) # Instance attribute hides a class attribute with the same name
+assert(MyClass.class_attr == 25)
+
+MyClass.class_attr = 50
 assert(MyClass.class_attr == 50)
-obj3 = MyClass(10)
-assert(obj3.class_attr == 50)
-MyClass.class_attr = 45
-assert(obj3.class_attr == 45)
-assert(obj2.class_attr == 45)
-assert(obj1.class_attr == 45)
-assert(MyClass.class_attr == 45)
+assert(obj3.class_attr == 35)
+
+assert(obj1.class_attr == 50) # Class attribute might be referred as obj1 don't have instance attributes
+assert(obj2.class_attr == 50) # Class attribute might be referred as obj2 don't have instance attributes

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -1,7 +1,4 @@
 class MyClass:
-    # Class attribute
-    class_attr:int = 25
-
     def __init__(self, value: int):
         self.data:int = value
 
@@ -10,21 +7,10 @@ obj1 = MyClass(5)
 assert(obj1.data == 5)
 obj1.data = 10
 assert(obj1.data == 10)
+obj1.data = 20
+assert(obj1.data == 20)
 
-obj2 = MyClass(15)
-obj2.data = 20
-assert(obj2.data == 20)
-
-assert(MyClass.class_attr == 25)
-
-obj3 = MyClass(30)
-obj3.class_attr = 35 # Instance attributes can be set in a method with self.name = value
-assert(obj3.class_attr == 35) # Instance attribute hides a class attribute with the same name
-assert(MyClass.class_attr == 25)
-
-MyClass.class_attr = 50
-assert(MyClass.class_attr == 50)
-assert(obj3.class_attr == 35)
-
-assert(obj1.class_attr == 50) # Class attribute might be referred as obj1 don't have instance attributes
-assert(obj2.class_attr == 50) # Class attribute might be referred as obj2 don't have instance attributes
+obj2 = MyClass(30)
+assert(obj2.data == 30)
+obj2.data = 40
+assert(obj2.data == 40)

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -19,3 +19,10 @@ obj2.data = 40
 assert(obj2.data == 40)
 
 assert(MyClass.class_attr == 50)
+obj3 = MyClass(10)
+assert(obj3.class_attr == 50)
+#MyClass.class_attr = 45
+# assert(obj3.class_attr == 45)
+# assert(obj2.class_attr == 45)
+# assert(obj1.class_attr == 45)
+# assert(MyClass.class_attr == 45)

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -21,8 +21,8 @@ assert(obj2.data == 40)
 assert(MyClass.class_attr == 50)
 obj3 = MyClass(10)
 assert(obj3.class_attr == 50)
-#MyClass.class_attr = 45
-# assert(obj3.class_attr == 45)
-# assert(obj2.class_attr == 45)
-# assert(obj1.class_attr == 45)
-# assert(MyClass.class_attr == 45)
+MyClass.class_attr = 45
+assert(obj3.class_attr == 45)
+assert(obj2.class_attr == 45)
+assert(obj1.class_attr == 45)
+assert(MyClass.class_attr == 45)

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -1,4 +1,7 @@
 class MyClass:
+    # Class attribute
+    class_attr:int = 50
+
     def __init__(self, value: int):
         self.data:int = value
 
@@ -14,3 +17,5 @@ obj2 = MyClass(30)
 assert(obj2.data == 30)
 obj2.data = 40
 assert(obj2.data == 40)
+
+assert(MyClass.class_attr == 50)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -174,8 +174,7 @@ void python_converter::adjust_statement_types(exprt &lhs, exprt &rhs) const
   typet &lhs_type = lhs.type();
   typet &rhs_type = rhs.type();
 
-  auto update_symbol = [&](exprt &expr)
-  {
+  auto update_symbol = [&](exprt &expr) {
     std::string id = create_symbol_id() + "@" + expr.name().c_str();
     symbolt *s = context.find_symbol(id);
     if (s != nullptr)
@@ -244,8 +243,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   else if (element.contains("value"))
     rhs = get_expr(element["value"]);
 
-  auto to_side_effect_call = [](exprt &expr)
-  {
+  auto to_side_effect_call = [](exprt &expr) {
     side_effect_expr_function_callt side_effect;
     code_function_callt &code = static_cast<code_function_callt &>(expr);
     side_effect.function() = code.function();
@@ -548,8 +546,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         instance_attr_map[symbol->id.as_string()].push_back(attr_name);
       }
 
-      auto is_instance_attr = [&]() -> bool
-      {
+      auto is_instance_attr = [&]() -> bool {
         auto it = instance_attr_map.find(symbol->id.as_string());
         if (it != instance_attr_map.end())
         {
@@ -620,15 +617,13 @@ bool python_converter::is_constructor_call(const nlohmann::json &json)
    * rhs corresponds to the name of a class. */
 
   bool is_ctor_call = false;
-  context.foreach_operand(
-    [&](const symbolt &s)
+  context.foreach_operand([&](const symbolt &s) {
+    if (s.type.id() == "struct" && s.name == func_name)
     {
-      if (s.type.id() == "struct" && s.name == func_name)
-      {
-        is_ctor_call = true;
-        return;
-      }
-    });
+      is_ctor_call = true;
+      return;
+    }
+  });
   return is_ctor_call;
 }
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -18,7 +18,7 @@ private:
   void
   get_return_statements(const nlohmann::json &ast_node, codet &target_block);
   void get_function_definition(const nlohmann::json &function_node);
-  void get_class_definition(const nlohmann::json &class_node);
+  void get_class_definition(const nlohmann::json &class_node, codet &target_block);
 
   locationt get_location_from_decl(const nlohmann::json &ast_node);
   exprt get_expr(const nlohmann::json &element);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -3,6 +3,8 @@
 #include <util/context.h>
 #include <nlohmann/json.hpp>
 
+#include <map>
+
 class codet;
 class struct_typet;
 
@@ -47,4 +49,8 @@ private:
   std::string current_func_name;
   std::string current_class_name;
   exprt *ref_instance;
+  bool is_converting_lhs = false;
+
+  // Map object to list of instance attributes
+  std::map<std::string, std::vector<std::string>> instance_attr_map;
 };

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -52,5 +52,5 @@ private:
   bool is_converting_lhs = false;
 
   // Map object to list of instance attributes
-  std::map<std::string, std::vector<std::string>> instance_attr_map;
+  std::unordered_map<std::string, std::vector<std::string>> instance_attr_map;
 };


### PR DESCRIPTION
This PR adds support for **class attributes** as described by Python documentation (https://docs.python.org/3/reference/compound_stmts.html#class-definitions):

"_Variables defined in the class definition are class attributes; they are shared by instances. Instance attributes can be set in a method with self.name = value. Both class and instance attributes are accessible through the notation “self.name”, and an instance attribute hides a class attribute with the same name when accessed in this way._"

Class attributes are modeled as static class members in C++. Thus, when a class attribute is identified, a symbol with an id in the format _filename@C@classname@varname_ is inserted into the context.