### PR TITLE
[clang-cpp] fix implicit copy & move ctor bodies in unions

### DIFF
--- a/regression/esbmc-cpp11/constructors/CpyConstructorUnion/main.cpp
+++ b/regression/esbmc-cpp11/constructors/CpyConstructorUnion/main.cpp
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+union MyUnion
+{
+  int value;
+};
+
+int main()
+{
+  MyUnion a = {10};
+
+  // copy ctor
+  MyUnion c(a);
+
+  assert(c.value == 10);
+}

--- a/regression/esbmc-cpp11/constructors/CpyConstructorUnion/test.desc
+++ b/regression/esbmc-cpp11/constructors/CpyConstructorUnion/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/CpyConstructorUnion_fail/main.cpp
+++ b/regression/esbmc-cpp11/constructors/CpyConstructorUnion_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+union MyUnion
+{
+  int value;
+};
+
+int main()
+{
+  MyUnion a = {10};
+
+  // copy ctor
+  MyUnion c(a);
+
+  assert(c.value == 0); //should be 10
+}

--- a/regression/esbmc-cpp11/constructors/CpyConstructorUnion_fail/test.desc
+++ b/regression/esbmc-cpp11/constructors/CpyConstructorUnion_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/constructors/MoveConstructorUnion/main.cpp
+++ b/regression/esbmc-cpp11/constructors/MoveConstructorUnion/main.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <utility>
+
+union MyUnion
+{
+  int value;
+};
+
+int main()
+{
+  MyUnion a = {10};
+
+  // move ctor
+  MyUnion c(std::move(a));
+
+  assert(c.value == 10);
+}

--- a/regression/esbmc-cpp11/constructors/MoveConstructorUnion/test.desc
+++ b/regression/esbmc-cpp11/constructors/MoveConstructorUnion/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11 
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/MoveConstructorUnion_fail/main.cpp
+++ b/regression/esbmc-cpp11/constructors/MoveConstructorUnion_fail/main.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <utility>
+
+union MyUnion
+{
+  int value;
+};
+
+int main()
+{
+  MyUnion a = {10};
+
+  // move ctor
+  MyUnion c(std::move(a));
+
+  assert(c.value == 0); //should be 10
+}

--- a/regression/esbmc-cpp11/constructors/MoveConstructorUnion_fail/test.desc
+++ b/regression/esbmc-cpp11/constructors/MoveConstructorUnion_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -107,6 +107,15 @@ public:
     const std::string &suffix,
     std::vector<irep_idt> &ids,
     bool is_catch = false);
+
+  /**
+   * Generates an implicit copy and move constructor for a symbol if it is a union.
+   * Clang does not generate copy and move constructors for unions, so we
+   * need to generate one ourselves.
+   *
+   * @param symbol The symbol for which the implicit copy and move constructor is generated.
+   */
+  void gen_implicit_union_copy_move_constructor(symbolt &symbol);
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -10,6 +10,55 @@ clang_cpp_adjust::clang_cpp_adjust(contextt &_context)
 {
 }
 
+void clang_cpp_adjust::gen_implicit_union_copy_move_constructor(symbolt &symbol)
+{
+  if (!symbol.type.is_code())
+    return;
+
+  code_typet &ctor_type = to_code_type(symbol.type);
+
+  if (
+    ctor_type.return_type().id() != "constructor" ||
+    !ctor_type.return_type().get_bool("#implicit_union_copy_move_constructor"))
+    return;
+
+  if (symbol.value.is_not_nil())
+  {
+    code_blockt &ctor_body = to_code_block(to_code(symbol.value));
+    assert(
+      ctor_body.operands().size() == 1 &&
+      ctor_body.op0().statement() ==
+        "throw_decl"); // just a sanity check that we don't accidentally change any clang generated body in the future
+  }
+  else
+  {
+    code_blockt ctor_body;
+    symbol.value = ctor_body;
+  }
+  code_blockt &ctor_body = to_code_block(to_code(symbol.value));
+  /* https://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor
+   * > If the implicitly-declared copy constructor is not deleted, it is defined (that is, a function body is generated and compiled)
+   * > by the compiler if odr-used or needed for constant evaluation(since C++11).
+   * > **For union types, the implicitly-defined copy constructor copies the object representation (as by std::memmove).**
+   * We don't call std::memmove here, we should be able to just assign the union.
+   * (The wording is similar for https://en.cppreference.com/w/cpp/language/move_constructor#Implicitly-defined_move_constructor)
+   */
+
+  code_assignt copy_ctor_assign;
+  auto this_argument = ctor_type.arguments().at(0);
+  auto this_copy_ref_argument = ctor_type.arguments().at(1);
+  exprt lhs = dereference_exprt(
+    symbol_exprt(this_argument.cmt_identifier(), this_argument.type()),
+    this_argument.type());
+  exprt rhs = symbol_exprt(
+    this_copy_ref_argument.cmt_identifier(), this_copy_ref_argument.type());
+  copy_ctor_assign.lhs() = lhs;
+  copy_ctor_assign.rhs() = rhs;
+  copy_ctor_assign.location() = ctor_body.location();
+  adjust_assign(copy_ctor_assign);
+  ctor_body.operands().push_back(copy_ctor_assign);
+}
+
 void clang_cpp_adjust::adjust_symbol(symbolt &symbol)
 {
   clang_c_adjust::adjust_symbol(symbol);
@@ -21,6 +70,7 @@ void clang_cpp_adjust::adjust_symbol(symbolt &symbol)
    * class to point to the corresponding virtual table.
    */
   gen_vptr_initializations(symbol);
+  gen_implicit_union_copy_move_constructor(symbol);
 }
 
 void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -175,7 +175,8 @@ protected:
    *  cxxmdd: clang AST node representing the constructor we are dealing with
    *  rtn_type: the corresponding return type node
    */
-  void annotate_implicit_copy_move_ctor_union(const clang::CXXMethodDecl &cxxmdd,
+  void annotate_implicit_copy_move_ctor_union(
+    const clang::CXXMethodDecl &cxxmdd,
     typet &ctor_return_type);
   /*
    * Flag return type in ctor or dtor, e.g.

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -175,7 +175,8 @@ protected:
    *  cxxmdd: clang AST node representing the constructor we are dealing with
    *  rtn_type: the corresponding return type node
    */
-  void annotate_cpyctor(const clang::CXXMethodDecl &cxxmdd, typet &rtn_type);
+  void annotate_implicit_copy_move_ctor_union(const clang::CXXMethodDecl &cxxmdd,
+    typet &ctor_return_type);
   /*
    * Flag return type in ctor or dtor, e.g.
    * A default copy constructor would have the return type below:
@@ -189,7 +190,7 @@ protected:
   void annotate_ctor_dtor_rtn_type(
     const clang::CXXMethodDecl &cxxmdd,
     typet &rtn_type);
-  bool is_cpyctor(const clang::DeclContext &dcxt);
+  bool is_copy_or_move_ctor(const clang::DeclContext &dcxt);
   bool is_defaulted_ctor(const clang::CXXMethodDecl &md);
 
   /*


### PR DESCRIPTION
Clang does not generate copy and move constructors for unions, so we
need to generate one ourselves.

https://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor
 > If the implicitly-declared copy constructor is not deleted, it is defined (that is, a function body is generated and compiled)
 > by the compiler if odr-used or needed for constant evaluation(since C++11).
 > **For union types, the implicitly-defined copy constructor copies the object representation (as by std::memmove).**

 We don't call std::memmove here, we should be able to just assign the union (`*this = copy_ref`).
 (The wording is similar for https://en.cppreference.com/w/cpp/language/move_constructor#Implicitly-defined_move_constructor)