### PR TITLE
[C++ verification] Fix cpp new alloc size

### DIFF
--- a/regression/esbmc-cpp/algorithm/algorithm32/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm32/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm34/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm34/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm35/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm35/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm39/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm39/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_2151/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_2151/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 7
+--unwind 1 --no-unwinding-assertion
 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_float/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_float/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/algorithm34/test.desc
+++ b/regression/esbmc-cpp/vector/algorithm34/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/vector11/test.desc
+++ b/regression/esbmc-cpp/vector/vector11/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/vector13/test.desc
+++ b/regression/esbmc-cpp/vector/vector13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/vector14/test.desc
+++ b/regression/esbmc-cpp/vector/vector14/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -2293,46 +2293,30 @@ void pop_heap(RanIt first, RanIt last, Pr pred)
 template <class RanIt>
 void make_heap(RanIt first, RanIt last)
 {
-  int n = 0;
-  RanIt t = first;
-  while (t++ != last)
-    n++;
-  int i = n / 2;
-  int parent, child;
-  t = last;
-  for (int j = 0; j < n / 2; j++)
+  auto n = last - first;
+
+  for (int i = (n / 2) - 1; i >= 0; --i)
   {
-    if (i > 0)
+    int parent = i;
+    auto value = *(first + parent);
+    while (1)
     {
-      i--;
-      *t = *(first + i);
-    }
-    else
-    {
-      n--;
-      if (n == 0)
-      {
-        return;
-      }
-      *t = *(first + n);
-      *(first + n) = *first;
-    }
-    parent = i;
-    child = i * 2 + 1;
-    while (child < n)
-    {
-      if ((child + 1 < n) && (*(first + child + 1) > *(first + child)))
-        child++;
-      if (*(first + child) > *t)
+      int child = 2 * parent + 1;
+      if (child >= n)
+        break;
+
+      if (child + 1 < n && *(first + child + 1) > *(first + child))
+        ++child;
+
+      if (*(first + child) > value)
       {
         *(first + parent) = *(first + child);
         parent = child;
-        child = parent * 2 + 1;
       }
       else
         break;
     }
-    *(first + parent) = *t;
+    *(first + parent) = value;
   }
 }
 

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -1875,7 +1875,7 @@ __ESBMC_HIDE:
     two[k] = this->str[i];
   }
   int totalLen = s.length() + len;
-  this->str = new char[totalLen];
+  this->str = new char[totalLen + 1];
   this->_size = totalLen;
 
   for (i = 0; i < lenOne - 1; i++)

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -130,9 +130,9 @@ public:
   // construct:
   explicit vector() : _size(0), _capacity(1)
   {
-    buf = new T[1];
+    buf = new T[10];
     _size = 0;
-    _capacity = 1;
+    _capacity = 10;
   }
 
   explicit vector(iterator t1, iterator t2) : _size(0)

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -302,7 +302,7 @@ void goto_convertt::do_cpp_new(
     remove_sideeffects(alloc_size, dest);
 
     // jmorse: multiply alloc size by size of subtype.
-    type2tc subtype = migrate_type(rhs.type());
+    type2tc subtype = migrate_type(ns.follow(rhs.type().subtype()));
     expr2tc alloc_units;
     migrate_expr(alloc_size, alloc_units);
 


### PR DESCRIPTION
This issue has been around since we used the wrong type to calculate the allocation size for cpp new in the past, which resulted in the failure to detect some buffer overflows, such as:

```c
char *p = new char[10];
p[11]; -->ver successful in master
```

The TCs failed is mainly due to the `push_back` in vector, which uses `realloc`, which has been problematic:
https://github.com/esbmc/esbmc/issues/2005
https://github.com/esbmc/esbmc/issues/1982#issuecomment-2290909339

I'm thinking about getting OM out of `realloc`.