### PR TITLE
[BUILDING] updated Yices version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | CVC4      | no       | 1.8             |
 | CVC5      | no       | 1.1.2           |
 | MathSAT   | no       | 5.5.4           |
-| Yices     | no       | 2.6.1           |
+| Yices     | no       | 2.6.4           |
 | Z3        | no       | 4.8.9           |
 | Bitwuzla  | no       | 0.3.1           |
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -259,10 +259,10 @@ Then, we are able to build and setup Yices 2 using the following command:
 
 ```
 Linux:
-git clone https://github.com/SRI-CSL/yices2.git && cd yices2 && git checkout Yices-2.6.1 && autoreconf -fi && ./configure --prefix $PWD/../yices --with-static-gmp=$PWD/../gmp/lib/libgmp.a && make -j9 && make static-lib && make install && cp ./build/x86_64-pc-linux-gnu-release/static_lib/libyices.a ../yices/lib && cd ..
+git clone https://github.com/SRI-CSL/yices2.git && cd yices2 && git checkout Yices-2.6.4 && autoreconf -fi && ./configure --prefix $PWD/../yices --with-static-gmp=$PWD/../gmp/lib/libgmp.a && make -j9 && make static-lib && make install && cp ./build/x86_64-pc-linux-gnu-release/static_lib/libyices.a ../yices/lib && cd ..
 
 macOS:
-git clone https://github.com/SRI-CSL/yices2.git && cd yices2 && git checkout Yices-2.6.1 && autoreconf -fi && ./configure --prefix $PWD/../yices && make -j9 && make static-lib && make install && cp ./build/x86_64-apple-darwin*release/static_lib/libyices.a ../yices/lib && cd ..
+git clone https://github.com/SRI-CSL/yices2.git && cd yices2 && git checkout Yices-2.6.4 && autoreconf -fi && ./configure --prefix $PWD/../yices && make -j9 && make static-lib && make install && cp ./build/x86_64-apple-darwin*release/static_lib/libyices.a ../yices/lib && cd ..
 ```
 
 If you need more details on Yices 2, please refer to [its Github](https://github.com/SRI-CSL/yices2).


### PR DESCRIPTION
I encountered an error when trying to build `Yice -2.6.1` and resolved it after trying a new version `2.6.4`. I think we should change to the new version.

ENV: Ubuntu 22.04.3 LTS