### PR TITLE
[C++ verification] fixed array type init

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_1962-0/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_1962-0/main.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+
+class Base
+{
+public:
+  int a;
+  int ss[1];
+  int sss[1];
+  Base(): a{1}, ss{2}, sss{3} {}
+};
+
+int main()
+{
+  Base x;
+  assert(x.a == 1);
+  assert(x.ss[0] == 2);
+  assert(x.sss[0] == 3);
+}

--- a/regression/esbmc-cpp/bug_fixes/github_1962-0/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_1962-0/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_1962-1/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_1962-1/main.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+
+class Base
+{
+public:
+  int ss[1];
+  int a;
+  int sss[1];
+  Base(): ss{1}, a{2}, sss{3} {}
+};
+
+int main()
+{
+  Base x;
+  assert(x.ss[0] == 1);
+  assert(x.a == 2);
+  assert(x.sss[0] == 3);
+}

--- a/regression/esbmc-cpp/bug_fixes/github_1962-1/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_1962-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -57,7 +57,7 @@ void clang_c_adjust::adjust_code(codet &code)
        * unused.
        */
       exprt &op = code.op0();
-      if (op.op0().type().is_pointer())
+      if (op.has_operands() && op.op0().type().is_pointer())
         op = address_of_exprt(index_exprt(op, constant_exprt(0, index_type())));
     }
     adjust_operands(code);

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -57,7 +57,7 @@ void clang_c_adjust::adjust_code(codet &code)
        * unused.
        */
       exprt &op = code.op0();
-      if (op.has_operands() && op.op0().type().is_pointer())
+      if (op.statement() != "assign")
         op = address_of_exprt(index_exprt(op, constant_exprt(0, index_type())));
     }
     adjust_operands(code);

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -57,7 +57,8 @@ void clang_c_adjust::adjust_code(codet &code)
        * unused.
        */
       exprt &op = code.op0();
-      op = address_of_exprt(index_exprt(op, constant_exprt(0, index_type())));
+      if (op.op0().type().is_pointer())
+        op = address_of_exprt(index_exprt(op, constant_exprt(0, index_type())));
     }
     adjust_operands(code);
   }

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1257,7 +1257,6 @@ bool clang_cpp_convertert::get_function_body(
         else
         {
           initializer = side_effect_exprt("assign", member.type());
-          initializer.set("#member_init", 1);
           initializer.move_to_operands(member, rhs);
           initializer.location() = new_expr.location();
           initializers.push_back(initializer);
@@ -1269,15 +1268,10 @@ bool clang_cpp_convertert::get_function_body(
         log_error("Unsupported initializer in {}", __func__);
         abort();
       }
-
-      // Convert to code and insert side-effect in the operands list
-      // Essentially we convert an initializer to assignment, e.g:
-      // t1() : i(2){ }
-      // is converted to
-      // t1() { this->i = 2; }
-      for (exprt &initializer : initializers)
-        convert_expression_to_code(initializer);
     }
+
+    for (exprt &initializer : initializers)
+      convert_expression_to_code(initializer);
 
     // Insert initializers at the beginning of the body
     body.operands().insert(

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1135,7 +1135,7 @@ bool clang_cpp_convertert::get_function_body(
     bool init_sym_uptodate = true;
 
     // Parse the initializers, if any
- 
+
     // `init` type is clang::CXXCtorInitializer
     for (auto init : cxxcd.inits())
     {
@@ -1287,7 +1287,7 @@ bool clang_cpp_convertert::get_function_body(
       /* Need to declare the temp symbol for array initialization if it has
        * been used. */
       code_declt init_decl(symbol_expr(*array_init_sym));
-       body.operands().insert(body.operands().begin(), init_decl);
+      body.operands().insert(body.operands().begin(), init_decl);
     }
   }
 


### PR DESCRIPTION
Here's the solution I came up with

```cpp
#include <cassert>

class Base
{
public:
  int ss[1];
  int sss[1];
  Base(): ss{1}, sss{1} {}

};

int main()
{
  Base x;
  assert(x.ss[0] == 1);
  assert(x.sss[0] == 1);
}
```

Goto:
```cpp
Base (c:@S@Base@F@Base#):
        // 20 no location
        DECL Base array_init$;
        // 21 no location
        ASSIGN array_init$=NONDET(struct);
        // 22 
        ASSIGN array_init$.ss={ 1 };
        // 23 
        OTHER &array_init$.ss[0];     ---> Where did this come from

        // 24 
        ASSIGN *this=array_init$;
        // 25 
        ASSIGN array_init$.sss={ 1 };
        // 26 
        OTHER &array_init$.sss[0];   ---> Where did this come from

        // 27 
        ASSIGN *this=array_init$;
        // 28 file main1.cpp line 8 column 26 function Base
        DEAD c:@S@Base@F@Base#this_array_init$
        // 29 file main1.cpp line 8 column 26 function Base
        END_FUNCTION // Base
```
But I'm a little confused there are some extra instructions, I'm not sure where they came from, but I'm pretty sure this PR didn't cause that problem.
