### PR TITLE
Prevent recursion when parsing a member function that calls itself

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+
+struct a
+{
+  int b(int i)
+  {
+    if (i == 0)
+    {
+      return i;
+    }
+    else
+    {
+      return i + b(i - 1);
+    }
+  }
+};
+int main()
+{
+  a a;
+  assert(a.b(2) == 3);
+}

--- a/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call_fail/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+
+struct a
+{
+  int b(int i)
+  {
+    if (i == 0)
+    {
+      return i;
+    }
+    else
+    {
+      return i + b(i - 1);
+    }
+  }
+};
+int main()
+{
+  a a;
+  assert(a.b(2) == 33333);
+}

--- a/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/63_recursion_cxx_member_call_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ch17_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_5/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ch17_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch17_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/nec_ex1-bintree-duplicate/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex1-bintree-duplicate/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1496,7 +1496,8 @@ bool clang_c_convertert::get_bitfield_type(
   if (get_expr(*fd.getBitWidth(), width))
     return true;
 
-  new_type = unsignedbv_typet(result.Val.getInt().getSExtValue());
+  new_type = orig_type;
+  new_type.width(result.Val.getInt().getSExtValue());
   new_type.set("#bitfield", true);
   new_type.subtype() = orig_type;
   return false;

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -196,7 +196,7 @@ protected:
 
   bool get_atomic_expr(const clang::AtomicExpr &atm, exprt &new_expr);
 
-  virtual bool get_member_expr(const clang::MemberExpr &memb,exprt &new_expr);
+  virtual bool get_member_expr(const clang::MemberExpr &memb, exprt &new_expr);
 
   bool get_cast_expr(const clang::CastExpr &cast, exprt &new_expr);
 

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -178,6 +178,11 @@ protected:
 
   bool get_builtin_type(const clang::BuiltinType &bt, typet &new_type);
 
+  bool get_bitfield_type(
+    const clang::FieldDecl &,
+    const typet &orig_type,
+    typet &new_type);
+
   virtual bool get_expr(const clang::Stmt &stmt, exprt &new_expr);
 
   bool get_enum_value(const clang::EnumConstantDecl *e, exprt &new_expr);

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -196,6 +196,8 @@ protected:
 
   bool get_atomic_expr(const clang::AtomicExpr &atm, exprt &new_expr);
 
+  virtual bool get_member_expr(const clang::MemberExpr &memb,exprt &new_expr);
+
   bool get_cast_expr(const clang::CastExpr &cast, exprt &new_expr);
 
   void get_default_symbol(

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1969,6 +1969,19 @@ bool clang_cpp_convertert::annotate_class_method(
   return false;
 }
 
+bool clang_cpp_convertert::get_member_expr(
+  const clang::MemberExpr &memb,
+  exprt &new_expr)
+{
+  if (!perform_virtual_dispatch(memb))
+    return clang_c_convertert::get_member_expr(memb, new_expr);
+
+  if (get_vft_binding_expr(memb, new_expr))
+    return true;
+
+  return false;
+}
+
 void clang_cpp_convertert::gen_typecast_base_ctor_call(
   const exprt &callee_decl,
   side_effect_expr_function_callt &call,

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1973,13 +1973,10 @@ bool clang_cpp_convertert::get_member_expr(
   const clang::MemberExpr &memb,
   exprt &new_expr)
 {
-  if (!perform_virtual_dispatch(memb))
-    return clang_c_convertert::get_member_expr(memb, new_expr);
+  if (perform_virtual_dispatch(memb))
+    return get_vft_binding_expr(memb, new_expr);
 
-  if (get_vft_binding_expr(memb, new_expr))
-    return true;
-
-  return false;
+  return clang_c_convertert::get_member_expr(memb, new_expr);
 }
 
 void clang_cpp_convertert::gen_typecast_base_ctor_call(

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -528,7 +528,7 @@ protected:
    */
   void make_temporary(exprt &expr);
 
-  bool get_member_expr(const clang::MemberExpr &memb,exprt &new_expr) override;
+  bool get_member_expr(const clang::MemberExpr &memb, exprt &new_expr) override;
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -527,6 +527,8 @@ protected:
    *  expr: ESBMC IR to represent Function call
    */
   void make_temporary(exprt &expr);
+
+  bool get_member_expr(const clang::MemberExpr &memb,exprt &new_expr) override;
 };
 
 #endif /* CLANG_C_FRONTEND_CLANG_C_CONVERT_H_ */


### PR DESCRIPTION
It should replace PR #2011 

We split the handling of members and removed the recursive call that may cause an infinite recursion.