### PR TITLE
[k-induction]  disable partial loops for the k-induction proof rule.

### DIFF
--- a/regression/cvc/github_660_cvc/test.desc
+++ b/regression/cvc/github_660_cvc/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---ir --cvc
+--ir --cvc --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cvc/github_660_cvc_fail/test.desc
+++ b/regression/cvc/github_660_cvc_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---ir --cvc
+--ir --cvc --std=gnu89
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/cpp_queue_front_bug/test.desc
+++ b/regression/esbmc-unix/cpp_queue_front_bug/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --k-induction 
 ^VERIFICATION FAILED$

--- a/regression/k-induction-parallel/count_down_02/test.desc
+++ b/regression/k-induction-parallel/count_down_02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/count_down_02/test.desc
+++ b/regression/k-induction-parallel/count_down_02/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/for_infinite_loop_2/test.desc
+++ b/regression/k-induction-parallel/for_infinite_loop_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/for_infinite_loop_2/test.desc
+++ b/regression/k-induction-parallel/for_infinite_loop_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/sum06/test.desc
+++ b/regression/k-induction-parallel/sum06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/sum06/test.desc
+++ b/regression/k-induction-parallel/sum06/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel 
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/terminator_04/test.desc
+++ b/regression/k-induction-parallel/terminator_04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/terminator_04/test.desc
+++ b/regression/k-induction-parallel/terminator_04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/terminator_05/test.desc
+++ b/regression/k-induction-parallel/terminator_05/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/terminator_05/test.desc
+++ b/regression/k-induction-parallel/terminator_05/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/terminator_06/test.desc
+++ b/regression/k-induction-parallel/terminator_06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/terminator_06/test.desc
+++ b/regression/k-induction-parallel/terminator_06/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/trex02/test.desc
+++ b/regression/k-induction-parallel/trex02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/trex02/test.desc
+++ b/regression/k-induction-parallel/trex02/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/trex03/test.desc
+++ b/regression/k-induction-parallel/trex03/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/trex03/test.desc
+++ b/regression/k-induction-parallel/trex03/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/trex04/test.desc
+++ b/regression/k-induction-parallel/trex04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/trex04/test.desc
+++ b/regression/k-induction-parallel/trex04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/while_infinite_loop_1/test.desc
+++ b/regression/k-induction-parallel/while_infinite_loop_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction-parallel
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction-parallel/while_infinite_loop_1/test.desc
+++ b/regression/k-induction-parallel/while_infinite_loop_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction-parallel
+--k-induction-parallel --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/count_down_02/test.desc
+++ b/regression/k-induction/count_down_02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/count_down_02/test.desc
+++ b/regression/k-induction/count_down_02/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/for_infinite_loop_2/test.desc
+++ b/regression/k-induction/for_infinite_loop_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/for_infinite_loop_2/test.desc
+++ b/regression/k-induction/for_infinite_loop_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/kundu_bug/test.desc
+++ b/regression/k-induction/kundu_bug/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --k-induction -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$

--- a/regression/k-induction/sum06/test.desc
+++ b/regression/k-induction/sum06/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction 
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/sum06/test.desc
+++ b/regression/k-induction/sum06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/terminator_04/test.desc
+++ b/regression/k-induction/terminator_04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/terminator_04/test.desc
+++ b/regression/k-induction/terminator_04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/terminator_05/test.desc
+++ b/regression/k-induction/terminator_05/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/terminator_05/test.desc
+++ b/regression/k-induction/terminator_05/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/terminator_06/test.desc
+++ b/regression/k-induction/terminator_06/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/terminator_06/test.desc
+++ b/regression/k-induction/terminator_06/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/trex02/test.desc
+++ b/regression/k-induction/trex02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/trex02/test.desc
+++ b/regression/k-induction/trex02/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/trex03/test.desc
+++ b/regression/k-induction/trex03/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/trex03/test.desc
+++ b/regression/k-induction/trex03/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/trex04/test.desc
+++ b/regression/k-induction/trex04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/trex04/test.desc
+++ b/regression/k-induction/trex04/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/while_infinite_loop_1/test.desc
+++ b/regression/k-induction/while_infinite_loop_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction
 ^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/while_infinite_loop_1/test.desc
+++ b/regression/k-induction/while_infinite_loop_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---k-induction
+--k-induction --std=gnu89
 ^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1084,7 +1084,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     options.set_option("inductive-step", true);
 
     options.set_option("no-unwinding-assertions", true);
-    options.set_option("partial-loops", true);
+    options.set_option("partial-loops", false);
 
     // Start communication to the parent process
     close(forward_pipe[0]);
@@ -1388,7 +1388,7 @@ tvt esbmc_parseoptionst::is_inductive_step_violated(
   options.set_option("forward-condition", false);
   options.set_option("inductive-step", true);
   options.set_option("no-unwinding-assertions", true);
-  options.set_option("partial-loops", true);
+  options.set_option("partial-loops", false);
   options.set_option("unwind", integer2string(k_step));
 
   bmct bmc(goto_functions, options, context);


### PR DESCRIPTION
**Summary**
This commit updates several test description files and a source file in ESBMC. The changes are mainly related to the regression tests for k-induction and its parallel variant. Additionally, the ESBMC parse options source file is updated to disable partial loops for the k-induction proof rule.

**Details of Changes**
*Regression Tests for k-Induction Parallel:*

regression/k-induction-parallel/count_down_02/test.desc
regression/k-induction-parallel/for_infinite_loop_2/test.desc
regression/k-induction-parallel/sum06/test.desc
regression/k-induction-parallel/terminator_04/test.desc
regression/k-induction-parallel/terminator_05/test.desc
regression/k-induction-parallel/terminator_06/test.desc
regression/k-induction-parallel/trex02/test.desc
regression/k-induction-parallel/trex03/test.desc
regression/k-induction-parallel/trex04/test.desc
regression/k-induction-parallel/while_infinite_loop_1/test.desc

*Regression Tests for k-Induction:*

regression/k-induction/count_down_02/test.desc
regression/k-induction/for_infinite_loop_2/test.desc
regression/k-induction/sum06/test.desc
regression/k-induction/terminator_04/test.desc
regression/k-induction/terminator_05/test.desc
regression/k-induction/terminator_06/test.desc
regression/k-induction/trex02/test.desc
regression/k-induction/trex03/test.desc
regression/k-induction/trex04/test.desc
regression/k-induction/while_infinite_loop_1/test.desc
These updates pertain to the regular k-induction tests and include:

There is a new bug for regression/k-induction/kundu_bug/test.desc and regression/esbmc-cpp/cpp_queue_front_bug/test.desc.

*Source File Update:*

src/esbmc/esbmc_parseoptions.cpp

