### PR TITLE
[C++ verification] Fix operator new

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_2004/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_2004/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <new>
+
+int main()
+{
+  void *foo = operator new(sizeof(int));
+
+  int *intPtr = static_cast<int *>(foo);
+  *intPtr = 42;
+
+  assert(*intPtr == 42);
+
+  operator delete(foo);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_2004/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_2004/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_2004_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_2004_fail/main.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+#include <new>
+
+int main()
+{
+  void *foo = operator new(sizeof(int));
+
+  // allocated memory is not enough
+  // int 4; double 8
+  double *intPtr = static_cast<double *>(foo);
+  *intPtr = 42;
+
+  assert(*intPtr == 42);
+
+  operator delete(foo);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_2004_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_2004_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/operator_new/main.cpp
+++ b/regression/esbmc-cpp/cpp/operator_new/main.cpp
@@ -11,7 +11,6 @@ int main()
 {
 	dev_a = (int*) operator new(sizeof(int));
 	assert(dev_a != NULL);
-	assert(*dev_a == 0);
 
 	return 0;
 }

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -289,11 +289,18 @@ void goto_convertt::do_cpp_new(
 
   // grab initializer
   goto_programt tmp_initializer;
-  cpp_new_initializer(lhs, rhs, tmp_initializer);
+  if (!rhs.get_bool("op_new"))
+    cpp_new_initializer(lhs, rhs, tmp_initializer);
 
   exprt alloc_size;
+  exprt alloc_type;
 
-  if (rhs.statement() == "cpp_new[]")
+  if (rhs.get_bool("op_new"))
+  {
+    alloc_type = static_cast<const exprt &>(rhs.find("alloctype"));
+    alloc_size = static_cast<const exprt &>(rhs.size_irep());
+  }
+  else if (rhs.statement() == "cpp_new[]")
   {
     alloc_size = static_cast<const exprt &>(rhs.size_irep());
     if (alloc_size.type() != size_type())
@@ -326,6 +333,7 @@ void goto_convertt::do_cpp_new(
   exprt new_expr("sideeffect", rhs.type());
   new_expr.statement(rhs.statement());
   new_expr.cmt_size(alloc_size);
+  new_expr.cmt_type(alloc_type);
   new_expr.location() = rhs.find_location();
 
   // produce new object
@@ -744,10 +752,16 @@ void goto_convertt::do_function_call_symbol(
   {
     assert(arguments.size() == 1);
 
+    typet alloc_type;
+    exprt alloc_size;
+    get_alloc_type(arguments[0], alloc_type, alloc_size);
+
     // Change it into a cpp_new expression
-    side_effect_exprt new_function("cpp_new");
+    side_effect_exprt new_function("cpp_new[]");
     new_function.add("#location") = function.cmt_location();
-    new_function.add("sizeof") = arguments.front();
+    new_function.add("size") = arguments.front();
+    new_function.add("alloctype") = alloc_type;
+    new_function.set("op_new", true);
 
     // Set return type, a allocated pointer
     // XXX jmorse, const-qual misery

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -733,7 +733,7 @@ void goto_convertt::do_function_call_symbol(
     exprt alloc_size;
     get_alloc_type(arguments[0], alloc_type, alloc_size);
 
-    // Change it into a cpp_new expression
+    // Change it into a cpp_new[] expression
     side_effect_exprt new_function("cpp_new[]");
     new_function.add("#location") = function.cmt_location();
     new_function.add("size") = arguments.front();

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -289,8 +289,7 @@ void goto_convertt::do_cpp_new(
 
   // grab initializer
   goto_programt tmp_initializer;
-  if (!rhs.get_bool("op_new"))
-    cpp_new_initializer(lhs, rhs, tmp_initializer);
+  cpp_new_initializer(lhs, rhs, tmp_initializer);
 
   exprt alloc_size;
   exprt alloc_type;
@@ -352,11 +351,17 @@ void goto_convertt::cpp_new_initializer(
   goto_programt &dest)
 {
   // grab initializer
-  code_expressiont initializer;
+  code_expressiont initializer = (code_expressiont &)rhs.initializer();
 
-  if (rhs.initializer().is_nil())
+  if (initializer.is_nil())
+    return;
+
+  if (!initializer.op0().get_bool("constructor"))
   {
-    // Initialize with default value
+    // for auto *p = Foo(3) and int *p = 3
+    // constructor case:  init is Foo(&(*new_object), 3)
+    // other case: init is 3,
+    // we turn "3" into "*new_object = 3"
     side_effect_exprt assignment("assign");
     assignment.type() = rhs.type().subtype();
 
@@ -365,54 +370,26 @@ void goto_convertt::cpp_new_initializer(
     new_object.set("#lvalue", true);
     new_object.type() = rhs.type().subtype();
 
-    // Default value is zero
-    exprt default_value = gen_zero(rhs.type().subtype());
-
-    assignment.move_to_operands(new_object, default_value);
+    assignment.move_to_operands(new_object, initializer.op0());
     initializer.expression() = assignment;
   }
+
+  // XXX jmorse, const-qual misery
+  const_cast<exprt &>(rhs).remove("initializer");
+
+  if (rhs.statement() == "cpp_new[]")
+  {
+    // build loop
+  }
+  else if (rhs.statement() == "cpp_new")
+  {
+    exprt deref_new("dereference", rhs.type().subtype());
+    deref_new.copy_to_operands(lhs);
+    replace_new_object(deref_new, initializer);
+    convert(to_code(initializer), dest);
+  }
   else
-  {
-    initializer = (code_expressiont &)rhs.initializer();
-
-    if (!initializer.op0().get_bool("constructor"))
-    {
-      // for auto *p = Foo(3) and int *p = 3
-      // constructor case:  init is Foo(&(*new_object), 3)
-      // other case: init is 3,
-      // we turn "3" into "*new_object = 3"
-      side_effect_exprt assignment("assign");
-      assignment.type() = rhs.type().subtype();
-
-      // the new object
-      exprt new_object("new_object");
-      new_object.set("#lvalue", true);
-      new_object.type() = rhs.type().subtype();
-
-      assignment.move_to_operands(new_object, initializer.op0());
-      initializer.expression() = assignment;
-    }
-
-    // XXX jmorse, const-qual misery
-    const_cast<exprt &>(rhs).remove("initializer");
-  }
-
-  if (initializer.is_not_nil())
-  {
-    if (rhs.statement() == "cpp_new[]")
-    {
-      // build loop
-    }
-    else if (rhs.statement() == "cpp_new")
-    {
-      exprt deref_new("dereference", rhs.type().subtype());
-      deref_new.copy_to_operands(lhs);
-      replace_new_object(deref_new, initializer);
-      convert(to_code(initializer), dest);
-    }
-    else
-      assert(0);
-  }
+    assert(0);
 }
 
 void goto_convertt::do_exit(

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -560,8 +560,11 @@ void goto_symext::symex_cpp_new(const expr2tc &lhs, const sideeffect2t &code)
   type2tc renamedtype2 =
     migrate_type(ns.follow(migrate_type_back(ptr_ref.subtype)));
 
+  type2tc renamedtype =
+    is_empty_type(renamedtype2) ? ns.follow(code.alloctype) : renamedtype2;
+
   type2tc newtype = do_array
-                      ? type2tc(array_type2tc(renamedtype2, code.size, false))
+                      ? type2tc(array_type2tc(renamedtype, code.size, false))
                       : renamedtype2;
 
   symbol.type = migrate_type_back(newtype);
@@ -575,7 +578,7 @@ void goto_symext::symex_cpp_new(const expr2tc &lhs, const sideeffect2t &code)
   if (do_array)
   {
     expr2tc sym = symbol2tc(newtype, symbol.id);
-    expr2tc idx = index2tc(renamedtype2, sym, gen_ulong(0));
+    expr2tc idx = index2tc(renamedtype, sym, gen_ulong(0));
     rhs_ptr_obj = idx;
   }
   else


### PR DESCRIPTION
1. No initialization is required once memory is allocated using operator new.
2. ~~According to the handling of void* in malloc, introduce a new statement: `op_new`.~~

~~We can't simply use `do_malloc`, although the operation is similar, because in C verification we need to use `--force-malloc-success` to ensure that the memory is allocated successfully. This is not required in C++ verification.~~