### PR TITLE
Feat/actions update deps versions

### DIFF
--- a/.github/workflows/benchbringup.yml
+++ b/.github/workflows/benchbringup.yml
@@ -37,7 +37,7 @@ jobs:
           BENCHMARK_TO_RUN: ${{ inputs.benchmark }}
           LOG_DIR: ${{ inputs.logdirectory }}
         run: ./scripts/build.sh -b Release -r On
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: release-linux
           path: ./build/src/esbmc/esbmc
@@ -47,7 +47,7 @@ jobs:
           ESBMC_OPTS: ${{ inputs.options }}
           LOG_DIR: ${{ inputs.logdirectory }}
         run: cd build/ && ctest -j4 --output-on-failure --progress .
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: benchmark-logs
           path: ./build/regression/${{ inputs.logdirectory }}

--- a/.github/workflows/benchbringup.yml
+++ b/.github/workflows/benchbringup.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Confirm the benchmark
         run: echo ${{ github.event.inputs.benchmark }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build ESBMC
         env:
           TEST_TIMEOUT: ${{ inputs.timeout }}

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -145,7 +145,7 @@ jobs:
         run: mv $HOME/output.zip ./output.zip      
       - name: Debug Info
         run: ls
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: esbmc-result
           path: output.zip  
@@ -169,7 +169,7 @@ jobs:
       - name: Show summary (CPAChecker)
         if: ${{ inputs.cpachecker == true }}
         run: tail $HOME/witness-output/*results*.txt
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.cpachecker == true }}
         with:
           name: witness-result

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Setup SV-Benchmarks version
         run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }}
       - name: Download Linux Build
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: 'release-ubuntu-latest--b Release -e Off -C'
           path: ./

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -112,7 +112,7 @@ jobs:
           name: 'release-ubuntu-latest--b Release -e Off -C'
           path: ./
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: esbmc-src
       - name: Set up the custom runset
@@ -151,7 +151,7 @@ jobs:
           path: output.zip  
       - name: Checkout code
         if: ${{ inputs.cpachecker == true }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: esbmc-src      
       - name: Run Validation (Full)

--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -9,7 +9,7 @@ jobs:
   testing-tool:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Runs testing tool unit test
       run: cd regression && python3 testing_tool_test.py
 

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build ESBMC (${{ inputs.operating-system }})
     runs-on: ${{ inputs.operating-system }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Add apt.llvm.org repository
       run: |
         wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -30,7 +30,7 @@ jobs:
       if: ${{ startsWith(inputs.operating-system, 'ubuntu-') }}
     - name: Build ESBMC
       run: ./scripts/build.sh ${{ inputs.build-flags }}
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: release-${{ inputs.operating-system }}-${{ inputs.build-flags }}
         path: ./release

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Configure ESBMC
       run: ./scripts/build.ps1
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: release-windows-latest
         path: C:/deps/esbmc

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ inputs.operating-system }}
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: check python

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         git config --system core.autocrlf false
         git config --system core.eol lf
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Configure ESBMC
       run: ./scripts/build.ps1
     - uses: actions/upload-artifact@master

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: check python
       run: python --version
     - name: Update vcpkg

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install cmakelint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
   testing-tool:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Runs testing tool unit test
       run: cd regression && python3 testing_tool_test.py
  
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v2
       with:
@@ -88,7 +88,7 @@ jobs:
       # added or changed files to the repository.
       contents: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install libtinfo-dev
     - name: Download Clang 11
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-20.04
     continue-on-error: true # TODO: Eventually this will be removed
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -114,10 +114,10 @@ jobs:
     continue-on-error: true # TODO: Eventually this will be removed
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install cmakelint
       run: pip install cmakelint
     - name: Run CMake Lint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         root_file: docs/manual.tex
     - name: Upload PDF file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Developer-Manual
         path: manual.pdf    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,14 @@ jobs:
     needs: [build]
     steps:
       - name: Download Linux Build
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: 'release-ubuntu-latest--b Release -e Off'
           path: ./linux-release
       - name: Create Linux Release file
         run: zip -r esbmc-linux.zip ./linux-release
       - name: Download Windows Build
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v4
         with:
           name: release-windows-latest
           path: ./windows-release


### PR DESCRIPTION
TODO/RFC:
1. ~~benchexec currently [fails](https://github.com/esbmc/esbmc/actions/runs/9587363003):
Suggested solution is to look at https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#communication-between-self-hosted-runners-and-github
I don't have sufficient access to the self-hosted runner so don't know what exactly has to change.~~ Solved.
2. PR jobs currently [fail](https://github.com/esbmc/esbmc/actions/runs/9584512859).
This is because we try to upload multiple artifacts with the name "release-ubuntu-latest":
https://github.com/esbmc/esbmc/blob/3a3d934dc6bd737bef602b26f45eccbedcf57e60/.github/workflows/pull_request.yml#L64-L80
We could consider changing [this](https://github.com/esbmc/esbmc/blob/3a3d934dc6bd737bef602b26f45eccbedcf57e60/.github/workflows/build-unix.yml#L35) to also include the `build-flags` in the filename which would work, but also look a bit ugly.
Alternatively, we could add a new workflow input `prefix` that allows us to distinguish between the artifacts.
NOTE:
The way it currently works is that the last job to finish overwrites the result of the previous job.
E.g. [here](https://github.com/esbmc/esbmc/actions/runs/9583234178) the release is 320 MB, but [here](https://github.com/esbmc/esbmc/actions/runs/9572900556) it's 378 MB.
It's actually possible to replicate the old behavior, but I don't think that is what we really want.

This PR supersedes https://github.com/esbmc/esbmc/pull/1883, because I can not try the `benchexec` workflow from a fork