### PR TITLE
Push/Pop aware symbol table for Bitwuzla, Boolector and CVC5

### DIFF
--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -833,8 +833,7 @@ void bitwuzla_convt::dump_smt()
 
 void bitw_smt_ast::dump() const
 {
-  //@TODO: find a replacement
-  //bitwuzla_print_term(a, "smt2", messaget::state.out);
+  log_status("{}", bitwuzla_term_to_string(a));
 }
 
 void bitwuzla_convt::print_model()

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -55,6 +55,9 @@ void bitwuzla_convt::push_ctx()
 
 void bitwuzla_convt::pop_ctx()
 {
+  symtabt::nth_index<1>::type &symtab_levels = symtable.get<1>();
+  symtab_levels.erase(ctx_level);
+
   bitwuzla_pop(bitw, 1);
   smt_convt::pop_ctx();
 }
@@ -598,9 +601,9 @@ smt_astt bitwuzla_convt::mk_array_symbol(
 smt_astt
 bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 {
-  symtable_type::iterator it = symtable.find(name);
+  symtabt::iterator it = symtable.find(name);
   if (it != symtable.end())
-    return it->second;
+    return it->ast;
 
   BitwuzlaTerm node;
 
@@ -623,7 +626,7 @@ bitwuzla_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 
   smt_astt ast = new_ast(node, s);
 
-  symtable.insert(symtable_type::value_type(name, ast));
+  symtable.emplace(name, ast, ctx_level);
 
   return ast;
 }

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -109,8 +109,7 @@ public:
   BitwuzlaOptions *bitw_options;
   BitwuzlaTermManager *bitw_term_manager;
 
-  typedef std::unordered_map<std::string, smt_astt> symtable_type;
-  symtable_type symtable;
+  symtabt symtable;
 };
 
 #endif /* _ESBMC_SOLVERS_BITWUZLA_BITWUZLA_CONV_H_ */

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -54,6 +54,9 @@ void boolector_convt::push_ctx()
 
 void boolector_convt::pop_ctx()
 {
+  symtabt::nth_index<1>::type &symtab_levels = symtable.get<1>();
+  symtab_levels.erase(ctx_level);
+
   boolector_pop(btor, 1);
   smt_convt::pop_ctx();
 }
@@ -548,9 +551,9 @@ smt_astt boolector_convt::mk_array_symbol(
 smt_astt
 boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 {
-  symtable_type::iterator it = symtable.find(name);
+  symtabt::iterator it = symtable.find(name);
   if (it != symtable.end())
-    return it->second;
+    return it->ast;
 
   BoolectorNode *node;
 
@@ -581,7 +584,7 @@ boolector_convt::mk_smt_symbol(const std::string &name, const smt_sort *s)
 
   smt_astt ast = new_ast(node, s);
 
-  symtable.insert(symtable_type::value_type(name, ast));
+  symtable.emplace(name, ast, ctx_level);
   return ast;
 }
 

--- a/src/solvers/boolector/boolector_conv.h
+++ b/src/solvers/boolector/boolector_conv.h
@@ -107,8 +107,7 @@ public:
   // Members
   Btor *btor;
 
-  typedef std::unordered_map<std::string, smt_astt> symtable_type;
-  symtable_type symtable;
+  symtabt symtable;
 };
 
 #endif /* _ESBMC_SOLVERS_BOOLECTOR_BOOLECTOR_CONV_H_ */

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -104,7 +104,7 @@ expr2tc cvc_convt::get_array_elem(
 const std::string cvc_convt::solver_text()
 {
   std::stringstream ss;
-  ss << "CVC " << CVC4::Configuration::getVersionString();
+  ss << "CVC4 " << CVC4::Configuration::getVersionString();
   return ss.str();
 }
 

--- a/src/solvers/cvc5/cvc5_conv.cpp
+++ b/src/solvers/cvc5/cvc5_conv.cpp
@@ -107,7 +107,7 @@ expr2tc cvc5_convt::get_array_elem(
 const std::string cvc5_convt::solver_text()
 {
   std::stringstream ss;
-  ss << "CVC " << slv.getVersion();
+  ss << "CVC5 " << slv.getVersion();
   return ss.str();
 }
 

--- a/src/solvers/cvc5/cvc5_conv.h
+++ b/src/solvers/cvc5/cvc5_conv.h
@@ -159,8 +159,7 @@ public:
 
   cvc5::Solver slv;
 
-  typedef std::unordered_map<std::string, smt_astt> symtable_type;
-  symtable_type symtable;
+  symtabt symtable;
 };
 
 #endif /* _ESBMC_SOLVERS_CVC_CVC_CONV_H_ */

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -863,4 +863,28 @@ inline smt_ast::smt_ast(smt_convt *ctx, smt_sortt s) : sort(s), context(ctx)
   ctx->live_asts.push_back(this);
 }
 
+/* Type for push/pop-aware symbol table cache, required by some solvers */
+
+struct symtab_entryt
+{
+  std::string val;
+  smt_astt ast;
+  unsigned int level;
+
+  symtab_entryt(std::string val, smt_astt ast, unsigned int level)
+    : val(std::move(val)), ast(ast), level(level)
+  {
+  }
+};
+
+typedef boost::multi_index_container<
+  symtab_entryt,
+  boost::multi_index::indexed_by<
+    boost::multi_index::hashed_unique<
+      BOOST_MULTI_INDEX_MEMBER(symtab_entryt, std::string, val)>,
+    boost::multi_index::ordered_non_unique<
+      BOOST_MULTI_INDEX_MEMBER(symtab_entryt, unsigned int, level),
+      std::greater<unsigned int>>>>
+  symtabt;
+
 #endif /* _ESBMC_PROP_SMT_SMT_CONV_H_ */


### PR DESCRIPTION
Fixes #1913 by making the respective symbol tables (a cache similar to the smt_cache) aware of the push/pop level (called ctx_level in smt_convt). Also distinguishes CVC4 from cvc5 in log output and enables dump'ing Bitwuzla terms.