### PR TITLE
[SMT] fix pointer typecast for byte update

### DIFF
--- a/regression/esbmc/github_2153/main.c
+++ b/regression/esbmc/github_2153/main.c
@@ -1,0 +1,10 @@
+int some_var;
+
+int main()
+{
+  void *bar;
+  char *ptr = &bar;
+  ptr[0] = nondet_char();
+
+  __ESBMC_assert(bar != &some_var, "");
+}

--- a/regression/esbmc/github_2153/test.desc
+++ b/regression/esbmc/github_2153/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -507,22 +507,26 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
 
   if (is_byte_update2t(cast.from))
   {
-    // byte_update(nondet_sym, offset, update) special handling is needed
-    // in this case cause the nondet pointer cannot match any address
-    // Assign obj of int_to_ptr to nondet pointer obj
+    // Handle byte_update(nondet_sym, offset, update) case
+    // The nondet pointer cannot match any address.
+    // Assign the object of int_to_ptr to the nondet pointer's object.
     byte_update2t bu = to_byte_update2t(cast.from);
     bitcast2t bc = to_bitcast2t(bu.source_value);
     smt_astt sym = convert_ast(bc.from);
+
+    // Convert symbolic representation and project the object
     smt_astt obj = sym->project(this, 0);
     inv_obj = obj;
 
+    // Derive the numeric representation of the pointer object
+    // Access the current address space using obj_num as an index
     expr2tc obj_num = pointer_object2tc(ptraddr_type2(), bc.from);
     expr2tc from_addr = index2tc(
       addr_space_type,
       symbol2tc(addr_space_arr_type, get_cur_addrspace_ident()),
       obj_num);
 
-    // calculate the offset of byte_update: target - addr_start(nondet poiner obj)
+    // Compute the offset between target and the start address
     const struct_type2t &addr_space = to_struct_type(addr_space_type);
     expr2tc from_start =
       member2tc(addr_space.members[0], from_addr, addr_space.member_names[0]);

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -505,6 +505,33 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
   smt_astt inv_obj = id;
   smt_astt inv_offs = offs;
 
+  if (is_byte_update2t(cast.from))
+  {
+    // byte_update(nondet_sym, offset, update) special handling is needed
+    // in this case cause the nondet pointer cannot match any address
+    // Assign obj of int_to_ptr to nondet pointer obj
+    byte_update2t bu = to_byte_update2t(cast.from);
+    bitcast2t bc = to_bitcast2t(bu.source_value);
+    smt_astt sym = convert_ast(bc.from);
+    smt_astt obj = sym->project(this, 0);
+    inv_obj = obj;
+
+    expr2tc obj_num = pointer_object2tc(ptraddr_type2(), bc.from);
+    expr2tc from_addr = index2tc(
+      addr_space_type,
+      symbol2tc(addr_space_arr_type, get_cur_addrspace_ident()),
+      obj_num);
+
+    // calculate the offset of byte_update: target - addr_start(nondet poiner obj)
+    const struct_type2t &addr_space = to_struct_type(addr_space_type);
+    expr2tc from_start =
+      member2tc(addr_space.members[0], from_addr, addr_space.member_names[0]);
+
+    smt_astt addr_start = convert_ast(from_start);
+    inv_offs =
+      int_encoding ? mk_sub(target, addr_start) : mk_bvsub(target, addr_start);
+  }
+
   smt_astt obj_eq = inv_obj->eq(this, output_obj);
   smt_astt offs_eq = inv_offs->eq(this, output_offs);
   smt_astt is_inv = mk_and(obj_eq, offs_eq);


### PR DESCRIPTION
For this code:
```c
int some_var;

int main()
{
  void *bar;
  char *ptr = &bar;
  ptr[0] = nondet_char();
  
  __ESBMC_assert(bar != &some_var, "");
}
```
Nondet pointer breaks byte update, see details: https://github.com/esbmc/esbmc/issues/2153#issuecomment-2528543047

```c
ASSIGNMENT ()
bar?1!0&0#1 == nondet_symbol(symex::nondet0)

Thread 0 file main4.c line 7 column 12 function main
ASSIGNMENT ()
bar?1!0&0#2 == byte_update_little_endian(bar?1!0&0#1, 0, (unsigned char)(nondet_symbol(symex::nondet1)))
```

We take into account the constraint, the counterexample to `bar != &some_var` is `bar == &some_var`, i.e.
`byte_update_little_endian(bar, 0, symex::nondet1) == &some_var`

====> bar = &some_var
