### PR TITLE
Support (cross-)compiling for mingw64

### DIFF
--- a/BUILDING-cross-mingw.md
+++ b/BUILDING-cross-mingw.md
@@ -1,0 +1,166 @@
+# Cross-compiling a MinGW version of ESBMC for Windows
+
+This guide describes the procedure to obtain a Windows build of ESBMC via
+cross-compilation to mingw64 on x86_64 Ubuntu-22.04.
+
+## Prerequisites
+
+This guide assumes that the ESBMC repository is set up in $PWD/esbmc and that
+the files
+
+- llvm+clang-14-mingw.zip
+- z3-4.13.0-x64-win.zip
+
+are available in the current directory as well. The first one should contain a
+pre-built Clang-14 for mingw with the `posix` thread model.
+
+	sudo apt-get install -y \
+		mingw-w64-{i686-dev,x86-64-dev,tools} wine64 \
+		gcc-mingw-w64-x86-64-posix{,-runtime} \
+		g++-mingw-w64-x86-64-posix \
+		gcc-mingw-w64-i686-posix-runtime \
+		ninja cmake libboost1.74-tools-dev &&
+	unzip llvm+clang-14-mingw.zip &&
+	LLVM_OPT=-DLLVM_DIR=$PWD/llvm+clang-14-mingw/lib/cmake/llvm &&
+	CLANG_OPT=-DClang_DIR=$PWD/llvm+clang-14-mingw/lib/cmake/clang &&
+	unzip z3-4.13.0-x64-win.zip &&
+	Z3_OPT=-DZ3_DIR=$PWD/z3-4.13.0-x64-win
+
+## Create the toolchain file
+
+Create a CMake toolchain file for cross-compilation
+`/tmp/x86_64-w64-mingw32.toolchain.cmake` with the following contents:
+
+	set(CMAKE_SYSTEM_NAME         Windows)
+	set(CMAKE_SYSTEM_PROCESSOR    x86_64)
+
+	set(arch                      "x86_64")
+	set(os                        "w64")
+	set(flavor                    "mingw32")
+
+	set(triple                    "${arch}-${os}-${flavor}")
+
+	set(TOOLCHAIN_PREFIX          "${triple}-")
+	set(CMAKE_SYSROOT             "/usr/${triple}")
+
+	set(CMAKE_CROSSCOMPILING_EMULATOR /tmp/${triple}.cross-emu.sh)
+
+	set(CMAKE_ASM_COMPILER_TARGET ${triple})
+	set(CMAKE_C_COMPILER_TARGET   ${triple})
+	set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
+	set(CMAKE_AR                  ${TOOLCHAIN_PREFIX}ar${CMAKE_EXECUTABLE_SUFFIX})
+	set(CMAKE_ASM_COMPILER        ${TOOLCHAIN_PREFIX}gcc${CMAKE_EXECUTABLE_SUFFIX})
+	set(CMAKE_C_COMPILER          ${TOOLCHAIN_PREFIX}gcc${CMAKE_EXECUTABLE_SUFFIX})
+	set(CMAKE_CXX_COMPILER        ${TOOLCHAIN_PREFIX}g++${CMAKE_EXECUTABLE_SUFFIX})
+	set(CMAKE_LINKER              ${TOOLCHAIN_PREFIX}ld${CMAKE_EXECUTABLE_SUFFIX})
+	set(CMAKE_OBJCOPY             ${TOOLCHAIN_PREFIX}objcopy${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+	set(CMAKE_RANLIB              ${TOOLCHAIN_PREFIX}ranlib${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+	set(CMAKE_SIZE                ${TOOLCHAIN_PREFIX}size${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+	set(CMAKE_STRIP               ${TOOLCHAIN_PREFIX}strip${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+
+	# -lmsvcrt-os added for symbol '_setjmp' in llvm+clang-14-mingw
+	set(CMAKE_CXX_STANDARD_LIBRARIES "-lmsvcrt-os -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32" CACHE STRING "")
+	set(CMAKE_C_STANDARD_LIBRARIES "-lmsvcrt-os -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32" CACHE STRING "")
+
+	set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+	set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+	set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+	set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+## Create the cross-compile emulator wrapper around wine
+
+Create a file `/tmp/x86_64-w64-mingw32.cross-emu.sh` with the following
+contents
+
+	#!/bin/sh
+
+	exec env \
+		WINEDEBUG=fixme-all \
+		WINEPATH='/usr/x86_64-w64-mingw32/usr/bin;/usr/x86_64-w64-mingw32/usr/lib;/usr/lib/gcc/x86_64-w64-mingw32/13' \
+		wine64 "$@"
+
+and set it executable with
+
+	chmod +x /tmp/x86_64-w64-mingw32.cross-emu.sh
+
+## Compiling Boolector (optional)
+
+Note, this is experimental, since upstream only tested the win32 thread model:
+<https://github.com/Boolector/boolector/blob/master/COMPILING_WINDOWS.md#mingw>
+
+	git clone --depth 1 -b 3.2.3 https://github.com/Boolector/boolector.git &&
+	cd boolector &&
+	env \
+		CC=x86_64-w64-mingw32-gcc \
+		CXX=x86_64-w64-mingw32-g++ \
+		CPPFLAGS=-DNDEBUG\ -DMS_WIN64\ -DNGETRUSAGE \
+		AR=x86_64-w64-mingw32-ar \
+		RANLIB=x86_64-w64-mingw32-ranlib \
+		contrib/setup-picosat.sh &&
+	env \
+		CC=x86_64-w64-mingw32-gcc \
+		CXX=x86_64-w64-mingw32-g++ \
+		CPPFLAGS=-DNDEBUG\ -DMS_WIN64\ -DNGETRUSAGE \
+		AR=x86_64-w64-mingw32-ar \
+		RANLIB=x86_64-w64-mingw32-ranlib \
+		contrib/setup-btor2tools.sh &&
+	mkdir build &&
+	cd build &&
+	cmake .. \
+		-DPYTHON=OFF \
+		-DIS_WINDOWS_BUILD=1 \
+		-GNinja \
+		--toolchain /tmp/x86_64-w64-mingw32.toolchain.cmake \
+		-DCMAKE_INSTALL_PREFIX=$PWD/installed &&
+	ninja install &&
+	cd ../.. &&
+	BOOLECTOR_OPT=-DBoolector_DIR=$PWD/boolector/build/installed/lib/cmake/Boolector
+
+## Compiling Boost
+
+Boost uses a program called `b2` for building. In the prerequisites we've
+installed it, but the version needs to match the one installed on the system.
+That's why we're using v1.74.
+
+	cat > /tmp/boost-user-config.jam << EOF &&
+	using gcc : 10.3 : x86_64-w64-mingw32-g++ --sysroot=/usr/x86_64-w64-mingw32 : <cflags>" -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DMS_WIN64 -O3 -DNDEBUG -DNGETRUSAGE -std=gnu11" <cxxflags>" -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DMS_WIN64 -O3 -DNDEBUG -DNGETRUSAGE -std=gnu++11 -std=c++17" <linkflags>"" <archiver>"x86_64-w64-mingw32-ar" <ranlib>"x86_64-w64-mingw32-ranlib" ;
+	EOF
+	wget https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2 &&
+	tar xfj boost_1_74_0.tar.bz2 &&
+	cd boost_1_74_0 &&
+	b2 \
+		--user-config=/tmp/boost-user-config.jam \
+		--without-python \
+		--prefix=$PWD/installed \
+		-j`nproc` -q -d+2 pch=off --disable-icu boost.locale.icu=off \
+		--without-mpi --without-context --without-coroutine \
+		--without-fiber --without-stacktrace --layout=system \
+		threading=multi link=static \
+		-sNO_BZIP2=1 -sNO_LZMA=1 -sNO_ZLIB=0 -sNO_ZSTD=1 \
+		install &&
+	cd .. &&
+	BOOST_OPT=-DBoost_INCLUDE_DIR=$PWD/boost_1_74_0/installed/include &&
+	BOOST_OPT+=\ -DBoost_LIBRARY_DIR=$PWD/boost_1_74_0/installed/lib
+
+## Compiling ESBMC
+
+	mkdir esbmc/build &&
+	cd esbmc/build &&
+	cmake .. \
+		--toolchain /tmp/x86_64-w64-mingw32.toolchain.cmake \
+		-DBUILD_STATIC=ON \
+		-DBUILD_TESTING=OFF \
+		-GNinja \
+		-DC2GOTO_SYSROOT=/usr/x86_64-w64-mingw32 \
+		$LLVM_OPT \
+		$CLANG_OPT \
+		$Z3_OPT \
+		$BOOLECTOR_OPT \
+		$BOOST_OPT \
+		-DZLIB_LIBRARY=/usr/x86_64-w64-mingw32/lib/zlib1.dll \
+		-DZLIB_INCLUDE_DIR=/usr/x86_64-w64-mingw32/include \
+		-DCMAKE_INSTALL_PREFIX=$PWD/installed \
+		-DCMAKE_BUILD_TYPE:STRING=Release &&
+	ninja install &&
+	cd ../..

--- a/BUILDING-cross-mingw.md
+++ b/BUILDING-cross-mingw.md
@@ -76,8 +76,8 @@ contents
 	#!/bin/sh
 
 	exec env \
-		WINEDEBUG=fixme-all \
-		WINEPATH='/usr/x86_64-w64-mingw32/usr/bin;/usr/x86_64-w64-mingw32/usr/lib;/usr/lib/gcc/x86_64-w64-mingw32/13' \
+		WINEDEBUG=fixme-all,err-all \
+		WINEPATH='/usr/x86_64-w64-mingw32/usr/bin;/usr/x86_64-w64-mingw32/usr/lib;/usr/lib/gcc/x86_64-w64-mingw32/10-posix' \
 		wine64 "$@"
 
 and set it executable with

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -24,9 +24,13 @@ endif()
 
 function(add_esbmc_regression_test folder modes test)
     set(test_name "regression/${folder}/${test}")
+    set(cmd ${CMAKE_CROSSCOMPILING_EMULATOR}\ ${ESBMC_BIN})
+    if (DEFINED C2GOTO_SYSROOT)
+      string(APPEND cmd \ --sysroot\ ${C2GOTO_SYSROOT})
+    endif()
     add_test(NAME ${test_name}
              COMMAND ${Python_EXECUTABLE} ${ESBMC_REGRESSION_TOOL}
-                     --tool=${CMAKE_CROSSCOMPILING_EMULATOR}\ ${ESBMC_BIN}
+                     --tool=${cmd}
                      --regression=${CMAKE_CURRENT_SOURCE_DIR}/${folder}
                      --modes ${modes}
                      --file=${test}

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -26,7 +26,7 @@ function(add_esbmc_regression_test folder modes test)
     set(test_name "regression/${folder}/${test}")
     add_test(NAME ${test_name}
              COMMAND ${Python_EXECUTABLE} ${ESBMC_REGRESSION_TOOL}
-                     --tool=${ESBMC_BIN}
+                     --tool=${CMAKE_CROSSCOMPILING_EMULATOR}\ ${ESBMC_BIN}
                      --regression=${CMAKE_CURRENT_SOURCE_DIR}/${folder}
                      --modes ${modes}
                      --file=${test}

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -139,6 +139,7 @@ class Executor:
 
         try:
             # use subprocess.run because we want to wait for the subprocess to finish
+            print('running:' + repr(cmd))
             p = subprocess.run(cmd, stdout=PIPE, stderr=PIPE, timeout=self.timeout);
 
             # get the RSS (resident set size) of the subprocess that just terminated.

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -139,7 +139,7 @@ class Executor:
 
         try:
             # use subprocess.run because we want to wait for the subprocess to finish
-            print('running:' + repr(cmd))
+            print('running:' + repr(cmd), file=sys.stderr)
             p = subprocess.run(cmd, stdout=PIPE, stderr=PIPE, timeout=self.timeout);
 
             # get the RSS (resident set size) of the subprocess that just terminated.

--- a/scripts/cmake/UnixConfiguration.cmake
+++ b/scripts/cmake/UnixConfiguration.cmake
@@ -3,7 +3,7 @@
 if(UNIX AND NOT APPLE)    
     # Linux and BSDs
     message(STATUS "Detected non-apple Unix")
-    set(LIBGOMP_LIB "-lgomp -ldl")
+    set(LIBGOMP_LIB "-lgomp")
     set(OS_FLEX_SMTLIB_FLAGS "")
     set(OS_X86_INCLUDE_FOLDER "/usr/include/${CMAKE_LIBRARY_ARCHITECTURE}")
     set(OS_C2GOTO_FLAGS "")

--- a/scripts/cmake/Utils.cmake
+++ b/scripts/cmake/Utils.cmake
@@ -2,7 +2,7 @@
 
 set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc/esbmc")
 if(WIN32)
-    set(ESBMC_BIN "${CMAKE_INSTALL_PREFIX}/bin/esbmc.exe")
+    set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc/esbmc.exe")
 endif()
 
 # Assert that a variable is defined

--- a/scripts/cmake/Utils.cmake
+++ b/scripts/cmake/Utils.cmake
@@ -1,12 +1,8 @@
 # Module to utilities used throughout the project
 
-set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc")
-if (MSVC)
-    string(APPEND ESBMC_BIN "/${CMAKE_BUILD_TYPE}")
-endif()
-string(APPEND ESBMC_BIN "/esbmc")
-if (WIN32)
-    string(APPEND ESBMC_BIN ".exe")
+set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc/esbmc")
+if(WIN32)
+    set(ESBMC_BIN "${CMAKE_INSTALL_PREFIX}/bin/esbmc.exe")
 endif()
 
 # Assert that a variable is defined

--- a/scripts/cmake/Utils.cmake
+++ b/scripts/cmake/Utils.cmake
@@ -1,8 +1,12 @@
 # Module to utilities used throughout the project
 
-set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc/esbmc")
-if(WIN32)
-    set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc/esbmc.exe")
+set(ESBMC_BIN "${CMAKE_BINARY_DIR}/src/esbmc")
+if (MSVC)
+    string(APPEND ESBMC_BIN "/${CMAKE_BUILD_TYPE}")
+endif()
+string(APPEND ESBMC_BIN "/esbmc")
+if (WIN32)
+    string(APPEND ESBMC_BIN ".exe")
 endif()
 
 # Assert that a variable is defined

--- a/scripts/cmake/WindowsConfiguration.cmake
+++ b/scripts/cmake/WindowsConfiguration.cmake
@@ -16,7 +16,7 @@ if (WIN32)
 	set(Python_EXECUTABLE python)
   endif()
   message(STATUS "Found Python: ${Python_EXECUTABLE}")
-  set(LIBGOMP_LIB "-lgomp -ldl")
+  set(LIBGOMP_LIB "-lgomp")
   set(OS_X86_INCLUDE_FOLDER "C:/")
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/scripts/cmake/WindowsConfiguration.cmake
+++ b/scripts/cmake/WindowsConfiguration.cmake
@@ -17,9 +17,7 @@ if (WIN32)
   endif()
   message(STATUS "Found Python: ${Python_EXECUTABLE}")
   set(LIBGOMP_LIB "-lgomp -ldl")
-  set(OS_FLEX_SMTLIB_FLAGS "--wincompat")
   set(OS_X86_INCLUDE_FOLDER "C:/")
-  set(OS_C2GOTO_FLAGS "-D_MSVC")
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	  # There are a LOT of warnings from clang headers
@@ -36,10 +34,22 @@ if (WIN32)
       set(OS_Z3_LIBS "")
   else()
 	  message(AUTHOR_WARNING "${CMAKE_CXX_COMPILER_ID} is not tested in Windows. You may run into issues.")
+      set(OS_Z3_LIBS "")
 	endif()
+
+  if (MINGW)
+	set(OS_C2GOTO_FLAGS "")
+	set(OS_FLEX_SMTLIB_FLAGS "")
+  else()
+	set(OS_C2GOTO_FLAGS "-D_MSVC")
+	set(OS_FLEX_SMTLIB_FLAGS "--wincompat") # only for non-mingw
+  endif()
 
   # Produce static builds in windows
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-  set(Boost_USE_STATIC_LIBS        ON)
+
+  if (BUILD_STATIC)
+	set(Boost_USE_STATIC_LIBS        ON)
+  endif()
 
 endif()

--- a/src/c2goto/headers/CMakeLists.txt
+++ b/src/c2goto/headers/CMakeLists.txt
@@ -2,6 +2,7 @@ set(inputs
            ctype.h
            limits.h
            fenv.h
+           setjmp.h
            stdarg.h
            stdbool.h
            stddef.h

--- a/src/c2goto/headers/setjmp.h
+++ b/src/c2goto/headers/setjmp.h
@@ -1,0 +1,8 @@
+
+#pragma once
+
+#include_next <setjmp.h>
+
+/* mingw64 at least since v7 defines _setjmp to the incompatible
+ * __intrinsic_setjmpex. We don't care. */
+#undef _setjmp

--- a/src/c2goto/library/setjmp.c
+++ b/src/c2goto/library/setjmp.c
@@ -2,6 +2,7 @@
 #include <setjmp.h>
 
 #undef setjmp
+
 int setjmp(jmp_buf __env)
 {
   __ESBMC_unreachable();
@@ -9,7 +10,12 @@ int setjmp(jmp_buf __env)
 }
 
 // Due to some macro expansion some programs may have the _setjmp instead
+#ifdef __MINGW32__
+int __cdecl __attribute__((__nothrow__, __returns_twice__))
+_setjmp(jmp_buf __env, void *_Ctx)
+#else
 int _setjmp(jmp_buf __env)
+#endif
 {
   return setjmp(__env);
 }

--- a/src/c2goto/library/time.c
+++ b/src/c2goto/library/time.c
@@ -12,7 +12,15 @@
 
 time_t __VERIFIER_nondet_time_t();
 
+/* mingw has a static inline definition of time() in <time.h> delegating to
+ * either _time32 or _time64 */
+#if defined(__MINGW64__)
+time_t _time64(time_t *tloc)
+#elif defined(__MINGW32__)
+time_t _time32(time_t *tloc)
+#else
 time_t time(time_t *tloc)
+#endif
 {
 __ESBMC_HIDE:;
   time_t res = __VERIFIER_nondet_time_t();

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -710,7 +710,7 @@ void goto_convertt::do_function_call_symbol(
     t->location.comment(description);
     // we ignore any LHS
   }
-  else if (base_name == "_wassert")
+  else if (base_name == "_assert" || base_name == "_wassert")
   {
     // this is Windows
 

--- a/src/solvers/boolector/CMakeLists.txt
+++ b/src/solvers/boolector/CMakeLists.txt
@@ -62,6 +62,14 @@ if(ENABLE_BOOLECTOR)
 
   target_link_libraries(solvers INTERFACE solverbtor)
 
+  if (WIN32)
+    find_file(BTOR_DLL libbtor2parser.dll HINTS ${Boolector_DIR} PATH_SUFFIXES lib bin)
+    if (NOT BTOR_DLL STREQUAL "BTOR_DLL-NOTFOUND")
+      message(STATUS "Windows will install ${BTOR_DLL}")
+      install(FILES ${BTOR_DLL} DESTINATION bin)
+    endif()
+  endif()
+
   set(ESBMC_ENABLE_boolector 1 PARENT_SCOPE)
   set(ESBMC_AVAILABLE_SOLVERS "${ESBMC_AVAILABLE_SOLVERS} boolector"
       PARENT_SCOPE)

--- a/src/solvers/z3/CMakeLists.txt
+++ b/src/solvers/z3/CMakeLists.txt
@@ -50,7 +50,7 @@ if(ENABLE_Z3)
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
     if (BUILD_STATIC)
-        target_link_libraries(solverz3 fmt::fmt "${Z3_LIB}" -pthread "${LIBGOMP_LIB}" -ldl)
+        target_link_libraries(solverz3 fmt::fmt "${Z3_LIB}" -pthread "${LIBGOMP_LIB}")
     else ()
         target_link_libraries(solverz3 fmt::fmt "${Z3_LIB}")
     endif ()

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -398,15 +398,19 @@ std::string configt::this_operating_system()
 {
   std::string this_os;
 
-#ifdef _WIN32
+#if defined(__MINGW32__)
+  this_os = "mingw32";
+#elif defined(__MINGW64__)
+  this_os = "mingw64";
+#elif defined(_WIN32)
   this_os = "windows";
-#elif __APPLE__
+#elif defined(__APPLE__)
   this_os = "macos";
-#elif __FreeBSD__
+#elif defined(__FreeBSD__)
   this_os = "freebsd";
-#elif __linux__
+#elif defined(__linux__)
   this_os = "linux";
-#elif __SVR4
+#elif defined(__SVR4)
   this_os = "solaris";
 #else
   this_os = "unknown";


### PR DESCRIPTION
This PR contains the changes necessary for cross-compiling ESBMC from Gentoo to mingw64-11.0.0 using gcc-13.2.1 against Z3-4.13.0 (only, for now) and a mingw-build of Clang provided by @rafaelsamenezes in <https://github.com/esbmc/esbmc/issues/1801#issuecomment-2089891798>. For reference, this is the CMake --toolchain file I used:
<details>

```
set(CMAKE_SYSTEM_NAME               Windows)
set(CMAKE_SYSTEM_PROCESSOR          x86_64)

## Without that flag CMake is not able to pass test compilation check
#set(CMAKE_TRY_COMPILE_TARGET_TYPE   STATIC_LIBRARY)

# aarch64-linux-gnueabihf
set(arch                      "x86_64")
set(os                        "w64")
set(flavor                    "mingw32")

set(triple                    "${arch}-${os}-${flavor}")

set(TOOLCHAIN_PREFIX          "${triple}-")
set(CMAKE_SYSROOT             "/usr/${triple}")

#set(CMAKE_CROSSCOMPILING_EMULATOR qemu-${arch} -L "${CMAKE_SYSROOT}"
#                                               -E LD_LIBRARY_PATH=/usr/lib/gcc/${triple}/11.2.0)

#set(CMAKE_CROSSCOMPILING_EMULATOR sh -c '"$0" "$@" 2>/dev/null' wine64)
set(CMAKE_CROSSCOMPILING_EMULATOR /home/kane/scorch/esbmc/x86_64-w64-mingw32.cross-emu.sh)
#set(CMAKE_CROSSCOMPILING_EMULATOR env WINEDEBUG=fixme-all WINEPATH='/usr/x86_64-w64-mingw32/usr/bin\;/usr/x86_64-w64-mingw32/usr/lib\;/usr/lib/gcc/x86_64-w64-mingw32/13' wine64)

set(CMAKE_ASM_COMPILER_TARGET ${triple})
set(CMAKE_C_COMPILER_TARGET   ${triple})
set(CMAKE_CXX_COMPILER_TARGET ${triple})

set(CMAKE_AR                  ${TOOLCHAIN_PREFIX}ar${CMAKE_EXECUTABLE_SUFFIX})
set(CMAKE_ASM_COMPILER        ${TOOLCHAIN_PREFIX}gcc${CMAKE_EXECUTABLE_SUFFIX})
set(CMAKE_C_COMPILER          ${TOOLCHAIN_PREFIX}gcc${CMAKE_EXECUTABLE_SUFFIX})
set(CMAKE_CXX_COMPILER        ${TOOLCHAIN_PREFIX}g++${CMAKE_EXECUTABLE_SUFFIX})
set(CMAKE_LINKER              ${TOOLCHAIN_PREFIX}ld${CMAKE_EXECUTABLE_SUFFIX})
set(CMAKE_OBJCOPY             ${TOOLCHAIN_PREFIX}objcopy${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
set(CMAKE_RANLIB              ${TOOLCHAIN_PREFIX}ranlib${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
set(CMAKE_SIZE                ${TOOLCHAIN_PREFIX}size${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
set(CMAKE_STRIP               ${TOOLCHAIN_PREFIX}strip${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")

#set(CMAKE_C_FLAGS             "-Wno-psabi --specs=nosys.specs -fdata-sections -ffunction-sections -Wl,--gc-sections" CACHE INTERNAL "")
#set(CMAKE_C_FLAGS             "-Wno-psabi -fdata-sections -ffunction-sections -Wl,--gc-sections" CACHE INTERNAL "")
#set(CMAKE_CXX_FLAGS           "${CMAKE_C_FLAGS} -fno-exceptions" CACHE INTERNAL "")

#set(CMAKE_C_FLAGS_DEBUG       "-Os -g" CACHE INTERNAL "")
#set(CMAKE_C_FLAGS_RELEASE     "-Os -DNDEBUG" CACHE INTERNAL "")
#set(CMAKE_CXX_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG}" CACHE INTERNAL "")
#set(CMAKE_CXX_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE}" CACHE INTERNAL "")

# for symbol '_setjmp' in llvm+clang-14-mingw
set(CMAKE_CXX_STANDARD_LIBRARIES "-lmsvcrt-os -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32" CACHE STRING "")
set(CMAKE_C_STANDARD_LIBRARIES "-lmsvcrt-os -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32" CACHE STRING "")

set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
```

</details>

and this is the x86_64-w64-mingw32.cross-emu.sh: <details>

```sh
#!/bin/sh

ulimit -m $((8<<20))
exec env \
	WINEDEBUG=fixme-all \
	WINEPATH='/usr/x86_64-w64-mingw32/usr/bin;/usr/x86_64-w64-mingw32/usr/lib;/usr/lib/gcc/x86_64-w64-mingw32/13' \
	wine64 "$@"
```

</details>