### PR TITLE
Revert "simplify "<<" opreation for alignment"

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -801,12 +801,8 @@ void value_sett::get_reference_set_rec(const expr2tc &expr, object_mapt &dest)
       const irept &a = sym->type.find("alignment");
       if (a.is_not_nil())
       {
-        expr2tc temp;
-        migrate_expr(static_cast<const exprt &>(a), temp);
-        simplify(temp);
-        auto temp2 = migrate_expr_back(temp);
-        assert(temp2.is_constant());
-        irep_idt v = temp2.value();
+        assert(a.is_constant());
+        irep_idt v = static_cast<const exprt &>(a).value();
         BigInt V = binary2integer(v.as_string(), false);
         assert(V.is_positive());
         assert(V <= UINT_MAX);


### PR DESCRIPTION
This reverts commit 2d36db19bfa4e04b0d3477ba9aa6853dd2246ce2.