### PR TITLE
[C++ verification] supported more type of expction var

### DIFF
--- a/regression/esbmc-cpp/try_catch/ch13_1/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/ch13_2/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/ch13_3/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/ch13_8/test.desc
+++ b/regression/esbmc-cpp/try_catch/ch13_8/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex10-io_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex10-io_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex10-io_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex10-io_02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex12-template/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex12-template/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex13-nested-try-catch/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex13-nested-try-catch/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex14-loop-break-continue/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex14-loop-break-continue/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex15-nested-rethrow/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex15-nested-rethrow/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions  --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex16-multiple-live/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex16-multiple-live/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_05/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_05/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_06_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_06_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_07/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_07/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_08_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_08_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_decl_09/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_decl_09/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_order_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_order_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_order_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_order_03_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_pointer_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_pointer_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_pointer_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_pointer_02_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_03_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_04_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_04_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_06/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_14_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_14_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_15_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_15_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_simple_17_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_simple_17_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_03/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_03/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_04/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_05/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_05/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_06/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_07_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_07_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_03_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_vector_01/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_vector_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_vector_02_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_vector_02_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 11 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_vector_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_vector_03_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 11 --no-unwinding-assertions --timeout 900
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -614,7 +614,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
     code_declt decl(symbol_expr(*added_symbol));
     decl.location() = location_begin;
 
-    if (vd.hasInit())
+    if (vd.hasInit() && !vd.isExceptionVariable())
     {
       exprt val;
       if (get_expr(*vd.getInit(), val))

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -91,7 +91,8 @@ public:
   void convert_exception_id(
     const typet &type,
     const std::string &suffix,
-    std::vector<irep_idt> &ids);
+    std::vector<irep_idt> &ids,
+    bool is_catch = false);
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -911,13 +911,17 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::CXXThrowExpr &cxxte =
       static_cast<const clang::CXXThrowExpr &>(stmt);
 
+    new_expr = side_effect_exprt("cpp-throw", empty_typet());
+
     exprt tmp;
     if (cxxte.getSubExpr())
+    {
       if (get_expr(*cxxte.getSubExpr(), tmp))
         return true;
 
-    new_expr = side_effect_exprt("cpp-throw", tmp.type());
-    new_expr.move_to_operands(tmp);
+      new_expr.move_to_operands(tmp);
+      new_expr.type() = tmp.type();
+    }
 
     break;
   }
@@ -1052,6 +1056,9 @@ bool clang_cpp_convertert::get_function_body(
   // Parse body
   if (clang_c_convertert::get_function_body(fd, new_expr, ftype))
     return true;
+
+  if (new_expr.statement() != "block")
+    return false;
 
   code_blockt &body = to_code_block(to_code(new_expr));
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1696,6 +1696,7 @@ void clang_cpp_convertert::get_base_components_methods(
   base_map &map,
   struct_union_typet &type)
 {
+  irept::subt &base_ids = type.add("bases").get_sub();
   for (const auto &base : map)
   {
     std::string class_id = base.first;
@@ -1703,6 +1704,7 @@ void clang_cpp_convertert::get_base_components_methods(
     // get base class symbol
     symbolt *s = context.find_symbol(class_id);
     assert(s);
+    base_ids.emplace_back(s->id);
 
     const struct_typet &base_type = to_struct_type(s->type);
 

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -199,23 +199,7 @@ void goto_programt::instructiont::output_instruction(
     break;
 
   case THROW_DECL_END:
-    out << "THROW_DECL_END (";
-
-    if (!is_nil_expr(code))
-    {
-      const code_cpp_throw_decl_end2t &decl_end =
-        to_code_cpp_throw_decl_end2t(code);
-
-      for (auto const &it : decl_end.exception_list)
-      {
-        if (it != *decl_end.exception_list.begin())
-          out << ", ";
-        out << it;
-      }
-    }
-
-    out << ")";
-
+    out << "THROW_DECL_END";
     out << "\n";
     break;
 

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -78,6 +78,10 @@ unsigned goto_symext::argument_assignments(
     {
       ; // XXX jmorse, is this valid?
     }
+    else if (is_constant_string2t(*it1))
+    {
+      // ignore
+    }
     else
     {
       expr2tc rhs = *it1;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -220,14 +220,24 @@ void goto_symext::symex_step(reachability_treet &art)
           it != thrown_obj_map.end())
       {
         const expr2tc &thrown_obj = it->second;
-        assert(is_symbol2t(thrown_obj) || is_constant(thrown_obj));
 
         if (
           is_pointer_type(deref_code.target->type) &&
           !is_pointer_type(thrown_obj->type))
         {
-          expr2tc new_thrown_obj = address_of2tc(thrown_obj->type, thrown_obj);
-          deref_code.source = new_thrown_obj;
+          if (is_constant(thrown_obj))
+          {
+            expr2tc new_target =
+              dereference2tc(thrown_obj->type, deref_code.target);
+            deref_code.target = new_target;
+            deref_code.source = thrown_obj;
+          }
+          else
+          {
+            expr2tc new_thrown_obj =
+              address_of2tc(thrown_obj->type, thrown_obj);
+            deref_code.source = new_thrown_obj;
+          }
         }
         else
           deref_code.source = thrown_obj;


### PR DESCRIPTION
This RP supports exception ids of struct and array types:

1. Add a record for the base class to the type expression of the struct/class.
2. Exception variables are no longer initialized. (The initialized expression is incomplete for the struct type)
3. Ajusted the format of THROW_DECL_END goto function.
4. Fixed the empty expression in rethrow.
5. Adjusted C++get body function: `void func() try{ }catch{ }` In this case there is no block, so it is skipped.

esbmc-cpp/try_catch pass rate: 75%
old frontend: 88%