### PR TITLE
[C++ verification] added OMs for std::trunc and std::to_string

### DIFF
--- a/regression/esbmc-cpp11/cpp/trunc/main.cpp
+++ b/regression/esbmc-cpp11/cpp/trunc/main.cpp
@@ -1,0 +1,31 @@
+#include <cmath>
+#include <cassert>
+
+int main()
+{
+  float f1 = 3.99f;
+  float f2 = -2.99f;
+  float f3 = 0.0f;
+
+  assert(trunc(f1) == 3.0f);
+  assert(trunc(f2) == -2.0f);
+  assert(trunc(f3) == 0.0f);
+
+  double d1 = 5.99;
+  double d2 = -5.01;
+  double d3 = 123456789.123456;
+
+  assert(trunc(d1) == 5.0);
+  assert(trunc(d2) == -5.0);
+  assert(trunc(d3) == 123456789.0);
+
+  long double ld1 = 9.99L;
+  long double ld2 = -9.999L;
+  long double ld3 = 0.12345L;
+
+  assert(trunc(ld1) == 9.0L);
+  assert(trunc(ld2) == -9.0L);
+  assert(trunc(ld3) == 0.0L);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/cpp/trunc/test.desc
+++ b/regression/esbmc-cpp11/cpp/trunc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/cmath
+++ b/src/cpp/library/cmath
@@ -6,11 +6,12 @@
  * there. But we don't want theirs... */
 #define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #if __has_include(<sys/_types.h>) /* FreeBSD nonsense about __char{16,32}_t */
-#include <sys/_types.h>
+#  include <sys/_types.h>
 #endif
 
 /* delegates to math.h in the C++ headers */
 #include <math.h>
+#include <type_traits>
 
 namespace std
 {
@@ -164,10 +165,34 @@ double modf(Integer num, double *iptr);
   bool name(long double x)                                                     \
   {                                                                            \
     return __builtin_##name(x);                                                \
-  }                                                                            \
+  }
 
 CIMPORT3(isnan);
 CIMPORT3(isnormal);
+
+#undef trunc
+#undef truncf
+#undef truncl
+
+using ::trunc;
+using ::truncf;
+using ::truncl;
+
+float trunc(float x)
+{
+  return __builtin_truncf(x);
+}
+
+long double trunc(long double x)
+{
+  return __builtin_truncl(x);
+}
+
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value, double>::type trunc(T x)
+{
+  return __builtin_trunc(x);
+}
 
 #undef CIMPORT1
 #undef CIMPORT2

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -3,6 +3,7 @@
 
 #include "definitions.h"
 #include "cstring"
+#include "cstdio"
 #include "cassert"
 #include "iostream"
 
@@ -1259,7 +1260,7 @@ char string::at(size_t pos) const
     //throw out_of_range();
     __ESBMC_assert(0, "string append failed, out_of_range");
   }
-  
+
   return this->str[pos];
 }
 
@@ -1307,7 +1308,7 @@ __ESBMC_HIDE:
   this->_size = strlen(s);
   this->str = new char[this->_size + 1];
   strcpy(this->str, s); // Copy the contents of s to str
-  return *this; // Return a reference to the modified string object
+  return *this;         // Return a reference to the modified string object
 }
 
 string &string::operator=(char s)
@@ -1683,13 +1684,13 @@ __ESBMC_HIDE:
 
 size_t string::find(char c, size_t pos) const
 {
-  __ESBMC_HIDE:
+__ESBMC_HIDE:
   __ESBMC_assert(pos < this->length(), "string overflow");
 
   for (size_t i = pos; i < this->length(); i++)
     if (this->str[i] == c)
       return i; // Return the index if character found
-  
+
   return npos; // Return npos if character not found
 }
 
@@ -3222,6 +3223,75 @@ __ESBMC_HIDE:
 
 istream &getline(istream &is, string &str, char delim);
 istream &getline(istream &is, string &str);
+
+/* 
+ * TODO: Model the to_string
+ * Fix the incorrect buffer value
+ * Extend goto_symext::symex_printf
+ * Ref: https://en.cppreference.com/w/cpp/string/basic_string/to_string
+ */
+inline string to_string(int value)
+{
+  char buffer[50];
+  sprintf(buffer, "%d", value);
+  return string(buffer);
+}
+
+inline string to_string(long value)
+{
+  char buffer[50];
+  sprintf(buffer, "%ld", value);
+  return string(buffer);
+}
+
+inline string to_string(long long value)
+{
+  char buffer[50];
+  sprintf(buffer, "%lld", value);
+  return string(buffer);
+}
+
+inline string to_string(unsigned value)
+{
+  char buffer[50];
+  sprintf(buffer, "%u", value);
+  return string(buffer);
+}
+
+std::string to_string(unsigned long value)
+{
+  char buffer[50];
+  sprintf(buffer, "%lu", value);
+  return string(buffer);
+}
+
+std::string to_string(unsigned long long value)
+{
+  char buffer[50];
+  sprintf(buffer, "%llu", value);
+  return string(buffer);
+}
+
+std::string to_string(float value)
+{
+  char buffer[50];
+  sprintf(buffer, "%f", value);
+  return string(buffer);
+}
+
+std::string to_string(double value)
+{
+  char buffer[50];
+  sprintf(buffer, "%f", value);
+  return string(buffer);
+}
+
+std::string to_string(long double value)
+{
+  char buffer[50];
+  sprintf(buffer, "%Lf", value);
+  return string(buffer);
+}
 
 } // namespace std
 #endif


### PR DESCRIPTION
For std::to_string, we have some unimplemented for printf in symbolic execution, this PR resolves parsing errors first. The return value of to_string is currently problematic and needs further implementation and should not affect the verification.