### PR TITLE
[Concurrency] New thread schedule policy

### DIFF
--- a/regression/esbmc-unix2/github_402_fail3/test.desc
+++ b/regression/esbmc-unix2/github_402_fail3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --no-por --no-goto-merge
-^ERROR: There are goto statements that shouldn't be merged at this point$
+^VERIFICATION FAILED$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -256,7 +256,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
                  check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
-    command_line += " --no-por --context-bound 2 "
+    command_line += " --no-por --context-bound 3 --default-solver bitwuzla --smt-symex-assume "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -256,7 +256,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
                  check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
-    command_line += " --no-por --context-bound 3 --default-solver bitwuzla --smt-symex-assume "
+    command_line += " --no-por --context-bound 2 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -162,32 +162,42 @@ bool reachability_treet::step_next_state()
 unsigned int
 reachability_treet::decide_ileave_direction(execution_statet &ex_state)
 {
-  unsigned int tid = 0, user_tid = 0;
+  auto is_thread_schedulable = [&](int tid) {
+    return check_thread_viable(tid, true) && ex_state.dfs_explore_thread(tid);
+  };
 
+  signed int tid = 0, user_tid = 0;
+
+  // Get thread ID from user if interactive mode is enabled
+  tid = get_cur_state().active_thread + 1;
   if (interactive_ileaves)
   {
     tid = get_ileave_direction_from_user();
     user_tid = tid;
   }
 
-  for (; tid < ex_state.threads_state.size(); tid++)
+  // Try finding a schedulable thread in the forward direction
+  for (; tid < (int)ex_state.threads_state.size(); ++tid)
   {
-    /* For all threads: */
-    if (!check_thread_viable(tid, true))
-      continue;
-
-    if (!ex_state.dfs_explore_thread(tid))
-      continue;
-
-#if 0
-    //apply static partial-order reduction
-    if (por && !ex_state.is_thread_mpor_schedulable(tid))
-      continue;
-#endif
-
-    break;
+    if (is_thread_schedulable(tid))
+      break;
   }
 
+  // If no thread was found, search in the reverse direction
+  if (tid == (int)ex_state.threads_state.size())
+  {
+    for (tid = get_cur_state().active_thread; tid >= 0; --tid)
+    {
+      if (is_thread_schedulable(tid))
+        break;
+    }
+  }
+
+  // If no valid thread is found, set tid to the size of threads_state
+  if (tid < 0)
+    tid = ex_state.threads_state.size();
+
+  // Validate user choice in interactive mode
   if (interactive_ileaves && tid != user_tid)
   {
     log_error("Ileave code selected different thread from user choice");


### PR DESCRIPTION
When context switch happens, current thread schedule policy is trying to start with the lowest thread id (tid = 0) and then increase the thread id, but this is not very efficient for bug detection, because the newly created thread will be the last to switch to, and the interleaving could not reach deeper child threads quickly.

Here introduces a new policy: for a list of threads: [0,1,2, 3, active_thread, 4, 5, n-1], when a context switch occurs at active_thread, it first traverse to the right until n-1, if no threads can be scheduled, then reverse from active_thread to explore the left until reach 0.

 This PR with` --context bound 3 --no-por`
```
Statistics:            725 Files
  correct:             425
    correct true:      131
    correct false:     294
  incorrect:            10
    incorrect true:      6
    incorrect false:     4
  unknown:             290
  Score:               300 (max: 1099)
```

Master with `--context-bound 2 --no-por`
```
Statistics:            725 Files
  correct:             426
    correct true:      137
    correct false:     289
  incorrect:            11
    incorrect true:      8
    incorrect false:     3
  unknown:             288
  Score:               259 (max: 1099)
```
There are 2 more incorrect false from new benchmark set `libvsync` (Timeout to incorrect false), should be a guard bug, I will need to take a look today.

BTW, symex-assume didn't improve the result, the previous runs are based on different benchmark set :) (See #2177 )
This PR with `--default-solver bitwuzla --smt-symex-assume --context-bound 3 --no-por`
```
Statistics:            725 Files
  correct:             409
    correct true:      119
    correct false:     290
  incorrect:            10
    incorrect true:      6
    incorrect false:     4
  unknown:             306
  Score:               272 (max: 1099)
```
It runs faster in a subset of benchmarks though, should take a look this week.