### PR TITLE
[smt_convt] fiexed seg fault in error trace

### DIFF
--- a/regression/esbmc-cpp/map/map_begin_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_begin_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_clear_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_clear_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_end_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_end_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_erase_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_erase_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 7 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_insert2_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_insert2_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_key_comp_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_key_comp_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_rbegin_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_rbegin_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_swap_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_swap_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_upper_lower_bound_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_upper_lower_bound_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_value_comp_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_value_comp_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_begin_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_begin_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_constructor_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_constructor_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_end_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_end_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_erase_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_erase_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 7 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_insert1_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert1_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_insert2_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert2_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_insert3_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_insert3_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_key_comp_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_key_comp_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_swap_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_swap_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_value_comp_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_value_comp_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/priority_queue/priority_queue_empty_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_empty_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 20 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/priority_queue/priority_queue_pop_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_pop_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/priority_queue/priority_queue_push_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_push_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/priority_queue/priority_queue_size_bug/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_size_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/k-induction-parallel/cpp_priority_queue_size_bug/test.desc
+++ b/regression/k-induction-parallel/cpp_priority_queue_size_bug/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --k-induction-parallel --max-k-step 5 
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/regression/k-induction/cpp_priority_queue_size_bug/test.desc
+++ b/regression/k-induction/cpp_priority_queue_size_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --k-induction 
 ^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2352,6 +2352,9 @@ expr2tc smt_convt::get(const expr2tc &expr)
 
   case expr2t::member_id:
   {
+    const member2t &mem = to_member2t(res);
+    expr2tc mem_src = mem.source_value;
+
     if (is_array_type(expr))
     {
       if (extracting_from_array_tuple_is_error)
@@ -2363,6 +2366,10 @@ expr2tc smt_convt::get(const expr2tc &expr)
       }
       return expr2tc(); // TODO: ??? This is horrible
     }
+    else if (
+      is_symbol2t(mem_src) && !is_pointer_type(expr) && !is_struct_type(expr))
+      return get_by_type(res);
+
     simplify(res);
     return res;
   }


### PR DESCRIPTION
For the code:

`int x = q->element[q->head];`

seg fault when building error trace, this is because `q->head` has not been converted into `int`.