### PR TITLE
Interval analysis now inverts boolean correctly

### DIFF
--- a/regression/esbmc/github_1565-2/test.desc
+++ b/regression/esbmc/github_1565-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --interval-analysis
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_1565/main.c
+++ b/regression/esbmc/github_1565/main.c
@@ -1,0 +1,20 @@
+extern void __VERIFIER_error(void);
+
+extern long __VERIFIER_nondet_long(void);
+extern _Bool __VERIFIER_nondet_bool(void);
+
+int main(){
+        _Bool b1 = __VERIFIER_nondet_bool();
+        _Bool b2 = __VERIFIER_nondet_bool();
+        long l1 = __VERIFIER_nondet_long();
+        long l2 = __VERIFIER_nondet_long();
+        if(b2){
+                if(!(((b1) || ((l2) == (0))) && (!(b2)))){
+                        if(!(((b2) || ((l1) == (0))) && (!(b1)))){
+                        __VERIFIER_error();
+                        }
+                }
+        }
+    return 0;
+}
+

--- a/regression/esbmc/github_1565/test.desc
+++ b/regression/esbmc/github_1565/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis
+^VERIFICATION FAILED

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -539,13 +539,25 @@ public:
 
   static interval_templatet<T> invert_bool(const interval_templatet<T> &i)
   {
-    if (!i.singleton())
-      return i;
-
-    auto result = i;
-    auto inverted = result.get_lower() == 0 ? 1 : 0;
-    result.set_lower(inverted);
-    result.set_upper(inverted);
+    interval_templatet<T> result;
+    if (!i.contains(0))
+    {
+      // i is always true, return false
+      result.set_lower(0);
+      result.set_upper(0);
+    }
+    else if (i.singleton())
+    {
+      // i is always false, return true
+      result.set_lower(1);
+      result.set_upper(1);
+    }
+    else
+    {
+      // i is a maybe
+      result.set_lower(0);
+      result.set_upper(1);
+    }
     return result;
   }
 


### PR DESCRIPTION
Solves #1565

The original issue was that the `invert_bool` function expected an interval to be a singleton i.e., [0,0] or [1,1]. If the interval was not that, it would assume that it was (-inf,+inf). This resulted in invert bool for [1,+inf) return [1, +inf) which is wrong.