### PR TITLE
[Incremental SMT] Verify if --smt-during-symex is enabled before performing incremental assertion checks

### DIFF
--- a/regression/incremental-smt/incremental-30/main.c
+++ b/regression/incremental-smt/incremental-30/main.c
@@ -1,0 +1,23 @@
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "vnew2.c", 3, "reach_error"); }
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+void __VERIFIER_assert(int cond) {
+  if (!(cond)) {
+    ERROR: {reach_error();abort();}
+  }
+  return;
+}
+int SIZE = 20000001;
+int __VERIFIER_nondet_int();
+int main() {
+   int n = 0;
+   int j = 1;
+   int k = __VERIFIER_nondet_int();
+  __ESBMC_assume(k == j * -1);
+  __VERIFIER_assert(k == (2 - 1) * j * -1);
+}
+

--- a/regression/incremental-smt/incremental-30/test.desc
+++ b/regression/incremental-smt/incremental-30/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--smt-during-symex --smt-symex-assert
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -345,7 +345,7 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("no-slice", true);
   }
 
-  if (cmdline.isset("smt-thread-guard") || cmdline.isset("smt-symex-guard"))
+  if (cmdline.isset("smt-thread-guard") || cmdline.isset("smt-symex-guard") || cmdline.isset("smt-symex-assert"))
   {
     if (!cmdline.isset("smt-during-symex"))
     {

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -349,13 +349,8 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     cmdline.isset("smt-thread-guard") || cmdline.isset("smt-symex-guard") ||
     cmdline.isset("smt-symex-assert"))
   {
-    if (!cmdline.isset("smt-during-symex"))
-    {
-      log_error(
-        "Please explicitly specify --smt-during-symex if you want "
-        "to use features that involve encoding SMT during symex");
-      abort();
-    }
+    log_status("Enabling --smt-during-symex to use features that involve encoding SMT during symex");
+    options.set_option("smt-during-symex", true);
   }
 
   // check the user's parameters to run incremental verification

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -345,7 +345,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("no-slice", true);
   }
 
-  if (cmdline.isset("smt-thread-guard") || cmdline.isset("smt-symex-guard") || cmdline.isset("smt-symex-assert"))
+  if (
+    cmdline.isset("smt-thread-guard") || cmdline.isset("smt-symex-guard") ||
+    cmdline.isset("smt-symex-assert"))
   {
     if (!cmdline.isset("smt-during-symex"))
     {

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -349,7 +349,9 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     cmdline.isset("smt-thread-guard") || cmdline.isset("smt-symex-guard") ||
     cmdline.isset("smt-symex-assert"))
   {
-    log_status("Enabling --smt-during-symex to use features that involve encoding SMT during symex");
+    log_status(
+      "Enabling --smt-during-symex to use features that involve encoding SMT "
+      "during symex");
     options.set_option("smt-during-symex", true);
   }
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/1367.