### PR TITLE
[goto-program] try to remove the redundant op

### DIFF
--- a/regression/goto-coverage/branch_cov_10/test.desc
+++ b/regression/goto-coverage/branch_cov_10/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.cpp
 --branch-coverage-claims --unwind 3 --no-unwinding-assertions
-^Branches : 10
-^Reached : 3
-^Branch Coverage: 30%
-^VERIFICATION FAILED$
+^Branches : 4
+^Reached : 0
+^Branch Coverage: 0%
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/remove_no_op.cpp
+++ b/src/goto-programs/remove_no_op.cpp
@@ -57,6 +57,11 @@ bool is_no_op(
         // something like (void)0
         return true;
       }
+      else if (is_constant_expr(expr))
+      {
+        // something like other 0;
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
This PR simplifies some redundant statements:

For example, assert in C++ :

```
    ASSERT valve == 0
    IF !(valve == 0) THEN GOTO 2
    OTHER 0;
```
We need to remove this useless GOTO statement:

```
    ASSERT valve == 0
```
