### PR TITLE
[z3-smt] never pass nullptr as name. Breaks `--smt-model`

### DIFF
--- a/regression/z3/github_1876/gh-1876.cpp
+++ b/regression/z3/github_1876/gh-1876.cpp
@@ -1,0 +1,61 @@
+#include <stack>
+#include <string>
+#include <cassert>
+using namespace std;
+
+template <class T>
+class A
+{
+public:
+  A()
+  {
+    this->a = true;
+  }
+  bool get()
+  {
+    return this->a;
+  }
+  void set(bool x)
+  {
+    this->a = x;
+  }
+
+private:
+  bool a;
+};
+
+bool operator!=(A<bool> x, A<bool> y)
+{
+  if (x.get() != y.get())
+    return true;
+  return false;
+}
+
+bool operator==(A<bool> x, A<bool> y)
+{
+  if (x.get() == y.get())
+    return true;
+  return false;
+}
+
+bool operator<(A<bool> x, A<bool> y)
+{
+  return false;
+}
+
+int main()
+{
+  stack<A<bool>> first;
+  A<bool> x;
+  A<bool> y;
+  A<bool> z;
+  first.push(x);
+  first.push(y);
+  first.push(z);
+  first.pop();
+  assert(!(first.empty()));
+  assert((first.top()).get());
+  assert(first.size() == 2);
+  assert(false);
+  return 0;
+}

--- a/regression/z3/github_1876/test.desc
+++ b/regression/z3/github_1876/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+gh-1876.cpp
+--unwind 1 --smt-model --no-unwinding-assertions --timeout 900 --z3
+^VERIFICATION FAILED$

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1028,8 +1028,8 @@ smt_astt z3_convt::tuple_create(const expr2tc &structdef)
 
 smt_astt z3_convt::tuple_fresh(const smt_sort *s, std::string name)
 {
-  const char *n = (name == "") ? nullptr : name.c_str();
-  return new_ast(z3_ctx.constant(n, to_solver_smt_sort<z3::sort>(s)->s), s);
+  return new_ast(
+    z3_ctx.constant(name.c_str(), to_solver_smt_sort<z3::sort>(s)->s), s);
 }
 
 smt_astt
@@ -1078,7 +1078,8 @@ smt_astt z3_convt::tuple_array_create(
     is_constant_int2t(arrtype.array_size) &&
     "array_of sizes should be constant");
 
-  z3::expr output = z3_ctx.constant(nullptr, array_sort);
+  std::string name = mk_fresh_name("z3_convt::tuple_array_create");
+  z3::expr output = z3_ctx.constant(name.c_str(), array_sort);
   for (std::size_t i = 0; i < to_constant_int2t(arrtype.array_size).as_ulong();
        ++i)
   {


### PR DESCRIPTION
Fixes #1876.

I have no idea, what the original purpose of passing a nullptr could have been.
I basically just did what yices also does:
https://github.com/esbmc/esbmc/blob/749b9673062870fdf86c5ee349ac6948f5cc772a/src/solvers/yices/yices_conv.cpp#L969