### PR TITLE
[python-frontend] Support for class methods

### DIFF
--- a/regression/python/class-methods-fail/main.py
+++ b/regression/python/class-methods-fail/main.py
@@ -1,0 +1,6 @@
+class MyClass:
+    @classmethod
+    def my_method(cls) -> int:
+        return 1
+
+assert MyClass.my_method() == 2

--- a/regression/python/class-methods-fail/test.desc
+++ b/regression/python/class-methods-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/class-methods/main.py
+++ b/regression/python/class-methods/main.py
@@ -1,0 +1,6 @@
+class MyClass:
+    @classmethod
+    def my_method(cls) -> int:
+        return 1
+
+assert MyClass.my_method() == 1

--- a/regression/python/class-methods/test.desc
+++ b/regression/python/class-methods/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -165,16 +165,24 @@ private:
         }
 
         // Get type from RHS variable
-        else if (element["value"]["_type"] == "Name")
+        else if (
+          element["value"]["_type"] == "Name" ||
+          element["value"]["_type"] == "Subscript")
         {
+          std::string rhs_var_name;
+          if (element["value"]["_type"] == "Name")
+            rhs_var_name = element["value"]["id"];
+          else if (element["value"]["_type"] == "Subscript")
+            rhs_var_name = element["value"]["value"]["id"];
+
           // Find RHS variable declaration in the current scope
           auto rhs_node =
-            find_annotated_assign(element["value"]["id"], body["body"]);
+            find_annotated_assign(rhs_var_name, body["body"]);
 
           // Find RHS variable declaration in the current function
           if (rhs_node.empty() && current_func)
             rhs_node = find_annotated_assign(
-              element["value"]["id"], (*current_func)["body"]);
+              rhs_var_name, (*current_func)["body"]);
 
           // Find RHS variable in the function args
           if (rhs_node.empty() && body.contains("args"))

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -213,7 +213,10 @@ private:
            is_builtin_type(element["value"]["func"]["id"]) ||
            is_consensus_type(element["value"]["func"]["id"])))
           type = element["value"]["func"]["id"];
-
+        else if (
+          element["value"]["_type"] == "Call" &&
+          is_consensus_func(element["value"]["func"]["id"]))
+          type = get_type_from_consensus_func(element["value"]["func"]["id"]);
         else
           continue;
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -176,13 +176,12 @@ private:
             rhs_var_name = element["value"]["value"]["id"];
 
           // Find RHS variable declaration in the current scope
-          auto rhs_node =
-            find_annotated_assign(rhs_var_name, body["body"]);
+          auto rhs_node = find_annotated_assign(rhs_var_name, body["body"]);
 
           // Find RHS variable declaration in the current function
           if (rhs_node.empty() && current_func)
-            rhs_node = find_annotated_assign(
-              rhs_var_name, (*current_func)["body"]);
+            rhs_node =
+              find_annotated_assign(rhs_var_name, (*current_func)["body"]);
 
           // Find RHS variable in the function args
           if (rhs_node.empty() && body.contains("args"))

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1282,7 +1282,7 @@ void python_converter::get_function_definition(
     std::string arg_name = element["arg"].get<std::string>();
     // Argument type
     typet arg_type;
-    if (arg_name == "self")
+    if (arg_name == "self" || arg_name == "cls")
       arg_type = gen_pointer_type(get_typet(current_class_name));
     else
       arg_type = get_typet(element["annotation"]["id"].get<std::string>());

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -557,11 +557,15 @@ function_id python_converter::build_function_id(const nlohmann::json &element)
       else if (is_member_function_call)
       {
         assert(!obj_name.empty());
-        auto obj_node = find_var_decl(obj_name, ast_json);
-        if (obj_node == nlohmann::json())
-          abort();
-
-        class_name = obj_node["annotation"]["id"].get<std::string>();
+        if (is_builtin_type(obj_name))
+          class_name = obj_name;
+        else
+        {
+          auto obj_node = find_var_decl(obj_name, ast_json);
+          if (obj_node == nlohmann::json())
+            abort();
+          class_name = obj_node["annotation"]["id"].get<std::string>();
+        }
       }
       func_symbol_id.insert(pos, "@C@" + class_name);
     }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -106,6 +106,8 @@ typet python_converter::get_typet(const std::string &ast_type, size_t type_size)
     return long_long_uint_type();
   if (ast_type == "bool")
     return bool_type();
+  if (ast_type == "uint256" || ast_type == "BLSFieldElement")
+    return uint256_type();
   if (ast_type == "bytes")
   {
     typet char_type = signed_char_type();

--- a/src/python-frontend/python_frontend_types.cpp
+++ b/src/python-frontend/python_frontend_types.cpp
@@ -1,4 +1,6 @@
 #include <python_frontend_types.h>
+#include <map>
+#include <string>
 
 bool is_builtin_type(const std::string &name)
 {
@@ -8,4 +10,20 @@ bool is_builtin_type(const std::string &name)
 bool is_consensus_type(const std::string &name)
 {
   return (name == "uint64");
+}
+
+std::map<std::string, std::string> consensus_func_to_type = {
+  {"hash", "uint256"}};
+
+bool is_consensus_func(const std::string &name)
+{
+  return consensus_func_to_type.find(name) != consensus_func_to_type.end();
+}
+
+std::string get_type_from_consensus_func(const std::string &name)
+{
+  if (!is_consensus_func(name))
+    return std::string();
+
+  return consensus_func_to_type[name];
 }

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -44,3 +44,7 @@ bool is_builtin_type(const std::string &name);
 
 // TODO: Add a compilation flag or move it to a specific implementation
 bool is_consensus_type(const std::string &name);
+
+bool is_consensus_func(const std::string &name);
+
+std::string get_type_from_consensus_func(const std::string &name);

--- a/src/util/c_types.cpp
+++ b/src/util/c_types.cpp
@@ -150,6 +150,11 @@ type2tc uint128_type2()
   return get_uint_type(128);
 }
 
+typet uint256_type()
+{
+  return unsignedbv_typet(256);
+}
+
 typet long_uint_type()
 {
   return unsignedbv_typet(config.ansi_c.long_int_width);

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -15,6 +15,7 @@ typet int128_type();
 type2tc int128_type2();
 typet uint128_type();
 type2tc uint128_type2();
+typet uint256_type();
 typet long_int_type();
 type2tc long_int_type2();
 


### PR DESCRIPTION
This PR adds support for: 

- Conversion of class methods and their corresponding calls:
```python
class MyClass:
    @classmethod
    def my_method(cls) -> int:
        return 1

assert MyClass.my_method() == 1
```

- [BLSFieldElement](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#custom-types) type, which corresponds to an uint256.