### PR TITLE
[python-frontend] Fix list indexing and inference

### DIFF
--- a/regression/python/function-option-fail/main.py
+++ b/regression/python/function-option-fail/main.py
@@ -1,0 +1,7 @@
+def ok() -> None:
+    assert(1)
+
+def fail() -> None:
+    assert(0)
+
+ok()

--- a/regression/python/function-option-fail/test.desc
+++ b/regression/python/function-option-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--function fail
+
+^VERIFICATION FAILED$

--- a/regression/python/function-option/main.py
+++ b/regression/python/function-option/main.py
@@ -1,7 +1,9 @@
-def ok() -> None:
-    assert(1)
+def foo() -> None:
+    pass
 
-def fail() -> None:
-    assert(0)
-
-ok()
+def bar() -> None:
+    foo()
+    x = int(5)
+    bytes_data = b'\x00\x10'
+    y:int = int.from_bytes(bytes_data, 'big', False)
+    z = x.bit_length();

--- a/regression/python/function-option/test.desc
+++ b/regression/python/function-option/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
---function fail
+--function bar
 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list/main.py
+++ b/regression/python/list/main.py
@@ -14,3 +14,8 @@ assert l3[1] == 2.5
 l4 = ["abc", "def"]
 assert l4[0] == "abc"
 assert l4[1] == "def"
+
+def make_list() -> list[int]:
+    l5 = [1,2,3]
+    return l5
+

--- a/regression/python/list/main.py
+++ b/regression/python/list/main.py
@@ -20,3 +20,6 @@ def make_list() -> list[int]:
     return l5
 
 l6 = make_list()
+assert l6[0] == 1
+assert l6[1] == 2
+assert l6[2] == 3

--- a/regression/python/list/main.py
+++ b/regression/python/list/main.py
@@ -19,3 +19,4 @@ def make_list() -> list[int]:
     l5 = [1,2,3]
     return l5
 
+l6 = make_list()

--- a/src/python-frontend/models/consensus.py
+++ b/src/python-frontend/models/consensus.py
@@ -1,0 +1,4 @@
+# Stubs used for consensus specification verification
+
+def hash(data: bytes) -> int:
+  return 42

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -160,7 +160,10 @@ private:
         elem["_type"] == "FunctionDef" && elem["name"] == func_name &&
         elem.contains("returns") && !elem["returns"].is_null())
       {
-        return elem["returns"]["id"];
+        if (elem["returns"]["_type"] == "Subscript")
+          return elem["returns"]["value"]["id"];
+        else
+          return elem["returns"]["id"];
       }
     }
     return std::string();

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -111,7 +111,7 @@ typet python_converter::get_typet(const std::string &ast_type, size_t type_size)
 {
   if (ast_type == "float")
     return double_type();
-  if (ast_type == "int")
+  if (ast_type == "int" || ast_type == "GeneralizedIndex")
     /* FIXME: We need to map 'int' to another irep type that provides unlimited precision
 	https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex */
     return int_type();

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -763,7 +763,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         func_name = obj_type;
     }
 
-    if (!is_builtin_type(func_name) && !is_consensus_type(func_name))
+    if (
+      !is_builtin_type(func_name) && !is_consensus_type(func_name) &&
+      !is_consensus_func(func_name))
     {
       const auto &func_node = find_function(ast_json["body"], func_name);
       assert(!func_node.empty());
@@ -1963,7 +1965,7 @@ bool python_converter::convert()
     // Load operational models -----
     const std::string &ast_output_dir =
       ast_json["ast_output_dir"].get<std::string>();
-    std::list<std::string> model_files = {"range", "int"};
+    std::list<std::string> model_files = {"range", "int", "consensus"};
     is_loading_models = true;
 
     for (const auto &file : model_files)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -157,7 +157,7 @@ std::string type_to_string(const typet &t)
     return "uint256";
   if (t.is_array())
   {
-    const array_typet& arr_type = static_cast<const array_typet &>(t);
+    const array_typet &arr_type = static_cast<const array_typet &>(t);
     if (arr_type.subtype() == char_type())
       return "str";
     if (arr_type.subtype() == int_type())
@@ -1394,7 +1394,7 @@ typet python_converter::get_list_type(const nlohmann::json &list_value)
 {
   if (list_value["_type"] == "List") // Get list value type from elements
   {
-	const nlohmann::json& elts = list_value["elts"];
+    const nlohmann::json &elts = list_value["elts"];
     if (!has_multiple_types(elts)) // All elements have the same type
     {
       typet t = get_typet(elts[0]["value"]); // Get the first element type
@@ -1672,7 +1672,7 @@ void python_converter::get_function_definition(
 {
   // Function return type
   code_typet type;
-  const nlohmann::json& return_node = function_node["returns"];
+  const nlohmann::json &return_node = function_node["returns"];
   if (return_node.contains("id"))
   {
     type.return_type() = get_typet(return_node["id"].get<std::string>());

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -82,7 +82,7 @@ private:
   exprt *ref_instance;
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;
-  bool is_loading_models =  false;
+  bool is_loading_models = false;
   bool base_ctor_called = false;
 
   // Map object to list of instance attributes

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -34,7 +34,6 @@ private:
   exprt get_binary_operator_expr(const nlohmann::json &element);
   exprt get_logical_operator_expr(const nlohmann::json &element);
   exprt get_conditional_stm(const nlohmann::json &ast_node);
-  function_id build_function_id(const nlohmann::json &element);
   exprt get_function_call(const nlohmann::json &ast_block);
   exprt get_literal(const nlohmann::json &element);
   exprt get_block(const nlohmann::json &ast_block);
@@ -42,6 +41,7 @@ private:
   bool has_multiple_types(const nlohmann::json &container);
   void adjust_statement_types(exprt &lhs, exprt &rhs) const;
 
+  symbol_id build_function_id(const nlohmann::json &element);
   symbol_id create_symbol_id() const;
   symbol_id create_symbol_id(const std::string &filename) const;
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -82,6 +82,7 @@ private:
   exprt *ref_instance;
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;
+  bool is_loading_models =  false;
   bool base_ctor_called = false;
 
   // Map object to list of instance attributes

--- a/src/python-frontend/python_frontend_types.cpp
+++ b/src/python-frontend/python_frontend_types.cpp
@@ -11,7 +11,8 @@ bool is_consensus_type(const std::string &name)
 {
   return (
     name == "uint64" || name == "uint256" || name == "Epoch" ||
-    name == "Gwei" || name == "BLSFieldElement" || name == "Slot");
+    name == "Gwei" || name == "BLSFieldElement" || name == "Slot" ||
+    name == "GeneralizedIndex");
 }
 
 std::map<std::string, std::string> consensus_func_to_type = {

--- a/src/python-frontend/python_frontend_types.cpp
+++ b/src/python-frontend/python_frontend_types.cpp
@@ -11,7 +11,7 @@ bool is_consensus_type(const std::string &name)
 {
   return (
     name == "uint64" || name == "uint256" || name == "Epoch" ||
-    name == "Gwei" || name == "BLSFieldElement");
+    name == "Gwei" || name == "BLSFieldElement" || name == "Slot");
 }
 
 std::map<std::string, std::string> consensus_func_to_type = {

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -35,7 +35,6 @@ enum class ExpressionType
   UNKNOWN,
 };
 
-
 bool is_builtin_type(const std::string &name);
 
 // TODO: Add a compilation flag or move it to a specific implementation

--- a/src/python-frontend/python_frontend_types.h
+++ b/src/python-frontend/python_frontend_types.h
@@ -35,12 +35,6 @@ enum class ExpressionType
   UNKNOWN,
 };
 
-struct function_id
-{
-  std::string function_name;
-  std::string symbol_id;
-  std::string class_name;
-};
 
 bool is_builtin_type(const std::string &name);
 

--- a/src/python-frontend/symbol_id.h
+++ b/src/python-frontend/symbol_id.h
@@ -40,6 +40,11 @@ public:
     return function_name_;
   }
 
+  const std::string &get_class() const
+  {
+    return classname_;
+  }
+
   void clear();
 
   std::string to_string() const;


### PR DESCRIPTION
- When invoking ESBMC with the `--function` flag, the called functions are now identified and converted.
```
def func1() -> int:
  return 0

def func2() -> int:
  return func1()

def func3() -> int:
  return 1
```
Runnnig `esbmc file.py --function func2` will convert func2 and func1 (since func1() is called by func2()).

- Variables initialized from functions that returns a _**list**_ are now correctly inferred.
```
def make_list: list[int]
  l = [1,2,3]
  return l

l1 = make_list()  # l1 should now be inferred as list[int]
```

- Previously, **_lists_** created from function returns could not be indexed.