### PR TITLE
[Concurrency] Do not record __ESBMC_rounding_mode

### DIFF
--- a/regression/esbmc-unix/03_circular_buffer_02/test.desc
+++ b/regression/esbmc-unix/03_circular_buffer_02/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --context-bound 3
 ^VERIFICATION FAILED$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -837,7 +837,8 @@ void execution_statet::get_expr_globals(
       name == "c:@__ESBMC_alloc" || name == "c:@__ESBMC_alloc_size" ||
       name == "c:@__ESBMC_is_dynamic" ||
       name == "c:@__ESBMC_blocked_threads_count" ||
-      name.find("c:pthread_lib") != std::string::npos)
+      name.find("c:pthread_lib") != std::string::npos ||
+      name == "c:@__ESBMC_rounding_mode")
     {
       return;
     }


### PR DESCRIPTION
I feel there may be no need to perform context switches for every global variables that not from user's program, for example, disabling context switches if meet `__ESBMC_rounding_mode` can reduce the interleavings size.

This PR: https://github.com/esbmc/esbmc/actions/runs/8155914160/job/22293103022

```
Statistics:            665 Files
  correct:             428
    correct true:      143
    correct false:     285
  incorrect:             5
    incorrect true:      4
    incorrect false:     1
  unknown:             232
  Score:               427 (max: 999)

Runtime: 9730s
```
master:
```
Statistics:            665 Files
  correct:             427
    correct true:      142
    correct false:     285
  incorrect:             5
    incorrect true:      4
    incorrect false:     1
  unknown:             233
  Score:               425 (max: 999)

Runtime: 12600s
```
Total runtime reduction is 2870 (s).

And there is a bug in the regression, should be a guard problem, while using `--no-por` can trigger the violation.

Another minimal case:


```c
#include <assert.h>
#include <pthread.h>
_Bool receive = 0;
int i = 0;
void *t1() {
  for (int i = 0; i < 2; i++) {
    if (receive) {
      assert(i < 1);
      receive = 0;
    }
  }
  return NULL;
}
int main() {
  pthread_t id;
  pthread_create(&id, NULL, t1, NULL);
  receive = 1;
  return 0;
}
```
esbmc --no-simplify --unwind 3 main.c: assertion i < 1 failure
esbmc --no-por main.c: success