### PR TITLE
[bitwuzla] get raw string value in bv instead of smt2-formatted

### DIFF
--- a/regression/bitwuzla/get_model_values/main.cpp
+++ b/regression/bitwuzla/get_model_values/main.cpp
@@ -1,0 +1,63 @@
+int Contains(float value)
+{
+  for (;;)
+    ;
+}
+float main_min = -0.0f;
+int main()
+{
+  float finite_float;
+  float infinite_float;
+  float nan_float;
+
+  double finite_double;
+  double infinite_double;
+  double nan_double;
+
+  char char_1;
+  char char_2;
+  short short_1;
+  short short_2;
+  int int_1;
+  int int_2;
+  long long long_long_1;
+  long long long_long_2;
+  unsigned char uchar_1;
+  unsigned char uchar_2;
+  unsigned short ushort_1;
+  unsigned short ushort_2;
+  unsigned int uint_1;
+  unsigned int uint_2;
+  unsigned long long ulong_long_1;
+  unsigned long long ulong_long_2;
+
+  __ESBMC_assume(finite_float == 1.1234f);
+  __ESBMC_assume(infinite_float == 1.0f / 0.0f);
+  __ESBMC_assume(nan_float != nan_float);
+  __ESBMC_assume(finite_double == 1.1234);
+  __ESBMC_assume(infinite_double == 1.0 / 0.0);
+  __ESBMC_assume(nan_double != nan_double);
+  __ESBMC_assume(char_1 == 'a');
+  __ESBMC_assume(char_2 == 0x7f);
+  __ESBMC_assume(short_1 == 1);
+  __ESBMC_assume(short_2 == 0x7fff);
+  __ESBMC_assume(int_1 == 1);
+  __ESBMC_assume(int_2 == 0x7fffffff);
+  __ESBMC_assume(long_long_1 == 1LL);
+  __ESBMC_assume(long_long_2 == 0x7fffffffffffffffLL);
+  __ESBMC_assume(uchar_1 == 1U);
+  __ESBMC_assume(uchar_2 == 0xffU);
+  __ESBMC_assume(ushort_1 == 1U);
+  __ESBMC_assume(ushort_2 == 0xffffU);
+  __ESBMC_assume(uint_1 == 1U);
+  __ESBMC_assume(uint_2 == 0xffffffffU);
+  __ESBMC_assume(ulong_long_1 == 1U);
+  __ESBMC_assume(ulong_long_2 == 0xffffffffffffffffULL);
+
+  __ESBMC_assume(main_min = finite_float);
+  int bar = finite_float + infinite_float + nan_float +
+            finite_double + infinite_double + nan_double +
+            char_1 + char_2 + short_1 + short_2 + int_1 + int_2 + long_long_1 + long_long_2 +
+            uchar_1 + uchar_2 + ushort_1 + ushort_2 + uint_1 + uint_2 + ulong_long_1 + ulong_long_2;
+  Contains(bar);
+}

--- a/regression/bitwuzla/get_model_values/main.cpp
+++ b/regression/bitwuzla/get_model_values/main.cpp
@@ -55,9 +55,9 @@ int main()
   __ESBMC_assume(ulong_long_2 == 0xffffffffffffffffULL);
 
   __ESBMC_assume(main_min = finite_float);
-  int bar = finite_float + infinite_float + nan_float +
-            finite_double + infinite_double + nan_double +
-            char_1 + char_2 + short_1 + short_2 + int_1 + int_2 + long_long_1 + long_long_2 +
-            uchar_1 + uchar_2 + ushort_1 + ushort_2 + uint_1 + uint_2 + ulong_long_1 + ulong_long_2;
+  int bar = finite_float + infinite_float + nan_float + finite_double +
+            infinite_double + nan_double + char_1 + char_2 + short_1 + short_2 +
+            int_1 + int_2 + long_long_1 + long_long_2 + uchar_1 + uchar_2 +
+            ushort_1 + ushort_2 + uint_1 + uint_2 + ulong_long_1 + ulong_long_2;
   Contains(bar);
 }

--- a/regression/bitwuzla/get_model_values/test.desc
+++ b/regression/bitwuzla/get_model_values/test.desc
@@ -1,102 +1,102 @@
 CORE
 main.cpp
 --bitwuzla --unwind 1
-^State 1 file main\.cpp line 9 column 3 function main thread 0
+^State 1 file .*main\.cpp line 9 column 3 function main thread 0
 ^----------------------------------------------------
 ^  finite_float = 1\.123400e\+0f \(00111111 10001111 11001011 10010010\)
 ^
-^State 2 file main\.cpp line 10 column 3 function main thread 0
+^State 2 file .*main\.cpp line 10 column 3 function main thread 0
 ^----------------------------------------------------
 ^  infinite_float = \+INFINITY \(01111111 10000000 00000000 00000000\)
 ^
-^State 3 file main\.cpp line 11 column 3 function main thread 0
+^State 3 file .*main\.cpp line 11 column 3 function main thread 0
 ^----------------------------------------------------
 ^  nan_float = \+NAN \(01111111 10000000 00000000 00000001\)
 ^
-^State 4 file main\.cpp line 13 column 3 function main thread 0
+^State 4 file .*main\.cpp line 13 column 3 function main thread 0
 ^----------------------------------------------------
 ^  finite_double = 1\.123400e\+0 \(00111111 11110001 11111001 01110010 01000111 01000101 00111000 11101111\)
 ^
-^State 5 file main\.cpp line 14 column 3 function main thread 0
+^State 5 file .*main\.cpp line 14 column 3 function main thread 0
 ^----------------------------------------------------
 ^  infinite_double = \+INFINITY \(01111111 11110000 00000000 00000000 00000000 00000000 00000000 00000000\)
 ^
-^State 6 file main\.cpp line 15 column 3 function main thread 0
+^State 6 file .*main\.cpp line 15 column 3 function main thread 0
 ^----------------------------------------------------
 ^  nan_double = \+NAN \(01111111 11110000 00000000 00000000 00000000 00000000 00000000 00000001\)
 ^
-^State 7 file main\.cpp line 17 column 3 function main thread 0
+^State 7 file .*main\.cpp line 17 column 3 function main thread 0
 ^----------------------------------------------------
 ^  char_1 = 97 \(01100001\)
 ^
-^State 8 file main\.cpp line 18 column 3 function main thread 0
+^State 8 file .*main\.cpp line 18 column 3 function main thread 0
 ^----------------------------------------------------
 ^  char_2 = 127 \(01111111\)
 ^
-^State 9 file main\.cpp line 19 column 3 function main thread 0
+^State 9 file .*main\.cpp line 19 column 3 function main thread 0
 ^----------------------------------------------------
 ^  short_1 = 1 \(00000000 00000001\)
 ^
-^State 10 file main\.cpp line 20 column 3 function main thread 0
+^State 10 file .*main\.cpp line 20 column 3 function main thread 0
 ^----------------------------------------------------
 ^  short_2 = 32767 \(01111111 11111111\)
 ^
-^State 11 file main\.cpp line 21 column 3 function main thread 0
+^State 11 file .*main\.cpp line 21 column 3 function main thread 0
 ^----------------------------------------------------
 ^  int_1 = 1 \(00000000 00000000 00000000 00000001\)
 ^
-^State 12 file main\.cpp line 22 column 3 function main thread 0
+^State 12 file .*main\.cpp line 22 column 3 function main thread 0
 ^----------------------------------------------------
 ^  int_2 = 2147483647 \(01111111 11111111 11111111 11111111\)
 ^
-^State 13 file main\.cpp line 23 column 3 function main thread 0
+^State 13 file .*main\.cpp line 23 column 3 function main thread 0
 ^----------------------------------------------------
 ^  long_long_1 = 1 \(00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000001\)
 ^
-^State 14 file main\.cpp line 24 column 3 function main thread 0
+^State 14 file .*main\.cpp line 24 column 3 function main thread 0
 ^----------------------------------------------------
 ^  long_long_2 = 9223372036854775807 \(01111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111\)
 ^
-^State 15 file main\.cpp line 25 column 3 function main thread 0
+^State 15 file .*main\.cpp line 25 column 3 function main thread 0
 ^----------------------------------------------------
 ^  uchar_1 = 1 \(00000001\)
 ^
-^State 16 file main\.cpp line 26 column 3 function main thread 0
+^State 16 file .*main\.cpp line 26 column 3 function main thread 0
 ^----------------------------------------------------
 ^  uchar_2 = 255 \(11111111\)
 ^
-^State 17 file main\.cpp line 27 column 3 function main thread 0
+^State 17 file .*main\.cpp line 27 column 3 function main thread 0
 ^----------------------------------------------------
 ^  ushort_1 = 1 \(00000000 00000001\)
 ^
-^State 18 file main\.cpp line 28 column 3 function main thread 0
+^State 18 file .*main\.cpp line 28 column 3 function main thread 0
 ^----------------------------------------------------
 ^  ushort_2 = 65535 \(11111111 11111111\)
 ^
-^State 19 file main\.cpp line 29 column 3 function main thread 0
+^State 19 file .*main\.cpp line 29 column 3 function main thread 0
 ^----------------------------------------------------
 ^  uint_1 = 1 \(00000000 00000000 00000000 00000001\)
 ^
-^State 20 file main\.cpp line 30 column 3 function main thread 0
+^State 20 file .*main\.cpp line 30 column 3 function main thread 0
 ^----------------------------------------------------
 ^  uint_2 = 4294967295 \(11111111 11111111 11111111 11111111\)
 ^
-^State 21 file main\.cpp line 31 column 3 function main thread 0
+^State 21 file .*main\.cpp line 31 column 3 function main thread 0
 ^----------------------------------------------------
 ^  ulong_long_1 = 1 \(00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000001\)
 ^
-^State 22 file main\.cpp line 32 column 3 function main thread 0
+^State 22 file .*main\.cpp line 32 column 3 function main thread 0
 ^----------------------------------------------------
 ^  ulong_long_2 = 0xFFFFFFFFFFFFFFFF \(11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111\)
 ^
-^State 45 file main\.cpp line 57 column 18 function main thread 0
+^State 45 file .*main\.cpp line 57 column 18 function main thread 0
 ^----------------------------------------------------
 ^  main_min = 1\.123400e\+0f \(00111111 10001111 11001011 10010010\)
 ^
-^State 47 file main\.cpp line 3 column 3 function Contains thread 0
+^State 47 file .*main\.cpp line 3 column 3 function Contains thread 0
 ^----------------------------------------------------
 ^Violated property:
-^  file main\.cpp line 3 column 3 function Contains
+^  file .*main\.cpp line 3 column 3 function Contains
 ^  unwinding assertion loop 2
 ^
 ^

--- a/regression/bitwuzla/get_model_values/test.desc
+++ b/regression/bitwuzla/get_model_values/test.desc
@@ -1,0 +1,103 @@
+CORE
+main.cpp
+--bitwuzla --unwind 1
+^State 1 file main\.cpp line 9 column 3 function main thread 0
+^----------------------------------------------------
+^  finite_float = 1\.123400e\+0f \(00111111 10001111 11001011 10010010\)
+^
+^State 2 file main\.cpp line 10 column 3 function main thread 0
+^----------------------------------------------------
+^  infinite_float = \+INFINITY \(01111111 10000000 00000000 00000000\)
+^
+^State 3 file main\.cpp line 11 column 3 function main thread 0
+^----------------------------------------------------
+^  nan_float = \+NAN \(01111111 10000000 00000000 00000001\)
+^
+^State 4 file main\.cpp line 13 column 3 function main thread 0
+^----------------------------------------------------
+^  finite_double = 1\.123400e\+0 \(00111111 11110001 11111001 01110010 01000111 01000101 00111000 11101111\)
+^
+^State 5 file main\.cpp line 14 column 3 function main thread 0
+^----------------------------------------------------
+^  infinite_double = \+INFINITY \(01111111 11110000 00000000 00000000 00000000 00000000 00000000 00000000\)
+^
+^State 6 file main\.cpp line 15 column 3 function main thread 0
+^----------------------------------------------------
+^  nan_double = \+NAN \(01111111 11110000 00000000 00000000 00000000 00000000 00000000 00000001\)
+^
+^State 7 file main\.cpp line 17 column 3 function main thread 0
+^----------------------------------------------------
+^  char_1 = 97 \(01100001\)
+^
+^State 8 file main\.cpp line 18 column 3 function main thread 0
+^----------------------------------------------------
+^  char_2 = 127 \(01111111\)
+^
+^State 9 file main\.cpp line 19 column 3 function main thread 0
+^----------------------------------------------------
+^  short_1 = 1 \(00000000 00000001\)
+^
+^State 10 file main\.cpp line 20 column 3 function main thread 0
+^----------------------------------------------------
+^  short_2 = 32767 \(01111111 11111111\)
+^
+^State 11 file main\.cpp line 21 column 3 function main thread 0
+^----------------------------------------------------
+^  int_1 = 1 \(00000000 00000000 00000000 00000001\)
+^
+^State 12 file main\.cpp line 22 column 3 function main thread 0
+^----------------------------------------------------
+^  int_2 = 2147483647 \(01111111 11111111 11111111 11111111\)
+^
+^State 13 file main\.cpp line 23 column 3 function main thread 0
+^----------------------------------------------------
+^  long_long_1 = 1 \(00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000001\)
+^
+^State 14 file main\.cpp line 24 column 3 function main thread 0
+^----------------------------------------------------
+^  long_long_2 = 9223372036854775807 \(01111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111\)
+^
+^State 15 file main\.cpp line 25 column 3 function main thread 0
+^----------------------------------------------------
+^  uchar_1 = 1 \(00000001\)
+^
+^State 16 file main\.cpp line 26 column 3 function main thread 0
+^----------------------------------------------------
+^  uchar_2 = 255 \(11111111\)
+^
+^State 17 file main\.cpp line 27 column 3 function main thread 0
+^----------------------------------------------------
+^  ushort_1 = 1 \(00000000 00000001\)
+^
+^State 18 file main\.cpp line 28 column 3 function main thread 0
+^----------------------------------------------------
+^  ushort_2 = 65535 \(11111111 11111111\)
+^
+^State 19 file main\.cpp line 29 column 3 function main thread 0
+^----------------------------------------------------
+^  uint_1 = 1 \(00000000 00000000 00000000 00000001\)
+^
+^State 20 file main\.cpp line 30 column 3 function main thread 0
+^----------------------------------------------------
+^  uint_2 = 4294967295 \(11111111 11111111 11111111 11111111\)
+^
+^State 21 file main\.cpp line 31 column 3 function main thread 0
+^----------------------------------------------------
+^  ulong_long_1 = 1 \(00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000001\)
+^
+^State 22 file main\.cpp line 32 column 3 function main thread 0
+^----------------------------------------------------
+^  ulong_long_2 = 0xFFFFFFFFFFFFFFFF \(11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111\)
+^
+^State 45 file main\.cpp line 57 column 18 function main thread 0
+^----------------------------------------------------
+^  main_min = 1\.123400e\+0f \(00111111 10001111 11001011 10010010\)
+^
+^State 47 file main\.cpp line 3 column 3 function Contains thread 0
+^----------------------------------------------------
+^Violated property:
+^  file main\.cpp line 3 column 3 function Contains
+^  unwinding assertion loop 2
+^
+^
+^VERIFICATION FAILED$

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -715,7 +715,7 @@ BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
   const char *result =
-    bitwuzla_term_to_string(bitwuzla_get_value(bitw, ast->a));
+    bitwuzla_term_value_get_str(bitwuzla_get_value(bitw, ast->a));
   BigInt val = binary2integer(result, is_signed);
   return val;
 }


### PR DESCRIPTION
If we use `bitwuzla_term_to_string` we'll get e.g. ``#b010101` as a result which we will pass to binary2integer which does not handle strings that start with `#b` properly.
Instead, we use `bitwuzla_term_value_get_str` because it would just return `010101` instead of the unwanted prefix. **The end result of the old behavior was incorrect values (every value was just zero) in traces!**