### PR TITLE
Optimization of Interval Analysis

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -254,8 +254,6 @@ void dump_intervals(
           interval.second.is_top());
       }
     };
-    d.enable_wrapped_intervals ? print_vars(d.get_wrap_map())
-                               : print_vars(d.get_int_map());
   }
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -76,7 +76,7 @@ static void optimize_expression(expr2tc &expr, const interval_domaint &state)
   if (interval_domaint::enable_wrapped_intervals)
     optimize_expr_interval<wrapped_interval>(expr, state);
   else
-    optimize_expr_interval<integer_intervalt>(expr, state);
+    optimize_expr_interval<interval_domaint::integer_intervalt>(expr, state);
 
   // Try sub-expressions
   expr->Foreach_operand(

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -54,8 +54,9 @@ void interval_domaint::update_symbol_interval(
     intervals.erase(sym.thename);
     return;
   }
-    
-  intervals[sym.thename] = std::make_shared<interval_domaint::integer_intervalt>(value); 
+
+  intervals[sym.thename] =
+    std::make_shared<interval_domaint::integer_intervalt>(value);
 }
 
 template <>
@@ -68,7 +69,8 @@ void interval_domaint::update_symbol_interval(
     intervals.erase(sym.thename);
     return;
   }
-  intervals[sym.thename] = std::make_shared<interval_domaint::real_intervalt>(value);
+  intervals[sym.thename] =
+    std::make_shared<interval_domaint::real_intervalt>(value);
 }
 
 template <>
@@ -113,7 +115,6 @@ void interval_domaint::apply_assume_symbol_truth(
     interval.make_le_than(1);
   }
 
-
   update_symbol_interval(sym, interval);
 }
 
@@ -133,7 +134,8 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
 #include <cmath>
 
 template <>
-interval_domaint::real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e) const
+interval_domaint::real_intervalt
+interval_domaint::get_interval_from_const(const expr2tc &e) const
 {
   interval_domaint::real_intervalt result; // (-infinity, infinity)
   if (!is_constant_floatbv2t(e))
@@ -197,9 +199,8 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
 }
 
 template <>
-interval_domaint::integer_intervalt
-interval_domaint::generate_modular_interval<interval_domaint::integer_intervalt>(
-  const symbol2t sym) const
+interval_domaint::integer_intervalt interval_domaint::generate_modular_interval<
+  interval_domaint::integer_intervalt>(const symbol2t sym) const
 {
   auto t = sym.type;
   interval_domaint::integer_intervalt result;
@@ -224,7 +225,8 @@ interval_domaint::generate_modular_interval<interval_domaint::integer_intervalt>
 }
 
 template <>
-interval_domaint::real_intervalt interval_domaint::generate_modular_interval<interval_domaint::real_intervalt>(
+interval_domaint::real_intervalt
+interval_domaint::generate_modular_interval<interval_domaint::real_intervalt>(
   const symbol2t) const
 {
   // TODO: Support this
@@ -508,7 +510,6 @@ T interval_domaint::get_interval(const expr2tc &e) const
 
       else if (is_modulus2t(e))
         result = lhs % rhs;
-
     }
     break;
 
@@ -667,15 +668,16 @@ void interval_domaint::apply_assume_less<wrapped_interval>(
     make_bottom();
 }
 
-
 template <>
-bool interval_domaint::is_mapped<interval_domaint::integer_intervalt>(const symbol2t &sym) const
+bool interval_domaint::is_mapped<interval_domaint::integer_intervalt>(
+  const symbol2t &sym) const
 {
   return intervals.find(sym.thename) != intervals.end();
 }
 
 template <>
-bool interval_domaint::is_mapped<interval_domaint::real_intervalt>(const symbol2t &sym) const
+bool interval_domaint::is_mapped<interval_domaint::real_intervalt>(
+  const symbol2t &sym) const
 {
   return intervals.find(sym.thename) != intervals.end();
 }
@@ -686,9 +688,9 @@ bool interval_domaint::is_mapped<wrapped_interval>(const symbol2t &sym) const
   return intervals.find(sym.thename) != intervals.end();
 }
 
-
 template <>
-expr2tc interval_domaint::make_expression_value<interval_domaint::integer_intervalt>(
+expr2tc
+interval_domaint::make_expression_value<interval_domaint::integer_intervalt>(
   const interval_domaint::integer_intervalt &interval,
   const type2tc &type,
   bool is_upper) const
@@ -697,7 +699,8 @@ expr2tc interval_domaint::make_expression_value<interval_domaint::integer_interv
 }
 
 template <>
-expr2tc interval_domaint::make_expression_value<interval_domaint::real_intervalt>(
+expr2tc
+interval_domaint::make_expression_value<interval_domaint::real_intervalt>(
   const interval_domaint::real_intervalt &interval,
   const type2tc &type,
   bool upper) const
@@ -842,7 +845,10 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
 // END TEMPLATES
 
 template <class Interval>
-void print_interval(const interval_templatet<Interval> &i, const std::string &name, std::ostream &out)
+void print_interval(
+  const interval_templatet<Interval> &i,
+  const std::string &name,
+  std::ostream &out)
 {
   if (i.is_top())
     return;
@@ -881,8 +887,8 @@ void interval_domaint::output(std::ostream &out) const
     default:
       // unreachable
       break;
-    }    
-  }  
+    }
+  }
 }
 
 bool contains_float(const expr2tc &e)
@@ -1052,14 +1058,16 @@ void interval_domaint::transform(
 }
 
 template <class Interval>
-bool interval_domaint::join_intervals(const std::shared_ptr<Interval> &after, std::shared_ptr<Interval> &dst, bool can_extrapolate) const
+bool interval_domaint::join_intervals(
+  const std::shared_ptr<Interval> &after,
+  std::shared_ptr<Interval> &dst,
+  bool can_extrapolate) const
 {
   const Interval before = *dst;
   Interval joined = *dst;
   joined.join(*after);
   if (before != joined)
   {
-
     if (widening_extrapolate && can_extrapolate)
       joined = extrapolate_intervals(before, joined);
 
@@ -1128,7 +1136,7 @@ bool interval_domaint::join(
         std::get<0>(next_it->second),
         std::get<0>(previous_it->second),
         should_extrapolate_instruction);
-     break;
+      break;
     case 1:
       join_changed = join_intervals<interval_domaint::real_intervalt>(
         std::get<1>(next_it->second),
@@ -1136,7 +1144,7 @@ bool interval_domaint::join(
         should_extrapolate_instruction);
       break;
     case 2:
-       join_changed = join_intervals<wrapped_interval>(
+      join_changed = join_intervals<wrapped_interval>(
         std::get<2>(next_it->second),
         std::get<2>(previous_it->second),
         should_extrapolate_instruction);
@@ -1190,10 +1198,12 @@ void interval_domaint::assign(const expr2tc &expr, const bool recursive)
     if (enable_wrapped_intervals)
       apply_assignment<wrapped_interval>(c.target, c.source, recursive);
     else
-      apply_assignment<interval_domaint::integer_intervalt>(c.target, c.source, recursive);
+      apply_assignment<interval_domaint::integer_intervalt>(
+        c.target, c.source, recursive);
   }
   else if (isfloatbvop && enable_real_intervals)
-    apply_assignment<interval_domaint::real_intervalt>(c.target, c.source, recursive);
+    apply_assignment<interval_domaint::real_intervalt>(
+      c.target, c.source, recursive);
 }
 
 void interval_domaint::havoc_rec(const expr2tc &expr)
@@ -1334,7 +1344,6 @@ void interval_domaint::assume(const expr2tc &cond)
         default:
           break;
         }
-
       }
       contractor.apply_contractor();
       new_cond = contractor.result_of_outer();
@@ -1439,7 +1448,8 @@ void interval_domaint::assume_rec(const expr2tc &cond, bool negation)
           to_symbol2t(cond), negation);
     }
     else if (is_floatbv_type(cond) && enable_real_intervals)
-      apply_assume_symbol_truth<interval_domaint::real_intervalt>(to_symbol2t(cond), negation);
+      apply_assume_symbol_truth<interval_domaint::real_intervalt>(
+        to_symbol2t(cond), negation);
   }
   //added in case "cond = false" which happens when the ibex contractor results in empty set.
   else if (is_constant_bool2t(cond))
@@ -1467,7 +1477,8 @@ expr2tc interval_domaint::make_expression(const expr2tc &symbol) const
     if (enable_wrapped_intervals)
       return make_expression_helper<wrapped_interval>(symbol);
     else
-      return make_expression_helper<interval_domaint::integer_intervalt>(symbol);
+      return make_expression_helper<interval_domaint::integer_intervalt>(
+        symbol);
   }
   if (is_floatbv_type(symbol) && enable_real_intervals)
     return make_expression_helper<interval_domaint::real_intervalt>(symbol);

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1077,6 +1077,16 @@ bool interval_domaint::join_intervals(
   return false;
 }
 
+
+bool do_is_subset(const interval_domaint::interval &a, const interval_domaint::interval &b)
+{
+  //  return false;
+  if (a.index() != 0)
+    return false;
+
+  return std::get<0>(b)->is_subseteq(*std::get<0>(a));
+}
+
 template <class IntervalMap>
 bool interval_domaint::join(
   IntervalMap &a0,
@@ -1089,9 +1099,19 @@ bool interval_domaint::join(
   bool result = false;
   std::unordered_set<irep_idt, irep_id_hash> symbol_map;
   for (const auto &myPair : a0)
-    symbol_map.insert(myPair.first);
-  for (const auto &myPair : a1)
-    symbol_map.insert(myPair.first);
+  {
+    const auto next_it = a1.find(myPair.first);
+    if (next_it == a1.end())
+    {
+      symbol_map.insert(myPair.first);
+      continue;
+    }
+
+    if (!do_is_subset(myPair.second, next_it->second))
+      symbol_map.insert(myPair.first);   
+    
+  }
+
 
   // Here we apply the HULL operation (before, after)
   for (const irep_idt &symbol : symbol_map)

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -15,9 +15,9 @@ template <size_t Index, class Interval>
 Interval interval_domaint::get_interval_from_variant(const symbol2t &sym) const
 {
   const auto &it = intervals.find(sym.thename);
-  if (it != intervals.end())
+  // TODO: mix floats/integer
+  if (it != intervals.end() && it->second.index() == Index)
   {
-    assert(it->second.index() == Index);
     return *std::get<Index>(it->second);
   }
   return Interval(sym.type);
@@ -89,7 +89,6 @@ void interval_domaint::apply_assume_symbol_truth(
   const symbol2t &sym,
   bool is_false)
 {
-  sym.dump();
   Interval interval = get_interval_from_symbol<Interval>(sym);
   // [0,0]
   if (is_false)

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1077,8 +1077,9 @@ bool interval_domaint::join_intervals(
   return false;
 }
 
-
-bool do_is_subset(const interval_domaint::interval &a, const interval_domaint::interval &b)
+bool do_is_subset(
+  const interval_domaint::interval &a,
+  const interval_domaint::interval &b)
 {
   //  return false;
   if (a.index() != 0)
@@ -1108,10 +1109,8 @@ bool interval_domaint::join(
     }
 
     if (!do_is_subset(myPair.second, next_it->second))
-      symbol_map.insert(myPair.first);   
-    
+      symbol_map.insert(myPair.first);
   }
-
 
   // Here we apply the HULL operation (before, after)
   for (const irep_idt &symbol : symbol_map)

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -45,13 +45,17 @@ interval_domaint::get_interval_from_symbol(const symbol2t &sym) const
 }
 
 template <size_t Index, class Interval>
-void interval_domaint::update_symbol_from_variant(const symbol2t &sym, const Interval &value)
+void interval_domaint::update_symbol_from_variant(
+  const symbol2t &sym,
+  const Interval &value)
 {
   const auto &it = intervals->find(sym.thename);
   const bool is_new_value_top = value.is_top();
 
   // Are we actually changing it?
-  if ((it == intervals->end() && is_new_value_top) || (it != intervals->end() && *std::get<Index>(it->second) == value))
+  if (
+    (it == intervals->end() && is_new_value_top) ||
+    (it != intervals->end() && *std::get<Index>(it->second) == value))
     return;
 
   copy_if_needed();
@@ -64,13 +68,13 @@ void interval_domaint::update_symbol_from_variant(const symbol2t &sym, const Int
   (*intervals)[sym.thename] = std::make_shared<Interval>(value);
 }
 
-
 template <>
 void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
   const interval_domaint::integer_intervalt &value)
 {
-  update_symbol_from_variant<0, interval_domaint::integer_intervalt>(sym,value);
+  update_symbol_from_variant<0, interval_domaint::integer_intervalt>(
+    sym, value);
 }
 
 template <>
@@ -78,7 +82,7 @@ void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
   const interval_domaint::real_intervalt &value)
 {
-  update_symbol_from_variant<1, interval_domaint::real_intervalt>(sym,value);
+  update_symbol_from_variant<1, interval_domaint::real_intervalt>(sym, value);
 }
 
 template <>
@@ -86,7 +90,7 @@ void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
   const wrapped_interval &value)
 {
-  update_symbol_from_variant<2, wrapped_interval>(sym,value);
+  update_symbol_from_variant<2, wrapped_interval>(sym, value);
 }
 
 template <class Interval>
@@ -1179,7 +1183,6 @@ bool interval_domaint::join(
     result |= join_changed;
   }
 
-  
   return result;
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -973,8 +973,8 @@ void interval_domaint::transform(
   case ASSERT:
   {
     // There is a bug in Floats that need to be investigated! regression-float/nextafter
-    //    if (!contains_float(instruction.guard) && enable_assume_asserts)
-    assume(instruction.guard);
+    if (!contains_float(instruction.guard) && enable_assume_asserts)
+      assume(instruction.guard);
     break;
   }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -24,17 +24,17 @@ Interval interval_domaint::get_interval_from_variant(const symbol2t &sym) const
 }
 
 template <>
-integer_intervalt
+interval_domaint::integer_intervalt
 interval_domaint::get_interval_from_symbol(const symbol2t &sym) const
 {
-  return get_interval_from_variant<0, integer_intervalt>(sym);
+  return get_interval_from_variant<0, interval_domaint::integer_intervalt>(sym);
 }
 
 template <>
-real_intervalt
+interval_domaint::real_intervalt
 interval_domaint::get_interval_from_symbol(const symbol2t &sym) const
 {
-  return get_interval_from_variant<1, real_intervalt>(sym);
+  return get_interval_from_variant<1, interval_domaint::real_intervalt>(sym);
 }
 
 template <>
@@ -47,21 +47,21 @@ interval_domaint::get_interval_from_symbol(const symbol2t &sym) const
 template <>
 void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
-  const integer_intervalt value)
+  const interval_domaint::integer_intervalt value)
 {
   if (value.is_top())
     return;
-  intervals[sym.thename] = std::make_shared<integer_intervalt>(value); 
+  intervals[sym.thename] = std::make_shared<interval_domaint::integer_intervalt>(value); 
 }
 
 template <>
 void interval_domaint::update_symbol_interval(
   const symbol2t &sym,
-  const real_intervalt value)
+  const interval_domaint::real_intervalt value)
 {
   if (value.is_top())
     return;
-  intervals[sym.thename] = std::make_shared<real_intervalt>(value);
+  intervals[sym.thename] = std::make_shared<interval_domaint::real_intervalt>(value);
 }
 
 template <>
@@ -109,10 +109,10 @@ void interval_domaint::apply_assume_symbol_truth(
 }
 
 template <>
-integer_intervalt
+interval_domaint::integer_intervalt
 interval_domaint::get_interval_from_const(const expr2tc &e) const
 {
-  integer_intervalt result; // (-infinity, infinity)
+  interval_domaint::integer_intervalt result; // (-infinity, infinity)
   if (!is_constant_int2t(e))
     return result;
   auto value = to_constant_int2t(e).value;
@@ -124,9 +124,9 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
 #include <cmath>
 
 template <>
-real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e) const
+interval_domaint::real_intervalt interval_domaint::get_interval_from_const(const expr2tc &e) const
 {
-  real_intervalt result; // (-infinity, infinity)
+  interval_domaint::real_intervalt result; // (-infinity, infinity)
   if (!is_constant_floatbv2t(e))
     return result;
 
@@ -188,12 +188,12 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
 }
 
 template <>
-integer_intervalt
-interval_domaint::generate_modular_interval<integer_intervalt>(
+interval_domaint::integer_intervalt
+interval_domaint::generate_modular_interval<interval_domaint::integer_intervalt>(
   const symbol2t sym) const
 {
   auto t = sym.type;
-  integer_intervalt result;
+  interval_domaint::integer_intervalt result;
   if (is_unsignedbv_type(t))
   {
     result.make_le_than(BigInt::power2m1(t->get_width()));
@@ -215,11 +215,11 @@ interval_domaint::generate_modular_interval<integer_intervalt>(
 }
 
 template <>
-real_intervalt interval_domaint::generate_modular_interval<real_intervalt>(
+interval_domaint::real_intervalt interval_domaint::generate_modular_interval<interval_domaint::real_intervalt>(
   const symbol2t) const
 {
   // TODO: Support this
-  real_intervalt t;
+  interval_domaint::real_intervalt t;
   assert(t.is_top() && !t.is_bottom());
   return t;
 }
@@ -660,13 +660,13 @@ void interval_domaint::apply_assume_less<wrapped_interval>(
 
 
 template <>
-bool interval_domaint::is_mapped<integer_intervalt>(const symbol2t &sym) const
+bool interval_domaint::is_mapped<interval_domaint::integer_intervalt>(const symbol2t &sym) const
 {
   return intervals.find(sym.thename) != intervals.end();
 }
 
 template <>
-bool interval_domaint::is_mapped<real_intervalt>(const symbol2t &sym) const
+bool interval_domaint::is_mapped<interval_domaint::real_intervalt>(const symbol2t &sym) const
 {
   return intervals.find(sym.thename) != intervals.end();
 }
@@ -679,8 +679,8 @@ bool interval_domaint::is_mapped<wrapped_interval>(const symbol2t &sym) const
 
 
 template <>
-expr2tc interval_domaint::make_expression_value<integer_intervalt>(
-  const integer_intervalt &interval,
+expr2tc interval_domaint::make_expression_value<interval_domaint::integer_intervalt>(
+  const interval_domaint::integer_intervalt &interval,
   const type2tc &type,
   bool is_upper) const
 {
@@ -688,8 +688,8 @@ expr2tc interval_domaint::make_expression_value<integer_intervalt>(
 }
 
 template <>
-expr2tc interval_domaint::make_expression_value<real_intervalt>(
-  const real_intervalt &interval,
+expr2tc interval_domaint::make_expression_value<interval_domaint::real_intervalt>(
+  const interval_domaint::real_intervalt &interval,
   const type2tc &type,
   bool upper) const
 {
@@ -1115,13 +1115,13 @@ bool interval_domaint::join(
     switch (next_it->second.index())
     {
     case 0:
-      join_changed = join_intervals<integer_intervalt>(
+      join_changed = join_intervals<interval_domaint::integer_intervalt>(
         std::get<0>(next_it->second),
         std::get<0>(previous_it->second),
         should_extrapolate_instruction);
      break;
     case 1:
-      join_changed = join_intervals<real_intervalt>(
+      join_changed = join_intervals<interval_domaint::real_intervalt>(
         std::get<1>(next_it->second),
         std::get<1>(previous_it->second),
         should_extrapolate_instruction);
@@ -1181,10 +1181,10 @@ void interval_domaint::assign(const expr2tc &expr, const bool recursive)
     if (enable_wrapped_intervals)
       apply_assignment<wrapped_interval>(c.target, c.source, recursive);
     else
-      apply_assignment<integer_intervalt>(c.target, c.source, recursive);
+      apply_assignment<interval_domaint::integer_intervalt>(c.target, c.source, recursive);
   }
   else if (isfloatbvop && enable_real_intervals)
-    apply_assignment<real_intervalt>(c.target, c.source, recursive);
+    apply_assignment<interval_domaint::real_intervalt>(c.target, c.source, recursive);
 }
 
 void interval_domaint::havoc_rec(const expr2tc &expr)
@@ -1264,11 +1264,11 @@ void interval_domaint::assume_rec(
     if (enable_wrapped_intervals)
       apply_assume_less<wrapped_interval>(lhs, rhs);
     else
-      apply_assume_less<integer_intervalt>(lhs, rhs);
+      apply_assume_less<interval_domaint::integer_intervalt>(lhs, rhs);
   }
   else if (
     is_floatbv_type(lhs) && is_floatbv_type(rhs) && enable_real_intervals)
-    apply_assume_less<real_intervalt>(lhs, rhs);
+    apply_assume_less<interval_domaint::real_intervalt>(lhs, rhs);
 }
 
 void interval_domaint::assume(const expr2tc &cond)
@@ -1287,7 +1287,6 @@ void interval_domaint::assume(const expr2tc &cond)
     return;
   }
 #endif
-#if 0
 #ifdef ENABLE_GOTO_CONTRACTOR
   /// use ibex contractors to reduce the intervals for interval analysis
   if (enable_ibex_contractor)
@@ -1295,13 +1294,42 @@ void interval_domaint::assume(const expr2tc &cond)
     interval_analysis_ibex_contractor contractor;
     if (contractor.parse_guard(new_cond))
     {
-      contractor.maps_to_domains(int_map, real_map);
+      for (const auto &i : intervals)
+      {
+        switch (i.second.index())
+        {
+        case 0:
+        {
+          integer_intervalt &int_interval = *std::get<0>(i.second);
+          std::optional<BigInt> upper;
+          std::optional<BigInt> lower;
+          if (int_interval.upper)
+            upper = int_interval.get_upper();
+          if (int_interval.lower)
+            lower = int_interval.get_lower();
+          contractor.interval_to_domain(lower, upper, i.first.as_string());
+        }
+        case 1:
+        {
+          real_intervalt &real_interval = *std::get<1>(i.second);
+          std::optional<double> upper;
+          std::optional<double> lower;
+          if (real_interval.upper)
+            upper = (double)real_interval.get_upper();
+          if (real_interval.lower)
+            lower = (double)real_interval.get_lower();
+          contractor.interval_to_domain(lower, upper, i.first.as_string());
+        }
+        default:
+          break;
+        }
+
+      }
       contractor.apply_contractor();
       new_cond = contractor.result_of_outer();
       simplify(new_cond);
     }
   }
-#endif
 #endif
   assume_rec(new_cond, false);
 }
@@ -1324,7 +1352,7 @@ tvt interval_domaint::eval_boolean_expression(
     return tvt(tvt::TV_UNKNOWN);
   }
 
-  auto interval = id.get_interval<integer_intervalt>(cond);
+  auto interval = id.get_interval<interval_domaint::integer_intervalt>(cond);
 
   // If the interval does not contain zero then it's always true
   if (!interval.contains(0))
@@ -1396,11 +1424,11 @@ void interval_domaint::assume_rec(const expr2tc &cond, bool negation)
         apply_assume_symbol_truth<wrapped_interval>(
           to_symbol2t(cond), negation);
       else
-        apply_assume_symbol_truth<integer_intervalt>(
+        apply_assume_symbol_truth<interval_domaint::integer_intervalt>(
           to_symbol2t(cond), negation);
     }
     else if (is_floatbv_type(cond) && enable_real_intervals)
-      apply_assume_symbol_truth<real_intervalt>(to_symbol2t(cond), negation);
+      apply_assume_symbol_truth<interval_domaint::real_intervalt>(to_symbol2t(cond), negation);
   }
   //added in case "cond = false" which happens when the ibex contractor results in empty set.
   else if (is_constant_bool2t(cond))
@@ -1428,10 +1456,10 @@ expr2tc interval_domaint::make_expression(const expr2tc &symbol) const
     if (enable_wrapped_intervals)
       return make_expression_helper<wrapped_interval>(symbol);
     else
-      return make_expression_helper<integer_intervalt>(symbol);
+      return make_expression_helper<interval_domaint::integer_intervalt>(symbol);
   }
   if (is_floatbv_type(symbol) && enable_real_intervals)
-    return make_expression_helper<real_intervalt>(symbol);
+    return make_expression_helper<interval_domaint::real_intervalt>(symbol);
   return gen_true_expr();
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1309,7 +1309,7 @@ void interval_domaint::assume(const expr2tc &cond)
         {
         case 0:
         {
-          integer_intervalt &int_interval = *std::get<0>(i.second);
+          const integer_intervalt &int_interval = *std::get<0>(i.second);
           std::optional<BigInt> upper;
           std::optional<BigInt> lower;
           if (int_interval.upper)
@@ -1317,10 +1317,11 @@ void interval_domaint::assume(const expr2tc &cond)
           if (int_interval.lower)
             lower = int_interval.get_lower();
           contractor.interval_to_domain(lower, upper, i.first.as_string());
+          break;
         }
         case 1:
         {
-          real_intervalt &real_interval = *std::get<1>(i.second);
+          const real_intervalt &real_interval = *std::get<1>(i.second);
           std::optional<double> upper;
           std::optional<double> lower;
           if (real_interval.upper)
@@ -1328,6 +1329,7 @@ void interval_domaint::assume(const expr2tc &cond)
           if (real_interval.lower)
             lower = (double)real_interval.get_lower();
           contractor.interval_to_domain(lower, upper, i.first.as_string());
+          break;
         }
         default:
           break;

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -50,7 +50,11 @@ void interval_domaint::update_symbol_interval(
   const interval_domaint::integer_intervalt value)
 {
   if (value.is_top())
+  {
+    intervals.erase(sym.thename);
     return;
+  }
+    
   intervals[sym.thename] = std::make_shared<interval_domaint::integer_intervalt>(value); 
 }
 
@@ -60,7 +64,10 @@ void interval_domaint::update_symbol_interval(
   const interval_domaint::real_intervalt value)
 {
   if (value.is_top())
+  {
+    intervals.erase(sym.thename);
     return;
+  }
   intervals[sym.thename] = std::make_shared<interval_domaint::real_intervalt>(value);
 }
 
@@ -70,7 +77,10 @@ void interval_domaint::update_symbol_interval(
   const wrapped_interval value)
 {
   if (value.is_top())
+  {
+    intervals.erase(sym.thename);
     return;
+  }
   intervals[sym.thename] = std::make_shared<wrapped_interval>(value);
 }
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -32,6 +32,8 @@ public:
     std::shared_ptr<real_intervalt>,
     std::shared_ptr<wrapped_interval>>;
 
+  // Map of variables into intervals.
+  // If a key does not exist then imply the TOP interval.
   using interval_map = std::unordered_map<irep_idt, interval, irep_id_hash>;
 
   interval_domaint() : bottom(true)

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -34,6 +34,7 @@ public:
 
   // Map of variables into intervals.
   // If a key does not exist then imply the TOP interval.
+  // If a key exists then the shared_ptr must point to a valid place
   using interval_map = std::unordered_map<irep_idt, interval, irep_id_hash>;
 
   interval_domaint() : bottom(true)

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -13,14 +13,8 @@
 #include <util/mp_arith.h>
 #include <util/threeval.h>
 #include <boost/multiprecision/cpp_bin_float.hpp>
+#include <variant>
 
-using integer_intervalt =  interval_templatet<BigInt>;
-using real_intervalt =
-  interval_templatet<boost::multiprecision::cpp_bin_float_100>;
-
-using interval = std::variant<std::shared_ptr<integer_intervalt>, std::shared_ptr<real_intervalt>, std::shared_ptr<wrapped_interval>>;
-
-using interval_map = std::unordered_map<irep_idt, interval, irep_id_hash>;
 /**
  * @brief Trivial, conjunctive interval domain for both float
  *        and integers. The categorization 'float' and 'integers'
@@ -29,6 +23,14 @@ using interval_map = std::unordered_map<irep_idt, interval, irep_id_hash>;
 class interval_domaint : public ai_domain_baset
 {
 public:
+  using integer_intervalt =  interval_templatet<BigInt>;
+  using real_intervalt =
+    interval_templatet<boost::multiprecision::cpp_bin_float_100>;
+
+  using interval = std::variant<std::shared_ptr<integer_intervalt>, std::shared_ptr<real_intervalt>, std::shared_ptr<wrapped_interval>>;
+
+  using interval_map = std::unordered_map<irep_idt, interval, irep_id_hash>;
+
   interval_domaint() : bottom(true)
   {
   }

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -23,11 +23,14 @@
 class interval_domaint : public ai_domain_baset
 {
 public:
-  using integer_intervalt =  interval_templatet<BigInt>;
+  using integer_intervalt = interval_templatet<BigInt>;
   using real_intervalt =
     interval_templatet<boost::multiprecision::cpp_bin_float_100>;
 
-  using interval = std::variant<std::shared_ptr<integer_intervalt>, std::shared_ptr<real_intervalt>, std::shared_ptr<wrapped_interval>>;
+  using interval = std::variant<
+    std::shared_ptr<integer_intervalt>,
+    std::shared_ptr<real_intervalt>,
+    std::shared_ptr<wrapped_interval>>;
 
   using interval_map = std::unordered_map<irep_idt, interval, irep_id_hash>;
 
@@ -184,12 +187,12 @@ public:
   virtual bool
   ai_simplify(expr2tc &condition, const namespacet &ns) const override;
 
-    interval_map intervals;
+  interval_map intervals;
+
 protected:
   // Abstract state information
   /// Is this state a bottom. I.e., there is a contradiction between an assignment and an assume
   bool bottom;
-
 
   /**
    * @brief Recursively explores an Expression until it reaches a symbol. If the
@@ -273,7 +276,8 @@ protected:
    * @param rhs
    */
   template <class Interval>
-  Interval extrapolate_intervals(const Interval &before, const Interval &after) const;
+  Interval
+  extrapolate_intervals(const Interval &before, const Interval &after) const;
 
   /**
    * @brief Applies Interpolation narrowing algorithm
@@ -358,7 +362,10 @@ public:
   Interval get_interval_from_variant(const symbol2t &sym) const;
 
   template <class Interval>
-  bool join_intervals(const std::shared_ptr<Interval> &after, std::shared_ptr<Interval> &dst, bool can_extrapolate) const;
+  bool join_intervals(
+    const std::shared_ptr<Interval> &after,
+    std::shared_ptr<Interval> &dst,
+    bool can_extrapolate) const;
 
   /**
    * @brief Get the interval from constant expression

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -204,7 +204,7 @@ public:
     std::shared_ptr<interval_map> cpy = std::make_shared<interval_map>();
     *cpy = *intervals;
     intervals = cpy;
-    copied = true;    
+    copied = true;
   }
 
 protected:
@@ -429,7 +429,6 @@ protected:
 
   template <size_t Index, class Interval>
   void update_symbol_from_variant(const symbol2t &sym, const Interval &value);
-
 };
 
 #endif // CPROVER_ANALYSES_INTERVAL_DOMAIN_H

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -23,6 +23,8 @@ public:
 
   interval_templatet() = default;
 
+  explicit interval_templatet(const type2tc &) { }
+
   explicit interval_templatet(const T &x) : lower(x), upper(x)
   {
   }

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -227,6 +227,19 @@ public:
     }
   }
 
+  // Wether *this \subseteq other
+  bool is_subseteq(const interval_templatet &other) const
+  {
+   if ((!lower && other.lower) || (!upper && other.upper))
+      return false;
+    if (other.lower && *lower < *other.lower)
+      return false;
+    if (other.upper && *upper > *other.upper)
+      return false;
+
+    return true;
+  }
+
   virtual void approx_union_with(const interval_templatet &i)
   {
     if (i.lower && lower)

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -23,7 +23,9 @@ public:
 
   interval_templatet() = default;
 
-  explicit interval_templatet(const type2tc &) { }
+  explicit interval_templatet(const type2tc &)
+  {
+  }
 
   explicit interval_templatet(const T &x) : lower(x), upper(x)
   {

--- a/src/goto-programs/abstract-interpretation/interval_template.h
+++ b/src/goto-programs/abstract-interpretation/interval_template.h
@@ -230,7 +230,7 @@ public:
   // Wether *this \subseteq other
   bool is_subseteq(const interval_templatet &other) const
   {
-   if ((!lower && other.lower) || (!upper && other.upper))
+    if ((!lower && other.lower) || (!upper && other.upper))
       return false;
     if (other.lower && *lower < *other.lower)
       return false;

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -1,6 +1,5 @@
 #include <goto-programs/goto_contractor.h>
 #include <goto-programs/abstract-interpretation/interval_domain.h>
-#include <goto-programs/abstract-interpretation/interval_analysis.h>
 
 void goto_contractor(
   goto_functionst &goto_functions,
@@ -57,7 +56,13 @@ void goto_contractort::get_intervals(
         while (it != map.var_map.end())
         {
           auto var_name = to_symbol2t(it->second.getSymbol()).get_symbol_name();
-          auto new_interval = interval_analysis[i_it].get_int_map()[var_name];
+          auto _new_interval = interval_analysis[i_it].intervals[var_name];
+          if (_new_interval.index() != 0)
+          {
+            it++;
+            continue;
+          }
+          interval_templatet<BigInt> new_interval = *std::get<0>(_new_interval);
           if (!new_interval.is_top())
           {
             auto lb = new_interval.get_lower().to_int64();
@@ -312,18 +317,18 @@ void goto_contractort::goto_contractor_condition(
           }
 
           interval_analysis(goto_functions, namespacet);
-          auto interval_map = interval_analysis[i_it].get_int_map();
-          auto it = interval_map.begin();
-
-          while (it != interval_map.end())
+          for (const auto &i : interval_analysis[i_it].intervals)            
           {
-            if (it->second.lower)
+            if (i.second.index() != 0)
+              continue;
+
+            const interval_templatet<BigInt> &value = *std::get<0>(i.second);
+            if (value.lower)
               map.update_lb_interval(
-                it->second.get_lower().to_int64(), it->first.as_string());
-            if (it->second.upper)
+                value.get_lower().to_int64(), i.first.as_string());
+            if (value.upper)
               map.update_ub_interval(
-                it->second.get_upper().to_int64(), it->first.as_string());
-            it++;
+                value.get_upper().to_int64(), i.first.as_string());
           }
 
           auto in = contractor.get_inner();
@@ -390,18 +395,20 @@ void goto_contractort::goto_contractor_condition(
 
         //get intervals and convert them to ibex intervals by updating the map
         interval_analysis(goto_functions, namespacet);
-        auto interval_map = interval_analysis[i_it].get_int_map();
-        auto it = interval_map.begin();
-        while (it != interval_map.end())
-        {
-          if (it->second.lower)
-            map.update_lb_interval(
-              it->second.get_lower().to_int64(), it->first.as_string());
-          if (it->second.upper)
-            map.update_ub_interval(
-              it->second.get_upper().to_int64(), it->first.as_string());
-          it++;
-        }
+        for (const auto &i : interval_analysis[i_it].intervals)            
+          {
+            if (i.second.index() != 0)
+              continue;
+
+            const interval_templatet<BigInt> &value = *std::get<0>(i.second);
+            if (value.lower)
+              map.update_lb_interval(
+                value.get_lower().to_int64(), i.first.as_string());
+            if (value.upper)
+              map.update_ub_interval(
+                value.get_upper().to_int64(), i.first.as_string());
+          }
+
         auto X = map.create_interval_vector();
 
         out->contract(X);
@@ -879,6 +886,7 @@ void expr_to_ibex_parser::parse_error(const expr2tc &expr)
   log_debug("contractor", "{}", oss.str());
 }
 
+#if 0
 void interval_analysis_ibex_contractor::maps_to_domains(
   int_mapt int_map,
   real_mapt real_map)
@@ -938,7 +946,7 @@ void interval_analysis_ibex_contractor::maps_to_domains(
     std::chrono::duration<double>(std::chrono::steady_clock::now() - t_0)
       .count();
 }
-
+#endif
 void interval_analysis_ibex_contractor::apply_contractor()
 {
   auto t_0 = std::chrono::steady_clock::now();
@@ -1098,3 +1106,4 @@ void interval_analysis_ibex_contractor::dump(bool is_timed)
     std::chrono::duration<double>(std::chrono::steady_clock::now() - t_0)
       .count();
 }
+

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -317,7 +317,7 @@ void goto_contractort::goto_contractor_condition(
           }
 
           interval_analysis(goto_functions, namespacet);
-          for (const auto &i : interval_analysis[i_it].intervals)            
+          for (const auto &i : interval_analysis[i_it].intervals)
           {
             if (i.second.index() != 0)
               continue;
@@ -395,19 +395,19 @@ void goto_contractort::goto_contractor_condition(
 
         //get intervals and convert them to ibex intervals by updating the map
         interval_analysis(goto_functions, namespacet);
-        for (const auto &i : interval_analysis[i_it].intervals)            
-          {
-            if (i.second.index() != 0)
-              continue;
+        for (const auto &i : interval_analysis[i_it].intervals)
+        {
+          if (i.second.index() != 0)
+            continue;
 
-            const interval_templatet<BigInt> &value = *std::get<0>(i.second);
-            if (value.lower)
-              map.update_lb_interval(
-                value.get_lower().to_int64(), i.first.as_string());
-            if (value.upper)
-              map.update_ub_interval(
-                value.get_upper().to_int64(), i.first.as_string());
-          }
+          const interval_templatet<BigInt> &value = *std::get<0>(i.second);
+          if (value.lower)
+            map.update_lb_interval(
+              value.get_lower().to_int64(), i.first.as_string());
+          if (value.upper)
+            map.update_ub_interval(
+              value.get_upper().to_int64(), i.first.as_string());
+        }
 
         auto X = map.create_interval_vector();
 
@@ -1106,4 +1106,3 @@ void interval_analysis_ibex_contractor::dump(bool is_timed)
     std::chrono::duration<double>(std::chrono::steady_clock::now() - t_0)
       .count();
 }
-

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -56,7 +56,7 @@ void goto_contractort::get_intervals(
         while (it != map.var_map.end())
         {
           auto var_name = to_symbol2t(it->second.getSymbol()).get_symbol_name();
-          auto _new_interval = interval_analysis[i_it].intervals[var_name];
+          auto _new_interval = interval_analysis[i_it].intervals->at(var_name);
           if (_new_interval.index() != 0)
           {
             it++;
@@ -317,7 +317,7 @@ void goto_contractort::goto_contractor_condition(
           }
 
           interval_analysis(goto_functions, namespacet);
-          for (const auto &i : interval_analysis[i_it].intervals)
+          for (const auto &i : *interval_analysis[i_it].intervals)
           {
             if (i.second.index() != 0)
               continue;
@@ -395,7 +395,7 @@ void goto_contractort::goto_contractor_condition(
 
         //get intervals and convert them to ibex intervals by updating the map
         interval_analysis(goto_functions, namespacet);
-        for (const auto &i : interval_analysis[i_it].intervals)
+        for (const auto &i : *interval_analysis[i_it].intervals)
         {
           if (i.second.index() != 0)
             continue;

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -18,10 +18,9 @@
 #include <ibex/ibex_Ctc.h>
 #include <irep2/irep2.h>
 #include <util/type_byte_size.h>
-#include <goto-programs/abstract-interpretation/interval_domain.h>
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
 #include <limits>
-
+#include <chrono>
 void goto_contractor(
   goto_functionst &goto_functions,
   const namespacet &namespacet,
@@ -393,6 +392,8 @@ public:
     }
   }
 
+
+
 private:
   size_t n = 0;
   bool is_empty_vector = false;
@@ -460,6 +461,7 @@ private:
   bool is_unsupported_operator_in_constraint_not(const expr2tc &expr);
 
 public:
+
   expr_to_ibex_parser(CspMap *map, ibex::Variable *vars)
   {
     this->map = map;
@@ -620,14 +622,6 @@ private:
 class interval_analysis_ibex_contractor
 {
 public:
-  typedef interval_templatet<BigInt> integer_intervalt;
-  using real_intervalt =
-    interval_templatet<boost::multiprecision::cpp_bin_float_100>;
-  typedef std::unordered_map<irep_idt, integer_intervalt, irep_id_hash>
-    int_mapt;
-
-  typedef std::unordered_map<irep_idt, real_intervalt, irep_id_hash> real_mapt;
-
   double parse_time{}, apply_time{}, mod_time{}, cpy_time{};
 
   interval_analysis_ibex_contractor()
@@ -658,7 +652,7 @@ public:
     return true;
   }
 
-  void maps_to_domains(int_mapt, real_mapt);
+  // void maps_to_domains(int_mapt, real_mapt);
 
   void apply_contractor();
 
@@ -667,6 +661,29 @@ public:
   void dump(bool is_timed);
 
   [[maybe_unused]] void modularize_intervals();
+
+      void interval_to_domain(
+    const std::optional<BigInt> &lower,
+    const std::optional<BigInt> &upper,
+    const std::string &name)
+  {
+    if (lower)
+      map.update_lb_interval(lower->to_int64(), name);
+    if (upper)
+      map.update_ub_interval(upper->to_int64(), name);
+  }
+
+  void interval_to_domain(
+    const std::optional<double> &lower,
+    const std::optional<double> &upper,
+    const std::string &name)
+  {
+    if (lower)
+      map.update_lb_interval(*lower, name);
+    if (upper)
+      map.update_ub_interval(*upper, name);    
+  }
+
 
 private:
   ibex::IntervalVector domains;

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -392,8 +392,6 @@ public:
     }
   }
 
-
-
 private:
   size_t n = 0;
   bool is_empty_vector = false;
@@ -461,7 +459,6 @@ private:
   bool is_unsupported_operator_in_constraint_not(const expr2tc &expr);
 
 public:
-
   expr_to_ibex_parser(CspMap *map, ibex::Variable *vars)
   {
     this->map = map;
@@ -662,7 +659,7 @@ public:
 
   [[maybe_unused]] void modularize_intervals();
 
-      void interval_to_domain(
+  void interval_to_domain(
     const std::optional<BigInt> &lower,
     const std::optional<BigInt> &upper,
     const std::string &name)
@@ -681,9 +678,8 @@ public:
     if (lower)
       map.update_lb_interval(*lower, name);
     if (upper)
-      map.update_ub_interval(*upper, name);    
+      map.update_ub_interval(*upper, name);
   }
-
 
 private:
   ibex::IntervalVector domains;

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -20,6 +20,7 @@
 #include <util/type_byte_size.h>
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
 #include <limits>
+#include <chrono>
 
 void goto_contractor(
   goto_functionst &goto_functions,

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -20,7 +20,7 @@
 #include <util/type_byte_size.h>
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
 #include <limits>
-#include <chrono>
+
 void goto_contractor(
   goto_functionst &goto_functions,
   const namespacet &namespacet,

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -4,7 +4,7 @@
 #include <catch2/catch.hpp>
 
 #include "../testing-utils/goto_factory.h"
-#include "goto-programs/abstract-interpretation/interval_domain.h"
+#include <goto-programs/abstract-interpretation/interval_domain.h>
 
 struct test_item
 {
@@ -22,32 +22,37 @@ public:
 
   void run_configs(bool needs_overflow_support = false)
   {
+
     if (!needs_overflow_support)
     {
+     
       // Common Interval Analysis (Linear from -infinity into +infinity)
       SECTION("Baseline")
       {
         log_status("Baseline");
         set_baseline_config();
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::int_mapt>(baseline);
+        run_test<0>(baseline);
       }
+
       SECTION("Interval Arithmetic")
       {
         log_status("Interval Arithmetic");
         set_baseline_config();
         interval_domaint::enable_interval_arithmetic = true;
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::int_mapt>(baseline);
+        run_test<0>(baseline);
       }
+
       SECTION("Modular Intervals")
       {
         log_status("Modular Intervals");
         set_baseline_config();
         interval_domaint::enable_modular_intervals = true;
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::int_mapt>(baseline);
+        run_test<0>(baseline);
       }
+
 
       SECTION("Contractor")
       {
@@ -55,7 +60,7 @@ public:
         set_baseline_config();
         interval_domaint::enable_contraction_for_abstract_states = true;
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::int_mapt>(baseline);
+        run_test<0>(baseline);
       }
 
       SECTION("Interval Arithmetic + Modular")
@@ -65,7 +70,7 @@ public:
         interval_domaint::enable_interval_arithmetic = true;
         interval_domaint::enable_modular_intervals = true;
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::int_mapt>(baseline);
+        run_test<0>(baseline);
       }
 
       SECTION("Interval Arithmetic + Modular + Contractor")
@@ -76,8 +81,9 @@ public:
         interval_domaint::enable_modular_intervals = true;
         interval_domaint::enable_contraction_for_abstract_states = true;
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::int_mapt>(baseline);
+        run_test<0>(baseline);
       }
+
       // Wrapped Intervals logic (see "Interval Analysis and Machine Arithmetic 2015" paper)
       SECTION("Wrapped Intervals")
       {
@@ -85,9 +91,12 @@ public:
         set_baseline_config();
         interval_domaint::enable_wrapped_intervals = true;
         ait<interval_domaint> baseline;
-        run_test<interval_domaint::wrap_mapt>(baseline);
+        run_test<2>(baseline);
       }
+
     }
+
+
     SECTION("Wrapped Intervals + Arithmetic + Bitwise")
     {
       log_status("Wrapped + Arithmetic + Bitwise");
@@ -96,8 +105,10 @@ public:
       interval_domaint::enable_interval_arithmetic = true;
       interval_domaint::enable_interval_bitwise_arithmetic = true;
       ait<interval_domaint> baseline;
-      run_test<interval_domaint::wrap_mapt>(baseline, true);
+      run_test<2>(baseline, true);
+     
     }
+
   }
 
   static void set_baseline_config()
@@ -114,10 +125,7 @@ public:
     interval_domaint::widening_narrowing = false;
   }
 
-  template <class T>
-  T get_map(interval_domaint &d) const;
-
-  template <class IntervalMap>
+  template <size_t Index>
   void run_test(
     ait<interval_domaint> &interval_analysis,
     bool precise_intervals = false)
@@ -140,7 +148,7 @@ public:
             property.find(i_it->location.get_line().as_string());
           if (to_check != property.end())
           {
-            auto state = get_map<IntervalMap>(interval_analysis[i_it]);
+            auto state = interval_analysis[i_it].intervals;
 
             for (auto property_it = to_check->second.begin();
                  property_it != to_check->second.end();
@@ -152,10 +160,10 @@ public:
               const auto &value = property_it->v;
 
               // we need to find the actual interval however... getting the original name is hard
-              auto interval = state.begin();
-              for (; interval != state.end(); interval++)
+              auto interval_it = state.begin();
+              for (; interval_it != state.end(); interval_it++)
               {
-                auto real_name = interval->first.as_string();
+                auto real_name = interval_it->first.as_string();
                 auto var_name = property_it->var;
 
                 if (var_name.size() > real_name.size())
@@ -166,7 +174,7 @@ public:
                   break;
               }
 
-              if (interval == state.end())
+              if (interval_it == state.end())
               {
                 CAPTURE(
                   precise_intervals,
@@ -177,13 +185,19 @@ public:
                 continue; // Var not present means TOP (which is always correct)
               }
 
-              // Hack to get values!
-              auto cpy = interval->second;
-              cpy.set_lower(value);
-              assert(cpy.lower);
-              REQUIRE(
-                interval->second.contains(*cpy.lower) ==
-                property_it->should_contain);
+              const interval &ref_variant = interval_it->second;
+	      REQUIRE(Index == ref_variant.index());
+	      const auto &ref = std::get<Index>(ref_variant);
+	      integer_intervalt cpy = *ref;
+	      cpy.set_lower(value);
+	      CAPTURE(
+		      ref->is_top(),
+		      ref->is_bottom(),
+		      property_it->should_contain,
+		      cpy.get_lower());
+	      REQUIRE((ref->is_top() || ref->is_bottom() || ref->upper || ref->lower));
+	      ref->dump();
+	      REQUIRE(ref->contains(cpy.get_lower()) == property_it->should_contain);      	    
             }
           }
         }
@@ -193,18 +207,6 @@ public:
     log_status("Success");
   }
 };
-
-template <>
-interval_domaint::int_mapt test_program::get_map(interval_domaint &d) const
-{
-  return d.get_int_map();
-}
-
-template <>
-interval_domaint::wrap_mapt test_program::get_map(interval_domaint &d) const
-{
-  return d.get_wrap_map();
-}
 
 TEST_CASE("Interval Analysis - Base Sign", "[ai][interval-analysis]")
 {
@@ -523,12 +525,15 @@ TEST_CASE("Interval Analysis - While Statement", "[ai][interval-analysis]")
     "return a;\n" // a : [100, 100]
     "}";
 
+  T.property["5"].push_back({"@F@main@a", 99, true});
+#if 0
   T.property["2"].push_back({"@F@main@a", 0, true});
   T.property["5"].push_back({"@F@main@a", 0, true});
-  T.property["5"].push_back({"@F@main@a", 99, true});
+
   T.property["7"].push_back({"@F@main@a", 1, true});
   T.property["7"].push_back({"@F@main@a", 100, true});
   T.property["9"].push_back({"@F@main@a", 100, true});
+  #endif
 
   T.run_configs();
 }

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -185,10 +185,10 @@ public:
                 continue; // Var not present means TOP (which is always correct)
               }
 
-              const interval &ref_variant = interval_it->second;
+              const interval_domaint::interval &ref_variant = interval_it->second;
 	      REQUIRE(Index == ref_variant.index());
 	      const auto &ref = std::get<Index>(ref_variant);
-	      integer_intervalt cpy = *ref;
+              interval_domaint::integer_intervalt cpy = *ref;
 	      cpy.set_lower(value);
 	      CAPTURE(
 		      ref->is_top(),

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -526,14 +526,12 @@ TEST_CASE("Interval Analysis - While Statement", "[ai][interval-analysis]")
     "}";
 
   T.property["5"].push_back({"@F@main@a", 99, true});
-#if 0
   T.property["2"].push_back({"@F@main@a", 0, true});
   T.property["5"].push_back({"@F@main@a", 0, true});
 
   T.property["7"].push_back({"@F@main@a", 1, true});
   T.property["7"].push_back({"@F@main@a", 100, true});
   T.property["9"].push_back({"@F@main@a", 100, true});
-  #endif
 
   T.run_configs();
 }

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -153,8 +153,8 @@ public:
               const auto &value = property_it->v;
 
               // we need to find the actual interval however... getting the original name is hard
-              auto interval_it = state.begin();
-              for (; interval_it != state.end(); interval_it++)
+              auto interval_it = state->begin();
+              for (; interval_it != state->end(); interval_it++)
               {
                 auto real_name = interval_it->first.as_string();
                 auto var_name = property_it->var;
@@ -167,7 +167,7 @@ public:
                   break;
               }
 
-              if (interval_it == state.end())
+              if (interval_it == state->end())
               {
                 CAPTURE(
                   precise_intervals,

--- a/unit/goto-programs/interval_analysis.test.cpp
+++ b/unit/goto-programs/interval_analysis.test.cpp
@@ -22,10 +22,8 @@ public:
 
   void run_configs(bool needs_overflow_support = false)
   {
-
     if (!needs_overflow_support)
     {
-     
       // Common Interval Analysis (Linear from -infinity into +infinity)
       SECTION("Baseline")
       {
@@ -52,7 +50,6 @@ public:
         ait<interval_domaint> baseline;
         run_test<0>(baseline);
       }
-
 
       SECTION("Contractor")
       {
@@ -93,9 +90,7 @@ public:
         ait<interval_domaint> baseline;
         run_test<2>(baseline);
       }
-
     }
-
 
     SECTION("Wrapped Intervals + Arithmetic + Bitwise")
     {
@@ -106,9 +101,7 @@ public:
       interval_domaint::enable_interval_bitwise_arithmetic = true;
       ait<interval_domaint> baseline;
       run_test<2>(baseline, true);
-     
     }
-
   }
 
   static void set_baseline_config()
@@ -185,19 +178,22 @@ public:
                 continue; // Var not present means TOP (which is always correct)
               }
 
-              const interval_domaint::interval &ref_variant = interval_it->second;
-	      REQUIRE(Index == ref_variant.index());
-	      const auto &ref = std::get<Index>(ref_variant);
+              const interval_domaint::interval &ref_variant =
+                interval_it->second;
+              REQUIRE(Index == ref_variant.index());
+              const auto &ref = std::get<Index>(ref_variant);
               interval_domaint::integer_intervalt cpy = *ref;
-	      cpy.set_lower(value);
-	      CAPTURE(
-		      ref->is_top(),
-		      ref->is_bottom(),
-		      property_it->should_contain,
-		      cpy.get_lower());
-	      REQUIRE((ref->is_top() || ref->is_bottom() || ref->upper || ref->lower));
-	      ref->dump();
-	      REQUIRE(ref->contains(cpy.get_lower()) == property_it->should_contain);      	    
+              cpy.set_lower(value);
+              CAPTURE(
+                ref->is_top(),
+                ref->is_bottom(),
+                property_it->should_contain,
+                cpy.get_lower());
+              REQUIRE((
+                ref->is_top() || ref->is_bottom() || ref->upper || ref->lower));
+              ref->dump();
+              REQUIRE(
+                ref->contains(cpy.get_lower()) == property_it->should_contain);
             }
           }
         }


### PR DESCRIPTION
This PR changes how the Interval Domain defines its state by:

1. Using more references and variants
2. Not storing TOP variables.
3. Filtering the variables that need to be joined
4. The interval domain is now a reference.