### PR TITLE
[witness] fixed overflow in ID node

### DIFF
--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -11,8 +11,8 @@
 
 typedef boost::property_tree::ptree xmlnodet;
 
-short int nodet::_id = 0;
-short int edget::_id = 0;
+unsigned int nodet::_id = 0;
+unsigned int edget::_id = 0;
 
 void grapht::generate_graphml(optionst &options)
 {

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -11,8 +11,8 @@
 
 typedef boost::property_tree::ptree xmlnodet;
 
-unsigned int nodet::_id = 0;
-unsigned int edget::_id = 0;
+BigInt nodet::_id = 0;
+BigInt edget::_id = 0;
 
 void grapht::generate_graphml(optionst &options)
 {

--- a/src/goto-symex/witnesses.h
+++ b/src/goto-symex/witnesses.h
@@ -5,6 +5,7 @@
 #include <goto-symex/goto_trace.h>
 #include <string>
 #include <regex>
+#include <big-int/bigint.hh>
 
 typedef boost::property_tree::ptree xmlnodet;
 
@@ -13,7 +14,7 @@ typedef boost::property_tree::ptree xmlnodet;
 class nodet
 {
 private:
-  static unsigned int _id;
+  static BigInt _id;
 
 public:
   std::string id;
@@ -25,15 +26,15 @@ public:
   std::string invariant_scope;
   nodet(void)
   {
-    id = "N" + std::to_string(_id);
-    _id++;
+    id = "N" + integer2string(_id);
+    _id += 1;
   }
 };
 
 class edget
 {
 private:
-  static unsigned int _id;
+  static BigInt _id;
 
 public:
   std::string id;
@@ -54,15 +55,15 @@ public:
   nodet *to_node;
   edget(void)
   {
-    id = "E" + std::to_string(_id);
-    _id++;
+    id = "E" + integer2string(_id);
+    _id += 1;
     from_node = NULL;
     to_node = NULL;
   }
   edget(nodet *from_node, nodet *to_node)
   {
-    id = "E" + std::to_string(_id);
-    _id++;
+    id = "E" + integer2string(_id);
+    _id += 1;
     this->from_node = from_node;
     this->to_node = to_node;
   }

--- a/src/goto-symex/witnesses.h
+++ b/src/goto-symex/witnesses.h
@@ -13,7 +13,7 @@ typedef boost::property_tree::ptree xmlnodet;
 class nodet
 {
 private:
-  static short int _id;
+  static unsigned int _id;
 
 public:
   std::string id;
@@ -33,7 +33,7 @@ public:
 class edget
 {
 private:
-  static short int _id;
+  static unsigned int _id;
 
 public:
   std::string id;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/1621.

Here is the command line used to produce the witness:

````
time esbmc --no-div-by-zero-check --force-malloc-success --state-hashing --add-symex-value-sets --no-align-check --k-step 2 --floatbv --unlimited-k-steps --no-vla-size-check szymanski.4.prop1-func-interl.c --64 --witness-output witness.graphml --enable-unreachability-intrinsic --no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind --k-induction --max-inductive-step 3
````

The newly generated witness is here: [witness.zip](https://github.com/esbmc/esbmc/files/14039888/witness.zip)



