### PR TITLE
[clang-cpp] Add support for simple lambdas

### DIFF
--- a/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits-fail/main.cpp
+++ b/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits-fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+#include <functional>
+
+int main()
+{
+  std::function<int(int, int)> sum = [](int a, int b) -> int { return a + b; };
+
+  assert(sum(5, 7) == 12222);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits-fail/test.desc
+++ b/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION FAILED

--- a/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits/main.cpp
+++ b/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+#include <functional>
+
+int main()
+{
+  std::function<int(int, int)> sum = [](int a, int b) -> int { return a + b; };
+
+  assert(sum(5, 7) == 12);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits/test.desc
+++ b/regression/esbmc-cpp11/lambda/Lambda--as-function-no-capture-no-inits/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits-fail/main.cpp
+++ b/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits-fail/main.cpp
@@ -1,0 +1,6 @@
+#include <cassert>
+
+int main()
+{
+  assert([](int a) { return a + 2; }(2) == 444);
+}

--- a/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits-fail/test.desc
+++ b/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION FAILED

--- a/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits/main.cpp
+++ b/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits/main.cpp
@@ -1,0 +1,6 @@
+#include <cassert>
+
+int main()
+{
+  assert([](int a) { return a + 2; }(2) == 4);
+}

--- a/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits/test.desc
+++ b/regression/esbmc-cpp11/lambda/Lambda-no-capture-no-inits/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -976,6 +976,34 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::LambdaExprClass:
+  {
+    const clang::LambdaExpr &lambda_expr =
+      static_cast<const clang::LambdaExpr &>(stmt);
+
+    if (lambda_expr.capture_size() > 0)
+    {
+      log_error("ESBMC does not support lambdas with captures for now");
+      return true;
+    }
+
+    get_struct_union_class(*lambda_expr.getLambdaClass());
+
+    // Construct a new object of the lambda class
+    typet lambda_class_type;
+    if (get_type(
+          *lambda_expr.getLambdaClass()->getTypeForDecl(), lambda_class_type))
+      return true;
+    new_expr = gen_zero(pointer_typet(lambda_class_type));
+    // Generating a null pointer only works as long as we don't have captures
+    // When we want to add support for captures, we have to probably call
+    // the lambda class constructor here
+    // See https://cppinsights.io/ which is a great tool to see how lambdas
+    // are translated to C++ code
+
+    break;
+  }
+
   default:
     if (clang_c_convertert::get_expr(stmt, new_expr))
       return true;


### PR DESCRIPTION
Indirectly fixes #1666.

Indirectly because the parse error has probably been fixed in some other PR while the segfault (when using system headers) has also likely been fixed on some other PR.

