### PR TITLE
[cpp-references] first adjust references, then assign.

### DIFF
--- a/regression/esbmc-cpp11/reference/Reference5-fail/main.cpp
+++ b/regression/esbmc-cpp11/reference/Reference5-fail/main.cpp
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+float dd = 50.0f;
+struct f
+{
+  float &c = dd;
+};
+int main()
+{
+  f i;
+  i.c = 20.0f;
+  assert(i.c == 0.0f);
+}

--- a/regression/esbmc-cpp11/reference/Reference5-fail/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference5-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/reference/Reference5/main.cpp
+++ b/regression/esbmc-cpp11/reference/Reference5/main.cpp
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+float dd = 50.0f;
+struct f
+{
+  float &c = dd;
+};
+int main()
+{
+  f i;
+  i.c = 20.0f;
+  assert(i.c == 20.0f);
+}

--- a/regression/esbmc-cpp11/reference/Reference5/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference5/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11 
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -225,8 +225,13 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
     }
     else if (has_prefix(id2string(statement), "assign"))
     {
-      adjust_side_effect_assignment(expr);
+      // _First_ adjust references. Otherwise, for
+      // `i.c = 20.0f;` where `c` is a reference, we would try to cast `20.0f`
+      // to a reference type. This would only be possible if we would take the
+      // address of `20.0f` and assign it to `i.c`, which is not what we want.
+      // Instead, after adjustment, we will get `*(i.c) = 20.0f;` which works.
       adjust_reference(expr);
+      adjust_side_effect_assignment(expr);
     }
     else if (statement == "statement_expression")
       adjust_side_effect_statement_expression(expr);


### PR DESCRIPTION
Makes this TC pass:
```cpp
#include <assert.h>

float dd = 50.0f;
struct f
{
  float &c = dd;
};
int main()
{
  f i;
  i.c = 20.0f;
  assert(i.c == 20.0f);
}
```

Found while adding decomposition declaration support to tuples.