### PR TITLE
[symex] make alloca handling more robust

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te/main.cpp
@@ -1,0 +1,23 @@
+#include <stddef.h>
+#include <stdlib.h>
+struct
+{
+  float *alloca$te()
+  {
+    return static_cast<float *>(malloc(sizeof(float)));
+  }
+} a;
+float *alloca$te()
+{
+  return a.alloca$te();
+}
+float *b()
+{
+  return alloca$te();
+}
+int main()
+{
+  float *x = b();
+  free(x);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te_fail/main.cpp
@@ -1,0 +1,24 @@
+#include <stddef.h>
+#include <stdlib.h>
+struct
+{
+  float *alloca$te()
+  {
+    return static_cast<float *>(malloc(sizeof(float)));
+  }
+} a;
+float *alloca$te()
+{
+  return a.alloca$te();
+}
+float *b()
+{
+  return alloca$te();
+}
+int main()
+{
+  float *x = b();
+  free(x);
+  free(x);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_alloca$te_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate/main.cpp
@@ -1,0 +1,23 @@
+#include <stddef.h>
+#include <stdlib.h>
+struct
+{
+  float *allocate()
+  {
+    return static_cast<float *>(malloc(sizeof(float)));
+  }
+} a;
+float *allocate()
+{
+  return a.allocate();
+}
+float *b()
+{
+  return allocate();
+}
+int main()
+{
+  float *x = b();
+  free(x);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate_fail/main.cpp
@@ -1,0 +1,24 @@
+#include <stddef.h>
+#include <stdlib.h>
+struct
+{
+  float *allocate()
+  {
+    return static_cast<float *>(malloc(sizeof(float)));
+  }
+} a;
+float *allocate()
+{
+  return a.allocate();
+}
+float *b()
+{
+  return allocate();
+}
+int main()
+{
+  float *x = b();
+  free(x);
+  free(x);
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/2095_incorrect_freed_objects_allocate_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -518,7 +518,7 @@ void goto_symext::pop_frame()
 
     // Call free on alloca'd objects
     if (
-      it.base_name.as_string().find("return_value$_alloca") !=
+      it.base_name.as_string().find("return_value$_alloca$") !=
       std::string::npos)
       symex_free(code_free2tc(l1_sym));
 

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -128,7 +128,7 @@ void goto_symext::symex_dead(const expr2tc code)
   cur_state->top().level1.get_ident_name(l1_sym);
 
   // Call free on alloca'd objects
-  if (identifier.as_string().find("return_value$_alloca") != std::string::npos)
+  if (identifier.as_string().find("return_value$_alloca$") != std::string::npos)
     symex_free(code_free2tc(l1_sym));
 
   // Erase from level 1 propagation


### PR DESCRIPTION
Don't free pointers returned from `alloca`te functions. Pointers from functions called `alloca$` will still be incorrectly freed, but this is for a future PR.