### PR TITLE
[C++ verification] fix circular type dependencies issue [do not merge]

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/template_dep/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/template_dep/main.cpp
@@ -1,0 +1,22 @@
+template <class T>
+class A
+{
+  void foo(T t)
+  {
+  }
+};
+
+template <class d>
+class g
+{
+  A<d> f;
+};
+
+class i
+{
+  g<i> h;
+};
+
+int main()
+{
+}

--- a/regression/esbmc-cpp/bug_fixes/template_dep/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/template_dep/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/template_dep_fail/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/template_dep_fail/main.cpp
@@ -27,5 +27,5 @@ public:
 int main()
 {
   i obj;
-  assert(obj.h.f.foo(obj).a == 1);
+  assert(obj.h.f.foo(obj).a != 1);
 }

--- a/regression/esbmc-cpp/bug_fixes/template_dep_fail/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/template_dep_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -349,7 +349,14 @@ void goto_convert_functionst::wallop_type(
 
   // Iterate over our dependancies ensuring they're resolved.
   for (const auto &dep : deps)
+  {
+    // In C++ we have to avoid circular dependencies
+    // Break out of it when we get stuck in an endless loop
+    if (sname == dep)
+      return;
+
     wallop_type(dep, typenames, sname);
+  }
 
   // And finally perform renaming.
   symbolt *s = context.find_symbol(name);

--- a/src/goto-programs/goto_convert_functions.h
+++ b/src/goto-programs/goto_convert_functions.h
@@ -19,6 +19,10 @@ public:
   void goto_convert();
   void convert_function(symbolt &symbol);
   void thrash_type_symbols();
+  bool has_circular_dependency(
+    irep_idt name,
+    typename_mapt &typenames,
+    const irep_idt &sname);
   void collect_type(const irept &type, typename_sett &set);
   void collect_expr(const irept &expr, typename_sett &set);
   void


### PR DESCRIPTION
```cpp
template <class T>
class A
{
  void foo(T t)
  {
  }
};

template <class d>
class g
{
  A<d> f;
};

class i
{
  g<i> h;
};

int main()
{
}
```

tag-A<i> --> tag-i
tag-i --> tag-g<i>
tag-g<i> --> tag-A<i>

