### PR TITLE
Fix html report

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -42,10 +42,7 @@
 #include <atomic>
 #include <goto-symex/witnesses.h>
 
-bmct::bmct(
-  goto_functionst &funcs,
-  optionst &opts,
-  contextt &_context)
+bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
   : options(opts), context(_context), ns(context)
 {
   interleaving_number = 0;

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -45,9 +45,8 @@
 bmct::bmct(
   goto_functionst &funcs,
   optionst &opts,
-  const cmdlinet::options_mapt &option_map,
   contextt &_context)
-  : options(opts), opt_map(option_map), context(_context), ns(context)
+  : options(opts), context(_context), ns(context)
 {
   interleaving_number = 0;
   interleaving_failed = 0;
@@ -145,7 +144,7 @@ void bmct::error_trace(smt_convt &smt_conv, const symex_target_equationt &eq)
   }
 
   if (options.get_bool_option("generate-html-report"))
-    generate_html_report("1", ns, goto_trace, opt_map);
+    generate_html_report("1", ns, goto_trace, options);
 
   if (options.get_bool_option("generate-json-report"))
     generate_json_report("1", ns, goto_trace);

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -379,7 +379,7 @@ void bmct::report_multi_property_trace(
         "testcase-" + std::to_string(ce_counter) + ".xml", local_eq, *solver);
     }
     if (options.get_bool_option("generate-html-report"))
-      generate_html_report(std::to_string(ce_counter), ns, goto_trace, opt_map);
+      generate_html_report(std::to_string(ce_counter), ns, goto_trace, options);
 
     if (options.get_bool_option("generate-json-report"))
       generate_json_report(std::to_string(ce_counter), ns, goto_trace);

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -21,11 +21,9 @@ public:
   bmct(
     goto_functionst &funcs,
     optionst &opts,
-    const cmdlinet::options_mapt &option_map,
     contextt &_context);
 
   optionst &options;
-  const cmdlinet::options_mapt &opt_map;
   enum ltl_res
   {
     ltl_res_good,

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -18,10 +18,7 @@
 class bmct
 {
 public:
-  bmct(
-    goto_functionst &funcs,
-    optionst &opts,
-    contextt &_context);
+  bmct(goto_functionst &funcs, optionst &opts, contextt &_context);
 
   optionst &options;
   enum ltl_res

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -616,7 +616,7 @@ int esbmc_parseoptionst::doit()
 
   // If no strategy is chosen, just rely on the simplifier
   // and the flags set through CMD
-  bmct bmc(goto_functions, options, cmdline.options_map, context);
+  bmct bmc(goto_functions, options, context);
   return do_bmc(bmc);
 }
 
@@ -968,7 +968,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     for (BigInt k_step = k_step_base; k_step <= max_k_step;
          k_step += k_step_inc)
     {
-      bmct bmc(goto_functions, options, cmdline.options_map, context);
+      bmct bmc(goto_functions, options, context);
       bmc.options.set_option("unwind", integer2string(k_step));
 
       log_status("Checking base case, k = {:d}\n", k_step);
@@ -1073,7 +1073,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     for (BigInt k_step = k_step_base + 1; k_step <= max_k_step;
          k_step += k_step_inc)
     {
-      bmct bmc(goto_functions, options, cmdline.options_map, context);
+      bmct bmc(goto_functions, options, context);
       bmc.options.set_option("unwind", integer2string(k_step));
 
       log_status("Checking forward condition, k = {:d}", k_step);
@@ -1141,7 +1141,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
     for (BigInt k_step = k_step_base + 1; k_step <= max_k_step;
          k_step += k_step_inc)
     {
-      bmct bmc(goto_functions, options, cmdline.options_map, context);
+      bmct bmc(goto_functions, options, context);
 
       bmc.options.set_option("unwind", integer2string(k_step));
 
@@ -1320,7 +1320,7 @@ tvt esbmc_parseoptionst::is_base_case_violated(
   options.set_option("partial-loops", false);
   options.set_option("unwind", integer2string(k_step));
 
-  bmct bmc(goto_functions, options, cmdline.options_map, context);
+  bmct bmc(goto_functions, options, context);
 
   log_status("Checking base case, k = {:d}", k_step);
   switch (do_bmc(bmc))
@@ -1379,7 +1379,7 @@ tvt esbmc_parseoptionst::does_forward_condition_hold(
   options.set_option("no-assertions", true);
   options.set_option("unwind", integer2string(k_step));
 
-  bmct bmc(goto_functions, options, cmdline.options_map, context);
+  bmct bmc(goto_functions, options, context);
 
   log_progress("Checking forward condition, k = {:d}", k_step);
   auto res = do_bmc(bmc);
@@ -1446,7 +1446,7 @@ tvt esbmc_parseoptionst::is_inductive_step_violated(
   options.set_option("partial-loops", true);
   options.set_option("unwind", integer2string(k_step));
 
-  bmct bmc(goto_functions, options, cmdline.options_map, context);
+  bmct bmc(goto_functions, options, context);
 
   log_progress("Checking inductive step, k = {:d}", k_step);
   switch (do_bmc(bmc))

--- a/src/goto-symex/goto_trace.h
+++ b/src/goto-symex/goto_trace.h
@@ -142,7 +142,7 @@ void generate_html_report(
   const std::string_view uuid,
   const namespacet &ns,
   const goto_tracet &goto_trace,
-  const cmdlinet::options_mapt &options_map);
+  const optionst &options);
 
 void generate_json_report(
   const std::string_view uuid,

--- a/src/goto-symex/html.cpp
+++ b/src/goto-symex/html.cpp
@@ -1,15 +1,8 @@
-#include "util/message.h"
-#include <fstream>
+#include <filesystem>
 #include <goto-symex/goto_trace.h>
-#include <ostream>
-#include <sstream>
-#include <unordered_map>
-#include <list>
-#include <util/language.h>
 #include <langapi/language_util.h>
 #include <optional>
-#include <filesystem>
-#include <util/cmdline.h>
+#include <regex>
 
 // TODO: Multiple files
 // TODO: Control Trace
@@ -377,7 +370,7 @@ public:
   html_report(
     const goto_tracet &goto_trace,
     const namespacet &ns,
-    const cmdlinet::options_mapt &options_map);
+    const optionst &options);
   void output(std::ostream &oss) const;
 
   bool show_partial_assertions = false;
@@ -389,7 +382,7 @@ protected:
 
 private:
   const namespacet &ns;
-  const cmdlinet::options_mapt &opt_map;
+  const optionst &options;
   std::optional<goto_trace_stept> violation_step;
   void print_file_table(
     std::ostream &os,
@@ -426,8 +419,8 @@ private:
 html_report::html_report(
   const goto_tracet &goto_trace,
   const namespacet &ns,
-  const cmdlinet::options_mapt &options_map)
-  : goto_trace(goto_trace), ns(ns), opt_map(options_map)
+  const optionst &_options)
+  : goto_trace(goto_trace), ns(ns), options(_options)
 {
   // TODO: C++20 reverse view
   for (const goto_trace_stept &step : goto_trace.steps)
@@ -482,12 +475,17 @@ const std::string html_report::generate_body() const
   // Annotated Source Header
   {
     std::ostringstream oss;
-    for (const auto &item : opt_map)
+    std::string input_file_str;
+
+    oss << "esbmc ";
+    for (const auto &item : options.option_map)
     {
-      oss << item.first << " ";
-      for (const std::string &value : item.second)
-        oss << value << " ";
+      if (item.first == "input-file")
+        input_file_str.append(item.second);
+      else
+        oss << "--" << item.first << "=" << item.second << " ";
     }
+    oss << input_file_str;
     body << fmt::format(
       clang_bug_report::annotated_source_header_fmt, oss.str());
   }
@@ -630,16 +628,15 @@ void generate_html_report(
   const std::string_view uuid,
   const namespacet &ns,
   const goto_tracet &goto_trace,
-  const cmdlinet::options_mapt &options_map)
+  const optionst &options)
 {
   log_status("Generating HTML report for trace: {}", uuid);
-  const html_report report(goto_trace, ns, options_map);
+  const html_report report(goto_trace, ns, options);
 
   std::ofstream html(fmt::format("report-{}.html", uuid));
   report.output(html);
 }
 
-#include <regex>
 std::string html_report::code_lines::to_html() const
 {
   // TODO: C++23 has constexpr for regex

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -150,13 +150,9 @@ const char *cmdlinet::getval(const char *option) const
 {
   cmdlinet::options_mapt::const_iterator value = options_map.find(option);
   if (value == options_map.end())
-  {
     return (const char *)nullptr;
-  }
   if (value->second.empty())
-  {
     return (const char *)nullptr;
-  }
   return value->second.front().c_str();
 }
 

--- a/src/util/options.cpp
+++ b/src/util/options.cpp
@@ -59,15 +59,11 @@ void optionst::cmdline(cmdlinet &cmds)
     const auto option_name = it.first;
     if (cmds.isset(option_name.c_str()) && !it.second.defaulted())
     {
-      std::string value_str;
       for (const auto &value : cmds.get_values(option_name.c_str()))
-        if (!value.empty())
-          value_str.append(value).append(" ");
-
-      if (value_str.empty())
-        set_option(option_name, true);
-      else
-        set_option(option_name, value_str);
+        if (value.empty())
+          set_option(option_name, true);
+        else
+          set_option(option_name, value);
     }
   }
 }

--- a/src/util/options.cpp
+++ b/src/util/options.cpp
@@ -54,17 +54,20 @@ bool optionst::get_option(const std::string &option, std::string &value) const
 void optionst::cmdline(cmdlinet &cmds)
 {
   // Pump command line options into options list
-  for (auto &it : cmds.vm)
+  for (const auto &it : cmds.vm)
   {
-    std::string option_name = it.first;
+    const auto option_name = it.first;
     if (cmds.isset(option_name.c_str()) && !it.second.defaulted())
     {
-      const char *value = cmds.getval(option_name.c_str());
-      bool hasArgument = *value != 0;
-      if (hasArgument)
-        set_option(option_name, value);
-      else
+      std::string value_str;
+      for (const auto &value : cmds.get_values(option_name.c_str()))
+        if (!value.empty())
+          value_str.append(value).append(" ");
+
+      if (value_str.empty())
         set_option(option_name, true);
+      else
+        set_option(option_name, value_str);
     }
   }
 }


### PR DESCRIPTION
This patch addresses the comment to improve the code that generates html reports:
* Fixed unordered includes
* Removed regex include in the middle of file html.cpp
* Removed the usage of cmdline.options_map in favor of the optionst obj
* Added "esbmc" to the invocation printed in the html
* Added "--" prior to flags and "=" before value in the invocation printed in the html
* Changed optionst::cmdline to store multi-values to optionst
* Changed the invocation line in the html so that the files are printed last