### PR TITLE
Investigating std::shared_ptr overhead

### DIFF
--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -398,6 +398,8 @@ typedef std::list<member_entryt> list_of_memberst;
 
 class irep2t
 {
+public:
+  virtual ~irep2t() noexcept = default;
 };
 
 /** Base class for all types.

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -396,7 +396,7 @@ typedef irep_container<expr2t> expr2tc;
 typedef std::pair<std::string, std::string> member_entryt;
 typedef std::list<member_entryt> list_of_memberst;
 
-class irep2t : public std::enable_shared_from_this<irep2t>
+class irep2t
 {
 };
 

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -220,8 +220,7 @@ public:
   // Obviously this is fairly unwise because any std::shared_ptr
   // won't be using the detach facility to manipulate things, however it's
   // necessary for std::make_shared.
-  explicit irep_container(ksptr::sptr<T> &&p)
-    : ksptr::sptr<T>(std::move(p))
+  explicit irep_container(ksptr::sptr<T> &&p) : ksptr::sptr<T>(std::move(p))
   {
   }
 

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -396,7 +396,7 @@ typedef irep_container<expr2t> expr2tc;
 typedef std::pair<std::string, std::string> member_entryt;
 typedef std::list<member_entryt> list_of_memberst;
 
-class irep2t
+class irep2t : public ksptr::control_block
 {
 public:
   virtual ~irep2t() noexcept = default;

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1409,8 +1409,8 @@ public:
   template <typename... Args>                                                  \
   inline expr2tc basename##2tc(Args && ...args)                                \
   {                                                                            \
-    return expr2tc(std::static_pointer_cast<expr2t>(                           \
-      std::make_shared<basename##2t>(std::forward<Args>(args)...)));           \
+    return expr2tc(                           \
+      ksptr::make_shared<basename##2t>(std::forward<Args>(args)...));         \
   }                                                                            \
   typedef esbmct::expr_methods2<basename##2t, superclass, superclass::traits>  \
     basename##_expr_methods;                                                   \

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1409,8 +1409,8 @@ public:
   template <typename... Args>                                                  \
   inline expr2tc basename##2tc(Args && ...args)                                \
   {                                                                            \
-    return expr2tc(                           \
-      ksptr::make_shared<basename##2t>(std::forward<Args>(args)...));         \
+    return expr2tc(                                                            \
+      ksptr::make_shared<basename##2t>(std::forward<Args>(args)...));          \
   }                                                                            \
   typedef esbmct::expr_methods2<basename##2t, superclass, superclass::traits>  \
     basename##_expr_methods;                                                   \

--- a/src/irep2/irep2_meta_templates.h
+++ b/src/irep2/irep2_meta_templates.h
@@ -123,7 +123,7 @@ auto esbmct::irep_methods2<derived, baseclass, traits, enable, fields>::clone()
   // container.
   // Generally, storing an irep in a bare std::shared_ptr loses the detach
   // facility and breaks everything, this is an exception.
-  return base_container2tc(std::make_shared<derived>(*derived_this));
+  return base_container2tc(ksptr::make_shared<derived>(*derived_this));
 }
 
 template <

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -292,8 +292,8 @@ public:
   template <typename... Args>                                                  \
   inline type2tc basename##_type2tc(Args &&...args)                            \
   {                                                                            \
-    return type2tc(                           \
-      ksptr::make_shared<basename##_type2t>(std::forward<Args>(args)...));    \
+    return type2tc(                                                            \
+      ksptr::make_shared<basename##_type2t>(std::forward<Args>(args)...));     \
   }                                                                            \
   typedef esbmct::                                                             \
     type_methods2<basename##_type2t, superclass, superclass::traits>           \

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -292,8 +292,8 @@ public:
   template <typename... Args>                                                  \
   inline type2tc basename##_type2tc(Args &&...args)                            \
   {                                                                            \
-    return type2tc(std::static_pointer_cast<type2t>(                           \
-      std::make_shared<basename##_type2t>(std::forward<Args>(args)...)));      \
+    return type2tc(                           \
+      ksptr::make_shared<basename##_type2t>(std::forward<Args>(args)...));    \
   }                                                                            \
   typedef esbmct::                                                             \
     type_methods2<basename##_type2t, superclass, superclass::traits>           \

--- a/src/util/ksptr.hh
+++ b/src/util/ksptr.hh
@@ -6,9 +6,19 @@
 
 namespace ksptr
 {
+/* A type that is large enough to count any number of copies existing in memory
+ * (even on Windows) */
 typedef std::conditional_t<sizeof(void *) >= sizeof(long), long long, long>
   cnt_t;
 
+/**
+ * A somewhat dumbed-down shared_ptr implementation, still missing weak pointers
+ * and reference/array support. The purpose of this class is to provide
+ * shared pointers that
+ * (a) do not have an atomic reference count, and
+ * (b) do not provide for separate storage of control block and actual data,
+ *     which allows to reduce space.
+ */
 template <typename T>
 class sptr
 {
@@ -22,11 +32,11 @@ class sptr
   friend sptr<S> make_shared(Args &&...args);
 
 protected:
-  struct make
+  struct make /* tag type to select correct constructor */
   {
   };
 
-  struct control_block
+  struct control_block /* meta-data together with the concrete data */
   {
     cnt_t use_count;
     void (*dtor)(void *);
@@ -57,20 +67,26 @@ protected:
   }
 
 public:
+  /* constructor and destructor */
+
+  /* default */
   constexpr sptr() noexcept : cb(nullptr)
   {
   }
 
+  /* copy */
   constexpr sptr(const sptr &o) noexcept : cb(o.cb)
   {
     if (cb)
       cb->use_count++;
   }
 
+  /* move */
   constexpr sptr(sptr &&o) noexcept : cb(std::exchange(o.cb, nullptr))
   {
   }
 
+  /* type-cast from an sptr of type convertible to T */
   template <
     typename S,
     typename = std::enable_if_t<std::is_convertible_v<S *, T *>>>
@@ -85,6 +101,8 @@ public:
     if (cb && !--cb->use_count)
       delete cb;
   }
+
+  /* swap & assignment operators */
 
   void swap(sptr &b) noexcept
   {
@@ -102,6 +120,8 @@ public:
     return *this;
   }
 
+  /* observers */
+
   cnt_t use_count() const noexcept
   {
     return cb ? cb->use_count : 0;
@@ -111,6 +131,7 @@ public:
   {
     return *get();
   }
+
   T *operator->() const noexcept
   {
     return get();
@@ -125,6 +146,8 @@ public:
   {
     return cb != nullptr;
   }
+
+  /* mutators */
 
   void reset() noexcept
   {

--- a/src/util/ksptr.hh
+++ b/src/util/ksptr.hh
@@ -1,0 +1,141 @@
+
+#pragma once
+
+#include <utility>
+#include <type_traits>
+
+namespace ksptr
+{
+typedef std::conditional_t<sizeof(void *) >= sizeof(long), long long, long>
+  cnt_t;
+
+template <typename T>
+class sptr
+{
+  static_assert(!std::is_reference_v<T>, "reference types are not supported");
+  static_assert(!std::is_array_v<T>, "array types are not supported");
+
+  template <typename S>
+  friend class sptr;
+
+  template <typename S, typename... Args>
+  friend sptr<S> make_shared(Args &&...args);
+
+protected:
+  struct make
+  {
+  };
+
+  struct control_block
+  {
+    cnt_t use_count;
+    void (*dtor)(void *);
+    alignas(T) char value[sizeof(T)];
+
+    explicit control_block(void (*dtor)(void *)) : use_count(1), dtor(dtor)
+    {
+    }
+
+    ~control_block()
+    {
+      dtor(value);
+    }
+  };
+
+  control_block *cb;
+
+  T *ptr() const noexcept
+  {
+    return reinterpret_cast<T *>(cb->value);
+  }
+
+  template <typename... Args>
+  explicit sptr(make, Args &&...args)
+    : cb(new control_block([](void *p) { reinterpret_cast<T *>(p)->~T(); }))
+  {
+    new (ptr()) T(std::forward<Args>(args)...);
+  }
+
+public:
+  constexpr sptr() noexcept : cb(nullptr)
+  {
+  }
+
+  constexpr sptr(const sptr &o) noexcept : cb(o.cb)
+  {
+    if (cb)
+      cb->use_count++;
+  }
+
+  constexpr sptr(sptr &&o) noexcept : cb(std::exchange(o.cb, nullptr))
+  {
+  }
+
+  template <
+    typename S,
+    typename = std::enable_if_t<std::is_convertible_v<S *, T *>>>
+  constexpr sptr(sptr<S> o) noexcept
+    : cb(reinterpret_cast<control_block *>(o.cb))
+  {
+    o.cb = nullptr;
+  }
+
+  ~sptr()
+  {
+    if (cb && !--cb->use_count)
+      delete cb;
+  }
+
+  void swap(sptr &b) noexcept
+  {
+    std::swap(cb, b.cb);
+  }
+
+  friend void swap(sptr &a, sptr &b) noexcept
+  {
+    a.swap(b);
+  }
+
+  sptr &operator=(sptr o) noexcept
+  {
+    swap(o);
+    return *this;
+  }
+
+  cnt_t use_count() const noexcept
+  {
+    return cb ? cb->use_count : 0;
+  }
+
+  T &operator*() const noexcept
+  {
+    return *get();
+  }
+  T *operator->() const noexcept
+  {
+    return get();
+  }
+
+  T *get() const noexcept
+  {
+    return cb ? ptr() : nullptr;
+  }
+
+  constexpr operator bool() const noexcept
+  {
+    return cb != nullptr;
+  }
+
+  void reset() noexcept
+  {
+    *this = sptr();
+  }
+};
+
+template <typename T, typename... Args>
+sptr<T> make_shared(Args &&...args)
+{
+  return sptr<T>(typename sptr<T>::make{}, std::forward<Args>(args)...);
+}
+
+} // namespace ksptr

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -278,8 +278,8 @@ static expr2tc simplify_arith_2ops(
     // Were we able to simplify the sides?
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
-      expr2tc new_op(
-        ksptr::make_shared<constructor>(type, simplied_side_1, simplied_side_2));
+      expr2tc new_op(ksptr::make_shared<constructor>(
+        type, simplied_side_1, simplied_side_2));
 
       return typecast_check_return(type, new_op);
     }

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -279,7 +279,7 @@ static expr2tc simplify_arith_2ops(
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
       expr2tc new_op(
-        std::make_shared<constructor>(type, simplied_side_1, simplied_side_2));
+        ksptr::make_shared<constructor>(type, simplied_side_1, simplied_side_2));
 
       return typecast_check_return(type, new_op);
     }
@@ -669,7 +669,7 @@ static expr2tc simplify_arith_1op(const type2tc &type, const expr2tc &value)
     // Were we able to simplify anything?
     if (value != to_simplify)
     {
-      expr2tc new_neg(std::make_shared<constructor>(type, to_simplify));
+      expr2tc new_neg(ksptr::make_shared<constructor>(type, to_simplify));
       return typecast_check_return(type, new_neg);
     }
 
@@ -1094,7 +1094,7 @@ static expr2tc simplify_logic_2ops(
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
       expr2tc new_op(
-        std::make_shared<constructor>(simplied_side_1, simplied_side_2));
+        ksptr::make_shared<constructor>(simplied_side_1, simplied_side_2));
 
       return typecast_check_return(type, new_op);
     }
@@ -1412,7 +1412,7 @@ static expr2tc do_bit_munge_operation(
   if (side_1 != simplified_side_1 || side_2 != simplified_side_2)
     return typecast_check_return(
       type,
-      expr2tc(std::make_shared<constructor>(
+      expr2tc(ksptr::make_shared<constructor>(
         type, simplified_side_1, simplified_side_2)));
 
   return expr2tc();
@@ -1871,7 +1871,7 @@ static expr2tc simplify_relations(
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
       expr2tc new_op(
-        std::make_shared<constructor>(simplied_side_1, simplied_side_2));
+        ksptr::make_shared<constructor>(simplied_side_1, simplied_side_2));
 
       return typecast_check_return(type, new_op);
     }
@@ -1985,7 +1985,7 @@ static expr2tc simplify_floatbv_relations(
   if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
   {
     expr2tc new_op(
-      std::make_shared<constructor>(simplied_side_1, simplied_side_2));
+      ksptr::make_shared<constructor>(simplied_side_1, simplied_side_2));
 
     return typecast_check_return(type, new_op);
   }
@@ -2453,7 +2453,7 @@ static expr2tc simplify_floatbv_1op(const type2tc &type, const expr2tc &value)
     // Were we able to simplify anything?
     if (value != to_simplify)
     {
-      expr2tc new_neg(std::make_shared<constructor>(to_simplify));
+      expr2tc new_neg(ksptr::make_shared<constructor>(to_simplify));
       return typecast_check_return(type, new_neg);
     }
 
@@ -2638,7 +2638,7 @@ static expr2tc simplify_floatbv_2ops(
     // Were we able to simplify the sides?
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
-      expr2tc new_op(std::make_shared<constructor>(
+      expr2tc new_op(ksptr::make_shared<constructor>(
         type, simplied_side_1, simplied_side_2, rounding_mode));
 
       return typecast_check_return(type, new_op);


### PR DESCRIPTION
The std::shared_ptr is quite flexible, allowing for custom deleters, allocators, and for casting between nearly arbitrary base-classes of the types of the objects being tracked while requiring no changes to the types themselves. It is also thread-safe (except for its use_count() method).

This flexibility comes with a cost. This PR is trying to figure out the cost. For this purpose, I've moved irep2 from being based on std::shared_ptr to being based on a custom type, that has less flexibility (and thus requires a bit more care when being used for arbitrary types).

In comparison to libstdc++'s std::shared_ptr implementation, the new ksptr::sptr one only requires storing a single pointer instead of two, and I've also externalized the control block (where the use-count and potentially deleter, etc. are being tracked).

First, for 30s SV-COMP there are not many changes. Master:
```
Statistics:          23805 Files
  correct:           13965
    correct true:     7709
    correct false:    6256
  incorrect:            31
    incorrect true:     13
    incorrect false:    18
  unknown:            9809
  Score:             20970 (max: 38482)

https://github.com/esbmc/esbmc/actions/runs/8102075164
```
This PR:
```
Statistics:          23805 Files
  correct:           13995
    correct true:     7717
    correct false:    6278
  incorrect:            32
    incorrect true:     13
    incorrect false:    19
  unknown:            9778
  Score:             20992 (max: 38482)

https://github.com/esbmc/esbmc/actions/runs/8110826297
```
(The "new" incorrect is noise.)

However, it seems that ESBMC is using about 10% less memory with this PR in the memory-intensive benchmarks. Running time is nearly unaffected, a reduction between 0 and maybe 3% in local experiments. I did expect more, since the use-count is not atomic anymore. Nevertheless, I could confirm that the 10% reduction in memory consumption is *only* due to the fact, that the ksptr::sptr stores a single pointer, while std::shared_ptr stores two of them internally.

I'm not sure whether this is a way we want to go. Atm. the ksptr::sptr isn't even pretending to be thread-safe, but that could be changed.

Any thoughts? Maybe also about what else to try?