### PR TITLE
[Need help][C verification] add new builtin function for memcpy

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2873,7 +2873,6 @@ void clang_c_convertert::rewrite_builtin_ref(
 {
   static const std::list<std::string> builtins_to_rewrite = {
     "__builtin_malloc",
-    "__builtin_memcpy",
     "__builtin_memmove",
     "__builtin_strcpy",
     "__builtin_free",


### PR DESCRIPTION
This is the feasible way I can come up with.

I used _extract_ and _concat_ to simulate the behavior of _memcpy_ to avoid the for loop. However, there are a few points that I think are important. First, bound checking requires additional implementation, and second, even if we disable bound checking, once out of bound, it would violate the assertion of the solver (In the past is the verification successful). 

I'm not sure if this implementation is necessary, maybe there is a better one?