### PR TITLE
[clang-cpp-frontend] Fix the copy and move constructor

### DIFF
--- a/regression/esbmc-cpp/cpp/ch18_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch18_3/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/cpp/ch7_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_4/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp11/constructors/CpyConstructor/main.cpp
+++ b/regression/esbmc-cpp11/constructors/CpyConstructor/main.cpp
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+struct MyStruct
+{
+  int value;
+};
+
+int main()
+{
+  MyStruct a = {10};
+
+  // copy ctor
+  MyStruct c(a);
+
+  assert(c.value == 10);
+}

--- a/regression/esbmc-cpp11/constructors/CpyConstructor/test.desc
+++ b/regression/esbmc-cpp11/constructors/CpyConstructor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/CpyConstructor_fail/main.cpp
+++ b/regression/esbmc-cpp11/constructors/CpyConstructor_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+struct MyStruct
+{
+  int value;
+};
+
+int main()
+{
+  MyStruct a = {10};
+
+  // copy ctor
+  MyStruct c(a);
+
+  assert(c.value == 0); //should be 10
+}

--- a/regression/esbmc-cpp11/constructors/CpyConstructor_fail/test.desc
+++ b/regression/esbmc-cpp11/constructors/CpyConstructor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/constructors/MoveAssignOperator/main.cpp
+++ b/regression/esbmc-cpp11/constructors/MoveAssignOperator/main.cpp
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <utility>
+
+struct MyStruct
+{
+  int value;
+};
+
+int main()
+{
+  MyStruct a = {10};
+
+  MyStruct b = {5};
+
+  // move assign
+  b = std::move(a);
+
+  assert(b.value == 10);
+}

--- a/regression/esbmc-cpp11/constructors/MoveAssignOperator/test.desc
+++ b/regression/esbmc-cpp11/constructors/MoveAssignOperator/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--cppstd 11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/MoveAssignOperator_fail/main.cpp
+++ b/regression/esbmc-cpp11/constructors/MoveAssignOperator_fail/main.cpp
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <utility>
+
+struct MyStruct
+{
+  int value;
+};
+
+int main()
+{
+  MyStruct a = {10};
+
+  MyStruct b = {5};
+
+  // move assign
+  b = std::move(a);
+
+  assert(b.value == 5); //should be 10
+}

--- a/regression/esbmc-cpp11/constructors/MoveAssignOperator_fail/test.desc
+++ b/regression/esbmc-cpp11/constructors/MoveAssignOperator_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--cppstd 11
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/constructors/MoveConstructor/main.cpp
+++ b/regression/esbmc-cpp11/constructors/MoveConstructor/main.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <utility>
+
+struct MyStruct
+{
+  int value;
+};
+
+int main()
+{
+  MyStruct a = {10};
+
+  // move ctor
+  MyStruct c(std::move(a));
+
+  assert(c.value == 10);
+}

--- a/regression/esbmc-cpp11/constructors/MoveConstructor/test.desc
+++ b/regression/esbmc-cpp11/constructors/MoveConstructor/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--cppstd 11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/MoveConstructor_fail/main.cpp
+++ b/regression/esbmc-cpp11/constructors/MoveConstructor_fail/main.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <utility>
+
+struct MyStruct
+{
+  int value;
+};
+
+int main()
+{
+  MyStruct a = {10};
+
+  // move ctor
+  MyStruct c(std::move(a));
+
+  assert(c.value == 0); //should be 10
+}

--- a/regression/esbmc-cpp11/constructors/MoveConstructor_fail/test.desc
+++ b/regression/esbmc-cpp11/constructors/MoveConstructor_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--cppstd 11
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
@@ -149,6 +149,7 @@ void clang_cpp_adjust::adjust_decl_block(codet &code)
     if (it->is_code() && (it->statement() == "skip"))
       continue;
 
+    adjust_expr(*it);
     code_declt &code_decl = to_code_decl(to_code(*it));
 
     if (code_decl.operands().size() == 2)
@@ -195,8 +196,6 @@ void clang_cpp_adjust::adjust_decl_block(codet &code)
         rhs.swap(result_expr);
       }
     }
-
-    adjust_expr(*it);
 
     new_block.copy_to_operands(code_decl);
   }


### PR DESCRIPTION
This PR fixes the incorrect function call and adds the rvalue reference test case.

example:
```
struct MyStruct {
    int value;
};

int main() {
    MyStruct a = {10};

    MyStruct c(a);
}
```
`esbmc main.cpp --goto-functions-only`

result:
![9_R5(9DG8%D34T{T7HZU2KG](https://github.com/esbmc/esbmc/assets/115160284/57ce4fd2-52a0-4223-903a-992cc5cccc40)
