### PR TITLE
Keep sv-benchmarks up to date

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all --tags && { [ "${{inputs_svbenchmarks}}" == "main" ] && git checkout main && git reset --hard origin/main || git checkout ${{inputs_svbenchmarks}}}
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags && { [ "${{inputs.svbenchmarks}}" == "main" ] && git checkout main && git reset --hard origin/main || git checkout ${{inputs.svbenchmarks}}}
       - name: Download Linux Build
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all --tags && { [ "${{inputs.svbenchmarks}}" == "main" ] && git checkout main && git reset --hard origin/main || git checkout ${{inputs.svbenchmarks}}}
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags && { [ "${{ inputs.svbenchmarks }}" == "main" ] && git checkout main && git reset --hard origin/main || git checkout ${{ inputs.svbenchmarks }} }
       - name: Download Linux Build
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all --tags && { [ "${{ inputs.svbenchmarks }}" == "main" ] && git checkout main && git reset --hard origin/main || git checkout ${{ inputs.svbenchmarks }} }
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }} && [ "${{ inputs.svbenchmarks }}" == "main" ] && git reset --hard origin/main
       - name: Download Linux Build
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }} && [ "${{ inputs.svbenchmarks }}" == "main" ] && git reset --hard origin/main
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }} && if [ "${{ inputs.svbenchmarks }}" == "main" ]; then git reset --hard origin/main; fi
       - name: Download Linux Build
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -107,7 +107,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }}
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags && { [ "${{inputs_svbenchmarks}}" == "main" ] && git checkout main && git reset --hard origin/main || git checkout ${{inputs_svbenchmarks}}}
       - name: Download Linux Build
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
We are currently running the sv-benchmarks main branch, but the repos in different machines are behind with origin/master,  which results in different benchmark set:

https://github.com/esbmc/esbmc/actions/runs/12088163144
https://github.com/esbmc/esbmc/actions/runs/12088171663

This PR keeps the main branch up-to-date with origin/master (if we are benchmarking main branch).