### PR TITLE
[c++ verification] Fix the string type in Conditional Operator

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_1930/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_1930/main.cpp
@@ -1,0 +1,18 @@
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+int main()
+{
+  for (int i = 0; i < 2; ++i)
+  {
+    string expectedSound = (i == 0) ? "Woof!" : "Meow!";
+    if (i == 0)
+      assert(expectedSound == "Woof!");
+    else
+      assert(expectedSound == "Meow!");
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_1930/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_1930/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 7
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_1930_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_1930_fail/main.cpp
@@ -1,0 +1,18 @@
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+int main()
+{
+  for (int i = 0; i < 2; ++i)
+  {
+    string expectedSound = (i == 0) ? "Woof!" : "Meow!";
+    if (i == 0)
+      assert(expectedSound == "Woof!");
+    else
+      assert(expectedSound == "Woof!"); // Meow!
+  }
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_1930_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_1930_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 7
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ch6_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch6_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch6_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 Time1.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch6_7/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 Time2.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch6_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch6_9/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 Time3.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch7_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_8/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 Time6.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -1360,8 +1360,11 @@ void clang_c_adjust::adjust_if(exprt &expr)
 
   // Typecast both the true and false results
   // If the types are inconsistent
-  gen_typecast(ns, expr.op1(), expr.type());
-  gen_typecast(ns, expr.op2(), expr.type());
+  if (expr.type() != expr.op1().type() || expr.type() != expr.op2().type())
+  {
+    gen_typecast(ns, expr.op1(), expr.type());
+    gen_typecast(ns, expr.op2(), expr.type());
+  }
 }
 
 void clang_c_adjust::align_se_function_call_return_type(

--- a/src/util/c_typecast.cpp
+++ b/src/util/c_typecast.cpp
@@ -872,6 +872,17 @@ void c_typecastt::do_typecast(exprt &dest, const typet &type)
 
   if (dest_type.is_array() || dest_type.is_incomplete_array())
   {
+    if (dest.id() == "if")
+    {
+      // Special case: if expression
+      // To typecast the if expression, we need to apply the operations: true and false
+      dest.type() = type;
+
+      do_typecast(dest.op1(), type);
+      do_typecast(dest.op2(), type);
+      return;
+    }
+
     index_exprt index;
     index.array() = dest;
     index.index() = gen_zero(index_type());


### PR DESCRIPTION
When the `true` and `false` expressions in the conditional operator are `string` type, we need to cast them to pointer types.

This happens in AST when both StringLiterals are of the same size:
`string expectedSound = (i == 0) ? "Woof!" : "Meow!";`
"Woof!": char[6]
"Meow!": char[6]
<details>

```cpp
    | `-CompoundStmt 0x6dcef48 <line:9:3, line:11:3>
    |   `-DeclStmt 0x6dcef30 <line:10:5, col:56>
    |     `-VarDecl 0x6dcebd8 <col:5, col:49> col:12 expectedSound 'std::string' cinit
    |       `-ExprWithCleanups 0x6dcef18 <col:12, col:49> 'std::string'
    |         `-CXXConstructExpr 0x6dceee8 <col:12, col:49> 'std::string' 'void (const std::string &) noexcept' elidable
    |           `-MaterializeTemporaryExpr 0x6dceed0 <col:28, col:49> 'const std::string' lvalue
    |             `-ImplicitCastExpr 0x6dceeb8 <col:28, col:49> 'const std::string' <NoOp>
    |               `-ImplicitCastExpr 0x6dcedb0 <col:28, col:49> 'std::string' <ConstructorConversion>
    |                 `-CXXConstructExpr 0x6dced80 <col:28, col:49> 'std::string' 'void (const char *)'
    |                   `-ImplicitCastExpr 0x6dced48 <col:28, col:49> 'const char *' <ArrayToPointerDecay>
    |                     `-ConditionalOperator 0x6dced18 <col:28, col:49> 'const char [6]' lvalue
    |                       |-ParenExpr 0x6dcecb8 <col:28, col:35> 'bool'
    |                       | `-BinaryOperator 0x6dcec98 <col:29, col:34> 'bool' '=='
    |                       |   |-ImplicitCastExpr 0x6dcec80 <col:29> 'int' <LValueToRValue>
    |                       |   | `-DeclRefExpr 0x6dcec40 <col:29> 'int' lvalue Var 0x6dcea78 'i' 'int'
    |                       |   `-IntegerLiteral 0x6dcec60 <col:34> 'int' 0
    |                       |-StringLiteral 0x6dcecd8 <col:39> 'const char [6]' lvalue "Woof!"
    |                       `-StringLiteral 0x6dcecf8 <col:49> 'const char [6]' lvalue "Meow!"
```
</details>
