### PR TITLE
[cex] fix get array from tuple

### DIFF
--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2563,6 +2563,7 @@ expr2tc smt_convt::get_array(const type2tc &type, smt_astt array)
   array_type2t ar = to_array_type(flat_type);
   expr2tc arr_size;
   if (type == flat_type)
+    // avoid handelling the flattend multidimensional arrays
     arr_size = to_array_type(flat_type).array_size;
   else
     arr_size = constant_int2tc(index_type2(), BigInt(1ULL << w));

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2561,9 +2561,10 @@ expr2tc smt_convt::get_array(const type2tc &type, smt_astt array)
 
   const type2tc flat_type = flatten_array_type(type);
   array_type2t ar = to_array_type(flat_type);
+
   expr2tc arr_size;
-  if (type == flat_type)
-    // avoid handelling the flattend multidimensional arrays
+  if (type == flat_type && !ar.size_is_infinite)
+    // avoid handelling the flattend multidimensional and malloc arrays(assume size is infinite)
     arr_size = to_array_type(flat_type).array_size;
   else
     arr_size = constant_int2tc(index_type2(), BigInt(1ULL << w));

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2559,14 +2559,29 @@ expr2tc smt_convt::get_array(const type2tc &type, smt_astt array)
   if (w > 10)
     w = 10;
 
-  array_type2t ar = to_array_type(flatten_array_type(type));
-  expr2tc arr_size = constant_int2tc(index_type2(), BigInt(1ULL << w));
+  const type2tc flat_type = flatten_array_type(type);
+  array_type2t ar = to_array_type(flat_type);
+  expr2tc arr_size;
+  if (type == flat_type)
+    arr_size = to_array_type(flat_type).array_size;
+  else
+    arr_size = constant_int2tc(index_type2(), BigInt(1ULL << w));
+
   type2tc arr_type = array_type2tc(ar.subtype, arr_size, false);
   std::vector<expr2tc> fields;
 
   bool uses_tuple_api = is_tuple_array_ast_type(type);
 
-  for (size_t i = 0; i < (1ULL << w); i++)
+  BigInt elem_size;
+  if (is_constant_int2t(arr_size))
+  {
+    elem_size = to_constant_int2t(arr_size).value;
+    assert(elem_size.is_uint64());
+  }
+  else
+    elem_size = BigInt(1ULL << w);
+
+  for (size_t i = 0; i < elem_size; i++)
   {
     expr2tc elem;
     if (uses_tuple_api)

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -186,10 +186,9 @@ expr2tc smt_tuple_node_flattener::tuple_get_rec(tuple_node_smt_astt tuple)
           "sorry");
         abort();
       }
-      log_warning(
-        "Fetching array elements inside tuples currently unimplemented, "
-        "returning empty expression...");
-      res = expr2tc();
+
+      // this will eventually jump to get_array()
+      res = ctx->get_by_ast(it, tuple->elements[i]);
     }
     else
     {


### PR DESCRIPTION
Issue #2181 

After fix:
```sh
[Counterexample]


State 1 file 1.c line 8 column 5 function main thread 0
----------------------------------------------------
  data = { .values={ 0, 0, 0, 2, 0 } }

State 2 file 1.c line 9 column 5 function main thread 0
----------------------------------------------------
Violated property:
  file 1.c line 9 column 5 function main
  assertion data.values[3] !=2
  data.values[3] != 2


VERIFICATION FAILED

Bug found (k = 1)
```

---

Issue #2182 

After fix:

```sh
[Counterexample]


State 1 file 2.c line 8 column 5 function main thread 0
----------------------------------------------------
  values = { 0, 9, 0, 0, 0 }

State 2 file 2.c line 9 column 5 function main thread 0
----------------------------------------------------
Violated property:
  file 2.c line 9 column 5 function main
  assertion values[1] == 10
  values[1] == 10


VERIFICATION FAILED

Bug found (k = 1)
```

---

This, however, does not fix ##362. In fact, I do not think we can do anything with that issue.