### PR TITLE
[python-frontend] Add type annotation to methods

### DIFF
--- a/regression/python/annotate-function/main.py
+++ b/regression/python/annotate-function/main.py
@@ -2,4 +2,5 @@ def error() -> None:
     a = b  ## Python annotation will fail here if esbmc is invoked without --function foo
 
 def foo() -> int:
-    return 1
+  x = 1
+  return x

--- a/regression/python/annotate-method/main.py
+++ b/regression/python/annotate-method/main.py
@@ -1,0 +1,3 @@
+class MyClass:
+    def foo() -> None:
+        x = 1

--- a/regression/python/annotate-method/test.desc
+++ b/regression/python/annotate-method/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic-typing/main.py
+++ b/regression/python/dynamic-typing/main.py
@@ -4,6 +4,7 @@ p = n  # Infer type of lhs from rhs variable type (int)
 def foo(a:int) -> None:
   b = 10
   c = a # Infer type of lhs from function arg type (int)
+  d = n # Infer from global scope variable
 
 v:uint64 = 16
 y = 1

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -26,6 +26,18 @@ public:
         add_annotation(element);
         update_end_col_offset(element);
       }
+      else if (element["_type"] == "ClassDef")
+      {
+        for (auto &class_member : element["body"])
+        {
+          // Process methods
+          if (class_member["_type"] == "FunctionDef")
+          {
+            add_annotation(class_member);
+            update_end_col_offset(class_member);
+          }
+        }
+      }
     }
   }
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -44,6 +44,9 @@ public:
   // Add annotation in a specific function
   void add_type_annotation(const std::string &func_name)
   {
+    // Add type annotation in global scope variables
+    add_annotation(ast_);
+
     for (Json &elem : ast_["body"])
     {
       if (elem["_type"] == "FunctionDef" && elem["name"] == func_name)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -57,6 +57,8 @@ private:
   symbolt *
   find_function_in_imported_modules(const std::string &symbol_id) const;
 
+  symbolt *find_symbol_in_global_scope(std::string &symbol_id) const;
+
   void update_instance_from_self(
     const std::string &class_name,
     const std::string &func_name,


### PR DESCRIPTION
- Extending type annotation to include methods. Previously, only functions were considered.
- Updated variable lookup to search in the global scope when not found in local functions. Now this scenario can be handled:
```
x = 10

def func():
  y = x
```