### PR TITLE
Support for explicit sliceable assumes

### DIFF
--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -349,6 +349,7 @@ std::string clang_c_languaget::internal_additions()
     R"(
 # 1 "esbmc_intrinsics.h" 1
 void __ESBMC_assume(_Bool);
+void __ESBMC_sliceable_assume(_Bool);
 void __ESBMC_assert(_Bool, const char *);
 _Bool __ESBMC_same_object(const void *, const void *);
 void __ESBMC_yield();

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -203,7 +203,6 @@ const struct group_opt_templ all_cmd_options[] = {
     {"unlimited-goto-unwind",
      NULL,
      "do not unroll bounded loops at goto level"},
-    {"slice-assumes", NULL, "remove unused assume statements"},
     {"extended-try-analysis", NULL, ""},
     {"skip-bmc", NULL, ""}}},
   {"Incremental BMC",

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -122,6 +122,7 @@ inline void instrument_symbol_constraints(
     goto_programt::instructiont instruction;
     instruction.make_assumption(conjunction(symbol_constraints));
     instruction.inductive_step_instruction = config.options.is_kind();
+    instruction.sliceable = true;
     instruction.location = it->location;
     instruction.function = it->function;
     goto_function.body.insert_swap(it++, instruction);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -501,8 +501,9 @@ void goto_convertt::do_function_call_symbol(
 
   std::string base_name = symbol->name.as_string();
 
-  bool is_assume =
-    (base_name == "__ESBMC_assume") || (base_name == "__VERIFIER_assume") || (base_name == "__ESBMC_sliceable_assume");
+  bool is_assume = (base_name == "__ESBMC_assume") ||
+                   (base_name == "__VERIFIER_assume") ||
+                   (base_name == "__ESBMC_sliceable_assume");
   bool is_assert = (base_name == "assert");
 
   if (is_assume || is_assert)

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -521,7 +521,7 @@ void goto_convertt::do_function_call_symbol(
       dest.add_instruction(is_assume ? ASSUME : ASSERT);
     migrate_expr(arguments.front(), t->guard);
 
-    t->sliceable = base_name == "__ESBMC_sliceable_assume";
+    t->sliceable = is_assume && base_name == "__ESBMC_sliceable_assume";
 
     // The user may have re-declared the assert or assume functions to take an
     // integer argument, rather than a boolean. This leads to problems at the

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -502,7 +502,7 @@ void goto_convertt::do_function_call_symbol(
   std::string base_name = symbol->name.as_string();
 
   bool is_assume =
-    (base_name == "__ESBMC_assume") || (base_name == "__VERIFIER_assume");
+    (base_name == "__ESBMC_assume") || (base_name == "__VERIFIER_assume") || (base_name == "__ESBMC_sliceable_assume");
   bool is_assert = (base_name == "assert");
 
   if (is_assume || is_assert)
@@ -519,6 +519,8 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t =
       dest.add_instruction(is_assume ? ASSUME : ASSERT);
     migrate_expr(arguments.front(), t->guard);
+
+    t->sliceable = base_name == "__ESBMC_sliceable_assume";
 
     // The user may have re-declared the assert or assume functions to take an
     // integer argument, rather than a boolean. This leads to problems at the

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -341,7 +341,7 @@ public:
         type(NO_INSTRUCTION_TYPE),
         inductive_step_instruction(false),
         inductive_assertion(false),
-	sliceable(false),
+        sliceable(false),
         location_number(0),
         loop_number(unsigned(0)),
         target_number(unsigned(-1))
@@ -354,7 +354,7 @@ public:
         type(_type),
         inductive_step_instruction(false),
         inductive_assertion(false),
-	sliceable(false),
+        sliceable(false),
         location_number(0),
         loop_number(unsigned(0)),
         target_number(unsigned(-1))
@@ -375,8 +375,7 @@ public:
         inductive_step_instruction, instruction.inductive_step_instruction);
       std::swap(inductive_assertion, instruction.inductive_assertion);
       std::swap(instruction.loop_number, loop_number);
-      std::swap(
-        sliceable, instruction.sliceable);
+      std::swap(sliceable, instruction.sliceable);
     }
 
     //! A globally unique number to identify a program location.

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -139,7 +139,7 @@ public:
 
     bool inductive_assertion;
 
-    // for slicer
+    // for slicer (assumptions only)
     bool sliceable;
 
     //! is this node a branch target?

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -139,6 +139,9 @@ public:
 
     bool inductive_assertion;
 
+    // for slicer
+    bool sliceable;
+
     //! is this node a branch target?
     inline bool is_target() const
     {
@@ -154,6 +157,7 @@ public:
       code = expr2tc();
       inductive_step_instruction = false;
       inductive_assertion = false;
+      sliceable = false;
     }
 
     inline void make_goto()
@@ -337,6 +341,7 @@ public:
         type(NO_INSTRUCTION_TYPE),
         inductive_step_instruction(false),
         inductive_assertion(false),
+	sliceable(false),
         location_number(0),
         loop_number(unsigned(0)),
         target_number(unsigned(-1))
@@ -349,6 +354,7 @@ public:
         type(_type),
         inductive_step_instruction(false),
         inductive_assertion(false),
+	sliceable(false),
         location_number(0),
         loop_number(unsigned(0)),
         target_number(unsigned(-1))
@@ -369,6 +375,8 @@ public:
         inductive_step_instruction, instruction.inductive_step_instruction);
       std::swap(inductive_assertion, instruction.inductive_assertion);
       std::swap(instruction.loop_number, loop_number);
+      std::swap(
+        sliceable, instruction.sliceable);
     }
 
     //! A globally unique number to identify a program location.

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -38,7 +38,6 @@ void symex_slicet::run_on_assert(symex_target_equationt::SSA_stept &SSA_step)
       "happened");
     abort();
   }
-   
   get_symbols<true>(SSA_step.guard);
   get_symbols<true>(SSA_step.cond);
 }
@@ -76,8 +75,12 @@ void symex_slicet::run_on_assume(symex_target_equationt::SSA_stept &SSA_step)
 void symex_slicet::run_on_assignment(
   symex_target_equationt::SSA_stept &SSA_step)
 {
+  #ifndef NDEBUG
   if (!SSA_step.sliceable)
-    log_warning("[slicer] there is no support for unsliceable assignments. Slicing it...");
+    log_warning(
+      "[slicer] there is no support for unsliceable assignments. Slicing "
+      "it...");
+  #endif
   assert(is_symbol2t(SSA_step.lhs));
   // TODO: create an option to ignore nondet symbols (test case generation)
 
@@ -117,9 +120,12 @@ void symex_slicet::run_on_assignment(
 void symex_slicet::run_on_renumber(symex_target_equationt::SSA_stept &SSA_step)
 {
   assert(is_symbol2t(SSA_step.lhs));
-    if (!SSA_step.sliceable)
-    log_warning("[slicer] there is no support for unsliceable renumbering. Slicing it...");
-
+#ifndef NDEBUG
+  if (!SSA_step.sliceable)
+    log_warning(
+      "[slicer] there is no support for unsliceable renumbering. Slicing "
+      "it...");
+  #endif
   if (!get_symbols<false>(SSA_step.lhs))
   {
     // we don't really need it

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -75,12 +75,12 @@ void symex_slicet::run_on_assume(symex_target_equationt::SSA_stept &SSA_step)
 void symex_slicet::run_on_assignment(
   symex_target_equationt::SSA_stept &SSA_step)
 {
-  #ifndef NDEBUG
+#ifndef NDEBUG
   if (!SSA_step.sliceable)
     log_warning(
       "[slicer] there is no support for unsliceable assignments. Slicing "
       "it...");
-  #endif
+#endif
   assert(is_symbol2t(SSA_step.lhs));
   // TODO: create an option to ignore nondet symbols (test case generation)
 
@@ -125,7 +125,7 @@ void symex_slicet::run_on_renumber(symex_target_equationt::SSA_stept &SSA_step)
     log_warning(
       "[slicer] there is no support for unsliceable renumbering. Slicing "
       "it...");
-  #endif
+#endif
   if (!get_symbols<false>(SSA_step.lhs))
   {
     // we don't really need it

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -37,7 +37,7 @@ void symex_slicet::run_on_assert(symex_target_equationt::SSA_stept &SSA_step)
 
 void symex_slicet::run_on_assume(symex_target_equationt::SSA_stept &SSA_step)
 {
-  if (!slice_assumes)
+  if (!slice_assumes && !SSA_step.sliceable)
   {
     get_symbols<true>(SSA_step.guard);
     get_symbols<true>(SSA_step.cond);

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -31,13 +31,21 @@ bool symex_slicet::get_symbols(const expr2tc &expr)
 
 void symex_slicet::run_on_assert(symex_target_equationt::SSA_stept &SSA_step)
 {
+  if (SSA_step.sliceable)
+  {
+    log_error(
+      "[slicer] Found a sliceable assertion. Something very bad must have "
+      "happened");
+    abort();
+  }
+   
   get_symbols<true>(SSA_step.guard);
   get_symbols<true>(SSA_step.cond);
 }
 
 void symex_slicet::run_on_assume(symex_target_equationt::SSA_stept &SSA_step)
 {
-  if (!slice_assumes && !SSA_step.sliceable)
+  if (!SSA_step.sliceable)
   {
     get_symbols<true>(SSA_step.guard);
     get_symbols<true>(SSA_step.cond);
@@ -68,6 +76,8 @@ void symex_slicet::run_on_assume(symex_target_equationt::SSA_stept &SSA_step)
 void symex_slicet::run_on_assignment(
   symex_target_equationt::SSA_stept &SSA_step)
 {
+  if (!SSA_step.sliceable)
+    log_warning("[slicer] there is no support for unsliceable assignments. Slicing it...");
   assert(is_symbol2t(SSA_step.lhs));
   // TODO: create an option to ignore nondet symbols (test case generation)
 
@@ -107,6 +117,8 @@ void symex_slicet::run_on_assignment(
 void symex_slicet::run_on_renumber(symex_target_equationt::SSA_stept &SSA_step)
 {
   assert(is_symbol2t(SSA_step.lhs));
+    if (!SSA_step.sliceable)
+    log_warning("[slicer] there is no support for unsliceable renumbering. Slicing it...");
 
   if (!get_symbols<false>(SSA_step.lhs))
   {

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -82,8 +82,7 @@ class symex_slicet : public slicer
 {
 public:
   explicit symex_slicet(const optionst &options)
-    : slice_assumes(options.get_bool_option("slice-assumes")),
-      slice_nondet(!options.get_bool_option("generate-testcase"))
+    : slice_nondet(!options.get_bool_option("generate-testcase"))
   {
   }
 
@@ -141,8 +140,6 @@ public:
    */
 
 protected:
-  /// whether assumes should be sliced
-  const bool slice_assumes;
   /// Whether we should slice nondet symbols
   const bool slice_nondet;
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -126,7 +126,12 @@ void goto_symext::assume(const expr2tc &the_assumption)
 
   // Irritatingly, assumption destroys its expr argument
   expr2tc tmp_guard = cur_state->guard.as_expr();
-  target->assumption(tmp_guard, assumption, cur_state->source, first_loop, cur_state->source.pc->sliceable);
+  target->assumption(
+    tmp_guard,
+    assumption,
+    cur_state->source,
+    first_loop,
+    cur_state->source.pc->sliceable);
 
   // If we're assuming false, make the guard for the following statement false
   if (is_false(the_assumption))

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -126,7 +126,7 @@ void goto_symext::assume(const expr2tc &the_assumption)
 
   // Irritatingly, assumption destroys its expr argument
   expr2tc tmp_guard = cur_state->guard.as_expr();
-  target->assumption(tmp_guard, assumption, cur_state->source, first_loop);
+  target->assumption(tmp_guard, assumption, cur_state->source, first_loop, cur_state->source.pc->sliceable);
 
   // If we're assuming false, make the guard for the following statement false
   if (is_false(the_assumption))

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -59,7 +59,8 @@ public:
     const expr2tc &guard,
     const expr2tc &cond,
     const sourcet &source,
-    unsigned loop_number) = 0;
+    unsigned loop_number,
+    const bool sliceable = false) = 0;
 
   // record an assertion
   // cond is destroyed

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -106,7 +106,7 @@ void symex_target_equationt::assertion(
   SSA_step.comment = msg;
   SSA_step.stack_trace = stack_trace;
   SSA_step.loop_number = loop_number;
-  SSA_step.sliceable = true;
+  SSA_step.sliceable = false;
 
   if (debug_print)
     debug_print_step(SSA_step);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -83,7 +83,7 @@ void symex_target_equationt::assumption(
   SSA_step.source = source;
   SSA_step.loop_number = loop_number;
   SSA_step.sliceable = sliceable;
-  
+
   if (debug_print)
     debug_print_step(SSA_step);
 }

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -71,7 +71,8 @@ void symex_target_equationt::assumption(
   const expr2tc &guard,
   const expr2tc &cond,
   const sourcet &source,
-  unsigned loop_number)
+  unsigned loop_number,
+  const bool sliceable)
 {
   SSA_steps.emplace_back();
   SSA_stept &SSA_step = SSA_steps.back();
@@ -81,7 +82,8 @@ void symex_target_equationt::assumption(
   SSA_step.type = goto_trace_stept::ASSUME;
   SSA_step.source = source;
   SSA_step.loop_number = loop_number;
-
+  SSA_step.sliceable = sliceable;
+  
   if (debug_print)
     debug_print_step(SSA_step);
 }
@@ -104,6 +106,7 @@ void symex_target_equationt::assertion(
   SSA_step.comment = msg;
   SSA_step.stack_trace = stack_trace;
   SSA_step.loop_number = loop_number;
+  SSA_step.sliceable = true;
 
   if (debug_print)
     debug_print_step(SSA_step);

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -53,7 +53,8 @@ public:
     const expr2tc &guard,
     const expr2tc &cond,
     const sourcet &source,
-    unsigned loop_number) override;
+    unsigned loop_number,
+    const bool sliceable) override;
 
   // record an assertion
   // cond is destroyed
@@ -127,6 +128,7 @@ public:
     // for ASSUME/ASSERT
     expr2tc cond;
     std::string comment;
+    bool sliceable;
 
     // for OUTPUT
     std::string format_string;
@@ -136,7 +138,7 @@ public:
     smt_astt guard_ast, cond_ast;
     std::list<expr2tc> converted_output_args;
 
-    // for slicing
+    // to mark step as uneeded
     bool ignore;
 
     // for visibility
@@ -145,7 +147,7 @@ public:
     // for bidirectional search
     unsigned loop_number;
 
-    SSA_stept() : ignore(false), hidden(false)
+    SSA_stept() : sliceable(false), ignore(false), hidden(false)
     {
     }
 


### PR DESCRIPTION
Closes #1634

This adds the concept of an sliceable assumption, which differs from the common assumptions as it is an invariant instead of a precondition. This mostly affects the Interval Analysis (specially the more aggressive instrumentation modes) as adding complex invariants made the program difficult to slice. This results in the invariant assumption affecting falsification of programs, leading us to use weaker instrumentations mode (i.e., guard local). 

Master -  120s, Action 797

```
Statistics:           9537 Files
  correct:            4259
    correct true:     2657
    correct false:    1602
  incorrect:             6
    incorrect true:      6
    incorrect false:     0
  unknown:            5272
  Score:              6724 (max: 15923)
```

PR - 120s, Action 809

```
Statistics:           9537 Files
  correct:            4288
    correct true:     2669
    correct false:    1619
  incorrect:             6
    incorrect true:      6
    incorrect false:     0
  unknown:            5243
  Score:              6765 (max: 15923)
```

