### PR TITLE
[python-frontend] Basic support for strings

### DIFF
--- a/regression/python/built-in-functions/main.py
+++ b/regression/python/built-in-functions/main.py
@@ -1,5 +1,11 @@
+def foo() -> None:
+    a = int(2)
+    assert a == 2
+
+foo()
+
 x = int(1)
-assert(x == 1)
+assert x == 1
 
 y = bool(True)
-assert(y == True)
+assert y == True

--- a/regression/python/recursion-fail/main.py
+++ b/regression/python/recursion-fail/main.py
@@ -4,8 +4,9 @@ def factorial(n:int) -> int:
     else:
         return n * factorial(n - 1)
 
-result:int = factorial(5)
-assert(result == 120)
+n:int = nondet_int()
+__ESBMC_assume(n > 0);
+__ESBMC_assume(n < 6);
 
-result = factorial(4)
-assert(result == 20) # result == 24
+result:int = factorial(n)
+assert(result != 120)

--- a/regression/python/recursion-fail/test.desc
+++ b/regression/python/recursion-fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.py
+--unwind 5
 
 ^VERIFICATION FAILED$

--- a/regression/python/strings-bounds-fail/main.py
+++ b/regression/python/strings-bounds-fail/main.py
@@ -1,0 +1,4 @@
+str1 = 'abcde'
+
+assert len(str1) == 5
+assert str1[5] == 'f'  #out-of-bounds

--- a/regression/python/strings-bounds-fail/test.desc
+++ b/regression/python/strings-bounds-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/strings/main.py
+++ b/regression/python/strings/main.py
@@ -1,0 +1,11 @@
+str1 = 'abcde'
+str2 = "python"
+
+assert len(str1) == 5
+assert len(str2) == 6
+
+assert str1[0] == 'a'
+assert str1[1] == 'b'
+assert str1[2] == 'c'
+assert str1[3] == 'd'
+assert str1[4] == 'e'

--- a/regression/python/strings/test.desc
+++ b/regression/python/strings/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -646,6 +646,15 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       }
     }
 
+    if (is_builtin_type(func_name) || is_consensus_type(func_name))
+    {
+      // Replace the function call with a constant value. For example, x = int(1) becomes x = 1
+      typet t = get_typet(func_name);
+      exprt expr = get_expr(element["args"][0]);
+      expr.type() = t;
+      return expr;
+    }
+
     const symbolt *func_symbol = context.find_symbol(func_symbol_id.c_str());
 
     // Find function in imported modules
@@ -686,14 +695,6 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
             func_name,
             obj_symbol_id);
         }
-      }
-      else if (is_builtin_type(func_name) || is_consensus_type(func_name))
-      {
-        // Replace the function call with a constant value. For example, x = int(1) becomes x = 1
-        typet t = get_typet(func_name);
-        exprt expr = get_expr(element["args"][0]);
-        expr.type() = t;
-        return expr;
       }
       else
       {

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -34,6 +34,7 @@ private:
   exprt get_conditional_stm(const nlohmann::json &ast_node);
   function_id build_function_id(const nlohmann::json &element);
   exprt get_function_call(const nlohmann::json &ast_block);
+  exprt get_literal(const nlohmann::json &element);
   exprt get_block(const nlohmann::json &ast_block);
 
   const nlohmann::json


### PR DESCRIPTION
Adding basic support for **strings**. Specifically, it is now possible to initialize variables with strings, index string elements and compare them with characters, and check strings length.

In future commits, we will add support for other operations such as concatenation, substrings, and more. A complete list of operations is available here: https://docs.python.org/3/library/stdtypes.html#textseq