### PR TITLE
[OM] hide ATOI_MAP from the counterexample

### DIFF
--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -226,12 +226,20 @@ __ESBMC_HIDE:;
 }
 
 /* one plus the numeric value, rest is zero */
-static const unsigned char get_atoi_map(unsigned char pos) {
-  __ESBMC_HIDE:;
+static const unsigned char get_atoi_map(unsigned char pos)
+{
+__ESBMC_HIDE:;
   const unsigned char ATOI_MAP[256] = {
-    ['0'] = 1, ['1'] = 2, ['2'] = 3, ['3'] = 4,
-    ['4'] = 5, ['5'] = 6, ['6'] = 7, ['7'] = 8,
-    ['8'] = 9, ['9'] = 10,
+    ['0'] = 1,
+    ['1'] = 2,
+    ['2'] = 3,
+    ['3'] = 4,
+    ['4'] = 5,
+    ['5'] = 6,
+    ['6'] = 7,
+    ['7'] = 8,
+    ['8'] = 9,
+    ['9'] = 10,
   };
   return ATOI_MAP[pos];
 }

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -226,18 +226,15 @@ __ESBMC_HIDE:;
 }
 
 /* one plus the numeric value, rest is zero */
-static const unsigned char ATOI_MAP[256] = {
-  ['0'] = 1,
-  ['1'] = 2,
-  ['2'] = 3,
-  ['3'] = 4,
-  ['4'] = 5,
-  ['5'] = 6,
-  ['6'] = 7,
-  ['7'] = 8,
-  ['8'] = 9,
-  ['9'] = 10,
-};
+static const unsigned char get_atoi_map(unsigned char pos) {
+  __ESBMC_HIDE:;
+  const unsigned char ATOI_MAP[256] = {
+    ['0'] = 1, ['1'] = 2, ['2'] = 3, ['3'] = 4,
+    ['4'] = 5, ['5'] = 6, ['6'] = 7, ['7'] = 8,
+    ['8'] = 9, ['9'] = 10,
+  };
+  return ATOI_MAP[pos];
+}
 
 #define ATOI_DEF(name, type, TYPE)                                             \
   type name(const char *s)                                                     \
@@ -254,7 +251,7 @@ static const unsigned char ATOI_MAP[256] = {
     else if (*s == '+')                                                        \
       s++;                                                                     \
     unsigned type r = 0;                                                       \
-    for (unsigned char c; (c = ATOI_MAP[(unsigned char)*s]); s++)              \
+    for (unsigned char c; (c = get_atoi_map((unsigned char)*s)); s++)          \
     {                                                                          \
       c--;                                                                     \
       if (r > (TYPE##_MAX - c) / 10)                                           \


### PR DESCRIPTION
````C
#include <stdlib.h>

int main(){
  char* ptr = (char *)malloc(sizeof(char));

  if(ptr==NULL)
    return -1;

  *ptr = 'a';

  free(ptr);
  free(ptr);

  return 0;
}
````

Before this PR:

````
$ esbmc exampleB.c --compact-trace
ESBMC version 7.8.1 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing exampleB.c
Converting
Generating GOTO Program
GOTO program creation time: 0.574s
GOTO program processing time: 0.013s
Starting Bounded Model Checking
Symex completed in: 0.009s (27 assignments)
Slicing time: 0.000s (removed 3 assignments)
Generated 10 VCC(s), 6 remaining after simplification (24 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.008s
Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.089s
Building error trace

[Counterexample]


State 1 file /home/lucas/ESBMC_Project/esbmc/src/c2goto/library/stdlib.c line 231 column 3 function get_atoi_map thread 0
----------------------------------------------------
  ATOI_MAP = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }

State 2 file exampleB.c line 4 column 3 function main thread 0
----------------------------------------------------
  ptr = &dynamic_1_value

State 5 file exampleB.c line 9 column 3 function main thread 0
----------------------------------------------------
  *ptr = 97 (01100001)

State 8 file exampleB.c line 12 column 3 function main thread 0
----------------------------------------------------
Violated property:
  file exampleB.c line 12 column 3 function main
  dereference failure: invalidated dynamic object freed


VERIFICATION FAILED
````

After this PR:

````
$ esbmc exampleB.c --compact-trace
ESBMC version 7.8.1 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing exampleB.c
Converting
Generating GOTO Program
GOTO program creation time: 0.593s
GOTO program processing time: 0.015s
Starting Bounded Model Checking
Symex completed in: 0.008s (26 assignments)
Slicing time: 0.000s (removed 3 assignments)
Generated 10 VCC(s), 6 remaining after simplification (23 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.006s
Building error trace

[Counterexample]


State 1 file exampleB.c line 4 column 3 function main thread 0
----------------------------------------------------
  ptr = &dynamic_1_value

State 4 file exampleB.c line 9 column 3 function main thread 0
----------------------------------------------------
  *ptr = 97 (01100001)

State 7 file exampleB.c line 12 column 3 function main thread 0
----------------------------------------------------
Violated property:
  file exampleB.c line 12 column 3 function main
  dereference failure: invalidated dynamic object freed


VERIFICATION FAILED
````