### PR TITLE
Revert "Jimple throws are now shown at --show-claims"

### DIFF
--- a/src/goto-programs/show_claims.cpp
+++ b/src/goto-programs/show_claims.cpp
@@ -27,20 +27,6 @@ void show_claims(
         description,
         from_expr(ns, identifier, instruction.guard));
     }
-
-#ifdef ENABLE_JIMPLE_FRONTEND
-    // In jimple asserts are modelled as throws (and try/catch is not really supported)
-    if (instruction.is_throw())
-    {
-      count++;
-      log_status(
-        "Claim {}:\n  {}\n  {}\n  {}\n",
-        count,
-        instruction.location,
-        "assertion",
-        from_expr(ns, identifier, instruction.guard));
-    }
-#endif
   }
 }
 

--- a/src/goto-programs/show_claims.cpp
+++ b/src/goto-programs/show_claims.cpp
@@ -28,6 +28,7 @@ void show_claims(
         from_expr(ns, identifier, instruction.guard));
     }
 
+#ifdef ENABLE_JIMPLE_FRONTEND
     // In jimple asserts are modelled as throws (and try/catch is not really supported)
     if (instruction.is_throw())
     {
@@ -38,6 +39,7 @@ void show_claims(
         instruction.location,
         "exception: assertion failed");
     }
+#endif
   }
 }
 

--- a/src/goto-programs/show_claims.cpp
+++ b/src/goto-programs/show_claims.cpp
@@ -34,10 +34,11 @@ void show_claims(
     {
       count++;
       log_status(
-        "Claim {}:\n  {}\n  {}\n",
+        "Claim {}:\n  {}\n  {}\n  {}\n",
         count,
         instruction.location,
-        "exception: assertion failed");
+        "assertion",
+        from_expr(ns, identifier, instruction.guard));
     }
 #endif
   }


### PR DESCRIPTION
Reverts esbmc/esbmc#1632

This workaround is the reason for https://github.com/esbmc/esbmc/issues/2109
This is because we also add claims for THROW instructions:
https://github.com/esbmc/esbmc/blob/ea42da3613c6027f0ac81e08f3ac74850e032205/src/goto-programs/show_claims.cpp#L32-L40
But don't account for them here:
https://github.com/esbmc/esbmc/blob/ea42da3613c6027f0ac81e08f3ac74850e032205/src/goto-programs/set_claims.cpp#L19-L25
This then causes a mismatch.

<details>
<summary>Test</summary>

```cpp
#include <cassert>
void unused()
{
  throw;
}

int main()
{
  assert(0);
}

void unused2()
{
  assert(1);
}
```
</details>

One could "fix" this by adding THROW instructions to `set_claims`, but this would be wrong.
We can't just replace a throw in C++ with a skip.