### PR TITLE
[Concurrency] Avoid forced switching in built-in library

### DIFF
--- a/regression/esbmc-unix/01_cond_01/test.desc
+++ b/regression/esbmc-unix/01_cond_01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --no-unwinding-assertions --unwind 3 --lock-order-check --context-bound 3 --smt-during-symex --smt-thread-guard --z3
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -46,7 +46,7 @@ public:
     const exprt &original_expr,
     bool deref)
   {
-    if (deref)
+    if (deref || original_expr.is_member())
     {
       // introduce a new expression: RACE_CHECK(&x)
       // its operand is the address of the variable

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -146,9 +146,15 @@ void goto_convertt::do_atomic_begin(
   // We should allow a context switch to happen before synchronization points.
   // In particular, here we force a context switch to happen before an atomic block
   // via the intrinsic function __ESBMC_yield();
-  code_function_callt call;
-  call.function() = symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
-  do_function_call(call.lhs(), call.function(), call.arguments(), dest);
+  if (
+    function.location().function() != "pthread_create" &&
+    function.location().function() != "pthread_join_noswitch" &&
+    function.location().function() != "pthread_trampoline")
+  {
+    code_function_callt call;
+    call.function() = symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
+    do_function_call(call.lhs(), call.function(), call.arguments(), dest);
+  }
 
   goto_programt::targett t = dest.add_instruction(ATOMIC_BEGIN);
   t->location = function.location();


### PR DESCRIPTION
```

#include <pthread.h>

void* t1(void *arg) {
    int* shared1 = (int*) arg;
    *shared1 = 4;                 //race here

    return NULL;
}

void* t2(void *arg) {
    int* shared2 = (int*) arg;
    *shared2 = 2;                //race here

    return NULL;
}

int main() {
    pthread_t id1, id2;
    int shared_data = 0;

    pthread_create(&id1, NULL, t1, &shared_data);
    pthread_create(&id2, NULL, t2, &shared_data);

    pthread_join(id1, NULL);
    pthread_join(id2, NULL);

    return 0;
}
```

Master: Thread interleavings 221

This PR: Thread interleavings 7