### PR TITLE
Fixes for interval bitwise arithmetic

### DIFF
--- a/src/goto-programs/abstract-interpretation/bitwise_bounds.h
+++ b/src/goto-programs/abstract-interpretation/bitwise_bounds.h
@@ -987,20 +987,12 @@ INT_X unsigned_2_signed_min_extend(UINT_X a, UINT_X b, UINT_X n)
   return a;
 }
 
-#define IS_UINT(LHS, RHS)                                                      \
-  LHS.get_lower().is_uint64() && LHS.get_upper().is_uint64() &&                \
-    RHS.get_lower().is_uint64() && RHS.get_upper().is_uint64()
-
 #define UINT_FUNC(FUNC, LHS, RHS)                                              \
   FUNC(                                                                        \
     LHS.get_lower().to_uint64(),                                               \
     LHS.get_upper().to_uint64(),                                               \
     RHS.get_lower().to_uint64(),                                               \
     RHS.get_upper().to_uint64())
-
-#define IS_INT(LHS, RHS)                                                       \
-  LHS.get_lower().is_int64() && LHS.get_upper().is_int64() &&                  \
-    RHS.get_lower().is_int64() && RHS.get_upper().is_int64()
 
 #define INT_FUNC(FUNC, LHS, RHS)                                               \
   FUNC(                                                                        \
@@ -1015,13 +1007,16 @@ INT_X unsigned_2_signed_min_extend(UINT_X a, UINT_X b, UINT_X n)
     const interval_templatet<BigInt> &lhs,                                     \
     const interval_templatet<BigInt> &rhs) const                               \
   {                                                                            \
+    assert(lhs.type && rhs.type);                                              \
     interval_templatet<BigInt> result;                                         \
-    if (IS_UINT(lhs, rhs))                                                     \
+    if(!lhs.lower || !lhs.upper || !rhs.lower || !rhs.upper)                   \
+       return result;                                                          \
+    if (is_unsignedbv_type(*lhs.type) && is_unsignedbv_type(*rhs.type))        \
     {                                                                          \
       result.set_lower(UINT_FUNC(MIN_UFUNC, lhs, rhs));                        \
       result.set_upper(UINT_FUNC(MAX_UFUNC, lhs, rhs));                        \
     }                                                                          \
-    else if (IS_INT(lhs, rhs))                                                 \
+    else if (is_signedbv_type(*lhs.type) && is_signedbv_type(*rhs.type))            \
     {                                                                          \
       result.set_lower(INT_FUNC(MIN_FUNC, lhs, rhs));                          \
       result.set_upper(INT_FUNC(MAX_FUNC, lhs, rhs));                          \
@@ -1066,8 +1061,6 @@ GET_BIT_INTERVALS(
   signed_min_left_shift,
   signed_max_left_shift)
 
-#undef IS_UINT
-#undef IS_INT
 #undef UINT_FUNC
 #undef INT_FUNC
 #undef GET_BIT_INTERVALS

--- a/src/goto-programs/abstract-interpretation/bitwise_bounds.h
+++ b/src/goto-programs/abstract-interpretation/bitwise_bounds.h
@@ -1007,16 +1007,16 @@ INT_X unsigned_2_signed_min_extend(UINT_X a, UINT_X b, UINT_X n)
     const interval_templatet<BigInt> &lhs,                                     \
     const interval_templatet<BigInt> &rhs) const                               \
   {                                                                            \
-    assert(lhs.type && rhs.type);                                              \
+    assert(lhs.type &&rhs.type);                                               \
     interval_templatet<BigInt> result;                                         \
-    if(!lhs.lower || !lhs.upper || !rhs.lower || !rhs.upper)                   \
-       return result;                                                          \
+    if (!lhs.lower || !lhs.upper || !rhs.lower || !rhs.upper)                  \
+      return result;                                                           \
     if (is_unsignedbv_type(*lhs.type) && is_unsignedbv_type(*rhs.type))        \
     {                                                                          \
       result.set_lower(UINT_FUNC(MIN_UFUNC, lhs, rhs));                        \
       result.set_upper(UINT_FUNC(MAX_UFUNC, lhs, rhs));                        \
     }                                                                          \
-    else if (is_signedbv_type(*lhs.type) && is_signedbv_type(*rhs.type))            \
+    else if (is_signedbv_type(*lhs.type) && is_signedbv_type(*rhs.type))       \
     {                                                                          \
       result.set_lower(INT_FUNC(MIN_FUNC, lhs, rhs));                          \
       result.set_upper(INT_FUNC(MAX_FUNC, lhs, rhs));                          \

--- a/src/goto-programs/abstract-interpretation/bitwise_bounds.h
+++ b/src/goto-programs/abstract-interpretation/bitwise_bounds.h
@@ -1007,16 +1007,15 @@ INT_X unsigned_2_signed_min_extend(UINT_X a, UINT_X b, UINT_X n)
     const interval_templatet<BigInt> &lhs,                                     \
     const interval_templatet<BigInt> &rhs) const                               \
   {                                                                            \
-    assert(lhs.type &&rhs.type);                                               \
     interval_templatet<BigInt> result;                                         \
     if (!lhs.lower || !lhs.upper || !rhs.lower || !rhs.upper)                  \
       return result;                                                           \
-    if (is_unsignedbv_type(*lhs.type) && is_unsignedbv_type(*rhs.type))        \
+    if (is_unsignedbv_type(lhs.type) && is_unsignedbv_type(rhs.type))          \
     {                                                                          \
       result.set_lower(UINT_FUNC(MIN_UFUNC, lhs, rhs));                        \
       result.set_upper(UINT_FUNC(MAX_UFUNC, lhs, rhs));                        \
     }                                                                          \
-    else if (is_signedbv_type(*lhs.type) && is_signedbv_type(*rhs.type))       \
+    else if (is_signedbv_type(lhs.type) && is_signedbv_type(rhs.type))         \
     {                                                                          \
       result.set_lower(INT_FUNC(MIN_FUNC, lhs, rhs));                          \
       result.set_upper(INT_FUNC(MAX_FUNC, lhs, rhs));                          \

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -495,7 +495,8 @@ T interval_domaint::get_interval(const expr2tc &e) const
       const auto &bit_op = dynamic_cast<const bit_2ops &>(*e);
       auto lhs = get_interval<T>(bit_op.side_1);
       auto rhs = get_interval<T>(bit_op.side_2);
-
+      lhs.type = bit_op.side_1->type;
+      rhs.type = bit_op.side_2->type;
       if (is_shl2t(e))
         result = T::left_shift(lhs, rhs);
 

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -33,7 +33,8 @@ public:
 
   /// Bound value
   std::optional<T> lower, upper;
-
+  /// Type to be used for shift operations
+  std::optional<type2tc> type;
   T get_lower() const
   {
     return get(false);

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -34,7 +34,7 @@ public:
   /// Bound value
   std::optional<T> lower, upper;
   /// Type to be used for shift operations
-  std::optional<type2tc> type;
+  type2tc type = empty_type2tc();
   T get_lower() const
   {
     return get(false);

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -34,7 +34,7 @@ public:
   /// Bound value
   std::optional<T> lower, upper;
   /// Type to be used for shift operations
-  type2tc type = empty_type2tc();
+  type2tc type;
   T get_lower() const
   {
     return get(false);

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -509,8 +509,6 @@ public:
   static interval_templatet<T> bitnot(const interval_templatet<T> &w)
   {
     interval_templatet<T> result;
-    result.set_lower(-w.get_upper() - 1);
-    result.set_upper(-w.get_lower() - 1);
     return result;
   }
 


### PR DESCRIPTION
This PR fixes the bitwise operations for Integer intervals by:

1. Fixed the computation of whether we are dealing with signed or unsigned type. This is done by adding an optional type parameter into the integer intervals.
2. Removed the incorrect bitnot implementation.

| ID  | Mode | CT  | CF  | IT  | IF  | Notes |
| --- | --- | --- | --- | --- | --- | --- |
| 797 | No Arithmetic | 2657 | 1602 | 6   | 0   | Baseline |
| 802 | Arithmetic | 2194 | 1228 | 3   | 0   | The new unique were most in product-lines. |
| 828 | Arithmetic + Bitwise | 2195 | 1225 | 3   | 0 | Same as 802 |

