### PR TITLE
more typos and anglicisms

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -21,7 +21,7 @@
 
 This ``manual'' is supposed to be an introduction to how the ESBMC model
 checkers internals are arranged and operate. It is not supposed to be a
-comprehensive piece of documentation on the exact behaviour of particular
+comprehensive piece of documentation on the exact behavior of particular
 functions or facilities; nor will it ever, ever be up to date. Exact
 documentation on a particular function or method should be written in
 doxygen in headers; this documentation can be built to HTML by executing
@@ -114,7 +114,7 @@ program-too & Like program-only, but don't exit, instead continue
 verification.\\
 \hline
 function & Specify function to begin execution at. If function takes arguments,
-horrible undefined behaviour occurs.\\
+horrible undefined behavior occurs.\\
 \hline
 preprocess & Run the input source files through preprocessing, write the output
 to stdout, then exit. Useful for debugging.\\
@@ -126,7 +126,7 @@ false, and we end up always exploring to the top of the unwind bound.\\
 unwind & Takes integer parameter. Specifies the general unwind bound to apply
 to all loops in the program.\\
 \hline
-unwindset & Takes string parameter, a comma seperate list of loopidnum:bound
+unwindset & Takes string parameter, a comma separate list of loopidnum:bound
 pairs. Allows exact specification of a loop bound for a particular loop, see
 the show-loops option.\\
 \hline
@@ -509,7 +509,7 @@ of variable.
 of variable.
 \end{description}
 
-All behaviours of GOTO programs are described by lists of these instructions.
+All behaviors of GOTO programs are described by lists of these instructions.
 Additional annotations are stored with each instruction, for example the
 \url{function} and \url{location} fields identify where in the source
 files the instruction came from. The \url{targets} list contains a list
@@ -595,7 +595,7 @@ in the map indicates that the variable may be pointed at. The
 \url{value_sett::objectt} object records whether the offset into the
 variable that is pointed at is nondeterministic or constant; and if fixed,
 then what the offset is. (NB: the actual implementation of this stores
-\url{symbol} ireps as the map keys. To optimise this, it uses a (global)
+\url{symbol} ireps as the map keys. To optimize this, it uses a (global)
 pooling technique to assign each irep an ID number; see the
 \url{value_sett::object_numbering} object. The ID number is then used
 as the key into the \url{value_sett::entryt} map).
@@ -634,7 +634,7 @@ course of the current code path. The variables it tracks are also ``L1 renamed''
 
 It is speculated that the static analysis can be removed, and assertions
 encoded on-the-fly when dereferences occur during symbolic execution. While
-this might be a valid optimisation, the TACAS13 performance figures indicate
+this might be a valid optimization, the TACAS13 performance figures indicate
 that execution time is dominated by symex, rather than the pointer
 analysis\footnote{660 seconds ``GOTO processing'' compared to 20,000 seconds
 ``BMC time''}.
@@ -825,7 +825,7 @@ overrides a number of methods and injects logic for discovering when
 multithreading operations must occur. The logic in this class only relates
 to operations on the program state rather than interleaving exploration.
 It stores a set of thread state objects, of class
-\url{goto_symex_statet}, while some specialised information is broken out
+\url{goto_symex_statet}, while some specialized information is broken out
 into \url{execution_statet} for easy accessibility (such as what threads
 are still running, atomic blocks, startup parameters). Global program state
 is also stored here as a \url{value_sett} object to track pointer value
@@ -1463,8 +1463,8 @@ things.
 As defined by the C standard, ESBMC has a concept of naming scopes. Variables
 declared in one scope are not necessarily accessible from another. The substance
 of this is that any variable declared receives a symbol name that contains
-a series of double-colon (::) seperated components that specify its scope. All
-symbols start with ``c::'' to seperate program symbols from any internal
+a series of double-colon (::) separated components that specify its scope. All
+symbols start with ``c::'' to separate program symbols from any internal
 ESBMC modelling variables. From there, if the symbol is of internal linkage
 (i.e. declared ``static'') it has the name of the C file it originated as
 the next scope component. Then follows the global name of the symbol, i.e.
@@ -1526,7 +1526,7 @@ The frequent complication that can occur along the way is a type mistmatch.
 If we are selecting an integer out of some structure, but the pointer object
 can point at a wide range of variables, we will end up with an expression
 that attempts to select an integer out of, say, a float, or across a struct
-boundry. When this happens we can perform some limited type coercion, but
+boundary. When this happens we can perform some limited type coercion, but
 will fall back to creating a \url{byte_extract} irep if that fails. A
 \url{byte_extract} irep represents the operation of extracting a particular
 type of data from some incompatible object, at a particular offset. Rather than

--- a/regression/bitwuzla/stack-access/stack_access.c
+++ b/regression/bitwuzla/stack-access/stack_access.c
@@ -1,4 +1,4 @@
-// This example allows getting the value of "a" in "fun2()" only when compiled without an optimisation flag
+// This example allows getting the value of "a" in "fun2()" only when compiled without an optimization flag
 
 #include <stdio.h>
 

--- a/regression/cbmc/01_cbmc_return3/main.c
+++ b/regression/cbmc/01_cbmc_return3/main.c
@@ -2,7 +2,7 @@
 
 // If inlined, irep2-migrating ESBMC would forget to evaluate the return
 // value if the return value was discarded. This eliminated an illegal
-// behaviour. It's a legitimate optimisation, but not guarenteed by the
+// behavior. It's a legitimate optimization, but not guaranteed by the
 // spec.
 inline int
 foo(int *bar)

--- a/regression/esbmc-cpp/vector/vector15/main.cpp
+++ b/regression/esbmc-cpp/vector/vector15/main.cpp
@@ -28,13 +28,13 @@ int main()
     // copy assignment copies data from nums1 to nums2
     nums2 = nums1;
  
-    std::cout << "After assigment:\n"; 
+    std::cout << "After assignment:\n"; 
     display_sizes(nums1, nums2, nums3);
  
     // move assignment moves data from nums1 to nums3,
     // modifying both nums1 and nums3
     //nums3 = move(nums1);
  
-    std::cout << "After move assigment:\n"; 
+    std::cout << "After move assignment:\n"; 
     display_sizes(nums1, nums2, nums3);
 }

--- a/regression/esbmc-cpp11/cpp/README.md
+++ b/regression/esbmc-cpp11/cpp/README.md
@@ -8,14 +8,14 @@ Test cases with asterisk(\*) are modified manually to verify a specific feature.
 | ch2_03    | same as above   |
 | ch2_04    | same as above   |
 | ch2_05    | COM <iostream>, standard input stream, variable decl, arithmetic operators, *+*, *=*|
-| ch2_13    | preceeding features plus *if* statement, relational operator *<*, *using* directive|
+| ch2_13    | preceding features plus *if* statement, relational operator *<*, *using* directive|
 | ch3_01    | class member function call without parameter, const member function|
 | ch3_03    | COM <string>, getline, member function call with parameter|
 | ch3_05    | private access specifier, setter, getter|
 | ch3_07    | explicit constructor, member-initializer list|
 | ch3_09    | separate implementation from interfaces (header)|
 | ch3_11    | scope resolution, function prototypes|
-| ch3_15    | preceeding features plus *substr* function of COM <string>, standard error stream|
+| ch3_15    | preceding features plus *substr* function of COM <string>, standard error stream|
 | ch4_08    | counter-controlled *while* loop with definite repetition, int division|
 | ch4_12    | sentinel-controlled *while* loop w/o definite repetition, double, static_cast, COM <iomanip> *setprecision* and *fixed* functions|
 | ch4_16\*  | C++11 list initialisation (aka uniform initialisation)|

--- a/regression/esbmc-cpp11/cpp/ch4_16/main.cpp
+++ b/regression/esbmc-cpp11/cpp/ch4_16/main.cpp
@@ -9,7 +9,7 @@ int main()
    unsigned int passes = 0; // number of passes
    unsigned int failures = 0; // number of failures
    //unsigned int studentCounter = 1; // student counter
-   unsigned int studentCounter{ 1 }; // student counter initialised using C++11 list initialisation
+   unsigned int studentCounter{ 1 }; // student counter initialized using C++11 list initialization
 
    // process 10 students using counter-controlled loop
    while ( studentCounter <= 10 )

--- a/regression/esbmc-solidity/string_literal/test.desc
+++ b/regression/esbmc-solidity/string_literal/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test --sol constract.sol
+--function test --sol contract.sol
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/00_account_01/account.c
+++ b/regression/esbmc-unix/00_account_01/account.c
@@ -48,7 +48,7 @@ void transfer(Account *src, Account *dst, double money) {
         dst->amount +=money;
         pthread_mutex_unlock(dst->lock);
     }
-    //printf("Transfered $%0.2f from %c to %c\n", money, src->name, dst->name);
+    //printf("Transferred $%0.2f from %c to %c\n", money, src->name, dst->name);
 
     pthread_mutex_unlock(src->lock);
 }

--- a/regression/esbmc-unix/00_account_02/account.c
+++ b/regression/esbmc-unix/00_account_02/account.c
@@ -48,7 +48,7 @@ void transfer(Account *src, Account *dst, double money) {
         dst->amount +=money;
         pthread_mutex_unlock(dst->lock);
     }
-    //printf("Transfered $%0.2f from %c to %c\n", money, src->name, dst->name);
+    //printf("Transferred $%0.2f from %c to %c\n", money, src->name, dst->name);
 
     pthread_mutex_unlock(src->lock);
 }

--- a/regression/esbmc-unix2/23_picosat-846_01/picosat.c
+++ b/regression/esbmc-unix2/23_picosat-846_01/picosat.c
@@ -4712,11 +4712,11 @@ static void
 flbcp (void)
 {
 #ifdef STATS
-  unsigned long long propagaions_before_bcp = propagations;
+  unsigned long long propagations_before_bcp = propagations;
 #endif
   bcp ();
 #ifdef STATS
-  flprops += propagations - propagaions_before_bcp;
+  flprops += propagations - propagations_before_bcp;
 #endif
 }
 

--- a/regression/esbmc-unix2/23_picosat-846_02/picosat.c
+++ b/regression/esbmc-unix2/23_picosat-846_02/picosat.c
@@ -4712,11 +4712,11 @@ static void
 flbcp (void)
 {
 #ifdef STATS
-  unsigned long long propagaions_before_bcp = propagations;
+  unsigned long long propagations_before_bcp = propagations;
 #endif
   bcp ();
 #ifdef STATS
-  flprops += propagations - propagaions_before_bcp;
+  flprops += propagations - propagations_before_bcp;
 #endif
 }
 

--- a/regression/esbmc-unix2/23_picosat-846_03/picosat.c
+++ b/regression/esbmc-unix2/23_picosat-846_03/picosat.c
@@ -4712,11 +4712,11 @@ static void
 flbcp (void)
 {
 #ifdef STATS
-  unsigned long long propagaions_before_bcp = propagations;
+  unsigned long long propagations_before_bcp = propagations;
 #endif
   bcp ();
 #ifdef STATS
-  flprops += propagations - propagaions_before_bcp;
+  flprops += propagations - propagations_before_bcp;
 #endif
 }
 

--- a/regression/esbmc-unix2/23_picosat-846_04/picosat.c
+++ b/regression/esbmc-unix2/23_picosat-846_04/picosat.c
@@ -4712,11 +4712,11 @@ static void
 flbcp (void)
 {
 #ifdef STATS
-  unsigned long long propagaions_before_bcp = propagations;
+  unsigned long long propagations_before_bcp = propagations;
 #endif
   bcp ();
 #ifdef STATS
-  flprops += propagations - propagaions_before_bcp;
+  flprops += propagations - propagations_before_bcp;
 #endif
 }
 

--- a/regression/esbmc-unix2/23_picosat-846_05/picosat.c
+++ b/regression/esbmc-unix2/23_picosat-846_05/picosat.c
@@ -4712,11 +4712,11 @@ static void
 flbcp (void)
 {
 #ifdef STATS
-  unsigned long long propagaions_before_bcp = propagations;
+  unsigned long long propagations_before_bcp = propagations;
 #endif
   bcp ();
 #ifdef STATS
-  flprops += propagations - propagaions_before_bcp;
+  flprops += propagations - propagations_before_bcp;
 #endif
 }
 

--- a/regression/esbmc/ub_01_shift_left_negative_op2/main.c
+++ b/regression/esbmc/ub_01_shift_left_negative_op2/main.c
@@ -1,7 +1,7 @@
 /*
  * According with the section "Bitwise shift operators" of the C99 ISO specification:
  * "If the value of the right operand is negative or is greater than or equal to the
-    width of the promoted left operand, the behaviour is undefined."
+    width of the promoted left operand, the behavior is undefined."
  */
 
 int main() {

--- a/regression/esbmc/ub_02_shift_right_negative_op2/main.c
+++ b/regression/esbmc/ub_02_shift_right_negative_op2/main.c
@@ -1,7 +1,7 @@
 /*
  * According with the section "Bitwise shift operators" of the C99 ISO specification:
  * "If the value of the right operand is negative or is greater than or equal to the
-    width of the promoted left operand, the behaviour is undefined."
+    width of the promoted left operand, the behavior is undefined."
  */
 
 int main() {

--- a/regression/esbmc/ub_03_shift_left_negative_op1/main.c
+++ b/regression/esbmc/ub_03_shift_left_negative_op1/main.c
@@ -1,7 +1,7 @@
 /*
  * The section "Bitwise shift operators" of the C99 ISO specifies the following about shift left:
  * "If E1 has a signed type and nonnegative value, and E1 × 2^E2 is representable in the result type,
- * then that is the resulting value; otherwise, the behaviour is undefined."
+ * then that is the resulting value; otherwise, the behavior is undefined."
  */
 
 int main() {

--- a/regression/esbmc/ub_04_shift_left_overflow/main.c
+++ b/regression/esbmc/ub_04_shift_left_overflow/main.c
@@ -1,7 +1,7 @@
 /*
  * The section "Bitwise shift operators" of the C99 ISO specifies the following about shift left:
  * If E1 has a signed type and nonnegative value, and E1 × 2^E2 is representable in the result type,
- * then that is the resulting value; otherwise, the behaviour is undefined.
+ * then that is the resulting value; otherwise, the behavior is undefined.
  */
 
 #include <limits.h>

--- a/regression/esbmc/ub_05_shift_left_op2_size/main.c
+++ b/regression/esbmc/ub_05_shift_left_op2_size/main.c
@@ -1,7 +1,7 @@
 /*
  * According with the section "Bitwise shift operators" of the C99 ISO specification:
  * "If the value of the right operand is negative or is greater than or equal to the
-    width of the promoted left operand, the behaviour is undefined."
+    width of the promoted left operand, the behavior is undefined."
  */
 
 #include <limits.h>

--- a/regression/esbmc/ub_06_shift_right_op2_size/main.c
+++ b/regression/esbmc/ub_06_shift_right_op2_size/main.c
@@ -1,7 +1,7 @@
 /*
  * According with the section "Bitwise shift operators" of the C99 ISO specification:
  * "If the value of the right operand is negative or is greater than or equal to the
-    width of the promoted left operand, the behaviour is undefined."
+    width of the promoted left operand, the behavior is undefined."
  */
 
 #include <limits.h>

--- a/regression/floats-regression/nextafter-spec/main.c
+++ b/regression/floats-regression/nextafter-spec/main.c
@@ -37,7 +37,7 @@ int main()
   }
   if(isfinite(x) && !isfinite(z))
   {
-    /* This is part of nextafter's behaviour, but w/o a model of
+    /* This is part of nextafter's behavior, but w/o a model of
      * feraiseexcept() and fetestexcept() we cannot prove it, yet.
     assert(fetestexcept(FE_OVERFLOW));
      */
@@ -45,7 +45,7 @@ int main()
   }
   if(islessgreater(x, y) && isfinite(z) && !isnormal(z))
   {
-    /* This is part of nextafter's behaviour, but w/o a model of
+    /* This is part of nextafter's behavior, but w/o a model of
      * feraiseexcept() and fetestexcept() we cannot prove it, yet.
     assert(fetestexcept(FE_UNDERFLOW));
      */
@@ -54,7 +54,7 @@ int main()
   if(isinf(x))
     assert(isinf(z) == isinf(x));
 
-  /* This is part of nextafter's behaviour, but w/o a model of
+  /* This is part of nextafter's behavior, but w/o a model of
    * feraiseexcept() and fetestexcept() we cannot prove it, yet.
   assert(!fetestexcept(FE_UNDERFLOW) || !fetestexcept(FE_OVERFLOW));
    */

--- a/regression/floats-regression/nextafterf-spec/main.c
+++ b/regression/floats-regression/nextafterf-spec/main.c
@@ -37,7 +37,7 @@ int main()
   }
   if(isfinite(x) && !isfinite(z))
   {
-    /* This is part of nextafter's behaviour, but w/o a model of
+    /* This is part of nextafter's behavior, but w/o a model of
      * feraiseexcept() and fetestexcept() we cannot prove it, yet.
     assert(fetestexcept(FE_OVERFLOW));
      */
@@ -45,7 +45,7 @@ int main()
   }
   if(islessgreater(x, y) && isfinite(z) && !isnormal(z))
   {
-    /* This is part of nextafter's behaviour, but w/o a model of
+    /* This is part of nextafter's behavior, but w/o a model of
      * feraiseexcept() and fetestexcept() we cannot prove it, yet.
     assert(fetestexcept(FE_UNDERFLOW));
      */
@@ -54,7 +54,7 @@ int main()
   if(isinf(x))
     assert(isinf(z) == isinf(x));
 
-  /* This is part of nextafter's behaviour, but w/o a model of
+  /* This is part of nextafter's behavior, but w/o a model of
    * feraiseexcept() and fetestexcept() we cannot prove it, yet.
   assert(!fetestexcept(FE_UNDERFLOW) || !fetestexcept(FE_OVERFLOW));
    */

--- a/scripts/cmake/Options.cmake
+++ b/scripts/cmake/Options.cmake
@@ -48,7 +48,7 @@ option(ENABLE_FUZZER "Add fuzzing targets (default: OFF)" OFF)
 option(ENABLE_CLANG_TIDY "Activate clang tidy analysis (default: OFF)" OFF)
 option(ENABLE_CSMITH "Add csmith Tests (default: OFF) (depends: ENABLE_REGRESSION)" OFF)
 option(BENCHBRINGUP "Run a user-specified benchmark in Github workflow" OFF)
-option(DOWNLOAD_DEPENDENCIES "Download and build dpendencies if needed (default: OFF)" OFF)
+option(DOWNLOAD_DEPENDENCIES "Download and build dependencies if needed (default: OFF)" OFF)
 option(ACADEMIC_BUILD "Check and Enable libs that available only in Academic builds (default: OFF)" OFF)
 option(ESBMC_SVCOMP "Enable an SV-COMP build of ESBMC (default: OFF)" OFF)
 

--- a/scripts/release-notes.txt
+++ b/scripts/release-notes.txt
@@ -186,11 +186,11 @@ Release Notes of the ESBMC model checker
 - Integers (signed and unsigned) and floats are converted from one to another correctly now (#1638).
 * Concurrency
 - Fixed monolithic partial order-reduction (#1633)
-- Optimise the efficiency of data race detection (#1544).
+- Optimize the efficiency of data race detection (#1544).
 - Support for "printf" for data races check (#1477).
 - Take cur_state->guard into account for creating a new thread (#1463).
 - Fixing dereference in data-races check (#1460).
-- Optimise index races check (#1456).
+- Optimize index races check (#1456).
 * Operational models
 - Add libm musl float OMs used in svcomp24 (#1601).
 - Fix range of rand() and random() to include upper endpoint (#1596).

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -51,7 +51,7 @@ static void internal_additions(std::string &code)
     "int __ESBMC_rounding_mode = 0;\n"
     "_Bool __ESBMC_floatbv_mode();\n"
 
-    // Forward decs for pthread main thread begin/end hooks. Because they're
+    // Forward decls for pthread main thread begin/end hooks. Because they're
     // pulled in from the C library, they need to be declared prior to pulling
     // them in, for type checking.
     "void __ESBMC_pthread_start_main_hook(void);\n"

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -263,7 +263,7 @@ bool c_preprocess(const std::string &path, std::ostream &outstream, bool is_cpp)
   int err, ret;
   char out_file_buf[288], tmpdir[256];
 
-  // For Windows, we can't fork and run the preprocessor in a seperate process.
+  // For Windows, we can't fork and run the preprocessor in a separate process.
   // Instead, just run it within the existing ESBMC process.
 
   GetTempPath(sizeof(tmpdir), tmpdir);

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -74,7 +74,7 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
   }
   else if (symbol.is_extern && !final_type.is_code())
   {
-    // variables mared as "extern" go into the global namespace
+    // variables marked as "extern" go into the global namespace
     // and have static lifetime
     new_name = root_name;
     symbol.static_lifetime = true;

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1894,7 +1894,7 @@ void c_typecheck_baset::typecheck_side_effect_assignment(exprt &expr)
   exprt &op0 = expr.op0();
   exprt &op1 = expr.op1();
 
-  // se if we have a typecast on the LHS
+  // see if we have a typecast on the LHS
   if (op0.id() == "typecast")
   {
     assert(op0.operands().size() == 1);

--- a/src/ansi-c/cpp/cpp.c
+++ b/src/ansi-c/cpp/cpp.c
@@ -2197,7 +2197,7 @@ getsymtab(const usch *str)
 
 /*
  * Do symbol lookup in a patricia tree.
- * Only do full string matching, no pointer optimisations.
+ * Only do full string matching, no pointer optimizations.
  */
 struct symtab *
 lookup(const usch *key, int enterf)

--- a/src/big-int/bigint.cpp
+++ b/src/big-int/bigint.cpp
@@ -348,7 +348,7 @@ void BigInt::assign(ullong_t ul)
   digit_set(ul, digit, length);
 }
 
-// Dito signed.
+// Ditto signed.
 void BigInt::assign(llong_t l)
 {
   if (l >= 0)
@@ -685,7 +685,7 @@ inline int BigInt::ucompare(BigInt const &b) const
   return digit_cmp(digit, b.digit, length);
 }
 
-// Comparision primitives.
+// Comparison primitives.
 
 int BigInt::compare(ullong_t b) const
 {

--- a/src/c2goto/headers/ubuntu20.04/kernel_5.15.0-76/include/linux/spinlock.h
+++ b/src/c2goto/headers/ubuntu20.04/kernel_5.15.0-76/include/linux/spinlock.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 #include <stdatomic.h>
 #include <stdbool.h>
-/* The declarations of mock spin lock behaviour*/
+/* The declarations of mock spin lock behavior*/
 /** mock spinlock struct*/
 #define SPIN_LIMIT 80
 typedef struct {

--- a/src/c2goto/library/semaphore_lib.c
+++ b/src/c2goto/library/semaphore_lib.c
@@ -28,9 +28,9 @@ __ESBMC_HIDE:;
 
 static int sem_init_check(sem_t *__sem)
 {
-  // check whether this sem has been initialised
+  // check whether this sem has been initialized
   __ESBMC_atomic_begin();
-  __ESBMC_assert(__ESBMC_sem_init_field(*__sem), "Sem is not initialised");
+  __ESBMC_assert(__ESBMC_sem_init_field(*__sem), "Sem is not initialized");
   __ESBMC_atomic_end();
   return 0;
 }

--- a/src/clang-c-frontend/clang_c_adjust_code.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_code.cpp
@@ -86,7 +86,7 @@ void clang_c_adjust::adjust_decl(codet &code)
   // Check type
   adjust_type(code.op0().type());
 
-  // Create typecast on assingments, if needed
+  // Create typecast on assignments, if needed
   gen_typecast(ns, code.op1(), code.op0().type());
 }
 
@@ -149,6 +149,6 @@ void clang_c_adjust::adjust_assign(codet &code)
 {
   adjust_operands(code);
 
-  // Create typecast on assingments, if needed
+  // Create typecast on assignments, if needed
   gen_typecast(ns, code.op1(), code.op0().type());
 }

--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -191,7 +191,7 @@ static void add_padding(struct_typet &type, const namespacet &ns)
         bit_field_bits = 0;
       }
 
-      // Pad out extints that arent in bitfields
+      // Pad out extints that aren't in bitfields
       if (is_extint && !is_bitfield)
       {
         assert(bit_field_bits == 0);

--- a/src/cpp/cpp_is_pod.cpp
+++ b/src/cpp/cpp_is_pod.cpp
@@ -23,8 +23,8 @@ bool cpp_typecheckt::cpp_is_pod(const typet &type) const
     // XXX jmorse: certain things listed above don't always make their way into
     // the class definition though, such as templated constructors. In that
     // case, we set a flag to indicate that such methods have been seen, before
-    // removing them. The "is_not_pod" flag thus only guarentees that it /isn't/
-    // and its absence doesn't guarentee that it is.
+    // removing them. The "is_not_pod" flag thus only guarantees that it /isn't/
+    // and its absence doesn't guarantee that it is.
     if (!type.find("is_not_pod").is_nil())
       return false;
 

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -95,7 +95,7 @@ void cpp_languaget::internal_additions(std::ostream &out)
   out << "long double __ESBMC_fabsl(long double x);" << std::endl;
   out << "float __ESBMC_fabsf(float x);" << std::endl;
 
-  // Forward decs for pthread main thread begin/end hooks. Because they're
+  // Forward decls for pthread main thread begin/end hooks. Because they're
   // pulled in from the C library, they need to be declared prior to pulling
   // them in, for type checking.
   out << "void __ESBMC_pthread_start_main_hook(void);" << std::endl;

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -727,7 +727,7 @@ bool cpp_typecheckt::user_defined_conversion_sequence(
     else if (expr.id() == "symbol")
     {
       // Can't blindly cast aggregate / composite types. NB: Nothing here
-      // actually appears to look up any custom convertors.
+      // actually appears to look up any custom converters.
       if (
         expr.type().id() == "array" || expr.type().id() == "struct" ||
         expr.type().id() == "union")
@@ -1031,7 +1031,7 @@ bool cpp_typecheckt::reference_binding(
   if (!type.subtype().cmt_constant() || type.subtype().cmt_volatile())
     return false;
 
-  // TODO: hanlde the case for implicit parameters
+  // TODO: handle the case for implicit parameters
   if (!type.subtype().cmt_constant() && !expr.cmt_lvalue())
     return false;
 

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -436,7 +436,7 @@ smt_convt::resultt bmct::start_bmc()
   std::shared_ptr<symex_target_equationt> eq;
   smt_convt::resultt res = run(eq);
   if (!options.get_bool_option("multi-property"))
-    // multi-property trace are outputed during the run(eq)
+    // multi-property traces are output during the run(eq)
     report_trace(res, *eq);
   report_result(res);
   return res;
@@ -508,7 +508,7 @@ void bmct::bidirectional_search(
   smt_convt &smt_conv,
   const symex_target_equationt &eq)
 {
-  // We should only analyse the inductive step's cex and we're running
+  // We should only analyze the inductive step's cex and we're running
   // in k-induction mode
   if (!(options.get_bool_option("inductive-step") &&
         options.get_bool_option("k-induction")))
@@ -1077,7 +1077,7 @@ smt_convt::resultt bmct::multi_property_check(
         log_result("Total Assertion Instances: {}", total_instance);
       else
         // this could be
-        // 1. the loop is too large that we cannot goto-uwnind it
+        // 1. the loop is too large that we cannot goto-unwind it
         // 2. the loop is somewhat non-deterministic that we cannot run goto-unwind
         log_result("Total Assertion Instances: unknown / non-deterministic");
       log_result("Reached Assertion Instances: {}", tracked_instance);
@@ -1183,7 +1183,7 @@ smt_convt::resultt bmct::multi_property_check(
       }
     }
 
-    // the remain unreached instrumentaion are regarded as short-circuited
+    // the remain unreached instrumentations are regarded as short-circuited
     //! the reached_claims might not be empty (due to unwinding assertions)
     short_circuit_instance = total_cond_assert_cpy.size();
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -933,7 +933,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
       }
     }
 
-    // Couldn't find a bug or a proof for the current deepth
+    // Couldn't find a bug or a proof for the current depth
     log_fail("\nVERIFICATION UNKNOWN");
     return false;
   }
@@ -1199,7 +1199,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 //  3) Falsification
 //  4) k-induction
 //
-// Applying a strategy in this context means solving a paticular sequence
+// Applying a strategy in this context means solving a particular sequence
 // of decision problems from the list below for the given unwinding bound k:
 //
 //  - Base case             (see "is_base_case_violated")
@@ -1207,7 +1207,7 @@ int esbmc_parseoptionst::doit_k_induction_parallel()
 //  - Inductive step        (see "is_inductive_step_violated")
 //
 // \param options - options for setting the verification strategy
-// and conrolling symbolic execution
+// and controlling symbolic execution
 // \param goto_functions - GOTO program under verification
 int esbmc_parseoptionst::do_bmc_strategy(
   optionst &options,
@@ -1684,7 +1684,7 @@ bool esbmc_parseoptionst::parse_goto_program(
         exit(0);
     }
 
-    // Typecheking (old frontend) or adjust (clang frontend)
+    // Typechecking (old frontend) or adjust (clang frontend)
     if (typecheck())
       return true;
     if (final())
@@ -1782,7 +1782,7 @@ bool esbmc_parseoptionst::process_goto_program(
     // We should skip this 'remove-unreachable' removal in goto-cov and multi-property
     // - multi-property wants to find all the bugs in the src code
     // - assertion-coverage wants to find out unreached codes (asserts)
-    // - however, the optimisation below will remove codes during the Goto stage
+    // - however, the optimization below will remove codes during the Goto stage
     if (!(cmdline.isset("no-remove-unreachable") || is_mul || is_coverage))
       remove_unreachable(goto_functions);
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -343,7 +343,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "enable arithmetic over- and underflow check for unsigned integers"},
     {"ub-shift-check",
      NULL,
-     "enable undefined behaviour check on shift operations"},
+     "enable undefined behavior check on shift operations"},
     {"struct-fields-check",
      NULL,
      "enable over-sized read checks for struct fields"},
@@ -529,7 +529,7 @@ const struct group_opt_templ all_cmd_options[] = {
    {
      // Print commit hash for current binary
      {"git-hash", NULL, ""},
-     // Check if there is two or more assingments to the same SSA instruction
+     // Check if there is two or more assignments to the same SSA instruction
      {"double-assign-check", NULL, ""},
      {"no-pointer-relation-check",
       NULL,

--- a/src/goto-programs/abstract-interpretation/ai.cpp
+++ b/src/goto-programs/abstract-interpretation/ai.cpp
@@ -182,7 +182,7 @@ bool ai_baset::do_function_call(
 
   if (!goto_function.body_available)
   {
-    // if we don't have a body, we just do an edige call -> return
+    // if we don't have a body, we just do an edge call -> return
     std::unique_ptr<statet> tmp_state(make_temporary_state(get_state(l_call)));
     tmp_state->transform(l_call, l_return, *this, ns);
 
@@ -268,7 +268,7 @@ bool ai_baset::do_function_call_rec(
 
   /* NOTE: Ideally we could let the domains deal with this with a more grained level.
      For example, a function pointer that has no parameters can only affect global state.
-     However, I do not think its a good idea to optimize for a hacky behaviour. Let's first
+     However, I do not think its a good idea to optimize for a hacky behavior. Let's first
      fix the AI. */
   tmp_state->make_entry();
   return merge(*tmp_state, l_call, l_return);

--- a/src/goto-programs/abstract-interpretation/ai_domain.h
+++ b/src/goto-programs/abstract-interpretation/ai_domain.h
@@ -32,7 +32,7 @@ public:
   ///    (this also needs to set the LHS, if applicable)
   ///
   /// "this" is the domain before the instruction "from"
-  /// "from" is the instruction to be interpretted
+  /// "from" is the instruction to be interpreted
   /// "to" is the next instruction (for GOTO, FUNCTION_CALL, END_FUNCTION)
   ///
   /// PRECONDITION(from.is_dereferenceable(), "Must not be _::end()")

--- a/src/goto-programs/abstract-interpretation/bitwise_bounds.h
+++ b/src/goto-programs/abstract-interpretation/bitwise_bounds.h
@@ -835,7 +835,7 @@ INT_X unsigned_2_signed_max_truncate(UINT_X a, UINT_X b, UINT_X n)
   if ((b & sign_bit) == 0)
     return unsigned_2_signed(b, n);
 
-  // if we are forced to return a negative number, try to maximise it
+  // if we are forced to return a negative number, try to maximize it
   if (alternate_b >= a && alternate_b <= b)
     return unsigned_2_signed(alternate_b, n);
 

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -150,7 +150,7 @@ interval_domaint::get_interval_from_const(const expr2tc &e) const
 
   auto real_value = to_constant_floatbv2t(e).value;
 
-  // Health check, is the convertion to double ok? See #1037
+  // Health check, is the conversion to double ok? See #1037
   if (!real_value.is_normal() || real_value.is_zero())
   {
     if (real_value.is_double())
@@ -810,7 +810,7 @@ expr2tc interval_domaint::make_expression_helper(const expr2tc &symbol) const
 
   // Some intervals can be beyond what the type can hold
   // e.g., [-infinity,256] for an unsigned char.
-  // Althugh this is expected (when modular intervals are off)
+  // Although this is expected (when modular intervals are off)
   // We still need to deal with the out-of-bounds when generating
   // the expressions, as 256 would be converted to 0.
   T type_interval = generate_modular_interval<T>(src);
@@ -1258,7 +1258,7 @@ void interval_domaint::havoc_rec(const expr2tc &expr)
   }
   else if (is_symbol2t(expr) || is_code_decl2t(expr))
   {
-    // Reset the interval domain if it is being reasigned (-infinity, +infinity).
+    // Reset the interval domain if it is being reassigned (-infinity, +infinity).
     irep_idt identifier = is_symbol2t(expr) ? to_symbol2t(expr).thename
                                             : to_code_decl2t(expr).value;
     if (intervals->count(identifier))

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -58,7 +58,7 @@ public:
   static bool
     enable_interval_arithmetic; /// Enable simplification for arithmetic operators
   static bool
-    enable_interval_bitwise_arithmetic; /// Enable simplfication for bitwise opeations
+    enable_interval_bitwise_arithmetic; /// Enable simplification for bitwise operations
   static bool
     enable_modular_intervals; /// Make a modular operation after every assignment
   static bool
@@ -75,7 +75,7 @@ public:
   static bool enable_ibex_contractor; /// Use ibex contractor
   // Widening options
   static unsigned
-    fixpoint_limit; /// Sets a limit for number of iteartions before widening
+    fixpoint_limit; /// Sets a limit for number of iterations before widening
   static bool
     widening_under_approximate_bound; /// Whether to considers overflows for Integers
   static bool

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -490,8 +490,8 @@ void goto_convertt::do_function_call_symbol(
       "Function `{}' type mismatch: expected code", id2string(identifier));
   }
 
-  // If the symbol is not nil, i.e., the user defined the expected behaviour of
-  // the builtin function, we should honour the user function and call it
+  // If the symbol is not nil, i.e., the user defined the expected behavior of
+  // the builtin function, we should honor the user function and call it
   if (symbol->value.is_not_nil())
   {
     // insert function call

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -119,7 +119,7 @@ void goto_checkt::div_by_zero_check(
 
   assert(is_div2t(expr) || is_modulus2t(expr));
 
-  // add divison by zero subgoal
+  // add division by zero subgoal
   expr2tc side_2;
   if (is_div2t(expr))
     side_2 = to_div2t(expr).side_2;
@@ -513,8 +513,8 @@ void goto_checkt::shift_check(
 
   add_guarded_claim(
     ub_check,
-    "undefined behaviour on shift operation " + get_expr_id(expr),
-    "undef-behaviour",
+    "undefined behavior on shift operation " + get_expr_id(expr),
+    "undef-behavior",
     loc,
     guard);
 }
@@ -630,7 +630,7 @@ void goto_checkt::bounds_check(
     "array bounds violated: " + array_name(ns, ind.source_value);
   const expr2tc &the_index = ind.index;
 
-  // Lower bound access should be greather than zero
+  // Lower bound access should be greater than zero
   expr2tc zero = gen_zero(the_index->type);
   assert(!is_nil_expr(zero));
 
@@ -809,7 +809,7 @@ void goto_checkt::check_rec(
   case expr2t::ieee_mul_id:
   case expr2t::ieee_div_id:
   {
-    // No division by zero for ieee_div, as it's defined behaviour
+    // No division by zero for ieee_div, as it's defined behavior
     float_overflow_check(expr, guard, loc);
     nan_check(expr, guard, loc);
     break;

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -240,7 +240,7 @@ void goto_contractort::insert_assume_at(
 {
   /// Here we build an assume instruction with a conjunction of multiple conditions.
   /// We start with a true expression and add other conditions with and2tc
-  /// eventually, we will have somthing like: true and x>0 and x<10
+  /// eventually, we will have something like: true and x>0 and x<10
   expr2tc cond = gen_true_expr();
   for (auto const &var : map.var_map)
   {
@@ -344,7 +344,7 @@ void goto_contractort::goto_contractor_condition(
           auto goto_target = i_it->get_target();
           goto_target--;
 
-          if (goto_target->is_goto()) //tarrget-1 is goto and
+          if (goto_target->is_goto()) //target-1 is goto and
           {
             if (!goto_target->is_backwards_goto())
             {

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -571,7 +571,7 @@ private:
   /// \param functionst list of functions in the goto program
   void get_contractors(goto_functionst goto_functions);
 
-  /// \Function get_intervals is a function that will go through each asert in
+  /// \Function get_intervals is a function that will go through each assert in
   /// the program and parse it from ESBMC expression to a triplet that are the
   /// variable name and and update its interval depending on the relation it
   /// will decide if the lower or the upper limit or both. the function will

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -138,7 +138,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   if (targets.has_return_value)
     add_return(f, end_location);
 
-  // Wrap the body of functions name __VERIFIER_atomic_* with atomic_bengin
+  // Wrap the body of functions name __VERIFIER_atomic_* with atomic_begin
   // and atomic_end
   if (
     !f.body.instructions.empty() &&
@@ -268,7 +268,7 @@ void goto_convert_functionst::rename_types(
       // It should also never happen, but with C++ code it does, because methods
       // are part of the type, and methods can take a full struct/object as a
       // parameter, not just a reference/pointer. So, that's a legitimate place
-      // where we have this recursive symbol dependancy situation.
+      // where we have this recursive symbol dependency situation.
       // The workaround to this is to just ignore it, and hope that it doesn't
       // become a problem in the future.
       return;

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -87,7 +87,7 @@ The CBMC extends it to the entry of the function. So we will do the same.
 
 Algo:
   1. convert assertions to true
-  2. add false assertion add the begining of the function and the branch()
+  2. add false assertion add the beginning of the function and the branch()
 */
 void goto_coveraget::branch_function_coverage()
 {
@@ -122,7 +122,7 @@ void goto_coveraget::branch_function_coverage()
 
         if (flg)
         {
-          // add a false assert in the begining
+          // add a false assert in the beginning
           // to check if the function is entered.
           insert_assert(goto_program, it, gen_false_expr());
           flg = false;
@@ -277,7 +277,7 @@ int goto_coveraget::get_total_instrument() const
 // run the algorithm on the copy of the original goto program
 int goto_coveraget::get_total_assert_instance() const
 {
-  // 1. execute goto uniwnd
+  // 1. execute goto unwind
   bounded_loop_unroller unwind_loops;
   unwind_loops.run(goto_functions);
   // 2. calculate the number of assertion instance

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -90,8 +90,8 @@ protected:
   goto_functionst &goto_functions;
 
   // we need to skip the conditions within the built-in library
-  // while kepping the file manually included by user
-  // this filter, however, is unsound.. E.g. if the src filename is the same as the biuilt in library name
+  // while keeping the file manually included by user
+  // this filter, however, is unsound.. E.g. if the src filename is the same as the builtin library name
   std::string filename;
 
   int target_num;

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -143,7 +143,7 @@ void goto_inlinet::replace_return(
         assignment->location = it->location;
         assignment->function = it->location.get_function();
 
-        assert(constrain.is_nil()); // bp_constrain gumpf reomved
+        assert(constrain.is_nil()); // bp_constrain gumpf removed
 
         dest.insert_swap(it, *assignment);
         it++;

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -89,7 +89,7 @@ void goto_convertt::remove_sideeffects(
 
       if (expr.is_and())
       {
-        // We need to reacord the location of the newly generated expression
+        // We need to record the location of the newly generated expression
         exprt false_expr = false_exprt();
         false_expr.location() = op.location();
         if_exprt if_e(op, tmp, false_expr);
@@ -98,7 +98,7 @@ void goto_convertt::remove_sideeffects(
       }
       else // ID_or
       {
-        // We need to reacord the location of the newly generated expression
+        // We need to record the location of the newly generated expression
         exprt true_expr = true_exprt();
         true_expr.location() = op.location();
         if_exprt if_e(op, true_expr, tmp);
@@ -685,7 +685,7 @@ void goto_convertt::remove_post(
 //    ...
 //  However, if the return value of function "foo()" is never
 //  used in the program, or the return type <type> of "foo()"
-//  is void, the same code is tranformed to:
+//  is void, the same code is transformed to:
 //    ...
 //    foo();
 //    a = b;

--- a/src/goto-programs/mark_decl_as_non_det.cpp
+++ b/src/goto-programs/mark_decl_as_non_det.cpp
@@ -18,7 +18,7 @@ bool mark_decl_as_non_det::runOnFunction(
 
     // find_symbol should always work here
     assert(s);
-    // Global variables and function declaration shouldn`t reach here
+    // Global variables and function declaration shouldn't reach here
     assert(!s->static_lifetime || !s->type.is_code());
 
     // Explicit initialization of return_values is not needed as it will always be

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -1280,7 +1280,7 @@ static inline expr2tc gen_value_by_byte(
 /**
  * @brief This function will try to initialize the object pointed by
  * the address in a smarter way, minimizing the number of assignments.
- * This is intend to optimize the behaviour of a memset operation:
+ * This is intend to optimize the behavior of a memset operation:
  *
  * memset(void* ptr, int value, size_t num_of_bytes)
  *

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -398,10 +398,10 @@ public:
    *  accessed by the last transition of thread j and the last transition of
    *  thread l.
    *  @param j Most recently executed thread id
-   *  @param l Other thread id to check dependancy with
-   *  @return True if scheduling dependancy exists between threads j and l
+   *  @param l Other thread id to check dependency with
+   *  @return True if scheduling dependency exists between threads j and l
    */
-  bool check_mpor_dependancy(unsigned int j, unsigned int l) const;
+  bool check_mpor_dependency(unsigned int j, unsigned int l) const;
 
   /**
    *  Calculate MPOR schedulable threads. I.E. what threads we can schedule
@@ -557,7 +557,7 @@ public:
   bool mon_thread_warning;
   /** Minimum number of threads to exist to consider a context switch.
    *  In certain special cases, such as LTL checking, various pieces of
-   *  code and information are bunged into seperate threads which aren't
+   *  code and information are bunged into separate threads which aren't
    *  necessarily scheduled. In these cases we don't want to consider
    *  cswitches, because even though they're not taken, they'll heavily
    *  inflate memory size.
@@ -577,8 +577,8 @@ protected:
    *  data that could have storage in C. */
   std::vector<std::set<expr2tc>> thread_last_writes;
   /** Dependancy chain for POR calculations. In mpor paper, DCij elements map
-   *  to dependancy_chain[i][j] here. */
-  std::vector<std::vector<int>> dependancy_chain;
+   *  to dependency_chain[i][j] here. */
+  std::vector<std::vector<int>> dependency_chain;
   /** MPOR scheduling outcome. If we've just taken a transition that MPOR
    *  rejects, this becomes true. For various reasons, we can't tell whether or
    *  not MPOR rejects a transition in advance. */

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -68,9 +68,9 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
   {
     array_type2t arr = to_array_type(expr->type);
 
-    // Don't permit const propagaion of infinite-size arrays. They're going to
+    // Don't permit const propagation of infinite-size arrays. They're going to
     // be special modelling arrays that require special handling either at SMT
-    // or some other level, so attempting to optimse them is a Bad Plan (TM).
+    // or some other level, so attempting to optimize them is a Bad Plan (TM).
     if (arr.size_is_infinite)
       return false;
 

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -18,7 +18,7 @@
 #include <irep2/irep2.h>
 #include <vector>
 
-class execution_statet; // foward dec
+class execution_statet; // forward decl
 
 /**
  *  Class for storing a particular threads state.
@@ -350,7 +350,7 @@ public:
 
   /**
    *  Perform renaming of contents of an address_of operation.
-   *  This requires different behaviour, because what we really want is a
+   *  This requires different behavior, because what we really want is a
    *  pointer to a global variable or l1 variable on the stack, or a heap
    *  object. So, don't perform second level of renaming in this function.
    *  @param expr Expression to rename contents of.
@@ -440,7 +440,7 @@ public:
   symex_targett::sourcet source;
   /** Counter for how many times a particular variable has been declared:
    *  becomes the l1 renaming number in renamed variables. Used to be a counter
-   *  for each function invocation, but the existance of decl insns makes l1
+   *  for each function invocation, but the existence of decl insns makes l1
    *  re-naming out of step with function invocations. */
   std::map<irep_idt, unsigned> variable_instance_nums;
   /** Record of how many loop unwinds we've performed. For each target in the

--- a/src/goto-symex/html.cpp
+++ b/src/goto-symex/html.cpp
@@ -479,7 +479,7 @@ const std::string html_report::generate_body() const
       violation_str);
   }
 
-  // Annoted Source Header
+  // Annotated Source Header
   {
     std::ostringstream oss;
     for (const auto &item : opt_map)

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -385,7 +385,7 @@ bool reachability_treet::dfs_position::write_to_file(
     i += 7;
     i >>= 3;
 
-    assert(i != 0); // Always at least one thread in _existance_.
+    assert(i != 0); // Always at least one thread in _existence_.
     if (fwrite(buffer, i, 1, f) != 1)
       goto fail;
   }

--- a/src/goto-symex/renaming.cpp
+++ b/src/goto-symex/renaming.cpp
@@ -300,7 +300,7 @@ void renaming::level2t::make_assignment(
     to_symbol2t(lhs_symbol).rlevel == symbol2t::level1_global);
   valuet &entry = current_names[name_record(to_symbol2t(lhs_symbol))];
 
-  // This'll update entry beneath our feet; could reengineer it in the future.
+  // This'll update entry beneath our feet; could re-engineer it in the future.
   rename(lhs_symbol, entry.count + 1);
 
   symbol2t &symbol = to_symbol2t(lhs_symbol);

--- a/src/goto-symex/renaming.h
+++ b/src/goto-symex/renaming.h
@@ -24,7 +24,7 @@ public:
   virtual ~renaming_levelt() = default;
   //  protected:
   //  XXX: should leave protected enabled, but g++ 5.4 on ubuntu 16.04 does not
-  //  appear to honour the following friend directive?
+  //  appear to honor the following friend directive?
   static void get_original_name(expr2tc &expr, symbol2t::renaming_level lev);
   friend void build_goto_symex_classes();
 };

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -700,7 +700,7 @@ void goto_symext::symex_assign_extract(
   assert(rhs->type->get_width() == lhs->type->get_width());
 
   // We need to: read the rest of the bitfield and reconstruct it. Extract
-  // and concats are probably the best approach for the solver to optimise for.
+  // and concats are probably the best approach for the solver to optimize for.
   unsigned int bitblob_width = ex.from->type->get_width();
   expr2tc top_part;
   if (ex.upper != bitblob_width - 1)

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -191,7 +191,7 @@ void goto_symext::dereference(expr2tc &expr, dereferencet::modet mode)
 
     assert(is_pointer_type(tmp));
     std::list<expr2tc> dummy;
-    // Dereference to byte type, because it's guarenteed to succeed.
+    // Dereference to byte type, because it's guaranteed to succeed.
     tmp = dereference2tc(get_uint8_type(), tmp);
 
     dereference.dereference_expr(tmp, guard, dereferencet::FREE);

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -365,7 +365,7 @@ void goto_symext::symex_function_call_deref(const expr2tc &expr)
      to_symbol2t(func_ptr).thename.as_string().find("$object") !=
        std::string::npos))
   {
-    // Emit warning; perform no function call behaviour. Increment PC
+    // Emit warning; perform no function call behavior. Increment PC
     // XXX jmorse - no location information any more.
     log_status(
       "No target candidate for function call {}",

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -380,7 +380,7 @@ void goto_symext::phi_function(const statet::goto_statet &goto_state)
     migrate_expr(symbol_expr(symbol), lhs);
     expr2tc new_lhs = lhs;
 
-    // Again, specifiy which l1 data object we're going to make the assignment
+    // Again, specify which l1 data object we're going to make the assignment
     // to.
     renaming::level2t::rename_to_record(new_lhs, variable);
 

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -68,7 +68,7 @@ void goto_symext::symex_decl(const expr2tc code)
 
   const code_decl2t &decl_code = to_code_decl2t(code2);
 
-  // just do the L2 renaming to preseve locality
+  // just do the L2 renaming to preserve locality
   const irep_idt &identifier = decl_code.value;
 
   // Generate dummy symbol as a vehicle for renaming.
@@ -118,7 +118,7 @@ void goto_symext::symex_dead(const expr2tc code)
 
   const code_dead2t &dead_code = to_code_dead2t(code2);
 
-  // just do the L2 renaming to preseve locality
+  // just do the L2 renaming to preserve locality
   const irep_idt &identifier = dead_code.value;
 
   // Generate dummy symbol as a vehicle for renaming.

--- a/src/goto2c/expr2c.cpp
+++ b/src/goto2c/expr2c.cpp
@@ -169,7 +169,7 @@ std::string expr2ct::convert_rec(
     // we rely on the "#cpp_type" field which contains a string
     // representation of the corresponding type in the original
     // program. If "#cpp_type" is not empty, we try to use
-    // this information first, and only resort to infering the type name
+    // this information first, and only resort to inferring the type name
     // from its width otherwise.
     std::string cpp_type = src.get("#cpp_type").as_string();
     if (!cpp_type.empty() && width % 8 == 0)
@@ -270,7 +270,7 @@ std::string expr2ct::convert_rec(
     {
       // Can cast "src.subtype()" to "code_typet"
       const code_typet type = to_code_type(src.subtype());
-      // Buidling the resulting string
+      // Building the resulting string
       std::string dest = "";
       // Starting with the function parameters
       dest += "(";
@@ -354,7 +354,7 @@ std::string expr2ct::convert_rec(
     // This is a function declaration.
     // Can cast "src" to "code_typet"
     const code_typet type = to_code_type(src);
-    // Buidling the resulting string
+    // Building the resulting string
     std::string dest = "";
     // Starting with the function parameters
     dest += "(";
@@ -1065,10 +1065,10 @@ std::string expr2ct::convert_union(const exprt &src, unsigned &precedence)
 
   if (operands.size() == 1)
   {
-    // Fedor: The following assert is triggered if the initialised
+    // Fedor: The following assert is triggered if the initialized
     // member of the union is an anonymous struct/union, which
     // is perfectly legal. So we intercept this scenario and go
-    // straight into converting the initialiser.
+    // straight into converting the initializer.
     if (init.empty())
       return convert(src.op0());
 

--- a/src/goto2c/goto2c_check.cpp
+++ b/src/goto2c/goto2c_check.cpp
@@ -126,7 +126,7 @@ void goto2ct::check_goto(goto_programt::instructiont instruction)
   assert(
     !is_nil_expr(instruction.guard) && "The GOTO guard must contain a value");
   check_guard(instruction.guard);
-  // Fedor: I think it will be best if we harmonise both:
+  // Fedor: I think it will be best if we harmonize both:
   // each GOTO instruction must contain a code expression
   // of type "code_goto2t" OR the "code_goto2t" code information
   // is transferred to the list of targets

--- a/src/goto2c/goto2c_preprocess.cpp
+++ b/src/goto2c/goto2c_preprocess.cpp
@@ -89,7 +89,7 @@ typet goto2ct::get_base_type(typet type, namespacet ns)
   return type;
 }
 
-// This method recursivelly iterates through all members of the given
+// This method recursively iterates through all members of the given
 // struct/union "type" and builds a list "sorted_types" of all
 // struct/union types appearing in "type" in the order where each
 // successive element does not feature a struct/union member whose
@@ -139,7 +139,7 @@ void goto2ct::sort_compound_types(namespacet &ns, std::list<typet> &types)
 // them into separate lists/tables for easier/quicker access.
 void goto2ct::extract_symbol_tables()
 {
-  // Going throught the symbol table
+  // Going through the symbol table
   ns.get_context().foreach_operand_in_order([this](const symbolt &s) {
     // Skipping everything that appears in "esbmc_intrinsics.h"
     // or with an empty location.
@@ -181,7 +181,7 @@ void goto2ct::extract_symbol_tables()
 
 // This methods tries to resolve one step in the chains of initializers.
 //
-// In other words, the following "two-step" initializtion
+// In other words, the following "two-step" initialization
 // (which is also illegal in C, but allowed in GOTO programs
 // that ESBMC produces):
 //
@@ -399,8 +399,8 @@ void goto2ct::assign_scope_ids(goto_programt &goto_program)
 // constructs like (int) i = (int) i + 1, which come from adjusting
 // expressions like i += 1.
 //
-// 2) The variables initialisers are converted into assignments
-// by the GOTO converter, and they become sintactically invalid
+// 2) The variables initializers are converted into assignments
+// by the GOTO converter, and they become syntactically invalid
 // assignments in C syntax.
 void goto2ct::adjust_invalid_assignment_rec(
   goto_programt::instructionst &new_instructions,

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -162,7 +162,7 @@
   BOOST_PP_LIST_NIL))))))))))))))
 // clang-format on
 
-// Even crazier forward decs,
+// Even crazier forward decls,
 namespace esbmct
 {
 template <typename... Args>
@@ -182,7 +182,7 @@ class constant_vector2t;
  *  crucially it ensures that the only way to get a non-const reference or
  *  pointer is via the get() method, which call the detach() method.
  *
- *  This exists to ensure that we honour the model set forth by the old string
+ *  This exists to ensure that we honor the model set forth by the old string
  *  based internal representation - specifically, that if you performed a const
  *  operation on an irept (fetching data) then the contained piece of data
  *  could continue to be shared between numerous data structures, for example
@@ -1036,9 +1036,9 @@ public:
   typedef expr2t base2t;
 };
 
-// "Specialisation" for expr kinds where the type is derived, like boolean
+// "Specialization" for expr kinds where the type is derived, like boolean
 // typed exprs. Should actually become a more structured expr2t_traits
-// that can be specialised in this way, at a later date. Might want to
+// that can be specialized in this way, at a later date. Might want to
 // move the presumed type down to the _data class at that time too.
 template <typename... Args>
 class expr2t_traits_notype

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -12,7 +12,7 @@
 // definitions. If you'd like to add another type - don't. Vast tracts of code
 // only expect the types below, it's be extremely difficult to hack new ones in.
 
-// Start of definitions for expressions. Forward decs,
+// Start of definitions for expressions. Forward decls
 
 // Iterate, in the preprocessor, over all expr ids and produce a forward
 // class declaration for them
@@ -3013,7 +3013,7 @@ public:
 };
 
 /** Record invalid data value. Exclusively for use in pointer analysis to record
- *  the fact that what we point at is guarenteed to be invalid or nonexistant.
+ *  the fact that what we point at is guaranteed to be invalid or nonexistant.
  *  @extends expr2t */
 class invalid2t : public invalid_expr_methods
 {

--- a/src/irep2/irep2_templates_expr.h
+++ b/src/irep2/irep2_templates_expr.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <irep2/irep2_templates_types.h>
 
-// Explicit instanciation for exprs.
+// Explicit instantiation for exprs.
 
 #define expr_typedefs1(basename, superclass)                                   \
   template class esbmct::                                                      \

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -127,7 +127,7 @@ void type2t::hash(crypto_hash &hash) const
 
 unsigned int bool_type2t::get_width() const
 {
-  // For the purpose of the byte representating memory model
+  // For the purpose of the byte representing memory model
   return 8;
 }
 

--- a/src/irep2/irep2_type.h
+++ b/src/irep2/irep2_type.h
@@ -512,7 +512,7 @@ public:
     : array_type_methods(array_id, _subtype, size, inf)
   {
     // If we can simplify the array size, do so
-    // XXX, this is probably massively inefficient. Some kind of boundry in
+    // XXX, this is probably massively inefficient. Some kind of boundary in
     // the checking process should exist to eliminate this requirement.
     if (!is_nil_expr(size))
     {
@@ -578,7 +578,7 @@ public:
     : vector_type_methods(vector_id, _subtype, size, false)
   {
     // If we can simplify the array size, do so
-    // XXX, this is probably massively inefficient. Some kind of boundry in
+    // XXX, this is probably massively inefficient. Some kind of boundary in
     // the checking process should exist to eliminate this requirement.
     if (!is_nil_expr(size))
     {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -220,7 +220,7 @@ void dereferencet::dereference_guard_expr(
     expr->Foreach_operand([this, &guard, &expr](expr2tc &op) {
       assert(is_bool_type(op));
 
-      // Handle any derererences in this operand
+      // Handle any dereferences in this operand
       if (has_dereference(op))
         dereference_expr(op, guard, dereferencet::READ);
 
@@ -1507,7 +1507,7 @@ void dereferencet::construct_from_multidir_array(
 
   // Right: any access across the boundary of the outer dimension of this array
   // is an alignment violation as that can possess extra padding.
-  // So, divide the offset by size of the inner dimention, make an index2t, and
+  // So, divide the offset by size of the inner dimension, make an index2t, and
   // construct a reference to that.
   expr2tc subtype_sz = type_byte_size_bits_expr(arr_type.subtype);
   if (subtype_sz->type != offset->type)
@@ -1627,7 +1627,7 @@ void dereferencet::construct_struct_ref_from_const_offset(
       {
         // It's this field. However, zero sized structs may have conspired
         // to make life miserable: we might be creating a reference to one,
-        // or there might be one preceeding the desired struct.
+        // or there might be one preceding the desired struct.
 
         // Zero sized struct and we don't want one,
         if (size == 0 && type_size != 0)
@@ -1968,7 +1968,7 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   assert(num_bytes != 0);
 
   // We are composing a larger data type out of bytes -- we must consider
-  // what byte order we are giong to stitch it together out of.
+  // what byte order we are going to stitch it together out of.
   expr2tc accuml;
   if (is_big_endian)
   {
@@ -2181,7 +2181,7 @@ void dereferencet::bounds_check(
   {
     // Calculate size from type.
 
-    // Dance around getting the array type normalised.
+    // Dance around getting the array type normalized.
     type2tc new_string_type;
 
     // XXX -- arrays were assigned names, but we're skipping that for the moment
@@ -2279,7 +2279,7 @@ void dereferencet::check_data_obj_access(
   expr2tc access_sz_e = gen_long(offset->type, access_sz);
 
   // Only erroneous thing we check for right now is that the offset is out of
-  // bounds, misaligned access happense elsewhere. The highest byte read is at
+  // bounds, misaligned access happens elsewhere. The highest byte read is at
   // offset+access_sz-1, so check fail if the (offset+access_sz) > data_sz.
   // Lower bound not checked, instead we just treat everything as unsigned,
   // which has the same effect.
@@ -2351,7 +2351,7 @@ unsigned int dereferencet::compute_num_bytes_to_extract(
 {
   // We need to calculate the correct number of bytes to extract.
   // This is so that we do not miss any bits in case there are
-  // bitfields lying on the border of two neighbouring bytes
+  // bitfields lying on the border of two neighboring bytes
   // (e.g., |ooooooox|xooooooo|).
   //
   // By default we assume that the "offset" is aligned to 8 bits.

--- a/src/pointer-analysis/dereference.h
+++ b/src/pointer-analysis/dereference.h
@@ -32,7 +32,7 @@
  *  variablea free variable. These are recorded by calling methods in the
  *  dereference_callbackt object. Assertions can be disabled with the
  *  --no-pointer-check and --no-align-check options, but code modelled then
- *  relies on undefined behaviour.
+ *  relies on undefined behavior.
  *
  *  There are four steps to the dereferencing process:
  *   1) Interpretation of the expression surrounding the dereference. The
@@ -64,7 +64,7 @@
  *  The value set tracking code also maintains a 'minimum alignment' piece of
  *  data when the offset is nondeterministic, guarenteeing that the offset used
  *  will be aligned to at least that many bytes. This allows for reducing the
- *  number of behaviours we have to support when dereferencing, particularly
+ *  number of behaviors we have to support when dereferencing, particularly
  *  useful when accessing array elements.
  *
  *  The majority of code is in the reference building stuff. It would be aimless
@@ -91,7 +91,7 @@
 /** Class providing interface to value set tracking code.
  *  This class allows dereference code to get more data out of the environment
  *  in which it is dereferencing, fetching the set of values that a pointer
- *  points at, and also encoding any asertions that occur regarding the validity
+ *  points at, and also encoding any assertions that occur regarding the validity
  *  of the dereference.
  */
 class dereference_callbackt
@@ -100,7 +100,7 @@ public:
   virtual ~dereference_callbackt() = default;
 
   /** Encode a dereference failure assertion. If a dereference does, or can
-   *  trigger undefined or illegal behaviour, then this method is called to
+   *  trigger undefined or illegal behavior, then this method is called to
    *  record it so that it can be asserted against.
    *  @param property Classification of the assertion being violated.
    *  @param msg Description of the reason for this assertion.
@@ -127,7 +127,7 @@ public:
   has_failed_symbol(const expr2tc &expr, const symbolt *&symbol) = 0;
 
   /** Optionally rename the given expression. This exists to provide potential
-   *  optimisation expansion in the future, it isn't currently used by anything.
+   *  optimization expansion in the future, it isn't currently used by anything.
    *  @param expr An expression to be renamed
    */
   virtual void rename(expr2tc &expr [[maybe_unused]])
@@ -262,7 +262,7 @@ public:
     const expr2tc &extra_offset);
 
   /** Does the given expression have a dereference in it somewhere?
-   *  @param expr The expression to check for existance of a dereference.
+   *  @param expr The expression to check for existence of a dereference.
    *  @return True when the given expression does have a dereference.
    */
   bool has_dereference(const expr2tc &expr) const;

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -137,11 +137,11 @@ bool value_sett::make_union(const value_sett::valuest &new_values, bool keepnew)
   {
     valuest::iterator it2 = values.find(new_value.first);
 
-    // If the new variable isnt in this' set,
+    // If the new variable isn't in this set
     if (it2 == values.end())
     {
       // We always track these when merging value sets, as these store data
-      // that's transfered back and forth between function calls. So, the
+      // that's transferred back and forth between function calls. So, the
       // variables not existing in the state we're merging into is irrelevant.
       if (
         has_prefix(
@@ -156,7 +156,7 @@ bool value_sett::make_union(const value_sett::valuest &new_values, bool keepnew)
       continue;
     }
 
-    // The variable was in this' set, merge the values.
+    // The variable was in this set, merge the values.
     entryt &e = it2->second;
     const entryt &new_e = new_value.second;
 
@@ -520,7 +520,7 @@ void value_sett::get_value_set_rec(
   if (is_symbol2t(expr))
   {
     // This is a symbol, and if it's a pointer then this expression might
-    // evalutate to what it points at. So, return this symbols value set.
+    // evaluate to what it points at. So, return this symbols value set.
     const symbol2t &sym = to_symbol2t(expr);
 
     // If it's null however, create a null_object2t with the appropriate type.
@@ -1029,7 +1029,7 @@ void value_sett::assign(
 
   if (is_if2t(rhs))
   {
-    // If the rhs could be either side of this if, perform the assigment of
+    // If the rhs could be either side of this if, perform the assignment of
     // either side. In case it refers to itself, assign to a temporary first,
     // then assign back.
     const if2t &ifref = to_if2t(rhs);

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -367,7 +367,7 @@ public:
         return false;
 
       // Merge the tracking for two offsets; take the minimum alignment
-      // guarenteed by them.
+      // guaranteed by them.
       unsigned long old_align = offset2align(expr_obj, old.offset);
       unsigned long new_align = offset2align(expr_obj, object.offset);
       old.offset_is_set = false;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -512,7 +512,7 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   bin_expr.copy_to_operands(lhs, rhs);
 
   // floor division (//) operation corresponds to an int division with floor rounding
-  // So we need to emulate this behaviour here:
+  // So we need to emulate this behavior here:
   // int result = (num/div) - (num%div != 0 && ((num < 0) ^ (den<0)) ? 1 : 0)
   // e.g.: -5//2 equals to -3, and 5//2 equals to 2
   if (op == "FloorDiv")
@@ -1080,7 +1080,7 @@ exprt python_converter::get_literal(const nlohmann::json &element)
     typet &char_type = t.subtype();
     exprt expr = gen_zero(t);
 
-    // Initialise array
+    // Initialize array
     unsigned int i = 0;
     for (uint8_t &ch : string_literal)
     {

--- a/src/solidity-frontend/pattern_check.cpp
+++ b/src/solidity-frontend/pattern_check.cpp
@@ -106,7 +106,7 @@ void pattern_checker::check_require_call(const nlohmann::json &expr)
 
 void pattern_checker::check_require_argument(const nlohmann::json &call_args)
 {
-  // This function is used to check the authorization argument of require() funciton
+  // This function is used to check the authorization argument of require() function
   const nlohmann::json &arg_expr = call_args[0];
 
   // look for BinaryOperation "=="

--- a/src/solidity-frontend/pattern_check.h
+++ b/src/solidity-frontend/pattern_check.h
@@ -13,9 +13,9 @@
 class pattern_checker
 {
   // There are two types of vulnerabilities:
-  //  - pattern-based vulnerability (e.g. Authoriation via TxOrigin)
+  //  - pattern-based vulnerability (e.g. Authorization via TxOrigin)
   //  - reasoning-based vulnerability (e.g. array out-of-bound access)
-  // This class implements the detection of pattern-based vulnerbaility.
+  // This class implements the detection of pattern-based vulnerability.
   // The reasoning-based vulnerability is handled by ESBMC verification pipeline.
 public:
   pattern_checker(

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -126,8 +126,8 @@ bool solidity_convertert::convert()
     {
       current_contractName = (*itr)["name"].get<std::string>();
 
-      // poplulate linearizedBaseList
-      // this is esstinally the calling order of the constructor
+      // populate linearizedBaseList
+      // this is essentially the calling order of the constructor
       for (const auto &id : (*itr)["linearizedBaseContracts"].items())
         linearizedBaseList[current_contractName].push_back(
           id.value().get<int>());
@@ -165,7 +165,7 @@ bool solidity_convertert::convert()
       if (convert_ast_nodes(*itr))
         return true; // 'true' indicates something goes wrong.
 
-      // add implicit construcor function
+      // add implicit constructor function
       if (add_implicit_constructor())
         return true;
 
@@ -314,7 +314,7 @@ std::vector<nlohmann::json> solidity_convertert::topological_sort(
     zero_in_degree_queue.pop();
     // add the node's corresponding JSON file to the sorted result
     sorted_files.push_back(path_to_json[node]);
-    // Update the in-degree of neighbouring nodes and add the new node with in-degree 0 to the queue
+    // Update the in-degree of neighboring nodes and add the new node with in-degree 0 to the queue
     for (const auto &neighbor : graph[node])
     {
       if (node != neighbor)
@@ -377,7 +377,7 @@ bool solidity_convertert::get_non_function_decl(
   SolidityGrammar::ContractBodyElementT type =
     SolidityGrammar::get_contract_body_element_t(ast_node);
 
-  // based on each element as in Solidty grammar "rule contract-body-element"
+  // based on each element as in Solidity grammar "rule contract-body-element"
   switch (type)
   {
   case SolidityGrammar::ContractBodyElementT::VarDecl:
@@ -412,7 +412,7 @@ bool solidity_convertert::get_function_decl(const nlohmann::json &ast_node)
   SolidityGrammar::ContractBodyElementT type =
     SolidityGrammar::get_contract_body_element_t(ast_node);
 
-  // based on each element as in Solidty grammar "rule contract-body-element"
+  // based on each element as in Solidity grammar "rule contract-body-element"
   switch (type)
   {
   case SolidityGrammar::ContractBodyElementT::FunctionDef:
@@ -481,7 +481,7 @@ bool solidity_convertert::get_var_decl(
   typet t;
   // VariableDeclaration node contains both "typeName" and "typeDescriptions".
   // However, ExpressionStatement node just contains "typeDescriptions".
-  // For consistensy, we use ["typeName"]["typeDescriptions"] as in state-variable-declaration
+  // For consistency, we use ["typeName"]["typeDescriptions"] as in state-variable-declaration
   // to improve the re-usability of get_type* function, when dealing with non-array var decls.
   // For array, do NOT use ["typeName"]. Otherwise, it will cause problem
   // when populating typet in get_cast
@@ -616,7 +616,7 @@ bool solidity_convertert::get_var_decl(
       ast_node["typeName"]["typeDescriptions"]) ==
     SolidityGrammar::ContractTypeName)
   {
-    // 1. get constract name
+    // 1. get contract name
     assert(
       ast_node["typeName"]["nodeType"].get<std::string>() ==
       "UserDefinedTypeName");
@@ -831,7 +831,7 @@ bool solidity_convertert::get_noncontract_defition(nlohmann::json &ast_node)
   return false;
 }
 
-// add a "body" node to funcitons within interfacae && abstract && event
+// add a "body" node to functions within interface && abstract && event
 // the idea is to utilize the function-handling APIs.
 void solidity_convertert::add_empty_function_body(nlohmann::json &ast_node)
 {
@@ -1048,7 +1048,7 @@ bool solidity_convertert::get_function_definition(
     (*current_functionDecl).contains("kind") &&
     (*current_functionDecl)["kind"] == "constructor")
   {
-    // for construcotr
+    // for constructor
     is_ctor = true;
     if (get_current_contract_name(*current_functionDecl, current_functionName))
       return true;
@@ -1080,7 +1080,7 @@ bool solidity_convertert::get_function_definition(
 
   // 5. Check fd.isVariadic(), fd.isInlined()
   //  Skipped since Solidity does not support variadic (optional args) or inline function.
-  //  Actually "inline" doesn not make sense in Solidity
+  //  Actually "inline" does not make sense in Solidity.
 
   // 6. Populate "locationt location_begin"
   locationt location_begin;
@@ -1109,7 +1109,7 @@ bool solidity_convertert::get_function_definition(
   // 10. Add symbol into the context
   symbolt &added_symbol = *move_symbol_to_context(symbol);
 
-  // 11. Convert parameters, if no parameter, assume ellipis
+  // 11. Convert parameters, if no parameter, assume ellipsis
   //  - Convert params before body as they may get referred by the statement in the body
   if (is_ctor)
   {
@@ -1147,7 +1147,7 @@ bool solidity_convertert::get_function_definition(
 
   // 12. Convert body and embed the body into the same symbol
   // skip for 'unimplemented' functions which has no body,
-  // e.g. asbstract/interface, the symbol value would be left as unset
+  // e.g. abstract/interface, the symbol value would be left as unset
   if (
     ast_node.contains("body") ||
     (ast_node.contains("implemented") && ast_node["implemented"] == true))
@@ -1334,7 +1334,7 @@ bool solidity_convertert::get_statement(
     codet decls("decl-block");
     unsigned ctr = 0;
     // N.B. Although Solidity AST JSON uses "declarations": [],
-    // the size of this array is alway 1!
+    // the size of this array is always 1!
     // A second declaration will become another stmt in "statements" array
     // e.g. "statements" : [
     //  {"declarations": [], "id": 1}
@@ -1374,7 +1374,7 @@ bool solidity_convertert::get_statement(
     }
 
     // 1. get return type
-    // TODO: Fixme! Assumptions:
+    // TODO: FIXME! Assumptions:
     //  a). It's "return <expr>;" not "return;"
     //  b). <expr> is pointing to a DeclRefExpr, we need to wrap it in an ImplicitCastExpr as a subexpr
     //  c). For multiple return type, the return statement represented as a tuple expression using a components field.
@@ -1469,7 +1469,7 @@ bool solidity_convertert::get_statement(
 
         for (size_t i = 0; i < ls; i++)
         {
-          // lop: struct member call (e.g. tupleA.men0)
+          // lop: struct member call (e.g. tupleA.mem0)
           exprt lop;
           if (get_tuple_member_call(
                 lhs.identifier(),
@@ -1477,7 +1477,7 @@ bool solidity_convertert::get_statement(
                 lop))
             return true;
 
-          // rop: struct member call (e.g. tupleB.men0)
+          // rop: struct member call (e.g. tupleB.mem0)
           exprt rop;
           if (get_tuple_member_call(
                 rhs.identifier(),
@@ -1729,7 +1729,7 @@ bool solidity_convertert::get_expr(const nlohmann::json &expr, exprt &new_expr)
      * !Always check if the expression is a Literal before calling get_expr
      * !Unless you are 100% sure it will not be a constant
      * 
-     * This function is called throught two paths:
+     * This function is called through two paths:
      * 1. get_non_function_decl => get_var_decl => get_expr
      * 2. get_non_function_decl => get_function_definition => get_statement => get_expr
      * 
@@ -1795,7 +1795,7 @@ bool solidity_convertert::get_expr(
         return true;
       }
 
-      // Soldity uses +ve odd numbers to refer to var or functions declared in the contract
+      // Solidity uses +ve odd numbers to refer to var or functions declared in the contract
       const nlohmann::json &decl = find_decl_ref(expr["referencedDeclaration"]);
       if (decl == empty_json)
         return true;
@@ -1858,7 +1858,7 @@ bool solidity_convertert::get_expr(
     }
     else
     {
-      // Soldity uses -ve odd numbers to refer to built-in var or functions that
+      // Solidity uses -ve odd numbers to refer to built-in var or functions that
       // are NOT declared in the contract
       if (get_esbmc_builtin_ref(expr, new_expr))
         return true;
@@ -2072,7 +2072,7 @@ bool solidity_convertert::get_expr(
         ? any potential scope issue?
 
       case 2:
-        1. when parsing the funciton definition, if the returnParam > 1
+        1. when parsing the function definition, if the returnParam > 1
            make the function return void instead, and create a struct type
         2. when parsing the return statement, if the return value is a tuple,
            create a struct type instance, do assignments,  and return empty;
@@ -2269,7 +2269,7 @@ bool solidity_convertert::get_expr(
       const nlohmann::json members = struct_ref["members"];
       const nlohmann::json args = expr["arguments"];
 
-      // popluate components
+      // populate components
       for (size_t i = 0; i < inits.operands().size() && i < args.size(); i++)
       {
         exprt init;
@@ -2288,7 +2288,7 @@ bool solidity_convertert::get_expr(
       break;
     }
 
-    // funciton call expr
+    // function call expr
     assert(callee_expr.type().is_code());
     typet type = to_code_type(callee_expr.type()).return_type();
 
@@ -2575,7 +2575,7 @@ bool solidity_convertert::get_expr(
     // 4. (?)internal property: tx.origin, msg.sender, ...
 
     // Function symbol id is sol:@C@referenced_function_contract_name@F@function_name#referenced_function_id
-    // Using referencedDeclaration will point us to the original declared function. This works even for inherited function and overrided functions.
+    // Using referencedDeclaration will point us to the original declared function. This works even for inherited function and overridden functions.
     assert(expr.contains("expression"));
     const nlohmann::json callee_expr_json = expr["expression"];
 
@@ -2797,7 +2797,7 @@ bool solidity_convertert::get_binary_operator_expr(
 
   // special handling for mapping set value
   // for any mapping index access, we will initially return as map_get
-  // here, we further identidy it as map_get or map_set
+  // here, we further identity it as map_get or map_set
   std::string op_str = SolidityGrammar::expression_to_str(opcode);
   if (
     lhs.type().get("#sol_type").as_string() == "MAP_GET" &&
@@ -2964,7 +2964,7 @@ bool solidity_convertert::get_binary_operator_expr(
         // do #3 #4
         while (i < ls && j < rs)
         {
-          // construct assignemnt
+          // construct assignment
           exprt lcomp = to_struct_type(lhs.type()).components().at(i);
           exprt rcomp = to_struct_type(rhs.type()).components().at(j);
           exprt lop = lhs.operands().at(i);
@@ -3209,7 +3209,7 @@ bool solidity_convertert::get_binary_operator_expr(
       //    data1 = "test"; data2 = 0x74657374; // "test"
       //    assert(data1 == data2); // true
       // Do type conversion before the bswap
-      // the arguement of bswap should only be int/uint type, not string
+      // the argument of bswap should only be int/uint type, not string
       // e.g. data1 == "test", it should not be bswap("test")
       // instead it should be bswap(0x74657374)
       // this may overwrite the lhs & rhs.
@@ -3647,7 +3647,7 @@ bool solidity_convertert::get_esbmc_builtin_ref(
   // manually unrolled recursion here
   // type config for Builtin && Int
   typet type;
-  // Creat a new code_typet, parse the return_type and copy the code_typet to typet
+  // Create a new code_typet, parse the return_type and copy the code_typet to typet
   code_typet convert_type;
   typet return_type;
   if (
@@ -3697,7 +3697,7 @@ bool solidity_convertert::get_sol_builtin_ref(
   {
     //  e.g. gasleft() <=> c:@F@gasleft
     if (expr["expression"]["nodeType"].get<std::string>() != "Identifier")
-      // this means it's not a builtin funciton
+      // this means it's not a builtin function
       return true;
 
     std::string name = expr["expression"]["name"].get<std::string>();
@@ -3864,7 +3864,7 @@ bool solidity_convertert::get_type_description(
     //      func(){ data = [1,2,3]; data = new uint[](10); }
     //    and
     //      data.pop(); data.push();
-    //    Idealy, this should be set as a vector_type.
+    //    Ideally, this should be set as a vector_type.
     exprt size_expr;
 
     if (type_name.contains("sizeExpr"))
@@ -3992,7 +3992,7 @@ bool solidity_convertert::get_type_description(
     int cnt = 1;
     std::string token;
 
-    // extract the seconde string
+    // extract the second string
     while (cnt >= 0)
     {
       if (typeString.find(delimiter) == std::string::npos)
@@ -4072,7 +4072,7 @@ bool solidity_convertert::get_func_decl_ref_type(
 {
   // For FunctionToPointer decay:
   // Get type when we make a function call:
-  //  - FunnctionNoProto: x = nondet()
+  //  - FunctionNoProto: x = nondet()
   //  - FunctionProto:    z = add(x, y)
   // Similar to the function get_type_description()
   SolidityGrammar::FunctionDeclRefT type =
@@ -4302,7 +4302,7 @@ bool solidity_convertert::get_tuple_instance(
   // populate initial value
   // e.g. (1,2) ==> Tuple tuple = Tuple(1,2);
   //! since there is no tuple type variable in solidity
-  // we can just convert it as inital value instead of assignment
+  // we can just convert it as initial value instead of assignment
   //? should we set the default value as zero?
 
   exprt inits = gen_zero(t);
@@ -4589,7 +4589,7 @@ bool solidity_convertert::get_mapping_definition(
   std::string debug_modulename =
     get_modulename_from_path(location_begin.file().as_string());
 
-  // populate symbool
+  // populate symbol
   symbolt symbol;
   get_default_symbol(symbol, debug_modulename, t, name, id, location_begin);
   symbol.is_extern = false;
@@ -5184,7 +5184,7 @@ void solidity_convertert::get_location_from_decl(
 {
   location.set_line(get_line_number(ast_node));
   location.set_file(
-    absolute_path); // assume absolute_path is the name of the contrace file, since we ran solc in the same directory
+    absolute_path); // assume absolute_path is the name of the contract file, since we ran solc in the same directory
 
   // To annotate local declaration within a function
   if (
@@ -5207,11 +5207,11 @@ void solidity_convertert::get_start_location_from_stmt(
   if (current_functionDecl)
     function_name = current_functionName;
 
-  // The src manager of Solidity AST JSON is too encryptic.
+  // The src manager of Solidity AST JSON is too cryptic.
   // For the time being we are setting it to "1".
   location.set_line(get_line_number(ast_node));
   location.set_file(
-    absolute_path); // assume absolute_path is the name of the contrace file, since we ran solc in the same directory
+    absolute_path); // assume absolute_path is the name of the contract file, since we ran solc in the same directory
 
   if (!function_name.empty())
     location.set_function(function_name);
@@ -5226,11 +5226,11 @@ void solidity_convertert::get_final_location_from_stmt(
   if (current_functionDecl)
     function_name = current_functionName;
 
-  // The src manager of Solidity AST JSON is too encryptic.
+  // The src manager of Solidity AST JSON is too cryptic.
   // For the time being we are setting it to "1".
   location.set_line(get_line_number(ast_node, true));
   location.set_file(
-    absolute_path); // assume absolute_path is the name of the contrace file, since we ran solc in the same directory
+    absolute_path); // assume absolute_path is the name of the contract file, since we ran solc in the same directory
 
   if (!function_name.empty())
     location.set_function(function_name);
@@ -5265,7 +5265,7 @@ const nlohmann::json &solidity_convertert::find_decl_ref(int ref_decl_id)
 const nlohmann::json &
 solidity_convertert::find_decl_ref(int ref_decl_id, std::string &contract_name)
 {
-  //TODO: Clean up this funciton. Such a mess...
+  //TODO: Clean up this function. Such a mess...
 
   if (ref_decl_id < 0)
   {
@@ -5472,7 +5472,7 @@ solidity_convertert::find_decl_ref(int ref_decl_id, std::string &contract_name)
   return empty_json;
 }
 
-// return construcor node
+// return constructor node
 const nlohmann::json &solidity_convertert::find_constructor_ref(int ref_decl_id)
 {
   nlohmann::json &nodes = src_ast_json["nodes"];
@@ -6073,7 +6073,7 @@ bool solidity_convertert::get_empty_array_ref(
 
   symbolt &added_symbol = *move_symbol_to_context(symbol);
 
-  // Poplulate default value
+  // Populate default value
   if (size.value().as_string() != "" && size.value().as_string() != "0")
   {
     added_symbol.value = gen_zero(arr_type);
@@ -6300,7 +6300,7 @@ bool solidity_convertert::multi_transaction_verification(
 
 /*
   This function perform multi-transaction verification on each contract in isolation.
-  To do so, we construct nondetered switch_case;
+  To do so, we construct non-determined switch_case;
 */
 bool solidity_convertert::multi_contract_verification()
 {

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -232,7 +232,7 @@ protected:
   // Use current level of BinOp type as the "anchor" type for numerical literal conversion:
   // In order to remove the unnecessary implicit IntegralCast. We need type of current level of BinaryOperator.
   // All numeric literals will be implicitly converted to this type. Pop it when finishing the current level of BinaryOperator.
-  // TODO: find a better way to deal with implicit type casting if it's not able to cope with compelx rules
+  // TODO: find a better way to deal with implicit type casting if it's not able to cope with complex rules
   std::stack<const nlohmann::json *> current_BinOp_type;
   std::string current_functionName;
 

--- a/src/solidity-frontend/solidity_grammar.cpp
+++ b/src/solidity-frontend/solidity_grammar.cpp
@@ -144,7 +144,7 @@ const char *contract_body_element_to_str(ContractBodyElementT type)
 // rule type-name
 TypeNameT get_type_name_t(const nlohmann::json &type_name)
 {
-  // Solidity AST node has duplicate descrptions: ["typeName"]["typeDescriptions"] and ["typeDescriptions"]
+  // Solidity AST node has duplicate descriptions: ["typeName"]["typeDescriptions"] and ["typeDescriptions"]
   //! Order matters
 
   if (type_name.contains("typeString"))

--- a/src/solidity-frontend/solidity_grammar.h
+++ b/src/solidity-frontend/solidity_grammar.h
@@ -338,7 +338,7 @@ enum ExpressionT
   // i.e. x.caller();
   ContractMemberCall,
 
-  // Type Converion
+  // Type Conversion
   ElementaryTypeNameExpression,
 
   // Struct Member Access

--- a/src/solidity-frontend/solidity_template.h
+++ b/src/solidity-frontend/solidity_template.h
@@ -245,7 +245,7 @@ bool *map_get_bool(map_bool_t *m, const char *key)
 unsigned map_hash(const char *str)
 {
 	unsigned hash = 5381;
-	// avoid derefencing null ptr
+	// avoid dereferencing null ptr
 	if (str != NULL)
 		while (*str)
 		{

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -724,7 +724,7 @@ void array_convt::join_array_indexes()
     }
   } while (modified);
 
-  // Right -- now join all ther indexes. This can be optimised, but not now.
+  // Right -- now join all ther indexes. This can be optimized, but not now.
   for (arrid = 0; arrid < array_updates.size(); arrid++)
   {
     auto const &arrset = array_relations[arrid];
@@ -793,7 +793,7 @@ void array_convt::add_new_indexes()
     re_execute.push_back(true);
     start_pos.push_back(expr_index_map[arrid].size());
 
-    // We're guarenteed that each of these indexes are _new_ to this array.
+    // We're guaranteed that each of these indexes are _new_ to this array.
     // Enumerate them, giving them a location in the expr_index_map.
     // NB: if, actually they're not new, insert will fail, safely
     index_map_containert &idx_map = expr_index_map[arrid];
@@ -837,7 +837,7 @@ void array_convt::add_new_indexes()
     array_update_vect &array_values = array_valuation[arrid];
     smt_sortt subtype = array_subtypes[arrid];
 
-    // Fill inital values with either free variables or the initialiser
+    // Fill inital values with either free variables or the initializer
     array_of_val_containert::nth_index<0>::type &array_num_idx =
       array_of_vals.get<0>();
     auto it = array_num_idx.find(arrid);
@@ -911,7 +911,7 @@ void array_convt::apply_new_selects()
   // (through execute_new_updates).
   // That then leaves new selects that apply to previously encoded array
   // values. We can just pick those straight out of the array valuation vector.
-  // This could be optimised, but not now.
+  // This could be optimized, but not now.
 
   for (unsigned int arrid = 0; arrid < array_selects.size(); arrid++)
   {

--- a/src/solvers/smt/smt_ast.h
+++ b/src/solvers/smt/smt_ast.h
@@ -51,7 +51,7 @@ public:
   virtual smt_astt eq(smt_convt *ctx, smt_astt other) const;
 
   /** Abstractly produce an assign. Defaults to being an equality, however
-   *  for some special cases up to the backend, there may be optimisations made
+   *  for some special cases up to the backend, there may be optimizations made
    *  for array or tuple assigns, and so forth.
    *  @param ctx SMT context to do the assignment in.
    *  @param sym Symbol to assign to
@@ -63,7 +63,7 @@ public:
    *  @param value Value to insert into the updated field
    *  @param idx Array index or tuple field
    *  @param idx_expr If an array, expression representing the index
-   *  @return AST of this' type, representing the update */
+   *  @return AST of this type, representing the update */
   virtual smt_astt update(
     smt_convt *ctx,
     smt_astt value,

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -368,7 +368,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     {
       smt_sortt sort = convert_sort(expr->type);
 
-      // Don't honour inifinite sized array initializers. Modelling only.
+      // Don't honor inifinite sized array initializers. Modelling only.
       // If we have an array of tuples and no tuple support, use tuple_fresh.
       // Otherwise, mk_fresh.
       if (is_tuple_ast_type(arr.subtype))
@@ -846,7 +846,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
      * read illuminating how reasoning works from a certain compiler's
      * writers' points of view.
      *
-     * C++ has changed this one-past behaviour in [expr.eq] to "unspecified"
+     * C++ has changed this one-past behavior in [expr.eq] to "unspecified"
      * <https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#1652>
      * and C might eventually follow the same path.
      *
@@ -2652,7 +2652,7 @@ smt_astt smt_convt::convert_array_of_prep(const expr2tc &expr)
 
   // So: we have an array_of, that we have to convert into a bunch of stores.
   // However, it might be a nested array. If that's the case, then we're
-  // guarenteed to have another array_of in the initializer which we can flatten
+  // guaranteed to have another array_of in the initializer which we can flatten
   // to a single array of whatever's at the bottom of the array_of. Or, it's
   // a constant_array, in which case we can just copy the contents.
   if (is_array_type(arrtype.subtype))
@@ -2835,7 +2835,7 @@ void smt_convt::rewrite_ptrs_to_structs(type2tc &type)
   type->Foreach_subtype(delegate);
 }
 
-// Default behaviours for SMT AST's
+// Default behaviors for SMT AST's
 
 void smt_ast::assign(smt_convt *ctx, smt_astt sym) const
 {

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -564,10 +564,10 @@ public:
 
   /** Flatten pointer arithmetic. When faced with an addition or subtraction
    *  between a pointer and some integer or other pointer, perform whatever
-   *  multiplications or casting is requried to honour the C semantics of
+   *  multiplications or casting is requried to honor the C semantics of
    *  pointer arith. */
   smt_astt convert_pointer_arith(const expr2tc &expr, const type2tc &t);
-  /** Compare two pointers. This attempts to optimise cases where we can avoid
+  /** Compare two pointers. This attempts to optimize cases where we can avoid
    *  comparing the integer representation of a pointer, as that's hugely
    *  inefficient sometimes (and gets bitblasted).
    *  @param expr First pointer to compare

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -90,7 +90,7 @@ smt_astt smt_tuple_node_flattener::tuple_array_create(
   smt_sortt sort = ctx->convert_sort(array_type);
   smt_sortt subtype = ctx->convert_sort(get_array_subtype(array_type));
 
-  // Optimise the creation of a const array.
+  // Optimize the creation of a const array.
   if (const_array)
     return array_conv.convert_array_of_wsort(
       inputargs[0], domain->get_data_width(), sort);

--- a/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node_ast.cpp
@@ -6,7 +6,7 @@
 #include <util/base_type.h>
 #include <util/c_types.h>
 
-/* An optimisation of the tuple flattening technique found in smt_tuple_sym.cpp,
+/* An optimization of the tuple flattening technique found in smt_tuple_sym.cpp,
  * where we separate out tuple elements into their own variables without any
  * name mangling, and avoid un-necessary operations on elements when the tuple
  * is manipulated.

--- a/src/solvers/smtlib/smtlib.ypp
+++ b/src/solvers/smtlib/smtlib.ypp
@@ -77,7 +77,7 @@ sexpr *smtlib_output = NULL;
 
 /* Types */
 
-%type <text> error_behaviour reason_unknown info_response_arg
+%type <text> error_behavior reason_unknown info_response_arg
 %type <str> symbol
 %type <str_vec> symbol_list_empt
 %type <sexpr_list> sexpr_list info_response_list
@@ -395,7 +395,7 @@ gen_response: TOK_KW_UNSUPPORTED
            free($3);
          }
 
-error_behaviour: TOK_KW_IMMEXIT | TOK_KW_CONEXECUTION
+error_behavior: TOK_KW_IMMEXIT | TOK_KW_CONEXECUTION
 
 reason_unknown: TOK_KW_MEMOUT | TOK_KW_INCOMPLETE
 
@@ -418,7 +418,7 @@ status: TOK_KW_SAT
            free($1);
          }
 
-info_response_arg: error_behaviour | reason_unknown
+info_response_arg: error_behavior | reason_unknown
 
 info_response: attribute
        | TOK_KEYWORD info_response_arg

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -21,7 +21,7 @@ public:
   ~yices_smt_ast() override = default;
 
   // Provide assign semantics for arrays. While yices will swallow array
-  // equalities, it appears to silently not honour them? From observation.
+  // equalities, it appears to silently not honor them? From observation.
   void assign(smt_convt *ctx, smt_astt sym) const override;
 
   smt_astt project(smt_convt *ctx, unsigned int elem) const override;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -189,7 +189,7 @@ bool configt::set(const cmdlinet &cmdline)
   if (ansi_c.cheri)
   {
     log_error(
-      "This build of ESBMC does not have CHERI support, can't honour "
+      "This build of ESBMC does not have CHERI support, can't honor "
       "'--cheri'.");
     abort();
   }

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -158,7 +158,7 @@ static bool rebalance_associative_tree(
   // try to simplify all of their contents, then try to reconfigure into another
   // set of operations.
   // There's great scope for making this /much/ more efficient via passing modes
-  // and vectors downwards, but lets not prematurely optimise. All this is
+  // and vectors downwards, but lets not prematurely optimize. All this is
   // faster than stringly stuff.
 
   // Extract immediate operands
@@ -1379,7 +1379,7 @@ static expr2tc do_bit_munge_operation(
      * not representable. */
 
     /* Evaluating shifts with the shift amount >= 64 on (u)int64_t is undefined
-     * behaviour in C++, we should avoid doing that during simplification. */
+     * behavior in C++, we should avoid doing that during simplification. */
     can_eval &= !is_shift || br < 64;
     if (can_eval)
     {

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -148,7 +148,7 @@ BigInt type_sizet::size_bits(const type2tc &type) const
 
   case type2t::union_id:
   {
-    // Very simple: the largest field size, rounded up to a word boundry for
+    // Very simple: the largest field size, rounded up to a word boundary for
     // array allocation alignment.
     BigInt max_size = 0;
     for (auto const &it : to_union_type(type).members)
@@ -274,7 +274,7 @@ expr2tc type_sizet::size_bits_expr(const type2tc &type) const
 
   case type2t::union_id:
   {
-    // Very simple: the largest field size, rounded up to a word boundry for
+    // Very simple: the largest field size, rounded up to a word boundary for
     // array allocation alignment.
     BigInt max_cnst = 0;
     expr2tc max_dyn;

--- a/unit/util/string2integer.test.cpp
+++ b/unit/util/string2integer.test.cpp
@@ -28,7 +28,7 @@ TEST_CASE(
   REQUIRE(string2integer("c0fefe") == 0);
 }
 
-/* TODO: Is this the behaviour for string2integer?
+/* TODO: Is this the behavior for string2integer?
 TEST_CASE(
   "optionally converting string out of range to integer should return 0",
   "[core][util][string2int]")

--- a/unit/util/symbol.test.cpp
+++ b/unit/util/symbol.test.cpp
@@ -29,7 +29,7 @@ SCENARIO(
     }
   }
   /* TODO: Add check for well formed symbols
-  GIVEN("An improperly initialised symbol")
+  GIVEN("An improperly initialized symbol")
   {
     symbolt symbol;
 


### PR DESCRIPTION
this time I went through all comments with hunspell. also fixed some british anglicisms, where we had the same us-english counterpart, for consistency.

behaviour -> behavior
honour -> honor
dependancy -> dependency

there was even a wrong test filename constract.sol