### PR TITLE
[python][numpy] Handling dtype arguments

### DIFF
--- a/regression/numpy/add-overflow/main.py
+++ b/regression/numpy/add-overflow/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+
+x = np.add(2147483647, 1, dtype=np.int32)

--- a/regression/numpy/add-overflow/test.desc
+++ b/regression/numpy/add-overflow/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--overflow-check
+
+^VERIFICATION FAILED$

--- a/regression/numpy/add/main.py
+++ b/regression/numpy/add/main.py
@@ -5,3 +5,6 @@ assert x == 5.0
 
 y = np.add(1, 2)
 assert y == 3
+
+z = np.add(127, 1, dtype=np.int8)
+assert z == -128

--- a/regression/numpy/power-overflow-fail/main.py
+++ b/regression/numpy/power-overflow-fail/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+y = np.power(3, 21, dtype=np.int32) # 3^21 = 10460353203 -> overflow: 1870418611
+
+assert y == 10460353203

--- a/regression/numpy/power-overflow-fail/test.desc
+++ b/regression/numpy/power-overflow-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/numpy/power-overflow/main.py
+++ b/regression/numpy/power-overflow/main.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+y = np.power(3, 21, dtype=np.int32) # 3^21 = 10460353203 -> overflow: 1870418611
+
+assert y == 1870418611

--- a/regression/numpy/power-overflow/test.desc
+++ b/regression/numpy/power-overflow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/power/main.py
+++ b/regression/numpy/power/main.py
@@ -2,3 +2,6 @@ import numpy as np
 
 x = np.power(2, 3)
 assert x == 8
+
+y = np.power(2,7, dtype=np.int8)
+assert y == -128

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -227,8 +227,8 @@ exprt function_call_expr::get()
   if (function_type_ == FunctionType::Constructor)
   {
     // Self is the LHS
-    assert(converter_.ref_instance);
-    call.arguments().push_back(gen_address_of(*converter_.ref_instance));
+    assert(converter_.current_lhs);
+    call.arguments().push_back(gen_address_of(*converter_.current_lhs));
   }
   else if (function_type_ == FunctionType::InstanceMethod)
   {

--- a/src/python-frontend/numpy_call_expr.h
+++ b/src/python-frontend/numpy_call_expr.h
@@ -4,6 +4,7 @@
 
 class symbol_id;
 class exprt;
+class typet;
 class python_converter;
 
 class numpy_call_expr
@@ -14,11 +15,15 @@ public:
     const nlohmann::json &call,
     python_converter &converter);
 
-  exprt get();
-
-  bool is_math_function() const;
+  exprt get() const;
 
 private:
+  bool is_math_function() const;
+
+  std::string get_dtype() const;
+  typet get_typet_from_dtype() const;
+  size_t get_dtype_size() const;
+
   const symbol_id &function_id_;
   const nlohmann::json &call_;
   python_converter &converter_;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -64,6 +64,8 @@ public:
     symbol_table_.add(s);
   }
 
+  void update_symbol(const exprt &expr) const;
+
   symbolt *find_imported_symbol(const std::string &symbol_id) const;
 
   bool is_imported_module(const std::string &module_name) const;
@@ -158,7 +160,7 @@ private:
   nlohmann::json imported_module_json;
   std::string current_func_name_;
   std::string current_class_name_;
-  exprt *ref_instance;
+  exprt *current_lhs;
 
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -44,7 +44,7 @@ std::string type_handler::type_to_string(const typet &t) const
 {
   if (t == double_type())
     return "float";
-  if (t == int_type())
+  if (t == long_long_int_type())
     return "int";
   if (t == long_long_uint_type())
     return "uint64";
@@ -96,7 +96,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "int" || ast_type == "GeneralizedIndex")
     /* FIXME: We need to map 'int' to another irep type that provides unlimited precision
   	https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex */
-    return int_type();
+    return long_long_int_type();
   if (ast_type == "uint64" || ast_type == "Epoch" || ast_type == "Slot")
     return long_long_uint_type();
   if (ast_type == "bool")
@@ -107,7 +107,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   {
     // TODO: Keep "bytes" as signed char instead of "int_type()", and cast to an 8-bit integer in [] operations
     // or consider modelling it with string_constantt.
-    return build_array(int_type(), type_size);
+    return build_array(long_long_int_type(), type_size);
   }
   if (ast_type == "str")
   {
@@ -128,7 +128,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
 typet type_handler::get_typet(const nlohmann::json &elem) const
 {
   if (elem.is_number_integer() || elem.is_number_unsigned())
-    return int_type();
+    return long_long_int_type();
   else if (elem.is_boolean())
     return bool_type();
   else if (elem.is_number_float())

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -34,6 +34,7 @@ type2tc char_type2();
 typet float_type();
 type2tc float_type2();
 
+typet build_float_type(unsigned width);
 typet double_type();
 type2tc double_type2();
 


### PR DESCRIPTION
- Handling [dtype](https://numpy.org/doc/2.1/reference/generated/numpy.dtype.html#numpy.dtype) argument in math functions.
- Changing int representation to signedbv(64).
- Detecting arithmetic overflows.
- Adding assertion locations.