### PR TITLE
[OM] reimplement atexit using infinite arrays

### DIFF
--- a/regression/esbmc/atexit-5/main.c
+++ b/regression/esbmc/atexit-5/main.c
@@ -1,0 +1,81 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* Enhanced regression test for atexit */
+
+int **g = NULL;
+int *h_ptr = NULL;
+
+void free_g1() {
+    printf("Freeing g\n");
+    free(g);
+    g = NULL;
+}
+
+void free_g2() {
+    if (g != NULL) {
+        printf("Freeing *g\n");
+        free(*g);
+    }
+}
+
+void free_h_ptr() {
+    printf("Freeing h_ptr\n");
+    free(h_ptr);
+    h_ptr = NULL;
+}
+
+void extra_cleanup() {
+    printf("Performing extra cleanup\n");
+    if (g != NULL && *g != NULL) {
+        **g = 0; // Just to show additional manipulation before freeing
+    }
+}
+
+void h() {
+    if (__VERIFIER_nondet_bool()) {
+        printf("Exiting from h()\n");
+        exit(1);
+    }
+}
+
+void f() {
+    *g = (int *)malloc(sizeof(int));
+    if (*g == NULL) {
+        perror("malloc failed for *g");
+        exit(1);
+    }
+    **g = 42; // Assign a value
+    atexit(free_g2);
+
+    h_ptr = (int *)malloc(sizeof(int));
+    if (h_ptr == NULL) {
+        perror("malloc failed for h_ptr");
+        exit(1);
+    }
+    *h_ptr = 99;
+    atexit(free_h_ptr);
+
+    atexit(extra_cleanup);
+    h();
+}
+
+int main() {
+    g = (int **)malloc(sizeof(int *));
+    if (g == NULL) {
+        perror("malloc failed for g");
+        exit(1);
+    }
+    atexit(free_g1);
+
+    if (__VERIFIER_nondet_bool()) {
+        printf("Exiting from main() before f()\n");
+        exit(1);
+    }
+
+    f();
+    return 0;
+}
+

--- a/regression/esbmc/atexit-5/test.desc
+++ b/regression/esbmc/atexit-5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success --incremental-bmc --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/atexit-6/main.c
+++ b/regression/esbmc/atexit-6/main.c
@@ -1,0 +1,108 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+extern _Bool __VERIFIER_nondet_bool();
+
+/* Enhanced regression test for atexit with loops */
+
+int **g = NULL;
+int *h_ptr = NULL;
+int *array = NULL;
+
+void free_g1() {
+    printf("Freeing g\n");
+    free(g);
+    g = NULL;
+}
+
+void free_g2() {
+    if (g != NULL) {
+        printf("Freeing *g\n");
+        free(*g);
+    }
+}
+
+void free_h_ptr() {
+    printf("Freeing h_ptr\n");
+    free(h_ptr);
+    h_ptr = NULL;
+}
+
+void free_array() {
+    printf("Freeing array\n");
+    free(array);
+    array = NULL;
+}
+
+void extra_cleanup() {
+    printf("Performing extra cleanup\n");
+    if (g != NULL && *g != NULL) {
+        **g = 0; // Just to show additional manipulation before freeing
+    }
+    if (array != NULL) {
+        for (int i = 0; i < 4; i++) {
+            array[i] = 0; // Reset values before freeing
+        }
+    }
+}
+
+void h() {
+    for (int i = 0; i < 4; i++) {
+        if (__VERIFIER_nondet_bool()) {
+            printf("Exiting from h() in loop iteration %d\n", i);
+            exit(1);
+        }
+    }
+}
+
+void f() {
+    *g = (int *)malloc(sizeof(int));
+    if (*g == NULL) {
+        perror("malloc failed for *g");
+        exit(1);
+    }
+    **g = 42; // Assign a value
+    atexit(free_g2);
+    
+    h_ptr = (int *)malloc(sizeof(int));
+    if (h_ptr == NULL) {
+        perror("malloc failed for h_ptr");
+        exit(1);
+    }
+    *h_ptr = 99;
+    atexit(free_h_ptr);
+    
+    array = (int *)malloc(4 * sizeof(int));
+    if (array == NULL) {
+        perror("malloc failed for array");
+        exit(1);
+    }
+    for (int i = 0; i < 4; i++) {
+        array[i] = i * 2;
+    }
+    atexit(free_array);
+    
+    atexit(extra_cleanup);
+    h();
+}
+
+int main() {
+    g = (int **)malloc(sizeof(int *));
+    if (g == NULL) {
+        perror("malloc failed for g");
+        exit(1);
+    }
+    atexit(free_g1);
+    
+    for (int i = 0; i < 3; i++) {
+        if (__VERIFIER_nondet_bool()) {
+            printf("Exiting from main() in loop iteration %d before f()\n", i);
+            exit(1);
+        }
+    }
+    
+    f();
+    return 0;
+}
+
+

--- a/regression/esbmc/atexit-6/test.desc
+++ b/regression/esbmc/atexit-6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --force-malloc-success --incremental-bmc --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/stdlib.c
+++ b/src/c2goto/library/stdlib.c
@@ -26,8 +26,8 @@ typedef struct atexit_key
 } __ESBMC_atexit_key;
 
 // Infinite array for atexit functions
-__attribute__((annotate("__ESBMC_inf_size")))
-static __ESBMC_atexit_key __ESBMC_stdlib_atexit_key[1];
+__attribute__((annotate(
+  "__ESBMC_inf_size"))) static __ESBMC_atexit_key __ESBMC_stdlib_atexit_key[1];
 static size_t __ESBMC_atexit_count = 0;
 
 void __ESBMC_atexit_handler()


### PR DESCRIPTION
This PR reimplements our `atexit` handling code using infinite arrays (`__ESBMC_inf_size` annotation). This approach replaces dynamic memory allocation with an infinite array to prevent malloc-related verification efforts and thus simplifies the generation of verification conditions.

Master (30s):

````
Statistics:          33569 Files
  correct:           18070
    correct true:    10742
    correct false:    7328
  incorrect:            40
    incorrect true:     13
    incorrect false:    27
  unknown:           15459
  Score:             27964 (max: 55885)


https://github.com/esbmc/esbmc/actions/runs/13888616601
````

This PR (30s):

````
Statistics:          33569 Files
  correct:           18075
    correct true:    10743
    correct false:    7332
  incorrect:            40
    incorrect true:     13
    incorrect false:    27
  unknown:           15454
  Score:             27970 (max: 55885)

https://github.com/esbmc/esbmc/actions/runs/13906715936
````
