### PR TITLE
Fix unnamed parameter

### DIFF
--- a/regression/esbmc-cpp/cpp/unnamed-parameter-fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/unnamed-parameter-fail/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+struct a
+{
+  a(int, int *c) : b(*c)
+  {
+  }
+  int b;
+};
+int f = 42;
+int main()
+{
+  a a(0, &f);
+  assert(a.b == 11);
+}

--- a/regression/esbmc-cpp/cpp/unnamed-parameter-fail/test.desc
+++ b/regression/esbmc-cpp/cpp/unnamed-parameter-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/unnamed-parameter/main.cpp
+++ b/regression/esbmc-cpp/cpp/unnamed-parameter/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+struct a
+{
+  a(int, int *c) : b(*c)
+  {
+  }
+  int b;
+};
+int f = 42;
+int main()
+{
+  a a(0, &f);
+  assert(a.b == 42);
+}

--- a/regression/esbmc-cpp/cpp/unnamed-parameter/test.desc
+++ b/regression/esbmc-cpp/cpp/unnamed-parameter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/constructor_4/test.desc
+++ b/regression/esbmc-solidity/constructor_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 contract.solast
 --function D --sol contract.sol
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -59,7 +59,7 @@ unsigned goto_symext::argument_assignments(
 
   // iterates over the types of the arguments
   for (unsigned int name_idx = 0; name_idx < function_type.arguments.size();
-       ++name_idx)
+       ++name_idx, it1++)
   {
     // if you run out of actual arguments there was a mismatch
     if (it1 == arguments.end())
@@ -115,8 +115,6 @@ unsigned goto_symext::argument_assignments(
       // TODO: Should we hide it (true means hidden)?
       symex_assign(code_assign2tc(lhs, rhs), true);
     }
-
-    it1++;
   }
 
   unsigned va_index = UINT_MAX;


### PR DESCRIPTION
Previously, when an identifier was empty, we would skip the loop iteration
by `continue`-ing it. This however had the effect that the iterator `it1`
would not be advanced, because that statement was at the end of the loop
and we just skipped it.
Move the advancement of the iterator such that it is always executed once
per loop iteration regardless of whether we might skip parts of the current
iteration.


The end result of not advancing the iteration was that we would confuse arguments and e.g. dereference the wrong one.
`regression/esbmc-cpp/cpp/unnamed-parameter/main.cpp` would fail, because `*c` in `b(*c)` would not dereference `&f` (the correct argument) but `0` which would fail!
