### PR TITLE
[Concurrency] Enable race check for __VERIFIER_assert

### DIFF
--- a/regression/cuda/Supported_long_time/005_soundness_issue_pair/test.desc
+++ b/regression/cuda/Supported_long_time/005_soundness_issue_pair/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---unwind 5 --force-malloc-success --state-hashing --context-bound 2
+--unwind 5 --force-malloc-success --state-hashing --context-bound 2 --incremental-bmc
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/Supported_long_time/032_return_value/test.desc
+++ b/regression/cuda/Supported_long_time/032_return_value/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---context-bound 2 --force-malloc-success --unwind 9 --state-hashing
+--context-bound 2 --force-malloc-success --unwind 9 --state-hashing --incremental-bmc
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cuda/Supported_long_time/035_test2/test.desc
+++ b/regression/cuda/Supported_long_time/035_test2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.cu
---force-malloc-success --unwind 9 --state-hashing
+--force-malloc-success --unwind 9 --state-hashing --context-bound 2
 
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/cuda/Supported_long_time/105_pass/test.desc
+++ b/regression/cuda/Supported_long_time/105_pass/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---force-malloc-success --context-bound 2 --state-hashing --unwind 5
+--force-malloc-success --context-bound 2 --state-hashing --unwind 5 --incremental-bmc
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/SV_COMP_03/main.c
+++ b/regression/esbmc-unix/SV_COMP_03/main.c
@@ -1,0 +1,64 @@
+#include <pthread.h>
+#include <assert.h>
+
+volatile int stoppingFlag;
+volatile int pendingIo;
+volatile int stoppingEvent;
+volatile int stopped;
+
+int BCSP_IoIncrement() {
+    __VERIFIER_atomic_begin();
+    if (stoppingFlag) {
+        __VERIFIER_atomic_end();
+        return -1;
+    } else {
+        pendingIo = pendingIo + 1;
+    }
+    __VERIFIER_atomic_end();
+    return 0;
+}
+
+int dec() {
+    __VERIFIER_atomic_begin();
+    pendingIo--;
+    int tmp = pendingIo;
+    __VERIFIER_atomic_end();
+    return tmp;
+}
+
+void BCSP_IoDecrement() {
+    int pending;
+    pending = dec();
+    if (pending == 0) {
+        stoppingEvent = 1;
+    }
+}
+
+void* BCSP_PnpAdd(void* arg) {
+    int status;
+    status = BCSP_IoIncrement();
+    if (status == 0) {
+        __VERIFIER_assert(!stopped);
+    }
+    BCSP_IoDecrement();
+    return 0;
+}
+
+void* BCSP_PnpStop(void* arg) {
+    stoppingFlag = 1;
+    BCSP_IoDecrement();
+    assume_abort_if_not(stoppingEvent);
+    stopped = 1;
+    return 0;
+}
+
+int main() {
+    pthread_t t;
+    pendingIo = 1;
+    stoppingFlag = 0;
+    stoppingEvent = 0;
+    stopped = 0;
+    pthread_create(&t, 0, BCSP_PnpStop, 0);
+    BCSP_PnpAdd(0);
+    return 0;
+}

--- a/regression/esbmc-unix/SV_COMP_03/test.desc
+++ b/regression/esbmc-unix/SV_COMP_03/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---context-bound 2 --no-assertions --data-races-check
+--context-bound 2 --no-assertions --data-races-check -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/SV_COMP_03/test.desc
+++ b/regression/esbmc-unix/SV_COMP_03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--context-bound 2 --no-assertions --data-races-check
+^VERIFICATION FAILED$

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -127,7 +127,8 @@ void add_race_assertions(
     if (
       (instruction.is_assign() || instruction.is_other() ||
        instruction.is_return() || instruction.is_goto() ||
-       instruction.is_assert() || instruction.is_function_call()) &&
+       instruction.is_assert() || instruction.is_function_call() ||
+       instruction.is_assume()) &&
       !is_atomic)
     {
       exprt tmp_expr;

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -190,6 +190,7 @@ void add_race_assertions(
         migrate_expr(w_guards.get_assertion(e_it->second), assert);
         t->make_assertion(assert);
         t->location = original_instruction.location;
+        t->location.user_provided(false);
         t->location.comment(e_it->second.get_comment());
         i_it = ++t;
       }

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -127,7 +127,7 @@ void add_race_assertions(
     if (
       (instruction.is_assign() || instruction.is_other() ||
        instruction.is_return() || instruction.is_goto() ||
-       instruction.is_assert()) &&
+       instruction.is_assert() || instruction.is_function_call()) &&
       !is_atomic)
     {
       exprt tmp_expr;

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -541,7 +541,7 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
   }
-  else if (base_name == "__ESBMC_assert")
+  else if (base_name == "__ESBMC_assert" || base_name == "__VERIFIER_assert")
   {
     // 1 argument --> Default assertion
     // 2 arguments --> Normal assertion + MSG
@@ -551,7 +551,9 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
 
-    if (options.get_bool_option("no-assertions"))
+    if (
+      options.get_bool_option("no-assertions") &&
+      base_name != "__VERIFIER_assert")
       return;
 
     goto_programt::targett t = dest.add_instruction(ASSERT);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -541,7 +541,7 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
   }
-  else if (base_name == "__ESBMC_assert" || base_name == "__VERIFIER_assert")
+  else if (base_name == "__ESBMC_assert")
   {
     // 1 argument --> Default assertion
     // 2 arguments --> Normal assertion + MSG
@@ -551,9 +551,7 @@ void goto_convertt::do_function_call_symbol(
       abort();
     }
 
-    if (
-      options.get_bool_option("no-assertions") &&
-      base_name != "__VERIFIER_assert")
+    if (options.get_bool_option("no-assertions"))
       return;
 
     goto_programt::targett t = dest.add_instruction(ASSERT);

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -34,39 +34,15 @@ void rw_sett::compute(const exprt &expr)
     {
       assert(code.operands().size());
       read_write_rec(code.op0(), false, true, "", guardt(), exprt());
-      // check if the functions is __VERIFIER_assert(!cond)
-      if (code.op1().identifier() == "c:@F@__VERIFIER_assert")
-      {
-        // check the cond, usually has only one arg
-        assert(code.op2().operands().size() == 1);
-        read_rec(code.op2().op0());
-      }
-    }
-  }
-  else if (instruction.is_goto() || instruction.is_assert())
-  {
-    if (expr.is_not())
-    {
-      assert(expr.operands().size() == 1);
-      compute(expr.op0());
-    }
-    else if (expr.id() == "=" || expr.is_notequal())
-    {
-      assert(expr.operands().size() == 2);
-      read_rec(expr.op0());
-      read_rec(expr.op1());
-    }
-    else if (expr.is_or() || expr.is_and())
-    {
-      assert(expr.operands().size());
-      forall_operands (it, expr)
+      // check args of function call
+      Forall_operands (it, code.op2())
         read_rec(*it);
     }
-    else if (expr.is_typecast())
-    {
-      assert(expr.operands().size() == 1);
-      read_rec(expr.op0());
-    }
+  }
+  else if (
+    instruction.is_goto() || instruction.is_assert() || instruction.is_assume())
+  {
+    read_rec(expr);
   }
 }
 

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -35,8 +35,12 @@ void rw_sett::compute(const exprt &expr)
       assert(code.operands().size());
       read_write_rec(code.op0(), false, true, "", guardt(), exprt());
       // check args of function call
-      Forall_operands (it, code.op2())
-        read_rec(*it);
+      if (
+        !has_prefix(instruction.location.function(), "ESBMC_execute_kernel") &&
+        !has_prefix(instruction.location.function(), "ESBMC_verify_kernel"))
+        Forall_operands (it, code.op2())
+          if (!(*it).type().is_pointer())
+            read_rec(*it);
     }
   }
   else if (

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -30,6 +30,18 @@ void rw_sett::compute(const exprt &expr)
       assert(code.operands().size() == 1);
       read_rec(code.op0());
     }
+    else if (statement == "function_call")
+    {
+      assert(code.operands().size());
+      read_write_rec(code.op0(), false, true, "", guardt(), exprt());
+      // check if the functions is __VERIFIER_assert(!cond)
+      if (code.op1().identifier() == "c:@F@__VERIFIER_assert")
+      {
+        // check the cond, usually has only one arg
+        assert(code.op2().operands().size() == 1);
+        read_rec(code.op2().op0());
+      }
+    }
   }
   else if (instruction.is_goto() || instruction.is_assert())
   {

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -252,7 +252,8 @@ void execution_statet::symex_step(reachability_treet &art)
       owning_rt->main_thread_ended = true;
     }
     else if (
-      instruction.function == "c:@F@main" &&
+      (instruction.function == "c:@F@main" ||
+       instruction.function == "c:@F@main#") &&
       !options.get_bool_option("deadlock-check") &&
       !options.get_bool_option("memory-leak-check"))
     {


### PR DESCRIPTION
We use the flag of `--no-assertions` in SV-COMP, which causes the assertion not to be converted to GOTO. So I made some changes to `__VERIFIER_assert` to get it converted and race checked.