### PR TITLE
Simplified Trace

### DIFF
--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -41,6 +41,7 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "do not print unwinding information during symbolic execution"},
     {"compact-trace", NULL, ""},
+    {"simplified-trace", NULL, "print a simplified version of the trace"},
     {"symex-trace", NULL, "print instructions during symbolic execution"},
     {"ssa-trace", NULL, "print SSA during SMT encoding"},
     {"ssa-smt-trace", NULL, "print generated SMT during SMT encoding"},


### PR DESCRIPTION
This PR adds a simplified trace to ESBMC, using the `simplified-trace` flag option. The main goal of this PR is to present the counterexample trace in a less verbose, more human-readable format. Discussion on said format is welcome.

Closes #2080