### PR TITLE
[SMT solver] Updated Bitwuzla from v0.5.0 to v0.6.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.4           |
 | Z3        | no       | 4.8.9           |
-| Bitwuzla  | no       | 0.5.0           |
+| Bitwuzla  | no       | 0.6.0           |
 
 The version requirements are stable but can change between releases.
 
@@ -275,7 +275,7 @@ We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
 Linux/macOS:
-git clone --depth=1 --branch=0.5.0 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
+git clone --depth=1 --branch=0.6.0 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
 ```
 
 For more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
             NAME bitwuzla
             DOWNLOAD_ONLY YES
             GITHUB_REPOSITORY bitwuzla/bitwuzla
-            GIT_TAG 0.5.0)
+            GIT_TAG 0.6.0)
 	  
 	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
         message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")


### PR DESCRIPTION
This PR updates the version of the SMT solver Bitwuzla from 0.5.0 to 0.6.0.