### PR TITLE
[concurrency] use address of var for the data race check

### DIFF
--- a/regression/cuda/benchmarks/011_value_causing_race/test.desc
+++ b/regression/cuda/benchmarks/011_value_causing_race/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.cu
---unwind 9 --force-malloc-success --context-bound 3 --data-races-check --state-hashing
+--unwind 9 --force-malloc-success --context-bound 2 --data-races-check --state-hashing --no-bounds-check
 
 ^VERIFICATION FAILED$
 

--- a/regression/cuda/benchmarks/014_miscfail3_fail/test.desc
+++ b/regression/cuda/benchmarks/014_miscfail3_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---unwind 9 --force-malloc-success --state-hashing --context-bound 3 --data-races-check --no-bounds-check 
+--unwind 9 --force-malloc-success --state-hashing --context-bound 2 --data-races-check --no-bounds-check 
 
 ^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/016_bad_inter_group_fail/test.desc
+++ b/regression/cuda/benchmarks/016_bad_inter_group_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---unwind 17 --force-malloc-success --state-hashing --context-bound 3 --data-races-check --no-bounds-check
+--unwind 17 --force-malloc-success --state-hashing --context-bound 2 --data-races-check --no-bounds-check
 
 ^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/017_equality_abstraction_issue/test.desc
+++ b/regression/cuda/benchmarks/017_equality_abstraction_issue/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---force-malloc-success --context-bound 3 --unwind 9 --state-hashing --data-races-check --no-bounds-check
+--force-malloc-success --context-bound 2 --unwind 9 --state-hashing --data-races-check --no-bounds-check
 
 ^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/018_testbasicaliasing/test.desc
+++ b/regression/cuda/benchmarks/018_testbasicaliasing/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---unwind 9 --force-malloc-success --state-hashing --context-bound 3 --data-races-check --no-bounds-check
+--unwind 9 --force-malloc-success --state-hashing --context-bound 2 --data-races-check --no-bounds-check
 
 ^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/041_test_copy_between_memory_spaces/test.desc
+++ b/regression/cuda/benchmarks/041_test_copy_between_memory_spaces/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---unwind 9 --force-malloc-success --state-hashing --context-bound 3 --data-races-check
+--unwind 9 --force-malloc-success --state-hashing --context-bound 2 --data-races-check
 
 ^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/042_test_copy_between_pointers/test.desc
+++ b/regression/cuda/benchmarks/042_test_copy_between_pointers/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cu
---context-bound 3 --force-malloc-success --state-hashing --unwind 9 --data-races-check
+--context-bound 2 --force-malloc-success --state-hashing --unwind 9 --data-races-check
 
 ^VERIFICATION FAILED$

--- a/regression/cuda/benchmarks/093_bronken_shuffle/test.desc
+++ b/regression/cuda/benchmarks/093_bronken_shuffle/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cu
 --unwind 9 --force-malloc-success --state-hashing --context-bound 2 --data-races-check --no-bounds-check
 

--- a/regression/cuda/benchmarks/099_test8/test.desc
+++ b/regression/cuda/benchmarks/099_test8/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.cu
---context-bound 3 --force-malloc-success --state-hashing --unwind 9 --data-races-check
+--context-bound 2 --force-malloc-success --state-hashing --unwind 9 --data-races-check
 
 ^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -380,9 +380,6 @@ _Bool __ESBMC_is_dynamic[1];
 __attribute__((annotate("__ESBMC_inf_size")))
 __SIZE_TYPE__ __ESBMC_alloc_size[1];
 
-__attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_races_flag[1];
-
 // Get object size
 __SIZE_TYPE__ __ESBMC_get_object_size(const void *);
 

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -380,6 +380,9 @@ _Bool __ESBMC_is_dynamic[1];
 __attribute__((annotate("__ESBMC_inf_size")))
 __SIZE_TYPE__ __ESBMC_alloc_size[1];
 
+__attribute__((annotate("__ESBMC_inf_size")))
+_Bool __ESBMC_races_flag[1];
+
 // Get object size
 __SIZE_TYPE__ __ESBMC_get_object_size(const void *);
 

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -20,24 +20,13 @@ public:
     const exprt &original_expr,
     bool deref)
   {
-    // if (deref)
-    // {
-    //   irep_idt name = "__ESBMC_races_check";
-    //   const symbolt *symbol = context.find_symbol(name);
-    //   assert(symbol);
-
-    //   return *symbol;
-    // }
-
-    const irep_idt identifier =
-      deref ? "__ESBMC_deref_" + id2string(object) : "tmp_" + id2string(object);
+    const irep_idt identifier = "tmp_" + id2string(object);
 
     const symbolt *s = context.find_symbol(identifier);
     if (s != nullptr)
       return *s;
 
-    if (!deref)
-      w_guards.push_back(identifier);
+    w_guards.push_back(identifier);
 
     type2tc index = array_type2tc(get_bool_type(), expr2tc(), true);
 
@@ -108,7 +97,7 @@ void w_guardst::add_initialization(goto_programt &goto_program)
   const namespacet ns(context);
 
   type2tc arrayt = array_type2tc(get_bool_type(), expr2tc(), true);
-  const irep_idt identifier = "__ESBMC_races_flag";
+  const irep_idt identifier = "c:@F@__ESBMC_races_flag";
   w_guards.push_back(identifier);
   symbolt new_symbol;
   new_symbol.id = identifier;

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -48,8 +48,9 @@ public:
   {
     if (deref)
     {
+      exprt address = address_of_exprt(original_expr);
       exprt check("races_check", typet("bool"));
-      check.copy_to_operands(original_expr);
+      check.move_to_operands(address);
 
       return check;
     }

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -48,9 +48,8 @@ public:
   {
     if (deref)
     {
-      exprt address = address_of_exprt(original_expr);
       exprt check("races_check", typet("bool"));
-      check.copy_to_operands(address);
+      check.copy_to_operands(original_expr);
 
       return check;
     }

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -15,10 +15,8 @@ public:
 
   std::list<irep_idt> w_guards;
 
-  const symbolt &get_guard_symbol(
-    const irep_idt &object,
-    const exprt &original_expr,
-    bool deref)
+  const symbolt &
+  get_guard_symbol(const irep_idt &object, const exprt &original_expr)
   {
     const irep_idt identifier = "tmp_" + id2string(object);
 
@@ -57,7 +55,7 @@ public:
       return check;
     }
 
-    exprt expr = symbol_expr(get_guard_symbol(object, original_expr, deref));
+    exprt expr = symbol_expr(get_guard_symbol(object, original_expr));
     if (original_expr.is_index() && expr.type().is_array())
     {
       index_exprt full_expr = to_index_expr(original_expr);
@@ -106,7 +104,7 @@ void w_guardst::add_initialization(goto_programt &goto_program)
   new_symbol.static_lifetime = true;
   new_symbol.value.make_false();
   context.move_symbol_to_context(new_symbol);
-  
+
   for (const auto &w_guard : w_guards)
   {
     const symbolt &s = *ns.lookup(w_guard);
@@ -169,7 +167,8 @@ void add_race_assertions(
         goto_programt::targett t = goto_program.insert(i_it);
         t->type = FUNCTION_CALL;
         code_function_callt call;
-        call.function() = symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
+        call.function() =
+          symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
 
         migrate_expr(call, t->code);
         t->location = original_instruction.location;
@@ -233,7 +232,7 @@ void add_race_assertions(
       }
 
       // now add assignments for what is written -- reset
-      forall_rw_set_entries(e_it, rw_set) if(e_it->second.w)
+      forall_rw_set_entries(e_it, rw_set) if (e_it->second.w)
       {
         goto_programt::targett t = goto_program.insert(i_it);
 

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -100,7 +100,7 @@ void rw_sett::read_write_rec(
     entry.object = object;
     entry.r = entry.r || r;
     entry.w = entry.w || w;
-    entry.deref = expr.type().is_pointer() && dereferenced;
+    entry.deref = dereferenced;
     entry.guard = migrate_expr_back(guard.as_expr());
     entry.original_expr = original_expr;
   }
@@ -134,12 +134,9 @@ void rw_sett::read_write_rec(
       tmp = expr.op0();
 
     if (tmp.id() == "+")
-    {
-      index_exprt tmp_index(tmp.op0(), tmp.op1(), tmp.type());
-      tmp.swap(tmp_index);
-    }
+      tmp = tmp.op0();
 
-    read_write_rec(tmp, r, w, suffix, guard, original_expr, true);
+    read_write_rec(tmp, r, w, suffix, guard, expr, true);
   }
   else if (expr.is_address_of() || expr.id() == "implicit_address_of")
   {

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -33,7 +33,7 @@ void rw_sett::compute(const exprt &expr)
     else if (statement == "function_call")
     {
       assert(code.operands().size());
-      read_write_rec(code.op0(), false, true, "", guardt(), exprt());
+      read_write_rec(code.op0(), false, true, "", guardt(), nil_exprt());
       // check args of function call
       if (
         !has_prefix(instruction.location.function(), "ESBMC_execute_kernel") &&
@@ -53,7 +53,7 @@ void rw_sett::compute(const exprt &expr)
 void rw_sett::assign(const exprt &lhs, const exprt &rhs)
 {
   read_rec(rhs);
-  read_write_rec(lhs, false, true, "", guardt(), exprt());
+  read_write_rec(lhs, false, true, "", guardt(), nil_exprt());
 }
 
 void rw_sett::read_write_rec(
@@ -109,7 +109,7 @@ void rw_sett::read_write_rec(
     assert(expr.operands().size() == 1);
     const std::string &component_name = expr.component_name().as_string();
     read_write_rec(
-      expr.op0(), r, w, "." + component_name + suffix, guard, original_expr);
+      expr.op0(), r, w, "." + component_name + suffix, guard, expr);
   }
   else if (expr.is_index())
   {
@@ -136,7 +136,10 @@ void rw_sett::read_write_rec(
     if (tmp.id() == "+")
       tmp = tmp.op0();
 
-    read_write_rec(tmp, r, w, suffix, guard, expr, true);
+    if (original_expr.is_member())
+      read_write_rec(tmp, r, w, suffix, guard, original_expr, true);
+    else
+      read_write_rec(tmp, r, w, suffix, guard, expr, true);
   }
   else if (expr.is_address_of() || expr.id() == "implicit_address_of")
   {

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -108,21 +108,27 @@ void rw_sett::read_write_rec(
   {
     assert(expr.operands().size() == 1);
     const std::string &component_name = expr.component_name().as_string();
-    exprt tmp = original_expr.is_nil()? expr : original_expr;
+    exprt tmp = original_expr.is_nil() ? expr : original_expr;
 
     read_write_rec(
-      expr.op0(), r, w, "." + component_name + suffix, guard, tmp, dereferenced);
+      expr.op0(),
+      r,
+      w,
+      "." + component_name + suffix,
+      guard,
+      tmp,
+      dereferenced);
   }
   else if (expr.is_index())
   {
     assert(expr.operands().size() == 2);
-    exprt tmp = original_expr.is_nil()? expr : original_expr;
+    exprt tmp = original_expr.is_nil() ? expr : original_expr;
     read_write_rec(expr.op0(), r, w, suffix, guard, tmp, dereferenced);
   }
   else if (expr.is_dereference())
   {
     assert(expr.operands().size() == 1);
-    exprt tmp = original_expr.is_nil()? expr : original_expr;
+    exprt tmp = original_expr.is_nil() ? expr : original_expr;
 
     read_write_rec(expr.op0(), r, w, suffix, guard, tmp, true);
   }
@@ -139,12 +145,14 @@ void rw_sett::read_write_rec(
     expr2tc tmp_expr;
     migrate_expr(expr.op0(), tmp_expr);
     true_guard.add(tmp_expr);
-    read_write_rec(expr.op1(), r, w, suffix, true_guard, original_expr, dereferenced);
+    read_write_rec(
+      expr.op1(), r, w, suffix, true_guard, original_expr, dereferenced);
 
     guardt false_guard(guard);
     migrate_expr(gen_not(expr.op0()), tmp_expr);
     false_guard.add(tmp_expr);
-    read_write_rec(expr.op2(), r, w, suffix, false_guard, original_expr, dereferenced);
+    read_write_rec(
+      expr.op2(), r, w, suffix, false_guard, original_expr, dereferenced);
   }
   else
   {

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -34,7 +34,6 @@ void rw_sett::compute(const exprt &expr)
     {
       assert(code.operands().size());
       read_write_rec(code.op0(), false, true, "", guardt(), nil_exprt());
-      read_write_rec(code.op1(), false, true, "", guardt(), nil_exprt());
       // check args of function call
       if (
         !has_prefix(instruction.location.function(), "ESBMC_execute_kernel") &&
@@ -101,9 +100,9 @@ void rw_sett::read_write_rec(
     entry.object = object;
     entry.r = entry.r || r;
     entry.w = entry.w || w;
-    entry.deref = dereferenced || expr.type().is_pointer();
+    entry.deref = dereferenced;
     entry.guard = migrate_expr_back(guard.as_expr());
-    entry.original_expr = original_expr.is_nil()? expr : original_expr;
+    entry.original_expr = original_expr.is_nil() ? expr : original_expr;
   }
   else if (expr.is_member())
   {

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -34,6 +34,7 @@ void rw_sett::compute(const exprt &expr)
     {
       assert(code.operands().size());
       read_write_rec(code.op0(), false, true, "", guardt(), nil_exprt());
+      read_write_rec(code.op1(), false, true, "", guardt(), nil_exprt());
       // check args of function call
       if (
         !has_prefix(instruction.location.function(), "ESBMC_execute_kernel") &&
@@ -100,9 +101,9 @@ void rw_sett::read_write_rec(
     entry.object = object;
     entry.r = entry.r || r;
     entry.w = entry.w || w;
-    entry.deref = dereferenced;
+    entry.deref = dereferenced || expr.type().is_pointer();
     entry.guard = migrate_expr_back(guard.as_expr());
-    entry.original_expr = original_expr;
+    entry.original_expr = original_expr.is_nil()? expr : original_expr;
   }
   else if (expr.is_member())
   {

--- a/src/goto-programs/rw_set.h
+++ b/src/goto-programs/rw_set.h
@@ -65,7 +65,7 @@ public:
 
   void read_rec(const exprt &expr)
   {
-    read_write_rec(expr, true, false, "", guardt(), exprt());
+    read_write_rec(expr, true, false, "", guardt(), nil_exprt());
   }
 
   void

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1624,6 +1624,8 @@ void goto_symext::replace_races_check(expr2tc &expr)
   if (!options.get_bool_option("data-races-check"))
     return;
 
+  // replace RACE_CHECK(&x) with __ESBMC_races_flag[&x]
+  // recursion is needed for this case: !RACE_CHECK(&x)
   expr->Foreach_operand([this](expr2tc &e) {
     if (!is_nil_expr(e))
       replace_races_check(e);

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1634,16 +1634,12 @@ void goto_symext::replace_races_check(expr2tc &expr)
     // replace with __ESBMC_races_flag[address_of(var)]
     const races_check2t &obj = to_races_check2t(expr);
 
-    expr2tc ptr_obj;
-    if (is_symbol2t(obj.value))
-      ptr_obj = pointer_object2tc(pointer_type2(), obj.value);
-    else
-      ptr_obj = obj.value;
+    expr2tc ptr_addr = address_of2tc(pointer_type2(), obj.value);
 
     expr2tc flag;
     migrate_expr(symbol_expr(*ns.lookup("c:@F@__ESBMC_races_flag")), flag);
 
-    expr2tc index_expr = index2tc(get_bool_type(), flag, obj.value);
+    expr2tc index_expr = index2tc(get_bool_type(), flag, ptr_addr);
     expr = index_expr;
   }
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1634,12 +1634,10 @@ void goto_symext::replace_races_check(expr2tc &expr)
     // replace with __ESBMC_races_flag[address_of(var)]
     const races_check2t &obj = to_races_check2t(expr);
 
-    expr2tc ptr_addr = address_of2tc(pointer_type2(), obj.value);
-
     expr2tc flag;
     migrate_expr(symbol_expr(*ns.lookup("c:@F@__ESBMC_races_flag")), flag);
 
-    expr2tc index_expr = index2tc(get_bool_type(), flag, ptr_addr);
+    expr2tc index_expr = index2tc(get_bool_type(), flag, obj.value);
     expr = index_expr;
   }
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1634,12 +1634,10 @@ void goto_symext::replace_races_check(expr2tc &expr)
     // replace with __ESBMC_races_flag[address_of(var)]
     const races_check2t &obj = to_races_check2t(expr);
 
-    expr2tc obj_expr = pointer_object2tc(pointer_type2(), obj.value);
-
     expr2tc flag;
     migrate_expr(symbol_expr(*ns.lookup("c:@F@__ESBMC_races_flag")), flag);
 
-    expr2tc index_expr = index2tc(get_bool_type(), flag, obj_expr);
+    expr2tc index_expr = index2tc(get_bool_type(), flag, obj.value);
     expr = index_expr;
   }
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1634,6 +1634,12 @@ void goto_symext::replace_races_check(expr2tc &expr)
     // replace with __ESBMC_races_flag[address_of(var)]
     const races_check2t &obj = to_races_check2t(expr);
 
+    expr2tc ptr_obj;
+    if (is_symbol2t(obj.value))
+      ptr_obj = pointer_object2tc(pointer_type2(), obj.value);
+    else
+      ptr_obj = obj.value;
+
     expr2tc flag;
     migrate_expr(symbol_expr(*ns.lookup("c:@F@__ESBMC_races_flag")), flag);
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -837,7 +837,6 @@ void execution_statet::get_expr_globals(
     if (
       name == "c:@__ESBMC_alloc" || name == "c:@__ESBMC_alloc_size" ||
       name == "c:@__ESBMC_is_dynamic" ||
-      name == "c:@__ESBMC_races_check"||
       name == "c:@__ESBMC_blocked_threads_count" ||
       name.find("c:pthread_lib") != std::string::npos ||
       name == "c:@__ESBMC_rounding_mode" ||

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -837,6 +837,7 @@ void execution_statet::get_expr_globals(
     if (
       name == "c:@__ESBMC_alloc" || name == "c:@__ESBMC_alloc_size" ||
       name == "c:@__ESBMC_is_dynamic" ||
+      name == "c:@__ESBMC_races_check"||
       name == "c:@__ESBMC_blocked_threads_count" ||
       name.find("c:pthread_lib") != std::string::npos ||
       name == "c:@__ESBMC_rounding_mode" ||

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -474,7 +474,7 @@ protected:
     reachability_treet &art);
 
   /* Handles dereferencing between threads and is used only in data race checks. **/
-  void intrinsic_races_check_dereference(expr2tc &expr);
+  void replace_races_check(expr2tc &expr);
 
   /** Walk back up stack frame looking for exception handler. */
   bool symex_throw();
@@ -834,7 +834,7 @@ protected:
    *  These irep_idts contain the names of the arrays being used to store data
    *  modelling what pointers are active, which are freed, and so forth. They
    *  can change between C and C++, unfortunately. */
-  irep_idt valid_ptr_arr_name, alloc_size_arr_name, dyn_info_arr_name;
+  irep_idt valid_ptr_arr_name, alloc_size_arr_name, dyn_info_arr_name, races_check_flag;
   /** List of all allocated objects.
    *  Used to track what we should level memory-leak-assertions against when the
    *  program execution has finished */

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -834,7 +834,7 @@ protected:
    *  These irep_idts contain the names of the arrays being used to store data
    *  modelling what pointers are active, which are freed, and so forth. They
    *  can change between C and C++, unfortunately. */
-  irep_idt valid_ptr_arr_name, alloc_size_arr_name, dyn_info_arr_name, races_check_flag;
+  irep_idt valid_ptr_arr_name, alloc_size_arr_name, dyn_info_arr_name;
   /** List of all allocated objects.
    *  Used to track what we should level memory-leak-assertions against when the
    *  program execution has finished */

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -157,12 +157,12 @@ void goto_symext::symex_assign(
   replace_nondet(lhs);
   replace_nondet(rhs);
 
-  intrinsic_races_check_dereference(lhs);
-
   dereference(lhs, dereferencet::WRITE);
   dereference(rhs, dereferencet::READ);
   replace_dynamic_allocation(lhs);
   replace_dynamic_allocation(rhs);
+
+  replace_races_check(lhs);
 
   // printf expression that has lhs
   if (is_code_printf2t(rhs))

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -419,10 +419,10 @@ void goto_symext::symex_assert()
   expr2tc tmp = instruction.guard;
   replace_nondet(tmp);
 
-  intrinsic_races_check_dereference(tmp);
-
   dereference(tmp, dereferencet::READ);
   replace_dynamic_allocation(tmp);
+
+  replace_races_check(tmp);
 
   claim(tmp, msg);
 }

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -110,6 +110,7 @@
   BOOST_PP_LIST_CONS(null_object,                                              \
   BOOST_PP_LIST_CONS(dereference,                                              \
   BOOST_PP_LIST_CONS(valid_object,                                             \
+  BOOST_PP_LIST_CONS(races_check,                                              \
   BOOST_PP_LIST_CONS(deallocated_obj,                                          \
   BOOST_PP_LIST_CONS(dynamic_size,                                             \
   BOOST_PP_LIST_CONS(sideeffect,                                               \
@@ -141,7 +142,7 @@
   BOOST_PP_LIST_CONS(signbit,                                                  \
   BOOST_PP_LIST_CONS(concat,                                                   \
   BOOST_PP_LIST_CONS(extract,                                                  \
-  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 #define ESBMC_LIST_OF_TYPES                                                    \
   BOOST_PP_LIST_CONS(bool,                                                     \

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -81,6 +81,7 @@ static const char *expr_names[] = {
   "NULL-object",
   "dereference",
   "valid_object",
+  "races_check",  
   "deallocated_obj",
   "dynamic_size",
   "sideeffect",

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -389,7 +389,7 @@ void with2t::assert_consistency() const
 {
   if (is_array_type(source_value))
   {
-    assert(is_bv_type(update_field->type));
+    assert(is_bv_type(update_field->type) || is_pointer_type(update_field->type));
     const array_type2t &arr_type = to_array_type(source_value->type);
     assert_type_compat_for_with(arr_type.subtype, update_value->type);
   }

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -389,7 +389,8 @@ void with2t::assert_consistency() const
 {
   if (is_array_type(source_value))
   {
-    assert(is_bv_type(update_field->type) || is_pointer_type(update_field->type));
+    assert(
+      is_bv_type(update_field->type) || is_pointer_type(update_field->type));
     const array_type2t &arr_type = to_array_type(source_value->type);
     assert_type_compat_for_with(arr_type.subtype, update_value->type);
   }

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -81,7 +81,7 @@ static const char *expr_names[] = {
   "NULL-object",
   "dereference",
   "valid_object",
-  "races_check",  
+  "races_check",
   "deallocated_obj",
   "dynamic_size",
   "sideeffect",

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1491,6 +1491,7 @@ irep_typedefs(null_object, expr2t);
 irep_typedefs(dynamic_object, dynamic_object_data);
 irep_typedefs(dereference, dereference_data);
 irep_typedefs(valid_object, object_ops);
+irep_typedefs(races_check, object_ops);
 irep_typedefs(deallocated_obj, object_ops);
 irep_typedefs(dynamic_size, object_ops);
 irep_typedefs(sideeffect, sideeffect_data);
@@ -3088,6 +3089,18 @@ public:
   {
   }
   valid_object2t(const valid_object2t &ref) = default;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class races_check2t : public races_check_expr_methods
+{
+public:
+  races_check2t(const expr2tc &operand)
+    : races_check_expr_methods(get_bool_type(), races_check_id, operand)
+  {
+  }
+  races_check2t(const races_check2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -2848,7 +2848,7 @@ public:
     : with_expr_methods(type, with_id, source, field, value)
   {
 #ifndef NDEBUG /* only check consistency in non-Release builds */
-    assert_consistency();
+    // assert_consistency();
 #endif
   }
   with2t(const with2t &ref) = default;

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -2849,7 +2849,7 @@ public:
     : with_expr_methods(type, with_id, source, field, value)
   {
 #ifndef NDEBUG /* only check consistency in non-Release builds */
-    // assert_consistency();
+    assert_consistency();
 #endif
   }
   with2t(const with2t &ref) = default;

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -174,6 +174,8 @@ std::string dereference2t::field_names[esbmct::num_type_fields] =
   {"pointer", "", "", "", ""};
 std::string valid_object2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
+std::string races_check2t::field_names[esbmct::num_type_fields] =
+  {"value", "", "", "", ""};  
 std::string deallocated_obj2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
 std::string dynamic_size2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -175,7 +175,7 @@ std::string dereference2t::field_names[esbmct::num_type_fields] =
 std::string valid_object2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
 std::string races_check2t::field_names[esbmct::num_type_fields] =
-  {"value", "", "", "", ""};  
+  {"value", "", "", "", ""};
 std::string deallocated_obj2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
 std::string dynamic_size2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates_expr_ops.cpp
+++ b/src/irep2/templates/irep2_templates_expr_ops.cpp
@@ -34,6 +34,7 @@ expr_typedefs1(pointer_capability, pointer_ops);
 expr_typedefs1(address_of, pointer_ops);
 expr_typedefs1(overflow, overflow_ops);
 expr_typedefs1(valid_object, object_ops);
+expr_typedefs1(races_check, object_ops);
 expr_typedefs1(dynamic_size, object_ops);
 expr_typedefs1(deallocated_obj, object_ops);
 expr_typedefs1(invalid_pointer, invalid_pointer_ops);

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -2376,6 +2376,11 @@ std::string c_expr2stringt::convert(const exprt &src, unsigned &precedence)
     return convert_function(src, "VALID_OBJECT", precedence = 15);
   }
 
+  else if (src.id() == "races_check")
+  {
+    return convert_function(src, "RACE_CHECK", precedence = 15);
+  }
+
   else if (src.id() == "deallocated_object" || src.id() == "memory-leak")
   {
     return convert_function(src, "DEALLOCATED_OBJECT", precedence = 15);

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -2724,7 +2724,9 @@ exprt migrate_expr_back(const expr2tc &ref)
   case expr2t::races_check_id:
   {
     const races_check2t &ref2 = to_races_check2t(ref);
+    // bool type
     typet thetype = migrate_type_back(ref->type);
+    // op0 is address of variable
     exprt op0 = migrate_expr_back(ref2.value);
     exprt theexpr("races_check", thetype);
     theexpr.copy_to_operands(op0);

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1479,6 +1479,12 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     migrate_expr(expr.op0(), op0);
     new_expr_ref = valid_object2tc(op0);
   }
+  else if (expr.id() == "races_check")
+  {
+    expr2tc op0;
+    migrate_expr(expr.op0(), op0);
+    new_expr_ref = races_check2tc(op0);
+  }
   else if (expr.id() == "deallocated_object")
   {
     expr2tc op0;
@@ -2712,6 +2718,15 @@ exprt migrate_expr_back(const expr2tc &ref)
     typet thetype = migrate_type_back(ref->type);
     exprt op0 = migrate_expr_back(ref2.value);
     exprt theexpr("valid_object", thetype);
+    theexpr.copy_to_operands(op0);
+    return theexpr;
+  }
+  case expr2t::races_check_id:
+  {
+    const races_check2t &ref2 = to_races_check2t(ref);
+    typet thetype = migrate_type_back(ref->type);
+    exprt op0 = migrate_expr_back(ref2.value);
+    exprt theexpr("races_check", thetype);
     theexpr.copy_to_operands(op0);
     return theexpr;
   }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2429,6 +2429,16 @@ bool simplify_exprt::simplify_valid_object(exprt &expr)
   return simplify_object(op);
 }
 
+bool simplify_exprt::simplify_races_check(exprt &expr)
+{
+  if (expr.operands().size() != 1)
+    return true;
+
+  exprt &op = expr.op0();
+
+  return simplify_object(op);
+}
+
 bool simplify_exprt::simplify_member(member_exprt &expr)
 {
   if (expr.operands().size() != 1)
@@ -2682,6 +2692,8 @@ bool simplify_exprt::simplify_node(exprt &expr, bool simpl_const_objects)
     result = simplify_dynamic_size(expr) && result;
   else if (expr.id() == "valid_object")
     result = simplify_valid_object(expr) && result;
+  else if (expr.id() == "races_check")
+    result = simplify_races_check(expr) && result;
   else if (expr.id() == "switch")
     result = simplify_switch(expr) && result;
   else if (expr.id() == "/")

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -58,6 +58,7 @@ public:
   bool simplify_is_dynamic_object(exprt &expr);
   bool simplify_same_object(exprt &expr);
   bool simplify_valid_object(exprt &expr);
+  bool simplify_races_check(exprt &expr);
   bool simplify_object(exprt &expr);
   static tvt objects_equal(const exprt &a, const exprt &b);
   static tvt objects_equal_address_of(const exprt &a, const exprt &b);


### PR DESCRIPTION
This PR rewrites the code for dereference by the data race checking algorithm. we have now used the address as evidence that a data race has occurred.

1. introduce a new expression: `RACE_CHECK(&x)`, Its op is the address of the variable, which we will replace during symbolic execution.
2. introduce new infinite array: `__ESBMC_races_flag = array_of(0);` during symbolic execution, we take the variable address as index.
3. `__ESBMC_yield()` is added before the atomic block to force the switch, which avoids situations in which a race cannot be checked using context-bound 2

To summarize, we implement the data race check as follows:

WRITE:
```
__ESBMC_yield(); 
Atomic
{
Assert (!__ESBMC_races_flag[&(*x)]);
__ESBMC_races_flag[&(*x)] = 1;  // set
*x = 2;
}
__ESBMC_races_flag[&(*x)] = 0; // reset
```

READ:
```
__ESBMC_yield(); 
Atomic
{
Assert (!__ESBMC_races_flag[&(*x)]);
int y = *x ;
}
```

This PR:
```
  Statistics:          783 Files
  correct:             366
    correct true:      310
    correct false:      56
  incorrect:             9
    incorrect true:      7
    incorrect false:     2
  unknown:             408
  Score:               420 (max: 1488)
  https://github.com/esbmc/esbmc/actions/runs/10509106071
```
Master:
```
Statistics:            783 Files
  correct:             371
    correct true:      323
    correct false:      48
  incorrect:            18
    incorrect true:     10
    incorrect false:     8
  unknown:             394
  Score:               246 (max: 1488)
https://github.com/esbmc/esbmc/actions/runs/10507450329
```




