### PR TITLE
[SMT backend] Update API to Use Bitwuzla 0.5.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.4           |
 | Z3        | no       | 4.8.9           |
-| Bitwuzla  | no       | 0.3.1           |
+| Bitwuzla  | no       | 0.5.0           |
 
 The version requirements are stable but can change between releases.
 
@@ -281,7 +281,7 @@ We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
 Linux/macOS:
-git clone --depth=1 --branch=0.3.1 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
+git clone --depth=1 --branch=0.5.0 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
 ```
 
 For more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
             NAME bitwuzla
             DOWNLOAD_ONLY YES
             GITHUB_REPOSITORY bitwuzla/bitwuzla
-            GIT_TAG 0.3.1)
+            GIT_TAG 0.5.0)
 	  
 	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
         message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -225,7 +225,9 @@ smt_astt bitwuzla_convt::mk_bvneg(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw_TermManager, BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      bitw_TermManager,
+      BITWUZLA_KIND_BV_NEG,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
 }
 
@@ -234,7 +236,9 @@ smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw_TermManager, BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      bitw_TermManager,
+      BITWUZLA_KIND_BV_NOT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
 }
 
@@ -374,7 +378,10 @@ smt_astt bitwuzla_convt::mk_not(smt_astt a)
 {
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    bitwuzla_mk_term1(bitw_TermManager, BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+    bitwuzla_mk_term1(
+      bitw_TermManager,
+      BITWUZLA_KIND_NOT,
+      to_solver_smt_ast<bitw_smt_ast>(a)->a),
     boolean_sort);
 }
 
@@ -568,7 +575,8 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 
 smt_astt bitwuzla_convt::mk_smt_bool(bool val)
 {
-  BitwuzlaTerm node = (val) ? bitwuzla_mk_true(bitw_TermManager) : bitwuzla_mk_false(bitw_TermManager);
+  BitwuzlaTerm node = (val) ? bitwuzla_mk_true(bitw_TermManager)
+                            : bitwuzla_mk_false(bitw_TermManager);
   const smt_sort *sort = boolean_sort;
   return new_ast(node, sort);
 }
@@ -598,8 +606,8 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_BVFP_RM:
   case SMT_SORT_BOOL:
   case SMT_SORT_ARRAY:
-    node =
-      bitwuzla_mk_const(bitw_TermManager, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
+    node = bitwuzla_mk_const(
+      bitw_TermManager, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   default:
@@ -619,8 +627,8 @@ bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
 {
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm b =
-    bitwuzla_mk_term1_indexed2(bitw_TermManager, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
+  BitwuzlaTerm b = bitwuzla_mk_term1_indexed2(
+    bitw_TermManager, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
 
@@ -628,8 +636,8 @@ smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm b =
-    bitwuzla_mk_term1_indexed1(bitw_TermManager, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
+  BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
+    bitw_TermManager, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -637,8 +645,8 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
 {
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm b =
-    bitwuzla_mk_term1_indexed1(bitw_TermManager, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
+  BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
+    bitw_TermManager, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -745,44 +753,45 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
   {
     if (is_signed)
     {
-      res =
-        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw_TermManager, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res =
-        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw_TermManager, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_sub2t(overflow.operand))
   {
     if (is_signed)
     {
-      res =
-        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw_TermManager, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res =
-        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw_TermManager, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_mul2t(overflow.operand))
   {
     if (is_signed)
     {
-      res =
-        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw_TermManager, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
-      res =
-        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
+      res = bitwuzla_mk_term2(
+        bitw_TermManager, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
-    res = bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
+    res = bitwuzla_mk_term2(
+      bitw_TermManager, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {
@@ -848,7 +857,8 @@ smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
   auto domain_sort = to_solver_smt_sort<BitwuzlaSort>(domain);
   auto range_sort = to_solver_smt_sort<BitwuzlaSort>(range);
 
-  auto t = bitwuzla_mk_array_sort(bitw_TermManager, domain_sort->s, range_sort->s);
+  auto t =
+    bitwuzla_mk_array_sort(bitw_TermManager, domain_sort->s, range_sort->s);
   return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
@@ -856,7 +866,10 @@ smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BVFP, bitwuzla_mk_bv_sort(bitw_TermManager, ew + sw + 1), ew + sw + 1, sw + 1);
+    SMT_SORT_BVFP,
+    bitwuzla_mk_bv_sort(bitw_TermManager, ew + sw + 1),
+    ew + sw + 1,
+    sw + 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -26,16 +26,18 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
   : smt_convt(ns, options), array_iface(true, true), fp_convt(this)
 {
   bitw_options = bitwuzla_options_new();
+  bitw_TermManager = bitwuzla_term_manager_new();
 
   bitwuzla_set_option(bitw_options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
-  bitw = bitwuzla_new(bitw_options);
+  bitw = bitwuzla_new(bitw_TermManager, bitw_options);
 }
 
 bitwuzla_convt::~bitwuzla_convt()
 {
   bitwuzla_delete(bitw);
   bitwuzla_options_delete(bitw_options);
+  bitwuzla_term_manager_delete(bitw_TermManager);
   bitw = nullptr;
   bitw_options = nullptr;
 }
@@ -85,6 +87,7 @@ smt_astt bitwuzla_convt::mk_bvadd(smt_astt a, smt_astt b)
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_ADD,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -98,6 +101,7 @@ smt_astt bitwuzla_convt::mk_bvsub(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SUB,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -111,6 +115,7 @@ smt_astt bitwuzla_convt::mk_bvmul(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_MUL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -124,6 +129,7 @@ smt_astt bitwuzla_convt::mk_bvsmod(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SREM,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -137,6 +143,7 @@ smt_astt bitwuzla_convt::mk_bvumod(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_UREM,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -150,6 +157,7 @@ smt_astt bitwuzla_convt::mk_bvsdiv(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SDIV,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -163,6 +171,7 @@ smt_astt bitwuzla_convt::mk_bvudiv(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_UDIV,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -176,6 +185,7 @@ smt_astt bitwuzla_convt::mk_bvshl(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SHL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -189,6 +199,7 @@ smt_astt bitwuzla_convt::mk_bvashr(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_ASHR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -202,6 +213,7 @@ smt_astt bitwuzla_convt::mk_bvlshr(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SHR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -213,7 +225,7 @@ smt_astt bitwuzla_convt::mk_bvneg(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      bitw_TermManager, BITWUZLA_KIND_BV_NEG, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
 }
 
@@ -222,7 +234,7 @@ smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+      bitw_TermManager, BITWUZLA_KIND_BV_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
 }
 
@@ -233,6 +245,7 @@ smt_astt bitwuzla_convt::mk_bvnxor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_XNOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -246,6 +259,7 @@ smt_astt bitwuzla_convt::mk_bvnor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_NOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -259,6 +273,7 @@ smt_astt bitwuzla_convt::mk_bvnand(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_NAND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -272,6 +287,7 @@ smt_astt bitwuzla_convt::mk_bvxor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_XOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -285,6 +301,7 @@ smt_astt bitwuzla_convt::mk_bvor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_OR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -298,6 +315,7 @@ smt_astt bitwuzla_convt::mk_bvand(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_AND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -309,6 +327,7 @@ smt_astt bitwuzla_convt::mk_implies(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_IMPLIES,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -320,6 +339,7 @@ smt_astt bitwuzla_convt::mk_xor(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_XOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -331,6 +351,7 @@ smt_astt bitwuzla_convt::mk_or(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_OR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -342,6 +363,7 @@ smt_astt bitwuzla_convt::mk_and(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_AND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -352,7 +374,7 @@ smt_astt bitwuzla_convt::mk_not(smt_astt a)
 {
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
-    bitwuzla_mk_term1(BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
+    bitwuzla_mk_term1(bitw_TermManager, BITWUZLA_KIND_NOT, to_solver_smt_ast<bitw_smt_ast>(a)->a),
     boolean_sort);
 }
 
@@ -363,6 +385,7 @@ smt_astt bitwuzla_convt::mk_bvult(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_ULT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -376,6 +399,7 @@ smt_astt bitwuzla_convt::mk_bvslt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SLT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -389,6 +413,7 @@ smt_astt bitwuzla_convt::mk_bvugt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_UGT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -402,6 +427,7 @@ smt_astt bitwuzla_convt::mk_bvsgt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SGT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -415,6 +441,7 @@ smt_astt bitwuzla_convt::mk_bvule(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_ULE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -428,6 +455,7 @@ smt_astt bitwuzla_convt::mk_bvsle(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SLE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -441,6 +469,7 @@ smt_astt bitwuzla_convt::mk_bvuge(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_UGE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -454,6 +483,7 @@ smt_astt bitwuzla_convt::mk_bvsge(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_SGE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -465,6 +495,7 @@ smt_astt bitwuzla_convt::mk_eq(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_EQUAL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -476,6 +507,7 @@ smt_astt bitwuzla_convt::mk_neq(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_DISTINCT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -490,6 +522,7 @@ smt_astt bitwuzla_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
     a->sort->get_range_sort()->get_data_width() == c->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term3(
+      bitw_TermManager,
       BITWUZLA_KIND_ARRAY_STORE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a,
@@ -503,6 +536,7 @@ smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
   assert(a->sort->get_domain_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_ARRAY_SELECT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -525,6 +559,7 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   return new_ast(
     bitwuzla_mk_bv_value(
+      bitw_TermManager,
       to_solver_smt_sort<BitwuzlaSort>(s)->s,
       integer2binary(theint, s->get_data_width()).c_str(),
       2),
@@ -533,7 +568,7 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 
 smt_astt bitwuzla_convt::mk_smt_bool(bool val)
 {
-  BitwuzlaTerm node = (val) ? bitwuzla_mk_true() : bitwuzla_mk_false();
+  BitwuzlaTerm node = (val) ? bitwuzla_mk_true(bitw_TermManager) : bitwuzla_mk_false(bitw_TermManager);
   const smt_sort *sort = boolean_sort;
   return new_ast(node, sort);
 }
@@ -564,7 +599,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_BOOL:
   case SMT_SORT_ARRAY:
     node =
-      bitwuzla_mk_const(to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
+      bitwuzla_mk_const(bitw_TermManager, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   default:
@@ -585,7 +620,7 @@ bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm b =
-    bitwuzla_mk_term1_indexed2(BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
+    bitwuzla_mk_term1_indexed2(bitw_TermManager, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
 
@@ -594,7 +629,7 @@ smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm b =
-    bitwuzla_mk_term1_indexed1(BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
+    bitwuzla_mk_term1_indexed1(bitw_TermManager, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -603,7 +638,7 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm b =
-    bitwuzla_mk_term1_indexed1(BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
+    bitwuzla_mk_term1_indexed1(bitw_TermManager, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -614,6 +649,7 @@ smt_astt bitwuzla_convt::mk_concat(smt_astt a, smt_astt b)
 
   return new_ast(
     bitwuzla_mk_term2(
+      bitw_TermManager,
       BITWUZLA_KIND_BV_CONCAT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -627,6 +663,7 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 
   return new_ast(
     bitwuzla_mk_term3(
+      bitw_TermManager,
       BITWUZLA_KIND_ITE,
       to_solver_smt_ast<bitw_smt_ast>(cond)->a,
       to_solver_smt_ast<bitw_smt_ast>(t)->a,
@@ -681,6 +718,7 @@ expr2tc bitwuzla_convt::get_array_elem(
       mk_smt_bv(BigInt(index), mk_bv_sort(array_bound)));
 
   BitwuzlaTerm e = bitwuzla_mk_term2(
+    bitw_TermManager,
     BITWUZLA_KIND_ARRAY_SELECT,
     bitwuzla_get_value(bitw, za->a),
     bitwuzla_get_value(bitw, idx->a));
@@ -708,12 +746,12 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       res =
-        bitwuzla_mk_term2(BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
+        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res =
-        bitwuzla_mk_term2(BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
+        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_sub2t(overflow.operand))
@@ -721,12 +759,12 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       res =
-        bitwuzla_mk_term2(BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
+        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res =
-        bitwuzla_mk_term2(BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
+        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_mul2t(overflow.operand))
@@ -734,17 +772,17 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       res =
-        bitwuzla_mk_term2(BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
+        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res =
-        bitwuzla_mk_term2(BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
+        bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
-    res = bitwuzla_mk_term2(BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
+    res = bitwuzla_mk_term2(bitw_TermManager, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {
@@ -763,6 +801,7 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
   return new_ast(
     bitwuzla_mk_const_array(
+      bitw_TermManager,
       to_solver_smt_sort<BitwuzlaSort>(arrsort)->s,
       to_solver_smt_ast<bitw_smt_ast>(init_val)->a),
     arrsort);
@@ -789,19 +828,19 @@ void bitwuzla_convt::print_model()
 smt_sortt bitwuzla_convt::mk_bool_sort()
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(), 1);
+    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw_TermManager), 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BV, bitwuzla_mk_bv_sort(width), width);
+    SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw_TermManager, width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(width), width);
+    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw_TermManager, width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
@@ -809,7 +848,7 @@ smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
   auto domain_sort = to_solver_smt_sort<BitwuzlaSort>(domain);
   auto range_sort = to_solver_smt_sort<BitwuzlaSort>(range);
 
-  auto t = bitwuzla_mk_array_sort(domain_sort->s, range_sort->s);
+  auto t = bitwuzla_mk_array_sort(bitw_TermManager, domain_sort->s, range_sort->s);
   return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
@@ -817,11 +856,11 @@ smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BVFP, bitwuzla_mk_bv_sort(ew + sw + 1), ew + sw + 1, sw + 1);
+    SMT_SORT_BVFP, bitwuzla_mk_bv_sort(bitw_TermManager, ew + sw + 1), ew + sw + 1, sw + 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(3), 3);
+    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw_TermManager, 3), 3);
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -26,18 +26,18 @@ bitwuzla_convt::bitwuzla_convt(const namespacet &ns, const optionst &options)
   : smt_convt(ns, options), array_iface(true, true), fp_convt(this)
 {
   bitw_options = bitwuzla_options_new();
-  bitw_TermManager = bitwuzla_term_manager_new();
+  bitw_term_manager = bitwuzla_term_manager_new();
 
   bitwuzla_set_option(bitw_options, BITWUZLA_OPT_PRODUCE_MODELS, 1);
   bitwuzla_set_abort_callback(bitwuzla_error_handler);
-  bitw = bitwuzla_new(bitw_TermManager, bitw_options);
+  bitw = bitwuzla_new(bitw_term_manager, bitw_options);
 }
 
 bitwuzla_convt::~bitwuzla_convt()
 {
   bitwuzla_delete(bitw);
   bitwuzla_options_delete(bitw_options);
-  bitwuzla_term_manager_delete(bitw_TermManager);
+  bitwuzla_term_manager_delete(bitw_term_manager);
   bitw = nullptr;
   bitw_options = nullptr;
 }
@@ -87,7 +87,7 @@ smt_astt bitwuzla_convt::mk_bvadd(smt_astt a, smt_astt b)
   assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_ADD,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -101,7 +101,7 @@ smt_astt bitwuzla_convt::mk_bvsub(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SUB,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -115,7 +115,7 @@ smt_astt bitwuzla_convt::mk_bvmul(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_MUL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -129,7 +129,7 @@ smt_astt bitwuzla_convt::mk_bvsmod(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SREM,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -143,7 +143,7 @@ smt_astt bitwuzla_convt::mk_bvumod(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_UREM,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -157,7 +157,7 @@ smt_astt bitwuzla_convt::mk_bvsdiv(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SDIV,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -171,7 +171,7 @@ smt_astt bitwuzla_convt::mk_bvudiv(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_UDIV,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -185,7 +185,7 @@ smt_astt bitwuzla_convt::mk_bvshl(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SHL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -199,7 +199,7 @@ smt_astt bitwuzla_convt::mk_bvashr(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_ASHR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -213,7 +213,7 @@ smt_astt bitwuzla_convt::mk_bvlshr(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SHR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -225,7 +225,7 @@ smt_astt bitwuzla_convt::mk_bvneg(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_NEG,
       to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
@@ -236,7 +236,7 @@ smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_NOT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a),
     a->sort);
@@ -249,7 +249,7 @@ smt_astt bitwuzla_convt::mk_bvnxor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_XNOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -263,7 +263,7 @@ smt_astt bitwuzla_convt::mk_bvnor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_NOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -277,7 +277,7 @@ smt_astt bitwuzla_convt::mk_bvnand(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_NAND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -291,7 +291,7 @@ smt_astt bitwuzla_convt::mk_bvxor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_XOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -305,7 +305,7 @@ smt_astt bitwuzla_convt::mk_bvor(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_OR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -319,7 +319,7 @@ smt_astt bitwuzla_convt::mk_bvand(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_AND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -331,7 +331,7 @@ smt_astt bitwuzla_convt::mk_implies(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_IMPLIES,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -343,7 +343,7 @@ smt_astt bitwuzla_convt::mk_xor(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_XOR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -355,7 +355,7 @@ smt_astt bitwuzla_convt::mk_or(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_OR,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -367,7 +367,7 @@ smt_astt bitwuzla_convt::mk_and(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_AND,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -379,7 +379,7 @@ smt_astt bitwuzla_convt::mk_not(smt_astt a)
   assert(a->sort->id == SMT_SORT_BOOL);
   return new_ast(
     bitwuzla_mk_term1(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_NOT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a),
     boolean_sort);
@@ -392,7 +392,7 @@ smt_astt bitwuzla_convt::mk_bvult(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_ULT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -406,7 +406,7 @@ smt_astt bitwuzla_convt::mk_bvslt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SLT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -420,7 +420,7 @@ smt_astt bitwuzla_convt::mk_bvugt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_UGT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -434,7 +434,7 @@ smt_astt bitwuzla_convt::mk_bvsgt(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SGT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -448,7 +448,7 @@ smt_astt bitwuzla_convt::mk_bvule(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_ULE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -462,7 +462,7 @@ smt_astt bitwuzla_convt::mk_bvsle(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SLE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -476,7 +476,7 @@ smt_astt bitwuzla_convt::mk_bvuge(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_UGE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -490,7 +490,7 @@ smt_astt bitwuzla_convt::mk_bvsge(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_SGE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -502,7 +502,7 @@ smt_astt bitwuzla_convt::mk_eq(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_EQUAL,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -514,7 +514,7 @@ smt_astt bitwuzla_convt::mk_neq(smt_astt a, smt_astt b)
   assert(a->sort->get_data_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_DISTINCT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -529,7 +529,7 @@ smt_astt bitwuzla_convt::mk_store(smt_astt a, smt_astt b, smt_astt c)
     a->sort->get_range_sort()->get_data_width() == c->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term3(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_ARRAY_STORE,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a,
@@ -543,7 +543,7 @@ smt_astt bitwuzla_convt::mk_select(smt_astt a, smt_astt b)
   assert(a->sort->get_domain_width() == b->sort->get_data_width());
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_ARRAY_SELECT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -566,7 +566,7 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 {
   return new_ast(
     bitwuzla_mk_bv_value(
-      bitw_TermManager,
+      bitw_term_manager,
       to_solver_smt_sort<BitwuzlaSort>(s)->s,
       integer2binary(theint, s->get_data_width()).c_str(),
       2),
@@ -575,8 +575,8 @@ smt_astt bitwuzla_convt::mk_smt_bv(const BigInt &theint, smt_sortt s)
 
 smt_astt bitwuzla_convt::mk_smt_bool(bool val)
 {
-  BitwuzlaTerm node = (val) ? bitwuzla_mk_true(bitw_TermManager)
-                            : bitwuzla_mk_false(bitw_TermManager);
+  BitwuzlaTerm node = (val) ? bitwuzla_mk_true(bitw_term_manager)
+                            : bitwuzla_mk_false(bitw_term_manager);
   const smt_sort *sort = boolean_sort;
   return new_ast(node, sort);
 }
@@ -607,7 +607,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
   case SMT_SORT_BOOL:
   case SMT_SORT_ARRAY:
     node = bitwuzla_mk_const(
-      bitw_TermManager, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
+      bitw_term_manager, to_solver_smt_sort<BitwuzlaSort>(s)->s, name.c_str());
     break;
 
   default:
@@ -628,7 +628,7 @@ bitwuzla_convt::mk_extract(smt_astt a, unsigned int high, unsigned int low)
   smt_sortt s = mk_bv_sort(high - low + 1);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm b = bitwuzla_mk_term1_indexed2(
-    bitw_TermManager, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
+    bitw_term_manager, BITWUZLA_KIND_BV_EXTRACT, ast->a, high, low);
   return new_ast(b, s);
 }
 
@@ -637,7 +637,7 @@ smt_astt bitwuzla_convt::mk_sign_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
-    bitw_TermManager, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
+    bitw_term_manager, BITWUZLA_KIND_BV_SIGN_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -646,7 +646,7 @@ smt_astt bitwuzla_convt::mk_zero_ext(smt_astt a, unsigned int topwidth)
   smt_sortt s = mk_bv_sort(a->sort->get_data_width() + topwidth);
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   BitwuzlaTerm b = bitwuzla_mk_term1_indexed1(
-    bitw_TermManager, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
+    bitw_term_manager, BITWUZLA_KIND_BV_ZERO_EXTEND, ast->a, topwidth);
   return new_ast(b, s);
 }
 
@@ -657,7 +657,7 @@ smt_astt bitwuzla_convt::mk_concat(smt_astt a, smt_astt b)
 
   return new_ast(
     bitwuzla_mk_term2(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_BV_CONCAT,
       to_solver_smt_ast<bitw_smt_ast>(a)->a,
       to_solver_smt_ast<bitw_smt_ast>(b)->a),
@@ -671,7 +671,7 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 
   return new_ast(
     bitwuzla_mk_term3(
-      bitw_TermManager,
+      bitw_term_manager,
       BITWUZLA_KIND_ITE,
       to_solver_smt_ast<bitw_smt_ast>(cond)->a,
       to_solver_smt_ast<bitw_smt_ast>(t)->a,
@@ -726,7 +726,7 @@ expr2tc bitwuzla_convt::get_array_elem(
       mk_smt_bv(BigInt(index), mk_bv_sort(array_bound)));
 
   BitwuzlaTerm e = bitwuzla_mk_term2(
-    bitw_TermManager,
+    bitw_term_manager,
     BITWUZLA_KIND_ARRAY_SELECT,
     bitwuzla_get_value(bitw, za->a),
     bitwuzla_get_value(bitw, idx->a));
@@ -754,12 +754,12 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       res = bitwuzla_mk_term2(
-        bitw_TermManager, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
+        bitw_term_manager, BITWUZLA_KIND_BV_SADD_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res = bitwuzla_mk_term2(
-        bitw_TermManager, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
+        bitw_term_manager, BITWUZLA_KIND_BV_UADD_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_sub2t(overflow.operand))
@@ -767,12 +767,12 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       res = bitwuzla_mk_term2(
-        bitw_TermManager, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
+        bitw_term_manager, BITWUZLA_KIND_BV_SSUB_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res = bitwuzla_mk_term2(
-        bitw_TermManager, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
+        bitw_term_manager, BITWUZLA_KIND_BV_USUB_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_mul2t(overflow.operand))
@@ -780,18 +780,18 @@ smt_astt bitwuzla_convt::overflow_arith(const expr2tc &expr)
     if (is_signed)
     {
       res = bitwuzla_mk_term2(
-        bitw_TermManager, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
+        bitw_term_manager, BITWUZLA_KIND_BV_SMUL_OVERFLOW, side1->a, side2->a);
     }
     else
     {
       res = bitwuzla_mk_term2(
-        bitw_TermManager, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
+        bitw_term_manager, BITWUZLA_KIND_BV_UMUL_OVERFLOW, side1->a, side2->a);
     }
   }
   else if (is_div2t(overflow.operand) || is_modulus2t(overflow.operand))
   {
     res = bitwuzla_mk_term2(
-      bitw_TermManager, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
+      bitw_term_manager, BITWUZLA_KIND_BV_SDIV_OVERFLOW, side1->a, side2->a);
   }
   else
   {
@@ -810,7 +810,7 @@ bitwuzla_convt::convert_array_of(smt_astt init_val, unsigned long domain_width)
 
   return new_ast(
     bitwuzla_mk_const_array(
-      bitw_TermManager,
+      bitw_term_manager,
       to_solver_smt_sort<BitwuzlaSort>(arrsort)->s,
       to_solver_smt_ast<bitw_smt_ast>(init_val)->a),
     arrsort);
@@ -837,19 +837,19 @@ void bitwuzla_convt::print_model()
 smt_sortt bitwuzla_convt::mk_bool_sort()
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw_TermManager), 1);
+    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw_term_manager), 1);
 }
 
 smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw_TermManager, width), width);
+    SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw_term_manager, width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw_TermManager, width), width);
+    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw_term_manager, width), width);
 }
 
 smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
@@ -858,7 +858,7 @@ smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
   auto range_sort = to_solver_smt_sort<BitwuzlaSort>(range);
 
   auto t =
-    bitwuzla_mk_array_sort(bitw_TermManager, domain_sort->s, range_sort->s);
+    bitwuzla_mk_array_sort(bitw_term_manager, domain_sort->s, range_sort->s);
   return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
 }
@@ -867,7 +867,7 @@ smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
   return new solver_smt_sort<BitwuzlaSort>(
     SMT_SORT_BVFP,
-    bitwuzla_mk_bv_sort(bitw_TermManager, ew + sw + 1),
+    bitwuzla_mk_bv_sort(bitw_term_manager, ew + sw + 1),
     ew + sw + 1,
     sw + 1);
 }
@@ -875,5 +875,5 @@ smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
   return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw_TermManager, 3), 3);
+    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw_term_manager, 3), 3);
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -107,7 +107,7 @@ public:
   // Members
   Bitwuzla *bitw;
   BitwuzlaOptions *bitw_options;
-  BitwuzlaTermManager *bitw_TermManager;
+  BitwuzlaTermManager *bitw_term_manager;
 
   typedef std::unordered_map<std::string, smt_astt> symtable_type;
   symtable_type symtable;

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -107,6 +107,7 @@ public:
   // Members
   Bitwuzla *bitw;
   BitwuzlaOptions *bitw_options;
+  BitwuzlaTermManager *bitw_TermManager;
 
   typedef std::unordered_map<std::string, smt_astt> symtable_type;
   symtable_type symtable;


### PR DESCRIPTION
We are updating our API and documentation to integrate Bitwuzla v0.5.0, the latest release of the Bitwuzla SMT solver. For more details on the new release, visit [Bitwuzla Releases](https://github.com/bitwuzla/bitwuzla/releases).