### PR TITLE
[python-frontend] Get type from function arguments

### DIFF
--- a/regression/python/binary-ops/main.py
+++ b/regression/python/binary-ops/main.py
@@ -12,3 +12,10 @@ bitand = 1 & 0
 bitxor = 3 ^ 1
 bitlsh = 2 << 1
 bitrsh = 2 >> 1
+
+
+def add_nums(x:int, y:int) -> int:
+  z = x + y
+  return z
+
+assert add_nums(1,2) == 3

--- a/regression/python/inheritance/main.py
+++ b/regression/python/inheritance/main.py
@@ -31,3 +31,7 @@ assert Derived.data == 2  # Asserting that the derived class has its own 'data' 
 
 c: int = obj.bar()  # Testing the overridden 'bar' method in the derived class
 assert c == 2  # Asserting that the overridden 'bar' method returns the expected value (2)
+
+
+class MyFloat(float):
+  pass

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -344,7 +344,7 @@ private:
     element.erase("type_comment");
 
     // Update value fields with the correct offsets
-    auto update_offsets = [&](Json &value) {
+    auto update_offsets = [&inferred_type](Json &value) {
       value["col_offset"] =
         value["col_offset"].template get<int>() + inferred_type.size() + 1;
       value["end_col_offset"] =

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -114,7 +114,13 @@ private:
       // If the LHS of the binary operation is a variable, its type is retrieved
       if (lhs["_type"] == "Name")
       {
+        // Retrieve the type from the variable declaration within the current function body
         Json left_op = find_annotated_assign(lhs["id"], body["body"]);
+
+        // If not found in the function body, try to retrieve it from the function arguments
+        if (left_op.empty() && body.contains("args"))
+          left_op = find_annotated_assign(lhs["id"], body["args"]["args"]);
+
         if (!left_op.empty())
           type = left_op["annotation"]["id"];
       }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1771,6 +1771,12 @@ void python_converter::get_class_definition(
   for (auto &base_class : class_node["bases"])
   {
     const std::string &base_class_name = base_class["id"].get<std::string>();
+    /* TODO: Define OMs for built-in type classes.
+     * This will allow us to add their definitions to the context
+     * inherit from them, and extend their functionality. */
+    if (is_builtin_type(base_class_name) || is_consensus_type(base_class_name))
+      continue;
+
     // Get class definition from symbols table
     symbolt *class_symbol = context.find_symbol("tag-" + base_class_name);
     if (!class_symbol)

--- a/src/python-frontend/python_frontend_types.cpp
+++ b/src/python-frontend/python_frontend_types.cpp
@@ -10,7 +10,8 @@ bool is_builtin_type(const std::string &name)
 bool is_consensus_type(const std::string &name)
 {
   return (
-    name == "uint64" || name == "uint256" || name == "Epoch" || name == "Gwei" || name == "BLSFieldElement");
+    name == "uint64" || name == "uint256" || name == "Epoch" ||
+    name == "Gwei" || name == "BLSFieldElement");
 }
 
 std::map<std::string, std::string> consensus_func_to_type = {

--- a/src/python-frontend/python_frontend_types.cpp
+++ b/src/python-frontend/python_frontend_types.cpp
@@ -9,7 +9,8 @@ bool is_builtin_type(const std::string &name)
 
 bool is_consensus_type(const std::string &name)
 {
-  return (name == "uint64" || name == "Epoch" || name == "Gwei");
+  return (
+    name == "uint64" || name == "uint256" || name == "Epoch" || name == "Gwei" || name == "BLSFieldElement");
 }
 
 std::map<std::string, std::string> consensus_func_to_type = {


### PR DESCRIPTION
This PR enables inferring the type of variables from function arguments. For example:

```python
def foo(x:int, y:int):
  z = x # The type of 'z' is inferred as 'int' from the 'x' argument
```

Additionally, it refactors `python_annotation.h `to enhance readability.