### PR TITLE
Update BUILDING.md for CVC5 build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -29,6 +29,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | CMake     | yes      | 3.18.0          |
 | Boolector | no       | 3.2.2           |
 | CVC4      | no       | 1.8             |
+| CVC5      | no       | 1.1.2           |
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.1           |
 | Z3        | no       | 4.8.9           |
@@ -215,11 +216,13 @@ If you need more details on CVC4, please refer to [its Github](https://github.co
 We have wrapped the entire build and setup of CVC5 in the following command:
 
 ```
-Linux:
-
-
-macOS:
-pip3 install toml && git clone https://github.com/CVC5/CVC5.git && cd CVC5 && git reset --hard 4cb2ab9 && ./configure.sh --prefix=../cvc5 --auto-download --static --no-static-binary && cd build && make -j4 && make install && cd .. && cd ..
+pip3 install toml &&
+git clone https://github.com/CVC5/CVC5.git &&
+cd CVC5 &&
+git switch --detach cvc5-1.1.2 &&
+./configure.sh --prefix=../cvc5 --auto-download --static --no-static-binary &&
+cd build && make -j4 && make install && cd .. &&
+cd ..
 ```
 
 If you need more details on CVC5, please refer to [its Github](https://github.com/CVC5/CVC5).


### PR DESCRIPTION
Basically, switch from v1.0.5 to v1.1.2. See #1846.