### PR TITLE
[cpp-clang] Support sizeof expression

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -111,6 +111,7 @@ set(REGRESSIONS_CPP11 esbmc-cpp11/cpp
                       esbmc-cpp11/constructors
                       esbmc-cpp11/new-delete
                       esbmc-cpp11/reference
+                      esbmc-cpp11/template
                       )
 
 # NOTE: In order to make the best of the concurrency set sort the tests from the slowest to fastest.

--- a/regression/esbmc-cpp11/template/sizeof-pack-fail/main.cpp
+++ b/regression/esbmc-cpp11/template/sizeof-pack-fail/main.cpp
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+template <int... a>
+struct b
+{
+    int c() { return sizeof...(a); }
+};
+
+int main()
+{
+    b<0, 1, 2, 3> d;
+    int theSize = d.c();
+    assert(theSize == 0);
+}

--- a/regression/esbmc-cpp11/template/sizeof-pack-fail/test.desc
+++ b/regression/esbmc-cpp11/template/sizeof-pack-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--cppstd 11
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/template/sizeof-pack/main.cpp
+++ b/regression/esbmc-cpp11/template/sizeof-pack/main.cpp
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+template <int... a>
+struct b
+{
+    int c() { return sizeof...(a); }
+};
+
+int main()
+{
+    b<0, 1, 2, 3> d;
+    int theSize = d.c();
+    assert(theSize == 4);
+}

--- a/regression/esbmc-cpp11/template/sizeof-pack/test.desc
+++ b/regression/esbmc-cpp11/template/sizeof-pack/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--cppstd 11
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Adds support for sizeof expressions in the context of template packs:
> Represents an expression that computes the length of a parameter pack.
>```
> template<typename ...Types>
> struct count {
>  static const unsigned value = sizeof...(Types);
> };
> ```

Please be careful when reviewing this PR, it's my first one.

Here is a test, but I didn't know what the best location for it would be:

```cpp
#include <assert.h>

template <int... a>
struct b
{
    int c() { return sizeof...(a); }
};

int main()
{
    b<0, 1, 2, 3> d;
    int theSize = d.c();
    assert(theSize == 4);
}
```

```shell
Generating GOTO Program
GOTO program creation time: 0.016s
GOTO program processing time: 0.001s
Starting Bounded Model Checking
WARNING: no body for function __ESBMC_pthread_start_main_hook
WARNING: no body for function __ESBMC_atexit_handler
WARNING: no body for function __ESBMC_pthread_end_main_hook
Symex completed in: 0.000s (8 assignments)
Slicing time: 0.000s (removed 8 assignments)
Generated 1 VCC(s), 0 remaining after simplification (0 assignments)
BMC program time: 0.000s

VERIFICATION SUCCESSFUL
```