### PR TITLE
[BUILDING] update CHERI build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -127,12 +127,6 @@ ESBMC_CLANG=$(echo -D{LLVM,Clang}_DIR=$PWD/clang13) &&
 ESBMC_STATIC=Off
 ```
 
-If you want to build ESBMC-CHERI, please built with the option:
-
-```
--DESBMC_CHERI=On -DCMAKE_BUILD_TYPE=Sanitizer -DSANITIZER_TYPE=UBSAN
-```
-
 ## Preparing the Solidity frontend (optional)
 
 We developed a solidity frontend for the efficient SMT-based context-bounded model checker (ESBMC). ESBMC-solidity is a permissively licensed open-source context-bounded model checker to verify Solidity smart contracts. It can verify both predefined safety properties (e.g., bounds check, overflow, underflow) and user-defined program assertions automatically.
@@ -402,9 +396,9 @@ The following command will install the packages required for the most commonly u
 sudo apt install autoconf automake libtool pkg-config clang bison cmake mercurial ninja-build samba flex texinfo time libglib2.0-dev libpixman-1-dev libarchive-dev libarchive-tools libbz2-dev libattr1-dev libcap-ng-dev libexpat1-dev libgmp-dev bc
 ```
 
-Download and build Cheri:
+Download and build Cheri riscv64 purecap:
 ```
-git clone https://github.com/CTSRD-CHERI/cheribuild.git && cd cheribuild && python3 cheribuild.py cheribsd-riscv64-purecap disk-image-riscv64-purecap -d
+git clone https://github.com/CTSRD-CHERI/cheribuild.git && cd cheribuild && python3 cheribuild.py cheribsd-riscv64-purecap -d
 ```
 
 Once the build completed, you'll find `cheri` directory in your HOME directory.
@@ -413,10 +407,7 @@ CHERI-enabled ESBMC defaults to the platform mips64-unknown-freebsd and
 expects the corresponding sysroot, the default of which can be configured by
 passing the CMake flags
 ```
--DESBMC_CHERI_HYBRID_SYSROOT=<path> -DESBMC_CHERI_PURECAP_SYSROOT=<path>
+-DESBMC_CHERI=On -DESBMC_CHERI_HYBRID_SYSROOT=<path> -DESBMC_CHERI_PURECAP_SYSROOT=<path>
 ```
 e.g. the 'path' should point to `$HOME/cheri/output/rootfs-riscv64-purecap`. As for the `rootfs-riscv64-purecap` part, you may want to use a diffrent directory if you used a different variant in the `cheribuild.py` command above.
-
-
-
 


### PR DESCRIPTION
This PR updated the build instructions for CHERI.

I still had a few questions about CHERI:

1. Regarding `sysroot`, is there a difference between the libraries in `rootfs-riscv64-purecap` and `rootfs-riscv64-hybrid`? If not, do we need to build only one of them? 

2. CHERI TCs are present in regression, but it is not currently enabled. Is it possible to add CHERI TCs to CI? This might require architecture-specific runners? Like morello.