### PR TITLE
[C++ verification] added support for nullptr_t

### DIFF
--- a/regression/esbmc-cpp11/cpp/nullptr_t/main.cpp
+++ b/regression/esbmc-cpp11/cpp/nullptr_t/main.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+
+void myFunction(int* ptr) {
+    if (ptr == nullptr) {
+        std::cout << "Pointer is nullptr" << std::endl;
+    } else {
+        std::cout << "Pointer is not nullptr" << std::endl;
+    }
+}
+
+int main() {
+    int* ptr1 = nullptr;
+    int* ptr2 = new int(5);
+
+    myFunction(ptr1); // Passing nullptr
+    myFunction(ptr2); // Passing valid pointer
+
+    delete ptr2;
+
+    return 0;
+}

--- a/regression/esbmc-cpp11/cpp/nullptr_t/test.desc
+++ b/regression/esbmc-cpp11/cpp/nullptr_t/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--cppstd 11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/nullptr_t_01/main.cpp
+++ b/regression/esbmc-cpp11/cpp/nullptr_t_01/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+#include <cstddef>
+
+bool f(std::nullptr_t x)
+{
+  return x == &x;
+}
+int main()
+{ 
+  assert(!f(nullptr)); 
+}

--- a/regression/esbmc-cpp11/cpp/nullptr_t_01/test.desc
+++ b/regression/esbmc-cpp11/cpp/nullptr_t_01/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--cppstd 11
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1830,8 +1830,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
   case clang::Stmt::CXXNullPtrLiteralExprClass:
   case clang::Stmt::GNUNullExprClass:
   {
-    const clang::Expr &gnun =
-      static_cast<const clang::Expr &>(stmt);
+    const clang::Expr &gnun = static_cast<const clang::Expr &>(stmt);
 
     typet t;
     if (get_type(gnun.getType(), t))

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1397,6 +1397,11 @@ bool clang_c_convertert::get_builtin_type(
     c_type = "__uint128";
     break;
 
+  case clang::BuiltinType::NullPtr:
+    new_type = pointer_type();
+    c_type = "uintptr_t";
+    break;
+
 #ifdef ESBMC_CHERI_CLANG
   case clang::BuiltinType::IntCap:
     new_type = intcap_typet();
@@ -1822,10 +1827,11 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::CXXNullPtrLiteralExprClass:
   case clang::Stmt::GNUNullExprClass:
   {
-    const clang::GNUNullExpr &gnun =
-      static_cast<const clang::GNUNullExpr &>(stmt);
+    const clang::Expr &gnun =
+      static_cast<const clang::Expr &>(stmt);
 
     typet t;
     if (get_type(gnun.getType(), t))

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -796,7 +796,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     }
     break;
   }
-  
+
   default:
     if (clang_c_convertert::get_expr(stmt, new_expr))
       return true;

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -797,6 +797,14 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::CXXNullPtrLiteralExprClass:
+  {
+    typet t = unsignedbv_typet(config.ansi_c.pointer_width());
+
+    new_expr = gen_zero(t);
+    break;
+  }
+
   default:
     if (clang_c_convertert::get_expr(stmt, new_expr))
       return true;

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -796,15 +796,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     }
     break;
   }
-
-  case clang::Stmt::CXXNullPtrLiteralExprClass:
-  {
-    typet t = unsignedbv_typet(config.ansi_c.pointer_width());
-
-    new_expr = gen_zero(t);
-    break;
-  }
-
+  
   default:
     if (clang_c_convertert::get_expr(stmt, new_expr))
       return true;


### PR DESCRIPTION
Added a new node: `clang: : Stmt: : CXXNullPtrLiteralExprClass`, do the same with `GNUNullExprClass`.

In this PR, `BuiltinType::NullPtr` is modeled as `int`, (Maybe `long` would be more appropriate?)

For the code: 

`int* p = nullptr;`

AST:
```
    | `-VarDecl 0x7af1d18 <col:5, col:14> col:10 used p 'int *' cinit
    |   `-ImplicitCastExpr 0x7af1d90 <col:14> 'int *' <NullToPointer>
    |     `-CXXNullPtrLiteralExpr 0x7af1d80 <col:14> 'nullptr_t'
```

_Edit_: Does anyone know why `git-auto-commit-action` always fails?