### PR TITLE
llvm-19 works fine, bump MAX_SUPPORTED_LLVM_VERSION_MAJOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set (ESBMC_VERSION "${ESBMC_VERSION_MAJOR}.${ESBMC_VERSION_MINOR}.${ESBMC_VERSIO
 # The only default solver available is smtlib
 set (ESBMC_AVAILABLE_SOLVERS "smtlib")
 
-set(MAX_SUPPORTED_LLVM_VERSION_MAJOR 16)
+set(MAX_SUPPORTED_LLVM_VERSION_MAJOR 19)
 
 #################################
 # Configuration                 #


### PR DESCRIPTION
works fine on fedora core 41. 
llvm-18 on ubuntu 24.04 fail's, but ubuntu fails all the time for their own CXX ABI incompetencies.

e.g.
with clang++-18 and the gcc-13 libc++.

/usr/lib/llvm-18/include/cxxabi.h:51:1: error: functions that differ only in their return type cannot be overloaded
   50 | extern _LIBCXXABI_FUNC_VIS __cxa_exception*
      |                            ~~~~~~~~~~~~~~~~
   51 | __cxa_init_primary_exception(void* object, std::type_info* tinfo, void(_LIBCXXABI_DTOR_FUNC* dest)(void*)) throw();
      | ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/cxxabi_init_exception.h:70:7: note: previous declaration is here
   69 |       __cxa_refcounted_exception*

needs a seperate ticket. the workaround on ubuntu is to change /usr/lib/llvm-18/include/cxxabi.h:51 to __cxa_refcounted_exception