### PR TITLE
[C++ Verification] fixed base classes and tmp object

### DIFF
--- a/regression/esbmc-cpp/cpp/ch21_19/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_19/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch21_22/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_22/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/ch21_24/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_24/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/ch21_27/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_27/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -49,6 +49,7 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
   else if (statement == "temporary_object")
   {
     exprt &initializer = static_cast<exprt &>(expr.add("initializer"));
+    adjust_expr(initializer);
 
     side_effect_expr_function_callt &constructor_call =
       to_side_effect_expr_function_call(initializer.op0());

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -583,6 +583,8 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_expr(*cxxbtmp.getSubExpr(), new_expr))
       return true;
 
+    make_temporary(new_expr);
+
     break;
   }
 
@@ -745,13 +747,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_constructor_call(cxxtoe, new_expr))
       return true;
 
-    // make the temporary
-    side_effect_exprt tmp_obj("temporary_object", new_expr.type());
-    codet code_expr("expression");
-    code_expr.operands().push_back(new_expr);
-    tmp_obj.initializer(code_expr);
-    tmp_obj.location() = new_expr.location();
-    new_expr.swap(tmp_obj);
+    make_temporary(new_expr);
 
     break;
   }
@@ -1581,4 +1577,18 @@ bool clang_cpp_convertert::is_ConstructorOrDestructor(
 {
   return md.getKind() == clang::Decl::CXXConstructor ||
          md.getKind() == clang::Decl::CXXDestructor;
+}
+
+void clang_cpp_convertert::make_temporary(exprt &expr)
+{
+  if (expr.statement() != "temporary_object")
+  {
+    // make the temporary
+    side_effect_exprt tmp_obj("temporary_object", expr.type());
+    codet code_expr("expression");
+    code_expr.operands().push_back(expr);
+    tmp_obj.initializer(code_expr);
+    tmp_obj.location() = expr.location();
+    expr.swap(tmp_obj);
+  }
 }

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1412,6 +1412,9 @@ void clang_cpp_convertert::get_base_map(
     const clang::CXXRecordDecl &base_cxxrd =
       *(base.getType().getTypePtr()->getAsCXXRecordDecl());
 
+    if (get_struct_union_class(base_cxxrd))
+      continue;
+
     // recursively get more bases for this `base`
     if (base_cxxrd.bases_begin() != base_cxxrd.bases_end())
       get_base_map(base_cxxrd, map);

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1412,8 +1412,7 @@ void clang_cpp_convertert::get_base_map(
     const clang::CXXRecordDecl &base_cxxrd =
       *(base.getType().getTypePtr()->getAsCXXRecordDecl());
 
-    if (get_struct_union_class(base_cxxrd))
-      continue;
+    get_struct_union_class(base_cxxrd);
 
     // recursively get more bases for this `base`
     if (base_cxxrd.bases_begin() != base_cxxrd.bases_end())

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -286,7 +286,8 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
     if (cxxrd->bases_begin() != cxxrd->bases_end())
     {
       base_map bases;
-      get_base_map(*cxxrd, bases);
+      if (get_base_map(*cxxrd, bases))
+        return true;
       get_base_components_methods(bases, type);
     }
   }
@@ -1395,7 +1396,7 @@ symbolt *clang_cpp_convertert::get_fd_symbol(const clang::FunctionDecl &fd)
   return (context.find_symbol(id));
 }
 
-void clang_cpp_convertert::get_base_map(
+bool clang_cpp_convertert::get_base_map(
   const clang::CXXRecordDecl &cxxrd,
   base_map &map)
 {
@@ -1408,11 +1409,13 @@ void clang_cpp_convertert::get_base_map(
     const clang::CXXRecordDecl &base_cxxrd =
       *(base.getType().getTypePtr()->getAsCXXRecordDecl());
 
-    get_struct_union_class(base_cxxrd);
+    if (get_struct_union_class(base_cxxrd))
+      return true;
 
     // recursively get more bases for this `base`
     if (base_cxxrd.bases_begin() != base_cxxrd.bases_end())
-      get_base_map(base_cxxrd, map);
+      if (get_base_map(base_cxxrd, map))
+        return true;
 
     // get base class id
     std::string class_id, class_name;
@@ -1426,6 +1429,8 @@ void clang_cpp_convertert::get_base_map(
     (void)status;
     assert(status.second);
   }
+
+  return false;
 }
 
 void clang_cpp_convertert::get_base_components_methods(

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -513,6 +513,13 @@ protected:
    *  md: clang AST representing a C++ method
    */
   bool is_ConstructorOrDestructor(const clang::CXXMethodDecl &md);
+  /*
+   * Check if expr is a temporary object
+   * if not, convert expr to a temporary object
+   * Arguments:
+   *  expr: ESBMC IR to represent Function call
+   */
+  void make_temporary(exprt &expr);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -221,7 +221,7 @@ protected:
    *  - cxxrd: clang AST representing the class/struct we are currently dealing with
    *  - map: this map contains all base class(es) of this class std::map<class_id, pointer to clang AST of base class>
    */
-  void get_base_map(const clang::CXXRecordDecl &cxxrd, base_map &map);
+  bool get_base_map(const clang::CXXRecordDecl &cxxrd, base_map &map);
   /*
    * Check whether we've already got this component in a class type
    * Avoid copying duplicate component from a base class type to the derived class type.


### PR DESCRIPTION
This PR mainly addresses assertion failures in libraries **iterator** and **algorithm**.

1. The order of class declarations affects the get base class:
https://github.com/esbmc/esbmc/issues/1703
2. The `new_object` in the parameter of the function call was not removed correctly. Sol: Mark statemenet as a temporary object.
https://github.com/esbmc/esbmc/issues/1716
3. Type mismatch caused by not adjusting the initializer.
https://github.com/esbmc/esbmc/issues/1717

It mainly solves the problems in the following methods:

`std::ostream_iterator< int > output();`
`std::copy()`
`std::accumulate()`