### PR TITLE
[Concurrency] only consider pointer to global when analyzing reads and writes

### DIFF
--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -843,9 +843,28 @@ void execution_statet::get_expr_globals(
     {
       return;
     }
+
+    bool point_to_global = false;
+    if (symbol->type.is_pointer() && symbol->name != "invalid_object")
+    {
+      expr2tc tmp = expr;
+      cur_state->rename(tmp);
+
+      std::unordered_set<expr2tc, irep2_hash> symbols;
+      get_symbols(tmp, symbols);
+      for (const auto &symbol_expr : symbols)
+      {
+        const std::string &n = to_symbol2t(symbol_expr).thename.as_string();
+        const symbolt *s = ns.lookup(n);
+        if (!s)
+          return;
+        point_to_global = s->static_lifetime;
+      }
+    }
+
     if (
-      (symbol->static_lifetime || symbol->type.is_dynamic_set()) ||
-      symbol->type.is_pointer())
+      symbol->static_lifetime || symbol->type.is_dynamic_set() ||
+      point_to_global)
     {
       std::list<unsigned int> threadId_list;
       auto it_find = art1->vars_map.find(expr);

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -850,7 +850,9 @@ void execution_statet::get_expr_globals(
       !symbol->static_lifetime)
     {
       expr2tc tmp = expr;
+      /* Rename it so that it can be dereferenced in current state */
       cur_state->rename(tmp);
+      /* Collect all the objects pointed to by the pointer */
       expr2tc deref = dereference2tc(to_pointer_type(tmp->type).subtype, tmp);
       value_setst::valuest dest;
       cur_state->value_set.get_reference_set(deref, dest);
@@ -867,7 +869,7 @@ void execution_statet::get_expr_globals(
           if (!s)
             continue;
           point_to_global = s->static_lifetime || s->type.is_dynamic_set();
-
+          /* Stop when the global symbol is found */
           if (point_to_global)
             break;
         }


### PR DESCRIPTION
Support for pointers was added in the previous PR, and thread interleaving is added when reading or writing pointers, which results in very large thread interleaving when verifying multiple threads.

I think we should add some filtering to reduce thread interleaving, at least not unconditionally checking any pointers.

In this PR, I want to discuss the idea that there might be a better solution.

#1889
#1903 

_Update:_
This PR:
```
Statistics:          23805 Files
  correct:           14147
    correct true:     7761
    correct false:    6386
  incorrect:            29
    incorrect true:     12
    incorrect false:    17
  unknown:            9629
  Score:             21252 (max: 38482)
  
  https://github.com/esbmc/esbmc/actions/runs/10339896288/job/28620094507
```
Master:
```
Statistics:          23805 Files
  correct:           14100
    correct true:     7729
    correct false:    6371
  incorrect:            28
    incorrect true:     12
    incorrect false:    16
  unknown:            9677
  Score:             21189 (max: 38482)

  https://github.com/esbmc/esbmc/actions/runs/10339894034/job/28620090531
```

The incorrect one from no-data-race, TIMEOUT in master

