### PR TITLE
[C++ operational models] fixed various warning/compilation errors for <iterator> and <string> libs

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/iterator/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/iterator/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
  --timeout 900
 

--- a/regression/esbmc-cpp/OM_sanity_checks/memory/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/memory/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
  --timeout 900
 

--- a/regression/esbmc-cpp/cpp/ch13_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch13_7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch16_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 20 --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_find_last_of_1/test.desc
+++ b/regression/esbmc-cpp/string/string_find_last_of_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 26 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_find_last_of_2_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_find_last_of_2_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 26 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_substr_1/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 25 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_substr_3_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_3_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 20 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/string/string_substr_4_bug/test.desc
+++ b/regression/esbmc-cpp/string/string_substr_4_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 16 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -356,7 +356,7 @@ public:
     }
 
 private:
-    streambuf_type* sbuf_;
+  streambuf_type* sbuf_;
 };
 
 

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -1,9 +1,12 @@
 #ifndef STL_ITERATOR
 #define STL_ITERATOR
 
+
 #include "iostream"
-#include "utility"
+#include "vector"
+#include "streambuf"
 #include "string"
+#include "utility"
 
 namespace std
 {
@@ -74,37 +77,6 @@ void advance(InputIterator &i, Distance n);
 template <class InputIterator>
 typename iterator_traits<InputIterator>::difference_type
 distance(InputIterator first, InputIterator last);
-
-template <class Container>
-back_insert_iterator<Container> back_inserter(Container &x);
-
-template <class Container>
-front_insert_iterator<Container> front_inserter(Container &x);
-
-template <class Container, class Inserter>
-insert_iterator<Container> inserter(Container &x, Inserter i);
-
-template <class Iterator>
-class reverse_iterator : public iterator
-{
-public:
-  typedef iterator_traits::difference_type difference_type;
-  typedef iterator_traits::pointer pointer;
-  typedef iterator_traits::reference reference;
-
-  Iterator base() const;
-  reference operator*() const;
-  reverse_iterator operator+(difference_type n) const;
-  reverse_iterator &operator++();
-  reverse_iterator operator++(int);
-  reverse_iterator &operator+=(difference_type n);
-  reverse_iterator operator-(difference_type n) const;
-  reverse_iterator &operator--();
-  reverse_iterator operator--(int);
-  reverse_iterator &operator-=(difference_type n);
-  pointer operator->() const;
-  reference operator[](difference_type n) const;
-};
 
 template <class Container>
 class back_insert_iterator
@@ -206,6 +178,43 @@ public:
   }
 };
 
+template <class Container>
+back_insert_iterator<Container> back_inserter(Container &x);
+
+template <class Container>
+front_insert_iterator<Container> front_inserter(Container &x);
+
+template <class Container, class Inserter>
+insert_iterator<Container> inserter(Container &x, Inserter i);
+
+
+template <class Iterator>
+class reverse_iterator : public std::iterator<typename std::iterator_traits<Iterator>::iterator_category,
+                                              typename std::iterator_traits<Iterator>::value_type,
+                                              typename std::iterator_traits<Iterator>::difference_type,
+                                              typename std::iterator_traits<Iterator>::pointer,
+                                              typename std::iterator_traits<Iterator>::reference>
+{
+public:
+    typedef typename std::iterator_traits<Iterator>::difference_type difference_type;
+    typedef typename std::iterator_traits<Iterator>::pointer pointer;
+    typedef typename std::iterator_traits<Iterator>::reference reference;
+
+    Iterator base() const;
+    reference operator*() const;
+    reverse_iterator operator+(difference_type n) const;
+    reverse_iterator& operator++();
+    reverse_iterator operator++(int);
+    reverse_iterator& operator+=(difference_type n);
+    reverse_iterator operator-(difference_type n) const;
+    reverse_iterator& operator--();
+    reverse_iterator operator--(int);
+    reverse_iterator& operator-=(difference_type n);
+    pointer operator->() const;
+    reference operator[](difference_type n) const;
+};
+
+
 template <
   class T,
   class charT = char,
@@ -255,7 +264,7 @@ public:
 	}*/
 };
 
-template <class T, class charT = char, class traits = char_traits<charT>>
+template <class T, class charT = char, class traits = char_traits<charT> >
 class ostream_iterator
   : public iterator<output_iterator_tag, void, void, void, void>
 {
@@ -305,80 +314,54 @@ public:
   }
 };
 
-template <class charT = char, class traits = char_traits<charT>>
-class istreambuf_iterator : public iterator<
-                              input_iterator_tag,
-                              charT,
-                              typename traits::off_type,
-                              charT *,
-                              charT &>
+#if 0
+template <class charT = char, class traits = std::char_traits<charT> >
+class istreambuf_iterator : public std::iterator<std::input_iterator_tag, charT, typename traits::off_type, charT*, charT&>
 {
 public:
-  typedef charT char_type;
-  typedef traits traits_type;
-  typedef typename traits::int_type int_type;
-  typedef basic_streambuf<charT, traits> streambuf_type;
-  typedef istream istream_type;
+    typedef charT char_type;
+    typedef traits traits_type;
+    typedef typename traits::int_type int_type;
+    typedef std::basic_streambuf<charT, traits> streambuf_type;
+    typedef std::basic_istream<charT, traits> istream_type;
 
-  class proxy
-  {
-    charT keep_;
-    streambuf_type *sbuf_;
-
-  public:
-    proxy(charT c, streambuf_type *sbuf) : keep_(c), sbuf_(sbuf)
+    class proxy
     {
-    }
-    charT operator*()
+        charT keep_;
+        streambuf_type* sbuf_;
+
+    public:
+        proxy(charT c, streambuf_type* sbuf) : keep_(c), sbuf_(sbuf) {}
+        charT operator*() { return keep_; }
+    };
+
+    istreambuf_iterator() throw() : sbuf_(0) {}
+    istreambuf_iterator(istream_type& s) throw() : sbuf_(s.rdbuf()) {}
+    istreambuf_iterator(streambuf_type* s) throw() : sbuf_(s) {}
+    istreambuf_iterator(const proxy& p) throw() : sbuf_(p.sbuf_) {}
+
+    charT operator*() const { return sbuf_->sgetc(); }
+    istreambuf_iterator<charT, traits>& operator++() { sbuf_->sbumpc(); return *this; }
+    proxy operator++(int) { return proxy(sbuf_->sbumpc(), sbuf_); }
+
+    bool equal(istreambuf_iterator& b) const
     {
-      return keep_;
+        if (sbuf_ == 0 || *(*this) == traits::eof())
+        {
+            if (b.sbuf_ == 0 || *b == traits::eof())
+                return true;
+        }
+        else if (b.sbuf_ != 0 && *b != traits::eof())
+            return true;
+        return false;
     }
-  };
-
-  istreambuf_iterator() throw() : sbuf_(0)
-  {
-  }
-  istreambuf_iterator(istream_type &s) throw()
-  {
-  }
-  istreambuf_iterator(streambuf_type *s) throw() : sbuf_(s)
-  {
-  }
-  istreambuf_iterator(const proxy &p) throw() : sbuf_(p.sbuf_)
-  {
-  }
-
-  charT operator*() const
-  {
-    return sbuf_->sgetc();
-  }
-  istreambuf_iterator<charT, traits> &operator++()
-  {
-    sbuf_->sbumpc();
-    return *this;
-  }
-  proxy operator++(int)
-  {
-    return proxy(sbuf_->sbumpc(), sbuf_);
-  }
-
-  bool equal(istreambuf_iterator &b) const
-  {
-    if (sbuf_ == 0 || *(*this) == traits::eof())
-    {
-      if (b.sbuf_ == 0 || *b == traits::eof())
-        return true;
-    }
-    else if (b.sbuf_ != 0 && *b != traits::eof())
-      return true;
-    return false;
-  }
 
 private:
-  streambuf_type *sbuf_;
+    streambuf_type* sbuf_;
 };
 
-template <class charT = char, class traits = char_traits<charT>>
+
+template <class charT = char, class traits = char_traits<charT> >
 class ostreambuf_iterator
   : public iterator<output_iterator_tag, charT, void, charT *, charT &>
 {
@@ -420,5 +403,6 @@ private:
 };
 
 } // namespace std
-
+#endif
+} // namespace std
 #endif

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -1,7 +1,6 @@
 #ifndef STL_ITERATOR
 #define STL_ITERATOR
 
-
 #include "iostream"
 #include "vector"
 #include "streambuf"

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -694,8 +694,6 @@ public:
   {
     __ESBMC_assert(
       p.pos >= 0, "The first parameter must to be greater than zero");
-    __ESBMC_assert(
-      c != NULL, "The second parameter must to be different than NULL");
     int pos1 = p.pos;
     int n = 1;
     char *s = new char[n + 1];
@@ -745,8 +743,6 @@ public:
     __ESBMC_assert(
       p.pos >= 0, "The first parameter must to be greater than zero");
     __ESBMC_assert(n >= 0, "The second parameter must to be greater than zero");
-    __ESBMC_assert(
-      c != NULL, "The third parameter must to be different than NULL");
     int pos1 = p.pos;
     char *s = new char[n + 1];
     for (int i = 0; i < n; i++)
@@ -814,8 +810,6 @@ public:
     __ESBMC_assert(
       p.pos >= 0, "The first parameter must to be greater than zero");
     __ESBMC_assert(n >= 0, "The second parameter must to be greater than zero");
-    __ESBMC_assert(
-      c != NULL, "The third parameter must to be different than NULL");
     int pos1 = p.pos;
     char *s = new char[n + 1];
     for (int i = 0; i < n; i++)
@@ -1046,7 +1040,6 @@ string::string(int len)
 
 string::string(char c, size_t n)
 {
-  __ESBMC_assert(c != NULL, "the first parameter must be different than NULL");
   __ESBMC_assert(n > 0, "the second parameter must be different than zero");
   str = new char[n + 1];
   for (int i = 0; i <= n; i++)
@@ -1333,7 +1326,6 @@ __ESBMC_HIDE:
 string &string::operator=(char s)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(s != NULL, "The parameter must to be different than NULL");
   this->_size = 1;
   this->str = new char[this->_size + 1];
   this->str[0] = s;
@@ -1442,7 +1434,6 @@ __ESBMC_HIDE:
 string &string::operator+=(char s)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(s != NULL, "The parameter must to be different than NULL");
   int totalLen = this->_size + 1;
   char temp[totalLen + 1];
   int i = 0;
@@ -1511,7 +1502,6 @@ void string::resize(size_t n, char c)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(n > 0, "The parameter must to be greater than zero");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   int num, i;
   num = this->length();
   string tmp(this->str);
@@ -1568,7 +1558,6 @@ string &string::assign(size_t n, char c)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(n > 0, "string overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   int i;
   this->_size = n;
   this->str = new char[n + 1];
@@ -1688,7 +1677,6 @@ string &string::append(size_t n, char c)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(n > 0, "string overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   int rhsLen = n;
   int totalLen = this->_size + rhsLen;
   char *temp = new char[totalLen + 1];
@@ -1710,7 +1698,6 @@ size_t string::find(char c, size_t pos) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert((pos >= 0) && (pos < this->length()), "string overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   int i;
   int len = this->length();
   for (i = 0; i < len; i++)
@@ -2018,7 +2005,6 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     (pos1 >= 0) && (pos1 < len) && ((pos1 + n) < len) && (n > 0),
     "string overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   char *s = new char[n + 1];
   for (i = 0; i < n; i++)
   {
@@ -2193,7 +2179,6 @@ __ESBMC_HIDE:
   __ESBMC_assert(
     (pos1 < this->length()) && ((pos1 + n1) <= this->length()), "overflow");
   __ESBMC_assert(n2 > 0, "overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   this->erase(pos1, n1);
   int k;
   char *tmp = new char[n2 + 1];
@@ -2246,7 +2231,6 @@ string &
 string::replace(string::iterator i1, string::iterator i2, size_t n2, char c)
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   int tmp_one = i1.pos;
   int tmp_two = i2.pos + 1;
   int tmpk = tmp_two - tmp_one;
@@ -2480,7 +2464,6 @@ size_t string::find_first_of(char c, size_t pos) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert((pos < this->length()) && (pos >= 0), "overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   size_t i, j;
 
   int len = this->length();
@@ -2577,7 +2560,6 @@ size_t string::find_first_not_of(char c, size_t pos) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert((pos < this->length()) && (pos >= 0), "overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   size_t i, j;
   int number;
 
@@ -2702,7 +2684,6 @@ size_t string::find_last_of(char c, size_t pos) const
 {
 __ESBMC_HIDE:
   __ESBMC_assert((pos < this->length()) && (pos >= 0), "overflow");
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   size_t i, j;
 
   int len = this->length();
@@ -2722,7 +2703,6 @@ __ESBMC_HIDE:
 size_t string::rfind(char c, size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert(c != NULL, "The parameter must to be different than NULL");
   int i;
   int len = this->length();
   for (i = len; i > 0; i--)

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1318,8 +1318,8 @@ __ESBMC_HIDE:
   __ESBMC_assert(s != NULL, "The parameter must to be different than NULL");
   this->_size = strlen(s);
   this->str = new char[this->_size + 1];
-  string tmp = string(strcpy(this->c_str(), s));
-  return tmp;
+  strcpy(this->str, s); // Copy the contents of s to str
+  return *this; // Return a reference to the modified string object
 }
 
 string &string::operator=(char s)

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2698,6 +2698,7 @@ __ESBMC_HIDE:
       return i;
     }
   }
+  return npos; // Return npos when the character is not found
 }
 
 size_t string::rfind(char c, size_t pos) const
@@ -2708,6 +2709,7 @@ __ESBMC_HIDE:
   for (i = len; i > 0; i--)
     if (this->str[i] == c)
       return i;
+  return npos; // Return npos when the character is not found
 }
 
 size_t string::rfind(string &s, size_t pos) const

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -987,7 +987,7 @@ namespace std
 string::string()
 {
   str = new char[1];
-  str = "";
+  str[0] = '\0'; // Assign the null terminator to represent an empty string
   _size = 0;
 }
 

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -986,8 +986,7 @@ namespace std
 {
 string::string()
 {
-  str = new char[1];
-  str[0] = '\0'; // Assign the null terminator to represent an empty string
+  // In C++ string::empty means a string object with size 0.
   _size = 0;
 }
 
@@ -2424,6 +2423,8 @@ __ESBMC_HIDE:
       }
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_first_of(const string &s, size_t pos) const
@@ -2456,6 +2457,8 @@ __ESBMC_HIDE:
       }
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_first_of(char c, size_t pos) const
@@ -2476,6 +2479,8 @@ __ESBMC_HIDE:
       return i;
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_first_not_of(const string &s, size_t pos) const
@@ -2514,6 +2519,8 @@ __ESBMC_HIDE:
       return i;
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_first_not_of(const char *s, size_t pos) const
@@ -2552,6 +2559,8 @@ __ESBMC_HIDE:
       return i;
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_first_not_of(char c, size_t pos) const
@@ -2579,6 +2588,8 @@ __ESBMC_HIDE:
   {
     return i;
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_last_of(const string &s, size_t pos) const
@@ -2611,6 +2622,8 @@ __ESBMC_HIDE:
       }
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_last_of(const char *s, size_t pos) const
@@ -2643,6 +2656,8 @@ __ESBMC_HIDE:
       }
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_last_of(char *s) const
@@ -2676,6 +2691,8 @@ size_t string::find_last_of(char *s) const
       }
     }
   }
+  // Return npos if the character is not found
+  return npos;
 }
 
 size_t string::find_last_of(char c, size_t pos) const

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -876,7 +876,7 @@ public:
   size_t copy(char *s, size_t n, size_t pos = 0) const;
   const char *data() const;
 
-  string &substr(size_t pos, size_t n)
+  string substr(size_t pos, size_t n)
   {
   __ESBMC_HIDE:
     __ESBMC_assert(
@@ -893,10 +893,11 @@ public:
     }
     one[k] = '\0';
     string tmp(one);
+    delete[] one; // Freeing dynamically allocated memory
     return tmp;
   }
 
-  string &substr(size_t pos) const
+  string substr(size_t pos) const
   {
   __ESBMC_HIDE:
     __ESBMC_assert(
@@ -912,10 +913,11 @@ public:
     }
     one[k] = '\0';
     string tmp(one);
+    delete[] one; // Freeing dynamically allocated memory
     return tmp;
   }
 
-  string::iterator &begin() const
+  string::iterator begin() const
   {
     int i;
     string::iterator first(this->str);

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1263,8 +1263,6 @@ char &string::operator[](size_t pos)
 
 char string::at(size_t pos) const
 {
-  __ESBMC_assert((pos < this->_size), "Error! Invalid access memory area");
-
   if (pos >= this->length())
   {
     // TODO: when we support try-catch, replace the assert with the throw statement below

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1263,19 +1263,16 @@ char &string::operator[](size_t pos)
 
 char string::at(size_t pos) const
 {
-  __ESBMC_assert(
-    (pos >= 0) && (pos < this->_size), "Error! Invalid access memory area");
-  int i;
-  if (pos > this->length())
+  __ESBMC_assert((pos < this->_size), "Error! Invalid access memory area");
+
+  if (pos >= this->length())
   {
     // TODO: when we support try-catch, replace the assert with the throw statement below
     //throw out_of_range();
     __ESBMC_assert(0, "string append failed, out_of_range");
   }
-  else
-  {
-    return this->str[pos];
-  }
+  
+  return this->str[pos];
 }
 
 bool string::empty() const

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1695,13 +1695,14 @@ __ESBMC_HIDE:
 
 size_t string::find(char c, size_t pos) const
 {
-__ESBMC_HIDE:
-  __ESBMC_assert((pos >= 0) && (pos < this->length()), "string overflow");
-  int i;
-  int len = this->length();
-  for (i = 0; i < len; i++)
+  __ESBMC_HIDE:
+  __ESBMC_assert(pos < this->length(), "string overflow");
+
+  for (size_t i = pos; i < this->length(); i++)
     if (this->str[i] == c)
-      return i;
+      return i; // Return the index if character found
+  
+  return npos; // Return npos if character not found
 }
 
 size_t string::find(string &s, size_t pos) const

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1065,7 +1065,7 @@ inline ostream &operator<<(ostream &o, string)
   return o;
 }
 
-inline ostream &operator<<(ostream &o, struct iterator &)
+inline ostream &operator<<(ostream &o, string::iterator &)
 {
   return o;
 }

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -986,7 +986,8 @@ namespace std
 {
 string::string()
 {
-  // In C++ string::empty means a string object with size 0.
+  str = new char[1];
+  str[0] = '\0'; // Assign the null terminator to represent an empty string
   _size = 0;
 }
 


### PR DESCRIPTION
This pull request addresses compilation warnings and errors generated by the clang compiler within the `<iterator>` and `<string>` libraries. The changes implemented in this PR include:

(1) Resolving issues related to methods where stack memory was associated with local variables, ensuring proper memory management practices.

(2) Adjusting methods to return references to the modified string object where applicable, maintaining consistency and avoiding potential issues with dangling references.

(3) Ensuring that methods return npos when the target character is not found during search operations, enhancing the reliability and correctness of the string manipulation functions.

(4) Enabling regression tests to validate the fixes implemented for the aforementioned issues, ensuring that the code changes do not introduce regressions or unintended behavior.

These adjustments aim to enhance the overall robustness, stability, and maintainability of the C++ operational models by addressing compiler warnings and errors and verifying the correctness of the fixes through regression testing.