### PR TITLE
[ESBMC-CHERI] fix build errors

### DIFF
--- a/scripts/cmake/ExternalDependencies.cmake
+++ b/scripts/cmake/ExternalDependencies.cmake
@@ -24,6 +24,7 @@ if(ESBMC_CHERI_CLANG)
     GIT_REPOSITORY https://github.com/CTSRD-CHERI/cheri-compressed-cap.git)
   FetchContent_GetProperties(cheri_compressed_cap)
   if(NOT cheri_compressed_cap_POPULATED)
+    set(HAVE_UBSAN FALSE CACHE INTERNAL "")
     FetchContent_Populate(cheri_compressed_cap)
     add_subdirectory(${cheri_compressed_cap_SOURCE_DIR}
                      ${cheri_compressed_cap_BINARY_DIR}


### PR DESCRIPTION
This PR fixes a bug when building CHERI: When `-DESBMC_CHERI=On` and `-DBUILD_TESTING=On` are used together, the build 
will fail if we do not enable `ubsan` for the linker.

see comment: https://github.com/esbmc/esbmc/issues/1969#issue-2456532432

No longer compile `cheri_compressed_cap` with `Ubsan` enabled.