### PR TITLE
Prepare using more unmodified libstdc++ headers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,8 +84,12 @@ jobs:
     - name: Delete downloaded Clang 11
       run: rm -rf clang*
     # Commit all changed files back to the repository
-    - uses: stefanzweifel/git-auto-commit-action@v5  
-      
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      if: ${{ ! startsWith(github.head_ref, 'fb/') }}
+    - name: Throws error if changes were made
+      run: git diff --exit-code --ignore-cr-at-eol
+      if: ${{ startsWith(github.head_ref, 'fb/') }}
+
   cmake-lint:
     name: Check CMake modules
     runs-on: ubuntu-20.04

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -147,6 +147,7 @@ elseif(WIN32)
                     llvm
                     floats
                     k-induction
+                    windows
                     ${REGRESSIONS_JIMPLE}
                     ${REGRESSIONS_BITWUZLA}
                     ${REGRESSIONS_CVC}

--- a/regression/esbmc-cpp/cpp/ch21_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_append_13_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_append_13_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 30 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_assign_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_final_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 45 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_erase_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_4_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 30 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_erase_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_final_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 30 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_replace_16_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_16_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 35 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_replace_17_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_17_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 35 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_replace_18_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_18_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 35 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_replace_19_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_19_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 35 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_replace_20_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_20_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 35 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_replace_final_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_final_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 35 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/windows/k-induction_cpp_stack_empty_bug/main.cpp
+++ b/regression/windows/k-induction_cpp_stack_empty_bug/main.cpp
@@ -1,0 +1,1 @@
+../../esbmc-unix/cpp_stack_empty_bug/main.cpp

--- a/regression/windows/k-induction_cpp_stack_empty_bug/test.desc
+++ b/regression/windows/k-induction_cpp_stack_empty_bug/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--k-induction 
+^VERIFICATION FAILED$

--- a/src/c2goto/headers/CMakeLists.txt
+++ b/src/c2goto/headers/CMakeLists.txt
@@ -12,6 +12,7 @@ set(inputs
 
            # pthreads
            pthread.h
+           sched.h
            # Glibc
            bits/pthreadtypes.h
            bits/thread-shared-types.h

--- a/src/c2goto/headers/pthread.h
+++ b/src/c2goto/headers/pthread.h
@@ -17,11 +17,16 @@
    Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
    02111-1307 USA.  */
 
-#ifndef _PTHREAD_H
-#define _PTHREAD_H	1
+#pragma once
+
+#include <__esbmc/stddefs.h>
 
 #include <stddef.h>
 #include <stdint.h>
+
+#include <sched.h>
+
+__ESBMC_C_CPP_BEGIN
 
 #ifndef _MSVC
 #define NULL 0
@@ -120,10 +125,6 @@ typedef union
 #if __WORDSIZE == 32
 /* Extra attributes for the cleanup functions.  */
 # define __cleanup_fct_attribute __attribute__ ((__regparm__ (1)))
-#endif
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 /* Detach state.  */
@@ -795,8 +796,4 @@ __NTH (pthread_equal (pthread_t __thread1, pthread_t __thread2))
 }
 #endif
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif	/* pthread.h */
+__ESBMC_C_CPP_END

--- a/src/c2goto/headers/sched.h
+++ b/src/c2goto/headers/sched.h
@@ -1,0 +1,4 @@
+
+#pragma once
+
+int sched_yield(void);

--- a/src/c2goto/headers/stdlib.h
+++ b/src/c2goto/headers/stdlib.h
@@ -79,11 +79,15 @@ char get_char(int digit); //Converter from digit ie 0123456789 to char '0'......
 void rev(char *); //reverse function ;
 #endif
 
+float strtof(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr);
 double strtod(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr);
+long double strtold(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr);
 
 long int strtol(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr, int base);
+long long int strtoll(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr, int base);
 
 unsigned long int strtoul(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr, int base);
+unsigned long long int strtoull(const char *__ESBMC_restrict str, char **__ESBMC_restrict endptr, int base);
 
 char * getenv(const char * name);
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2619,7 +2619,13 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_type(tte.getType(), type))
       return true;
 
-    new_expr = constant_exprt(tte.getValue() ? 1 : 0, type);
+    assert(type.id() == typet::t_bool);
+
+    if (tte.getValue())
+      new_expr = true_exprt();
+    else
+      new_expr = false_exprt();
+
     break;
   }
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -395,9 +395,6 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
     }
   }
 
-  if (get_struct_union_class_methods_decls(*rd_def, t))
-    return true;
-
   /* We successfully constructed the type of this symbol; replace the
    * symbol with the incomplete type by one with the now-complete type
    * definition.
@@ -407,7 +404,10 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
   symbolt symbol = *sym;
   context.erase_symbol(symbol.id);
   symbol.type = t;
-  context.move_symbol_to_context(symbol);
+  sym = context.move_symbol_to_context(symbol);
+
+  if (get_struct_union_class_methods_decls(*rd_def, sym->type))
+    return true;
 
   return false;
 }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -807,8 +807,9 @@ bool clang_c_convertert::get_type(
   const clang::QualType &q_type,
   typet &new_type)
 {
-  const clang::Type &the_type = *q_type.getTypePtrOrNull();
-  if (get_type(the_type, new_type))
+  const clang::Type *the_type = q_type.getTypePtrOrNull();
+  assert(the_type);
+  if (get_type(*the_type, new_type))
     return true;
 
   if (q_type.isConstQualified())
@@ -1054,7 +1055,8 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     get_decl_name(rd, name, id);
 
     /* record in context if not already there */
-    get_struct_union_class(rd);
+    if (get_struct_union_class(rd))
+      return true;
 
     /* symbolic type referring to that type */
     new_type = symbol_typet(id);

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -435,12 +435,6 @@ void __VERIFIER_atomic_end();
 /* Causes a verification error when its call is reachable; internal use in math
  * models */
 void __ESBMC_unreachable();
-
-// TODO: implement this similarly to printf
-  #define fscanf __ESBMC_fscanf
-  #define sscanf __ESBMC_sscanf
-
-  #define scanf __ESBMC_scanf
     )";
 
   if (config.ansi_c.cheri)

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -687,18 +687,6 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
-  case clang::Stmt::TypeTraitExprClass:
-  {
-    const clang::TypeTraitExpr &tt =
-      static_cast<const clang::TypeTraitExpr &>(stmt);
-
-    if (tt.getValue())
-      new_expr = true_exprt();
-    else
-      new_expr = false_exprt();
-    break;
-  }
-
   case clang::Stmt::CXXConstructExprClass:
   {
     const clang::CXXConstructExpr &cxxc =

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -552,30 +552,30 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
     const function_switch &switch_map = vft_switch_kv_pair.second;
 
     // To create the vtable variable symbol we need to get the corresponding type
-    const symbolt *late_cast_symb =
-      namespacet(context).lookup(vft_switch_kv_pair.first);
+    const symbolt *late_cast_symb = ns.lookup(vft_switch_kv_pair.first);
     assert(late_cast_symb);
-    const symbolt &vt_symb_type = *namespacet(context).lookup(
-      "virtual_table::" + late_cast_symb->id.as_string());
+    const symbolt *vt_symb_type =
+      ns.lookup("virtual_table::" + late_cast_symb->id.as_string());
+    assert(vt_symb_type);
 
     // This is the class we are currently dealing with
     std::string class_id, class_name;
     get_decl_name(cxxrd, class_name, class_id);
 
     symbolt vt_symb_var;
-    vt_symb_var.id = vt_symb_type.id.as_string() + "@" + class_id;
-    vt_symb_var.name = vt_symb_type.name.as_string() + "@" + class_id;
+    vt_symb_var.id = vt_symb_type->id.as_string() + "@" + class_id;
+    vt_symb_var.name = vt_symb_type->name.as_string() + "@" + class_id;
     vt_symb_var.mode = mode;
     vt_symb_var.module =
       get_modulename_from_path(type.location().file().as_string());
-    vt_symb_var.location = vt_symb_type.location;
-    vt_symb_var.type = symbol_typet(vt_symb_type.id);
+    vt_symb_var.location = vt_symb_type->location;
+    vt_symb_var.type = symbol_typet(vt_symb_type->id);
     vt_symb_var.lvalue = true;
     vt_symb_var.static_lifetime = true;
 
     // add vtable variable symbols
-    const struct_typet &vt_type = to_struct_type(vt_symb_type.type);
-    exprt values("struct", symbol_typet(vt_symb_type.id));
+    const struct_typet &vt_type = to_struct_type(vt_symb_type->type);
+    exprt values("struct", symbol_typet(vt_symb_type->id));
     for (const auto &compo : vt_type.components())
     {
       std::map<irep_idt, exprt>::const_iterator cit2 =

--- a/src/cpp/library/cstdlib
+++ b/src/cpp/library/cstdlib
@@ -1,1 +1,17 @@
+
+#pragma once
+
 #include <stdlib.h>
+
+namespace std {
+
+using ::strtol;
+using ::strtoul;
+using ::strtoll;
+using ::strtoull;
+
+using ::strtof;
+using ::strtod;
+using ::strtold;
+
+}

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -606,10 +606,6 @@ void goto_convertt::do_function_call_symbol(
     a->location = function.location();
     a->location.user_provided(true);
   }
-  else if (base_name == "printf")
-  {
-    do_printf(lhs, function, arguments, dest, base_name);
-  }
   else if (
     (base_name == "__ESBMC_atomic_begin") ||
     (base_name == "__VERIFIER_atomic_begin"))

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -296,12 +296,12 @@ void goto_checkt::input_overflow_check(
 
   unsigned number_of_format_args, fmt_idx;
 
-  if (func_name.find("__ESBMC_scanf") != std::string::npos)
+  if (func_name == "c:@F@scanf")
   {
     fmt_idx = 0;
     number_of_format_args = func_call.operands.size() - 1;
   }
-  else if (func_name.find("__ESBMC_fscanf") != std::string::npos)
+  else if (func_name == "c:@F@fscanf" || func_name == "c:@F@sscanf")
   {
     fmt_idx = 1;
     number_of_format_args = func_call.operands.size() - 2;

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -483,20 +483,17 @@ void goto_symext::symex_input(const code_function_call2t &func_call)
   assert(is_symbol2t(func_call.function));
 
   unsigned number_of_format_args, fmt_idx;
-  const std::string func_name =
-    to_symbol2t(func_call.function).thename.as_string();
+  const irep_idt func_name = to_symbol2t(func_call.function).thename;
 
-  if (func_name.find("__ESBMC_scanf") != std::string::npos)
+  if (func_name == "c:@F@scanf")
   {
-    assert(func_call.operands.size() >= 2 && "Wrong __ESBMC_scanf signature");
+    assert(func_call.operands.size() >= 2 && "Wrong scanf signature");
     fmt_idx = 0;
     number_of_format_args = func_call.operands.size() - 1;
   }
-  else if (
-    (func_name.find("__ESBMC_fscanf") != std::string::npos) ||
-    (func_name.find("__ESBMC_sscanf") != std::string::npos))
+  else if (func_name == "c:@F@fscanf" || func_name == "c:@F@sscanf")
   {
-    assert(func_call.operands.size() >= 3 && "Wrong __ESBMC_fscanf signature");
+    assert(func_call.operands.size() >= 3 && "Wrong fscanf/sscanf signature");
     fmt_idx = 1;
     number_of_format_args = func_call.operands.size() - 2;
   }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -272,6 +272,18 @@ void goto_symext::symex_step(reachability_treet &art)
         run_intrinsic(call, art, id.as_string());
         return;
       }
+
+      if (id == "c:@F@scanf" || id == "c:@F@sscanf" || id == "c:@F@fscanf")
+      {
+        cur_state->source.pc++;
+
+        auto &ex_state = art.get_cur_state();
+        if (ex_state.cur_state->guard.is_false())
+          return;
+
+        symex_input(call);
+        return;
+      }
     }
 
     if (cur_state->guard.is_false())
@@ -649,19 +661,6 @@ void goto_symext::run_intrinsic(
     symex_assign(code_assign2tc(
       func_call.ret,
       is_constant_int2t(op1) ? gen_one(int_type2()) : gen_zero(int_type2())));
-    return;
-  }
-
-  if (
-    has_prefix(symname, "c:@F@__ESBMC_scanf") ||
-    has_prefix(symname, "c:@F@__ESBMC_sscanf") ||
-    has_prefix(symname, "c:@F@__ESBMC_fscanf"))
-  {
-    auto &ex_state = art.get_cur_state();
-    if (ex_state.cur_state->guard.is_false())
-      return;
-
-    symex_input(func_call);
     return;
   }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -675,8 +675,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         // Add member in the class
         if (!class_type.has_component(attr_name))
         {
-          struct_typet::componentt comp = std::move(build_component(
-            class_type.tag().as_string(), attr_name, current_element_type));
+          struct_typet::componentt comp = build_component(
+            class_type.tag().as_string(), attr_name, current_element_type);
           class_type.components().push_back(comp);
         }
         // Add instance attribute in the objects map
@@ -1139,7 +1139,7 @@ void python_converter::get_attributes_from_self(
       std::string attr_name = stmt["target"]["attr"];
       typet type = get_typet(stmt["annotation"]["id"].get<std::string>());
       struct_typet::componentt comp =
-        std::move(build_component(current_class_name, attr_name, type));
+        build_component(current_class_name, attr_name, type);
       clazz.components().push_back(comp);
     }
   }

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -1,8 +1,7 @@
 #include <util/compiler_defs.h>
 // Remove warnings from Clang headers
 CC_DIAGNOSTIC_PUSH()
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
+CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/Frontend/ASTUnit.h>
 CC_DIAGNOSTIC_POP()
 

--- a/src/util/compiler_defs.h
+++ b/src/util/compiler_defs.h
@@ -22,7 +22,8 @@
 #define CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()                                     \
   DO_PRAGMA(GCC diagnostic ignored "-Wstrict-aliasing")                        \
   DO_PRAGMA(GCC diagnostic ignored "-Wunused-parameter")                       \
-  DO_PRAGMA(GCC diagnostic ignored "-Wnonnull")
+  DO_PRAGMA(GCC diagnostic ignored "-Wnonnull")                                \
+  DO_PRAGMA(GCC diagnostic ignored "-Wdeprecated-declarations")
 #endif
 
 #ifndef GNUC_PREREQ

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -200,6 +200,16 @@ public:
 
   unsigned component_number(const irep_idt &component_name) const;
   typet component_type(const irep_idt &component_name) const;
+
+  const componentst &methods() const
+  {
+    return (const componentst &)(find(a_methods).get_sub());
+  }
+
+  componentst &methods()
+  {
+    return (componentst &)(add(a_methods).get_sub());
+  }
 };
 
 extern inline const struct_union_typet &to_struct_union_type(const typet &type)
@@ -226,16 +236,6 @@ public:
   }
 
   bool is_prefix_of(const struct_typet &other) const;
-
-  const componentst &methods() const
-  {
-    return (const componentst &)(find(a_methods).get_sub());
-  }
-
-  componentst &methods()
-  {
-    return (componentst &)(add(a_methods).get_sub());
-  }
 };
 
 extern inline const struct_typet &to_struct_type(const typet &type)


### PR DESCRIPTION
This PR contains some changes I needed for the next step, which is dropping some of our C++ headers overriding libstdc++'s ones. Most notably, I guess, the *scanf() family of functions is no longer prefixed with `__ESBMC_` by the clang-c frontend, because the actual symbols `::scanf` etc. are expected to exist by libstdc++. Same for the strtol() family, so declarations of the missing ones are added as well. Besides that, some minor fixes and getting rid of warnings.