### PR TITLE
[solidity] fix wrong expr being used

### DIFF
--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -4482,7 +4482,7 @@ bool solidity_convertert::get_mapping_definition(
 
   // get address: &m
   exprt address_of = address_of_exprt(mapping_ins);
-  call_expr.arguments().push_back(mapping_ins);
+  call_expr.arguments().push_back(address_of);
 
   // get block
   code_blockt _block;


### PR DESCRIPTION
Found while working on https://github.com/esbmc/esbmc/pull/1873

#1873 made all conversions from `struct` to `&struct` explicit, so this error has no longer been hidden.