### PR TITLE
[C++ VERIFICATION] Improved cpp new and delete

### DIFF
--- a/regression/esbmc-cpp/cpp/dangling_memleak/main.cpp
+++ b/regression/esbmc-cpp/cpp/dangling_memleak/main.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+
+class Foo {
+  public:
+    Foo() {value = 0;};
+    void Execute();
+    void Increment();
+  private:
+    int value;
+};
+
+void Foo::Execute() {
+        printf("Executing...");
+}
+
+void Foo::Increment() {
+    value++;
+}
+
+int main()
+{
+  Foo *foo = new Foo();
+
+  foo->Increment();  // Incrementing the value
+
+  foo->Execute(); // Executing
+
+  delete foo;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dangling_memleak/test.desc
+++ b/regression/esbmc-cpp/cpp/dangling_memleak/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--memory-leak-check
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/dangling_memleak_failed/main.cpp
+++ b/regression/esbmc-cpp/cpp/dangling_memleak_failed/main.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+
+class Foo {
+  public:
+    Foo() {value = 0;};
+    void Execute();
+    void Increment();
+  private:
+    int value;
+};
+
+void Foo::Execute() {
+        printf("Executing...");
+}
+
+void Foo::Increment() {
+    value++;
+}
+
+int main()
+{
+  Foo *foo = new Foo();
+
+  foo->Increment();  // Incrementing the value
+
+  foo->Execute(); // Executing
+
+  // Miss delete
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dangling_memleak_failed/test.desc
+++ b/regression/esbmc-cpp/cpp/dangling_memleak_failed/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--memory-leak-check
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/dangling_ptr/main.cpp
+++ b/regression/esbmc-cpp/cpp/dangling_ptr/main.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+
+class Foo {
+  public:
+    Foo() {value = 0;};
+    void Execute();
+    void Increment();
+  private:
+    int value;
+};
+
+void Foo::Execute() {
+        printf("Executing...");
+}
+
+void Foo::Increment() {
+    value++;
+}
+
+int main()
+{
+  Foo *foo = new Foo();
+
+  foo->Increment();  // Incrementing the value
+
+  foo->Execute(); // Executing
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dangling_ptr/test.desc
+++ b/regression/esbmc-cpp/cpp/dangling_ptr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/dangling_ptr_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/dangling_ptr_fail/main.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+
+class Foo {
+  public:
+    Foo() {value = 0;};
+    void Execute();
+    void Increment();
+  private:
+    int value;
+};
+
+void Foo::Execute() {
+        printf("Executing...");
+}
+
+void Foo::Increment() {
+    value++;
+}
+
+int main()
+{
+  Foo *foo = new Foo();
+
+  delete foo;
+
+  foo->Increment();  // Incrementing the value
+
+  foo->Execute(); // Executing
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/dangling_ptr_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/dangling_ptr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/double_free/test.desc
+++ b/regression/esbmc-cpp/cpp/double_free/test.desc
@@ -9,4 +9,4 @@
   <item_07_test_importance>High</item_07_test_importance>
   <item_08_execution_type>Automated</item_08_execution_type>
   <item_09_author>Ceteli/UFAM</item_09_author>
-<item_10_mode>KNOWNBUG</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>
+<item_10_mode>CORE</item_10_mode><item_11_issue>CXXThisExpr</item_11_issue></test-case>

--- a/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast1_fail/test.desc
+++ b/regression/esbmc-cpp/polymorphism_bringup/dynamic_cast1_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -330,20 +330,6 @@ void goto_convertt::do_cpp_new(
   valid_expr.copy_to_operands(lhs);
   exprt neg_valid_expr = gen_not(valid_expr);
 
-  exprt pointer_offset_expr("pointer_offset", pointer_type());
-  pointer_offset_expr.copy_to_operands(lhs);
-
-  equality_exprt offset_is_zero_expr(
-    pointer_offset_expr, gen_zero(pointer_type()));
-
-  // first assume that it's available and that it's a dynamic object
-  goto_programt::targett t_a = dest.add_instruction(ASSUME);
-  t_a->location = rhs.find_location();
-  migrate_expr(neg_valid_expr, t_a->guard);
-
-  migrate_expr(valid_expr, t_a->guard);
-  t_a->guard = not2tc(t_a->guard);
-
   // set size
   //nec: ex37.c
   exprt dynamic_size("dynamic_size", size_type());

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1128,16 +1128,6 @@ void goto_convertt::convert_cpp_delete(const codet &code, goto_programt &dest)
   goto_programt::targett t_c = dest.add_instruction(ASSIGN);
   t_c->code = assign2;
   t_c->location = code.location();
-
-  exprt deallocated_expr("deallocated_object", bool_typet());
-  deallocated_expr.copy_to_operands(tmp_op);
-
-  //indicate that memory has been deallocated
-  assign = code_assignt(deallocated_expr, true_exprt());
-  migrate_expr(assign, assign2);
-  goto_programt::targett t_d = dest.add_instruction(ASSIGN);
-  t_d->code = assign2;
-  t_d->location = code.location();
 }
 
 void goto_convertt::convert_assert(const codet &code, goto_programt &dest)

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -17,26 +17,14 @@ void goto_symext::symex_other(const expr2tc code)
     expr2tc operand = expr.operand;
     dereference(operand, dereferencet::READ);
   }
-  else if (is_code_cpp_delete2t(code2))
+  else if (is_code_cpp_del_array2t(code2) || is_code_cpp_delete2t(code2))
   {
     replace_dynamic_allocation(code2);
     replace_nondet(code2);
 
-    const code_cpp_delete2t &code = to_code_cpp_delete2t(code2);
+    const auto &code_expr = static_cast<const code_expression_data &>(*code2);
 
-    expr2tc deref = code.operand;
-    dereference(deref, dereferencet::FREE);
-
-    symex_cpp_delete(deref);
-  }
-  else if (is_code_cpp_del_array2t(code2))
-  {
-    replace_dynamic_allocation(code2);
-    replace_nondet(code2);
-
-    const code_cpp_del_array2t &code = to_code_cpp_del_array2t(code2);
-
-    expr2tc deref = code.operand;
+    expr2tc deref = code_expr.operand;
     dereference(deref, dereferencet::FREE);
 
     symex_cpp_delete(deref);

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -17,15 +17,29 @@ void goto_symext::symex_other(const expr2tc code)
     expr2tc operand = expr.operand;
     dereference(operand, dereferencet::READ);
   }
-  else if (is_code_cpp_del_array2t(code2) || is_code_cpp_delete2t(code2))
+  else if (is_code_cpp_delete2t(code2))
   {
-    expr2tc deref_code(code2);
+    replace_dynamic_allocation(code2);
+    replace_nondet(code2);
 
-    replace_dynamic_allocation(deref_code);
-    replace_nondet(deref_code);
-    dereference(deref_code, dereferencet::READ);
+    const code_cpp_delete2t &code = to_code_cpp_delete2t(code2);
 
-    symex_cpp_delete(deref_code);
+    expr2tc deref = code.operand;
+    dereference(deref, dereferencet::FREE);
+
+    symex_cpp_delete(deref);
+  }
+  else if (is_code_cpp_del_array2t(code2))
+  {
+    replace_dynamic_allocation(code2);
+    replace_nondet(code2);
+
+    const code_cpp_del_array2t &code = to_code_cpp_del_array2t(code2);
+
+    expr2tc deref = code.operand;
+    dereference(deref, dereferencet::FREE);
+
+    symex_cpp_delete(deref);
   }
   else if (is_code_free2t(code2))
   {


### PR DESCRIPTION
Fixed C++ dangling pointer checking. 

Fixed C++ double delete.

Next PR todo: move the adjustment of cpp new and delete into symex.

still wait for #1644 