### PR TITLE
[benchexec] Include all concurrency benchmarks in runset

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -137,7 +137,7 @@ jobs:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
       - name: Run Benchexec (RunSet)
-        if: ${{ inputs.mode == 'RunSet' }}
+        if: ${{ inputs.mode == 'RunSet'  && inputs.runset != 'SV-COMP25_ConcurrencySafety'}}
         run: ./esbmc-src/scripts/benchexec.sh -r ${{ inputs.runset }}
         env:
           TIMEOUT: ${{ inputs.timeout }}

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -35,6 +35,7 @@ on:
         - SV-COMP25_valid-memsafety
         - SV-COMP25_termination
         - SV-COMP25_no-overflow
+        - SV-COMP25_ConcurrencySafety
         - Custom
       task:
         type: choice

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Set up the custom runset
         if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'Custom' }}
         run: cp ./esbmc-src/scripts/competitions/svcomp/custom-reach.set $HOME/sv-benchmarks/c/ && mv ./esbmc-src/scripts/competitions/svcomp/custom.xml ./esbmc-src/scripts/competitions/svcomp/esbmc.xml
+      - name: Set up the Concurrency runset
+        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
+        run: mv ./esbmc-src/scripts/competitions/svcomp/ConcurrencySafety.xml ./esbmc-src/scripts/competitions/svcomp/esbmc.xml
       - name: Run Benchexec (Full)
         if: ${{ inputs.mode == 'Full' }}
         run: ./esbmc-src/scripts/benchexec.sh -f

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -130,6 +130,12 @@ jobs:
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
+      - name: Run Benchexec (ConcurrencyRunSet)
+        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
+        run: ./esbmc-src/scripts/benchexec.sh -f
+        env:
+          TIMEOUT: ${{ inputs.timeout }}
+          ESBMC_OPTS: ${{ inputs.options }}
       - name: Run Benchexec (RunSet)
         if: ${{ inputs.mode == 'RunSet' }}
         run: ./esbmc-src/scripts/benchexec.sh -r ${{ inputs.runset }}

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -130,12 +130,6 @@ jobs:
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
-      - name: Run Benchexec (ConcurrencyRunSet)
-        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
-        run: ./esbmc-src/scripts/benchexec.sh -f
-        env:
-          TIMEOUT: ${{ inputs.timeout }}
-          ESBMC_OPTS: ${{ inputs.options }}
       - name: Run Benchexec (RunSet)
         if: ${{ inputs.mode == 'RunSet' }}
         run: ./esbmc-src/scripts/benchexec.sh -r ${{ inputs.runset }}

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -130,9 +130,11 @@ jobs:
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
+      - name: Run Benchexec (ConcurrencyRunset)
+        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
       - name: Run Benchexec (RunSet)
         if: ${{ inputs.mode == 'RunSet' }}
-        run: ./esbmc-src/scripts/benchexec.sh -r ${{ inputs.runset }}
+        run: ./esbmc-src/scripts/benchexec.sh -f
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}

--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -130,11 +130,15 @@ jobs:
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
-      - name: Run Benchexec (ConcurrencyRunset)
+      - name: Run Benchexec (ConcurrencyRunSet)
         if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
+        run: ./esbmc-src/scripts/benchexec.sh -f
+        env:
+          TIMEOUT: ${{ inputs.timeout }}
+          ESBMC_OPTS: ${{ inputs.options }}
       - name: Run Benchexec (RunSet)
         if: ${{ inputs.mode == 'RunSet' }}
-        run: ./esbmc-src/scripts/benchexec.sh -f
+        run: ./esbmc-src/scripts/benchexec.sh -r ${{ inputs.runset }}
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}

--- a/scripts/competitions/svcomp/ConcurrencySafety.xml
+++ b/scripts/competitions/svcomp/ConcurrencySafety.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-2.3.dtd">
-<benchmark tool="esbmc" timelimit="15 min" memlimit="6 GB" cpuCores="2">
+<benchmark tool="esbmc" timelimit="15 min" memlimit="6 GB" cpuCores="1">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
 

--- a/scripts/competitions/svcomp/ConcurrencySafety.xml
+++ b/scripts/competitions/svcomp/ConcurrencySafety.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-2.3.dtd">
+<benchmark tool="esbmc" timelimit="15 min" memlimit="6 GB" cpuCores="2">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz"/>
+
+  <resultfiles>**/*.graphml</resultfiles>
+  
+  <option name="-s">kinduction</option>
+
+  <rundefinition name="SV-COMP25_ConcurrencySafety">
+    <tasks name="ConcurrencySafety-Main">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="NoDataRace-Main">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
+    </tasks>
+    <tasks name="ConcurrencySafety-MemSafety">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="ConcurrencySafety-NoOverflows">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
+  </rundefinition>
+
+</benchmark>

--- a/scripts/competitions/svcomp/ConcurrencySafety.xml
+++ b/scripts/competitions/svcomp/ConcurrencySafety.xml
@@ -8,19 +8,28 @@
   
   <option name="-s">kinduction</option>
 
-  <rundefinition name="SV-COMP25_ConcurrencySafety">
+  <rundefinition name="SV-COMP25_unreach-call">
     <tasks name="ConcurrencySafety-Main">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     </tasks>
+  </rundefinition>
+
+  <rundefinition name="SV-COMP25_no-data-race">
     <tasks name="NoDataRace-Main">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
     </tasks>
+  </rundefinition>
+
+  <rundefinition name="SV-COMP25_valid-memsafety">
     <tasks name="ConcurrencySafety-MemSafety">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     </tasks>
+  </rundefinition>
+
+  <rundefinition name="SV-COMP25_no-overflow">
     <tasks name="ConcurrencySafety-NoOverflows">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>


### PR DESCRIPTION
This PR merges the concurrency tasks of 4 categories into one runset:

![image](https://github.com/user-attachments/assets/63b73c26-a800-41da-9151-3b40b491468d)