### PR TITLE
[Concurrency] Guard and Interleavings fix

### DIFF
--- a/regression/esbmc-unix/SV_COMP_03/test.desc
+++ b/regression/esbmc-unix/SV_COMP_03/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --context-bound 2 --no-assertions --data-races-check -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -256,7 +256,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
                  check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
-    command_line += " --no-por --context-bound 2 "
+    command_line += " --no-por --context-bound 3 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -256,7 +256,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
                  check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
-    command_line += " --no-por --context-bound 3 "
+    command_line += " --no-por --context-bound 2 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -202,8 +202,9 @@ void execution_statet::symex_step(reachability_treet &art)
 
   merge_gotos();
 
-  // If current state guard is false, it shouldn't perform further context switch. 
-  if (!state.guard.is_false() || !is_cur_state_guard_false(state.guard.as_expr()))
+  // If current state guard is false, it shouldn't perform further context switch.
+  if (
+    !state.guard.is_false() || !is_cur_state_guard_false(state.guard.as_expr()))
     interleaving_unviable = false;
   else
     interleaving_unviable = true;

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -202,6 +202,7 @@ void execution_statet::symex_step(reachability_treet &art)
 
   merge_gotos();
 
+  // If current state guard is false, it shouldn't perform further context switch. 
   if (!state.guard.is_false() || !is_cur_state_guard_false(state.guard.as_expr()))
     interleaving_unviable = false;
   else
@@ -707,6 +708,7 @@ void execution_statet::execute_guard()
   // evaluating a particular interleaving early right now.
   if (is_false(parent_guard) || is_cur_state_guard_false(parent_guard))
   {
+    // A context switch happens, add last thread state guard to assumption.
     if (active_thread != last_active_thread)
     {
       target->assumption(

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -202,10 +202,10 @@ void execution_statet::symex_step(reachability_treet &art)
 
   merge_gotos();
 
-  if (state.guard.is_false() || is_cur_state_guard_false(state.guard.as_expr()))
-    interleaving_unviable = true;
-  else
+  if (!state.guard.is_false() || !is_cur_state_guard_false(state.guard.as_expr()))
     interleaving_unviable = false;
+  else
+    interleaving_unviable = true;
 
   if (break_insn != 0 && break_insn == instruction.location_number)
   {

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -563,7 +563,9 @@ goto_symext::symex_resultt reachability_treet::get_next_formula()
 
     next_thread_id = decide_ileave_direction(get_cur_state());
 
-    if (get_cur_state().interleaving_unviable && next_thread_id != get_cur_state().active_thread)
+    if (
+      get_cur_state().interleaving_unviable &&
+      next_thread_id != get_cur_state().active_thread)
       break;
     create_next_state();
 

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -563,7 +563,7 @@ goto_symext::symex_resultt reachability_treet::get_next_formula()
 
     next_thread_id = decide_ileave_direction(get_cur_state());
 
-    if (get_cur_state().interleaving_unviable)
+    if (get_cur_state().interleaving_unviable && next_thread_id != get_cur_state().active_thread)
       break;
     create_next_state();
 


### PR DESCRIPTION
This PR https://github.com/esbmc/esbmc/actions/runs/12218538927
The result score is the same as master: 
`--context-bound 3 --no-por`

```
Statistics:            725 Files
  correct:             425
    correct true:      131
    correct false:     294
  incorrect:            10
    incorrect true:      6
    incorrect false:     4
  unknown:             290
  Score:               300 (max: 1099)
```
But verification time is improved slightly:

![image](https://github.com/user-attachments/assets/be42c130-47ea-4950-9401-ca9348bc3cf0)

Master:
Correct true: 6650s
Correct false: 4890s

This PR:
Correct true: 6610s
Correct false: 4340s