### PR TITLE
add restriction for constant_union

### DIFF
--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -125,6 +125,7 @@ public:
     std::vector<expr2tc> m)
     : constant_datatype_data(t, id, std::move(m)), init_field(init_field)
   {
+    assert(m.size() <= 1);
   }
   constant_union_data(const constant_union_data &) = default;
 


### PR DESCRIPTION
In https://github.com/esbmc/esbmc/pull/2093#issuecomment-2435034215 we claim that there is at most 1 member in a constant union. This adds a explicit restriction for it.