### PR TITLE
Interval Analysis during symbolic execution

### DIFF
--- a/src/goto-symex/CMakeLists.txt
+++ b/src/goto-symex/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(symex symex_target.cpp symex_target_equation.cpp symex_assign.cpp
   builtin_functions.cpp slice.cpp symex_other.cpp xml_goto_trace.cpp
   symex_valid_object.cpp dynamic_allocation.cpp symex_catch.cpp renaming.cpp
   execution_state.cpp reachability_tree.cpp reachability_tree_cin.cpp
-  witnesses.cpp printf_formatter.cpp)
+  witnesses.cpp printf_formatter.cpp symex_intervals.cpp)
 target_include_directories(symex
     PRIVATE ${CMAKE_BINARY_DIR}/src
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -840,7 +840,7 @@ protected:
    *  program execution has finished */
   std::list<allocated_obj> dynamic_memory;
 
-  std::unordered_map<irep_idt, wrapped_interval, irep_id_hash> intervals;
+  std::unordered_map<std::string, wrapped_interval> intervals;
   wrapped_interval get_interval(const expr2tc &) const;
   void
   update_symbol_interval(const symbol2t &sym, const wrapped_interval value);

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -845,6 +845,7 @@ protected:
   void
   update_symbol_interval(const symbol2t &sym, const wrapped_interval value);
   void apply_assume_less(const expr2tc &a, const expr2tc &b);
+  void apply_assignment(expr2tc &a, expr2tc &b);
   void assume_rec(const expr2tc &expr, bool negation = false);
   void assume_rec(const expr2tc &lhs, expr2t::expr_ids id, const expr2tc &rhs);
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -11,6 +11,7 @@
 #include <irep2/irep2.h>
 #include <util/options.h>
 #include <util/std_types.h>
+#include <goto-programs/abstract-interpretation/wrapped_interval.h>
 
 class reachability_treet; // Forward dec
 class execution_statet;   // Forward dec
@@ -838,6 +839,19 @@ protected:
    *  Used to track what we should level memory-leak-assertions against when the
    *  program execution has finished */
   std::list<allocated_obj> dynamic_memory;
+
+  std::unordered_map<irep_idt, wrapped_interval, irep_id_hash> intervals;
+  wrapped_interval get_interval(const expr2tc &) const;
+  void update_symbol_interval(const symbol2t &sym,const wrapped_interval value);
+  void apply_assume_less(const expr2tc &a, const expr2tc &b);
+  void assume_rec(const expr2tc &expr, bool negation = false);
+  void assume_rec(const expr2tc &lhs, expr2t::expr_ids id, const expr2tc &rhs);
+
+  tvt eval_boolean_expression(const expr2tc &cond) const;
+  wrapped_interval get_interval_from_symbol(const symbol2t &) const; 
+  tvt assume_expression(const expr2tc &);
+  void make_bottom();
+  
 
   /* Exception Handling.
    * This will stack the try-catch blocks, so we always know which catch

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -842,16 +842,16 @@ protected:
 
   std::unordered_map<irep_idt, wrapped_interval, irep_id_hash> intervals;
   wrapped_interval get_interval(const expr2tc &) const;
-  void update_symbol_interval(const symbol2t &sym,const wrapped_interval value);
+  void
+  update_symbol_interval(const symbol2t &sym, const wrapped_interval value);
   void apply_assume_less(const expr2tc &a, const expr2tc &b);
   void assume_rec(const expr2tc &expr, bool negation = false);
   void assume_rec(const expr2tc &lhs, expr2t::expr_ids id, const expr2tc &rhs);
 
   tvt eval_boolean_expression(const expr2tc &cond) const;
-  wrapped_interval get_interval_from_symbol(const symbol2t &) const; 
+  wrapped_interval get_interval_from_symbol(const symbol2t &) const;
   tvt assume_expression(const expr2tc &);
   void make_bottom();
-  
 
   /* Exception Handling.
    * This will stack the try-catch blocks, so we always know which catch

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -311,6 +311,13 @@ void goto_symext::symex_assign_symbol(
   guardt tmp_guard(cur_state->guard);
   tmp_guard.append(guard);
 
+  if (is_signedbv_type(rhs) || is_unsignedbv_type(rhs))
+  {
+    assert(is_symbol2t(renamed_lhs));
+    update_symbol_interval(to_symbol2t(renamed_lhs), get_interval(rhs));
+  }
+    
+
   // do the assignment
   target->assignment(
     tmp_guard.as_expr(),

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -316,7 +316,6 @@ void goto_symext::symex_assign_symbol(
     assert(is_symbol2t(renamed_lhs));
     update_symbol_interval(to_symbol2t(renamed_lhs), get_interval(rhs));
   }
-    
 
   // do the assignment
   target->assignment(

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -311,11 +311,7 @@ void goto_symext::symex_assign_symbol(
   guardt tmp_guard(cur_state->guard);
   tmp_guard.append(guard);
 
-  if (is_signedbv_type(rhs) || is_unsignedbv_type(rhs))
-  {
-    assert(is_symbol2t(renamed_lhs));
-    update_symbol_interval(to_symbol2t(renamed_lhs), get_interval(rhs));
-  }
+  apply_assignment(renamed_lhs, rhs);
 
   // do the assignment
   target->assignment(

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -1,10 +1,9 @@
-#include "irep2/irep2_type.h"
 #include "util/threeval.h"
 #include <goto-symex/goto_symex.h>
 
 bool symex_contains_unsupported(const expr2tc &e)
 {
-  if (is_floatbv_type(e) || is_fixedbv_type(e) || is_pointer_type(e))
+  if (is_floatbv_type(e) || is_fixedbv_type(e) || is_pointer_type(e) || is_structure_type(e) || is_vector_type(e) || is_array_type(e))
     return true;
 
   bool result = false;
@@ -499,6 +498,9 @@ tvt goto_symext::assume_expression(const expr2tc &e)
   const static bool overflow_mode =
     config.options.get_bool_option("overflow-check");
   if (overflow_mode)
+    return tvt(tvt::TV_UNKNOWN);
+
+  if (symex_contains_unsupported(e))
     return tvt(tvt::TV_UNKNOWN);
 
   tvt result = eval_boolean_expression(e);

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -1,4 +1,4 @@
-#include "util/threeval.h"
+#include <util/threeval.h>
 #include <goto-symex/goto_symex.h>
 
 bool symex_contains_unsupported(const expr2tc &e)
@@ -25,7 +25,6 @@ tvt goto_symext::eval_boolean_expression(const expr2tc &cond) const
     return tvt(tvt::TV_UNKNOWN);
 
   wrapped_interval interval = get_interval(cond);
-
   // If the interval does not contain zero then it's always true
   if (!interval.contains(0))
     return tvt(tvt::TV_TRUE);

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -38,7 +38,7 @@ tvt goto_symext::eval_boolean_expression(const expr2tc &cond) const
 wrapped_interval
 goto_symext::get_interval_from_symbol(const symbol2t &sym) const
 {
-  auto it = intervals.find(sym.thename);
+  auto it = intervals.find(sym.get_symbol_name());
   return it != intervals.end() ? it->second : wrapped_interval(sym.type);
 }
 wrapped_interval goto_symext::get_interval(const expr2tc &e) const
@@ -469,7 +469,7 @@ void goto_symext::update_symbol_interval(
   const symbol2t &sym,
   const wrapped_interval value)
 {
-  intervals[sym.thename] = value;
+  intervals[sym.get_symbol_name()] = value;
 }
 
 void goto_symext::apply_assume_less(const expr2tc &a, const expr2tc &b)

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -1,8 +1,7 @@
 #include "util/threeval.h"
 #include <goto-symex/goto_symex.h>
 
-tvt goto_symext::eval_boolean_expression(
-  const expr2tc &cond) const
+tvt goto_symext::eval_boolean_expression(const expr2tc &cond) const
 {
   wrapped_interval interval = get_interval(cond);
 
@@ -17,8 +16,8 @@ tvt goto_symext::eval_boolean_expression(
   return tvt(tvt::TV_UNKNOWN);
 }
 
-
-wrapped_interval goto_symext::get_interval_from_symbol(const symbol2t &sym) const
+wrapped_interval
+goto_symext::get_interval_from_symbol(const symbol2t &sym) const
 {
   auto it = intervals.find(sym.thename);
   return it != intervals.end() ? it->second : wrapped_interval(sym.type);
@@ -28,7 +27,7 @@ wrapped_interval goto_symext::get_interval(const expr2tc &e) const
   log_status("Obtaining interval for expression");
   wrapped_interval result(e->type);
 
-    switch (e->expr_id)
+  switch (e->expr_id)
   {
   case expr2t::constant_bool_id:
     result.set_lower(to_constant_bool2t(e).is_true());
@@ -36,13 +35,13 @@ wrapped_interval goto_symext::get_interval(const expr2tc &e) const
     break;
 
   case expr2t::constant_int_id:
-    {
+  {
     auto value = to_constant_int2t(e).value;
     result.set_lower(value);
     result.set_upper(value);
     assert(!result.is_bottom());
     break;
-    }
+  }
 
   case expr2t::symbol_id:
     result = get_interval_from_symbol(to_symbol2t(e));
@@ -93,7 +92,6 @@ wrapped_interval goto_symext::get_interval(const expr2tc &e) const
         break;
       }
 
-      
       // Both sides are false, then false
       if (lhs.is_false() && rhs.is_false())
       {
@@ -183,27 +181,27 @@ wrapped_interval goto_symext::get_interval(const expr2tc &e) const
   case expr2t::mul_id:
   case expr2t::div_id:
   case expr2t::modulus_id:
-    {
-      const auto &arith_op = dynamic_cast<const arith_2ops &>(*e);
-      auto lhs = get_interval(arith_op.side_1);
-      auto rhs = get_interval(arith_op.side_2);
+  {
+    const auto &arith_op = dynamic_cast<const arith_2ops &>(*e);
+    auto lhs = get_interval(arith_op.side_1);
+    auto rhs = get_interval(arith_op.side_2);
 
-      if (is_add2t(e))
-        result = lhs + rhs;
+    if (is_add2t(e))
+      result = lhs + rhs;
 
-      else if (is_sub2t(e))
-        result = lhs - rhs;
+    else if (is_sub2t(e))
+      result = lhs - rhs;
 
-      else if (is_mul2t(e))
-        result = lhs * rhs;
+    else if (is_mul2t(e))
+      result = lhs * rhs;
 
-      else if (is_div2t(e))
-        result = lhs / rhs;
+    else if (is_div2t(e))
+      result = lhs / rhs;
 
-      else if (is_modulus2t(e))
-        result = lhs % rhs;
-    }
-    break;
+    else if (is_modulus2t(e))
+      result = lhs % rhs;
+  }
+  break;
 
   case expr2t::shl_id:
   case expr2t::ashr_id:
@@ -214,35 +212,35 @@ wrapped_interval goto_symext::get_interval(const expr2tc &e) const
   case expr2t::bitnand_id:
   case expr2t::bitnor_id:
   case expr2t::bitnxor_id:
-    {
-      const auto &bit_op = dynamic_cast<const bit_2ops &>(*e);
-      auto lhs = get_interval(bit_op.side_1);
-      auto rhs = get_interval(bit_op.side_2);
+  {
+    const auto &bit_op = dynamic_cast<const bit_2ops &>(*e);
+    auto lhs = get_interval(bit_op.side_1);
+    auto rhs = get_interval(bit_op.side_2);
 
-      if (is_shl2t(e))
-        result = wrapped_interval::left_shift(lhs, rhs);
-      else if (is_ashr2t(e))
-        result = wrapped_interval::arithmetic_right_shift(lhs, rhs);
+    if (is_shl2t(e))
+      result = wrapped_interval::left_shift(lhs, rhs);
+    else if (is_ashr2t(e))
+      result = wrapped_interval::arithmetic_right_shift(lhs, rhs);
 
-      else if (is_lshr2t(e))
-        result = wrapped_interval::logical_right_shift(lhs, rhs);
+    else if (is_lshr2t(e))
+      result = wrapped_interval::logical_right_shift(lhs, rhs);
 
-      else if (is_bitor2t(e))
-        result = lhs | rhs;
+    else if (is_bitor2t(e))
+      result = lhs | rhs;
 
-      else if (is_bitand2t(e))
-        result = lhs & rhs;
-      else if (is_bitxor2t(e))
-        result = lhs ^ rhs;
+    else if (is_bitand2t(e))
+      result = lhs & rhs;
+    else if (is_bitxor2t(e))
+      result = lhs ^ rhs;
 
-      else if (is_bitnand2t(e))
-        result = wrapped_interval::bitnot(lhs & rhs);
-      else if (is_bitnor2t(e))
-        result = wrapped_interval::bitnot(lhs | rhs);
-      else if (is_bitnxor2t(e))
-        result = wrapped_interval::bitnot(lhs ^ rhs);
-    }
-    break;
+    else if (is_bitnand2t(e))
+      result = wrapped_interval::bitnot(lhs & rhs);
+    else if (is_bitnor2t(e))
+      result = wrapped_interval::bitnot(lhs | rhs);
+    else if (is_bitnxor2t(e))
+      result = wrapped_interval::bitnot(lhs ^ rhs);
+  }
+  break;
 
   case expr2t::bitnot_id:
     result = wrapped_interval::bitnot(get_interval(to_bitnot2t(e).value));
@@ -359,7 +357,7 @@ void goto_symext::assume_rec(const expr2tc &cond, bool negation)
       apply_assume_symbol_truth<wrapped_interval>(
           to_symbol2t(cond), negation);
     }
-    #endif
+#endif
   }
   //added in case "cond = false" which happens when the ibex contractor results in empty set.
   else if (is_constant_bool2t(cond))
@@ -424,7 +422,7 @@ void goto_symext::assume_rec(
   assert(id == expr2t::lessthanequal_id);
 
   if (is_bv_type(lhs) && is_bv_type(rhs))
-      apply_assume_less(lhs, rhs);
+    apply_assume_less(lhs, rhs);
 }
 
 void goto_symext::update_symbol_interval(
@@ -434,9 +432,7 @@ void goto_symext::update_symbol_interval(
   intervals[sym.thename] = value;
 }
 
-void goto_symext::apply_assume_less(
-  const expr2tc &a,
-  const expr2tc &b)
+void goto_symext::apply_assume_less(const expr2tc &a, const expr2tc &b)
 {
   // 1. Apply contractor algorithms
   // 2. Update refs

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -8,24 +8,21 @@ bool symex_contains_float(const expr2tc &e)
     return true;
 
   bool result = false;
-  e->foreach_operand(
-    [&result](const expr2tc &o)
-    {
-      if(!result)
-	result |= symex_contains_float(o);
-    });
+  e->foreach_operand([&result](const expr2tc &o) {
+    if (!result)
+      result |= symex_contains_float(o);
+  });
   return result;
 }
-
 
 tvt goto_symext::eval_boolean_expression(const expr2tc &cond) const
 {
   // TODO: cache :)
-  
+
   // TODO: Deal with floats :(
   if (symex_contains_float(cond))
     return tvt(tvt::TV_UNKNOWN);
-  
+
   wrapped_interval interval = get_interval(cond);
 
   // If the interval does not contain zero then it's always true
@@ -396,12 +393,17 @@ void goto_symext::assume_rec(const expr2tc &cond, bool negation)
 void goto_symext::apply_assignment(expr2tc &lhs, expr2tc &rhs)
 {
   // TODO: overflows
-  const static bool overflow_mode = config.options.get_bool_option("overflow-check");
+  const static bool overflow_mode =
+    config.options.get_bool_option("overflow-check");
   if (overflow_mode)
     return;
-  
-  const bool lhs_precondition = (is_signedbv_type(lhs) || is_unsignedbv_type(lhs)) && !symex_contains_float(lhs) && is_symbol2t(lhs);
-  const bool rhs_precondition = (is_signedbv_type(rhs) || is_unsignedbv_type(rhs)) && !symex_contains_float(rhs);
+
+  const bool lhs_precondition =
+    (is_signedbv_type(lhs) || is_unsignedbv_type(lhs)) &&
+    !symex_contains_float(lhs) && is_symbol2t(lhs);
+  const bool rhs_precondition =
+    (is_signedbv_type(rhs) || is_unsignedbv_type(rhs)) &&
+    !symex_contains_float(rhs);
   if (lhs_precondition && rhs_precondition)
   {
     assert(is_symbol2t(lhs));
@@ -493,11 +495,11 @@ void goto_symext::apply_assume_less(const expr2tc &a, const expr2tc &b)
 tvt goto_symext::assume_expression(const expr2tc &e)
 {
   // TODO: overflows
-  const static bool overflow_mode = config.options.get_bool_option("overflow-check");
+  const static bool overflow_mode =
+    config.options.get_bool_option("overflow-check");
   if (overflow_mode)
     return tvt(tvt::TV_UNKNOWN);
 
-  
   tvt result = eval_boolean_expression(e);
 
   if (result.is_false())

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -1,0 +1,470 @@
+#include "util/threeval.h"
+#include <goto-symex/goto_symex.h>
+
+tvt goto_symext::eval_boolean_expression(
+  const expr2tc &cond) const
+{
+  wrapped_interval interval = get_interval(cond);
+
+  // If the interval does not contain zero then it's always true
+  if (!interval.contains(0))
+    return tvt(tvt::TV_TRUE);
+
+  // If it does contain zero and its singleton then it's always false
+  if (interval.singleton())
+    return tvt(tvt::TV_FALSE);
+
+  return tvt(tvt::TV_UNKNOWN);
+}
+
+
+wrapped_interval goto_symext::get_interval_from_symbol(const symbol2t &sym) const
+{
+  auto it = intervals.find(sym.thename);
+  return it != intervals.end() ? it->second : wrapped_interval(sym.type);
+}
+wrapped_interval goto_symext::get_interval(const expr2tc &e) const
+{
+  log_status("Obtaining interval for expression");
+  wrapped_interval result(e->type);
+
+    switch (e->expr_id)
+  {
+  case expr2t::constant_bool_id:
+    result.set_lower(to_constant_bool2t(e).is_true());
+    result.set_upper(to_constant_bool2t(e).is_true());
+    break;
+
+  case expr2t::constant_int_id:
+    {
+    auto value = to_constant_int2t(e).value;
+    result.set_lower(value);
+    result.set_upper(value);
+    assert(!result.is_bottom());
+    break;
+    }
+
+  case expr2t::symbol_id:
+    result = get_interval_from_symbol(to_symbol2t(e));
+    break;
+
+  case expr2t::neg_id:
+    result = -get_interval(to_neg2t(e).value);
+    break;
+
+  case expr2t::not_id:
+    result = wrapped_interval::invert_bool(get_interval(to_not2t(e).value));
+    break;
+
+  case expr2t::or_id:
+  case expr2t::and_id:
+  case expr2t::xor_id:
+  case expr2t::implies_id:
+  {
+    const auto &logic_op = dynamic_cast<const logic_2ops &>(*e);
+    tvt lhs = eval_boolean_expression(logic_op.side_1);
+    tvt rhs = eval_boolean_expression(logic_op.side_2);
+
+    if (is_and2t(e))
+    {
+      // If any side is false, (and => false)
+      if ((lhs.is_false() || rhs.is_false()))
+      {
+        result.set_lower(0);
+        result.set_upper(0);
+        break;
+      }
+
+      // Both sides are true, then true
+      if (lhs.is_true() && rhs.is_true())
+      {
+        result.set_lower(1);
+        result.set_upper(1);
+        break;
+      }
+    }
+
+    else if (is_or2t(e))
+    {
+      if (lhs.is_true() || rhs.is_true())
+      {
+        result.set_lower(1);
+        result.set_upper(1);
+        break;
+      }
+
+      
+      // Both sides are false, then false
+      if (lhs.is_false() && rhs.is_false())
+      {
+        result.set_lower(0);
+        result.set_upper(0);
+        break;
+      }
+    }
+
+    else if (is_xor2t(e))
+    {
+      if (lhs.is_unknown() || rhs.is_unknown())
+      {
+        result.set_lower(0);
+        result.set_upper(1);
+      }
+      else if (lhs == rhs)
+      {
+        result.set_lower(0);
+        result.set_upper(0);
+      }
+      else
+      {
+        result.set_lower(1);
+        result.set_upper(1);
+      }
+
+      break;
+    }
+
+    else if (is_implies2t(e))
+    {
+      // A --> B <=== > ¬A or B
+      if (lhs.is_true() && rhs.is_false())
+      {
+        result.set_lower(0);
+        result.set_upper(0);
+      }
+      else if (lhs.is_false() || rhs.is_true())
+      {
+        result.set_lower(1);
+        result.set_upper(1);
+      }
+      else
+      {
+        result.set_lower(0);
+        result.set_upper(1);
+      }
+      break;
+    }
+
+    log_debug("interval", "Could not simplify: {}", *e);
+    break;
+  }
+
+  case expr2t::if_id:
+  {
+    auto cond = get_interval(to_if2t(e).cond);
+    auto lhs = get_interval(to_if2t(e).true_value);
+    auto rhs = get_interval(to_if2t(e).false_value);
+    result = wrapped_interval::ternary_if(cond, lhs, rhs);
+    break;
+  }
+  case expr2t::typecast_id:
+  {
+    // Special case: boolean
+    if (is_bool_type(to_typecast2t(e).type))
+    {
+      tvt truth = eval_boolean_expression(to_typecast2t(e).from);
+      result.set_lower(0);
+      result.set_upper(1);
+
+      if (truth.is_true())
+        result.set_lower(1);
+
+      if (truth.is_false())
+        result.set_upper(0);
+
+      break;
+    }
+    auto inner = get_interval(to_typecast2t(e).from);
+    result = wrapped_interval::cast(inner, to_typecast2t(e).type);
+    break;
+  }
+  case expr2t::add_id:
+  case expr2t::sub_id:
+  case expr2t::mul_id:
+  case expr2t::div_id:
+  case expr2t::modulus_id:
+    {
+      const auto &arith_op = dynamic_cast<const arith_2ops &>(*e);
+      auto lhs = get_interval(arith_op.side_1);
+      auto rhs = get_interval(arith_op.side_2);
+
+      if (is_add2t(e))
+        result = lhs + rhs;
+
+      else if (is_sub2t(e))
+        result = lhs - rhs;
+
+      else if (is_mul2t(e))
+        result = lhs * rhs;
+
+      else if (is_div2t(e))
+        result = lhs / rhs;
+
+      else if (is_modulus2t(e))
+        result = lhs % rhs;
+    }
+    break;
+
+  case expr2t::shl_id:
+  case expr2t::ashr_id:
+  case expr2t::lshr_id:
+  case expr2t::bitor_id:
+  case expr2t::bitand_id:
+  case expr2t::bitxor_id:
+  case expr2t::bitnand_id:
+  case expr2t::bitnor_id:
+  case expr2t::bitnxor_id:
+    {
+      const auto &bit_op = dynamic_cast<const bit_2ops &>(*e);
+      auto lhs = get_interval(bit_op.side_1);
+      auto rhs = get_interval(bit_op.side_2);
+
+      if (is_shl2t(e))
+        result = wrapped_interval::left_shift(lhs, rhs);
+      else if (is_ashr2t(e))
+        result = wrapped_interval::arithmetic_right_shift(lhs, rhs);
+
+      else if (is_lshr2t(e))
+        result = wrapped_interval::logical_right_shift(lhs, rhs);
+
+      else if (is_bitor2t(e))
+        result = lhs | rhs;
+
+      else if (is_bitand2t(e))
+        result = lhs & rhs;
+      else if (is_bitxor2t(e))
+        result = lhs ^ rhs;
+
+      else if (is_bitnand2t(e))
+        result = wrapped_interval::bitnot(lhs & rhs);
+      else if (is_bitnor2t(e))
+        result = wrapped_interval::bitnot(lhs | rhs);
+      else if (is_bitnxor2t(e))
+        result = wrapped_interval::bitnot(lhs ^ rhs);
+    }
+    break;
+
+  case expr2t::bitnot_id:
+    result = wrapped_interval::bitnot(get_interval(to_bitnot2t(e).value));
+    break;
+
+  case expr2t::lessthan_id:
+  case expr2t::lessthanequal_id:
+  case expr2t::greaterthan_id:
+  case expr2t::greaterthanequal_id:
+  case expr2t::equality_id:
+  case expr2t::notequal_id:
+  {
+    const expr2tc &lhs = *e->get_sub_expr(0);
+    const expr2tc &rhs = *e->get_sub_expr(1);
+
+    auto lhs_i = get_interval(lhs);
+    auto rhs_i = get_interval(rhs);
+
+    if (is_equality2t(e))
+      result = wrapped_interval::equality(lhs_i, rhs_i);
+
+    else if (is_notequal2t(e))
+      result = wrapped_interval::not_equal(lhs_i, rhs_i);
+
+    else if (is_lessthan2t(e))
+      result = wrapped_interval::less_than(lhs_i, rhs_i);
+
+    else if (is_greaterthan2t(e))
+      result = wrapped_interval::greater_than(lhs_i, rhs_i);
+
+    else if (is_lessthanequal2t(e))
+      result = wrapped_interval::less_than_equal(lhs_i, rhs_i);
+
+    else if (is_greaterthanequal2t(e))
+      result = wrapped_interval::greater_than_equal(lhs_i, rhs_i);
+
+    break;
+  }
+
+  case expr2t::sideeffect_id:
+    // This is probably a nondet
+    log_debug("interval", "returning top for side effect {}", *e);
+    break;
+
+  default:
+    log_debug("interval", "Couldn't compute interval for expr: {}", *e);
+    break;
+  }
+
+  return result;
+}
+
+void goto_symext::make_bottom()
+{
+  log_status("Early exit");
+}
+
+void goto_symext::assume_rec(const expr2tc &cond, bool negation)
+{
+  if (is_comp_expr(cond))
+  {
+    assert(cond->get_num_sub_exprs() == 2);
+
+    if (negation) // !x<y  ---> x>=y
+    {
+      if (is_lessthan2t(cond))
+        assume_rec(
+          *cond->get_sub_expr(0),
+          expr2t::greaterthanequal_id,
+          *cond->get_sub_expr(1));
+      else if (is_lessthanequal2t(cond))
+        assume_rec(
+          *cond->get_sub_expr(0),
+          expr2t::greaterthan_id,
+          *cond->get_sub_expr(1));
+      else if (is_greaterthan2t(cond))
+        assume_rec(
+          *cond->get_sub_expr(0),
+          expr2t::lessthanequal_id,
+          *cond->get_sub_expr(1));
+      else if (is_greaterthanequal2t(cond))
+        assume_rec(
+          *cond->get_sub_expr(0), expr2t::lessthan_id, *cond->get_sub_expr(1));
+      else if (is_equality2t(cond))
+        assume_rec(
+          *cond->get_sub_expr(0), expr2t::notequal_id, *cond->get_sub_expr(1));
+      else if (is_notequal2t(cond))
+        assume_rec(
+          *cond->get_sub_expr(0), expr2t::equality_id, *cond->get_sub_expr(1));
+    }
+    else
+      assume_rec(*cond->get_sub_expr(0), cond->expr_id, *cond->get_sub_expr(1));
+  }
+  else if (is_not2t(cond))
+  {
+    assume_rec(to_not2t(cond).value, !negation);
+  }
+  // de morgan
+  else if (is_and2t(cond))
+  {
+    if (!negation)
+      cond->foreach_operand([this](const expr2tc &e) { assume_rec(e, false); });
+  }
+  else if (is_or2t(cond))
+  {
+    if (negation)
+      cond->foreach_operand([this](const expr2tc &e) { assume_rec(e, true); });
+  }
+  else if (is_symbol2t(cond))
+  {
+#if 0
+    if (is_bv_type(cond) || is_bool_type(cond))
+    {
+      apply_assume_symbol_truth<wrapped_interval>(
+          to_symbol2t(cond), negation);
+    }
+    #endif
+  }
+  //added in case "cond = false" which happens when the ibex contractor results in empty set.
+  else if (is_constant_bool2t(cond))
+  {
+    if ((negation && is_true(cond)) || (!negation && is_false(cond)))
+    {
+      make_bottom();
+    }
+  }
+  else
+    log_debug("interval", "[assume_rec] Missing support: {}", *cond);
+}
+
+void goto_symext::assume_rec(
+  const expr2tc &lhs,
+  expr2t::expr_ids id,
+  const expr2tc &rhs)
+{
+  if (id == expr2t::equality_id)
+  {
+    assume_rec(lhs, expr2t::greaterthanequal_id, rhs);
+    assume_rec(lhs, expr2t::lessthanequal_id, rhs);
+    return;
+  }
+
+  if (id == expr2t::notequal_id)
+    return; // won't do split
+
+  if (id == expr2t::greaterthanequal_id)
+    return assume_rec(rhs, expr2t::lessthanequal_id, lhs);
+
+  if (id == expr2t::greaterthan_id)
+    return assume_rec(rhs, expr2t::lessthan_id, lhs);
+
+  if (id == expr2t::lessthan_id)
+  {
+    if (is_bv_type(lhs) && is_bv_type(rhs))
+    {
+      // TODO: To properly do this we need a way to invert functions
+      if (!is_symbol2t(lhs))
+      {
+        // Gave-up for optimization
+        auto new_lhs =
+          add2tc(lhs->type, lhs, constant_int2tc(lhs->type, BigInt(1)));
+        if (simplify(new_lhs))
+          return assume_rec(new_lhs, expr2t::lessthanequal_id, rhs);
+      }
+      else if (!is_symbol2t(rhs))
+      {
+        // Gave-up for optimization
+        auto new_rhs =
+          sub2tc(rhs->type, rhs, constant_int2tc(rhs->type, BigInt(1)));
+        if (simplify(new_rhs))
+          return assume_rec(lhs, expr2t::lessthanequal_id, new_rhs);
+      }
+    }
+    return assume_rec(lhs, expr2t::lessthanequal_id, rhs);
+  }
+
+  // we now have lhs <= rhs
+
+  assert(id == expr2t::lessthanequal_id);
+
+  if (is_bv_type(lhs) && is_bv_type(rhs))
+      apply_assume_less(lhs, rhs);
+}
+
+void goto_symext::update_symbol_interval(
+  const symbol2t &sym,
+  const wrapped_interval value)
+{
+  intervals[sym.thename] = value;
+}
+
+void goto_symext::apply_assume_less(
+  const expr2tc &a,
+  const expr2tc &b)
+{
+  // 1. Apply contractor algorithms
+  // 2. Update refs
+  wrapped_interval lhs = get_interval(a);
+  wrapped_interval rhs = get_interval(b);
+
+  wrapped_interval s = lhs;
+  s.make_le_than(rhs);
+  wrapped_interval t = rhs;
+  t.make_ge_than(lhs);
+
+  // No need for widening, this is a restriction!
+  if (is_symbol2t(a))
+    update_symbol_interval(to_symbol2t(a), s);
+
+  if (is_symbol2t(b))
+    update_symbol_interval(to_symbol2t(b), t);
+}
+
+tvt goto_symext::assume_expression(const expr2tc &e)
+{
+  log_status("Assuming expression");
+  tvt result = eval_boolean_expression(e);
+
+  if (result.is_false())
+    return result;
+
+  assume_rec(e);
+
+  return result;
+}

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -3,7 +3,9 @@
 
 bool symex_contains_unsupported(const expr2tc &e)
 {
-  if (is_floatbv_type(e) || is_fixedbv_type(e) || is_pointer_type(e) || is_structure_type(e) || is_vector_type(e) || is_array_type(e))
+  if (
+    is_floatbv_type(e) || is_fixedbv_type(e) || is_pointer_type(e) ||
+    is_structure_type(e) || is_vector_type(e) || is_array_type(e))
     return true;
 
   bool result = false;

--- a/src/goto-symex/symex_intervals.cpp
+++ b/src/goto-symex/symex_intervals.cpp
@@ -509,7 +509,14 @@ tvt goto_symext::assume_expression(const expr2tc &e)
   if (result.is_false())
     return result;
 
-  assume_rec(e);
+  // TODO: we can't cut from the original symbol e.g.,
+  //
+  // int a = * ? 0 : 10 // a1: [0,10]
+  // if(a < 5)
+  //   ... a1: [0,4] is wrong. We need to maintain a set of guards over the symbol.
+  // Or just move towards SSA as well
+
+  //assume_rec(e);
 
   return result;
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -379,7 +379,15 @@ void goto_symext::symex_assume()
   dereference(cond, dereferencet::READ);
   replace_dynamic_allocation(cond);
 
-  assume(cond);
+  tvt interval_check = assume_expression(cond);
+
+  if (interval_check.is_known())
+  {
+    log_status("Managed to improve an assumption");
+      assume(interval_check.is_true() ? gen_true_expr() : gen_false_expr());
+    }
+  else
+    assume(cond);
 }
 
 void goto_symext::symex_assert()
@@ -406,7 +414,15 @@ void goto_symext::symex_assert()
   dereference(tmp, dereferencet::READ);
   replace_dynamic_allocation(tmp);
 
-  claim(tmp, msg);
+  tvt interval_check = assume_expression(tmp);
+
+  if (interval_check.is_known())
+  {
+    log_status("Managed to improve an assertion");
+    claim(interval_check.is_true() ? gen_true_expr() : gen_false_expr(), msg);
+    }
+  else
+    claim(tmp, msg);
 }
 
 void goto_symext::run_intrinsic(

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -384,8 +384,8 @@ void goto_symext::symex_assume()
   if (interval_check.is_known())
   {
     log_status("Managed to improve an assumption");
-      assume(interval_check.is_true() ? gen_true_expr() : gen_false_expr());
-    }
+    assume(interval_check.is_true() ? gen_true_expr() : gen_false_expr());
+  }
   else
     assume(cond);
 }
@@ -420,7 +420,7 @@ void goto_symext::symex_assert()
   {
     log_status("Managed to improve an assertion");
     claim(interval_check.is_true() ? gen_true_expr() : gen_false_expr(), msg);
-    }
+  }
   else
     claim(tmp, msg);
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -129,7 +129,7 @@ void goto_symext::assume(const expr2tc &the_assumption)
     assumption = interval_check.is_true() ? gen_true_expr() : gen_false_expr();
 
   if (is_true(assumption))
-    return;    
+    return;
 
   cur_state->guard.guard_expr(assumption);
 
@@ -387,7 +387,7 @@ void goto_symext::symex_assume()
   replace_nondet(cond);
   dereference(cond, dereferencet::READ);
   replace_dynamic_allocation(cond);
-  assume(cond);  
+  assume(cond);
 }
 
 void goto_symext::symex_assert()
@@ -413,7 +413,7 @@ void goto_symext::symex_assert()
 
   dereference(tmp, dereferencet::READ);
   replace_dynamic_allocation(tmp);
-  claim(tmp, msg);  
+  claim(tmp, msg);
 }
 
 void goto_symext::run_intrinsic(


### PR DESCRIPTION
This PR adds the support to compute intervals during symex. This has a few advantages such as early symex termination.

# Examples

## Size of type

### Program

```c
int main()
{
  char a;
  __ESBMC_assume(a > 300);
  __ESBMC_assert(0, "error");
}
``` 

### VCC

```
{-1} a?1!0&0#1 == nondet_symbol(symex::nondet0)
{-2} (signed int)a?1!0&0#1 > 300
|--------------------------
{1} !execution_statet::\guard_exec?0!0

```

### After symex intervals

The intervals will detect that the assumption is always false, resulting in not encoding the assertion (so no vccs).

## Nondeterministic arithmetic

Another example is for cases where the constant propagation cannot be used

### Program

```c
int main()
{
  char a = 4;
  char increment = nondet_int() ? 1 : 2;
  a += increment;
  __ESBMC_assert(a < 10, "error");
}
```

### VCC
```
{-1} main::$tmp::return_value$_nondet_int$1?1!0&0#1 == nondet_symbol(symex::nondet0)
{-2} increment?1!0&0#1 == ((signed char)(!(main::$tmp::return_value$_nondet_int$1?1!0&0#1 == 0) ? 1 : 2))
{-3} a?1!0&0#2 == (signed char)(4 + (signed int)((signed char)((signed int)increment?1!0&0#1)))
|--------------------------
{1} execution_statet::\guard_exec?0!0 => (signed int)a?1!0&0#2 < 10
```

### After symex intervals

The symex can confirm that the interval of "a" always hold in the assertion, resulting in no vccs.


## Bounded Assertions

Finally, since this is at symex level, we can also explore all ranges computed up to the bound.

### Program

```c
int main()
{
  char a = 4;
  char increment = nondet_int() ? 1 : 2;
  while(nondet_int())
    a += increment;
  __ESBMC_assert(a < 10, "error");
}
```

### VCC

With unwind 2

```
{-1} main::$tmp::return_value$_nondet_int$1?1!0&0#1 == nondet_symbol(symex::nondet0)
{-2} increment?1!0&0#1 == ((signed char)(!(main::$tmp::return_value$_nondet_int$1?1!0&0#1 == 0) ? 1 : 2))
{-3} main::$tmp::return_value$_nondet_int$2?1!0&0#1 == nondet_symbol(symex::nondet1)
{-4} goto_symex::guard?0!0&0#1 == !(main::$tmp::return_value$_nondet_int$2?1!0&0#1 == 0)
{-5} a?1!0&0#2 == (signed char)(4 + (signed int)((signed char)((signed int)increment?1!0&0#1)))
{-6} main::$tmp::return_value$_nondet_int$2?2!0&0#1 == nondet_symbol(symex::nondet2)
{-7} goto_symex::guard?0!0&0#2 == !(main::$tmp::return_value$_nondet_int$2?2!0&0#1 == 0)
{-8} a?1!0&0#4 == a?1!0&0#2
{-9} a?1!0&0#5 == (!goto_symex::guard?0!0&0#1 ? 4 : a?1!0&0#4)
|--------------------------
{1} execution_statet::\guard_exec?0!0 => (goto_symex::guard?0!0&0#1 && !goto_symex::guard?0!0&0#2 || !goto_symex::guard?0!0&0#1 => (signed int)a?1!0&0#5 < 10)
```

### After symex intervals

The symex can confirm that the interval of "a" always holds in the assertion up to the bound 2, resulting in no vccs. If we increase the bound to 3, then no change will be seen.

# TODO

This is a draft because there is still many things left to do:

- [ ] Optimize assumptions/assumes.
- [ ] Phi operations
- [ ] Overflow assertions
- [ ] Optimize guards. Some asserts are encoded using the state guard (which is a symbol).
- [ ] Refactor. I am copy-pasting a lot of the abstract interpretation for wrapped domain as a way to get this up and running. But I still need to fix things.
- [ ] Support for floats (I hate floats).
- [ ] Interval caching