### PR TITLE
[Concurrency] Remove Global Guard

### DIFF
--- a/regression/esbmc-solidity/github_497_5/test.desc
+++ b/regression/esbmc-solidity/github_497_5/test.desc
@@ -1,5 +1,4 @@
 CORE
 MyContract_array.solast
 --function func_array --falsification --sol MyContract_array.sol
-.*line 13 function func_array$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/global_guard/main.c
+++ b/regression/esbmc-unix/global_guard/main.c
@@ -1,0 +1,14 @@
+#include <pthread.h>
+#include <assert.h>
+pthread_t c;
+int d;
+void *e(void *) { d = 6; }
+int main() {
+  if (nondet_bool()) {
+    pthread_create(&c, NULL, e, NULL);
+    return 0;
+  }
+  d = 3;
+  assert(d == 0);  // should be fail
+  return 0;
+}

--- a/regression/esbmc-unix/global_guard/test.desc
+++ b/regression/esbmc-unix/global_guard/test.desc
@@ -1,0 +1,3 @@
+CORE
+main.c
+^VERIFICATION FAILED$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -688,8 +688,6 @@ void goto_symext::intrinsic_set_thread_data(
   expr2tc threadid = call.operands[0];
   expr2tc startdata = call.operands[1];
 
-  // TODO: remove this global guard
-  state.global_guard.add(cur_state->guard.as_expr());
   state.rename(threadid);
   state.rename(startdata);
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -66,8 +66,6 @@ execution_statet::execution_statet(
   threads_state.push_back(state);
   preserved_paths.emplace_back();
   cur_state = &threads_state.front();
-  cur_state->global_guard.make_true();
-  cur_state->global_guard.add(get_guard_identifier());
 
   atomic_numbers.push_back(0);
 
@@ -746,8 +744,6 @@ unsigned int execution_statet::add_thread(const goto_programt *prog)
   unsigned int thread_nr = threads_state.size();
   new_state.source.thread_nr = thread_nr;
   new_state.guard = cur_state->guard;
-  new_state.global_guard.make_true();
-  new_state.global_guard.add(get_guard_identifier());
   threads_state.push_back(new_state);
   preserved_paths.emplace_back();
   atomic_numbers.push_back(0);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -36,7 +36,6 @@ goto_symex_statet &goto_symex_statet::operator=(const goto_symex_statet &state)
   num_instructions = state.num_instructions;
   thread_ended = state.thread_ended;
   guard = state.guard;
-  global_guard = state.global_guard;
   source = state.source;
   variable_instance_nums = state.variable_instance_nums;
   loop_iterations = state.loop_iterations;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -434,8 +434,6 @@ public:
 
   /** Current state guard of this thread. */
   guardt guard;
-  /** Guard of global context. */
-  guardt global_guard;
   /** Current program location of this thread. */
   symex_targett::sourcet source;
   /** Counter for how many times a particular variable has been declared:

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -107,7 +107,6 @@ void goto_symext::assertion(
 {
   expr2tc expr = the_assertion;
   cur_state->guard.guard_expr(expr);
-  cur_state->global_guard.guard_expr(expr);
   remaining_claims++;
   target->assertion(
     cur_state->guard.as_expr(),


### PR DESCRIPTION
This PR fixes #1991.

Full bechexec run with 30s: https://github.com/esbmc/esbmc/actions/runs/12225704810

```
Statistics:          33569 Files
  correct:           18523
    correct true:    11184
    correct false:    7339
  incorrect:            83
    incorrect true:     62
    incorrect false:    21
  unknown:           14961
  Score:             27387 (max: 55885)
```
Master:

```
Statistics:          33569 Files
  correct:           18489
    correct true:    11159
    correct false:    7330
  incorrect:            82
    incorrect true:     61
    incorrect false:    21
  unknown:           14998
  Score:             27360 (max: 55885)
```

Concurrent: https://github.com/esbmc/esbmc/actions/runs/12226524553
```
Statistics:            725 Files
  correct:             425
    correct true:      131
    correct false:     294
  incorrect:            10
    incorrect true:      6
    incorrect false:     4
  unknown:             290
  Score:               300 (max: 1099)
```