### PR TITLE
[build] make buildidobj cope with missing .git repository & cleanup

### DIFF
--- a/scripts/buildidobj.py
+++ b/scripts/buildidobj.py
@@ -6,6 +6,7 @@ import subprocess  # For git
 from datetime import datetime  # For date
 import getpass  # For username
 import socket  # For hostname
+from typing import Union
 
 
 class BuildObj:
@@ -23,15 +24,29 @@ class BuildObj:
     STR_NOT_GIT = "no-hash"
 
     @staticmethod
-    def get_last_hash() -> str:
-        """Return the hash of the latest commit"""
+    def try_git_command(git_command_args: list[str]) -> Union[str, bool]:
         git = shutil.which("git")
         if git is None:
-            return BuildObj.STR_NOT_GIT
+            return False
 
-        return subprocess.check_output([git, "rev-parse", "HEAD"],
-                                       cwd=os.path.dirname(__file__)
-                                      ).decode().strip()
+        try:
+            cmd = [git]
+            cmd.extend(git_command_args)
+            return subprocess.check_output(cmd, cwd=os.path.dirname(__file__)).decode()
+        except subprocess.CalledProcessError as e:
+            # git rev-parse returns 128 if not in a git repository
+            if e.returncode == 128:
+                return False
+            else:
+                raise e
+
+    @staticmethod
+    def get_last_hash() -> str:
+        """Return the hash of the latest commit"""
+        result = BuildObj.try_git_command(["rev-parse", "HEAD"])
+        if isinstance(result, str):
+            return result.strip()
+        return BuildObj.STR_NOT_GIT
 
     @staticmethod
     def get_datetime() -> str:
@@ -49,18 +64,14 @@ class BuildObj:
 
     @staticmethod
     def is_dirty_tree() -> bool:
-        git = shutil.which("git")
-        if git is None:
-            return True
+        result = BuildObj.try_git_command(["status", "-s"])
+        if isinstance(result, str):
+            for x in result.splitlines():
+                if "??" not in x:
+                    return True
 
-        output = subprocess.check_output(
-            [git, "status", "-s"],cwd=os.path.dirname(__file__)).decode().splitlines()
-
-        for x in output:
-            if '??' not in x:
-                return True
-        
-        return False
+            return False
+        return True
 
     @staticmethod
     def run(output):


### PR DESCRIPTION
I've started use https://www.jetbrains.com/help/clion/remote-projects-support.html for running the tests remotely on a server.
However, clion by default does not copy the `.git` folder. So while `git` is installed, it still fails.

I changed the script to just return the information that we would have returned if `git` were not available.