### PR TITLE
Python: Add support for len()

### DIFF
--- a/regression/python/bytes-neg-index/main.py
+++ b/regression/python/bytes-neg-index/main.py
@@ -1,0 +1,7 @@
+data = b'Python'
+assert data[-1] == 110
+assert data[-2] == 111
+assert data[-3] == 104
+assert data[-4] == 116
+assert data[-5] == 121
+assert data[-6] == 80

--- a/regression/python/bytes-neg-index/test.desc
+++ b/regression/python/bytes-neg-index/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/len-fail/main.py
+++ b/regression/python/len-fail/main.py
@@ -1,0 +1,2 @@
+data_arr = b'Hello'
+assert len(data_arr) == 4

--- a/regression/python/len-fail/test.desc
+++ b/regression/python/len-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/len/main.py
+++ b/regression/python/len/main.py
@@ -1,0 +1,2 @@
+data_arr = b'Hello'
+assert len(data_arr) == 5

--- a/regression/python/len/test.desc
+++ b/regression/python/len/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -35,6 +35,9 @@ bool is_class(const std::string &name, const JsonType &ast_json)
                   << ".json";
 
       std::ifstream imported_file(module_path.str());
+      if (!imported_file.is_open())
+        return false;
+
       JsonType imported_module_json;
       imported_file >> imported_module_json;
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4,6 +4,7 @@
 #include <ansi-c/convert_float_literal.h>
 #include <util/std_code.h>
 #include <util/c_types.h>
+#include <util/c_typecast.h>
 #include <util/arith_tools.h>
 #include <util/expr_util.h>
 #include <util/message.h>
@@ -475,28 +476,81 @@ std::string python_converter::get_classname_from_symbol_id(
   return class_name;
 }
 
+function_id python_converter::build_function_id(const nlohmann::json &element)
+{
+  const std::string __ESBMC_get_object_size = "__ESBMC_get_object_size";
+  const std::string __ESBMC_assume = "__ESBMC_assume";
+  const std::string __VERIFIER_assume = "__VERIFIER_assume";
+
+  bool is_member_function_call = false;
+  const nlohmann::json &func_json = element["func"];
+  const std::string &func_type = func_json["_type"];
+  std::string func_name, obj_name;
+  std::string func_symbol_id = create_symbol_id();
+
+  if (func_type == "Name")
+    func_name = func_json["id"];
+  else if (func_type == "Attribute")
+  {
+    func_name = func_json["attr"];
+    obj_name = func_json["value"]["id"];
+    if (json_utils::is_module(obj_name, ast_json))
+      func_symbol_id = create_symbol_id(imported_modules[obj_name]);
+    else
+      is_member_function_call = true;
+  }
+
+  if (func_name == "len")
+  {
+    func_name = __ESBMC_get_object_size;
+    func_symbol_id = "c:@F@" + __ESBMC_get_object_size;
+  }
+  else if (func_name == __ESBMC_assume || func_name == __VERIFIER_assume)
+    func_symbol_id = func_name;
+  else if (func_symbol_id.find("@F@") == std::string::npos)
+    func_symbol_id += "@F@" + func_name;
+
+  bool is_ctor_call = is_constructor_call(element);
+
+  // Insert class name in the symbol id
+  std::string class_name;
+  if (is_ctor_call || is_member_function_call)
+  {
+    std::size_t pos = func_symbol_id.rfind("@F@");
+    if (pos != std::string::npos)
+    {
+      if (is_ctor_call)
+        class_name = func_name;
+      else if (is_member_function_call)
+      {
+        assert(!obj_name.empty());
+        auto obj_node = find_var_decl(obj_name, ast_json);
+        if (obj_node == nlohmann::json())
+          abort();
+
+        class_name = obj_node["annotation"]["id"].get<std::string>();
+      }
+      func_symbol_id.insert(pos, "@C@" + class_name);
+    }
+  }
+
+  return {func_name, func_symbol_id, class_name};
+}
+
 exprt python_converter::get_function_call(const nlohmann::json &element)
 {
   // TODO: Refactor into different classes/functions
   if (element.contains("func") && element["_type"] == "Call")
   {
     bool is_member_function_call = false;
-    bool is_imported_module_call = false;
-    std::string func_name, obj_name;
-
-    if (element["func"]["_type"] == "Name")
+    if (element["func"]["_type"] == "Attribute")
     {
-      func_name = element["func"]["id"];
-    }
-    else if (element["func"]["_type"] == "Attribute")
-    {
-      func_name = element["func"]["attr"];
-      obj_name = element["func"]["value"]["id"];
-      if (json_utils::is_module(obj_name, ast_json))
-        is_imported_module_call = true;
-      else
+      if (!json_utils::is_module(element["func"]["value"]["id"], ast_json))
         is_member_function_call = true;
     }
+
+    function_id func_id = build_function_id(element);
+    std::string func_name(func_id.function_name);
 
     // nondet_X() functions restricted to basic types supported in Python
     std::regex pattern(
@@ -513,56 +567,30 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
 
     locationt location = get_location_from_decl(element);
+    const std::string func_symbol_id(func_id.symbol_id);
+    assert(!func_symbol_id.empty());
 
-    std::string func_symbol_id =
-      (is_imported_module_call) ? create_symbol_id(imported_modules[obj_name])
-                                : create_symbol_id();
-
-    if (func_symbol_id.find("@F@") == func_symbol_id.npos)
-      func_symbol_id += std::string("@F@") + func_name;
-
-    // __ESBMC_assume
-    if (func_name == "__ESBMC_assume" || func_name == "__VERIFIER_assume")
+    if (
+      func_name == "__ESBMC_assume" || func_name == "__VERIFIER_assume" ||
+      func_name == "__ESBMC_get_object_size")
     {
-      func_symbol_id = func_name;
       if (context.find_symbol(func_symbol_id.c_str()) == nullptr)
       {
         // Create/init symbol
-        symbolt symbol;
-        symbol.mode = "C";
-        symbol.module = python_filename;
-        symbol.location = location;
-        symbol.type = code_typet();
-        symbol.name = func_name;
-        symbol.id = func_symbol_id;
+        code_typet code_type;
+        if (func_name == "__ESBMC_get_object_size")
+        {
+          code_type.return_type() = int_type();
+          code_type.arguments().push_back(pointer_typet(empty_typet()));
+        }
 
+        symbolt symbol = create_symbol(
+          python_filename, func_name, func_symbol_id, location, code_type);
         context.add(symbol);
       }
     }
 
     bool is_ctor_call = is_constructor_call(element);
-
-    // Insert class name in the symbol id
-    std::string class_name;
-    if (is_ctor_call || is_member_function_call)
-    {
-      std::size_t pos = func_symbol_id.rfind("@F@");
-      if (pos != std::string::npos)
-      {
-        if (is_ctor_call)
-          class_name = func_name;
-        else if (is_member_function_call)
-        {
-          // Get class name from obj annotation
-          auto obj_node = find_var_decl(obj_name, ast_json);
-          if (obj_node == nlohmann::json())
-            abort();
-
-          class_name = obj_node["annotation"]["id"].get<std::string>();
-        }
-        func_symbol_id.insert(pos, "@C@" + class_name);
-      }
-    }
 
     const symbolt *func_symbol = context.find_symbol(func_symbol_id.c_str());
 
@@ -575,6 +603,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       if (is_ctor_call || is_member_function_call)
       {
         // Get method from a base class when it is not defined in the current class
+        const std::string class_name(func_id.class_name);
+
         func_symbol = find_function_in_base_classes(
           class_name, func_symbol_id, func_name, is_ctor_call);
 
@@ -591,6 +621,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         else if (is_member_function_call)
         {
           // Update obj attributes from self
+          const std::string &obj_name = element["func"]["value"]["id"];
           const std::string obj_symbol_id = create_symbol_id() + "@" + obj_name;
           assert(context.find_symbol(obj_symbol_id));
 
@@ -640,7 +671,26 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
 
     for (const auto &arg_node : element["args"])
-      call.arguments().push_back(get_expr(arg_node));
+    {
+      exprt arg = get_expr(arg_node);
+      if (func_name == "__ESBMC_get_object_size")
+      {
+        c_typecastt c_typecast(ns);
+        c_typecast.implicit_typecast(arg, pointer_typet(empty_typet()));
+      }
+      call.arguments().push_back(arg);
+    }
+
+    if (func_name == "__ESBMC_get_object_size")
+    {
+      side_effect_expr_function_callt sideeffect;
+      sideeffect.function() = call.function();
+      sideeffect.arguments() = call.arguments();
+      sideeffect.location() = call.location();
+      sideeffect.type() =
+        static_cast<const typet &>(call.function().type().return_type());
+      return sideeffect;
+    }
 
     return call;
   }
@@ -1429,6 +1479,7 @@ python_converter::python_converter(
   contextt &_context,
   const nlohmann::json &ast)
   : context(_context),
+    ns(_context),
     ast_json(ast),
     current_func_name(""),
     current_class_name(""),

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/context.h>
+#include <util/namespace.h>
 #include <nlohmann/json.hpp>
 
 #include <map>
@@ -8,6 +9,7 @@
 
 class codet;
 class struct_typet;
+class function_id;
 
 class python_converter
 {
@@ -30,6 +32,7 @@ private:
   exprt get_binary_operator_expr(const nlohmann::json &element);
   exprt get_logical_operator_expr(const nlohmann::json &element);
   exprt get_conditional_stm(const nlohmann::json &ast_node);
+  function_id build_function_id(const nlohmann::json &element);
   exprt get_function_call(const nlohmann::json &ast_block);
   exprt get_block(const nlohmann::json &ast_block);
 
@@ -62,6 +65,7 @@ private:
   std::string get_classname_from_symbol_id(const std::string &symbol_id) const;
 
   contextt &context;
+  namespacet ns;
   typet current_element_type;
   std::string python_filename;
   const nlohmann::json &ast_json;

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -33,4 +33,11 @@ enum class ExpressionType
   UNKNOWN,
 };
 
+struct function_id
+{
+  std::string function_name;
+  std::string symbol_id;
+  std::string class_name;
+};
+
 bool is_builtin_type(const std::string &name);


### PR DESCRIPTION
- Add support for [len() ](https://docs.python.org/3/library/functions.html#len)based on the **__ESBMC_get_object_size** intrinsic function, currently restricted to `bytes` type.
- Refactor the generation of func_name/symbol_id in `get_function_call()`
- Handle negative indexes on subscript