### PR TITLE
SV-Comp builds should include all supported solvers

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -96,7 +96,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ubuntu-latest
-      build-flags: '-b Release -e Off'
+      build-flags: '-b Release -e Off -C'
       testing: false     
 
   run-benchexec:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -168,7 +168,7 @@ do
 	  -DENABLE_CVC4=OFF \
           -DENABLE_BITWUZLA=On \
 	  -DENABLE_Z3=On \
-          -DENABLE_Mathsat=OFF \
+          -DENABLE_Mathsat=ON \
           -DENABLE_GOTO_CONTRACTOR=On \
           -DACADEMIC_BUILD=ON"  ;;
     B) BASE_ARGS="$BASE_ARGS -DESBMC_BUNDLE_LIBC=$OPTARG" ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -161,7 +161,16 @@ do
     d) set -x; export ESBMC_OPTS='--verbosity 9' ;;
     S) STATIC=$OPTARG ;; # should be capital ON or OFF
     c) CLANG_VERSION=$OPTARG ;; # LLVM/Clang major version
-    C) BASE_ARGS="$BASE_ARGS -DESBMC_SVCOMP=ON" ;;
+    C) BASE_ARGS="$BASE_ARGS -DESBMC_SVCOMP=ON"
+       SOLVER_FLAGS="\
+          -DENABLE_BOOLECTOR=On \
+    	  -DENABLE_YICES=ON \
+	  -DENABLE_CVC4=OFF \
+          -DENABLE_BITWUZLA=On \
+	  -DENABLE_Z3=On \
+          -DENABLE_Mathsat=OFF \
+          -DENABLE_GOTO_CONTRACTOR=On \
+          -DACADEMIC_BUILD=ON"  ;;
     B) BASE_ARGS="$BASE_ARGS -DESBMC_BUNDLE_LIBC=$OPTARG" ;;
     *) exit 1 ;;
     esac

--- a/scripts/cmake/Options.cmake
+++ b/scripts/cmake/Options.cmake
@@ -61,12 +61,18 @@ set(DEFAULT_LLVM_NAME "llvm+clang+lld-11.0.0-x86_64-windows-msvc-release-mt")
 set(DEFAULT_Z3_URL "https://github.com/Z3Prover/z3/releases/download/z3-4.12.2/z3-4.12.2-x64-win.zip")
 set(DEFAULT_Z3_NAME z3-4.12.2-x64-win)
 
+set(MATHSAT_URL "https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-win64-msvc.zip")
+set(MATHSAT_NAME "mathsat-5.6.10-win64-msvc")
+
 else()
 set(DEFAULT_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz")
 set(DEFAULT_LLVM_NAME "clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04")
 
 set(DEFAULT_Z3_URL "https://github.com/Z3Prover/z3/releases/download/z3-4.12.2/z3-4.12.2-x64-glibc-2.35.zip")
 set(DEFAULT_Z3_NAME z3-4.12.2-x64-glibc-2.35)
+
+set(MATHSAT_URL "https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-linux-x86_64.tar.gz")
+set(MATHSAT_NAME "mathsat-5.6.10-linux-x86_64")
 endif()
 
 set(ESBMC_LLVM_URL ${DEFAULT_LLVM_URL} CACHE STRING "URL to download prebuilt LLVM")

--- a/src/solvers/boolector/CMakeLists.txt
+++ b/src/solvers/boolector/CMakeLists.txt
@@ -3,6 +3,8 @@ include(CPM)
 
 if(DEFINED Boolector_DIR)
   set(ENABLE_BOOLECTOR ON)
+elseif(EXISTS $ENV{HOME}/boolector)
+  set(ENABLE_BOOLECTOR ON)
 else()
   if(ENABLE_BOOLECTOR AND DOWNLOAD_DEPENDENCIES)
     # Sadly... Boolector requires some manual execution
@@ -40,9 +42,6 @@ else()
 
 endif()
 
-if(EXISTS $ENV{HOME}/boolector)
-  set(ENABLE_BOOLECTOR ON)
-endif()
 
 if(ENABLE_BOOLECTOR)
   find_package(Boolector REQUIRED HINTS ${Boolector_DIR}/lib/cmake

--- a/src/solvers/mathsat/CMakeLists.txt
+++ b/src/solvers/mathsat/CMakeLists.txt
@@ -2,10 +2,14 @@ set(Mathsat_MIN_VERSION 5.5.4)
 
 if (DEFINED Mathsat_DIR)
     set(ENABLE_MATHSAT ON)
-endif ()
-
-if (EXISTS $ENV{HOME}/mathsat)
-    set(ENABLE_MATHSAT ON)
+elseif (EXISTS $ENV{HOME}/mathsat)
+  set(ENABLE_MATHSAT ON)
+else()
+  if(ENABLE_MATHSAT AND DOWNLOAD_DEPENDENCIES AND ACADEMIC_BUILD)
+    message("Downloading Mathsat")
+    download_zip_and_extract(MATHSAT ${MATHSAT_URL})
+    set(Mathsat_DIR ${CMAKE_BINARY_DIR}/MATHSAT/${MATHSAT_NAME})
+  endif()
 endif ()
 
 if (ENABLE_MATHSAT)


### PR DESCRIPTION
This PR will enable the build of every solver for our SV-Comp testing builds. It also adds support for MathSAT.

I will leave CVC4 disabled as [the build is outdated](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266721#c3) and we should move to CVC5: https://github.com/esbmc/esbmc/pull/935

Run example: https://github.com/esbmc/esbmc/actions/runs/7602481313