### PR TITLE
[C++ Operational Models] Added <string_view> model

### DIFF
--- a/regression/esbmc-cpp/cpp/hello_world/main.cpp
+++ b/regression/esbmc-cpp/cpp/hello_world/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
-int main() {
+int main()
+{
   std::cout << "Hello World!" << std::endl;
   return 0;
 }
-

--- a/regression/esbmc-cpp/cpp/hello_world/main.cpp
+++ b/regression/esbmc-cpp/cpp/hello_world/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main() {
+  std::cout << "Hello World!" << std::endl;
+  return 0;
+}
+

--- a/regression/esbmc-cpp/cpp/hello_world/test.desc
+++ b/regression/esbmc-cpp/cpp/hello_world/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/hello_world2/main.cpp
+++ b/regression/esbmc-cpp/cpp/hello_world2/main.cpp
@@ -1,0 +1,7 @@
+#include <string_view>
+
+int main()
+{
+  std::string_view message = "Hello, World!";
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/hello_world2/test.desc
+++ b/regression/esbmc-cpp/cpp/hello_world2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ostream1/main.cpp
+++ b/regression/esbmc-cpp/cpp/ostream1/main.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <cstring>
+#include <cstdio> // For sprintf
+
+using namespace std;
+
+int main()
+{
+  // Character data type
+  char val = 65;
+  cout << "Character value: " << val << endl;
+
+  // Character array (C-string)
+  char cstr[25] = {'S', 'T', 'R', 'I', 'N', 'G'};
+  cout << "C-string: " << cstr << endl;
+
+  // Integer data type
+  int i = 10;
+  cout << "Integer value: " << i << endl;
+
+  // Floating-point data type
+  float f = 3.14f;
+  cout << "Floating-point value: " << f << endl;
+
+  // Double data type
+  double d = 2.71828;
+  cout << "Double value: " << d << endl;
+
+  // Boolean data type
+  bool b = true;
+  cout << "Boolean value: " << (b ? "true" : "false") << endl;
+
+  // String manipulation
+  char buffer[100];
+  sprintf(buffer, "Integer value: %d", i);
+  cout << "String from sprintf: " << buffer << endl;
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/ostream1/test.desc
+++ b/regression/esbmc-cpp/cpp/ostream1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/string_view1/main.cpp
+++ b/regression/esbmc-cpp/cpp/string_view1/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <string_view>
+
+int main()
+{
+  // Original test
+  std::string_view message = "Hello, World!";
+
+  // Accessing individual characters
+  std::cout << "First character: " << message[0] << std::endl;
+  std::cout << "Third character: " << message[2] << std::endl;
+
+  // Length of the string view
+  std::cout << "Length of message: " << message.length() << std::endl;
+
+  // Checking if empty
+  std::string_view emptyView;
+  std::cout << "Is emptyView empty? " << (emptyView.empty() ? "Yes" : "No")
+            << std::endl;
+
+  // Comparing string views
+  std::string_view otherMessage = "Hello, World!";
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/string_view1/test.desc
+++ b/regression/esbmc-cpp/cpp/string_view1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/iostream
+++ b/src/cpp/library/iostream
@@ -8,10 +8,6 @@
 
 namespace std
 {
-// Forward declaration of istream and ostream
-class istream;
-class ostream;
-
 // Definition of iostream
 class iostream : public ostream, public istream
 {

--- a/src/cpp/library/iostream
+++ b/src/cpp/library/iostream
@@ -8,31 +8,35 @@
 
 namespace std
 {
-    // Forward declaration of istream and ostream
-    class istream;
-    class ostream;
+// Forward declaration of istream and ostream
+class istream;
+class ostream;
 
-    // Definition of iostream
-    class iostream: public ostream, public istream
-    {
-    public:
-        // Default constructor
-        iostream() : ostream(), istream() {}
+// Definition of iostream
+class iostream : public ostream, public istream
+{
+public:
+  // Default constructor
+  iostream() : ostream(), istream()
+  {
+  }
 
-        // Destructor
-        virtual ~iostream () {}
+  // Destructor
+  virtual ~iostream()
+  {
+  }
 
-        // Disabled copy assignment operator
-        iostream& operator=(const iostream&);
-    };
+  // Disabled copy assignment operator
+  iostream &operator=(const iostream &);
+};
 
-    // Declaration of standard input/output streams
-    extern istream cin;
-    extern ostream cout;
-    extern ostream cerr;
+// Declaration of standard input/output streams
+extern istream cin;
+extern ostream cout;
+extern ostream cerr;
 
-    // Definition of standard end-of-line character
-    const char endl = '\n';
-}
+// Definition of standard end-of-line character
+const char endl = '\n';
+} // namespace std
 
 #endif

--- a/src/cpp/library/iostream
+++ b/src/cpp/library/iostream
@@ -8,23 +8,31 @@
 
 namespace std
 {
-	class iostream: public ostream, public istream
-	{
-	public:
-		iostream() : ostream(), istream() {}
+    // Forward declaration of istream and ostream
+    class istream;
+    class ostream;
 
-//		explicit iostream (streambuf * sb);
-//		iostream(const iostream&){ ostream(0); istream(0);} // disabled
-		virtual ~iostream (){}
-		iostream& operator=(const iostream&); // disabled
-	};
+    // Definition of iostream
+    class iostream: public ostream, public istream
+    {
+    public:
+        // Default constructor
+        iostream() : ostream(), istream() {}
 
-	extern istream cin;
-	extern ostream cout;
-	extern ostream cerr;
-//	extern ios_base ios;
+        // Destructor
+        virtual ~iostream () {}
 
-//	char endl = '\n';
+        // Disabled copy assignment operator
+        iostream& operator=(const iostream&);
+    };
+
+    // Declaration of standard input/output streams
+    extern istream cin;
+    extern ostream cout;
+    extern ostream cerr;
+
+    // Definition of standard end-of-line character
+    const char endl = '\n';
 }
 
 #endif

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -128,7 +128,7 @@ namespace std
 
 namespace std {
   //Output manipulators
-  ostream& endl ( ostream& os ) { return os; }
+  //ostream& endl ( ostream& os ) { return os; }
   ostream& ends ( ostream& os );
 }
 

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -128,7 +128,6 @@ namespace std
 
 namespace std {
   //Output manipulators
-  //ostream& endl ( ostream& os ) { return os; }
   ostream& ends ( ostream& os );
 }
 

--- a/src/cpp/library/string_view
+++ b/src/cpp/library/string_view
@@ -1,0 +1,52 @@
+#include <cstddef>
+
+namespace std
+{
+class string_view
+{
+public:
+  // Constructors
+  string_view();
+  string_view(const char *str);
+  string_view(const char *str, size_t len);
+
+  // Destructor
+  ~string_view();
+
+  // Capacity
+  size_t size();
+  size_t length();
+  size_t max_size();
+  bool empty();
+
+  // Element access
+  const char &operator[](size_t pos) const;
+  const char &at(size_t pos) const;
+  const char &front() const;
+  const char &back() const;
+  const char *data();
+
+  // Modifiers
+  void remove_prefix(size_t n);
+  void remove_suffix(size_t n);
+  void swap(string_view &sv);
+  void clear();
+
+  // Operations
+  size_t copy(char *dest, size_t count, size_t pos = 0) const;
+  int compare(string_view sv) const;
+  bool starts_with(string_view sv) const;
+  bool ends_with(string_view sv) const;
+  size_t find(string_view sv, size_t pos = 0) const;
+  size_t find_first_of(string_view sv, size_t pos = 0) const;
+  size_t find_first_not_of(string_view sv, size_t pos = 0) const;
+
+  // Non-member functions
+  friend bool operator==(string_view lhs, string_view rhs);
+  friend bool operator!=(string_view lhs, string_view rhs);
+  friend bool operator<(string_view lhs, string_view rhs);
+  friend bool operator<=(string_view lhs, string_view rhs);
+  friend bool operator>(string_view lhs, string_view rhs);
+  friend bool operator>=(string_view lhs, string_view rhs);
+};
+} // namespace std


### PR DESCRIPTION
This PR adds the C++ <string_view> operational model to address this issue https://github.com/esbmc/esbmc/issues/1667.

It also fixes the warning produced for the C++ `<iostream>` operational model.

````CPP
#include <iostream>

int main()
{
  std::cout << "Hello World!" << std::endl;
  return 0;
} 
````

````
hello.cpp:7:34: warning: address of function 'std::endl' will always evaluate to 'true' [-Wpointer-bool-conversion]
  std::cout << "Hello World!" << std::endl;
                              ~~ ^~~~~~~~~
hello.cpp:7:34: note: prefix with the address-of operator to silence this warning
  std::cout << "Hello World!" << std::endl;
                                 ^
                                 &
````