### PR TITLE
[CI] Specify the Ubuntu version

### DIFF
--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -17,6 +17,6 @@ jobs:
   build-unix:
     uses: ./.github/workflows/build-unix.yml
     with:
-      operating-system: ubuntu-latest
+      operating-system: ubuntu-22.04
       build-flags: '-b Debug'
       testing: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/build-unix.yml
     name: static llvm-16 DebugOpt
     with:
-      operating-system: ubuntu-latest
+      operating-system: ubuntu-22.04
       build-flags: '-b DebugOpt -e On'
       testing: true
 
@@ -66,7 +66,7 @@ jobs:
     name: dyn. llvm-13 DebugOpt
     uses: ./.github/workflows/build-unix.yml
     with:
-      operating-system: ubuntu-latest
+      operating-system: ubuntu-22.04
       build-flags: '-b DebugOpt -e On -S OFF -c 13'
       testing: true
 


### PR DESCRIPTION
GitHub action updated Ubuntu to the latest version 24.04. But we don't fully support it yet, so we specify 22.04 in CI.

BTW, the workflow was updated in the previous PR, now we should remove the llvm-11 "require" tag in workflow, and add a "require" tag to llvm-16.