### PR TITLE
[C++ verification] support CXXStdInitializerList and list ctor in vector OM

### DIFF
--- a/regression/esbmc-cpp/cpp/ch11_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch11_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch11_3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch22_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ch22_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 Array.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch7_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch7_9/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 employee2.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/nec_ex7-ctor-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex7-ctor-throw/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex8-virtual-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex8-virtual-throw/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/vector/vector8/test.desc
+++ b/regression/esbmc-cpp/vector/vector8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
-^ERROR: PARSING ERROR$
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -95,6 +95,7 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
       destructor.arguments().push_back(address_of_exprt(new_object));
       expr.set("destructor", destructor);
     }
+    adjust_operands(expr);
   }
   else if (statement == "temporary_object")
   {

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -83,6 +83,7 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
   }
   else if (statement == "cpp_delete" || statement == "cpp_delete[]")
   {
+    adjust_operands(expr);
     // adjust side effect node to explicitly call class destructor
     // e.g. the adjustment here will add the following instruction in GOTO:
     // FUNCTION_CALL:  ~t2(&(*p))
@@ -95,7 +96,6 @@ void clang_cpp_adjust::adjust_side_effect(side_effect_exprt &expr)
       destructor.arguments().push_back(address_of_exprt(new_object));
       expr.set("destructor", destructor);
     }
-    adjust_operands(expr);
   }
   else if (statement == "temporary_object")
   {

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -5,10 +5,12 @@
 #include <assert.h>
 
 #include "stdexcept"
-#include <initializer_list>
 
 #include <utility> /* std::move */
 #include <new> /* placement-new */
+#if __cplusplus >= 201103L
+# include <initializer_list>
+#endif
 
 #define VECTOR_CAPACITY 500
 
@@ -194,6 +196,7 @@ public:
     _capacity = _size;
   }
 
+#if __cplusplus >= 201103L
   vector(std::initializer_list<T> init) :_size(0), _capacity(1)
   {
     buf = new T[init.size()];
@@ -202,6 +205,7 @@ public:
       buf[i] = *(init.begin() + i);
     _capacity = _size;
   }
+#endif
 
   vector &operator=(const vector &x)
   {

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -5,6 +5,8 @@
 #include <assert.h>
 
 #include "stdexcept"
+#include <initializer_list>
+
 #include <utility> /* std::move */
 #include <new> /* placement-new */
 
@@ -189,6 +191,15 @@ public:
     _size = x._size;
     for (int i = 0; i < _size; i++)
       buf[i] = x.buf[i];
+    _capacity = _size;
+  }
+
+  vector(std::initializer_list<T> init) :_size(0), _capacity(1)
+  {
+    buf = new T[init.size()];
+    _size = init.size();
+    for (int i = 0; i < _size; i++)
+      buf[i] = *(init.begin() + i);
     _capacity = _size;
   }
 


### PR DESCRIPTION
This PR focuses on the CXXStdInitializerList node:

std::initializer_list<T> is not explicitly constructed in the AST; it needs to be constructed manually in the frontend.

code: `std::initializer_list<int> list = {1, 2, 3, 4, 5};`

AST:
```cpp
    |     `-CXXStdInitializerListExpr 0x5637bc3d0858 <col:39, col:53> 'std::initializer_list<int>':'std::initializer_list<int>'
    |       `-MaterializeTemporaryExpr 0x5637bc3d0840 <col:39, col:53> 'const int [5]' xvalue extended by Var 0x5637bc3cda48 'list' 'std::initializer_list<int>':'std::initializer_list<int>'
    |         `-InitListExpr 0x5637bc3d07d8 <col:39, col:53> 'const int [5]'
    |           |-IntegerLiteral 0x5637bc3cdab0 <col:40> 'int' 1
    |           |-IntegerLiteral 0x5637bc3cdad0 <col:43> 'int' 2
    |           |-IntegerLiteral 0x5637bc3cdaf0 <col:46> 'int' 3
    |           |-IntegerLiteral 0x5637bc3cdb10 <col:49> 'int' 4
    |           `-IntegerLiteral 0x5637bc3cdb30 <col:52> 'int' 5
```

```cpp
        DECL std::initializer_list<int> list;

        DECL signed int [5] tmp$1;

        ASSIGN tmp$1=NONDET(signed int [5]);

        ASSIGN tmp$1={ 1, 2, 3, 4, 5 };

        ASSIGN list={ ._M_array=&tmp$1[0], ._M_len=5 };
```

Fixed assertion violation caused by no adjustment of op in delete expr.