### PR TITLE
Extend regdb.py with categorized flags and allow querying using glob patterns

### DIFF
--- a/regression/regdb.py
+++ b/regression/regdb.py
@@ -6,6 +6,7 @@ import sys
 import os.path
 import getopt
 import shlex
+import fnmatch
 
 SOLVERS = [
     'smtlib',
@@ -18,35 +19,35 @@ SOLVERS = [
 ]
 
 EXTENSIONS = {
-    'c'     : {'c', 'i'},
-    'cxx'   : {'cc', 'cpp'},
-    'cuda'  : {'cuda'},
-    'py'    : {'py'},
-    'sol'   : {'solast'},
-    'jimple': {'jimple'},
+    'lang=c'     : {'c', 'i'},
+    'lang=cxx'   : {'cc', 'cpp'},
+    'lang=cuda'  : {'cu'},
+    'lang=py'    : {'py'},
+    'lang=sol'   : {'solast'},
+    'lang=jimple': {'jimple'},
 }
 
 OPT2FLAGS = {
-    '--' + solver: {solver} for solver in SOLVERS
+    '--' + solver: {'solver=' + solver} for solver in SOLVERS
 } | { # Frontend related
-    '--16'           : {'16'},
-    '--32'           : {'32'},
-    '--64'           : {'64'},
+    '--16'           : {'bitw=16'},
+    '--32'           : {'bitw=32'},
+    '--64'           : {'bitw=64'},
     '--binary'       : {'goto'},
-    '--little-endian': {'le'},
-    '--big-endian'   : {'be'},
-    '--no-arch'      : {'ne', 'no-arch'},
-    '--ppc-macos'    : {'ppc', 'macos', '32'},
-    '--i386-macos'   : {'x86', 'macos', '32'},
-    '--i386-linux'   : {'x86', 'linux', '32'},
-    '--i386-win32'   : {'x86', 'win', '32'},
+    '--little-endian': {'endian=little'},
+    '--big-endian'   : {'endian=big'},
+    '--no-arch'      : {'endian=none', 'arch=none'},
+    '--ppc-macos'    : {'arch=ppc', 'os=macos', 'bitw=32'},
+    '--i386-macos'   : {'arch=x86', 'os=macos', 'bitw=32'},
+    '--i386-linux'   : {'arch=x86', 'os=linux', 'bitw=32'},
+    '--i386-win32'   : {'arch=x86', 'os=win', 'bitw=32'},
     '--cheri'        : {'cheri'},
     '--old-frontend' : {'old'},
 } | { # Strategy related
-    '--k-induction'    : {'kind'},
-    '--incremental-bmc': {'incr'},
-    '--falsification'  : {'falsify'},
-    '--termination'    : {'term'},
+    '--k-induction'    : {'strat=kind'},
+    '--incremental-bmc': {'strat=incr'},
+    '--falsification'  : {'strat=falsify'},
+    '--termination'    : {'strat=term'},
 } | { # Optimiziation related
     '--interval-analysis': {'ia'},
     '--gcse'             : {'gcse'},
@@ -56,13 +57,39 @@ BUG = 'bug'
 
 FLAG_DESC = {}
 
-def list_flags(verbose : bool):
+class Flag(str):
+    def __new__(cls, s):
+        assert(len(s) > 0)
+        return super().__new__(cls, s)
+
+    @property
+    def value(self):
+        s = super().__str__()
+        return s[s.find('=') + 1:]
+
+    @property
+    def category(self):
+        s = super().__str__()
+        eq = s.find('=')
+        return None if eq < 0 else s[:eq]
+
+    def matches(self, gpat_flag):
+        smatch = fnmatch.fnmatchcase
+        scat = self.category
+        pcat = gpat_flag.category
+        return ((pcat is None or scat is not None and smatch(scat, pcat)) and
+                smatch(self.value, gpat_flag.value))
+
+    def __repr__(self):
+        return "Flag(%s)" % super().__repr__()
+
+def list_flags(verbosity : int):
     # collect
     flgs = {BUG} | EXTENSIONS.keys()
     for v in OPT2FLAGS.values():
         flgs |= v
     # output
-    if verbose:
+    if verbosity > 0:
         max_w = max(len(f) for f in flgs)
         for f in sorted(flgs):
             print('%*s: %s' % (-max_w, f, FLAG_DESC.get(f, '<undocumented>')))
@@ -75,7 +102,7 @@ def list_flags(verbose : bool):
 def flags(tc : TestCase):
     r = set()
     if tc.test_mode in FAIL_MODES:
-        r.add(BUG)
+        r.add(Flag(BUG))
     opts = tc.generate_run_argument_list('true')[1:]
     for opt in opts:
         f = set()
@@ -84,11 +111,11 @@ def flags(tc : TestCase):
             ext = opt[opt.rfind('.') + 1:]
             for lang, exts in EXTENSIONS.items():
                 if ext in exts:
-                    f = {lang}
+                    f = {Flag(lang)}
                     break
         else:
             # not a file, so it's an option
-            f = OPT2FLAGS.get(opt, f)
+            f = {Flag(g) for g in OPT2FLAGS.get(opt, f)}
         # add all the new flags to the ones we already accumulated
         r |= f
     return r
@@ -97,19 +124,21 @@ def query(qstr, tcs):
     # parse query
     pos = set()
     neg = set()
-    if len(qstr) > 0:
-        for spec in qstr.split(' '):
-            if spec[0] == '-':
-                neg.add(spec[1:])
-            else:
-                pos.add(spec[1:] if spec[0] == '+' else spec)
+    for spec in qstr.split(' '):
+        if spec[0] == '-':
+            neg.add(Flag(spec[1:]))
+        else:
+            pos.add(Flag(spec[1:] if spec[0] == '+' else spec))
 
     # process TCs
-    def matches(tc):
-        flgs = flags(tc)
-        return pos.issubset(flgs) and neg.isdisjoint(flgs)
+    def qualify(flgs):
+        def matches_any(gpat_flag):
+            return any(f.matches(gpat_flag) for f in flgs)
 
-    return list(filter(matches, tcs))
+        return (all(matches_any(p) for p in pos) and
+                all(not matches_any(n) for n in neg))
+
+    return [tc for tc in tcs if qualify(flags(tc))]
 
 def usage():
     print('usage: %s [-OPTS] [--] [REG_PATH [REG_PATH [...]]]' %
@@ -128,10 +157,10 @@ Multiple paths can optionally be specified as REG_PATH parameters, which will
 restrict the test cases to process to only those given. If none are specified,
 the default is to search the built-in list of all non-disabled regression tests.
 
-QUERY is a space-separated list of flag specifiers of the form:
-  [+]flag : match only TCs that have this flag
-    -flag : match only TCs that do not have this flag
-All flag specifiers are conjunctively connected.
+QUERY is a space-separated list of flag patterns of the form:
+  [+]GPAT : match only TCs that have a flag matching the glob pattern GPAT
+    -GPAT : match only TCs that do not have any flag matching GPAT
+All flag patterns are conjunctively connected.
 '''[:-1])
     sys.exit(0)
 
@@ -142,11 +171,13 @@ def main():
         print(err, file=sys.stderr)
         sys.exit(1)
 
+    verbosity = len(tuple(opt for opt, val in opts if opt == '-v'))
+
     if ('-h', '') in opts:
         usage()
 
     if ('-l', '') in opts:
-        list_flags(('-v', '') in opts)
+        list_flags(verbosity)
 
     tcs = []
     if args:
@@ -155,28 +186,21 @@ def main():
     else:
         apply_transform_over_tests(tcs.append)
 
-    verbosity = 0
-    for opt, val in opts:
-        if opt == '-q':
-            tcs = query(val, tcs)
-        elif opt == '-v':
-            verbosity += 1
+    combined_query = ' '.join(val for opt, val in opts if opt == '-q').strip()
+    if combined_query:
+        tcs = query(combined_query, tcs)
 
     if len(tcs) == 0 or verbosity == 0:
         # just directory
         for tc in tcs:
             print(tc.test_dir)
-    elif verbosity == 1:
-        # directory + flags
-        max_w = max(len(tc.test_dir) for tc in tcs)
-        for tc in tcs:
-            print('%*s: %s' % (-max_w, tc.test_dir, ' '.join(sorted(flags(tc)))))
     else:
-        # directory + cmdline options
         max_w = max(len(tc.test_dir) for tc in tcs)
         for tc in tcs:
-            print('%*s: %s' % (-max_w, tc.test_dir,
-                               shlex.join(tc.generate_run_argument_list('true')[1:])))
+            # directory + flags or directory + cmdline options
+            value = (' '.join(sorted(flags(tc))) if verbosity == 1 else
+                     shlex.join(tc.generate_run_argument_list('true')[1:]))
+            print('%*s: %s' % (-max_w, tc.test_dir, value))
 
 if __name__ == '__main__':
     main()

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -356,8 +356,9 @@ TEST_SUITES = [
 
 def apply_transform_over_tests(functor):
     # Always double check TEST_SUITE variable!
+    script_dir_path = os.path.dirname(os.path.relpath(__file__))
     for base_dir in TEST_SUITES:
-        test_cases = get_test_objects(base_dir)
+        test_cases = get_test_objects(os.path.join(script_dir_path, base_dir))
         for test_case in test_cases:
             functor(test_case)
 


### PR DESCRIPTION
Example:
```
$ ./regdb.py -q 'bitw=32' -v # anything that assumes 32-bit, -q '32' would work as well (dropping category 'bitw')
[...]
esbmc/github_1253                                    : bitw=32 ia lang=c strat=kind
esbmc/github_1259_unroll-2-v1-success                : bitw=32 lang=c strat=incr
esbmc/github_1259_unroll-2-v2-fail                   : bitw=32 lang=c strat=incr
esbmc/cpachecker-long-min-32.c                       : bitw=32 lang=c
esbmc-cpp/cpp/ch20_1-32                              : bitw=32 lang=cxx
[...]
$ ./regdb.py -q '-lang=*' -v # anything that has no input language
esbmc/github_576_binary: goto
```