### PR TITLE
[python-frontend] Fix handling of function calls with string literals.

### DIFF
--- a/regression/python/function-call/main.py
+++ b/regression/python/function-call/main.py
@@ -1,0 +1,5 @@
+def foo(s:str) -> None:
+    x:int = len(s)
+    assert x == 4
+
+foo("test")

--- a/regression/python/function-call/test.desc
+++ b/regression/python/function-call/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -6,6 +6,7 @@
 #include <util/c_typecast.h>
 #include <util/expr_util.h>
 #include <util/message.h>
+#include <util/string_constant.h>
 #include <regex>
 
 using namespace json_utils;
@@ -426,7 +427,16 @@ exprt function_call_expr::build()
 
     // All array function arguments (e.g. bytes type) are handled as pointers.
     if (arg.type().is_array())
+    {
+      if (arg_node["_type"] == "Constant" && arg_node["value"].is_string())
+      {
+        arg = string_constantt(
+          arg_node["value"].get<std::string>(),
+          arg.type(),
+          string_constantt::k_default);
+      }
       call.arguments().push_back(address_of_exprt(arg));
+    }
     else
       call.arguments().push_back(arg);
   }


### PR DESCRIPTION
Handling string literals function arguments with `string_constantt`, as done by the C frontend, as a requirement for `address_of_exprt()`. This PR is part of the fix for #2237.