### PR TITLE
[smt] support extracting arrays from tuple

### DIFF
--- a/regression/esbmc/github_2205/main.cpp
+++ b/regression/esbmc/github_2205/main.cpp
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+struct iterator
+{
+  struct
+  {
+    int second;
+    int it_pos;
+  } iterator_data_object;
+};
+struct map
+{
+  struct
+  {
+    int _value[2];
+  } map_data_object;
+};
+int main()
+{
+  map mymap;
+  iterator it;
+  mymap.map_data_object._value[0] = 1337;
+  mymap.map_data_object._value[1] = 4269;
+  int *it_0 = mymap.map_data_object._value;
+  it.iterator_data_object.second = it_0[it.iterator_data_object.it_pos];
+  it_0[it.iterator_data_object.it_pos];
+}

--- a/regression/esbmc/github_2205/test.desc
+++ b/regression/esbmc/github_2205/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2361,14 +2361,7 @@ expr2tc smt_convt::get(const expr2tc &expr)
     }
     else if (is_array_type(expr))
     {
-      if (extracting_from_array_tuple_is_error)
-      {
-        log_error(
-          "Fetching array elements inside tuples currently "
-          "unimplemented, sorry");
-        abort();
-      }
-      return expr2tc(); // TODO: ??? This is horrible
+      return get_by_type(res);
     }
 
     simplify(res);

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -131,10 +131,6 @@ class smt_convt;
 class smt_convt
 {
 public:
-  /* NOTE: I've made this horrible so we remember that there is an
-   * even uglier implementation that just returns an empty
-   * look at where this variable is used for more info :) */
-  bool extracting_from_array_tuple_is_error = false;
   /** Shorthand for a vector of smt_ast's */
   typedef std::vector<smt_astt> ast_vec;
 


### PR DESCRIPTION
This appears to work fine and fixed a slightly changed TC from #2205.
Maybe @mikhailramalho knows why he didn't implement it this way in https://github.com/esbmc/esbmc/commit/590885b94c694a3c4448c0dc609e527ab1fd7368 ?