### PR TITLE
Intrigus/fix nan simplify

### DIFF
--- a/regression/esbmc/simplify-float-nan/main.cpp
+++ b/regression/esbmc/simplify-float-nan/main.cpp
@@ -1,0 +1,8 @@
+extern "C" void memcpy(void *, void *, int);
+float a = __builtin_nanf(0);
+double b = a;
+double other = 1;
+int main()
+{
+  memcpy(&other, &b, 8);
+}

--- a/regression/esbmc/simplify-float-nan/test.desc
+++ b/regression/esbmc/simplify-float-nan/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/simplify-float-nan/test.desc
+++ b/regression/esbmc/simplify-float-nan/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --overflow-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
NaN != NaN is always true, but this defeats the purpose of the check
The assumption is that `src != source_value` means that we were able to simplify
something and return a simplified expression.
In case of NaN, we would continuously return "simplified" expressions, because
NaN != NaN would always be true.

There might be other cases elsewhere, but I only encountered the problem in this specific simplification and honestly don't have time to look at those potential other cases.