### PR TITLE
Abstract Interpreter now considers functions pointer as a reset

### DIFF
--- a/regression/esbmc/interval-analysis-function-ptr-false/main.c
+++ b/regression/esbmc/interval-analysis-function-ptr-false/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+int counter = 0;
+
+void increment()
+{
+  counter = 1;
+}
+
+void check()
+{
+  assert(counter == 0);
+}
+
+int main()
+{
+  void (*fun_ptr)(void);
+  int a;
+  if (a)
+    {
+      fun_ptr();
+      // This is reachable with no-pointer-check!
+      increment();
+    }  
+  check();
+}

--- a/regression/esbmc/interval-analysis-function-ptr-false/test.desc
+++ b/regression/esbmc/interval-analysis-function-ptr-false/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --no-pointer-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/interval_can_handle_function_ptr/test.desc
+++ b/regression/esbmc/interval_can_handle_function_ptr/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 interval.i
 --interval-analysis
 ^VERIFICATION FAILED$

--- a/src/goto-programs/abstract-interpretation/ai.cpp
+++ b/src/goto-programs/abstract-interpretation/ai.cpp
@@ -268,7 +268,7 @@ bool ai_baset::do_function_call_rec(
 
   /* NOTE: Ideally we could let the domains deal with this with a more grained level.
      For example, a function pointer that has no parameters can only affect global state.
-     However, I do not thing its a good idea to optimize for a hacky behaviour. Let's first
+     However, I do not think its a good idea to optimize for a hacky behaviour. Let's first
      fix the AI. */
   tmp_state->make_entry();
   return merge(*tmp_state, l_call, l_return);

--- a/src/goto-programs/abstract-interpretation/ai.cpp
+++ b/src/goto-programs/abstract-interpretation/ai.cpp
@@ -264,8 +264,7 @@ bool ai_baset::do_function_call_rec(
 
   // TODO: We really should have a points-to for the AI.
   get_state(l_return);
-  std::unique_ptr<statet> tmp_state(
-				    make_temporary_state(get_state(l_call)));
+  std::unique_ptr<statet> tmp_state(make_temporary_state(get_state(l_call)));
 
   /* NOTE: Ideally we could let the domains deal with this with a more grained level.
      For example, a function pointer that has no parameters can only affect global state.

--- a/src/goto-programs/abstract-interpretation/ai.cpp
+++ b/src/goto-programs/abstract-interpretation/ai.cpp
@@ -245,10 +245,7 @@ bool ai_baset::do_function_call_rec(
   const namespacet &ns)
 {
   assert(!goto_functions.function_map.empty());
-  bool new_data = false;
 
-  // This is quite a strong assumption on the well-formedness of the program.
-  // It means function pointers must be removed before use.
   if (is_symbol2t(function))
   {
     const irep_idt &identifier = to_symbol2t(function).thename;
@@ -258,10 +255,24 @@ bool ai_baset::do_function_call_rec(
 
     assert(it != goto_functions.function_map.end());
 
-    new_data = do_function_call(l_call, l_return, goto_functions, it, ns);
+    return do_function_call(l_call, l_return, goto_functions, it, ns);
   }
+  /* As we do not have a points-to analysis, we can't know where a function pointer
+     will point-to. For now we will assume that it always points to a valid place.
+     However we will assume that the function will result the state (as we don't know)
+     what it does. */
 
-  return new_data;
+  // TODO: We really should have a points-to for the AI.
+  get_state(l_return);
+  std::unique_ptr<statet> tmp_state(
+				    make_temporary_state(get_state(l_call)));
+
+  /* NOTE: Ideally we could let the domains deal with this with a more grained level.
+     For example, a function pointer that has no parameters can only affect global state.
+     However, I do not thing its a good idea to optimize for a hacky behaviour. Let's first
+     fix the AI. */
+  tmp_state->make_entry();
+  return merge(*tmp_state, l_call, l_return);
 }
 
 void ai_baset::sequential_fixedpoint(


### PR DESCRIPTION
The abstract interpreter has no support for function pointers. This was causing some functions to consider paths as unreachable, which when combined to Interval Analysis caused an incorrect true. This PR now considers a function pointer call as a full reset. 