### PR TITLE
[concurrency] support data race checking for GOTO instructions

### DIFF
--- a/regression/esbmc-unix/github_1936/main.c
+++ b/regression/esbmc-unix/github_1936/main.c
@@ -1,0 +1,32 @@
+#include <pthread.h>
+#include <assert.h>
+
+int x;
+
+pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+
+void* taskA(void* arg)
+{
+  pthread_mutex_lock(&m);
+  x++;
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+void* taskB(void* arg)
+{
+  pthread_mutex_lock(&m);
+  if(!x)
+    assert(1);
+  pthread_mutex_unlock(&m);
+  return NULL;
+}
+
+int main() {
+  pthread_t idA, idB;
+
+  pthread_create(&idA, NULL, taskA, NULL);
+  pthread_create(&idB, NULL, taskB, NULL);
+
+  return 0;
+}

--- a/regression/esbmc-unix/github_1936/test.desc
+++ b/regression/esbmc-unix/github_1936/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check --context-bound 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_1936_fail/main.c
+++ b/regression/esbmc-unix/github_1936_fail/main.c
@@ -1,0 +1,26 @@
+#include <pthread.h>
+#include <assert.h>
+
+int x;
+
+void* taskA(void* arg)
+{
+  x++;
+  return NULL;
+}
+
+void* taskB(void* arg)
+{
+  if(!x)
+    assert(1);
+  return NULL;
+}
+
+int main() {
+  pthread_t idA, idB;
+
+  pthread_create(&idA, NULL, taskA, NULL);
+  pthread_create(&idB, NULL, taskB, NULL);
+
+  return 0;
+}

--- a/regression/esbmc-unix/github_1936_fail/test.desc
+++ b/regression/esbmc-unix/github_1936_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check --context-bound 2
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/11_podelski.fig3.lics04/test.desc
+++ b/regression/esbmc-unix2/11_podelski.fig3.lics04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 podelski.fig3.lics04.c
 --unwind 1 --no-unwinding-assertions --data-races-check
 ^VERIFICATION FAILED$

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -36,13 +36,7 @@ void rw_sett::compute(const exprt &expr)
       assert(expr.operands().size() == 1);
       compute(expr.op0());
     }
-    else if (expr.id() == "=")
-    {
-      assert(expr.operands().size() == 2);
-      read_rec(expr.op0());
-      read_rec(expr.op1());
-    }
-    else if (expr.id() == "notequal")
+    else if (expr.id() == "=" || expr.id() == "notequal")
     {
       assert(expr.operands().size() == 2);
       read_rec(expr.op0());

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -5,25 +5,54 @@
 #include <util/namespace.h>
 #include <util/std_expr.h>
 
-void rw_sett::compute(const codet &code)
+void rw_sett::compute(const exprt &expr)
 {
-  const irep_idt &statement = code.get_statement();
+  if (expr.is_code())
+  {
+    codet code = to_code(expr);
+    const irep_idt &statement = code.get_statement();
 
-  if (statement == "assign")
-  {
-    assert(code.operands().size() == 2);
-    assign(code.op0(), code.op1());
+    if (statement == "assign")
+    {
+      assert(code.operands().size() == 2);
+      assign(code.op0(), code.op1());
+    }
+    else if (statement == "printf")
+    {
+      exprt expr = code;
+      Forall_operands (it, expr)
+        read_rec(*it);
+    }
+    else if (statement == "return")
+    {
+      assert(code.operands().size() == 1);
+      read_rec(code.op0());
+    }
   }
-  else if (statement == "printf")
+  else
   {
-    exprt expr = code;
-    Forall_operands (it, expr)
-      read_rec(*it);
-  }
-  else if (statement == "return")
-  {
-    assert(code.operands().size() == 1);
-    read_rec(code.op0());
+    if (expr.id() == "not")
+    {
+      assert(expr.operands().size() == 1);
+      compute(expr.op0());
+    }
+    else if (expr.id() == "=")
+    {
+      assert(expr.operands().size() == 2);
+      read_rec(expr.op0());
+      read_rec(expr.op1());
+    }
+    else if (expr.id() == "notequal")
+    {
+      assert(expr.operands().size() == 2);
+      read_rec(expr.op0());
+      read_rec(expr.op1());
+    }
+    else if (expr.id() == "typecast")
+    {
+      assert(expr.operands().size() == 1);
+      read_rec(expr.op0());
+    }
   }
 }
 

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -7,6 +7,8 @@
 
 void rw_sett::compute(const exprt &expr)
 {
+  const goto_programt::instructiont &instruction = *target;
+
   if (expr.is_code())
   {
     codet code = to_code(expr);
@@ -29,7 +31,7 @@ void rw_sett::compute(const exprt &expr)
       read_rec(code.op0());
     }
   }
-  else
+  else if (instruction.is_goto())
   {
     if (expr.id() == "not")
     {
@@ -82,7 +84,7 @@ void rw_sett::read_write_rec(
         symbol->name == "__ESBMC_alloc_size" || symbol->name == "stdin" ||
         symbol->name == "stdout" || symbol->name == "stderr" ||
         symbol->name == "sys_nerr" || symbol->name == "operator=::ref" ||
-        symbol->name == "this")
+        symbol->name == "this" || symbol->name == "__ESBMC_atexits")
       {
         return; // ignore for now
       }

--- a/src/goto-programs/rw_set.h
+++ b/src/goto-programs/rw_set.h
@@ -43,7 +43,7 @@ public:
   typedef std::unordered_map<irep_idt, entryt, irep_id_hash> entriest;
   entriest entries;
 
-  void compute(const codet &code);
+  void compute(const exprt &expr);
 
   rw_sett(
     const namespacet &_ns,
@@ -57,10 +57,10 @@ public:
     const namespacet &_ns,
     value_setst &_value_sets,
     goto_programt::const_targett _target,
-    const codet &code)
+    const exprt &expr)
     : ns(_ns), value_sets(_value_sets), target(_target)
   {
-    compute(code);
+    compute(expr);
   }
 
   void read_rec(const exprt &expr)


### PR DESCRIPTION
This PR adds a data race check for GOTO.

`if (!x)` Will be treated as reading `x`:

```cpp
        ASSIGN tmp_c:@x=false;
        ATOMIC_BEGIN
        ASSERT !tmp_c:@x // R/W data race on c:@x
        ATOMIC_END
        IF !(!(_Bool)x) THEN GOTO 1
```

_Still to explore:_ The C++ frontend treats Pointers differently than C, but the internal library GOTO should be the same (they are parsed and converted at build). The number of threads interleaved in C++ is mostly increased compared to C, which needs to be explored further.