### PR TITLE
[C++ verification] support std::forward and std::make_unique

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -118,7 +118,9 @@ set(REGRESSIONS_CPP11 esbmc-cpp11/cpp
                       )
 
 # list of C++14 test suites
-set(REGRESSIONS_CPP14 esbmc-cpp14/template)
+set(REGRESSIONS_CPP14 esbmc-cpp14/cpp
+                      esbmc-cpp14/template   
+                      )
 
 # list of C++20 test suites
 set(REGRESSIONS_CPP20 esbmc-cpp20/cpp)

--- a/regression/esbmc-cpp/try_catch/nec_ex2-list-baditerator/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex2-list-baditerator/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/regression/esbmc-cpp/try_catch/nec_ex3-delegation-dtor-throw/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex3-delegation-dtor-throw/test.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --error-label ERROR --timeout 900
+--unwind 2 --no-unwinding-assertions --error-label ERROR --depth 215 --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 2 --no-unwinding-assertions --error-label ERROR --depth 200 --timeout 900
+--unwind 2 --no-unwinding-assertions --error-label ERROR --depth 125 --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/try_catch/nec_ex6-std-uncaught-dtor/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex6-std-uncaught-dtor/test.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
+--unwind 2 --no-unwinding-assertions --error-label ERROR --depth 250 --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp14/cpp/make_unique/main.cpp
+++ b/regression/esbmc-cpp14/cpp/make_unique/main.cpp
@@ -1,0 +1,79 @@
+#include <iostream>
+#include <memory>
+#include <cassert>
+
+void testCreateUniquePtr()
+{
+  std::unique_ptr<int> ptr = std::make_unique<int>(10);
+  assert(ptr != nullptr); // Check that the pointer is not null
+  assert(*ptr == 10);     // Check that the value is correctly assigned
+  std::cout << "testCreateUniquePtr passed!" << std::endl;
+}
+
+void testTransferOwnership()
+{
+  std::unique_ptr<int> ptr1 = std::make_unique<int>(20);
+  assert(*ptr1 == 20); // Ensure ptr1 owns the resource
+
+  std::unique_ptr<int> ptr2 = std::move(ptr1); // Transfer ownership to ptr2
+  assert(ptr1 == nullptr);                     // ptr1 should be null after move
+  assert(*ptr2 == 20); // ptr2 should own the resource now
+
+  std::cout << "testTransferOwnership passed!" << std::endl;
+}
+
+void testRelease()
+{
+  std::unique_ptr<int> ptr = std::make_unique<int>(30);
+  assert(*ptr == 30); // Check the initial value
+
+  int *rawPtr = ptr.release(); // Release ownership to rawPtr
+  assert(ptr == nullptr);      // ptr should be null after release
+  assert(*rawPtr == 30);       // rawPtr should point to the original value
+
+  delete rawPtr; // Don't forget to free memory
+  std::cout << "testRelease passed!" << std::endl;
+}
+
+void testReset()
+{
+  std::unique_ptr<int> ptr = std::make_unique<int>(40);
+  assert(*ptr == 40); // Check the initial value
+
+  ptr.reset(new int(50)); // Reset to point to a new integer
+  assert(*ptr == 50);     // Ensure the new value is correct
+
+  ptr.reset();            // Reset to nullptr
+  assert(ptr == nullptr); // ptr should be null after reset
+
+  std::cout << "testReset passed!" << std::endl;
+}
+
+void testUniquePtrWithCustomDeleter()
+{
+  struct CustomDeleter
+  {
+    void operator()(int *ptr) const
+    {
+      std::cout << "Custom deleter called!" << std::endl;
+      delete ptr;
+    }
+  };
+
+  std::unique_ptr<int, CustomDeleter> ptr(new int(60), CustomDeleter());
+  assert(*ptr == 60); // Check that the value is correctly assigned
+
+  std::cout << "testUniquePtrWithCustomDeleter passed!" << std::endl;
+}
+
+int main()
+{
+  testCreateUniquePtr();
+  testTransferOwnership();
+  testRelease();
+  testReset();
+  testUniquePtrWithCustomDeleter();
+
+  std::cout << "All tests passed!" << std::endl;
+  return 0;
+}

--- a/regression/esbmc-cpp14/cpp/make_unique/test.desc
+++ b/regression/esbmc-cpp14/cpp/make_unique/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++14
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1764,7 +1764,9 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     const clang::Stmt *callee = function_call.getCallee();
 
 #if CLANG_VERSION_MAJOR > 14
-    if (function_call.isCallToStdMove())
+    if (
+      function_call.isCallToStdMove() ||
+      function_call.getBuiltinCallee() == clang::Builtin::BIforward)
     {
       if (get_expr(*function_call.getArg(0), new_expr))
         return true;

--- a/src/cpp/library/memory
+++ b/src/cpp/library/memory
@@ -3,6 +3,7 @@
 
 #include "cstddef"
 #include "iterator"
+#include "utility"
 
 #if 0
 template<class T> class allocator {
@@ -91,20 +92,32 @@ copy(InputIterator first, InputIterator last, ForwardIterator result)
 }
 
 #if __cplusplus >= 201103L // Check if C++11 or later is being used
+
 template <class T>
+struct default_delete
+{
+  void operator()(T *ptr) const
+  {
+    delete ptr;
+  }
+};
+
+template <class T, class D = default_delete<T>>
 class unique_ptr
 {
   T *ptr;
+  D deleter;
 
 public:
-  explicit unique_ptr(T *p = nullptr) : ptr(p)
+  explicit unique_ptr(T *p = nullptr, D del = D()) : ptr(p), deleter(del)
   {
   }
 
   unique_ptr(const unique_ptr &) = delete;
   unique_ptr &operator=(const unique_ptr &) = delete;
 
-  unique_ptr(unique_ptr &&other) noexcept : ptr(other.ptr)
+  unique_ptr(unique_ptr &&other) noexcept
+    : ptr(other.ptr), deleter(std::move(other.deleter))
   {
     other.ptr = nullptr;
   }
@@ -113,17 +126,22 @@ public:
   {
     if (this != &other)
     {
-      delete ptr;
+      deleter(ptr);
+
       ptr = other.ptr;
+      deleter = std::move(other.deleter);
       other.ptr = nullptr;
     }
     return *this;
   }
 
+#if 0
+  // TODO: fix remove goto sideeffect
   ~unique_ptr()
   {
-    delete ptr;
+    deleter(ptr);
   }
+#endif
 
   T *operator->() const
   {
@@ -146,7 +164,7 @@ public:
   {
     if (ptr != p)
     {
-      delete ptr;
+      deleter(ptr);
       ptr = p;
     }
   }
@@ -155,8 +173,81 @@ public:
   {
     return ptr;
   }
+
+  D &get_deleter()
+  {
+    return deleter;
+  }
+
+  const D &get_deleter() const
+  {
+    return deleter;
+  }
 };
+
+template <class T, class D>
+bool operator==(const unique_ptr<T, D> &x, std::nullptr_t) noexcept
+{
+  return x.get() == nullptr;
+}
+
+template <class T, class D>
+bool operator==(std::nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+  return x.get() == nullptr;
+}
+
+template <class T, class D>
+bool operator!=(const unique_ptr<T, D> &x, std::nullptr_t) noexcept
+{
+  return x.get() != nullptr;
+}
+
+template <class T, class D>
+bool operator!=(std::nullptr_t, const unique_ptr<T, D> &x) noexcept
+{
+  return x.get() != nullptr;
+}
+
+template <class T, class D>
+bool operator==(const unique_ptr<T, D> &x, const T *ptr) noexcept
+{
+  return x.get() == ptr;
+}
+
+template <class T, class D>
+bool operator!=(const unique_ptr<T, D> &x, const T *ptr) noexcept
+{
+  return x.get() != ptr;
+}
+
+template <class T, class D>
+bool operator==(const T *ptr, const unique_ptr<T, D> &x) noexcept
+{
+  return x.get() == ptr;
+}
+
+template <class T, class D>
+bool operator!=(const T *ptr, const unique_ptr<T, D> &x) noexcept
+{
+  return x.get() != ptr;
+}
 #endif
+
+#if __cplusplus >= 201402L
+template <class T, class... Args>
+unique_ptr<T> make_unique(Args &&...args)
+{
+  return unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template <class T>
+unique_ptr<T> make_unique(std::size_t size)
+{
+  return unique_ptr<T>(new typename std::remove_extent<T>::type[size]());
+}
+#endif
+
 #if 0
 template <class OutputIterator, class T>
 class raw_storage_iterator :

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -54,6 +54,19 @@ typename std::remove_reference<T>::type &&move(T &&t) noexcept
 {
   return static_cast<typename std::remove_reference<T>::type &&>(t);
 }
+
+template <typename T>
+T&& forward(typename remove_reference<T>::type& t) noexcept
+{
+  return static_cast<T&&>(t);
+}
+
+template <typename T>
+T&& forward(typename remove_reference<T>::type&& t) noexcept
+{
+  static_assert(!std::is_lvalue_reference<T>::value, "T must not be an lvalue reference");
+  return static_cast<T&&>(t);
+}
 #endif
 
 } // namespace std

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -611,16 +611,18 @@ void goto_symext::symex_cpp_delete(const expr2tc &expr)
 
   // we need to check the memory deallocation operator:
   // new and delete, new[] and delete[]
-  bool is_arr = is_array_type(internal_deref_items.front().object->type);
-  bool is_del_arr = is_code_cpp_del_array2t(expr);
-
-  if (is_arr != is_del_arr)
+  if (internal_deref_items.size())
   {
-    const std::string &msg =
-      "Mismatched memory deallocation operators: " + get_expr_id(expr);
-    claim(gen_false_expr(), msg);
-  }
+    bool is_arr = is_array_type(internal_deref_items.front().object->type);
+    bool is_del_arr = is_code_cpp_del_array2t(expr);
 
+    if (is_arr != is_del_arr)
+    {
+      const std::string &msg =
+        "Mismatched memory deallocation operators: " + get_expr_id(expr);
+      claim(gen_false_expr(), msg);
+    }
+  }
   // implement delete as a call to free
   symex_free(expr);
 }


### PR DESCRIPTION
There is a bug with `remove_sideeffect` that causes the destructor to generate the wrong goto function, which needs further investigation.