### PR TITLE
[TCs] add TCs for C++14 lambda capture init

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -130,6 +130,7 @@ set(REGRESSIONS_CPP11 esbmc-cpp11/cpp
 # list of C++14 test suites
 set(REGRESSIONS_CPP14 esbmc-cpp14/cpp
                       esbmc-cpp14/deduced-return-type
+                      esbmc-cpp14/lambda
                       esbmc-cpp14/template
                       )
 

--- a/regression/esbmc-cpp14/lambda/capture-init-fail/main.cpp
+++ b/regression/esbmc-cpp14/lambda/capture-init-fail/main.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+
+int main()
+{
+  int x = 42;
+  int y = 1;
+
+  auto lambda_with_capture_init_1 = [=, bar = 11]() {
+    assert(x == 421);
+    assert(y == 11);
+    assert(bar == 111);
+  };
+
+  auto lambda_with_capture_init_2 = [x, y, bar = 11]() {
+    assert(x == 421);
+    assert(y == 11);
+    assert(bar == 111);
+  };
+
+  auto lambda_with_capture_init_3 = [&, bar = 11]() {
+    y++;
+    assert(x == 421);
+    assert(y == 21);
+    assert(bar == 111);
+  };
+
+  auto lambda_with_capture_init_4 = [&x, &y, bar = 11]() {
+    y++;
+    assert(x == 421);
+    assert(y == 31);
+    assert(bar == 111);
+  };
+
+  int xx = 4;
+
+  auto yy = [&r = xx, xx = xx + 1]() -> int {
+    r += 2;
+    return xx * xx;
+  }(); // updates ::xx to 6 and initializes yy to 25.
+  assert(yy == 251);
+  assert(xx == 61);
+
+  struct test
+  {
+    int first;
+    int second;
+  };
+
+  struct test testStruct = {111, 444};
+  auto yyy = [&r = testStruct, testStruct2 = test{}]() -> int {
+    assert(r.first == 1111);
+    assert(r.second == 4441);
+    assert(testStruct2.first == 101);
+    assert(testStruct2.second == 101);
+    r.first++;
+    r.second = 222;
+    return r.second + r.first + testStruct2.first + testStruct2.second;
+  }();
+  assert(yyy == 3341);
+  assert(testStruct.first == 1121);
+  assert(testStruct.second == 2221);
+
+  // Call the lambda
+  lambda_with_capture_init_1();
+  lambda_with_capture_init_2();
+  lambda_with_capture_init_3();
+  lambda_with_capture_init_4();
+
+  return 0;
+}

--- a/regression/esbmc-cpp14/lambda/capture-init-fail/test.desc
+++ b/regression/esbmc-cpp14/lambda/capture-init-fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--std c++14
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp14/lambda/capture-init/main.cpp
+++ b/regression/esbmc-cpp14/lambda/capture-init/main.cpp
@@ -1,0 +1,70 @@
+#include <cassert>
+
+int main()
+{
+  int x = 42;
+  int y = 1;
+
+  auto lambda_with_capture_init_1 = [=, bar = 11]() {
+    assert(x == 42);
+    assert(y == 1);
+    assert(bar == 11);
+  };
+
+  auto lambda_with_capture_init_2 = [x, y, bar = 11]() {
+    assert(x == 42);
+    assert(y == 1);
+    assert(bar == 11);
+  };
+
+  auto lambda_with_capture_init_3 = [&, bar = 11]() {
+    y++;
+    assert(x == 42);
+    assert(y == 2);
+    assert(bar == 11);
+  };
+
+  auto lambda_with_capture_init_4 = [&x, &y, bar = 11]() {
+    y++;
+    assert(x == 42);
+    assert(y == 3);
+    assert(bar == 11);
+  };
+
+  int xx = 4;
+
+  auto yy = [&r = xx, xx = xx + 1]() -> int {
+    r += 2;
+    return xx * xx;
+  }(); // updates ::xx to 6 and initializes yy to 25.
+  assert(yy == 25);
+  assert(xx == 6);
+
+  struct test
+  {
+    int first;
+    int second;
+  };
+
+  struct test testStruct = {111, 444};
+  auto yyy = [&r = testStruct, testStruct2 = test{}]() -> int {
+    assert(r.first == 111);
+    assert(r.second == 444);
+    assert(testStruct2.first == 0);
+    assert(testStruct2.second == 0);
+    r.first++;
+    r.second = 222;
+    return r.second + r.first + testStruct2.first + testStruct2.second;
+  }();
+  assert(yyy == 334);
+  assert(testStruct.first == 112);
+  assert(testStruct.second == 222);
+
+  // Call the lambda
+  lambda_with_capture_init_1();
+  lambda_with_capture_init_2();
+  lambda_with_capture_init_3();
+  lambda_with_capture_init_4();
+
+  return 0;
+}

--- a/regression/esbmc-cpp14/lambda/capture-init/test.desc
+++ b/regression/esbmc-cpp14/lambda/capture-init/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--std c++14
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Currently all TCs fail with:
```
esbmc: /home/sg/dev/esbmc-contributing/src/pointer-analysis/value_set.cpp:545: void value_sett::get_value_set_rec(const expr2tc&, object_mapt&, const std::string&, const type2tc&, bool) const: Assertion `sym.rlevel != symbol2t::renaming_level::level2_global' failed.
```

likely because the referenced parameter can not be found as mentioned in https://github.com/esbmc/esbmc/pull/2168#issuecomment-2508702294