### PR TITLE
Remove shared_ptr from being used unnecessarily in API

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -99,9 +99,7 @@ void bmct::successful_trace()
   }
 }
 
-void bmct::error_trace(
-  std::shared_ptr<smt_convt> &smt_conv,
-  std::shared_ptr<symex_target_equationt> &eq)
+void bmct::error_trace(smt_convt &smt_conv, const symex_target_equationt &eq)
 {
   if (options.get_bool_option("result-only"))
     return;
@@ -141,8 +139,8 @@ void bmct::error_trace(
 }
 
 void bmct::generate_smt_from_equation(
-  std::shared_ptr<smt_convt> &smt_conv,
-  std::shared_ptr<symex_target_equationt> &eq)
+  smt_convt &smt_conv,
+  symex_target_equationt &eq)
 {
   std::string logic;
 
@@ -158,15 +156,14 @@ void bmct::generate_smt_from_equation(
   log_status("Encoding remaining VCC(s) using {}", logic);
 
   fine_timet encode_start = current_time();
-  eq->convert(*smt_conv.get());
+  eq.convert(smt_conv);
   fine_timet encode_stop = current_time();
   log_status(
     "Encoding to solver time: {}s", time2string(encode_stop - encode_start));
 }
 
-smt_convt::resultt bmct::run_decision_procedure(
-  std::shared_ptr<smt_convt> &smt_conv,
-  std::shared_ptr<symex_target_equationt> &eq)
+smt_convt::resultt
+bmct::run_decision_procedure(smt_convt &smt_conv, symex_target_equationt &eq)
 {
   generate_smt_from_equation(smt_conv, eq);
 
@@ -174,15 +171,15 @@ smt_convt::resultt bmct::run_decision_procedure(
     options.get_bool_option("smt-formula-too") ||
     options.get_bool_option("smt-formula-only"))
   {
-    smt_conv->dump_smt();
+    smt_conv.dump_smt();
     if (options.get_bool_option("smt-formula-only"))
       return smt_convt::P_SMTLIB;
   }
 
-  log_progress("Solving with solver {}", smt_conv->solver_text());
+  log_progress("Solving with solver {}", smt_conv.solver_text());
 
   fine_timet sat_start = current_time();
-  smt_convt::resultt dec_result = smt_conv->dec_solve();
+  smt_convt::resultt dec_result = smt_conv.dec_solve();
   fine_timet sat_stop = current_time();
 
   // output runtime
@@ -202,7 +199,7 @@ void bmct::report_failure()
   log_fail("\nVERIFICATION FAILED");
 }
 
-void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
+void bmct::show_program(const symex_target_equationt &eq)
 {
   unsigned int count = 1;
   std::ostringstream oss;
@@ -215,7 +212,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
 
   bool sliced = config.options.get_bool_option("ssa-sliced");
 
-  for (auto const &it : eq->SSA_steps)
+  for (auto const &it : eq.SSA_steps)
   {
     if (!(it.is_assert() || it.is_assignment() || it.is_assume()))
       continue;
@@ -264,7 +261,7 @@ void bmct::show_program(std::shared_ptr<symex_target_equationt> &eq)
 
 void bmct::report_trace(
   smt_convt::resultt &res,
-  std::shared_ptr<symex_target_equationt> &eq)
+  const symex_target_equationt &eq)
 {
   bool bs = options.get_bool_option("base-case");
   bool fc = options.get_bool_option("forward-condition");
@@ -287,11 +284,11 @@ void bmct::report_trace(
   case smt_convt::P_SATISFIABLE:
     if (!bs && show_cex)
     {
-      error_trace(runtime_solver, eq);
+      error_trace(*runtime_solver, eq);
     }
     else if (!is && !fc)
     {
-      error_trace(runtime_solver, eq);
+      error_trace(*runtime_solver, eq);
     }
     break;
 
@@ -390,7 +387,7 @@ smt_convt::resultt bmct::start_bmc()
 {
   std::shared_ptr<symex_target_equationt> eq;
   smt_convt::resultt res = run(eq);
-  report_trace(res, eq);
+  report_trace(res, *eq);
   report_result(res);
   return res;
 }
@@ -418,7 +415,7 @@ smt_convt::resultt bmct::run(std::shared_ptr<symex_target_equationt> &eq)
         runtime_solver->print_model();
 
       if (config.options.get_bool_option("bidirectional"))
-        bidirectional_search(runtime_solver, eq);
+        bidirectional_search(*runtime_solver, *eq);
     }
 
     if (res)
@@ -443,8 +440,8 @@ smt_convt::resultt bmct::run(std::shared_ptr<symex_target_equationt> &eq)
 }
 
 void bmct::bidirectional_search(
-  std::shared_ptr<smt_convt> &smt_conv,
-  std::shared_ptr<symex_target_equationt> &eq)
+  smt_convt &smt_conv,
+  const symex_target_equationt &eq)
 {
   // We should only analyse the inductive step's cex and we're running
   // in k-induction mode
@@ -455,9 +452,9 @@ void bmct::bidirectional_search(
   // We'll walk list of SSA steps and look for inductive assignments
   std::vector<stack_framet> frames;
   unsigned assert_loop_number = 0;
-  for (auto ssait : eq->SSA_steps)
+  for (const auto &ssait : eq.SSA_steps)
   {
-    if (ssait.is_assert() && smt_conv->l_get(ssait.cond_ast).is_false())
+    if (ssait.is_assert() && smt_conv.l_get(ssait.cond_ast).is_false())
     {
       if (!ssait.loop_number)
         return;
@@ -509,7 +506,7 @@ void bmct::bidirectional_search(
     std::unordered_map<irep_idt, std::pair<expr2tc, expr2tc>, irep_id_hash>
       var_ssa_list;
 
-    for (auto ssait : eq->SSA_steps)
+    for (const auto &ssait : eq.SSA_steps)
     {
       if (ssait.loop_number == lit->get_original_loop_head()->loop_number)
         break;
@@ -630,7 +627,7 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if (
       options.get_bool_option("program-only") ||
       options.get_bool_option("program-too"))
-      show_program(eq);
+      show_program(*eq);
 
     if (options.get_bool_option("program-only"))
       return smt_convt::P_SMTLIB;
@@ -644,14 +641,14 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if (options.get_bool_option("document-subgoals"))
     {
       std::ostringstream oss;
-      document_subgoals(*eq.get(), oss);
+      document_subgoals(*eq, oss);
       log_status("{}", oss.str());
       return smt_convt::P_SMTLIB;
     }
 
     if (options.get_bool_option("show-vcc"))
     {
-      show_vcc(eq);
+      show_vcc(*eq);
       return smt_convt::P_SMTLIB;
     }
 
@@ -677,9 +674,9 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if (
       options.get_bool_option("multi-property") &&
       options.get_bool_option("base-case"))
-      return multi_property_check(eq, result->remaining_claims);
+      return multi_property_check(*eq, result->remaining_claims);
 
-    return run_decision_procedure(runtime_solver, eq);
+    return run_decision_procedure(*runtime_solver, *eq);
   }
 
   catch (std::string &error_str)
@@ -702,7 +699,7 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 }
 
 smt_convt::resultt bmct::multi_property_check(
-  std::shared_ptr<symex_target_equationt> &eq,
+  const symex_target_equationt &eq,
   size_t remaining_claims)
 {
   // As of now, it only makes sense to do this for the base-case
@@ -765,19 +762,18 @@ smt_convt::resultt bmct::multi_property_check(
       return;
 
     // Since this is just a copy, we probably don't need a lock
-    auto local_eq = std::make_shared<symex_target_equationt>(*eq);
+    symex_target_equationt local_eq = eq;
 
     // Set up the current claim and slice it
     claim_slicer claim(i);
-    claim.run(local_eq->SSA_steps);
+    claim.run(local_eq.SSA_steps);
     symex_slicet slicer(options);
-    slicer.run(local_eq->SSA_steps);
+    slicer.run(local_eq.SSA_steps);
 
     // Initialize a solver
-    auto runtime_solver =
-      std::shared_ptr<smt_convt>(create_solver("", ns, options));
+    std::unique_ptr<smt_convt> runtime_solver(create_solver("", ns, options));
     // Save current instance
-    generate_smt_from_equation(runtime_solver, local_eq);
+    generate_smt_from_equation(*runtime_solver, local_eq);
 
     log_status(
       "Solving claim '{}' with solver {}",
@@ -801,7 +797,7 @@ smt_convt::resultt bmct::multi_property_check(
         is_compact_trace = false;
 
       goto_tracet goto_trace;
-      build_goto_trace(local_eq, runtime_solver, goto_trace, is_compact_trace);
+      build_goto_trace(local_eq, *runtime_solver, goto_trace, is_compact_trace);
 
       // Store the comment and location of the assertion
       // to avoid double verifying the claims that are already verified

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -69,8 +69,7 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
       funcs,
       ns,
       options,
-      std::shared_ptr<runtime_encoded_equationt>(
-        new runtime_encoded_equationt(ns, *runtime_solver)),
+      std::make_shared<runtime_encoded_equationt>(ns, *runtime_solver),
       _context);
   }
   else
@@ -79,7 +78,7 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
       funcs,
       ns,
       options,
-      std::shared_ptr<symex_target_equationt>(new symex_target_equationt(ns)),
+      std::make_shared<symex_target_equationt>(ns),
       _context);
   }
 }

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -63,9 +63,9 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
 
   if (options.get_bool_option("smt-during-symex"))
   {
-    runtime_solver = std::shared_ptr<smt_convt>(create_solver("", ns, options));
+    runtime_solver = std::unique_ptr<smt_convt>(create_solver("", ns, options));
 
-    symex = std::make_shared<reachability_treet>(
+    symex = std::make_unique<reachability_treet>(
       funcs,
       ns,
       options,
@@ -75,7 +75,7 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
   }
   else
   {
-    symex = std::make_shared<reachability_treet>(
+    symex = std::make_unique<reachability_treet>(
       funcs,
       ns,
       options,
@@ -640,7 +640,7 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
     if (!options.get_bool_option("smt-during-symex"))
     {
       runtime_solver =
-        std::shared_ptr<smt_convt>(create_solver("", ns, options));
+        std::unique_ptr<smt_convt>(create_solver("", ns, options));
     }
 
     if (

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -48,8 +48,7 @@ protected:
 
   virtual void show_vcc(const symex_target_equationt &eq);
 
-  virtual void
-  show_vcc(std::ostream &out, const symex_target_equationt &eq);
+  virtual void show_vcc(std::ostream &out, const symex_target_equationt &eq);
 
   virtual void
   report_trace(smt_convt::resultt &res, const symex_target_equationt &eq);
@@ -59,9 +58,8 @@ protected:
 
   virtual void report_result(smt_convt::resultt &res);
 
-  virtual void bidirectional_search(
-    smt_convt &smt_conv,
-    const symex_target_equationt &eq);
+  virtual void
+  bidirectional_search(smt_convt &smt_conv, const symex_target_equationt &eq);
 
   smt_convt::resultt run_thread(std::shared_ptr<symex_target_equationt> &eq);
 
@@ -71,9 +69,8 @@ protected:
 
   std::vector<std::unique_ptr<ssa_step_algorithm>> algorithms;
 
-  void generate_smt_from_equation(
-    smt_convt &smt_conv,
-    symex_target_equationt &eq);
+  void
+  generate_smt_from_equation(smt_convt &smt_conv, symex_target_equationt &eq);
 };
 
 #endif

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -31,8 +31,8 @@ protected:
   const contextt &context;
   namespacet ns;
 
-  std::shared_ptr<smt_convt> runtime_solver;
-  std::shared_ptr<reachability_treet> symex;
+  std::unique_ptr<smt_convt> runtime_solver;
+  std::unique_ptr<reachability_treet> symex;
 
   virtual smt_convt::resultt
   run_decision_procedure(smt_convt &smt_conv, symex_target_equationt &eq);

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -33,28 +33,26 @@ protected:
 
   std::shared_ptr<smt_convt> runtime_solver;
   std::shared_ptr<reachability_treet> symex;
-  virtual smt_convt::resultt run_decision_procedure(
-    std::shared_ptr<smt_convt> &smt_conv,
-    std::shared_ptr<symex_target_equationt> &eq);
 
-  virtual void show_program(std::shared_ptr<symex_target_equationt> &eq);
+  virtual smt_convt::resultt
+  run_decision_procedure(smt_convt &smt_conv, symex_target_equationt &eq);
+
+  virtual void show_program(const symex_target_equationt &eq);
   virtual void report_success();
   virtual void report_failure();
 
-  virtual void error_trace(
-    std::shared_ptr<smt_convt> &smt_conv,
-    std::shared_ptr<symex_target_equationt> &eq);
+  virtual void
+  error_trace(smt_convt &smt_conv, const symex_target_equationt &eq);
 
   virtual void successful_trace();
 
-  virtual void show_vcc(std::shared_ptr<symex_target_equationt> &eq);
+  virtual void show_vcc(const symex_target_equationt &eq);
 
   virtual void
-  show_vcc(std::ostream &out, std::shared_ptr<symex_target_equationt> &eq);
+  show_vcc(std::ostream &out, const symex_target_equationt &eq);
 
-  virtual void report_trace(
-    smt_convt::resultt &res,
-    std::shared_ptr<symex_target_equationt> &eq);
+  virtual void
+  report_trace(smt_convt::resultt &res, const symex_target_equationt &eq);
 
   virtual void
   report_multi_property_trace(smt_convt::resultt &res, const std::string &msg);
@@ -62,18 +60,20 @@ protected:
   virtual void report_result(smt_convt::resultt &res);
 
   virtual void bidirectional_search(
-    std::shared_ptr<smt_convt> &smt_conv,
-    std::shared_ptr<symex_target_equationt> &eq);
+    smt_convt &smt_conv,
+    const symex_target_equationt &eq);
 
   smt_convt::resultt run_thread(std::shared_ptr<symex_target_equationt> &eq);
+
   smt_convt::resultt multi_property_check(
-    std::shared_ptr<symex_target_equationt> &eq,
+    const symex_target_equationt &eq,
     size_t remaining_claims);
+
   std::vector<std::unique_ptr<ssa_step_algorithm>> algorithms;
 
   void generate_smt_from_equation(
-    std::shared_ptr<smt_convt> &smt_conv,
-    std::shared_ptr<symex_target_equationt> &eq);
+    smt_convt &smt_conv,
+    symex_target_equationt &eq);
 };
 
 #endif

--- a/src/esbmc/show_vcc.cpp
+++ b/src/esbmc/show_vcc.cpp
@@ -7,16 +7,15 @@
 #include <langapi/mode.h>
 #include <util/migrate.h>
 
-void bmct::show_vcc(
-  std::ostream &out,
-  std::shared_ptr<symex_target_equationt> &eq)
+void bmct::show_vcc(std::ostream &out, const symex_target_equationt &eq)
 {
   out << "\nVERIFICATION CONDITIONS:\n\n";
 
   languagest languages(ns, language_idt::C);
 
-  for (symex_target_equationt::SSA_stepst::iterator it = eq->SSA_steps.begin();
-       it != eq->SSA_steps.end();
+  for (symex_target_equationt::SSA_stepst::const_iterator it =
+         eq.SSA_steps.begin();
+       it != eq.SSA_steps.end();
        it++)
   {
     if (!it->is_assert() || it->ignore)
@@ -29,7 +28,7 @@ void bmct::show_vcc(
       out << it->comment << "\n";
 
     symex_target_equationt::SSA_stepst::const_iterator p_it =
-      eq->SSA_steps.begin();
+      eq.SSA_steps.begin();
 
     for (unsigned count = 1; p_it != it; p_it++)
       if (p_it->is_assume() || p_it->is_assignment())
@@ -52,7 +51,7 @@ void bmct::show_vcc(
   }
 }
 
-void bmct::show_vcc(std::shared_ptr<symex_target_equationt> &eq)
+void bmct::show_vcc(const symex_target_equationt &eq)
 {
   const std::string &filename = options.get_option("output");
 

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -2,7 +2,7 @@
 #include <goto-symex/build_goto_trace.h>
 #include <goto-symex/witnesses.h>
 
-expr2tc build_lhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &lhs)
+expr2tc build_lhs(smt_convt &smt_conv, const expr2tc &lhs)
 {
   if (is_nil_expr(lhs))
     return lhs;
@@ -18,7 +18,7 @@ expr2tc build_lhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &lhs)
     // Build new source value, it might be an index, in case of
     // multidimensional arrays
     expr2tc new_source_value = build_lhs(smt_conv, index.source_value);
-    expr2tc new_value = smt_conv->get(index.index);
+    expr2tc new_value = smt_conv.get(index.index);
     new_lhs = index2tc(new_lhs->type, new_source_value, new_value);
     break;
   }
@@ -39,30 +39,30 @@ expr2tc build_lhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &lhs)
   return new_lhs;
 }
 
-expr2tc build_rhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &rhs)
+expr2tc build_rhs(smt_convt &smt_conv, const expr2tc &rhs)
 {
   if (is_nil_expr(rhs) || is_constant_expr(rhs))
     return rhs;
 
-  auto new_rhs = smt_conv->get(rhs);
+  auto new_rhs = smt_conv.get(rhs);
   renaming::renaming_levelt::get_original_name(new_rhs, symbol2t::level0);
   return new_rhs;
 }
 
 void build_goto_trace(
-  const std::shared_ptr<symex_target_equationt> &target,
-  std::shared_ptr<smt_convt> &smt_conv,
+  const symex_target_equationt &target,
+  smt_convt &smt_conv,
   goto_tracet &goto_trace,
   const bool &is_compact_trace)
 {
   unsigned step_nr = 0;
 
-  for (auto const &SSA_step : target->SSA_steps)
+  for (auto const &SSA_step : target.SSA_steps)
   {
     if (SSA_step.hidden && is_compact_trace)
       continue;
 
-    if (!smt_conv->l_get(SSA_step.guard_ast).is_true())
+    if (!smt_conv.l_get(SSA_step.guard_ast).is_true())
       continue;
 
     goto_trace_stept goto_trace_step;
@@ -102,49 +102,46 @@ void build_goto_trace(
         if (is_constant_expr(arg))
           goto_trace_step.output_args.push_back(arg);
         else
-          goto_trace_step.output_args.push_back(smt_conv->get(arg));
+          goto_trace_step.output_args.push_back(smt_conv.get(arg));
       }
     }
 
     if (SSA_step.is_assert() || SSA_step.is_assume())
-      goto_trace_step.guard = !smt_conv->l_get(SSA_step.cond_ast).is_false();
+      goto_trace_step.guard = !smt_conv.l_get(SSA_step.cond_ast).is_false();
 
     goto_trace.steps.push_back(goto_trace_step);
   }
 }
 
 void build_successful_goto_trace(
-  const std::shared_ptr<symex_target_equationt> &target,
+  const symex_target_equationt &target,
   const namespacet &ns,
   goto_tracet &goto_trace)
 {
   unsigned step_nr = 0;
-  for (symex_target_equationt::SSA_stepst::const_iterator it =
-         target->SSA_steps.begin();
-       it != target->SSA_steps.end();
-       it++)
+  for (const symex_target_equationt::SSA_stept &SSA_step : target.SSA_steps)
   {
     if (
-      (it->is_assert() || it->is_assume()) &&
-      (is_valid_witness_expr(ns, it->lhs)))
+      (SSA_step.is_assert() || SSA_step.is_assume()) &&
+      (is_valid_witness_expr(ns, SSA_step.lhs)))
     {
       // When building the correctness witness, we only care about
       // asserts and assumes
-      if (!(it->is_assert() || it->is_assume()))
+      if (!(SSA_step.is_assert() || SSA_step.is_assume()))
         continue;
 
       goto_trace.steps.emplace_back();
       goto_trace_stept &goto_trace_step = goto_trace.steps.back();
-      goto_trace_step.thread_nr = it->source.thread_nr;
-      goto_trace_step.lhs = it->lhs;
-      goto_trace_step.rhs = it->rhs;
-      goto_trace_step.pc = it->source.pc;
-      goto_trace_step.comment = it->comment;
-      goto_trace_step.original_lhs = it->original_lhs;
-      goto_trace_step.type = it->type;
+      goto_trace_step.thread_nr = SSA_step.source.thread_nr;
+      goto_trace_step.lhs = SSA_step.lhs;
+      goto_trace_step.rhs = SSA_step.rhs;
+      goto_trace_step.pc = SSA_step.source.pc;
+      goto_trace_step.comment = SSA_step.comment;
+      goto_trace_step.original_lhs = SSA_step.original_lhs;
+      goto_trace_step.type = SSA_step.type;
       goto_trace_step.step_nr = step_nr++;
-      goto_trace_step.format_string = it->format_string;
-      goto_trace_step.stack_trace = it->stack_trace;
+      goto_trace_step.format_string = SSA_step.format_string;
+      goto_trace_step.stack_trace = SSA_step.stack_trace;
     }
   }
 }

--- a/src/goto-symex/build_goto_trace.h
+++ b/src/goto-symex/build_goto_trace.h
@@ -6,17 +6,17 @@
 #include <goto-symex/symex_target_equation.h>
 
 void build_goto_trace(
-  const std::shared_ptr<symex_target_equationt> &target,
-  std::shared_ptr<smt_convt> &smt_conv,
+  const symex_target_equationt &target,
+  smt_convt &smt_conv,
   goto_tracet &goto_trace,
   const bool &is_compact_trace);
 
 void build_successful_goto_trace(
-  const std::shared_ptr<symex_target_equationt> &target,
+  const symex_target_equationt &target,
   const namespacet &ns,
   goto_tracet &goto_trace);
 
-expr2tc build_lhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &lhs);
-expr2tc build_rhs(std::shared_ptr<smt_convt> &smt_conv, const expr2tc &rhs);
+expr2tc build_lhs(smt_convt &smt_conv, const expr2tc &lhs);
+expr2tc build_rhs(smt_convt &smt_conv, const expr2tc &rhs);
 
 #endif

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1226,7 +1226,7 @@ dfs_execution_statet::~dfs_execution_statet()
 std::shared_ptr<execution_statet> dfs_execution_statet::clone() const
 {
   std::shared_ptr<dfs_execution_statet> d =
-    std::shared_ptr<dfs_execution_statet>(new dfs_execution_statet(*this));
+    std::make_shared<dfs_execution_statet>(*this);
 
   // Duplicate target equation; or if we're encoding at runtime, push a context.
   if (smt_during_symex)
@@ -1250,8 +1250,7 @@ schedule_execution_statet::~schedule_execution_statet()
 std::shared_ptr<execution_statet> schedule_execution_statet::clone() const
 {
   std::shared_ptr<schedule_execution_statet> s =
-    std::shared_ptr<schedule_execution_statet>(
-      new schedule_execution_statet(*this));
+    std::make_shared<schedule_execution_statet>(*this);
 
   // Don't duplicate target equation.
   s->target = target;
@@ -1285,8 +1284,7 @@ execution_statet::state_hashing_level2t::state_hashing_level2t(
 std::shared_ptr<renaming::level2t>
 execution_statet::state_hashing_level2t::clone() const
 {
-  return std::shared_ptr<state_hashing_level2t>(
-    new state_hashing_level2t(*this));
+  return std::make_shared<state_hashing_level2t>(*this);
 }
 
 void execution_statet::state_hashing_level2t::make_assignment(

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -123,7 +123,7 @@ public:
   /**
    *  Create a symex result for this run.
    */
-  std::shared_ptr<goto_symext::symex_resultt> get_symex_result();
+  goto_symext::symex_resultt get_symex_result();
 
   /**
    *  Symbolically execute one instruction.

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -605,9 +605,8 @@ reachability_treet::generate_schedule_formula()
     go_next_state();
   }
 
-  return std::shared_ptr<goto_symext::symex_resultt>(
-    new goto_symext::symex_resultt(
-      schedule_target, schedule_total_claims, schedule_remaining_claims));
+  return std::make_shared<goto_symext::symex_resultt>(
+    schedule_target, schedule_total_claims, schedule_remaining_claims);
 }
 
 bool reachability_treet::restore_from_dfs_state(void *)

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -521,8 +521,7 @@ bool reachability_treet::check_thread_viable(unsigned int tid, bool quiet) const
   return true;
 }
 
-std::shared_ptr<goto_symext::symex_resultt>
-reachability_treet::get_next_formula()
+goto_symext::symex_resultt reachability_treet::get_next_formula()
 {
   assert(execution_states.size() > 0 && "Must setup RT before exploring");
 
@@ -572,8 +571,7 @@ bool reachability_treet::setup_next_formula()
   return reset_to_unexplored_state();
 }
 
-std::shared_ptr<goto_symext::symex_resultt>
-reachability_treet::generate_schedule_formula()
+goto_symext::symex_resultt reachability_treet::generate_schedule_formula()
 {
   int total_states = 0;
   while (has_more_states())
@@ -605,7 +603,7 @@ reachability_treet::generate_schedule_formula()
     go_next_state();
   }
 
-  return std::make_shared<goto_symext::symex_resultt>(
+  return goto_symext::symex_resultt(
     schedule_target, schedule_total_claims, schedule_remaining_claims);
 }
 

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -215,7 +215,7 @@ public:
    *  Explores a new thread interleaving and returns its trace.
    *  @return A symex_resultt recording the trace that we just generated.
    */
-  std::shared_ptr<goto_symext::symex_resultt> get_next_formula();
+  goto_symext::symex_resultt get_next_formula();
 
   /**
    *  Run threads in --schedule manner.
@@ -223,7 +223,7 @@ public:
    *  trace.
    *  @return Symex result representing all interleavings
    */
-  std::shared_ptr<goto_symext::symex_resultt> generate_schedule_formula();
+  goto_symext::symex_resultt generate_schedule_formula();
 
   /**
    *  Reset ex_state stack to unexplored state.

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -133,10 +133,9 @@ void goto_symext::assume(const expr2tc &the_assumption)
     cur_state->guard.make_false();
 }
 
-std::shared_ptr<goto_symext::symex_resultt> goto_symext::get_symex_result()
+goto_symext::symex_resultt goto_symext::get_symex_result()
 {
-  return std::make_shared<goto_symext::symex_resultt>(
-    target, total_claims, remaining_claims);
+  return goto_symext::symex_resultt(target, total_claims, remaining_claims);
 }
 
 void goto_symext::symex_step(reachability_treet &art)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -135,8 +135,8 @@ void goto_symext::assume(const expr2tc &the_assumption)
 
 std::shared_ptr<goto_symext::symex_resultt> goto_symext::get_symex_result()
 {
-  return std::shared_ptr<goto_symext::symex_resultt>(
-    new goto_symext::symex_resultt(target, total_claims, remaining_claims));
+  return std::make_shared<goto_symext::symex_resultt>(
+    target, total_claims, remaining_claims);
 }
 
 void goto_symext::symex_step(reachability_treet &art)

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -891,8 +891,8 @@ void generate_testcase_metadata()
 #include <goto-symex/slice.h>
 void generate_testcase(
   const std::string &file_name,
-  const std::shared_ptr<symex_target_equationt> &target,
-  std::shared_ptr<smt_convt> &smt_conv)
+  const symex_target_equationt &target,
+  smt_convt &smt_conv)
 {
   /* Unfortunately, TestCov rely on checking for '<!DOCTYPE test' and as Boost
    * Property Tree is not a proper XML generator... it does not support this */
@@ -919,7 +919,7 @@ void generate_testcase(
       !nondet.count(sym.thename.as_string()))
     {
       nondet.insert(sym.thename.as_string());
-      auto new_rhs = smt_conv->get(expr);
+      auto new_rhs = smt_conv.get(expr);
 
       // I don't think there is anything beyond constant int Test-Comp
       if (is_constant_int2t(new_rhs))
@@ -943,19 +943,18 @@ void generate_testcase(
       }
     }
   };
-  for (auto const &SSA_step : target->SSA_steps)
+  for (auto const &SSA_step : target.SSA_steps)
   {
-    if (!smt_conv->l_get(SSA_step.guard_ast).is_true())
+    if (!smt_conv.l_get(SSA_step.guard_ast).is_true())
       continue;
 
     if (SSA_step.is_assignment())
     {
-      /*
-         * AFAIK there are two ways to arrive here with a nondet symbol
-         *
-         * 1. As a plain symbol `int a = __VERIFIER_nondet_int();`
-         * 2. As a with operation `arr[4] == __VERIFIER_nondet_int();`
-         */
+      /* AFAIK there are two ways to arrive here with a nondet symbol
+       *
+       * 1. As a plain symbol `int a = __VERIFIER_nondet_int();`
+       * 2. As a with operation `arr[4] == __VERIFIER_nondet_int();`
+       */
       SSA_step.dump();
       generate_input(symex_slicet::get_nondet_symbol(SSA_step.rhs));
     }

--- a/src/goto-symex/witnesses.h
+++ b/src/goto-symex/witnesses.h
@@ -179,5 +179,5 @@ get_invariant(std::string verified_file, BigInt line_number, optionst &options);
 void generate_testcase_metadata();
 void generate_testcase(
   const std::string &file_name,
-  const std::shared_ptr<symex_target_equationt> &target,
-  std::shared_ptr<smt_convt> &smt_conv);
+  const symex_target_equationt &target,
+  smt_convt &smt_conv);


### PR DESCRIPTION
As @brcfarias mentioned in private conversation, shared_ptr (and unique_ptr as well, to some extent) as function parameters is quite uncommon and has some risks, in particular when passed by-reference.

The bmct class (and a few related APIs) were doing that for the `runtime_solver`, the `symex` instance, `symex_target_equationt`, and `symex_resultt`. This PR removes shared_ptr as parameter to functions in those APIs by instead passing the objects via reference. It also adds more `const` in order to communicate that an object is just read. The hope is that the code is a bit clearer to follow.

The first two, `runtime_solver` and `symex` are now held by unique-ptrs instead of shared ones, because they are not actually being shared in the sense that a copyable object needs to store them as members.