### PR TITLE
[symex] only increment pc if builtin is actually handled

### DIFF
--- a/regression/esbmc-cpp/list/list_merge_bug-2/test.desc
+++ b/regression/esbmc-cpp/list/list_merge_bug-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/list/list_merge_bug/test.desc
+++ b/regression/esbmc-cpp/list/list_merge_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/list/list_operator_assign/test.desc
+++ b/regression/esbmc-cpp/list/list_operator_assign/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/builtin_missing_body_wrong_pc/main.c
+++ b/regression/esbmc/builtin_missing_body_wrong_pc/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+extern void __builtin();
+
+int main()
+{
+  __builtin();
+
+  assert(0);
+}

--- a/regression/esbmc/builtin_missing_body_wrong_pc/test.desc
+++ b/regression/esbmc/builtin_missing_body_wrong_pc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -344,9 +344,11 @@ void goto_symext::symex_step(reachability_treet &art)
       const irep_idt &id = to_symbol2t(call.function).thename;
       if (has_prefix(id.as_string(), "c:@F@__builtin"))
       {
-        cur_state->source.pc++;
         if (run_builtin(call, id.as_string()))
+        {
+          cur_state->source.pc++;
           return;
+        }
       }
     }
 


### PR DESCRIPTION
Otherwise, `symex_function_call` would also increment pc, when a body for a builtin is not available.

Bug appears to have been introduced in #1435.