### PR TITLE
[python] try harder to find a python binary

### DIFF
--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -70,11 +70,26 @@ bool python_languaget::parse(const std::string &path)
 
   // Get Python interpreter path informed by the user
   std::string python_exec = config.options.get_option("python");
-  if (python_exec.empty())
-    python_exec = "python";
+  auto python_exec_path = bp::search_path(python_exec);
+  std::list<std::string> python_exec_names = {"python3", "python"};
+  if (!python_exec.empty())
+    python_exec_names.push_front(python_exec);
+  for (const auto &name : python_exec_names)
+  {
+    python_exec_path = bp::search_path(name);
+    if (!python_exec_path.empty())
+      break;
+  }
+  if (python_exec_path.empty())
+  {
+    log_error(
+      "No python executable was found. Tried: {}\n",
+      fmt::join(python_exec_names, ", "));
+    exit(1);
+  }
 
   // Create a child process to execute Python
-  bp::child process(bp::search_path(python_exec), args);
+  bp::child process(python_exec_path, args);
 
   // Wait for execution
   process.wait();


### PR DESCRIPTION
Some computers might only have `python3` installed so also search for it.
Previously, we would crash with a `permission denied` error, because `python` could not be executed (only `python3` exists).

Fix this so that we provide a helpful message to the user.