### PR TITLE
[C++ verification] add support for ArrayInitLoopExpr and ArrayInitIndexExpr

### DIFF
--- a/regression/esbmc-cpp/cpp/array_loop/main.cpp
+++ b/regression/esbmc-cpp/cpp/array_loop/main.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+
+struct Example
+{
+  int arr[3];
+
+  Example() : arr{1, 2, 3}
+  {
+  }
+};
+
+int main()
+{
+  Example original;
+  Example copy = original;
+
+  assert(copy.arr[0] == 1);
+  assert(copy.arr[1] == 2);
+  assert(copy.arr[2] == 3);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/array_loop/test.desc
+++ b/regression/esbmc-cpp/cpp/array_loop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/array_loop_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/array_loop_fail/main.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+
+struct Example
+{
+  int arr[3];
+
+  Example() : arr{1, 2, 3}
+  {
+  }
+};
+
+int main()
+{
+  Example original;
+  Example copy = original;
+
+  assert(copy.arr[0] == 1);
+  assert(copy.arr[1] == 2);
+  assert(copy.arr[2] == 0); // fail
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/array_loop_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/array_loop_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ch8_8/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_8/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 Hugeint1.cpp --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_string_class/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multimap/multimap_string_class-2_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_string_class-2_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multimap/multimap_string_class_bug/test.desc
+++ b/regression/esbmc-cpp/multimap/multimap_string_class_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 3 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1136,7 +1136,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         integer2binary(i, bv_width(ind.index().type())),
         integer2string(i),
         ind.index().type());
-      
+
       ind.index() = new_index;
       inits.copy_to_operands(ind);
     }

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1128,9 +1128,10 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     index_exprt ind = to_index_expr(init);
 
     const llvm::APInt &Int = aile.getArraySize();
+    std::size_t size = Int.getSExtValue();
     exprt inits("constant", common.type());
     // { ref->arr[0], ref->arr[1], ... ,ref->arr[i]}
-    for (unsigned int i = 0; i < Int.getSExtValue(); ++i)
+    for (std::size_t i = 0; i < size; ++i)
     {
       exprt new_index = constant_exprt(
         integer2binary(i, bv_width(ind.index().type())),


### PR DESCRIPTION
For array assignments, first of all, we can't dereference array types (at least not in C), and it would be inefficient if we added a For loop to initialize the array.

This PR uses constant expr to initialize the array members of the class:
```c
Example (c:@S@Example@F@Example#&1$@S@Example#):
        // 26 no location
        THROW_DECL (noexcept)
        // 27 no location
        DECL Example array_init$;
        // 28 no location
        ASSIGN array_init$=NONDET(struct);
        // 29 file main5.cpp line 3 column 8 function Example
        ASSIGN array_init$.arr={ Example::ref->arr[0], Example::ref->arr[1], Example::ref->arr[2] };
        // 30 file main5.cpp line 3 column 8 function Example
        ASSIGN *this=array_init$;
        // 31 file main5.cpp line 3 column 8 function Example
        DEAD c:@S@Example@F@Example#&1$@S@Example#this_array_init$
        // 32 file main5.cpp line 3 column 8 function Example
        END_FUNCTION // Example
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```