### PR TITLE
[python-frontend] Handling int.bit_length()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ out
 CMakeSettings.json
 build
 
+# eclipse
+.cproject
+.project
+.settings/
+
 # others
 __pycache__
 .DS_Store

--- a/regression/python/import-from-class-fail/test.desc
+++ b/regression/python/import-from-class-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-Assertion `!ref\.empty\(\)' failed\.\s*$
+ERROR: Type undefined for obj2\s*$

--- a/regression/python/int_bit_length/main.py
+++ b/regression/python/int_bit_length/main.py
@@ -1,0 +1,8 @@
+x = int(0)
+assert x.bit_length() == 0
+
+y = int(16)
+assert y.bit_length() == 5
+
+z = int(255)
+assert z.bit_length() == 8

--- a/regression/python/int_bit_length/test.desc
+++ b/regression/python/int_bit_length/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_bit_length_fail/main.py
+++ b/regression/python/int_bit_length_fail/main.py
@@ -1,0 +1,2 @@
+x = int(16)
+assert x.bit_length() == 4 # Expected bit length for integer 16 should be 5

--- a/regression/python/int_bit_length_fail/test.desc
+++ b/regression/python/int_bit_length_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -88,7 +88,7 @@ static const struct buffer
 #endif
 };
 
-static std::vector<std::string> python_c_models = {"strncmp"};
+const static std::vector<std::string> python_c_models = {"strncmp"};
 
 } // namespace
 

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -25,3 +25,14 @@ class int:
        result:int = result - (1 << (8 * len(bytes_data)))
 
     return result
+
+  @classmethod
+  # bit_lenght() count the bits needed to represent an integer in binary
+  def bit_length(cls, n:int) -> int:
+    length:int = 0
+
+    while n > 0:
+        n:int = n >> 1
+        length:int = length + 1  # Count how many times the number is shifted
+
+    return length

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -326,7 +326,18 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
   assert(!op.empty());
 
-  if (op == "Eq" && is_string(lhs.type()) && is_string(rhs.type()))
+  std::string lhs_type = get_var_type(lhs.name().as_string());
+  std::string rhs_type = get_var_type(rhs.name().as_string());
+
+  if (
+    rhs_type.empty() && element.contains("comparators") &&
+    element["comparators"][0].contains("value") &&
+    element["comparators"][0]["value"].is_string())
+  {
+    rhs_type = "str";
+  }
+
+  if (op == "Eq" && lhs_type == "str" && rhs_type == "str")
   {
     if (rhs.type() != lhs.type())
       return gen_boolean(false);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -45,7 +45,7 @@ private:
   bool is_constructor_call(const nlohmann::json &json);
   typet get_typet(const std::string &ast_type, size_t type_size = 0);
   typet get_typet(const nlohmann::json &elem);
-  std::string get_var_type(const std::string& var_name) const;
+  std::string get_var_type(const std::string &var_name) const;
   void get_attributes_from_self(
     const nlohmann::json &method_body,
     struct_typet &clazz);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -38,13 +38,14 @@ private:
   exprt get_block(const nlohmann::json &ast_block);
 
   const nlohmann::json
-  find_var_decl(const std::string &var_name, const nlohmann::json &json);
+  find_var_decl(const std::string &var_name, const nlohmann::json &json) const;
   void adjust_statement_types(exprt &lhs, exprt &rhs) const;
   std::string create_symbol_id() const;
   std::string create_symbol_id(const std::string &filename) const;
   bool is_constructor_call(const nlohmann::json &json);
   typet get_typet(const std::string &ast_type, size_t type_size = 0);
   typet get_typet(const nlohmann::json &elem);
+  std::string get_var_type(const std::string& var_name) const;
   void get_attributes_from_self(
     const nlohmann::json &method_body,
     struct_typet &clazz);

--- a/src/util/type.cpp
+++ b/src/util/type.cpp
@@ -19,11 +19,6 @@ bool is_array_like(const typet &type)
   return type.is_vector() || type.is_array() || type.is_incomplete_array();
 }
 
-bool is_string(const typet &type)
-{
-  return type.is_array() && type.subtype().is_signedbv();
-}
-
 irep_idt typet::t_signedbv = dstring("signedbv");
 irep_idt typet::t_unsignedbv = dstring("unsignedbv");
 irep_idt typet::t_complex = dstring("complex");

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -188,5 +188,4 @@ bool is_number(const typet &type);
  */
 bool is_array_like(const typet &type);
 
-bool is_string(const typet &type);
 #endif


### PR DESCRIPTION
This PR adds support for [int.bit_length()](https://docs.python.org/3/library/stdtypes.html) by:
- Providing an operational model for this function.
- Converting `obj.bit_length()` calls to `bit_length(obj)` in the python_converter.

Additionally, I'm removing the [is_string](https://github.com/esbmc/esbmc/blob/de10dee30288a464dbbfa2dfa6575ff3522130e6/src/util/type.cpp#L22C1-L25C2) function from util/type as suggested [here](https://github.com/esbmc/esbmc/pull/1919#discussion_r1661127280).