### PR TITLE
[SMT solver] Update Z3 to v4.13.3

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | CVC5      | no       | 1.1.2           |
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.4           |
-| Z3        | no       | 4.8.9           |
+| Z3        | no       | 4.13.3          |
 | Bitwuzla  | no       | 0.6.0           |
 
 The version requirements are stable but can change between releases.
@@ -255,7 +255,7 @@ We have wrapped the entire build and setup of Z3 in the following command:
 
 ```
 Linux:
-wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/z3-4.8.9-x64-ubuntu-16.04.zip && unzip z3-4.8.9-x64-ubuntu-16.04.zip && mv z3-4.8.9-x64-ubuntu-16.04 z3
+wget https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-glibc-2.35.zip && unzip z3-4.13.3-x64-glibc-2.35.zip && mv z3-4.13.3-x64-glibc-2.35 z3
 
 macOS:
 brew install z3

--- a/scripts/cmake/Options.cmake
+++ b/scripts/cmake/Options.cmake
@@ -61,8 +61,8 @@ if(WIN32)
   set(DEFAULT_LLVM_URL "https://gitlab.com/Anthonysdu/llvm11/-/raw/main/llvm+clang+lld-11.0.0-x86_64-windows-msvc-release-mt.zip")
   set(DEFAULT_LLVM_NAME "llvm+clang+lld-11.0.0-x86_64-windows-msvc-release-mt")
 
-  set(DEFAULT_Z3_URL "https://github.com/Z3Prover/z3/releases/download/z3-4.12.6/z3-4.12.6-x64-win.zip")
-  set(DEFAULT_Z3_NAME z3-4.12.6-x64-win)
+  set(DEFAULT_Z3_URL "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-win.zip")
+  set(DEFAULT_Z3_NAME z3-4.13.3-x64-win)
 
   set(MATHSAT_URL "https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-win64-msvc.zip")
   set(MATHSAT_NAME "mathsat-5.6.10-win64-msvc")
@@ -70,8 +70,8 @@ else()
   set(DEFAULT_LLVM_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0/clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz")
   set(DEFAULT_LLVM_NAME "clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04")
 
-  set(DEFAULT_Z3_URL "https://github.com/Z3Prover/z3/releases/download/z3-4.12.6/z3-4.12.6-x64-glibc-2.35.zip")
-  set(DEFAULT_Z3_NAME z3-4.12.6-x64-glibc-2.35)
+  set(DEFAULT_Z3_URL "https://github.com/Z3Prover/z3/releases/download/z3-4.13.3/z3-4.13.3-x64-glibc-2.35.zip")
+  set(DEFAULT_Z3_NAME z3-4.13.3-x64-glibc-2.35)
 
   set(MATHSAT_URL "https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-linux-x86_64.tar.gz")
   set(MATHSAT_NAME "mathsat-5.6.10-linux-x86_64")


### PR DESCRIPTION
This PR updates the SMT solver Z3 to v4.13.3.

Master: https://github.com/esbmc/esbmc/actions/runs/11520570403
This PR: https://github.com/esbmc/esbmc/actions/runs/11520576277