### PR TITLE
[clang-cpp-frontend] fix the cpp new initialisation

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/new_init/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/new_init/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+int main()
+{
+  int *p = new int(10);
+  double *s = new double(9.8);
+  bool *b = new bool(true);
+
+  assert(*p == 10);
+  assert(*s == 9.8);
+  assert(*b == true);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/new_init/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/new_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/new_init_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/new_init_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+int main() 
+{
+    int* p = new int(10);
+    double* s = new double(9.8);
+    bool* b = new bool(true);
+
+    assert(*p == 0); //should be 10
+    assert(*s == 0); //should be 9.8
+    assert(*b == true);
+
+    return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/new_init_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/new_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/new_init_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/new_init_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
-
+--multi-property
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/new2/test.desc
+++ b/regression/esbmc-cpp/cpp/new2/test.desc
@@ -5,7 +5,7 @@
   <item_03_summary>Aims to analyze the main function from module: esbmc-cpp</item_03_summary>
   <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
   <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
+  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>


### PR DESCRIPTION
The current C++ frontend does not initialise some types correctly.

```
#include <cassert>

int main() 
{
    int* p = new int(10);

    assert(*p == 10);

    return 0;
}
```
![image](https://github.com/esbmc/esbmc/assets/115160284/ee4c0568-c803-4159-a2b8-17d7b5ea55fc)

