### PR TITLE
Slicer support for Arrays/Structs

### DIFF
--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -104,23 +104,24 @@ void symex_slicet::run_on_assignment(
   // We can't really apply magic renumbering for now. We can, convert expressions into identities
   if (it != array_depends.end() && is_with2t(SSA_step.rhs))
   {
-
     with2t &w = to_with2t(SSA_step.rhs);
     bool can_slice = is_constant_int2t(w.update_field);
     // TODO: support for symbolic constraints
-    if(!can_slice)
+    if (!can_slice)
       it->second.insert(w.update_field);
-    for(const expr2tc &index : it->second) {
-      if(!can_slice)
+    for (const expr2tc &index : it->second)
+    {
+      if (!can_slice)
         break;
 
-      if(!is_constant_int2t(index))
+      if (!is_constant_int2t(index))
         can_slice = false;
       else
-        can_slice &= to_constant_int2t(index).value != to_constant_int2t(w.update_field).value;
+        can_slice &= to_constant_int2t(index).value !=
+                     to_constant_int2t(w.update_field).value;
     }
 
-    if(can_slice)
+    if (can_slice)
       SSA_step.cond = equality2tc(SSA_step.lhs, w.source_value);
   }
 

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -294,20 +294,24 @@ expr2tc symex_slicet::get_nondet_symbol(const expr2tc &expr)
   }
 }
 
-void replace_symbol_on_expression(expr2tc &step, const std::unordered_map<std::string, expr2tc> symbol_map)
+void replace_symbol_on_expression(
+  expr2tc &step,
+  const std::unordered_map<std::string, expr2tc> symbol_map)
 {
-  if(!step)
+  if (!step)
     return;
-   if(is_symbol2t(step))
-   {
-     auto it = symbol_map.find(to_symbol2t(step).get_symbol_name());
-     if(it != symbol_map.end())
-       step = it->second;
-   }
-   step->Foreach_operand([&symbol_map](expr2tc &e){ replace_symbol_on_expression(e, symbol_map);});
+  if (is_symbol2t(step))
+  {
+    auto it = symbol_map.find(to_symbol2t(step).get_symbol_name());
+    if (it != symbol_map.end())
+      step = it->second;
+  }
+  step->Foreach_operand(
+    [&symbol_map](expr2tc &e) { replace_symbol_on_expression(e, symbol_map); });
 }
 
-void symex_slicet::slice_id_operations(symex_target_equationt::SSA_stepst &eq) {
+void symex_slicet::slice_id_operations(symex_target_equationt::SSA_stepst &eq)
+{
   std::unordered_map<std::string, expr2tc> symbol_map;
 
   for (auto &step : eq)
@@ -325,7 +329,7 @@ void symex_slicet::slice_id_operations(symex_target_equationt::SSA_stepst &eq) {
       assert(is_equality2t(step.cond));
       equality2t &eq = to_equality2t(step.cond);
       assert(is_symbol2t(eq.side_1));
-      if(is_symbol2t(eq.side_2))
+      if (is_symbol2t(eq.side_2))
       {
         symbol_map[to_symbol2t(eq.side_1).get_symbol_name()] = eq.side_2;
         step.ignore = true;

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -1,6 +1,7 @@
 #ifndef CPROVER_GOTO_SYMEX_SLICE_H
 #define CPROVER_GOTO_SYMEX_SLICE_H
 
+#include <cstdint>
 #include <goto-symex/symex_target_equation.h>
 #include <util/time_stopping.h>
 #include <util/algorithms.h>
@@ -114,6 +115,11 @@ public:
    */
   std::unordered_set<std::string> depends;
 
+  /**
+   * Holds the array and indexes that the current equation depends on.
+   */
+  std::unordered_map< std::string, std::unordered_set<uint64_t>> array_depends;
+
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 
   /**
@@ -156,6 +162,8 @@ protected:
    */
   template <bool Add>
   bool get_symbols(const expr2tc &expr);
+
+  bool get_array_symbols(const expr2tc &expr);
 
   /**
    * Remove unneeded assumes from the formula

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -112,7 +112,6 @@ public:
     return true;
   }
 
-
   /**
    * Iterate over all steps of the \eq in order,
    * replacing ID operations of the form "symbol = symbol".

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -118,7 +118,8 @@ public:
   /**
    * Holds the array and indexes that the current equation depends on.
    */
-  std::unordered_map<std::string, std::unordered_set<expr2tc, irep2_hash>> array_depends;
+  std::unordered_map<std::string, std::unordered_set<expr2tc, irep2_hash>>
+    array_depends;
 
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -118,7 +118,7 @@ public:
   /**
    * Holds the array and indexes that the current equation depends on.
    */
-  std::unordered_map<std::string, std::unordered_set<uint64_t>> array_depends;
+  std::unordered_map<std::string, std::unordered_set<expr2tc, irep2_hash>> array_depends;
 
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -102,6 +102,8 @@ public:
     fine_timet algorithm_start = current_time();
     for (auto &step : boost::adaptors::reverse(eq))
       run_on_step(step);
+
+    slice_id_operations(eq);
     fine_timet algorithm_stop = current_time();
     log_status(
       "Slicing time: {}s (removed {} assignments)",
@@ -109,6 +111,14 @@ public:
       sliced);
     return true;
   }
+
+
+  /**
+   * Iterate over all steps of the \eq in order,
+   * replacing ID operations of the form "symbol = symbol".
+   * @param eq
+   */
+  void slice_id_operations(symex_target_equationt::SSA_stepst &eq);
 
   /**
    * Holds the symbols the current equation depends on.

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -118,7 +118,7 @@ public:
   /**
    * Holds the array and indexes that the current equation depends on.
    */
-  std::unordered_map< std::string, std::unordered_set<uint64_t>> array_depends;
+  std::unordered_map<std::string, std::unordered_set<uint64_t>> array_depends;
 
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 


### PR DESCRIPTION
This PR intends to expand our slicer to work with fields and structs by replacing the WITH operations with just the plain symbol. SMT solvers have big trouble dealing with all the updates. For example, the following program:

```c
#define N 50
int main()
{  
  int arr[N];
  for (unsigned long i = 0; i < N; i++)
    arr[i] = (int)i;

  __ESBMC_assert(arr[42] == 42, "");
}
```

Will generate:
```
Thread 0 file test.c line 9 column 3 function main
ASSIGNMENT ()
arr?1!0&0#44 == (arr?1!0&0#43 WITH [42:=42])
... 
Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
arr?1!0&0#51 == (arr?1!0&0#50 WITH [49:=49])

Thread 0 file test.c line 9 column 3 function main
ASSERT
execution_statet::\guard_exec?0!0 => arr?1!0&0#51[42] == 42
assertion
```

The increasing number of WITH takes progressively larger solving time. The slicer could replace the with id operations: 
```
Thread 0 file test.c line 9 column 3 function main
ASSIGNMENT ()
arr?1!0&0#44 == (arr?1!0&0#43 WITH [42:=42])
... 
Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
arr?1!0&0#51 == (arr?1!0&0#50

Thread 0 file test.c line 9 column 3 function main
ASSERT
execution_statet::\guard_exec?0!0 => arr?1!0&0#51[42] == 42
assertion
```

For the program above, changing the N resulted in the following Runtime decision procedure times with Z3 v4.12.4:

| N   | Master | Array Slicing |
| ---- | -----------| ------------- |
| 50 | 0.00s | 0.00s |
| 500 | 0.03s | 0.001s |
| 5 000 | 0.141s | 0.004s |
| 50 000 | 18.807s | 0.051s |
| 500 000 | +300s | 5.506s |

The implementation still requires a bit of testing, specially when an assertion depends on a symbolic index. Also, it would be great if we had some way of recursively replacing the equivalences. I think this could be done in another pass though. 