### PR TITLE
[Concurrency] Make interleavings unviable after main thread has ended.

### DIFF
--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -263,6 +263,7 @@ void execution_statet::symex_step(reachability_treet &art)
       // TODO: we should support verifying memory leaks in multi-threaded C programs.
       assume(gen_false_expr());
       end_thread();
+      interleaving_unviable = true;
     }
     else
     {


### PR DESCRIPTION
ESBMC does not verify the VCCs after the main thread has ended, however, it is still exploring them, we can stop the further interleavings to reduce states space.

The results of this PR: https://github.com/esbmc/esbmc/actions/runs/8048711271/job/21981301419

```
Statistics:            665 Files
  correct:             427
    correct true:      142
    correct false:     285
  incorrect:             5
    incorrect true:      4
    incorrect false:     1
  unknown:             233
  Score:               425 (max: 999)
```

master: 

```
Statistics:            665 Files
  correct:             421
    correct true:      138
    correct false:     283
  incorrect:             5
    incorrect true:      4
    incorrect false:     1
  unknown:             239
  Score:               415 (max: 999)
```

The incorrect false is at issue #1582 . (Need to check whether it's correctly labelled, cbmc also report failure)