### PR TITLE
Introduce new option to convert pointer and bound checks into assumptions

### DIFF
--- a/regression/esbmc/dangling_assume/main.c
+++ b/regression/esbmc/dangling_assume/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int main() {
+    int *ptr = (int*) malloc(sizeof(int));
+    *ptr = 42;
+    free(ptr);
+    *ptr = 50;
+
+    return 0;
+}
+

--- a/regression/esbmc/dangling_assume/test.desc
+++ b/regression/esbmc/dangling_assume/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --conv-assert-to-assume
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/double_free_assume/main.c
+++ b/regression/esbmc/double_free_assume/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int main() {
+    int *ptr = (int*) malloc(sizeof(int));
+    *ptr = 42;
+    free(ptr);
+    free(ptr);
+
+    return 0;
+}
+

--- a/regression/esbmc/double_free_assume/test.desc
+++ b/regression/esbmc/double_free_assume/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --conv-assert-to-assume
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/union_value_sets_assume/main.c
+++ b/regression/esbmc/union_value_sets_assume/main.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <assert.h>
+
+union cheri
+{
+  void *cap;
+  struct
+  {
+    uint64_t c;
+    uint64_t p;
+  };
+};
+
+int main()
+{
+  char *cap_ptr = "hello"; //64bits
+  union cheri u = {cap_ptr};
+  u.p = 0xFFFFFFFFFFFFFFFF;
+  char *initial_cursor = u.cap;
+
+  initial_cursor[6];
+  return 0;
+}

--- a/regression/esbmc/union_value_sets_assume/test.desc
+++ b/regression/esbmc/union_value_sets_assume/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--conv-assert-to-assume
+
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -362,7 +362,10 @@ const struct group_opt_templ all_cmd_options[] = {
     {"enable-unreachability-intrinsic",
      NULL,
      "enable the functionality of the __ESBMC_unreachable() intrinsic, which "
-     "results in a verification failure when its call is reachable"}}},
+     "results in a verification failure when its call is reachable"},
+    {"conv-assert-to-assume",
+     NULL,
+     "convert assertions for bounds and pointer checks into assumptions"}}},
   {"k-induction",
    {{"base-case", NULL, "check the base case"},
     {"forward-condition", NULL, "check the forward condition"},

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -305,7 +305,10 @@ void goto_symext::symex_free(const expr2tc &expr)
       expr2tc offset = item.offset;
       expr2tc eq = equality2tc(offset, gen_ulong(0));
       g.guard_expr(eq);
-      claim(eq, "Operand of free must have zero pointer offset");
+      if (options.get_bool_option("conv-assert-to-assume"))
+        assume(eq);
+      else
+        claim(eq, "Operand of free must have zero pointer offset");
 
       // Check if we are not freeing an dynamic object allocated using alloca
       for (auto const &a : allocad)
@@ -327,7 +330,10 @@ void goto_symext::symex_free(const expr2tc &expr)
         {
           expr2tc noteq = notequal2tc(alloc_obj, item.object);
           g.guard_expr(noteq);
-          claim(noteq, "dereference failure: invalid pointer freed");
+          if (options.get_bool_option("conv-assert-to-assume"))
+            assume(noteq);
+          else
+            claim(noteq, "dereference failure: invalid pointer freed");
         }
       }
     }

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -929,6 +929,8 @@ protected:
     const std::string &msg,
     const guardt &guard) override;
 
+  void dereference_assume(const guardt &guard) override;
+
   void
   get_value_set(const expr2tc &expr, value_setst::valuest &value_set) override;
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -15,6 +15,13 @@ void symex_dereference_statet::dereference_failure(
   goto_symex.claim(not2tc(g), "dereference failure: " + msg);
 }
 
+void symex_dereference_statet::dereference_assume(const guardt &guard)
+{
+  expr2tc g = guard.as_expr();
+  goto_symex.replace_dynamic_allocation(g);
+  goto_symex.assume(not2tc(g));
+}
+
 bool symex_dereference_statet::has_failed_symbol(
   const expr2tc &expr,
   const symbolt *&symbol)

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1869,7 +1869,12 @@ void dereferencet::dereference_failure(
 {
   // This just wraps dereference failure in a no-pointer-check check.
   if (!options.get_bool_option("no-pointer-check") && !block_assertions)
-    dereference_callback.dereference_failure(error_class, error_name, guard);
+  {
+    if (options.get_bool_option("conv-assert-to-assume"))
+      dereference_callback.dereference_assume(guard);
+    else
+      dereference_callback.dereference_failure(error_class, error_name, guard);
+  }
 }
 
 void dereferencet::bad_base_type_failure(

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -112,6 +112,8 @@ public:
     const std::string &msg,
     const guardt &guard) = 0;
 
+  virtual void dereference_assume(const guardt &guard) = 0;
+
   /** Fetch the set of values that the given pointer variable can point at.
    *  @param expr Pointer symbol to get the value set of.
    *  @param value_set A value set to store the output of this call into.

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -68,6 +68,30 @@ void goto_program_dereferencet::dereference_failure(
   }
 }
 
+void goto_program_dereferencet::dereference_assume(const guardt &guard)
+{
+  expr2tc guard_expr = guard.as_expr();
+
+  if (assumptions.insert(guard_expr).second)
+  {
+    guard_expr = not2tc(guard_expr);
+
+    // first try simplifier on it
+    if (!options.get_bool_option("no-simplify"))
+    {
+      base_type(guard_expr, ns);
+      simplify(guard_expr);
+    }
+
+    if (!is_true(guard_expr))
+    {
+      goto_programt::targett t = new_code.add_instruction(ASSUME);
+      t->guard = guard_expr;
+      t->location = dereference_location;
+    }
+  }
+}
+
 void goto_program_dereferencet::get_value_set(
   const expr2tc &expr,
   value_setst::valuest &dest)

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -49,6 +49,8 @@ protected:
     const std::string &msg,
     const guardt &guard) override;
 
+  void dereference_assume(const guardt &guard) override;
+
   bool is_live_variable(const expr2tc &sym) override
   {
     (void)sym;
@@ -71,6 +73,7 @@ protected:
   goto_programt::const_targett current_target;
 
   std::set<expr2tc> assertions;
+  std::set<expr2tc> assumptions;
   goto_programt new_code;
 };
 


### PR DESCRIPTION
According to CHERI's guarantee, for the checking of capability pointers, the assertions of pointer checking and boundary checking are converted into assumptions.