### PR TITLE
Fix order of params

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -206,7 +206,7 @@ protected:
     locationt location);
 
   virtual void
-  get_decl_name(const clang::NamedDecl &vd, std::string &id, std::string &name);
+  get_decl_name(const clang::NamedDecl &vd, std::string &name, std::string &id);
 
   void
   get_start_location_from_stmt(const clang::Stmt &stmt, locationt &location);


### PR DESCRIPTION
All the implementations already have this order.
If I don't fix this, clang-tidy always complains about this.