### PR TITLE
Dump non-return value function

### DIFF
--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1556,6 +1556,7 @@ void goto_convertt::convert_return(
   {
     if (!new_code.has_return_value())
     {
+      code.dump();
       log_error("function must return value");
       abort();
     }


### PR DESCRIPTION
In #1905 I ran into a problem were ESBMC would give `ERROR: function must return value` without any extra information to help debugging. This adds a dump on the expression just before crashing.