### PR TITLE
[Help needed] [clang-cpp] Support ArrayInitLoopExpr

### DIFF
--- a/regression/esbmc/array-init-loop-expr/copy-constructor/main.cpp
+++ b/regression/esbmc/array-init-loop-expr/copy-constructor/main.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+
+struct a
+{
+  int b[3];
+};
+int main()
+{
+  a d{};
+  assert(d.b[0] == 0);
+  assert(d.b[1] == 0);
+  assert(d.b[2] == 0);
+  d.b[0] = 1;
+  assert(d.b[0] == 1);
+  assert(d.b[1] == 0);
+  assert(d.b[2] == 0);
+
+  int i = 0;
+  a e{d};
+  assert(e.b[0] == 1);
+  assert(e.b[1] == 0);
+  assert(e.b[2] == 0);
+  e.b[2] = 20;
+  assert(e.b[0] == 1);
+  assert(e.b[1] == 0);
+  assert(e.b[2] == 20);
+
+  return 0;
+}

--- a/regression/esbmc/array-init-loop-expr/copy-constructor/test.desc
+++ b/regression/esbmc/array-init-loop-expr/copy-constructor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -2,6 +2,7 @@
 #define CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_
 
 #include <clang-c-frontend/clang_c_adjust.h>
+#include "util/symbol_generator.h"
 
 /**
  * clang C++ adjuster class for:
@@ -84,6 +85,10 @@ public:
   void align_se_function_call_return_type(
     exprt &f_op,
     side_effect_expr_function_callt &expr) override;
+  void adjust_array_init_loop_expr(exprt &lhs, exprt &rhs, exprt &new_expr);
+
+protected:
+  symbol_generator tmp_symbol;
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -848,6 +848,33 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     }
     break;
   }
+  case clang::Expr::ArrayInitLoopExprClass:
+  {
+    const clang::ArrayInitLoopExpr &array_init_loop =
+      static_cast<const clang::ArrayInitLoopExpr &>(stmt);
+
+    exprt source_array_expr;
+    if (get_expr(*array_init_loop.getCommonExpr(), source_array_expr))
+      return true;
+
+    exprt per_element_init_expr;
+    if (get_expr(*array_init_loop.getSubExpr(), per_element_init_expr))
+      return true;
+
+    exprt array_size_expr = constant_exprt(array_init_loop.getArraySize().getSExtValue(), index_type());
+
+    new_expr = side_effect_exprt("array_init_loop_expr", source_array_expr.type());
+    new_expr.copy_to_operands(source_array_expr, per_element_init_expr, array_size_expr);
+    break;
+  }
+
+  case clang::Stmt::ArrayInitIndexExprClass:
+  {
+    exprt array_init_index_expr;
+    array_init_index_expr.name("__ARRAY_INIT_INDEX_EXPR__");
+    new_expr = array_init_index_expr;
+    break;
+  }
 
   default:
     if (clang_c_convertert::get_expr(stmt, new_expr))


### PR DESCRIPTION
This PR _tries_ to fix #1792.

Unfortunately I could not get this to really work.
My proof of concept (basically: https://github.com/esbmc/esbmc/commit/6bad2dde73e66fa63ec01589e97bcaf3a04c7dd8#diff-784347884400427356b283749ef36cc6e458d4d4df4f8e3a2a4007244a637b1eR1057-R1176) which I implemented in `clang_cpp_convert.cpp` actually successfully verified the test case, however I would assume that this would be the wrong place for the code.

I was thinking that `clang_cpp_adjust_expr.cpp` would be a better place, so I tried to move my code there.
However it fails with `migrate expr failed`.

**I would really appreciate if someone could take a look at this or guide me because I _feel_ like this should be pretty simple to implement for someone that is more familiar with the code.**

The high level goal of the PR is to support code like this:
```cpp
struct a
{
  int b[3];
};
int main()
{
  a d{};
  a e{d}; // copy constructor
}
```

When copying `d` to `e`, the array `b` also has to be copied.
Clang represents that using an `ArrayInitLoopExpr`.
So basically this should compile to this code:
```cpp
Symbol......: c:@S@a@F@a#&1$@S@a#
Module......: cpptest.pre
Base name...: a
Mode........: C++
Type........: constructor  (struct a *, const struct a &)
Value.......: 
{

array_init_loop_expr_tmp1 = &a::ref->b[0];
this->b[0] = array_init_loop_expr_tmp1[0];
this->b[1] = array_init_loop_expr_tmp1[1];
this->b[2] = array_init_loop_expr_tmp1[2];

}
```

Currently it looks like this (maybe that is the problem?):
```cpp
Symbol......: c:@S@a@F@a#&1$@S@a#
Module......: cpptest.pre
Base name...: a
Mode........: C++
Type........: constructor  (struct a *, const struct a &)
Value.......: 
{

{
array_init_loop_expr_tmp1 = &a::ref->b[0];

this->b[0] = array_init_loop_expr_tmp1[0];

this->b[1] = array_init_loop_expr_tmp1[1];

this->b[2] = array_init_loop_expr_tmp1[2];

};

}
```

(The `dag_match_replace_helper` stuff can be moved elsewhere if needed)