### PR TITLE
[python-frontend] Converting "for v in range(start, end, step)"

### DIFF
--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -5,6 +5,9 @@ class MyClass:
     def foo(self) -> None:
         self.data = 1
 
+    def blah(self) -> None:
+        x:int = self.data
+
 
 obj1 = MyClass(5)
 assert(obj1.data == 5)

--- a/regression/python/classes/main.py
+++ b/regression/python/classes/main.py
@@ -2,6 +2,9 @@ class MyClass:
     def __init__(self, value: int):
         self.data:int = value
 
+    def foo(self) -> None:
+        self.data = 1
+
 
 obj1 = MyClass(5)
 assert(obj1.data == 5)

--- a/regression/python/if-global-var/main.py
+++ b/regression/python/if-global-var/main.py
@@ -1,0 +1,5 @@
+cond = True
+y = 1
+if cond == True:
+    x = y
+

--- a/regression/python/if-global-var/test.desc
+++ b/regression/python/if-global-var/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/range-fail/main.py
+++ b/regression/python/range-fail/main.py
@@ -1,0 +1,5 @@
+x = 0
+for y in range(1, 5, 1):
+    x = y
+
+assert x == 5

--- a/regression/python/range-fail/test.desc
+++ b/regression/python/range-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/range/main.py
+++ b/regression/python/range/main.py
@@ -1,0 +1,5 @@
+x = 0
+for y in range(1, 5, 1):
+    x = y
+
+assert x == 4

--- a/regression/python/range/test.desc
+++ b/regression/python/range/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(range_py ${CMAKE_CURRENT_SOURCE_DIR}/memory-model/range.py)
+set(link_name ${CMAKE_CURRENT_BINARY_DIR}/range.py)
+
+file(CREATE_LINK ${range_py} ${link_name} SYMBOLIC)
 
 # `mangle` function is defined in src/scripts/cmake/Utils.cmake
   mangle(${CMAKE_CURRENT_BINARY_DIR}/pythonastgen.c  # an C file output containing python code
@@ -8,6 +12,8 @@
          MACRO ESBMC_FLAIL
          ACC_HEADERS_INTO ${CMAKE_CURRENT_BINARY_DIR}/pythonastgen.h
   )
+
+file(REMOVE ${link_name})
 
 add_library(pythonfrontend STATIC
             python_language.cpp

--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -1,19 +1,14 @@
-set(range_py ${CMAKE_CURRENT_SOURCE_DIR}/memory-model/range.py)
-set(link_name ${CMAKE_CURRENT_BINARY_DIR}/range.py)
-
-file(CREATE_LINK ${range_py} ${link_name} SYMBOLIC)
-
 # `mangle` function is defined in src/scripts/cmake/Utils.cmake
   mangle(${CMAKE_CURRENT_BINARY_DIR}/pythonastgen.c  # an C file output containing python code
          ${CMAKE_CURRENT_SOURCE_DIR} # the input directory folder where python files are located
+         RECURSIVE 1
          WILDCARD *.py
          SINGLE
          PREFIX esbmc_pythonastgen_
          MACRO ESBMC_FLAIL
          ACC_HEADERS_INTO ${CMAKE_CURRENT_BINARY_DIR}/pythonastgen.h
+         LIST_DIRECTORIES FALSE
   )
-
-file(REMOVE ${link_name})
 
 add_library(pythonfrontend STATIC
             python_language.cpp

--- a/src/python-frontend/astgen.py
+++ b/src/python-frontend/astgen.py
@@ -110,6 +110,7 @@ def main():
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
+    # Process and convert AST for main file
     with open(filename, "r") as source:
         tree = ast.parse(source.read())
 
@@ -123,6 +124,14 @@ def main():
 
     # Generate JSON from AST for the main file.
     generate_ast_json(tree, filename, None, output_dir)
+
+    # Process and convert AST for memory models
+    mm_filename = output_dir + "/memory-models/range.py"
+    with open(output_dir + "/memory-models/range.py") as memory_model:
+        mm_tree = ast.parse(memory_model.read())
+
+    # Generate JSON from AST for the memory models.
+    generate_ast_json(mm_tree, "range.py", None, output_dir) # TODO: Convert all Python files in memory-models folder
 
 
 if __name__ == "__main__":

--- a/src/python-frontend/astgen.py
+++ b/src/python-frontend/astgen.py
@@ -113,11 +113,15 @@ def main():
     with open(filename, "r") as source:
         tree = ast.parse(source.read())
 
-    # Handle imports
+    range_import = ast.ImportFrom(module='range', names=[ast.alias(name='*', asname=None)], level=0)
+    tree.body.insert(0, range_import)
+
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
+            # Handle imports
             process_imports(node, output_dir)
         elif isinstance(node, ast.Assign):
+            # Add type annotation on assignments
             add_type_annotation(node)
 
     # Generate JSON from AST for the main file.

--- a/src/python-frontend/astgen.py
+++ b/src/python-frontend/astgen.py
@@ -17,7 +17,7 @@ class ForToWhileTransformer(ast.NodeTransformer):
             else:
                 step = ast.Constant(value=1)
 
-            start_assign = ast.Assign(targets=[ast.Name(id='start', ctx=ast.Store())], value=start)
+            start_assign = ast.AnnAssign(target=ast.Name(id='start', ctx=ast.Store()), annotation=ast.Name(id='int', ctx=ast.Load()), value=start, simple=1)
             has_next_call = ast.Call(func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()), args=[start, end, step], keywords=[])
             has_next_assign = ast.AnnAssign(target=ast.Name(id='has_next', ctx=ast.Store()), annotation=ast.Name(id='bool', ctx=ast.Load()), value=has_next_call, simple=1)
             has_next_name = ast.Name(id='has_next', ctx=ast.Load())

--- a/src/python-frontend/astgen.py
+++ b/src/python-frontend/astgen.py
@@ -4,6 +4,37 @@ import importlib.util
 import json
 import os
 
+class ForToWhileTransformer(ast.NodeTransformer):
+    def __init__(self):
+        self.target_name = ""
+
+    def visit_For(self, node):
+        if isinstance(node.iter, ast.Call) and isinstance(node.iter.func, ast.Name) and node.iter.func.id == "range":
+            start = node.iter.args[0]
+            end = node.iter.args[1]
+            if len(node.iter.args) > 2:
+                step = node.iter.args[2]
+            else:
+                step = ast.Constant(value=1)
+
+            start_assign = ast.Assign(targets=[ast.Name(id='start', ctx=ast.Store())], value=start)
+            has_next_call = ast.Call(func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()), args=[start, end, step], keywords=[])
+            has_next_assign = ast.AnnAssign(target=ast.Name(id='has_next', ctx=ast.Store()), annotation=ast.Name(id='bool', ctx=ast.Load()), value=has_next_call, simple=1)
+            has_next_name = ast.Name(id='has_next', ctx=ast.Load())
+            while_cond = ast.Compare(left=has_next_name, ops=[ast.Eq()], comparators=[ast.Constant(value=True)])
+            transformed_body = []
+            self.target_name = node.target.id
+            for statement in node.body:
+                transformed_body.append(self.visit(statement))
+            while_body = transformed_body + [ast.Assign(targets=[ast.Name(id='start', ctx=ast.Store())], value=ast.Call(func=ast.Name(id='ESBMC_range_next_', ctx=ast.Load()), args=[ast.Name(id='start', ctx=ast.Load()), step], keywords=[])), ast.Assign(targets=[has_next_name], value=ast.Call(func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()), args=[ast.Name(id='start', ctx=ast.Load()), end, step], keywords=[]))]
+            while_stmt = ast.While(test=while_cond, body=while_body, orelse=[])
+            return [start_assign, has_next_assign, while_stmt]
+        return node
+
+    def visit_Name(self, node):
+        if node.id == self.target_name:
+            node.id = 'start'
+        return node
 
 def check_usage():
     if len(sys.argv) != 3:
@@ -114,6 +145,9 @@ def main():
     with open(filename, "r") as source:
         tree = ast.parse(source.read())
 
+    transformer = ForToWhileTransformer()
+    tree = transformer.visit(tree)
+
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             # Handle imports
@@ -126,7 +160,6 @@ def main():
     generate_ast_json(tree, filename, None, output_dir)
 
     # Process and convert AST for memory models
-    mm_filename = output_dir + "/memory-models/range.py"
     with open(output_dir + "/memory-models/range.py") as memory_model:
         mm_tree = ast.parse(memory_model.read())
 

--- a/src/python-frontend/astgen.py
+++ b/src/python-frontend/astgen.py
@@ -113,9 +113,6 @@ def main():
     with open(filename, "r") as source:
         tree = ast.parse(source.read())
 
-    range_import = ast.ImportFrom(module='range', names=[ast.alias(name='*', asname=None)], level=0)
-    tree.body.insert(0, range_import)
-
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             # Handle imports

--- a/src/python-frontend/astgen.py
+++ b/src/python-frontend/astgen.py
@@ -4,7 +4,7 @@ import importlib.util
 import json
 import os
 
-class ForToWhileTransformer(ast.NodeTransformer):
+class ForRangeToWhileTransformer(ast.NodeTransformer):
     def __init__(self):
         self.target_name = ""
 
@@ -145,7 +145,7 @@ def main():
     with open(filename, "r") as source:
         tree = ast.parse(source.read())
 
-    transformer = ForToWhileTransformer()
+    transformer = ForRangeToWhileTransformer()
     tree = transformer.visit(tree)
 
     for node in ast.walk(tree):

--- a/src/python-frontend/memory-models/range.py
+++ b/src/python-frontend/memory-models/range.py
@@ -1,0 +1,5 @@
+def ESBMC_range_next_(curr: int, step: int) -> int:
+  return curr + step
+
+def ESBMC_range_has_next_(curr: int, end: int, step: int) -> bool:
+  return curr + step <= end

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -868,7 +868,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       };
 
       // Get instance attribute from class component
-      if (class_type.has_component(attr_name) && is_instance_attr())
+      if (
+        class_type.has_component(attr_name) &&
+        (is_instance_attr() || is_converting_rhs))
       {
         const typet &attr_type = class_type.get_component(attr_name).type();
         expr = member_exprt(
@@ -1079,8 +1081,10 @@ void python_converter::get_var_assign(
   bool has_value = false;
   if (!ast_node["value"].is_null())
   {
+    is_converting_rhs = true;
     rhs = get_expr(ast_node["value"]);
     has_value = true;
+    is_converting_rhs = false;
   }
 
   if (has_value && rhs != exprt("_init_undefined"))

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1557,6 +1557,19 @@ bool python_converter::convert()
 
   python_filename = ast_json["filename"].get<std::string>();
 
+  // Load memory models -----
+  std::stringstream model_path;
+  model_path << ast_json["ast_output_dir"].get<std::string>() << "/range.json";
+  std::ifstream model_file(model_path.str());
+  nlohmann::json model_json;
+  model_file >> model_json;
+
+  exprt mm_code = get_block(model_json["body"]);
+  convert_expression_to_code(mm_code);
+
+  // Add imported code to main symbol
+  main_symbol.value.swap(mm_code);
+
   // Handle --function option
   const std::string function = config.options.get_option("function");
   if (!function.empty())

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1337,7 +1337,12 @@ void python_converter::get_attributes_from_self(
       typet type = get_typet(stmt["annotation"]["id"].get<std::string>());
       struct_typet::componentt comp =
         build_component(current_class_name, attr_name, type);
-      clazz.components().push_back(comp);
+
+      auto &class_components = clazz.components();
+      if (
+        std::find(class_components.begin(), class_components.end(), comp) ==
+        class_components.end())
+        class_components.push_back(comp);
     }
   }
 }

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -75,6 +75,7 @@ private:
   std::string current_class_name;
   exprt *ref_instance;
   bool is_converting_lhs = false;
+  bool is_converting_rhs = false;
   bool base_ctor_called = false;
 
   // Map object to list of instance attributes

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -32,14 +32,13 @@ static const std::string &dump_python_script()
   {
     dumped = true;
 #define ESBMC_FLAIL(body, size, ...)                                           \
-{ \
-  fs::path filePath(fs::path(p.path()) / #__VA_ARGS__); \
-  fs::path directory = filePath.parent_path(); \
-  if (!directory.empty() && !fs::exists(directory)) \
-    fs::create_directories(directory); \
-  std::ofstream(filePath.string()).write(body, size); \
-}
-
+  {                                                                            \
+    fs::path filePath(fs::path(p.path()) / #__VA_ARGS__);                      \
+    fs::path directory = filePath.parent_path();                               \
+    if (!directory.empty() && !fs::exists(directory))                          \
+      fs::create_directories(directory);                                       \
+    std::ofstream(filePath.string()).write(body, size);                        \
+  }
 
 #include <pythonastgen.h>
 #undef ESBMC_FLAIL

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -21,6 +21,7 @@ extern "C"
 #undef ESBMC_FLAIL
 }
 
+// TODO: Rename this function as it is dumping other files now.
 static const std::string &dump_python_script()
 {
   // Dump astgen.py into a temporary directory
@@ -31,7 +32,14 @@ static const std::string &dump_python_script()
   {
     dumped = true;
 #define ESBMC_FLAIL(body, size, ...)                                           \
-  std::ofstream(p.path() + "/" #__VA_ARGS__).write(body, size);
+{ \
+  fs::path filePath(fs::path(p.path()) / #__VA_ARGS__); \
+  fs::path directory = filePath.parent_path(); \
+  if (!directory.empty() && !fs::exists(directory)) \
+    fs::create_directories(directory); \
+  std::ofstream(filePath.string()).write(body, size); \
+}
+
 
 #include <pythonastgen.h>
 #undef ESBMC_FLAIL


### PR DESCRIPTION
This PR addresses the conversion of for-range statements such as:
```
for x in range(1, 5, 1):
  print(x)
```

Our approach involves transforming this construct into a corresponding while loop with the following structure:
```
def ESBMC_range_next_(curr: int, step: int) -> int:
  return curr + step

def ESBMC_range_has_next_(curr: int, end: int, step: int) -> bool:
  return curr + step <= end

start = 1  # start value is copied from the first parameter of range call
has_next:bool = ESBMC_range_has_next_(1, 5, 1) # ESBMC_range_has_next_ parameters copied from range call
while has_next == True:
    print(start)
    start = ESBMC_range_next_(start, 1)
    has_next = ESBMC_range_has_next_(start, 5, 1)
```

This process involves the following steps:
1) The definition for **ESBMC_range_next_** and **ESBMC_range_has_next_** are provided as models in "_memory-models/range.py_". This file is bundled in the ESBMC binary and deployed via "flail" functions. These functions are loaded prior to the conversion of the main program, as we do for other languages (C/C++).
2) The conversion from the for-loop to the corresponding while loop is accomplished through AST manipulation in astgen.py.