### PR TITLE
[python-frontend] Filter global variables and classes during function verification

### DIFF
--- a/regression/python/global/main.py
+++ b/regression/python/global/main.py
@@ -1,0 +1,23 @@
+class OtherClass:
+  pass
+
+class MyClass:
+  m_data: OtherClass
+
+a = 1
+d = 2
+e = 1
+z = blah()
+
+def bar() -> None:
+  f = e
+
+def foo(e:MyClass) -> int:
+  b = a
+  assert b == 1
+  bar()
+  return d
+
+obj = MyClass()
+foo(obj)
+

--- a/regression/python/global/test.desc
+++ b/regression/python/global/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--function foo
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/global_scope.h
+++ b/src/python-frontend/global_scope.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <unordered_set>
+#include <string>
+
+class global_scope
+{
+public:
+  global_scope() = default;
+
+  void add_class(const std::string &class_name)
+  {
+    classes_.insert(class_name);
+  }
+
+  void add_variable(const std::string &var_name)
+  {
+    variables_.insert(var_name);
+  }
+
+  const std::unordered_set<std::string> &classes() const noexcept
+  {
+    return classes_;
+  }
+
+  const std::unordered_set<std::string> &variables() const noexcept
+  {
+    return variables_;
+  }
+
+private:
+  std::unordered_set<std::string> classes_;
+  std::unordered_set<std::string> variables_;
+};

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -84,7 +84,7 @@ JsonType find_function(const JsonType &json, const std::string &func_name)
 }
 
 template <typename JsonType>
-JsonType& find_function(JsonType &json, const std::string &func_name)
+JsonType &find_function(JsonType &json, const std::string &func_name)
 {
   for (auto &elem : json)
   {

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -84,6 +84,17 @@ JsonType find_function(const JsonType &json, const std::string &func_name)
 }
 
 template <typename JsonType>
+JsonType& find_function(JsonType &json, const std::string &func_name)
+{
+  for (auto &elem : json)
+  {
+    if (elem["_type"] == "FunctionDef" && elem["name"] == func_name)
+      return elem;
+  }
+  throw std::runtime_error("Function " + func_name + " not found\n");
+}
+
+template <typename JsonType>
 const JsonType get_var_node(const std::string &var_name, const JsonType &block)
 {
   for (auto &element : block["body"])
@@ -91,6 +102,12 @@ const JsonType get_var_node(const std::string &var_name, const JsonType &block)
     if (
       element["_type"] == "AnnAssign" && element["target"].contains("id") &&
       element["target"]["id"] == var_name)
+      return element;
+
+    if (
+      element["_type"] == "Assign" &&
+      element["targets"][0]["_type"] == "Name" &&
+      element["targets"][0]["id"] == var_name)
       return element;
   }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -798,7 +798,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
 
     if (
       !is_builtin_type(func_name) && !is_consensus_type(func_name) &&
-      !is_consensus_func(func_name) && !is_model_func(func_name))
+      !is_consensus_func(func_name) && !is_model_func(func_name) &&
+      !is_class(func_name, ast_json))
     {
       const auto &func_node = find_function(ast_json["body"], func_name);
       assert(!func_node.empty());
@@ -1433,7 +1434,7 @@ const nlohmann::json &get_return_statement(const nlohmann::json &function)
   }
 
   throw std::runtime_error(
-    "Function" + function["name"].get<std::string>() +
+    "Function " + function["name"].get<std::string>() +
     "has no return statement");
 }
 
@@ -1896,6 +1897,21 @@ void python_converter::get_class_definition(
     // Process class attributes
     else if (class_member["_type"] == "AnnAssign")
     {
+      /* Ensure the attribute's type is defined by checking for its symbol.
+       * If the symbol for the type is not found, attempt to locate
+       * the class definition in the AST and convert it if available. */
+      const std::string &class_name = class_member["annotation"]["id"];
+      if (!context.find_symbol("tag-" + class_name))
+      {
+        const auto &class_node = find_class(ast_json["body"], class_name);
+        if (!class_node.empty())
+        {
+          std::string current_class = current_class_name;
+          get_class_definition(class_node, target_block);
+          current_class_name = current_class;
+        }
+      }
+
       get_var_assign(class_member, target_block);
 
       symbol_id sid = create_symbol_id();
@@ -2018,13 +2034,15 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
 
 python_converter::python_converter(
   contextt &_context,
-  const nlohmann::json &ast)
+  const nlohmann::json &ast,
+  const std::vector<nlohmann::json> &filtered_global_elements)
   : context(_context),
     ns(_context),
     ast_json(ast),
     current_func_name(""),
     current_class_name(""),
-    ref_instance(nullptr)
+    ref_instance(nullptr),
+    filtered_global_elements_(filtered_global_elements)
 {
 }
 
@@ -2138,13 +2156,26 @@ void python_converter::convert()
 
     // Convert all variables from global scope and class definitions
     code_blockt block;
-    for (const auto &elem : ast_json["body"])
+    for (const auto &elem : filtered_global_elements_)
     {
       StatementType type = get_statement_type(elem);
       if (type == StatementType::VARIABLE_ASSIGN)
+      {
         get_var_assign(elem, block);
+      }
       else if (type == StatementType::CLASS_DEFINITION)
+      {
         get_class_definition(elem, block);
+        current_class_name.clear();
+      }
+    }
+
+    // Convert function arguments types
+    for (const auto &arg : function_node["args"]["args"])
+    {
+      auto node = find_class(ast_json["body"], arg["annotation"]["id"]);
+      if (!node.empty())
+        get_class_definition(node, block);
     }
 
     // Convert a single function

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -15,7 +15,10 @@ class symbol_id;
 class python_converter
 {
 public:
-  python_converter(contextt &_context, const nlohmann::json &ast);
+  python_converter(
+    contextt &_context,
+    const nlohmann::json &ast,
+    const std::vector<nlohmann::json> &filtered_global_elements);
   void convert();
 
 private:
@@ -97,4 +100,5 @@ private:
   std::unordered_map<std::string, std::set<std::string>> instance_attr_map;
   // Map imported modules to their corresponding paths
   std::unordered_map<std::string, std::string> imported_modules;
+  const std::vector<nlohmann::json> &filtered_global_elements_;
 };

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <python-frontend/global_scope.h>
 #include <util/context.h>
 #include <util/namespace.h>
 #include <nlohmann/json.hpp>
@@ -18,7 +19,7 @@ public:
   python_converter(
     contextt &_context,
     const nlohmann::json &ast,
-    const std::vector<nlohmann::json> &filtered_global_elements);
+    const global_scope &gs);
   void convert();
 
 private:
@@ -86,6 +87,7 @@ private:
   std::string main_python_file;
   std::string current_python_file;
   const nlohmann::json &ast_json;
+  const global_scope &global_scope_;
   nlohmann::json imported_module_json;
   std::string current_func_name;
   std::string current_class_name;
@@ -100,5 +102,4 @@ private:
   std::unordered_map<std::string, std::set<std::string>> instance_attr_map;
   // Map imported modules to their corresponding paths
   std::unordered_map<std::string, std::string> imported_modules;
-  const std::vector<nlohmann::json> &filtered_global_elements_;
 };

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -1,6 +1,7 @@
 #include <python-frontend/python_language.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_annotation.h>
+#include <python-frontend/global_scope.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
 #include <util/message.h>
 #include <util/filesystem.h>
@@ -96,6 +97,22 @@ bool python_languaget::parse(const std::string &path)
 
   ast = nlohmann::json::parse(ast_json);
 
+  try
+  {
+    // Add type information
+    python_annotation<nlohmann::json> ann(ast, global_scope_);
+    const std::string function = config.options.get_option("function");
+    if (!function.empty())
+      ann.add_type_annotation(function);
+    else
+      ann.add_type_annotation();
+  }
+  catch (const std::runtime_error &e)
+  {
+    log_error("{}", e.what());
+    exit(-1);
+  }
+
   return false;
 }
 
@@ -106,28 +123,19 @@ bool python_languaget::final(contextt &)
 
 bool python_languaget::typecheck(contextt &context, const std::string &)
 {
+  // Load c models
+  add_cprover_library(context, this);
+
   try
   {
-    // Add type information
-    python_annotation<nlohmann::json> ann(ast);
-    const std::string function = config.options.get_option("function");
-    if (!function.empty())
-      ann.add_type_annotation(function);
-    else
-      ann.add_type_annotation();
-
-    // Load c models
-    add_cprover_library(context, this);
-
     // Generate symbol table
-    python_converter converter(
-      context, ast, ann.get_referenced_global_elements());
+    python_converter converter(context, ast, global_scope_);
     converter.convert();
   }
   catch (const std::runtime_error &e)
   {
     log_error("{}", e.what());
-    exit(-1);
+    exit(-2);
   }
 
   clang_cpp_adjust adjuster(context);
@@ -158,7 +166,7 @@ void python_languaget::show_parse(std::ostream &out)
     }
   }
   log_error("Function {} not found.\n", function.c_str());
-  exit(-2);
+  exit(-3);
 }
 
 bool python_languaget::from_expr(

--- a/src/python-frontend/python_language.h
+++ b/src/python-frontend/python_language.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/language.h>
+#include <python-frontend/global_scope.h>
 
 #include <nlohmann/json.hpp>
 
@@ -42,6 +43,7 @@ public:
 private:
   std::string ast_output_dir;
   nlohmann::json ast;
+  global_scope global_scope_;
 };
 
 languaget *new_python_language();

--- a/unit/python-frontend/python_annotation_test.cpp
+++ b/unit/python-frontend/python_annotation_test.cpp
@@ -3,6 +3,7 @@
 
 #include <catch2/catch.hpp>
 #include <python-frontend/python_annotation.h>
+#include <python-frontend/global_scope.h>
 #include <nlohmann/json.hpp>
 
 TEST_CASE("Add type annotation")
@@ -104,7 +105,8 @@ TEST_CASE("Add type annotation")
     nlohmann::json expected_output;
     output_data >> expected_output;
 
-    python_annotation<nlohmann::json> ann(input_json);
+    global_scope gs;
+    python_annotation<nlohmann::json> ann(input_json, gs);
     ann.add_type_annotation();
 
     REQUIRE(input_json == expected_output);
@@ -280,7 +282,8 @@ TEST_CASE("Add type annotation")
     nlohmann::json expected_output;
     output_data >> expected_output;
 
-    python_annotation<nlohmann::json> ann(input_json);
+    global_scope gs;
+    python_annotation<nlohmann::json> ann(input_json, gs);
     ann.add_type_annotation();
 
     REQUIRE(input_json == expected_output);
@@ -449,7 +452,8 @@ TEST_CASE("Add type annotation")
     nlohmann::json expected_output;
     output_data >> expected_output;
 
-    python_annotation<nlohmann::json> ann(input_json);
+    global_scope gs;
+    python_annotation<nlohmann::json> ann(input_json, gs);
     ann.add_type_annotation();
 
     REQUIRE(input_json == expected_output);
@@ -660,7 +664,8 @@ TEST_CASE("Add type annotation")
     nlohmann::json expected_output;
     output_data >> expected_output;
 
-    python_annotation<nlohmann::json> ann(input_json);
+    global_scope gs;
+    python_annotation<nlohmann::json> ann(input_json, gs);
     ann.add_type_annotation();
 
     REQUIRE(input_json == expected_output);
@@ -1043,7 +1048,8 @@ TEST_CASE("Add type annotation")
     nlohmann::json expected_output;
     output_data >> expected_output;
 
-    python_annotation<nlohmann::json> ann(input_json);
+    global_scope gs;
+    python_annotation<nlohmann::json> ann(input_json, gs);
     ann.add_type_annotation();
 
     REQUIRE(input_json.dump(2) == expected_output.dump(2));
@@ -1188,7 +1194,8 @@ TEST_CASE("Add type annotation")
     nlohmann::json expected_output;
     output_data >> expected_output;
 
-    python_annotation<nlohmann::json> ann(input_json);
+    global_scope gs;
+    python_annotation<nlohmann::json> ann(input_json, gs);
     ann.add_type_annotation();
 
     REQUIRE(input_json == expected_output);


### PR DESCRIPTION
This PR enhances the verification process with the `--function` option by filtering global variables and classes. Previously converting all global elements could cause verification failures due to unsupported features, even if those elements weren't used in the specified function.

Now we track only the classes and variables used within the function being verified. This tracking is nested, meaning that if function A calls function B, we also verify the global variables and classes used in function B.

### **Example**
```python
x = 1
y = blah()  # function blah is undefined (could be an unsupported feature)

def foo() -> None:
    z = x
```
When running ESBMC with `esbmc --function foo`, the verification should not fail as the variable `y` isn't used in the function `foo()`. Only the global variable `x` is needed for verifying this function.