### PR TITLE
[C++ verification] adjust return type for ref type

### DIFF
--- a/regression/esbmc-cpp/algorithm/algorithm100/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm100/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm101_partial_sort/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm101_partial_sort/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions  --z3 --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm102_partial_sort_copy/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm102_partial_sort_copy/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm103_nth_element/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm103_nth_element/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm106/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm106/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm110/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm110/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm120/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm120/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm121/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm121/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm20/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm20/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm22/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm22/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm28/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm28/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm3/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm30/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm30/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm31/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm31/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm32/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm32/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm4/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm40_sort1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm40_sort1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm41_stable_sort1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm41_stable_sort1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm42_partial_sort1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm42_partial_sort1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm47/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm47/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm5/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm5/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm51/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm51/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm6/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm6/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm61/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm61/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm62/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm62/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm66/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm66/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm67/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm67/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 12 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm68/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm68/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm69_adjacent_find1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm69_adjacent_find1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm83/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm83/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 8 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm85/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm85/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm90_unique/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm90_unique/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm91_unique_copy/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm91_unique_copy/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/algorithm/algorithm97/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm97/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ch21_28/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_28/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch21_31/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_31/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch21_34/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_34/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch21_35/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_35/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch21_41/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_41/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/list_reference-2/test.desc
+++ b/regression/esbmc-cpp/cpp/list_reference-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_constructor/test.desc
+++ b/regression/esbmc-cpp/deque/deque_constructor/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_end/test.desc
+++ b/regression/esbmc-cpp/deque/deque_end/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_front/test.desc
+++ b/regression/esbmc-cpp/deque/deque_front/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_operator_assign/test.desc
+++ b/regression/esbmc-cpp/deque/deque_operator_assign/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_pop_front/test.desc
+++ b/regression/esbmc-cpp/deque/deque_pop_front/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_back/test.desc
+++ b/regression/esbmc-cpp/list/list_back/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_class/test.desc
+++ b/regression/esbmc-cpp/list/list_class/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_class_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_class_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/list/list_constructor/test.desc
+++ b/regression/esbmc-cpp/list/list_constructor/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_front/test.desc
+++ b/regression/esbmc-cpp/list/list_front/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 3 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_pop_back/test.desc
+++ b/regression/esbmc-cpp/list/list_pop_back/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_pop_front/test.desc
+++ b/regression/esbmc-cpp/list/list_pop_front/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_push_front/test.desc
+++ b/regression/esbmc-cpp/list/list_push_front/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_remove_if/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_if/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_remove_if_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_remove_if_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/list/list_resize/test.desc
+++ b/regression/esbmc-cpp/list/list_resize/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 14 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_sort-3/test.desc
+++ b/regression/esbmc-cpp/list/list_sort-3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_unique-2/test.desc
+++ b/regression/esbmc-cpp/list/list_unique-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_unique_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_unique_bug-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 12 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_insert3/test.desc
+++ b/regression/esbmc-cpp/map/map_insert3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_insert3_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_insert3_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/queue/queue_back/test.desc
+++ b/regression/esbmc-cpp/queue/queue_back/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/queue/queue_front/test.desc
+++ b/regression/esbmc-cpp/queue/queue_front/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/queue/queue_pop/test.desc
+++ b/regression/esbmc-cpp/queue/queue_pop/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/queue/queue_push/test.desc
+++ b/regression/esbmc-cpp/queue/queue_push/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stack/stack_class/test.desc
+++ b/regression/esbmc-cpp/stack/stack_class/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stack/stack_class_bug/test.desc
+++ b/regression/esbmc-cpp/stack/stack_class_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/stack/stack_push/test.desc
+++ b/regression/esbmc-cpp/stack/stack_push/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stack/stack_top/test.desc
+++ b/regression/esbmc-cpp/stack/stack_top/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/template/algorithm32/test.desc
+++ b/regression/esbmc-cpp/template/algorithm32/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm20/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm20/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm22/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm22/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm3/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/vector/algorithm30/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm30/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm31/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm31/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm4/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 11 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/vector/algorithm5/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm5/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm5_char/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm5_char/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm6/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm6/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/vector/algorithm61/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm61/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/ch21_16/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_16/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/ch21_18/test.desc
+++ b/regression/esbmc-cpp/vector/ch21_18/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/vector41/test.desc
+++ b/regression/esbmc-cpp/vector/vector41/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/vector60/test.desc
+++ b/regression/esbmc-cpp/vector/vector60/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 15 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/vector/vector_operators/test.desc
+++ b/regression/esbmc-cpp/vector/vector_operators/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -93,6 +93,8 @@ protected:
   virtual void align_se_function_call_return_type(
     exprt &f_op,
     side_effect_expr_function_callt &expr);
+
+  virtual void adjust_reference(exprt &expr);
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_ADJUST_H_ */

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -45,7 +45,7 @@ protected:
   void adjust_side_effect_function_call(side_effect_expr_function_callt &expr);
   void adjust_side_effect_statement_expression(side_effect_exprt &expr);
   virtual void adjust_member(member_exprt &expr);
-  void adjust_expr_binary_arithmetic(exprt &expr);
+  virtual void adjust_expr_binary_arithmetic(exprt &expr);
   void adjust_expr_shifts(exprt &expr);
   void adjust_expr_unary_boolean(exprt &expr);
   void adjust_expr_binary_boolean(exprt &expr);

--- a/src/clang-c-frontend/clang_c_adjust.h
+++ b/src/clang-c-frontend/clang_c_adjust.h
@@ -45,7 +45,7 @@ protected:
   void adjust_side_effect_function_call(side_effect_expr_function_callt &expr);
   void adjust_side_effect_statement_expression(side_effect_exprt &expr);
   virtual void adjust_member(member_exprt &expr);
-  virtual void adjust_expr_binary_arithmetic(exprt &expr);
+  void adjust_expr_binary_arithmetic(exprt &expr);
   void adjust_expr_shifts(exprt &expr);
   void adjust_expr_unary_boolean(exprt &expr);
   void adjust_expr_binary_boolean(exprt &expr);

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -720,7 +720,7 @@ void clang_c_adjust::adjust_side_effect_function_call(
 
         if (symbol.lvalue)
           f_op.cmt_lvalue(true);
-
+          
         align_se_function_call_return_type(f_op, expr);
       }
       else
@@ -745,7 +745,10 @@ void clang_c_adjust::adjust_side_effect_function_call(
     }
   }
   else
+  {
+    align_se_function_call_return_type(f_op, expr);
     adjust_expr(f_op);
+  }
 
   // do implicit dereference
   if (f_op.is_address_of() && f_op.implicit() && (f_op.operands().size() == 1))

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -97,6 +97,7 @@ void clang_c_adjust::adjust_expr(exprt &expr)
     expr.id() == "<=" || expr.id() == ">" || expr.id() == ">=")
   {
     adjust_expr_rel(expr);
+    adjust_reference(expr);
   }
   else if (expr.is_index())
   {
@@ -112,6 +113,7 @@ void clang_c_adjust::adjust_expr(exprt &expr)
     expr.id() == "bitxor" || expr.id() == "bitor")
   {
     adjust_expr_binary_arithmetic(expr);
+    adjust_reference(expr);
   }
   else if (expr.id() == "shl" || expr.id() == "shr")
   {
@@ -222,7 +224,10 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
     {
     }
     else if (has_prefix(id2string(statement), "assign"))
+    {
       adjust_side_effect_assignment(expr);
+      adjust_reference(expr);
+    }
     else if (statement == "statement_expression")
       adjust_side_effect_statement_expression(expr);
     else if (statement == "gcc_conditional_expression")
@@ -1346,4 +1351,9 @@ void clang_c_adjust::align_se_function_call_return_type(
   side_effect_expr_function_callt &)
 {
   // nothing to be aligned for C
+}
+
+void clang_c_adjust::adjust_reference(exprt &)
+{
+  // nothing to adjust for C
 }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -720,7 +720,7 @@ void clang_c_adjust::adjust_side_effect_function_call(
 
         if (symbol.lvalue)
           f_op.cmt_lvalue(true);
-          
+
         align_se_function_call_return_type(f_op, expr);
       }
       else

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -45,6 +45,7 @@ public:
   void adjust_function_call_arguments(
     side_effect_expr_function_callt &expr) override;
   void adjust_expr_rel(exprt &expr) override;
+  void adjust_expr_binary_arithmetic(exprt &expr) override;
   void adjust_new(exprt &expr);
   void adjust_cpp_member(member_exprt &expr);
   void adjust_if(exprt &expr) override;
@@ -78,6 +79,7 @@ public:
    * ancillary methods to support the expr/code adjustments above
    */
   void convert_expression_to_code(exprt &expr);
+  void convert_reference(exprt &expr);
   void convert_ref_to_deref_symbol(exprt &expr);
   void convert_lvalue_ref_to_deref_sideeffect(exprt &expr);
   void align_se_function_call_return_type(

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -44,8 +44,7 @@ public:
   void adjust_side_effect_assign(side_effect_exprt &expr);
   void adjust_function_call_arguments(
     side_effect_expr_function_callt &expr) override;
-  void adjust_expr_rel(exprt &expr) override;
-  void adjust_expr_binary_arithmetic(exprt &expr) override;
+  void adjust_reference(exprt &expr) override;
   void adjust_new(exprt &expr);
   void adjust_cpp_member(member_exprt &expr);
   void adjust_if(exprt &expr) override;

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -215,8 +215,8 @@ void clang_cpp_adjust::adjust_expr_rel(exprt &expr)
 {
   clang_c_adjust::adjust_expr_rel(expr);
 
-  exprt &op0 = expr.op0();
-  convert_reference(op0);
+  for (auto &op : expr.operands())
+    convert_reference(op);
 }
 
 void clang_cpp_adjust::convert_reference(exprt &expr)

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -53,7 +53,7 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
     exprt &initializer = (exprt &)expr.find("initializer");
     adjust_expr(initializer);
   }
-  else if (has_prefix(id2string(statement), "assign"))
+  else if (statement == "assign")
   {
     adjust_side_effect_assign(expr);
   }
@@ -206,14 +206,12 @@ void clang_cpp_adjust::adjust_side_effect_assign(side_effect_exprt &expr)
   }
   else
     clang_c_adjust::adjust_side_effect(expr);
-
-  for (auto &op : expr.operands())
-    convert_reference(op);
 }
 
-void clang_cpp_adjust::adjust_expr_rel(exprt &expr)
+void clang_cpp_adjust::adjust_reference(exprt &expr)
 {
-  clang_c_adjust::adjust_expr_rel(expr);
+  if (!expr.has_operands())
+    return;
 
   for (auto &op : expr.operands())
     convert_reference(op);
@@ -264,14 +262,6 @@ void clang_cpp_adjust::convert_lvalue_ref_to_deref_sideeffect(exprt &expr)
   tmp_deref.set("#lvalue", true);
   tmp_deref.set("#implicit", true);
   expr.swap(tmp_deref);
-}
-
-void clang_cpp_adjust::adjust_expr_binary_arithmetic(exprt &expr)
-{
-  clang_c_adjust::adjust_expr_binary_arithmetic(expr);
-
-  for (auto &op : expr.operands())
-    convert_reference(op);
 }
 
 void clang_cpp_adjust::adjust_function_call_arguments(

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -53,7 +53,7 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
     exprt &initializer = (exprt &)expr.find("initializer");
     adjust_expr(initializer);
   }
-  else if (statement == "assign")
+  else if (has_prefix(id2string(statement), "assign"))
   {
     adjust_side_effect_assign(expr);
   }
@@ -206,6 +206,9 @@ void clang_cpp_adjust::adjust_side_effect_assign(side_effect_exprt &expr)
   }
   else
     clang_c_adjust::adjust_side_effect(expr);
+
+  for (auto &op : expr.operands())
+    convert_reference(op);
 }
 
 void clang_cpp_adjust::adjust_expr_rel(exprt &expr)

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -222,9 +222,10 @@ void clang_cpp_adjust::convert_reference(exprt &expr)
   if (expr.is_typecast())
   {
     // special treatment for lvalue reference typecasting
-    // if lhs is a typecast of lvalue reference, e.g. (int)r == 1
+    // if lhs is a typecast of lvalue reference,
+    // e.g. (int)r == 1, (int)r + 1, (int)r += 1
     // where r is a reference
-    // we turn it into (int)*r == 1
+    // we turn it into (int)*r
     exprt &tp_op0 = expr.op0();
     if (tp_op0.is_symbol() && is_lvalue_or_rvalue_reference(tp_op0.type()))
       convert_ref_to_deref_symbol(tp_op0);
@@ -232,11 +233,12 @@ void clang_cpp_adjust::convert_reference(exprt &expr)
   if (is_lvalue_or_rvalue_reference(expr.type()))
   {
     // special treatment for lvalue reference
-    // if LHS is an lvalue reference, e.g.
-    //  r == 1 or F(a) == 1 where F is a function that returns a reference
-    // but RHS is not a pointer. We got to dereference the LHS
+    // if LHS is an lvalue reference,
+    // e.g. r == 1, r += 1 or F(a) == 1 where F is a function that
+    // returns a reference but RHS is not a pointer.
+    // We got to dereference the LHS
     // and turn it into:
-    //  *r == 1 *F(a) == 1
+    //  *r, *F(a)
     dereference_exprt tmp_deref(expr, expr.type());
     tmp_deref.location() = expr.location();
     tmp_deref.set("#lvalue", true);


### PR DESCRIPTION
In this PR we fixed the functions return type:

The return type of `T &func()`has been converted into `pointer`.

Also we adjust this return value `return = func();`:

`return = 1` to `*return = 1`
`return == 1` to `*return == 1`
`a += return` to `a += *return`
`return +1` to `*return +1`


