### PR TITLE
Fix some C++ APIs: memory, ios and istream

### DIFF
--- a/regression/esbmc-cpp11/cpp/istream-api/test-istream.cc
+++ b/regression/esbmc-cpp11/cpp/istream-api/test-istream.cc
@@ -1,0 +1,63 @@
+
+#include <istream>
+
+std::ios & g(std::ios &i)
+{
+	return i;
+}
+
+void f(std::istream &is)
+{
+	is >> std::boolalpha >> std::noboolalpha;
+	is >> std::showbase >> std::noshowbase;
+	is >> std::showpos >> std::noshowpos;
+	is >> std::skipws >> std::noskipws;
+	is >> std::uppercase >> std::nouppercase;
+	is >> std::unitbuf >> std::nounitbuf;
+	is >> std::internal >> std::left >> std::right;
+	is >> std::oct >> std::hex >> std::dec;
+	is >> std::hexfloat >> std::defaultfloat;
+	is >> std::fixed >> std::scientific;
+
+	is >> g;
+
+	bool b;
+	char c;
+	signed char sc;
+	unsigned char uc;
+	short s;
+	unsigned short us;
+	int i;
+	unsigned int ui;
+	long l;
+	unsigned long ul;
+	long long ll;
+	unsigned long long ull;
+	void *p;
+	float f;
+	double d;
+	long double ld;
+
+	is >> b;
+
+	is >> c;
+	is >> sc;
+	is >> uc;
+
+	is >> s;
+	is >> us;
+	is >> i;
+	is >> ui;
+	is >> l;
+	is >> ul;
+
+	is >> ll;
+	is >> ull;
+
+	is >> p;
+
+	is >> f;
+	is >> d;
+	is >> ld;
+}
+

--- a/regression/esbmc-cpp11/cpp/istream-api/test.desc
+++ b/regression/esbmc-cpp11/cpp/istream-api/test.desc
@@ -1,0 +1,4 @@
+CORE
+test-istream.cc
+--function f
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -427,6 +427,19 @@ ios_base &scientific(ios_base &str)
   return str;
 }
 
+#if __cplusplus >= 201103L
+ios_base &hexfloat(ios_base &str)
+{
+  str.ios_base::setf(__scientific | __fixed, __floatfield);
+  return str;
+}
+ios_base &defaultfloat(ios_base &str)
+{
+  str.ios_base::unsetf(__floatfield);
+  return str;
+}
+#endif
+
 //Adustment format flags ("adjustfield" flags):
 ios_base &internal(ios_base &str)
 {

--- a/src/cpp/library/istream
+++ b/src/cpp/library/istream
@@ -96,6 +96,16 @@ istream &operator>>(istream &is, char &val)
   is._gcount = 0;
   return is;
 }
+istream &operator>>(istream &is, signed char &val)
+{
+  is._gcount = 0;
+  return is;
+}
+istream &operator>>(istream &is, unsigned char &val)
+{
+  is._gcount = 0;
+  return is;
+}
 istream &operator>>(istream &is, short &val)
 {
   is._gcount = 0;
@@ -123,6 +133,18 @@ istream &operator>>(istream &is, long &val)
   return is;
 }
 istream &operator>>(istream &is, unsigned long &val)
+{
+  is._gcount = 0;
+  return is;
+}
+#endif
+#if __cplusplus >= 201103L
+istream &operator>>(istream &is, long long &val)
+{
+  is._gcount = 0;
+  return is;
+}
+istream &operator>>(istream &is, unsigned long long &val)
 {
   is._gcount = 0;
   return is;

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -90,22 +90,6 @@ copy(InputIterator first, InputIterator last, ForwardIterator result)
   return result;
 }
 
-template <class ForwardIterator, class T>
-void fill(ForwardIterator first, ForwardIterator last, const T &x)
-{
-  for (; first != last; ++first)
-    new (static_cast<void *>(&*first))
-      typename iterator_traits<ForwardIterator>::value_type(x);
-}
-
-template <class ForwardIterator, class Size, class T>
-void fill(ForwardIterator first, Size n, const T &x)
-{
-  for (; n--; ++first)
-    new (static_cast<void *>(&*first))
-      typename iterator_traits<ForwardIterator>::value_type(x);
-}
-
 #if 0
 template <class OutputIterator, class T>
 class raw_storage_iterator :


### PR DESCRIPTION
This PR:
- removes duplicate definitions of std::fill() from \<memory\>, fixing usage of that header for #1824
- adds operator>> support for std::istream and types (un)signed char and (un)signed long long (the latter for C++11 only)
- adds std::hexfloat() and std::defaultfloat() to \<ios\> for C++11

I've added a regression test using the std::istream operator>> APIs.