### PR TITLE
[C/C++] fix the old frontend

### DIFF
--- a/src/c2goto/cprover_libc_sources.cpp
+++ b/src/c2goto/cprover_libc_sources.cpp
@@ -123,7 +123,7 @@ void add_bundled_library_sources(contextt &context, const languaget &c_language)
         return;
       languaget *l = c_language.new_language();
       log_status("file {}: Parsing", path);
-      if (l->parse(path) || l->typecheck(context))
+      if (l->parse(path) || l->typecheck(context, path))
       {
         log_error("error processing internal libc source {}", path);
         abort();

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -260,7 +260,7 @@ void add_cprover_library(contextt &context, const languaget *language)
     }
   }
 
-  if (c_link(context, store_ctx))
+  if (c_link(context, store_ctx, "<built-in-library>"))
   {
     // Merging failed
     log_error("Failed to merge C library");

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -317,7 +317,7 @@ bool clang_c_languaget::parse(const std::string &path)
   return false;
 }
 
-bool clang_c_languaget::typecheck(contextt &context)
+bool clang_c_languaget::typecheck(contextt &context, const std::string &)
 {
   clang_c_convertert converter(context, AST, "C");
   if (converter.convert())

--- a/src/clang-c-frontend/clang_c_language.h
+++ b/src/clang-c-frontend/clang_c_language.h
@@ -21,7 +21,7 @@ public:
 
   bool final(contextt &context) override;
 
-  bool typecheck(contextt &context) override;
+  bool typecheck(contextt &context, const std::string &module) override;
 
   std::string id() const override
   {

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -81,7 +81,7 @@ extern "C" {
   return intrinsics;
 }
 
-bool clang_cpp_languaget::typecheck(contextt &context)
+bool clang_cpp_languaget::typecheck(contextt &context, const std::string &)
 {
   clang_cpp_convertert converter(context, AST, "C++");
   if (converter.convert())

--- a/src/clang-cpp-frontend/clang_cpp_language.h
+++ b/src/clang-cpp-frontend/clang_cpp_language.h
@@ -11,7 +11,7 @@ class clang_cpp_languaget : public clang_c_languaget
 public:
   bool final(contextt &context) override;
 
-  bool typecheck(contextt &context) override;
+  bool typecheck(contextt &context, const std::string &module) override;
 
   std::string id() const override
   {

--- a/src/jimple-frontend/jimple-language.h
+++ b/src/jimple-frontend/jimple-language.h
@@ -12,7 +12,7 @@ public:
   bool final(contextt &context) override;
 
   // AST -> GOTO
-  bool typecheck(contextt &context) override;
+  bool typecheck(contextt &context, const std::string &module) override;
 
   std::string id() const override
   {

--- a/src/jimple-frontend/jimple-typecheck.cpp
+++ b/src/jimple-frontend/jimple-typecheck.cpp
@@ -1,7 +1,7 @@
 #include <jimple-frontend/jimple-language.h>
 #include <jimple-frontend/jimple-converter.h>
 
-bool jimple_languaget::typecheck(contextt &context)
+bool jimple_languaget::typecheck(contextt &context, const std::string &)
 {
   log_status("Converting Jimple module {} to GOTO", root.class_name);
 

--- a/src/langapi/language_ui.cpp
+++ b/src/langapi/language_ui.cpp
@@ -93,7 +93,7 @@ bool language_uit::typecheck()
   log_progress("Converting");
 
   for (auto &it : langmap)
-    if (it.second->typecheck(context))
+    if (it.second->typecheck(context, ""))
     {
       log_error("CONVERSION ERROR");
       return true;

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -108,7 +108,7 @@ bool python_languaget::final(contextt &)
   return false;
 }
 
-bool python_languaget::typecheck(contextt &context)
+bool python_languaget::typecheck(contextt &context, const std::string &)
 {
   // Load c models
   add_cprover_library(context, this);

--- a/src/python-frontend/python_language.h
+++ b/src/python-frontend/python_language.h
@@ -11,7 +11,7 @@ public:
 
   bool final(contextt &context) override;
 
-  bool typecheck(contextt &context) override;
+  bool typecheck(contextt &context, const std::string &module) override;
 
   bool from_expr(
     const exprt &expr,

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -119,7 +119,7 @@ bool solidity_languaget::convert_intrinsics(contextt &context)
   return false;
 }
 
-bool solidity_languaget::typecheck(contextt &context)
+bool solidity_languaget::typecheck(contextt &context, const std::string &module)
 {
   contextt new_context;
   convert_intrinsics(
@@ -138,8 +138,8 @@ bool solidity_languaget::typecheck(contextt &context)
   if (adjuster.adjust())
     return true;
 
-  if (c_link(context,
-             new_context)) // also populates language_uit::context
+  if (c_link(
+        context, new_context, module)) // also populates language_uit::context
     return true;
 
   return false;

--- a/src/solidity-frontend/solidity_language.h
+++ b/src/solidity-frontend/solidity_language.h
@@ -17,7 +17,7 @@ public:
 
   bool final(contextt &context) override;
 
-  bool typecheck(contextt &context) override;
+  bool typecheck(contextt &context, const std::string &module) override;
 
   std::string id() const override
   {

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -38,9 +38,10 @@ public:
 class c_linkt : public typecheckt
 {
 public:
-  c_linkt(contextt &_context, contextt &_new_context)
+  c_linkt(contextt &_context, contextt &_new_context, std::string _module)
     : context(_context),
       new_context(_new_context),
+      module(std::move(_module)),
       ns(_context, _new_context),
       type_counter(0)
   {
@@ -76,6 +77,7 @@ protected:
 
   contextt &context;
   contextt &new_context;
+  std::string module;
   merged_namespacet ns;
 
   typedef std::unordered_set<irep_idt, irep_id_hash> known_modulest;
@@ -399,8 +401,8 @@ void c_linkt::move(symbolt &new_symbol)
 }
 } /* end anonymous namespace */
 
-bool c_link(contextt &context, contextt &new_context)
+bool c_link(contextt &context, contextt &new_context, const std::string &module)
 {
-  c_linkt c_link(context, new_context);
+  c_linkt c_link(context, new_context, module);
   return c_link.typecheck_main();
 }

--- a/src/util/c_link.h
+++ b/src/util/c_link.h
@@ -4,6 +4,9 @@
 #include <util/context.h>
 #include <util/message.h>
 
-bool c_link(contextt &context, contextt &new_context);
+bool c_link(
+  contextt &context,
+  contextt &new_context,
+  const std::string &module);
 
 #endif

--- a/src/util/language.h
+++ b/src/util/language.h
@@ -25,7 +25,7 @@ public:
   }
 
   // type check a module in the currently parsed file
-  virtual bool typecheck(contextt &context) = 0;
+  virtual bool typecheck(contextt &context, const std::string &module) = 0;
 
   // language id
   /* This is used by language_filest::final() to call languaget::final() only


### PR DESCRIPTION
I've looked at the code in the old frontend and there are a lot of methods that use the module parameter and I think the current solution is the simplest until we get rid of the old frontend.