### PR TITLE
[SMT backend] Add Overflow Detection for Integer Arithmetic 

### DIFF
--- a/regression/esbmc/integer1/main.c
+++ b/regression/esbmc/integer1/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b > 0);
+
+  assert((a + b) > 0);
+}

--- a/regression/esbmc/integer1/test.desc
+++ b/regression/esbmc/integer1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/integer11_fail/main.c
+++ b/regression/esbmc/integer11_fail/main.c
@@ -1,0 +1,61 @@
+/*
+  hardware integer division program, by Manna
+  returns q==A//B
+  */
+
+extern void abort(void);
+extern void __assert_fail(const char *, const char *, unsigned int, const char *) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+void reach_error() { __assert_fail("0", "hard2.c", 8, "reach_error"); }
+extern int __VERIFIER_nondet_int(void);
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        {reach_error();}
+    }
+    return;
+}
+
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = 1;
+
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        __VERIFIER_assert(q == 0);
+        __VERIFIER_assert(r == A);
+        __VERIFIER_assert(d == B * p);
+        if (!(r >= d)) break;
+
+        d = 2 * d;
+        p = 2 * p;
+    }
+
+    while (1) {
+        __VERIFIER_assert(A == q*B + r);
+        __VERIFIER_assert(d == B*p);
+
+        if (!(p != 1)) break;
+
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+
+    __VERIFIER_assert(A == d*q + r);
+    __VERIFIER_assert(B == d);    
+    return 0;
+}
+

--- a/regression/esbmc/integer11_fail/test.desc
+++ b/regression/esbmc/integer11_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+ --z3 --ir --unwind 33 --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer1_fail/main.c
+++ b/regression/esbmc/integer1_fail/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b > 0);
+
+  assert((a + b) > 0);
+}

--- a/regression/esbmc/integer1_fail/test.desc
+++ b/regression/esbmc/integer1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer2/main.c
+++ b/regression/esbmc/integer2/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a < 0 && b < 0);
+
+  assert((a + b) < 0);
+
+  return 0;
+}

--- a/regression/esbmc/integer2/test.desc
+++ b/regression/esbmc/integer2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/integer2_fail/main.c
+++ b/regression/esbmc/integer2_fail/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a < 0 && b < 0);
+
+  assert((a + b) < 0);
+
+  return 0;
+}

--- a/regression/esbmc/integer2_fail/test.desc
+++ b/regression/esbmc/integer2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer3/main.c
+++ b/regression/esbmc/integer3/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b < 0);
+
+  assert((a - b) > 0);
+}

--- a/regression/esbmc/integer3/test.desc
+++ b/regression/esbmc/integer3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/integer3_fail/main.c
+++ b/regression/esbmc/integer3_fail/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b < 0);
+
+  assert((a - b) > 0);
+}

--- a/regression/esbmc/integer3_fail/test.desc
+++ b/regression/esbmc/integer3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer4/main.c
+++ b/regression/esbmc/integer4/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b > 0);
+
+  assert((a * b) > 0);
+}

--- a/regression/esbmc/integer4/test.desc
+++ b/regression/esbmc/integer4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/integer4_fail/main.c
+++ b/regression/esbmc/integer4_fail/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b > 0);
+
+  assert((a * b) > 0);
+}

--- a/regression/esbmc/integer4_fail/test.desc
+++ b/regression/esbmc/integer4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer5/main.c
+++ b/regression/esbmc/integer5/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main() {
+  int a = nondet_int();
+  int b = nondet_int();
+
+  __ESBMC_assume(a > 0 && b > 0 && a > b);
+
+  assert((a / b) > 0);
+}

--- a/regression/esbmc/integer5/test.desc
+++ b/regression/esbmc/integer5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/integer5_fail/main.c
+++ b/regression/esbmc/integer5_fail/main.c
@@ -1,0 +1,12 @@
+#include <limits.h>
+
+int main() {
+    int a = INT_MIN;
+    int b = -1;
+    
+    // This operation results in signed integer overflow
+    int result = a / b;
+
+    return 0;
+}
+

--- a/regression/esbmc/integer5_fail/test.desc
+++ b/regression/esbmc/integer5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer6/main.cpp
+++ b/regression/esbmc/integer6/main.cpp
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main()
+{
+  int64_t onel = 1L;
+  uint64_t onelu = 1ul;
+  int32_t onei = 1;
+  uint32_t oneiu = 1u;
+  auto result_i_i = 1 << onei;
+  assert(result_i_i == 2);
+  auto result_i_iu = 1 << oneiu;
+  assert(result_i_iu == 2);
+  auto result_i_l = 1 << onel;
+  assert(result_i_l == 2);
+  auto result_i_lu = 1 << onelu;
+  assert(result_i_lu == 2);
+  auto result_iu_i = 1u << onei;
+  assert(result_iu_i == 2u);
+  auto result_iu_iu = 1u << oneiu;
+  assert(result_iu_iu == 2u);
+  auto result_iu_l = 1u << onel;
+  assert(result_iu_l == 2u);
+  auto result_iu_lu = 1u << onelu;
+  assert(result_iu_lu == 2u);
+  auto result_l_i = 1l << onei;
+  assert(result_l_i == 2l);
+  auto result_l_iu = 1l << oneiu;
+  assert(result_l_iu == 2l);
+  auto result_l_l = 1l << onel;
+  assert(result_l_l == 2l);
+  auto result_l_lu = 1l << onelu;
+  assert(result_l_lu == 2l);
+  auto result_lu_i = 1lu << onei;
+  assert(result_lu_i == 2lu);
+  auto result_lu_iu = 1lu << oneiu;
+  assert(result_lu_iu == 2lu);
+  auto result_lu_l = 1lu << onel;
+  assert(result_lu_l == 2lu);
+  auto result_lu_lu = 1lu << onelu;
+  assert(result_lu_lu == 2lu);
+}

--- a/regression/esbmc/integer6/test.desc
+++ b/regression/esbmc/integer6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--ub-shift-check --no-slice --no-simplify --unwind 1 --z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/integer6_fail/main.cpp
+++ b/regression/esbmc/integer6_fail/main.cpp
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main()
+{
+  int64_t onel = 64L;
+  uint64_t onelu = 64ul;
+  int32_t onei = 64;
+  uint32_t oneiu = 64u;
+  auto result_i_i = 1 << onei;
+  auto result_i_iu = 1 << oneiu;
+  auto result_i_l = 1 << onel;
+  auto result_i_lu = 1 << onelu;
+  auto result_iu_i = 1u << onei;
+  auto result_iu_iu = 1u << oneiu;
+  auto result_iu_l = 1u << onel;
+  auto result_iu_lu = 1u << onelu;
+  auto result_l_i = 1l << onei;
+  auto result_l_iu = 1l << oneiu;
+  auto result_l_l = 1l << onel;
+  auto result_l_lu = 1l << onelu;
+  auto result_lu_i = 1lu << onei;
+  auto result_lu_iu = 1lu << oneiu;
+  auto result_lu_l = 1lu << onel;
+  auto result_lu_lu = 1lu << onelu;
+}

--- a/regression/esbmc/integer6_fail/test.desc
+++ b/regression/esbmc/integer6_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--ub-shift-check --no-slice --no-simplify --unwind 1 --z3 --ir
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer7_fail/main.c
+++ b/regression/esbmc/integer7_fail/main.c
@@ -1,0 +1,11 @@
+#include <limits.h>
+
+int main() 
+{
+  int a = INT_MIN;
+  int b = 1;
+  // This operation results in signed integer overflow
+  int result = a - b;
+  return 0;
+}
+

--- a/regression/esbmc/integer7_fail/test.desc
+++ b/regression/esbmc/integer7_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer8_fail/main.c
+++ b/regression/esbmc/integer8_fail/main.c
@@ -1,0 +1,10 @@
+#include <limits.h>
+
+int main() 
+{
+  int a = INT_MIN;
+  // This operation results in signed integer overflow
+  int result = -a;
+  return 0;
+}
+

--- a/regression/esbmc/integer8_fail/test.desc
+++ b/regression/esbmc/integer8_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/integer9_fail/main.c
+++ b/regression/esbmc/integer9_fail/main.c
@@ -1,0 +1,9 @@
+#include <limits.h>
+
+int main() {
+  unsigned int a = 1;
+  // Unary negation of an unsigned int
+  unsigned int result = -a;
+  return 0;
+}
+

--- a/regression/esbmc/integer9_fail/test.desc
+++ b/regression/esbmc/integer9_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --unsigned-overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc/ub_07_shift_left_mixed_op_types/test.desc
+++ b/regression/esbmc/ub_07_shift_left_mixed_op_types/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --ub-shift-check --no-slice --no-simplify --unwind 1
-^VERIFICATION SUCCESSFUL
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -163,12 +163,12 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     smt_astt arg1_ext = convert_ast(opers.side_1);
     smt_astt arg2_ext = convert_ast(opers.side_2);
 
-    if (!int_encoding) 
+    if (!int_encoding)
     {
 
       arg1_ext = is_signedbv_type(opers.side_1) ? mk_sign_ext(arg1_ext, sz)
                                                 : mk_zero_ext(arg1_ext, sz);
-    
+
       expr2tc op2 = opers.side_2;
       if (is_shl2t(overflow.operand))
         if (opers.side_1->type->get_width() != opers.side_2->type->get_width())
@@ -179,13 +179,13 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     }
 
     smt_astt result;
-    if (int_encoding) 
+    if (int_encoding)
     {
       // If using int_encoding, use mk_mul and mk_shl for multiplication and shift left
-      result = is_mul2t(overflow.operand) ? mk_mul(arg1_ext, arg2_ext)  // Use mk_mul for multiplication
-                                          : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left
-    }
-    else 
+      result = is_mul2t(overflow.operand)
+                 ? mk_mul(arg1_ext, arg2_ext)  // Use mk_mul for multiplication
+                 : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left    }
+    else
     {
       // If not using int_encoding, fallback to original behavior (bvmul and bvshl)
       result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
@@ -218,12 +218,14 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       type2tc newtype = signedbv_type2tc(sz + 1);
       
       // Get min and max bounds for signed overflow detection
-      expr2tc min_bound_expr = constant_int2tc(newtype, -BigInt::power2(sz - 1));
-      expr2tc max_bound_expr = constant_int2tc(newtype, BigInt::power2(sz - 1) - 1);
-      
+      expr2tc min_bound_expr =
+        constant_int2tc(newtype, -BigInt::power2(sz - 1));
+      expr2tc max_bound_expr =
+        constant_int2tc(newtype, BigInt::power2(sz - 1) - 1);
+
       smt_astt min_bound = convert_ast(min_bound_expr);
       smt_astt max_bound = convert_ast(max_bound_expr);
-      
+
       // Convert result to signed type and check if it's out of bounds
       smt_astt overflow_high = mk_lt(result, min_bound);
       smt_astt overflow_low = mk_gt(result, max_bound);

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -190,7 +190,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
         result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
                                             : mk_bvshl(arg1_ext, arg2_ext);
       }
-      log_status("passou em 189");
+
       if (is_signed && !int_encoding)
       {
         // Extract top half plus one (for the sign)

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -97,8 +97,8 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     {
       // Get the width of the integer type
       auto const width = opers.side_1->type->get_width();
-      BigInt max_val = BigInt::power2(width - 1) - 1;  // MAX_INT
-      BigInt min_val = -BigInt::power2(width - 1);     // MIN_INT
+      BigInt max_val = BigInt::power2(width - 1) - 1; // MAX_INT
+      BigInt min_val = -BigInt::power2(width - 1);    // MIN_INT
 
       expr2tc max_int = constant_int2tc(opers.side_1->type, max_val);
       expr2tc min_int = constant_int2tc(opers.side_1->type, min_val);
@@ -125,7 +125,6 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       expr2tc overflow_check = or2tc(final_pos_overflow, final_neg_underflow);
       return convert_ast(overflow_check);
     }
-    
     // Just ensure the result is <= the first operand.
     expr2tc sub = sub2tc(opers.side_1->type, opers.side_1, opers.side_2);
     expr2tc le = lessthanequal2tc(sub, opers.side_1);

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -161,22 +161,38 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     unsigned int sz = zero->type->get_width();
 
     smt_astt arg1_ext = convert_ast(opers.side_1);
-    arg1_ext = is_signedbv_type(opers.side_1) ? mk_sign_ext(arg1_ext, sz)
-                                              : mk_zero_ext(arg1_ext, sz);
+    smt_astt arg2_ext = convert_ast(opers.side_2);
 
-    expr2tc op2 = opers.side_2;
-    if (is_shl2t(overflow.operand))
-      if (opers.side_1->type->get_width() != opers.side_2->type->get_width())
-        op2 = typecast2tc(opers.side_1->type, opers.side_2);
+    if (!int_encoding) 
+    {
 
-    smt_astt arg2_ext = convert_ast(op2);
-    arg2_ext = is_signedbv_type(op2) ? mk_sign_ext(arg2_ext, sz)
-                                     : mk_zero_ext(arg2_ext, sz);
+      arg1_ext = is_signedbv_type(opers.side_1) ? mk_sign_ext(arg1_ext, sz)
+                                                : mk_zero_ext(arg1_ext, sz);
+    
+      expr2tc op2 = opers.side_2;
+      if (is_shl2t(overflow.operand))
+        if (opers.side_1->type->get_width() != opers.side_2->type->get_width())
+          op2 = typecast2tc(opers.side_1->type, opers.side_2);
 
-    smt_astt result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
-                                                 : mk_bvshl(arg1_ext, arg2_ext);
+      arg2_ext = is_signedbv_type(op2) ? mk_sign_ext(arg2_ext, sz)
+                                       : mk_zero_ext(arg2_ext, sz);
+    }
 
-    if (is_signed)
+    smt_astt result;
+    if (int_encoding) 
+    {
+      // If using int_encoding, use mk_mul and mk_shl for multiplication and shift left
+      result = is_mul2t(overflow.operand) ? mk_mul(arg1_ext, arg2_ext)  // Use mk_mul for multiplication
+                                          : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left
+    }
+    else 
+    {
+      // If not using int_encoding, fallback to original behavior (bvmul and bvshl)
+      result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
+                                          : mk_bvshl(arg1_ext, arg2_ext);
+    }
+    log_status("passou em 189");
+    if (is_signed && !int_encoding)
     {
       // Extract top half plus one (for the sign)
       smt_astt toppart = mk_extract(result, (sz * 2) - 1, sz - 1);
@@ -195,6 +211,24 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
 
       smt_astt lor = mk_or(all_ones, all_zeros);
       return mk_not(lor);
+    }
+    else if (is_signed && int_encoding)
+    {
+      // Create a signed integer type of size sz + 1
+      type2tc newtype = signedbv_type2tc(sz + 1);
+      
+      // Get min and max bounds for signed overflow detection
+      expr2tc min_bound_expr = constant_int2tc(newtype, -BigInt::power2(sz - 1));
+      expr2tc max_bound_expr = constant_int2tc(newtype, BigInt::power2(sz - 1) - 1);
+      
+      smt_astt min_bound = convert_ast(min_bound_expr);
+      smt_astt max_bound = convert_ast(max_bound_expr);
+      
+      // Convert result to signed type and check if it's out of bounds
+      smt_astt overflow_high = mk_lt(result, min_bound);
+      smt_astt overflow_low = mk_gt(result, max_bound);
+      
+      return mk_or(overflow_high, overflow_low);
     }
 
     // Extract top half.

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -32,7 +32,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       expr2tc nounderflow =
         implies2tc(both_neg, lessthanequal2tc(overflow.operand, zero));
       return convert_ast(not2tc(and2tc(nooverflow, nounderflow)));
-    }   
+    }
     else if (is_signed && int_encoding)
     {
       // Get the width of the integer type

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -161,7 +161,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     unsigned int sz = zero->type->get_width();
 
     smt_astt arg1_ext = convert_ast(opers.side_1);
-    smt_astt arg2_ext = convert_ast(opers.side_2);
+    smt_astt arg2_ext;
 
     if (!int_encoding)
     {
@@ -172,6 +172,8 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       if (is_shl2t(overflow.operand))
         if (opers.side_1->type->get_width() != opers.side_2->type->get_width())
           op2 = typecast2tc(opers.side_1->type, opers.side_2);
+
+      arg2_ext = convert_ast(op2);
 
       arg2_ext = is_signedbv_type(op2) ? mk_sign_ext(arg2_ext, sz)
                                        : mk_zero_ext(arg2_ext, sz);

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -39,7 +39,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       auto const width = opers.side_1->type->get_width();
       BigInt max_val = BigInt::power2(width - 1) - 1; // MAX_INT
       BigInt min_val = -BigInt::power2(width - 1);    // MIN_INT
-     
+
       expr2tc max_int = constant_int2tc(opers.side_1->type, max_val);
       expr2tc min_int = constant_int2tc(opers.side_1->type, min_val);
 

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -164,28 +164,26 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     smt_astt arg2_ext;
 
     if (!int_encoding)
-    {
       arg1_ext = is_signedbv_type(opers.side_1) ? mk_sign_ext(arg1_ext, sz)
                                                 : mk_zero_ext(arg1_ext, sz);
 
-      expr2tc op2 = opers.side_2;
-      if (is_shl2t(overflow.operand))
-        if (opers.side_1->type->get_width() != opers.side_2->type->get_width())
-          op2 = typecast2tc(opers.side_1->type, opers.side_2);
+    expr2tc op2 = opers.side_2;
+    if (is_shl2t(overflow.operand))
+      if (opers.side_1->type->get_width() != opers.side_2->type->get_width())
+        op2 = typecast2tc(opers.side_1->type, opers.side_2);
 
-      arg2_ext = convert_ast(op2);
+    arg2_ext = convert_ast(op2);
 
+    if (!int_encoding)
       arg2_ext = is_signedbv_type(op2) ? mk_sign_ext(arg2_ext, sz)
                                        : mk_zero_ext(arg2_ext, sz);
-    }
-
     smt_astt result;
     if (int_encoding)
     {
       // If using int_encoding, use mk_mul and mk_shl for multiplication and shift left
       result = is_mul2t(overflow.operand)
                  ? mk_mul(arg1_ext, arg2_ext)  // Use mk_mul for multiplication
-                 : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left    }
+                 : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left
     }
     else
     {

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -79,7 +79,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
 
   case expr2t::sub_id:
   {
-    if (is_signed && !int_encoding)
+    if (is_signed)
     {
       // Convert to be an addition
       expr2tc negop2 = neg2tc(opers.side_2->type, opers.side_2);
@@ -93,38 +93,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       expr2tc is_min_int = equality2tc(min_int, opers.side_2);
       return convert_ast(or2tc(add_overflows, is_min_int));
     }
-    else if (is_signed && int_encoding)
-    {
-      // Get the width of the integer type
-      auto const width = opers.side_1->type->get_width();
-      BigInt max_val = BigInt::power2(width - 1) - 1; // MAX_INT
-      BigInt min_val = -BigInt::power2(width - 1);    // MIN_INT
-
-      expr2tc max_int = constant_int2tc(opers.side_1->type, max_val);
-      expr2tc min_int = constant_int2tc(opers.side_1->type, min_val);
-
-      // Extract the operand of the overflow expression
-      const overflow2t &overflow_expr = to_overflow2t(expr);
-      expr2tc result_expr = overflow_expr.operand;
-
-      // Overflow case: if a > 0 and b < 0 and a - b > MAX_INT
-      expr2tc op1pos = lessthan2tc(zero, opers.side_1);
-      expr2tc op2neg = lessthan2tc(opers.side_2, zero);
-      expr2tc pos_overflow = and2tc(op1pos, op2neg);
-      expr2tc overflow = greaterthan2tc(result_expr, max_int);
-      expr2tc final_pos_overflow = and2tc(pos_overflow, overflow);
-
-      // Underflow case: if a < 0 and b > 0 and a - b < MIN_INT
-      expr2tc op1neg = lessthan2tc(opers.side_1, zero);
-      expr2tc op2pos = lessthan2tc(zero, opers.side_2);
-      expr2tc neg_underflow = and2tc(op1neg, op2pos);
-      expr2tc underflow = lessthan2tc(result_expr, min_int);
-      expr2tc final_neg_underflow = and2tc(neg_underflow, underflow);
-
-      // Return true if either overflow or underflow occurs
-      expr2tc overflow_check = or2tc(final_pos_overflow, final_neg_underflow);
-      return convert_ast(overflow_check);
-    }
+    
     // Just ensure the result is <= the first operand.
     expr2tc sub = sub2tc(opers.side_1->type, opers.side_1, opers.side_2);
     expr2tc le = lessthanequal2tc(sub, opers.side_1);

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -186,155 +186,154 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
                  : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left    }
     }
     else
-      {
-        // If not using int_encoding, fallback to original behavior (bvmul and bvshl)
-        result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
-                                            : mk_bvshl(arg1_ext, arg2_ext);
-      }
-
-      if (is_signed && !int_encoding)
-      {
-        // Extract top half plus one (for the sign)
-        smt_astt toppart = mk_extract(result, (sz * 2) - 1, sz - 1);
-
-        // Create a now base 2 type
-        type2tc newtype = unsignedbv_type2tc(sz + 1);
-
-        // All one bit vector is tricky, might be 64 bits wide for all we know.
-        expr2tc allonesexpr =
-          constant_int2tc(newtype, BigInt::power2m1(sz + 1));
-        smt_astt allonesvector = convert_ast(allonesexpr);
-
-        // It should either be zero or all one's;
-        smt_astt all_ones = mk_eq(toppart, allonesvector);
-
-        smt_astt all_zeros = mk_eq(toppart, convert_ast(gen_zero(newtype)));
-
-        smt_astt lor = mk_or(all_ones, all_zeros);
-        return mk_not(lor);
-      }
-      else if (is_signed && int_encoding)
-      {
-        // Create a signed integer type of size sz + 1
-        type2tc newtype = signedbv_type2tc(sz + 1);
-
-        // Get min and max bounds for signed overflow detection
-        expr2tc min_bound_expr =
-          constant_int2tc(newtype, -BigInt::power2(sz - 1));
-        expr2tc max_bound_expr =
-          constant_int2tc(newtype, BigInt::power2(sz - 1) - 1);
-
-        smt_astt min_bound = convert_ast(min_bound_expr);
-        smt_astt max_bound = convert_ast(max_bound_expr);
-
-        // Convert result to signed type and check if it's out of bounds
-        smt_astt overflow_high = mk_lt(result, min_bound);
-        smt_astt overflow_low = mk_gt(result, max_bound);
-
-        return mk_or(overflow_high, overflow_low);
-      }
-
-      // Extract top half.
-      smt_astt toppart = mk_extract(result, (sz * 2) - 1, sz);
-
-      // It should be zero; if not, overflow
-      smt_astt iseq = mk_eq(toppart, convert_ast(zero));
-      return mk_not(iseq);
+    {
+      // If not using int_encoding, fallback to original behavior (bvmul and bvshl)
+      result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)
+                                          : mk_bvshl(arg1_ext, arg2_ext);
     }
+
+    if (is_signed && !int_encoding)
+    {
+      // Extract top half plus one (for the sign)
+      smt_astt toppart = mk_extract(result, (sz * 2) - 1, sz - 1);
+
+      // Create a now base 2 type
+      type2tc newtype = unsignedbv_type2tc(sz + 1);
+
+      // All one bit vector is tricky, might be 64 bits wide for all we know.
+      expr2tc allonesexpr = constant_int2tc(newtype, BigInt::power2m1(sz + 1));
+      smt_astt allonesvector = convert_ast(allonesexpr);
+
+      // It should either be zero or all one's;
+      smt_astt all_ones = mk_eq(toppart, allonesvector);
+
+      smt_astt all_zeros = mk_eq(toppart, convert_ast(gen_zero(newtype)));
+
+      smt_astt lor = mk_or(all_ones, all_zeros);
+      return mk_not(lor);
+    }
+    else if (is_signed && int_encoding)
+    {
+      // Create a signed integer type of size sz + 1
+      type2tc newtype = signedbv_type2tc(sz + 1);
+
+      // Get min and max bounds for signed overflow detection
+      expr2tc min_bound_expr =
+        constant_int2tc(newtype, -BigInt::power2(sz - 1));
+      expr2tc max_bound_expr =
+        constant_int2tc(newtype, BigInt::power2(sz - 1) - 1);
+
+      smt_astt min_bound = convert_ast(min_bound_expr);
+      smt_astt max_bound = convert_ast(max_bound_expr);
+
+      // Convert result to signed type and check if it's out of bounds
+      smt_astt overflow_high = mk_lt(result, min_bound);
+      smt_astt overflow_low = mk_gt(result, max_bound);
+
+      return mk_or(overflow_high, overflow_low);
+    }
+
+    // Extract top half.
+    smt_astt toppart = mk_extract(result, (sz * 2) - 1, sz);
+
+    // It should be zero; if not, overflow
+    smt_astt iseq = mk_eq(toppart, convert_ast(zero));
+    return mk_not(iseq);
+  }
 
   default:
     log_error("unexpected overflow_arith operand");
     abort();
   }
 
-    return nullptr;
-  }
+  return nullptr;
+}
 
-  smt_astt smt_convt::overflow_cast(const expr2tc &expr)
+smt_astt smt_convt::overflow_cast(const expr2tc &expr)
+{
+  // If in integer mode, this is completely pointless. Return false.
+  if (int_encoding)
+    return mk_smt_bool(false);
+
+  const overflow_cast2t &ocast = to_overflow_cast2t(expr);
+  unsigned int width = ocast.operand->type->get_width();
+  unsigned int bits = ocast.bits;
+
+  if (ocast.bits >= width || ocast.bits == 0)
   {
-    // If in integer mode, this is completely pointless. Return false.
-    if (int_encoding)
-      return mk_smt_bool(false);
-
-    const overflow_cast2t &ocast = to_overflow_cast2t(expr);
-    unsigned int width = ocast.operand->type->get_width();
-    unsigned int bits = ocast.bits;
-
-    if (ocast.bits >= width || ocast.bits == 0)
-    {
-      log_error("SMT conversion: overflow-typecast got wrong number of bits");
-      abort();
-    }
-
-    // Basically: if it's positive in the first place, ensure all the top bits
-    // are zero. If neg, then all the top are 1's /and/ the next bit, so that
-    // it's considered negative in the next interpretation.
-
-    expr2tc zero = constant_int2tc(ocast.operand->type, BigInt(0));
-    expr2tc isnegexpr = lessthan2tc(ocast.operand, zero);
-    smt_astt isneg = convert_ast(isnegexpr);
-    smt_astt orig_val = convert_ast(ocast.operand);
-
-    // Difference bits
-    unsigned int pos_zero_bits = width - bits;
-    unsigned int neg_one_bits = (width - bits) + 1;
-
-    smt_astt pos_bits = mk_smt_bv(BigInt(0), pos_zero_bits);
-    smt_astt neg_bits = mk_smt_bv(BigInt::power2m1(neg_one_bits), neg_one_bits);
-
-    smt_astt pos_sel = mk_extract(orig_val, width - 1, width - pos_zero_bits);
-    smt_astt neg_sel = mk_extract(orig_val, width - 1, width - neg_one_bits);
-
-    smt_astt pos_eq = mk_eq(pos_bits, pos_sel);
-    smt_astt neg_eq = mk_eq(neg_bits, neg_sel);
-
-    // isneg -> neg_eq, !isneg -> pos_eq
-    smt_astt notisneg = mk_not(isneg);
-    smt_astt c1 = mk_implies(isneg, neg_eq);
-    smt_astt c2 = mk_implies(notisneg, pos_eq);
-
-    smt_astt nooverflow = mk_and(c1, c2);
-    return mk_not(nooverflow);
+    log_error("SMT conversion: overflow-typecast got wrong number of bits");
+    abort();
   }
 
-  smt_astt smt_convt::overflow_neg(const expr2tc &expr)
+  // Basically: if it's positive in the first place, ensure all the top bits
+  // are zero. If neg, then all the top are 1's /and/ the next bit, so that
+  // it's considered negative in the next interpretation.
+
+  expr2tc zero = constant_int2tc(ocast.operand->type, BigInt(0));
+  expr2tc isnegexpr = lessthan2tc(ocast.operand, zero);
+  smt_astt isneg = convert_ast(isnegexpr);
+  smt_astt orig_val = convert_ast(ocast.operand);
+
+  // Difference bits
+  unsigned int pos_zero_bits = width - bits;
+  unsigned int neg_one_bits = (width - bits) + 1;
+
+  smt_astt pos_bits = mk_smt_bv(BigInt(0), pos_zero_bits);
+  smt_astt neg_bits = mk_smt_bv(BigInt::power2m1(neg_one_bits), neg_one_bits);
+
+  smt_astt pos_sel = mk_extract(orig_val, width - 1, width - pos_zero_bits);
+  smt_astt neg_sel = mk_extract(orig_val, width - 1, width - neg_one_bits);
+
+  smt_astt pos_eq = mk_eq(pos_bits, pos_sel);
+  smt_astt neg_eq = mk_eq(neg_bits, neg_sel);
+
+  // isneg -> neg_eq, !isneg -> pos_eq
+  smt_astt notisneg = mk_not(isneg);
+  smt_astt c1 = mk_implies(isneg, neg_eq);
+  smt_astt c2 = mk_implies(notisneg, pos_eq);
+
+  smt_astt nooverflow = mk_and(c1, c2);
+  return mk_not(nooverflow);
+}
+
+smt_astt smt_convt::overflow_neg(const expr2tc &expr)
+{
+  // If in integer mode, this check is irrelevant, return false
+  if (int_encoding)
+    return mk_smt_bool(false);
+
+  // Extract operand
+  const overflow_neg2t &neg = to_overflow_neg2t(expr);
+  unsigned int width = neg.operand->type->get_width();
+
+  // Check if operand is unsigned
+  bool is_unsigned = is_unsignedbv_type(neg.operand->type);
+
+  if (is_unsigned)
   {
-    // If in integer mode, this check is irrelevant, return false
-    if (int_encoding)
-      return mk_smt_bool(false);
+    // **Unsigned Negation Overflow Check**
+    // In unsigned arithmetic, negation (-x) is effectively (UINT_MAX + 1 - x).
+    // Any nonzero value negated will wrap around, which is unexpected behavior.
+    expr2tc zero = constant_int2tc(neg.operand->type, 0);
+    // Overflow occurs if operand is x != 0
+    expr2tc val = notequal2tc(neg.operand, zero);
 
-    // Extract operand
-    const overflow_neg2t &neg = to_overflow_neg2t(expr);
-    unsigned int width = neg.operand->type->get_width();
-
-    // Check if operand is unsigned
-    bool is_unsigned = is_unsignedbv_type(neg.operand->type);
-
-    if (is_unsigned)
-    {
-      // **Unsigned Negation Overflow Check**
-      // In unsigned arithmetic, negation (-x) is effectively (UINT_MAX + 1 - x).
-      // Any nonzero value negated will wrap around, which is unexpected behavior.
-      expr2tc zero = constant_int2tc(neg.operand->type, 0);
-      // Overflow occurs if operand is x != 0
-      expr2tc val = notequal2tc(neg.operand, zero);
-
-      return convert_ast(val);
-    }
-    else
-    {
-      // **Signed Negation Overflow Check**
-      // Cast operand to signed type
-      expr2tc operand = typecast2tc(signedbv_type2tc(width), neg.operand);
-      simplify(operand);
-
-      // Compute the minimum integer value for the operand's type (INT_MIN)
-      expr2tc min_int =
-        constant_int2tc(operand->type, -BigInt::power2(width - 1));
-
-      // Overflow occurs if operand is INT_MIN
-      expr2tc val = equality2tc(operand, min_int);
-
-      return convert_ast(val);
-    }
+    return convert_ast(val);
   }
+  else
+  {
+    // **Signed Negation Overflow Check**
+    // Cast operand to signed type
+    expr2tc operand = typecast2tc(signedbv_type2tc(width), neg.operand);
+    simplify(operand);
+
+    // Compute the minimum integer value for the operand's type (INT_MIN)
+    expr2tc min_int =
+      constant_int2tc(operand->type, -BigInt::power2(width - 1));
+
+    // Overflow occurs if operand is INT_MIN
+    expr2tc val = equality2tc(operand, min_int);
+
+    return convert_ast(val);
+  }
+}

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -32,7 +32,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       expr2tc nounderflow =
         implies2tc(both_neg, lessthanequal2tc(overflow.operand, zero));
       return convert_ast(not2tc(and2tc(nooverflow, nounderflow)));
-    }
+    }   
     else if (is_signed && int_encoding)
     {
       // Get the width of the integer type
@@ -93,7 +93,7 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       expr2tc is_min_int = equality2tc(min_int, opers.side_2);
       return convert_ast(or2tc(add_overflows, is_min_int));
     }
-    
+
     // Just ensure the result is <= the first operand.
     expr2tc sub = sub2tc(opers.side_1->type, opers.side_1, opers.side_2);
     expr2tc le = lessthanequal2tc(sub, opers.side_1);

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -37,15 +37,15 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
     {
       // Get the width of the integer type
       auto const width = opers.side_1->type->get_width();
-      BigInt max_val = BigInt::power2(width - 1) - 1;  // MAX_INT
-      BigInt min_val = -BigInt::power2(width - 1);     // MIN_INT
+      BigInt max_val = BigInt::power2(width - 1) - 1; // MAX_INT
+      BigInt min_val = -BigInt::power2(width - 1);    // MIN_INT
      
       expr2tc max_int = constant_int2tc(opers.side_1->type, max_val);
       expr2tc min_int = constant_int2tc(opers.side_1->type, min_val);
 
       // Extract the operand of the overflow expression
       const overflow2t &overflow_expr = to_overflow2t(expr);
-      expr2tc result_expr = overflow_expr.operand;  // Fix: Correctly extract the operand
+      expr2tc result_expr = overflow_expr.operand;
 
       // Two cases: positive overflow and negative underflow
       expr2tc op1pos = lessthan2tc(zero, opers.side_1);

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -184,7 +184,8 @@ smt_astt smt_convt::overflow_arith(const expr2tc &expr)
       result = is_mul2t(overflow.operand)
                  ? mk_mul(arg1_ext, arg2_ext)  // Use mk_mul for multiplication
                  : mk_shl(arg1_ext, arg2_ext); // Use mk_shl for shift left    }
-      else
+    }
+    else
       {
         // If not using int_encoding, fallback to original behavior (bvmul and bvshl)
         result = is_mul2t(overflow.operand) ? mk_bvmul(arg1_ext, arg2_ext)

--- a/src/solvers/smt/smt_overflow.cpp
+++ b/src/solvers/smt/smt_overflow.cpp
@@ -267,10 +267,6 @@ smt_astt smt_convt::overflow_cast(const expr2tc &expr)
 
 smt_astt smt_convt::overflow_neg(const expr2tc &expr)
 {
-  // If in integer mode, this check is irrelevant, return false
-  if (int_encoding)
-    return mk_smt_bool(false);
-
   // Extract operand
   const overflow_neg2t &neg = to_overflow_neg2t(expr);
   unsigned int width = neg.operand->type->get_width();


### PR DESCRIPTION
This pull request adds ESBMC's handling of overflow detection for integer arithmetic operations: addition, subtraction, division, and multiplication. Integer operations follow arithmetic rules, including overflow behavior, whereas bitvectors typically use modular arithmetic. Directly reusing bitvector encoding could misinterpret signed numbers and break integer arithmetic semantics for overflow check.

### Tasks
- [x] Addition
- [x] Subtraction
- [x] Multiplication
- [x] Division
- [x] Unary

Master (30s):

````
Statistics:          33569 Files
  correct:           18072
    correct true:    10748
    correct false:    7324
  incorrect:            41
    incorrect true:     14
    incorrect false:    27
  unknown:           15456
  Score:             27940 (max: 55885)

GitHub Actions: https://github.com/esbmc/esbmc/actions/runs/13723073292
````

This PR (30s):

````
Statistics:          33569 Files
  correct:           18063
    correct true:    10740
    correct false:    7323
  incorrect:            40
    incorrect true:     13
    incorrect false:    27
  unknown:           15466
  Score:             27955 (max: 55885)

GitHub Actions: https://github.com/esbmc/esbmc/actions/runs/13749597180
````
