### PR TITLE
[C++ verification] fix explicit destructor

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_2052/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_2052/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+class A
+{
+public:
+  int num;
+  A (int n) : num(n)
+  {
+  }
+  ~A()
+  {
+  }
+};
+
+A func(int n)
+{
+  return A(n);
+}
+
+int main()
+{
+  A a = func(1);
+  assert(a.num == 1);
+}

--- a/regression/esbmc-cpp/bug_fixes/github_2052/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_2052/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_2052_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_2052_fail/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+class A
+{
+public:
+  int num;
+  A (int n) : num(n)
+  {
+  }
+  ~A()
+  {
+  }
+};
+
+A func(int n)
+{
+  return A(n);
+}
+
+int main()
+{
+  A a = func(1);
+  assert(a.num == 0);
+}

--- a/regression/esbmc-cpp/bug_fixes/github_2052_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_2052_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2245,14 +2245,21 @@ bool clang_cpp_convertert::is_ConstructorOrDestructor(
 
 void clang_cpp_convertert::make_temporary(exprt &expr)
 {
-  if (expr.statement() != "temporary_object")
+  if (expr.statement() == "temporary_object")
+    return;
+
+  // make the temporary
+  side_effect_exprt tmp_obj("temporary_object", expr.type());
+  tmp_obj.location() = expr.location();
+  if (!expr.get_bool("constructor"))
   {
-    // make the temporary
-    side_effect_exprt tmp_obj("temporary_object", expr.type());
-    codet code_expr("expression");
-    code_expr.operands().push_back(expr);
-    tmp_obj.initializer(code_expr);
-    tmp_obj.location() = expr.location();
+    tmp_obj.move_to_operands(expr);
     expr.swap(tmp_obj);
+    return;
   }
+
+  codet code_expr("expression");
+  code_expr.operands().push_back(expr);
+  tmp_obj.initializer(code_expr);
+  expr.swap(tmp_obj);
 }


### PR DESCRIPTION
This PR fixes the GOTO error caused by the explicit destructor.

1. `FUNCTION_CALL:  func()` ---> `FUNCTION_CALL:  tmp$1 = func()`;
2. ~~No longer call destructors for temporary objects.~~

```
class MyClass {
private:
    int* data;
public:
    MyClass() {
        data = new int[10];
    }

    ~MyClass() {
        delete[] data;
    }
};
```
~~When we create a temporary object of type `MyClass`, calling the destructor dereferences the invalid object.~~