### PR TITLE
[python-frontend] Inferring type from function returns

### DIFF
--- a/regression/python/dynamic-typing/main.py
+++ b/regression/python/dynamic-typing/main.py
@@ -12,3 +12,8 @@ x = (v + y)//2
 
 f = -1
 
+def bar() -> int:
+    return 1
+
+a = bar() # Infer from function return
+assert a == 1

--- a/regression/python/import-from-class-fail/test.desc
+++ b/regression/python/import-from-class-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-ERROR: Type undefined for obj2\s*$
+ERROR: Type undefined for:\s*$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -257,7 +257,7 @@ private:
 
         if (type.empty())
         {
-          log_status("Type undefined for:\n{}", element.dump(2).c_str());
+          log_error("Type undefined for:\n{}", element.dump(2).c_str());
           abort();
         }
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -245,7 +245,8 @@ private:
         else if (
           value_type == "Call" &&
           is_consensus_func(element["value"]["func"]["id"]))
-          inferred_type = get_type_from_consensus_func(element["value"]["func"]["id"]);
+          inferred_type =
+            get_type_from_consensus_func(element["value"]["func"]["id"]);
 
         // Get type from function return
         else if (
@@ -293,7 +294,8 @@ private:
           {"lineno", target["lineno"]}};
 
         element["end_col_offset"] =
-          element["end_col_offset"].template get<int>() + inferred_type.size() + 1;
+          element["end_col_offset"].template get<int>() + inferred_type.size() +
+          1;
         element["end_lineno"] = element["lineno"];
         element["simple"] = 1;
 
@@ -306,10 +308,11 @@ private:
 
         // Update value fields
         element["value"]["col_offset"] =
-          element["value"]["col_offset"].template get<int>() + inferred_type.size() + 1;
+          element["value"]["col_offset"].template get<int>() +
+          inferred_type.size() + 1;
         element["value"]["end_col_offset"] =
-          element["value"]["end_col_offset"].template get<int>() + inferred_type.size() +
-          1;
+          element["value"]["end_col_offset"].template get<int>() +
+          inferred_type.size() + 1;
 
         /* Adjust column offset node on lines involving function
          * calls with arguments */
@@ -319,8 +322,8 @@ private:
           {
             arg["col_offset"] =
               arg["col_offset"].template get<int>() + inferred_type.size() + 1;
-            arg["end_col_offset"] =
-              arg["end_col_offset"].template get<int>() + inferred_type.size() + 1;
+            arg["end_col_offset"] = arg["end_col_offset"].template get<int>() +
+                                    inferred_type.size() + 1;
           }
         }
         // Adjust column offset in function call node

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -125,6 +125,22 @@ private:
     return type;
   }
 
+  std::string get_function_return_type(const std::string &func_name, const Json &ast)
+  {
+    std::string return_type("");
+    for (const Json &elem : ast["body"])
+    {
+      if (elem["_type"] == "FunctionDef" && elem["name"] == func_name)
+      {
+        if (elem.contains("returns") && !elem["returns"].is_null())
+        {
+         return_type = elem["name"]["returns"]["id"];
+        }
+      }
+    }
+    return return_type;
+  }
+
   void add_annotation(Json &body)
   {
     for (auto &element : body["body"])
@@ -231,6 +247,12 @@ private:
           element["value"]["_type"] == "Call" &&
           is_consensus_func(element["value"]["func"]["id"]))
           type = get_type_from_consensus_func(element["value"]["func"]["id"]);
+        // get type from function_return_type_ann 
+        else if (element["value"]["_type"] == "Call")
+        {
+          std::string func_name = element["value"]["func"]["id"];
+          type = get_function_return_type(func_name, ast_);
+        } 
         else
           continue;
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -125,20 +125,19 @@ private:
     return type;
   }
 
-  std::string get_function_return_type(const std::string &func_name, const Json &ast)
+  std::string
+  get_function_return_type(const std::string &func_name, const Json &ast)
   {
-    std::string return_type("");
     for (const Json &elem : ast["body"])
     {
-      if (elem["_type"] == "FunctionDef" && elem["name"] == func_name)
+      if (
+        elem["_type"] == "FunctionDef" && elem["name"] == func_name &&
+        elem.contains("returns") && !elem["returns"].is_null())
       {
-        if (elem.contains("returns") && !elem["returns"].is_null())
-        {
-         return_type = elem["name"]["returns"]["id"];
-        }
+        return elem["returns"]["id"];
       }
     }
-    return return_type;
+    return std::string();
   }
 
   void add_annotation(Json &body)
@@ -247,12 +246,12 @@ private:
           element["value"]["_type"] == "Call" &&
           is_consensus_func(element["value"]["func"]["id"]))
           type = get_type_from_consensus_func(element["value"]["func"]["id"]);
-        // get type from function_return_type_ann 
+        // Get type from function return
         else if (element["value"]["_type"] == "Call")
         {
           std::string func_name = element["value"]["func"]["id"];
           type = get_function_return_type(func_name, ast_);
-        } 
+        }
         else
           continue;
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -150,7 +150,7 @@ private:
 
       if (stmt_type == "Assign" && element["type_comment"].is_null())
       {
-        std::string type("");
+        std::string inferred_type("");
 
         // Check if LHS was previously annotated
         if (
@@ -170,31 +170,30 @@ private:
               find_annotated_assign(element["targets"][0]["id"], ast_["body"]);
 
           if (node != Json())
-            type = node["annotation"]["id"];
+            inferred_type = node["annotation"]["id"];
         }
 
+        const auto &value_type = element["value"]["_type"];
+
         // Get type from RHS constant
-        if (element["value"]["_type"] == "Constant")
+        if (value_type == "Constant")
         {
-          type = get_type_from_constant(element["value"]);
+          inferred_type = get_type_from_constant(element["value"]);
         }
         else if (
-          element["value"]["_type"] == "UnaryOp" &&
-          element["value"]["operand"]["_type"] ==
-            "Constant") // Handle negative numbers
+          value_type == "UnaryOp" && element["value"]["operand"]["_type"] ==
+                                       "Constant") // Handle negative numbers
         {
-          type = get_type_from_constant(element["value"]["operand"]);
+          inferred_type = get_type_from_constant(element["value"]["operand"]);
         }
 
         // Get type from RHS variable
-        else if (
-          element["value"]["_type"] == "Name" ||
-          element["value"]["_type"] == "Subscript")
+        else if (value_type == "Name" || value_type == "Subscript")
         {
           std::string rhs_var_name;
-          if (element["value"]["_type"] == "Name")
+          if (value_type == "Name")
             rhs_var_name = element["value"]["id"];
-          else if (element["value"]["_type"] == "Subscript")
+          else if (value_type == "Subscript")
             rhs_var_name = element["value"]["value"]["id"];
 
           // Find RHS variable declaration in the current scope
@@ -224,38 +223,42 @@ private:
           }
 
           // Get type from RHS type annotation
-          type = rhs_node["annotation"]["id"];
+          inferred_type = rhs_node["annotation"]["id"];
         }
 
         // Get type from RHS binary expression
-        else if (element["value"]["_type"] == "BinOp")
+        else if (value_type == "BinOp")
         {
           std::string got_type = get_type_from_binary_expr(element, body);
           if (!got_type.empty())
-            type = got_type;
+            inferred_type = got_type;
         }
 
         // Get type from constructor call
         else if (
-          element["value"]["_type"] == "Call" &&
+          value_type == "Call" &&
           (json_utils::is_class<Json>(element["value"]["func"]["id"], ast_) ||
            is_builtin_type(element["value"]["func"]["id"]) ||
            is_consensus_type(element["value"]["func"]["id"])))
-          type = element["value"]["func"]["id"];
+          inferred_type = element["value"]["func"]["id"];
+
         else if (
-          element["value"]["_type"] == "Call" &&
+          value_type == "Call" &&
           is_consensus_func(element["value"]["func"]["id"]))
-          type = get_type_from_consensus_func(element["value"]["func"]["id"]);
+          inferred_type = get_type_from_consensus_func(element["value"]["func"]["id"]);
+
         // Get type from function return
-        else if (element["value"]["_type"] == "Call" && !is_model_func(element["value"]["func"]["id"]))
+        else if (
+          value_type == "Call" &&
+          !is_model_func(element["value"]["func"]["id"]))
         {
           std::string func_name = element["value"]["func"]["id"];
-          type = get_function_return_type(func_name, ast_);
+          inferred_type = get_function_return_type(func_name, ast_);
         }
         else
           continue;
 
-        if (type.empty())
+        if (inferred_type.empty())
         {
           log_error("Type undefined for:\n{}", element.dump(2).c_str());
           abort();
@@ -284,13 +287,13 @@ private:
           {"_type", target["_type"]},
           {"col_offset", col_offset},
           {"ctx", {{"_type", "Load"}}},
-          {"end_col_offset", col_offset + type.size()},
+          {"end_col_offset", col_offset + inferred_type.size()},
           {"end_lineno", target["end_lineno"]},
-          {"id", type},
+          {"id", inferred_type},
           {"lineno", target["lineno"]}};
 
         element["end_col_offset"] =
-          element["end_col_offset"].template get<int>() + type.size() + 1;
+          element["end_col_offset"].template get<int>() + inferred_type.size() + 1;
         element["end_lineno"] = element["lineno"];
         element["simple"] = 1;
 
@@ -303,9 +306,9 @@ private:
 
         // Update value fields
         element["value"]["col_offset"] =
-          element["value"]["col_offset"].template get<int>() + type.size() + 1;
+          element["value"]["col_offset"].template get<int>() + inferred_type.size() + 1;
         element["value"]["end_col_offset"] =
-          element["value"]["end_col_offset"].template get<int>() + type.size() +
+          element["value"]["end_col_offset"].template get<int>() + inferred_type.size() +
           1;
 
         /* Adjust column offset node on lines involving function
@@ -315,9 +318,9 @@ private:
           for (auto &arg : element["value"]["args"])
           {
             arg["col_offset"] =
-              arg["col_offset"].template get<int>() + type.size() + 1;
+              arg["col_offset"].template get<int>() + inferred_type.size() + 1;
             arg["end_col_offset"] =
-              arg["end_col_offset"].template get<int>() + type.size() + 1;
+              arg["end_col_offset"].template get<int>() + inferred_type.size() + 1;
           }
         }
         // Adjust column offset in function call node
@@ -325,10 +328,10 @@ private:
         {
           element["value"]["func"]["col_offset"] =
             element["value"]["func"]["col_offset"].template get<int>() +
-            type.size() + 1;
+            inferred_type.size() + 1;
           element["value"]["func"]["end_col_offset"] =
             element["value"]["func"]["end_col_offset"].template get<int>() +
-            type.size() + 1;
+            inferred_type.size() + 1;
         }
       }
     }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -247,7 +247,7 @@ private:
           is_consensus_func(element["value"]["func"]["id"]))
           type = get_type_from_consensus_func(element["value"]["func"]["id"]);
         // Get type from function return
-        else if (element["value"]["_type"] == "Call")
+        else if (element["value"]["_type"] == "Call" && !is_model_func(element["value"]["func"]["id"]))
         {
           std::string func_name = element["value"]["func"]["id"];
           type = get_function_return_type(func_name, ast_);

--- a/src/python-frontend/python_frontend_types.cpp
+++ b/src/python-frontend/python_frontend_types.cpp
@@ -20,6 +20,11 @@ bool is_consensus_func(const std::string &name)
   return consensus_func_to_type.find(name) != consensus_func_to_type.end();
 }
 
+bool is_model_func(const std::string &name)
+{
+  return (name == "ESBMC_range_next_" || name == "ESBMC_range_has_next_");
+}
+
 std::string get_type_from_consensus_func(const std::string &name)
 {
   if (!is_consensus_func(name))

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -48,6 +48,6 @@ bool is_consensus_type(const std::string &name);
 bool is_consensus_func(const std::string &name);
 
 // Check if a function is defined in the "models" folder
-bool is_model_func(const std::string& name);
+bool is_model_func(const std::string &name);
 
 std::string get_type_from_consensus_func(const std::string &name);

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -47,4 +47,7 @@ bool is_consensus_type(const std::string &name);
 
 bool is_consensus_func(const std::string &name);
 
+// Check if a function is defined in the "models" folder
+bool is_model_func(const std::string& name);
+
 std::string get_type_from_consensus_func(const std::string &name);


### PR DESCRIPTION
This PR enables type inference from function returns in scenarios like:

```
def foo() -> int :
  return 1

x = foo()  # Inferred type of x: int
``` 