### PR TITLE
[SMT] set empty class/struct one width

### DIFF
--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -200,7 +200,7 @@ unsigned int struct_type2t::get_width() const
   for (it = members.begin(); it != members.end(); it++)
     width += (*it)->get_width();
 
-  return width;
+  return width == 0 ? 1 : width;
 }
 
 unsigned int union_type2t::get_width() const

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -94,6 +94,9 @@ static expr2tc flatten_to_bitvector(const expr2tc &new_expr)
 
     size_t sz = structtype.members.size();
 
+    if (sz == 0)
+      return constant_int2tc(get_uint_type(0), BigInt(0));
+
     // Iterate over each member and flatten them
 
     auto extract = [&](size_t i) {

--- a/src/util/type_byte_size.cpp
+++ b/src/util/type_byte_size.cpp
@@ -143,7 +143,7 @@ BigInt type_sizet::size_bits(const type2tc &type) const
     // At the end of that, the tests above should have rounded accumulated size
     // up to a size that contains the required trailing padding for array
     // allocation alignment.
-    return accumulated_size;
+    return accumulated_size == 0 ? 1 : accumulated_size;
   }
 
   case type2t::union_id:


### PR DESCRIPTION
https://www.geeksforgeeks.org/why-is-the-size-of-an-empty-class-not-zero-in-c/

As we discussed in https://github.com/esbmc/esbmc/issues/2180#issuecomment-2524253174, it may be necessary to allocate a byte for an empty Class, which currently exists only in C++:

```cpp
#include <map>
#include <string>
#include <tuple>

using namespace std;

int main() {
    map<tuple<string>, int> x;
    tuple<string> tmp;

    x[tmp];

    return 0;
}
```

This PR attempts to modify the bit width of empty class and fixes the assertion violation during SMT, however, it seems that our alignment check is giving it an error, so I think we need to add additional modifications to it.

`Incorrect alignment when accessing data object`
I'm confused about this error. I don't understand the part that breaks the check.
