### PR TITLE
< and <= fixes for Wrapped Intervals

### DIFF
--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -959,13 +959,13 @@ public:
       Examples (signed char):
 
       - get_interval_bounds([10, 127]) --> <10, 127>
-      - get_interval_bounds([10, 128]) --> <-128, 10>
-      - get_interval_bounds([10, 255]) --> <-128, 10>
+      - get_interval_bounds([10, 128]) --> <-128, 127>
+      - get_interval_bounds([10, 255]) --> <-128, 127>
       - get_interval_bounds([129, 130]) --> <-127, -126>
       - get_interval_bounds([255, 10]) --> <-1, 10>
 
-      @warning This is not to represent a range interval, wrapped can have holes!
-      From the example: [10, 128] contains both <-128, 10> but it does not contain 9 or -127!
+      Note: This is not to represent a range interval, wrapped can have holes!
+      From the example: [10, 128] contains both <-128, 127> but it does not contain 9 or -127!
   */
   std::pair<BigInt, BigInt> get_interval_bounds() const
   {

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -954,7 +954,7 @@ public:
     return invert_bool(equality(lhs, rhs));
   }
 
-  /** @brief flatten all intervals cuts into a BigInt pair. 
+  /** @brief Computes the minimum and maximum value inside the interval
 
       Examples (signed char):
 

--- a/src/goto-programs/abstract-interpretation/wrapped_interval.h
+++ b/src/goto-programs/abstract-interpretation/wrapped_interval.h
@@ -979,7 +979,7 @@ public:
 
       minimum = std::min(minimum, local_min);
       maximum = std::max(maximum, local_max);
-    }   
+    }
     return std::make_pair(minimum, maximum);
   }
 

--- a/unit/goto-programs/interval_template.test.cpp
+++ b/unit/goto-programs/interval_template.test.cpp
@@ -1488,3 +1488,66 @@ TEST_CASE("Bitnot Operations", "[ai][interval-analysis]")
     REQUIRE(*r.upper == 255); // 0xFF
   }
 }
+
+TEST_CASE("Wrapped interval bounds", "[ai][interval-analysis]")
+{
+  config.ansi_c.set_data_model(configt::ILP32);
+  wrapped_interval w1(get_int_type(8));
+  std::pair<BigInt, BigInt> result;
+  SECTION("[10, 127] --> <10, 127>")
+  {
+    w1.lower = 10; 
+    w1.upper = 127;
+
+    result = w1.get_interval_bounds();
+    CAPTURE(result.first, result.second);
+    REQUIRE(result.first == 10); 
+    REQUIRE(result.second == 127);
+  }
+
+  SECTION("[10, 128] --> <-128, 127>")
+  {
+    w1.lower = 10;  
+    w1.upper = 128; 
+
+    result = w1.get_interval_bounds();
+    CAPTURE(result.first, result.second);
+    REQUIRE(result.first == -128); 
+    REQUIRE(result.second == 127); 
+  }
+
+  SECTION("[10, 255] --> <-128, 127>")
+  {
+    w1.lower = 10;  
+    w1.upper = 255; 
+
+    result = w1.get_interval_bounds();
+    CAPTURE(result.first, result.second);
+    REQUIRE(result.first == -128);
+    REQUIRE(result.second == 127);
+  }
+
+  SECTION("[129, 130] --> <-127, -126>")
+  {
+    w1.lower = 129;  
+    w1.upper = 130; 
+
+    result = w1.get_interval_bounds();
+    CAPTURE(result.first, result.second);
+    REQUIRE(result.first == -127);
+    REQUIRE(result.second == -126);
+  }
+
+  SECTION("[255, 10] --> <-1, 10>")
+  {
+    w1.lower = 255;  
+    w1.upper = 10; 
+
+    result = w1.get_interval_bounds();
+    CAPTURE(result.first, result.second);
+    REQUIRE(result.first == -1);
+    REQUIRE(result.second == 10);
+  }
+
+}
+

--- a/unit/goto-programs/interval_template.test.cpp
+++ b/unit/goto-programs/interval_template.test.cpp
@@ -1496,30 +1496,30 @@ TEST_CASE("Wrapped interval bounds", "[ai][interval-analysis]")
   std::pair<BigInt, BigInt> result;
   SECTION("[10, 127] --> <10, 127>")
   {
-    w1.lower = 10; 
+    w1.lower = 10;
     w1.upper = 127;
 
     result = w1.get_interval_bounds();
     CAPTURE(result.first, result.second);
-    REQUIRE(result.first == 10); 
+    REQUIRE(result.first == 10);
     REQUIRE(result.second == 127);
   }
 
   SECTION("[10, 128] --> <-128, 127>")
   {
-    w1.lower = 10;  
-    w1.upper = 128; 
+    w1.lower = 10;
+    w1.upper = 128;
 
     result = w1.get_interval_bounds();
     CAPTURE(result.first, result.second);
-    REQUIRE(result.first == -128); 
-    REQUIRE(result.second == 127); 
+    REQUIRE(result.first == -128);
+    REQUIRE(result.second == 127);
   }
 
   SECTION("[10, 255] --> <-128, 127>")
   {
-    w1.lower = 10;  
-    w1.upper = 255; 
+    w1.lower = 10;
+    w1.upper = 255;
 
     result = w1.get_interval_bounds();
     CAPTURE(result.first, result.second);
@@ -1529,8 +1529,8 @@ TEST_CASE("Wrapped interval bounds", "[ai][interval-analysis]")
 
   SECTION("[129, 130] --> <-127, -126>")
   {
-    w1.lower = 129;  
-    w1.upper = 130; 
+    w1.lower = 129;
+    w1.upper = 130;
 
     result = w1.get_interval_bounds();
     CAPTURE(result.first, result.second);
@@ -1540,14 +1540,12 @@ TEST_CASE("Wrapped interval bounds", "[ai][interval-analysis]")
 
   SECTION("[255, 10] --> <-1, 10>")
   {
-    w1.lower = 255;  
-    w1.upper = 10; 
+    w1.lower = 255;
+    w1.upper = 10;
 
     result = w1.get_interval_bounds();
     CAPTURE(result.first, result.second);
     REQUIRE(result.first == -1);
     REQUIRE(result.second == 10);
   }
-
 }
-


### PR DESCRIPTION
The operators were implemented incorrectly. This PR fixes it by using a new intermediate function to compute the bounds of the interval. Additionally, some small fixes were done for the inver_bool and equality functions.

Master (with --interval-analysis-wrapped):

```
Statistics:           9537 Files
  correct:            4224
    correct true:     3161
    correct false:    1063
  incorrect:           771
    incorrect true:    579
    incorrect false:   192
  unknown:            4542
  Score:            -14215 (max: 15923)
```

This PR (with --interval-analysis-wrapped):

```
Statistics:           9537 Files
  correct:            4282
    correct true:     2667
    correct false:    1615
  incorrect:             6
    incorrect true:      6
    incorrect false:     0
  unknown:            5249
  Score:              6757 (max: 15923)
```