### PR TITLE
[C++ verification] adjust lambda operator

### DIFF
--- a/regression/esbmc-cpp11/lambda/lambda_02/main.cpp
+++ b/regression/esbmc-cpp11/lambda/lambda_02/main.cpp
@@ -1,0 +1,31 @@
+#include <cassert>
+
+class classA
+{
+public:
+  template <typename T>
+  static bool bar(T var)
+  {
+    var();
+    return true;
+  }
+};
+
+class classB
+{
+public:
+  bool foo()
+  {
+    return classA::bar([this]() { data++; });
+  }
+  int data = 0;
+};
+
+int main()
+{
+  classB obj;
+  obj.foo();
+  assert(obj.data == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/lambda/lambda_02/test.desc
+++ b/regression/esbmc-cpp11/lambda/lambda_02/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/lambda/lambda_02_fail/main.cpp
+++ b/regression/esbmc-cpp11/lambda/lambda_02_fail/main.cpp
@@ -1,0 +1,31 @@
+#include <cassert>
+
+class classA
+{
+public:
+  template <typename T>
+  static bool bar(T var)
+  {
+    var();
+    return true;
+  }
+};
+
+class classB
+{
+public:
+  bool foo()
+  {
+    return classA::bar([this]() { data++; });
+  }
+  int data = 0;
+};
+
+int main()
+{
+  classB obj;
+  obj.foo();
+  assert(obj.data == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp11/lambda/lambda_02_fail/test.desc
+++ b/regression/esbmc-cpp11/lambda/lambda_02_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -116,6 +116,10 @@ public:
    * @param symbol The symbol for which the implicit copy and move constructor is generated.
    */
   void gen_implicit_union_copy_move_constructor(symbolt &symbol);
+
+  void gen_lambda_operator(symbolt &symbol);
+
+  void replace_capture_this(const exprt &expr, exprt &dest);
 };
 
 #endif /* CLANG_CPP_FRONTEND_CLANG_CPP_ADJUST_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -72,7 +72,7 @@ void clang_cpp_adjust::gen_lambda_operator(symbolt &symbol)
   code_blockt &body = to_code_block(to_code(symbol.value));
 
   exprt this_ptr = symbol_exprt(
-    type.arguments().at(0).get("#identifier"), type.arguments()[0].type());
+    type.arguments()[0].get("#identifier"), type.arguments()[0].type());
 
   const typet &class_symb = ns.follow(type.arguments()[0].type().subtype());
 
@@ -83,7 +83,10 @@ void clang_cpp_adjust::gen_lambda_operator(symbolt &symbol)
   {
     if (c.get_bool("#capture_this"))
     {
-      // this->__this->data
+      // the clang declares the original variable (this->data)
+      // releace 'this->data' with 'this->__this->data'
+      // which this = this ptr of lambda and
+      // __this = capture this
       exprt deref = dereference_exprt(this_ptr, this_ptr.type());
       exprt dest = member_exprt(deref, c.get_name(), c.type());
       exprt memderef =

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -414,6 +414,8 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
     if (annotate_class_field(*field, type, comp))
       return true;
 
+    // Tag the components in the lambda to
+    // find capture this and other var names
     if (auto cxxrd = llvm::dyn_cast<clang::CXXRecordDecl>(&rd))
     {
       if (cxxrd->isLambda())
@@ -854,9 +856,6 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
   case clang::Stmt::CXXThisExprClass:
   {
-    const clang::CXXThisExpr &this_expr =
-      static_cast<const clang::CXXThisExpr &>(stmt);
-
     std::size_t address =
       reinterpret_cast<std::size_t>(current_functionDecl->getFirstDecl());
 
@@ -1513,6 +1512,8 @@ bool clang_cpp_convertert::get_function_body(
     }
   }
 
+  // Mark the member functions of the lambda class
+  // in order to adjust the body function later
   if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(&fd))
   {
     if (md->getParent()->isLambda())

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -420,7 +420,6 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
       {
         if ((cxxrd->captures_begin() + i)->capturesThis())
         {
-          comp.set_name("__this");
           comp.set_pretty_name("__this");
           comp.set("#capture_this", true);
         }
@@ -429,7 +428,6 @@ bool clang_cpp_convertert::get_struct_union_class_fields(
           std::string name, id;
           get_decl_name(
             *(cxxrd->captures_begin() + i)->getCapturedVar(), name, id);
-          comp.set_name(id);
           comp.set_pretty_name("__" + name);
         }
       }
@@ -870,12 +868,6 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         clang_c_convertert::get_decl_name(*current_functionDecl));
       abort();
     }
-
-    typet this_type;
-    if (get_type(this_expr.getType(), this_type))
-      return true;
-
-    //assert(this_type == it->second.second);
 
     new_expr = symbol_exprt(it->second.first, it->second.second);
     break;

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -543,6 +543,7 @@ const irep_idt irept::a_type_id = dstring("typeid");
 const irep_idt irept::a_derived_this_arg = dstring("#derived_this_arg");
 const irep_idt irept::a_base_ctor_derived = dstring("#base_ctor_derived");
 const irep_idt irept::a_need_vptr_init = dstring("#need_vptr_init");
+const irep_idt irept::a_need_lambda_init = dstring("#need_lambda_init");
 
 const irep_idt irept::s_type = dstring("type");
 const irep_idt irept::s_arguments = dstring("arguments");

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -281,6 +281,11 @@ public:
     return get_bool(a_need_vptr_init);
   }
 
+  inline bool need_lambda_init() const
+  {
+    return get_bool(a_need_lambda_init);
+  }
+
   inline const irep_idt &property() const
   {
     return get(a_property);
@@ -972,6 +977,11 @@ public:
     set(a_need_vptr_init, val);
   }
 
+  inline void need_lambda_init(bool val)
+  {
+    set(a_need_lambda_init, val);
+  }
+
   inline void restricted(bool val)
   {
     set(a_restricted, val);
@@ -1274,7 +1284,7 @@ public:
    * annotation to indicate whether virtual pointer(vptr) has been initialized in contrustor
    * This is used by implicit IR generation in adjuster
    */
-  static const irep_idt a_need_vptr_init;
+  static const irep_idt a_need_vptr_init, a_need_lambda_init;
 
   static const irep_idt id_address_of, id_and, id_or, id_array, id_bool,
     id_code;


### PR DESCRIPTION
Here is AST for lambda expr:
```c
| |       `-LambdaExpr 0x6f82f10 <col:28, line:22:9> '(lambda at main6.cpp:19:28)'
| |         |-CXXRecordDecl 0x6f82a78 <line:19:28> col:28 implicit class definition
| |         | |-DefinitionData lambda pass_in_registers standard_layout trivially_copyable literal can_const_default_init
| |         | | |-DefaultConstructor
| |         | | |-CopyConstructor simple trivial has_const_param needs_implicit implicit_has_const_param
| |         | | |-MoveConstructor exists simple trivial needs_implicit
| |         | | |-CopyAssignment trivial has_const_param needs_implicit implicit_has_const_param
| |         | | |-MoveAssignment
| |         | | `-Destructor simple irrelevant trivial
| |         | |-CXXMethodDecl 0x6f82bc0 <col:35, line:22:9> line:19:28 used constexpr operator() 'void () const' inline
| |         | | `-CompoundStmt 0x6f82d18 <line:20:9, line:22:9>
| |         | |   `-UnaryOperator 0x6f82d00 <line:21:13, col:17> 'int' postfix '++'
| |         | |     `-MemberExpr 0x6f82cd0 <col:13> 'int' lvalue ->data 0x6f828a8
| |         | |       `-CXXThisExpr 0x6f82cc0 <col:13> 'classB *' implicit this
| |         | |-FieldDecl 0x6f82e98 <line:19:29> col:29 implicit 'classB *'
| |         | `-CXXDestructorDecl 0x6f82f40 <col:28> col:28 implicit referenced ~(lambda at main6.cpp:19:28) 'void () noexcept' inline default trivial
```

When parsing the operator, the AST declares the original variable (this->data), however we should use a member variable (__this) from the lambda class, so we try to replace the operator expression in this PR.

Before:
```
operator() (c:@S@classB@F@foo#@Sa@F@operator()#1):
        // 30 file main6.cpp line 21 column 13 function operator()
        ASSIGN this->data=this->data + 1;                      
        // 31 file main6.cpp line 22 column 9 function operator()
        END_FUNCTION // operator()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
failed: "data" is not a member of lambda
```

this PR:
```
operator() (c:@S@classB@F@foo#@Sa@F@operator()#1):
        // 30 file main6.cpp line 21 column 13 function operator()
        ASSIGN this->__this->data=this->__this->data + 1;
        // 31 file main6.cpp line 22 column 9 function operator()
        END_FUNCTION // operator()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I tried to be as robust as possible, but the AST provides very limited information, and I expected better methods.