### PR TITLE
Add frontend support for some constructs used in the Linux kernel

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2756,6 +2756,18 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::AttributedStmtClass:
+  {
+    const clang::AttributedStmt &astmt =
+      static_cast<const clang::AttributedStmt &>(stmt);
+
+    /* ignore attributes for now */
+    if (get_expr(*astmt.getSubStmt(), new_expr))
+      return true;
+
+    break;
+  }
+
   default:
   {
     std::ostringstream oss;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1485,10 +1485,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
   switch (stmt.getStmtClass())
   {
-  /*
-       The following enum values are the the expr of a program,
-       defined on the Expr class
-    */
+  /* The following enum values are the the expr of a program,
+   * defined on the Expr class */
 
   // Objects that are implicit defined on the code syntax.
   // One example is the gcc ternary operator, which can be:

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2695,6 +2695,17 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::ChooseExprClass:
+  {
+    const clang::ChooseExpr &cexpr =
+      static_cast<const clang::ChooseExpr &>(stmt);
+
+    if (get_expr(*cexpr.getChosenSubExpr(), new_expr))
+      return true;
+
+    break;
+  }
+
   default:
   {
     std::ostringstream oss;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2685,7 +2685,9 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_type(tte.getType(), type))
       return true;
 
-    assert(type.id() == typet::t_bool);
+    assert(
+      type.id() == typet::t_bool || type.id() == typet::t_signedbv ||
+      type.id() == typet::t_unsignedbv);
 
     if (tte.getValue())
       new_expr = true_exprt();

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2745,6 +2745,20 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  /* Clang docs:
+   *
+   * GNU builtin-in function __builtin_choose_expr.
+   *
+   * This AST node is similar to the conditional operator (?:) in C, with the
+   * following exceptions:
+   *
+   * - the test expression must be a integer constant expression.
+   * - the expression returned acts like the chosen subexpression in every
+   *   visible way: the type is the same as that of the chosen subexpression,
+   *   and all predicates (whether it's an l-value, whether it's an integer
+   *   constant expression, etc.) return the same result as for the chosen
+   *   sub-expression.
+   */
   case clang::Stmt::ChooseExprClass:
   {
     const clang::ChooseExpr &cexpr =

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -207,6 +207,12 @@ void clang_c_languaget::build_compiler_args(const std::string &tmp_dir)
   for (auto const &inc : config.ansi_c.include_paths)
     compiler_args.push_back("-I" + inc);
 
+  for (const auto &inc : config.ansi_c.include_files)
+  {
+    compiler_args.push_back("-include");
+    compiler_args.push_back(inc);
+  }
+
   for (auto const &inc : config.ansi_c.forces)
     compiler_args.push_back("-f" + inc);
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -67,6 +67,10 @@ const struct group_opt_templ all_cmd_options[] = {
      boost::program_options::value<std::vector<std::string>>()->value_name(
        "path"),
      "set include path"},
+    {"include-file",
+     boost::program_options::value<std::vector<std::string>>()->value_name(
+       "file"),
+     "include files via frontend's -include option before anything else"},
     {"nostdinc", NULL, "do not include from standard system paths"},
     {"idirafter",
      boost::program_options::value<std::vector<std::string>>()->value_name(

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -119,6 +119,9 @@ bool configt::set(const cmdlinet &cmdline)
   if (cmdline.isset("define"))
     ansi_c.defines = cmdline.get_values("define");
 
+  if (cmdline.isset("include-file"))
+    ansi_c.include_files = cmdline.get_values("include-file");
+
   if (cmdline.isset("include"))
     ansi_c.include_paths = cmdline.get_values("include");
 

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -119,6 +119,7 @@ public:
     std::string locale_name;
 
     std::list<std::string> defines;
+    std::list<std::string> include_files;
     std::list<std::string> include_paths;
     std::list<std::string> idirafter_paths;
     std::list<std::string> forces;


### PR DESCRIPTION
This PR adds a new command-line option `--include-file` mapping to the `-include` option for Clang (also supported by GCC), which the kernel uses to include certain headers before the actual source code being translated. For now I'm testing this on `drivers/cxl/pci.c` via the following command line, corresponding to the (relevant) flags used by kernel's build system itself:
```
esbmc /usr/src/linux/drivers/cxl/pci.c -I /usr/src/linux/arch/x86/include/ -I /usr/src/linux/arch/x86/include/generated/  -I /usr/src/linux/include -I /usr/src/linux/arch/x86/include/uapi -I /usr/src/linux/arch/x86/include/generated/uapi -I /usr/src/linux/include/uapi -I /usr/src/linux/include/generated/uapi --include-file /usr/src/linux/./include/linux/compiler-version.h --include-file /usr/src/linux/./include/linux/kconfig.h --include-file /usr/src/linux/./include/linux/compiler_types.h  -D__KERNEL__ -DMODULE -DKBUILD_BASENAME='"pci"' -DKBUILD_MODNAME='"cxl_pci"' -D__KBUILD_MODNAME=kmod_cxl_pc
```
Additionally clang-c frontend support for features used in that driver (and its included headers):
- declared-only enum types as return value of function pointers (poorly, that's why I'd keep #1794 open for now),
- __builtin_choose_expr(), fixes #1796,
- dynamic members in offsetof(), fixes #1797, and
- clang::AttributedStmt such as [[fallthrough]].

With these changes, I'm now finally getting
```
ERROR: main symbol `main' not found
```
i.e., the C frontend handles all constructs in the unmodified kernel's CXL driver's "pci.c" file.