### PR TITLE
[C++ verification] supported noexcept

### DIFF
--- a/regression/esbmc-cpp/try_catch/try-catch_order_02/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_order_02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try-catch_tryblock_08/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_tryblock_08/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/try_catch_noexcept/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try_catch_noexcept/main.cpp
@@ -1,0 +1,12 @@
+void myfunction () noexcept {
+  // throw 5.0;
+}
+
+int main (void) {
+  try {
+    myfunction();
+  }
+  catch (...) { return 3; }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/try_catch_noexcept/test.desc
+++ b/regression/esbmc-cpp/try_catch/try_catch_noexcept/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900 --cppstd 11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/try_catch_noexcept_fail/main.cpp
+++ b/regression/esbmc-cpp/try_catch/try_catch_noexcept_fail/main.cpp
@@ -1,0 +1,12 @@
+void myfunction () noexcept {
+  throw 5.0;
+}
+
+int main (void) {
+  try {
+    myfunction();
+  }
+  catch (...) { return 3; }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/try_catch/try_catch_noexcept_fail/test.desc
+++ b/regression/esbmc-cpp/try_catch/try_catch_noexcept_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900 --cppstd 11
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -383,6 +383,11 @@ void clang_cpp_adjust::convert_exception_id(
     irep_idt identifier = "ellipsis";
     ids.emplace_back(id2string(identifier) + suffix);
   }
+  else if (type.id() == "noexcept")
+  {
+    irep_idt identifier = "noexcept";
+    ids.emplace_back(id2string(identifier) + suffix);
+  }
 
   // add C++ type
   std::string cpp_type = type.get("#cpp_type").as_string();

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -97,6 +97,7 @@ bool goto_symext::symex_throw()
   // a derived object with multiple inheritance
   unsigned old_id_number = -1, new_id_number = 0;
 
+  goto_symex_statet::call_stackt old_stack = cur_state->call_stack;
   for (auto const &it : throw_ref.exception_list)
   {
     // Handle throw declarations
@@ -132,6 +133,9 @@ bool goto_symext::symex_throw()
 
       if (new_id_number < old_id_number)
       {
+        cur_state->call_stack = old_stack;
+        cur_state->guard.make_true();
+
         update_throw_target(except, c_it->second, instruction.code);
         catch_insn = &c_it->second;
         catch_name = c_it->first;
@@ -287,7 +291,8 @@ void goto_symext::update_throw_target(
   symex_assign(code_assign2tc(thrown_obj, operand));
 
   // Now record that value for future reference.
-  cur_state->rename(thrown_obj);
+  if (!is_pointer_type(target->code->type))
+    cur_state->rename(thrown_obj);
 
   // Target is, as far as I can tell, always a declaration of the variable
   // that the thrown obj ends up in, and is followed by a (blank) assignment

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -167,6 +167,14 @@ void goto_symext::symex_step(reachability_treet &art)
   case END_FUNCTION:
     symex_end_of_function();
 
+    if (stack_catch.size())
+    {
+      // Get to the correct try (always the last one)
+      goto_symex_statet::exceptiont *except = &stack_catch.top();
+
+      except->has_throw_decl = false;
+      except->throw_list_set.clear();
+    }
     // Potentially skip to run another function ptr target; if not,
     // continue
     if (!run_next_function_ptr_target(false))

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -167,7 +167,7 @@ void goto_symext::symex_step(reachability_treet &art)
   case END_FUNCTION:
     symex_end_of_function();
 
-    if (stack_catch.size())
+    if (!stack_catch.empty())
     {
       // Get to the correct try (always the last one)
       goto_symex_statet::exceptiont *except = &stack_catch.top();


### PR DESCRIPTION
This PR support `noexcept` and fixed bugs:

1. Fixed catch order: `catch(base){} catch(base1){}`,  Assuming that both base and base1 can be caught, only the first catch block is now jumped.
2. Fixed `throw decl end`: `void a {throw_decl(); return; throw_decl_end; }` throw decl end will not execution in this case. Now this PR will be cleared when the function ends.
3. Fixed pointer type catch: catch(int &i), Pointer types don't use rename: `signed int *i = &thrown_obj`.

#1818 
