### PR TITLE
[ibex-contractor] Warning fix

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1238,7 +1238,7 @@ void interval_domaint::assume(const expr2tc &cond)
     {
       contractor.maps_to_domains(int_map, real_map);
       contractor.apply_contractor();
-      new_cond = contractor.result_of_outer(new_cond);
+      new_cond = contractor.result_of_outer();
       simplify(new_cond);
     }
   }

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -965,7 +965,7 @@ void interval_analysis_ibex_contractor::apply_contractor()
       .count();
 }
 
-expr2tc interval_analysis_ibex_contractor::result_of_outer(expr2tc exp)
+expr2tc interval_analysis_ibex_contractor::result_of_outer()
 {
   expr2tc cond = gen_true_expr();
 

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -662,7 +662,7 @@ public:
 
   void apply_contractor();
 
-  expr2tc result_of_outer(expr2tc exp);
+  expr2tc result_of_outer();
 
   void dump(bool is_timed);
 


### PR DESCRIPTION
Removed the cause of the warning.
```[354/379] Building CXX object src/goto-programs/CMakeFiles/gotocontractor.dir/goto_contractor.cpp.o
/home/lucas/ESBMC_Project/esbmc/src/goto-programs/goto_contractor.cpp: In member function ‘expr2tc interval_analysis_ibex_contractor::result_of_outer(expr2tc)’:
/home/lucas/ESBMC_Project/esbmc/src/goto-programs/goto_contractor.cpp:968:68: warning: unused parameter ‘exp’ [-Wunused-parameter]
  968 | expr2tc interval_analysis_ibex_contractor::result_of_outer(expr2tc exp)
      |                                                            ~~~~~~~^~```