### PR TITLE
Support for symbolic reconstruction of expression

### DIFF
--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -78,6 +78,22 @@ public:
     const expr2tc &size,
     const sourcet &source) = 0;
 
+  /**
+   * @brief Replaces trace symbols from expression with their values
+   *
+   * For example, for a trace `a0 = nondet_symbol(0); a1 = a0 + 1; guard = a1 > 5)`
+   * calling this function with "guard" will result in:
+   *
+   * - keep_local_variables(true): a1 > 5
+   * - keep_local_variables(false): nondet_symbol(0) + 1 > 5
+   *
+   * @param expr
+   * @param keep_local_variables
+   */
+  virtual void reconstruct_symbolic_expression(
+    expr2tc &expr,
+    bool keep_local_variables) const = 0;
+
   // Abstract method, with the purpose of duplicating a symex_targett from the
   // subclass.
   virtual std::shared_ptr<symex_targett> clone() const = 0;

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -396,8 +396,9 @@ void symex_target_equationt::replace_rec(
       e = step.rhs;
   }
 
-  e->Foreach_operand([&step, &keep_local, this](expr2tc &inner)
-                     { replace_rec(step, inner, keep_local); });
+  e->Foreach_operand([&step, &keep_local, this](expr2tc &inner) {
+    replace_rec(step, inner, keep_local);
+  });
 }
 
 void symex_target_equationt::reconstruct_symbolic_expression(
@@ -405,9 +406,9 @@ void symex_target_equationt::reconstruct_symbolic_expression(
   bool keep_local_variables) const
 {
   keep_local_variables = true;
-  for(auto rit = SSA_steps.rbegin();  rit != SSA_steps.rend(); rit++)
+  for (auto rit = SSA_steps.rbegin(); rit != SSA_steps.rend(); rit++)
   {
-    if(!rit->is_assignment())
+    if (!rit->is_assignment())
       continue;
 
     replace_rec(*rit, expr, keep_local_variables);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -405,7 +405,6 @@ void symex_target_equationt::reconstruct_symbolic_expression(
   expr2tc &expr,
   bool keep_local_variables) const
 {
-  keep_local_variables = true;
   for (auto rit = SSA_steps.rbegin(); rit != SSA_steps.rend(); rit++)
   {
     if (!rit->is_assignment())

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -78,6 +78,10 @@ public:
     smt_convt::ast_vec &assertions,
     SSA_stept &s);
 
+  void reconstruct_symbolic_expression(expr2tc &expr, bool keep_local_variables)
+    const override;
+  void replace_rec(const SSA_stept &step, expr2tc &e, bool keep_local) const;
+
   class SSA_stept
   {
   public:


### PR DESCRIPTION
This adds a method to "flatten" an expression given the current program state. This should help doing analysis at Symex and SSA level, specifically Interval Analysis.