### PR TITLE
[Coverage] Enable no-unwinding-assertions in Coverage mode

### DIFF
--- a/regression/goto-coverage/branch_cov_12/main.c
+++ b/regression/goto-coverage/branch_cov_12/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+int main() {
+  int valve = nondet_int();  // environment
+  int input = nondet_int();  // user input
+  while (input) {
+    if (!valve) {
+      assert(valve == 0); // "privacy"
+      valve = 1;
+    }
+    else if (valve == 1) {
+      assert(valve > 0); // "performance"
+       valve = 2;
+    }
+    else if (valve == 2) {
+      assert(valve >= 2); // "vulnerability"
+      valve = 3;
+    }
+  }
+  assert(valve == 3);
+}

--- a/regression/goto-coverage/branch_cov_12/test.desc
+++ b/regression/goto-coverage/branch_cov_12/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--branch-coverage-claims --unwind 2
+^Branches : 8
+^Reached : 8
+^Branch Coverage: 100
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_2072_1/main.c
+++ b/regression/goto-coverage/github_2072_1/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+
+void loop1()
+{
+   for (int i = 0; i < 2; i++)
+   {
+      assert(0);
+   }
+}
+
+void loop2()
+{
+   for (int i = 0; i < 4; i++)
+   {
+      assert(1);
+   }
+}
+
+int main()
+
+{
+   switch (nondet_int())
+   {
+   case 1:
+      loop1();
+      break;
+   case 2:
+      loop2();
+      break;
+   default:
+       ;
+   }
+   return 0;
+}

--- a/regression/goto-coverage/github_2072_1/test.desc
+++ b/regression/goto-coverage/github_2072_1/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--unwind 1 --assertion-coverage
+^Total Asserts: 2
+^Reached Assertion Instances: 2
+^Total Assertion Instances: 6
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_2072_2/main.c
+++ b/regression/goto-coverage/github_2072_2/main.c
@@ -1,0 +1,21 @@
+#include <stdbool.h>
+
+int a[20];
+
+bool foo(int il)
+{
+    return a[1];
+}
+
+int main()
+{
+    int il;
+    for (il = 0; foo(il) && il < 10; ++il)
+    {
+    }
+    // if(1 && 2 && 3 && 4);
+
+    for (il = 0; il < 10 && foo(il); ++il)
+    {
+    }
+}

--- a/regression/goto-coverage/github_2072_2/test.desc
+++ b/regression/goto-coverage/github_2072_2/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+ --condition-coverage-claims --no-cov-asserts --unwind 10 
+^Short Circuited Conditions:  2
+^VERIFICATION FAILED$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2120,17 +2120,17 @@ void esbmc_parseoptionst::add_property_monitors(
   std::map<std::string, std::pair<std::set<std::string>, expr2tc>> monitors;
 
   context.foreach_operand([this, &monitors](const symbolt &s) {
-      if (
-        !has_prefix(s.name, "__ESBMC_property_") ||
-        s.name.as_string().find("$type") != std::string::npos)
-        return;
+    if (
+      !has_prefix(s.name, "__ESBMC_property_") ||
+      s.name.as_string().find("$type") != std::string::npos)
+      return;
 
-      // strip prefix "__ESBMC_property_"
-      std::string prop_name = s.name.as_string().substr(17);
-      std::set<std::string> used_syms;
-      expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
-      monitors[prop_name] = std::pair{used_syms, main_expr};
-    });
+    // strip prefix "__ESBMC_property_"
+    std::string prop_name = s.name.as_string().substr(17);
+    std::set<std::string> used_syms;
+    expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
+    monitors[prop_name] = std::pair{used_syms, main_expr};
+  });
 
   if (monitors.size() == 0)
     return;
@@ -2226,9 +2226,9 @@ static void collect_symbol_names(
   else
   {
     e->foreach_operand([&prefix, &used_syms](const expr2tc &e) {
-        if (!is_nil_expr(e))
-          collect_symbol_names(e, prefix, used_syms);
-      });
+      if (!is_nil_expr(e))
+        collect_symbol_names(e, prefix, used_syms);
+    });
   }
 }
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1843,6 +1843,10 @@ bool esbmc_parseoptionst::process_goto_program(
       options.set_option("keep-verified-claims", false);
       options.set_option("no-pointer-check", true);
 
+      // enable '--no-unwinding-assertions' if '--unwind' is enabled
+      if (cmdline.isset("unwind"))
+        options.set_option("no-unwinding-assertions", true);
+
       std::string filename = cmdline.args[0];
       goto_coveraget tmp(ns, goto_functions, filename);
       tmp.assertion_coverage();
@@ -1861,6 +1865,10 @@ bool esbmc_parseoptionst::process_goto_program(
       // prevent adding property checking assertions during SymEx
       options.set_option("no-pointer-check", true);
       // unreachable conditions should be also considered as short-circuited
+
+      // enable '--no-unwinding-assertions' if '--unwind' is enabled
+      if (cmdline.isset("unwind"))
+        options.set_option("no-unwinding-assertions", true);
 
       // for re-do remove-sideeffects
       options.set_option("goto-instrumented", false);
@@ -1897,6 +1905,10 @@ bool esbmc_parseoptionst::process_goto_program(
       options.set_option("keep-verified-claims", false);
       options.set_option("no-pointer-check", true);
 
+      // enable '--no-unwinding-assertions' if '--unwind' is enabled
+      if (cmdline.isset("unwind"))
+        options.set_option("no-unwinding-assertions", true);
+
       std::string filename = cmdline.args[0];
       goto_coveraget tmp(ns, goto_functions, filename);
       tmp.branch_coverage();
@@ -1910,6 +1922,10 @@ bool esbmc_parseoptionst::process_goto_program(
       options.set_option("multi-property", true);
       options.set_option("keep-verified-claims", false);
       options.set_option("no-pointer-check", true);
+
+      // enable '--no-unwinding-assertions' if '--unwind' is enabled
+      if (cmdline.isset("unwind"))
+        options.set_option("no-unwinding-assertions", true);
 
       std::string filename = cmdline.args[0];
       goto_coveraget tmp(ns, goto_functions, filename);
@@ -2104,17 +2120,17 @@ void esbmc_parseoptionst::add_property_monitors(
   std::map<std::string, std::pair<std::set<std::string>, expr2tc>> monitors;
 
   context.foreach_operand([this, &monitors](const symbolt &s) {
-    if (
-      !has_prefix(s.name, "__ESBMC_property_") ||
-      s.name.as_string().find("$type") != std::string::npos)
-      return;
+      if (
+        !has_prefix(s.name, "__ESBMC_property_") ||
+        s.name.as_string().find("$type") != std::string::npos)
+        return;
 
-    // strip prefix "__ESBMC_property_"
-    std::string prop_name = s.name.as_string().substr(17);
-    std::set<std::string> used_syms;
-    expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
-    monitors[prop_name] = std::pair{used_syms, main_expr};
-  });
+      // strip prefix "__ESBMC_property_"
+      std::string prop_name = s.name.as_string().substr(17);
+      std::set<std::string> used_syms;
+      expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
+      monitors[prop_name] = std::pair{used_syms, main_expr};
+    });
 
   if (monitors.size() == 0)
     return;
@@ -2210,9 +2226,9 @@ static void collect_symbol_names(
   else
   {
     e->foreach_operand([&prefix, &used_syms](const expr2tc &e) {
-      if (!is_nil_expr(e))
-        collect_symbol_names(e, prefix, used_syms);
-    });
+        if (!is_nil_expr(e))
+          collect_symbol_names(e, prefix, used_syms);
+      });
   }
 }
 


### PR DESCRIPTION
The calculation of the coverage relies on the instrumented assertions. This, however, will be affected by other instrumentation like unwinding-assertions. Therefore, we need to enable `no-unwinding-assertions` by default