### PR TITLE
[python-frontend] Strings concatenation

### DIFF
--- a/regression/python/strings-concat-fail/main.py
+++ b/regression/python/strings-concat-fail/main.py
@@ -1,0 +1,5 @@
+str1 = "ab"
+str2 = "cd"
+str3 = str1 + str2
+assert str3 == "abcd"
+assert str3 == "abcde" # str3 == "abcd"

--- a/regression/python/strings-concat-fail/test.desc
+++ b/regression/python/strings-concat-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/strings-concat/main.py
+++ b/regression/python/strings-concat/main.py
@@ -3,5 +3,7 @@ str2 = "lo"
 str3 = str1 + str2
 assert str3 == "Hello"
 
-str4 = "Hel" + "lo"
-assert str4 == "Hello"
+str4 = "Wor" + "ld"
+assert str4 == "World"
+
+assert str1 + "lo" == "Hello"

--- a/regression/python/strings-concat/main.py
+++ b/regression/python/strings-concat/main.py
@@ -1,0 +1,7 @@
+str1 = "Hel"
+str2 = "lo"
+str3 = str1 + str2
+assert str3 == "Hello"
+
+str4 = "Hel" + "lo"
+assert str4 == "Hello"

--- a/regression/python/strings-concat/test.desc
+++ b/regression/python/strings-concat/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -310,8 +310,7 @@ std::string python_converter::get_operand_type(const nlohmann::json &element)
 
 exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 {
-  auto left =
-    (element.contains("left")) ? element["left"] : element["target"];
+  auto left = (element.contains("left")) ? element["left"] : element["target"];
 
   decltype(left) right;
   if (element.contains("right"))
@@ -407,8 +406,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
       unsigned int i = 0;
 
-      auto get_value_from_symbol = [&](const std::string &symbol_id, exprt &e)
-      {
+      auto get_value_from_symbol = [&](const std::string &symbol_id, exprt &e) {
         symbolt *symbol = context.find_symbol(symbol_id);
         assert(symbol);
         // Copy symbol value
@@ -416,8 +414,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
           e.operands().at(i++) = ch;
       };
 
-      auto get_value_from_json = [&](const nlohmann::json &elem, exprt &e)
-      {
+      auto get_value_from_json = [&](const nlohmann::json &elem, exprt &e) {
         const std::string &value = elem["value"].get<std::string>();
         std::vector<uint8_t> string_literal =
           std::vector<uint8_t>(std::begin(value), std::end(value));

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1401,6 +1401,13 @@ void python_converter::get_var_assign(
       {
         array_typet &arr_type =
           static_cast<array_typet &>(current_element_type);
+
+        /* When a string is assigned the result of a concatenation, we initially
+         * create the LHS type as a zero-size array: "current_element_type = get_typet(lhs_type, type_size);"
+         * After parsing the RHS, we need to adjust the LHS type size to match
+         * the size of the resulting RHS string.*/
+
+        // If the size of the LHS type is zero, update the LHS type with the type of the RHS.
         if (std::stoi(arr_type.size().value().as_string()) == 0)
           lhs_symbol->type = rhs.type();
       }

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -25,7 +25,7 @@ private:
   void get_function_definition(const nlohmann::json &function_node);
   void
   get_class_definition(const nlohmann::json &class_node, codet &target_block);
-  std::string get_operand_type(const nlohmann::json& element);
+  std::string get_operand_type(const nlohmann::json &element);
 
   locationt get_location_from_decl(const nlohmann::json &ast_node);
   exprt get_expr(const nlohmann::json &element);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -25,6 +25,7 @@ private:
   void get_function_definition(const nlohmann::json &function_node);
   void
   get_class_definition(const nlohmann::json &class_node, codet &target_block);
+  std::string get_operand_type(const nlohmann::json& element);
 
   locationt get_location_from_decl(const nlohmann::json &ast_node);
   exprt get_expr(const nlohmann::json &element);


### PR DESCRIPTION
This PR addresses strings concatenations, such as:

```
str1 = "He"
str2 = "llo"
str3 = str1 + str2
assert str3 == "Hello"
```

In the `python_converter` a resulting string `expr` is generated by combining the values of  each operand `expr`.