### PR TITLE
[clang-cpp] move struct to pointer conversion to adjuster.

### DIFF
--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -47,6 +47,7 @@ public:
   void adjust_side_effect_assign(side_effect_exprt &expr);
   void adjust_function_call_arguments(
     side_effect_expr_function_callt &expr) override;
+  void adjust_member_function_this_argument(exprt &expr);
   void adjust_reference(exprt &expr) override;
   void adjust_new(exprt &expr);
   void adjust_cpp_member(member_exprt &expr);

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -618,6 +618,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     exprt implicit_object;
     if (get_expr(*member_call.getImplicitObjectArgument(), implicit_object))
       return true;
+    implicit_object.set("#implicit_object", true);
 
     call.arguments().push_back(implicit_object);
 

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -4390,7 +4390,7 @@ bool solidity_convertert::get_mapping_definition(
 
   // get address: &m
   exprt address_of = address_of_exprt(mapping_ins);
-  call_expr.arguments().push_back(mapping_ins);
+  call_expr.arguments().push_back(address_of);
 
   // get block
   code_blockt _block;

--- a/src/util/c_typecast.cpp
+++ b/src/util/c_typecast.cpp
@@ -716,19 +716,6 @@ void c_typecastt::implicit_typecast_followed(
 
       return; // ok
     }
-
-    if (src_type.id() == "struct")
-    {
-      // We got a case to convert derived class object to base base class pointer, e.g.:
-      //  Convert from `derived_obj` to `(Base*)&derived_obj`
-      // (probably) as part of function call argument adjustment flow
-      // when calling a base method from a derived object
-      address_of_exprt base_ptr;
-      base_ptr.type() = dest_type; // base type
-      base_ptr.object() = expr;    // derived object
-      base_ptr.location() = expr.location();
-      expr.swap(base_ptr);
-    }
   }
   else if (dest_type.id() == "array")
   {


### PR DESCRIPTION
While investigating #1866 I noticed this code which IMHO shouldn't be a concern of a function that performs typecasting.
While any problematic struct to pointer conversion should be caught by the compiler (besides the conversion of foo.bar() to bar(&foo)), keeping this code would likely complicate my fix for #1866.