### PR TITLE
Test comp (will not merge)

### DIFF
--- a/scripts/competitions/testcomp/esbmc-wrapper-cov.py
+++ b/scripts/competitions/testcomp/esbmc-wrapper-cov.py
@@ -203,6 +203,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, coverage)
       command_line += "--branch-function-coverage "
   elif prop == Property.reach:
     command_line += "--base-k-step 5 --enable-unreachability-intrinsic "
+    command_line += "--generate-testcase "
     if concurrency:
       command_line += "--no-pointer-check --no-bounds-check "
     else:


### PR DESCRIPTION
We need to avoid generate test-case for array-type, struct-type... in test-comp.

Considering this C program from Test-Comp Cover-Branch. 
```C
int main()
{
  int i;
  int j=__VERIFIER_nondet_int();
  int n=__VERIFIER_nondet_int();
  assume_abort_if_not(n < 100000);
  int a[n];

  assume_abort_if_not(j>0 && j < 10000);
 
  for(i=1;i<n;i++) {
    int k=__VERIFIER_nondet_int();
    assume_abort_if_not(k>0 && k < 10000);
    a[i]=i+j+k;
  }

  for(i=1;i<n;i++)
    __VERIFIER_assert(a[i]>=(i+2));
  return 0;
}  
```

When using `--branch-coverage --generate-testcase`, we will try to generate a value for the uninitialized array `a[n]`. This will lead to an abort because we do not support it. However, since the test-comp only requires test cases for int/float/bool type variables, we don't need (and should not!) generate any other types.

<details><summary>Result:</summary><p>

```sh
# output file
testcase-0.xml
testcase-1.xml
...
testcase-6.xml

# testcase-0.xml
# CE
[Counterexample]


State 1 file 1.c line 13 column 3 function main thread 0
----------------------------------------------------
  j = 7 (00000000 00000000 00000000 00000111)

State 2 file 1.c line 14 column 3 function main thread 0
----------------------------------------------------
  n = 2 (00000000 00000000 00000000 00000010)

State 3 file 1.c line 21 column 5 function main thread 0
----------------------------------------------------
  k = 9 (00000000 00000000 00000000 00001001)

State 4 file 1.c line 23 column 5 function main thread 0
----------------------------------------------------
  a[1] = 17 (00000000 00000000 00000000 00010001)

State 5 file 1.c line 26 column 3 function main thread 0
----------------------------------------------------
Violated property:
  file 1.c line 26 column 3 function main
  !(!(i < n))
  !(!(i < n))

# XML
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE testcase PUBLIC "+//IDN sosy-lab.org//DTD test-format testcase 1.1//EN" "https://sosy-lab.org/test-format/testcase-1.1.dtd">
<input>7</input>
<input>2</input>
<input>9</input>
</testcase>
```

</p></details>


---

Known issue(?): We will still generate testcase for malloc-array. Might need to run `testcov` to see if it's allowed.

TODO: Pack the output XML files to a zip