### PR TITLE
Added total VCCs collumn

### DIFF
--- a/scripts/competitions/svcomp/table.xml
+++ b/scripts/competitions/svcomp/table.xml
@@ -11,4 +11,5 @@
   <column displayTitle="GOTO Preprocessing Time" sourceUnit="s" title="goto-preprocessing">GOTO program processing time: (.*)s</column>
   <column displayTitle="Total Symex Time" sourceUnit="s" title="symex-total">Symex completed in: (.*)s .*</column>
   <column displayTitle="Total Solving Time" sourceUnit="s" title="decision-total">Runtime decision procedure: (.*)s</column>
+  <column displayTitle="VCC(s)" sourceUnit="i" title="vcc-total">Generated (.*) VCC.*</column>
 </table>


### PR DESCRIPTION
This will add a collumn to show how many VCCs were checked to reach the veredict. It can help comparing the impact of some of our transformations.

![Screenshot 2024-05-17 at 10 24 06](https://github.com/esbmc/esbmc/assets/8601807/b78a435e-a69d-47ec-afba-a696de38a70d)
