### PR TITLE
Force update of tags in benchexec action

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -108,7 +108,7 @@ jobs:
     needs: build-unix
     steps:
       - name: Setup SV-Benchmarks version
-        run: cd $HOME/sv-benchmarks && git fetch --all --tags && git checkout ${{ inputs.svbenchmarks }} && if [ "${{ inputs.svbenchmarks }}" == "main" ]; then git reset --hard origin/main; fi
+        run: cd $HOME/sv-benchmarks && git fetch --all --tags --force && git checkout ${{ inputs.svbenchmarks }} && if [ "${{ inputs.svbenchmarks }}" == "main" ]; then git reset --hard origin/main; fi
       - name: Download Linux Build
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Git is complaining that the remote tags have changed. It should be fine to always force update. Example: https://github.com/esbmc/esbmc/actions/runs/12668133362/job/35303938167