### PR TITLE
[C++ verification] relax type assertions for vtable variable symbols

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/polymorphism_vtable/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/polymorphism_vtable/main.cpp
@@ -1,0 +1,27 @@
+#include <stdint.h>
+#include <cassert>
+
+class BaseClass
+{
+public:
+  virtual BaseClass *foo(bool var = false) = 0;
+};
+
+class DerivedClass : public BaseClass
+{
+public:
+  DerivedClass *foo(bool var = false) override
+  {
+    return this;
+  }
+};
+
+int main()
+{
+  DerivedClass obj;
+
+  assert(obj.foo() == &obj);
+  assert(obj.foo(true) == &obj);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/polymorphism_vtable/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/polymorphism_vtable/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -614,7 +614,7 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
         switch_map.find(compo.get("virtual_name").as_string());
       assert(cit2 != switch_map.end());
       const exprt &value = cit2->second;
-      assert(value.type() == compo.type());
+      assert(value.type().id() == compo.type().id());
       values.operands().push_back(value);
     }
     vt_symb_var.value = values;


### PR DESCRIPTION
```
Class BaseClass {
public:
    virtual BaseClass* foo(bool var = false) = 0;
};

class DerivedClass : public BaseClass {
public:
    DerivedClass* foo(bool var = false);
};
```
This conversion is a covariant return type, which allows the override function of a derived class to return a pointer or reference of the derived class type instead of a pointer or reference of the base class type.

I think the current assertions in debug builds are too restrictive and should be relaxed.