### PR TITLE
[C++ verification] supported throw decl

### DIFF
--- a/regression/esbmc-cpp/try_catch/try-catch_decl_01_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_01_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_04_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_04_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_10_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_10_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_07_bug/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_07_bug/main.cpp
@@ -16,7 +16,9 @@ class B {
   public: ~B() { throw E("Exception in ~B()"); }
 };
 
-int main() try {
+int main()
+{
+try {
   cout << "In main" << endl;
   static A cow;
   B bull;
@@ -24,4 +26,5 @@ int main() try {
 catch (E& e) {
   assert(0);
   cout << e.error << endl;
+}
 }

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_09/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_09/main.cpp
@@ -1,6 +1,7 @@
 #include<cassert>
 
 int main()
+{
 try {
   throw 5;
   return 0;
@@ -8,4 +9,4 @@ try {
 catch (int) {
   return -1;
 }
-
+}

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_09/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_09/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -36,6 +36,7 @@ public:
   void adjust_ifthenelse(codet &code) override;
   void adjust_decl_block(codet &code) override;
   void adjust_catch(codet &code);
+  void adjust_throw_decl(codet &code);
 
   /**
    * methods for expression (exprt) adjustment

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
@@ -20,6 +20,10 @@ void clang_cpp_adjust::adjust_code(codet &code)
   {
     adjust_catch(code);
   }
+  else if (statement == "throw_decl")
+  {
+    adjust_throw_decl(code);
+  }
   else
     clang_c_adjust::adjust_code(code);
 }
@@ -188,5 +192,19 @@ void clang_cpp_adjust::adjust_catch(codet &code)
 
     block.type() = code_typet();
     block.set("exception_id", ids.front());
+  }
+}
+
+void clang_cpp_adjust::adjust_throw_decl(codet &code)
+{
+  codet::operandst &operands = code.operands();
+
+  for (auto &op : operands)
+  {
+    std::vector<irep_idt> ids;
+    convert_exception_id(op.type(), "", ids);
+
+    op.type() = code_typet();
+    op.set("throw_decl_id", ids.front());
   }
 }

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1141,6 +1141,31 @@ bool clang_cpp_convertert::get_function_body(
     }
   }
 
+  auto *type = fd.getType().getTypePtr();
+  if (const auto *fpt = llvm::dyn_cast<const clang::FunctionProtoType>(type))
+  {
+    if (fpt->hasDynamicExceptionSpec())
+    {
+      codet decl = codet("throw_decl");
+      for (unsigned i = 0; i < fpt->getNumExceptions(); i++)
+      {
+        codet tmp;
+        if (get_type(fpt->getExceptionType(i), tmp.type()))
+          return true;
+
+        decl.move_to_operands(tmp);
+      }
+      body.operands().insert(body.operands().begin(), decl);
+
+      codet end = codet("throw_decl_end");
+      body.operands().push_back(end);
+    }
+    else if (fpt->hasNoexceptExceptionSpec())
+    {
+      // TODO
+    }
+  }
+
   return false;
 }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -912,8 +912,9 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       static_cast<const clang::CXXThrowExpr &>(stmt);
 
     exprt tmp;
-    if (get_expr(*cxxte.getSubExpr(), tmp))
-      return true;
+    if (cxxte.getSubExpr())
+      if (get_expr(*cxxte.getSubExpr(), tmp))
+        return true;
 
     new_expr = side_effect_exprt("cpp-throw", tmp.type());
     new_expr.move_to_operands(tmp);

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1147,6 +1147,9 @@ bool clang_cpp_convertert::get_function_body(
   {
     if (fpt->hasDynamicExceptionSpec())
     {
+      // e.g: void func() throw(int) { throw 1;}
+      // body is converted to
+      // {THROW_DECL(signed_int) throw 1; THROW_DECL_END}
       codet decl = codet("throw_decl");
       for (unsigned i = 0; i < fpt->getNumExceptions(); i++)
       {

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -237,7 +237,7 @@ bool goto_symext::unexpected_handler()
     return false;
 
   // We must look on the context if the user included exception lib
-  const symbolt *tmp = ns.lookup("std::unexpected()");
+  const symbolt *tmp = ns.lookup("c:@N@std@F@unexpected#");
   bool is_included = !tmp;
 
   // If it do, we must call the unexpected function:
@@ -252,7 +252,7 @@ bool goto_symext::unexpected_handler()
     // We only call it if the user replaced the default one
     if (
       to_symbol2t(to_code_function_call2t(the_call).function).thename ==
-      "std::default_unexpected()")
+      "c:@N@std@F@default_unexpected#")
       return false;
 
     // Indicate there we're inside the unexpected flow


### PR DESCRIPTION
This PR supported throw decl and updated the id of unexpected function.

for example code:
```cpp
void myfunction () throw (int) {
  throw 5.0;
}
```
goto-functions:
```cpp
myfunction (c:@F@myfunction#):
        // 20 no location
        THROW_DECL (signed_int)
        // 21 file main8.cpp line 2 column 3 function myfunction
        THROW double: 5.000000
        // 22 no location
        THROW_DECL_END ()
        // 23 file main8.cpp line 3 column 1 function myfunction
        END_FUNCTION // myfunction
```