### PR TITLE
Fix some more C++ APIs: bitset, csignal and string_view

### DIFF
--- a/regression/esbmc-cpp/OM_sanity_checks/bitset/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/bitset/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
  --timeout 900
-
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch21_26/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_26/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/llbmc_bitset-test/test.desc
+++ b/regression/esbmc-cpp/cpp/llbmc_bitset-test/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/bitset
+++ b/src/cpp/library/bitset
@@ -14,6 +14,7 @@ namespace std
 
 class reference
 {
+  template <size_t>
   friend class bitset;
   reference(); // no public constructor
 public:
@@ -65,13 +66,14 @@ public:
   bitset<N> operator>>(size_t pos) const;
   bool operator==(const bitset<N> &rhs) const;
   bool operator!=(const bitset<N> &rhs) const;
-  template <size_t N>
-  bitset<N> operator&(const bitset<N> &lhs, const bitset<N> &rhs);
-  template <size_t N>
-  bitset<N> operator|(const bitset<N> &lhs, const bitset<N> &rhs);
-  template <size_t N>
-  bitset<N> operator^(const bitset<N> &lhs, const bitset<N> &rhs);
 };
+
+template <size_t N>
+bitset<N> operator&(const bitset<N> &lhs, const bitset<N> &rhs);
+template <size_t N>
+bitset<N> operator|(const bitset<N> &lhs, const bitset<N> &rhs);
+template <size_t N>
+bitset<N> operator^(const bitset<N> &lhs, const bitset<N> &rhs);
 
 } // namespace std
 #endif

--- a/src/cpp/library/bitset
+++ b/src/cpp/library/bitset
@@ -5,9 +5,6 @@
 #include "utility"
 #include "iterator"
 #include "string"
-using namespace std;
-
-#define BITSET_CAPACITY 20
 
 namespace std
 {
@@ -29,21 +26,18 @@ public:
 template <size_t N>
 class bitset
 {
-  int _size = 0;
-
 public:
-  bitset() : _size(0)
+  bitset()
   {
   }
-  bitset(unsigned long val) : _size(0)
+  bitset(unsigned long val)
   {
   }
   bitset<N> &flip();
   bitset<N> &flip(size_t pos);
   size_t size() const
   {
-    assert(0 <= _size && _size <= BITSET_CAPACITY);
-    return _size;
+    return N;
   }
   unsigned long to_ulong() const;
   bool any() const;

--- a/src/cpp/library/csignal
+++ b/src/cpp/library/csignal
@@ -5,7 +5,7 @@
 
 typedef void (*sighandler)(int);
 
-sighandler vector[16];
+sighandler __sighandlers[16];
 
 void signal(int sig, sighandler func)
 {
@@ -14,7 +14,7 @@ void signal(int sig, sighandler func)
       (sig == 15),
     "Signal must be equal to defined at lib csignal");
 
-  vector[sig] = func;
+  __sighandlers[sig] = func;
 }
 
 int raise(int sig)
@@ -24,10 +24,9 @@ int raise(int sig)
       (sig == 15),
     "Signal must be equal to defined at lib csignal");
 
-  if (vector[sig] != 0)
+  if (__sighandlers[sig] != 0)
   {
-    void *ret;
-    (*(vector[sig]))(sig);
+    __sighandlers[sig](sig);
     return 0;
   }
 

--- a/src/cpp/library/string_view
+++ b/src/cpp/library/string_view
@@ -63,7 +63,9 @@ public:
   // Operations
   size_t copy(char *dest, size_t count, size_t pos = 0) const
   {
-    memcpy(dest, str + pos, std::min(count, len - pos));
+    size_t n = std::min(count, len - pos);
+    memcpy(dest, str + pos, n);
+    return n;
   }
   string_view substr(size_t pos = 0, size_t count = npos) const
   {


### PR DESCRIPTION
This PR:
- makes \<bitset\> usable with other C++ headers, see #1824
- makes \<csignal\> interoperable with \<vector\> (though it should eventually (a) be moved to \<signal.h\> and (b) ~needs some regression tests to confirm it works at all~ *edit:* it has: esbmc-cpp/cpp/ch20_4, esbmc-cpp/cpp/ch20_8 and esbmc-cpp/OM_sanity_checks/csignal)
- fixes a missing return in std::string_view.