### PR TITLE
[Z3] Support bitwise for integer arithmetic

### DIFF
--- a/regression/esbmc/bitwise1/main.c
+++ b/regression/esbmc/bitwise1/main.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdio.h>
+
+void test_xor_operations() {
+    // Test case 1: Basic XOR operation
+    int a = 5;  // 0101 in binary
+    int b = 3;  // 0011 in binary
+    int result = a ^ b;  // 0101 ^ 0011 = 0110 (should be 6)
+    assert(result == 6);
+    printf("Test case 1 passed\n");
+
+    // Test case 2: XOR with zero (should return the same number)
+    int c = 0;  // 0000 in binary
+    result = a ^ c;  // 0101 ^ 0000 = 0101 (should be 5)
+    assert(result == 5);
+    printf("Test case 2 passed\n");
+
+    // Test case 3: XOR of a number with itself (should return 0)
+    result = a ^ a;  // 0101 ^ 0101 = 0000 (should be 0)
+    assert(result == 0);
+    printf("Test case 3 passed\n");
+
+    // Test case 4: XOR with all bits set (should invert the bits)
+    int d = ~0;  // All bits set (typically -1)
+    result = a ^ d;  // 0101 ^ 1111...1111 = 1010...1010 (~5)
+    assert(result == ~5);
+    printf("Test case 4 passed\n");
+    
+    // Test case 5: XOR with alternating bits
+    int e = 0x55;  // 01010101 in binary
+    int f = 0xAA;  // 10101010 in binary
+    result = e ^ f;  // 01010101 ^ 10101010 = 11111111 (should be 255)
+    assert(result == 255);
+    printf("Test case 5 passed\n");
+}
+
+int main() {
+    // Run all the test cases
+    test_xor_operations();
+    return 0;
+}
+
+

--- a/regression/esbmc/bitwise1/test.desc
+++ b/regression/esbmc/bitwise1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/bitwise10/main.c
+++ b/regression/esbmc/bitwise10/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int my_nand(int a, int b) {
+    return !(a & b);  // NAND is the negation of AND
+}
+
+int main() {
+    // Test NAND operation
+    assert(my_nand(1, 1) != 0); // 1 NAND 1 should be 0
+    assert(my_nand(1, 0) != 1); // 1 NAND 0 should be 1
+    assert(my_nand(0, 1) != 1); // 0 NAND 1 should be 1
+    assert(my_nand(0, 0) != 1); // 0 NAND 0 should be 1
+    return 0;
+}
+

--- a/regression/esbmc/bitwise10/test.desc
+++ b/regression/esbmc/bitwise10/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--z3 --ir --no-simplify --multi-property
+VERIFICATION FAILED
+!= 1
+!= 0

--- a/regression/esbmc/bitwise11/main.c
+++ b/regression/esbmc/bitwise11/main.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+int main() {
+    float f = 3.14f;
+    uint32_t bits;
+
+    memcpy(&bits, &f, sizeof(f)); // Copy float's binary representation to an integer
+
+    bits ^= 0x80000000; // Flip the sign bit (example operation)
+
+    memcpy(&f, &bits, sizeof(bits)); // Copy back to float
+
+    printf("Modified float: %f\n", f);
+    return 0;
+}

--- a/regression/esbmc/bitwise11/test.desc
+++ b/regression/esbmc/bitwise11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --no-simplify --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/bitwise2/main.c
+++ b/regression/esbmc/bitwise2/main.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+
+
+void test_xor_operations() {
+    // Test case 1: Basic XOR operation
+    int a = 5;  // 0101 in binary
+    int b = 3;  // 0011 in binary
+    int result = a ^ b;  // 0101 ^ 0011 = 0110 (should be 6)
+    assert(result != 6);
+
+    // Test case 2: XOR with zero (should return the same number)
+    int c = 0;  // 0000 in binary
+    result = a ^ c;  // 0101 ^ 0000 = 0101 (should be 5)
+    assert(result != 5);
+
+    // Test case 3: XOR of a number with itself (should return 0)
+    result = a ^ a;  // 0101 ^ 0101 = 0000 (should be 0)
+    assert(result != 0);
+
+    // Test case 4: XOR with all bits set (should invert the bits)
+    int d = ~0;  // All bits set (typically -1)
+    result = a ^ d;  // 0101 ^ 1111...1111 = 1010...1010 (~5)
+    assert(result != ~5);
+    
+    // Test case 5: XOR with alternating bits
+    int e = 0x55;  // 01010101 in binary
+    int f = 0xAA;  // 10101010 in binary
+    result = e ^ f;  // 01010101 ^ 10101010 = 11111111 (should be 255)
+    assert(result != 255);
+}
+
+int main() {
+    // Run all the test cases
+    test_xor_operations();
+    return 0;
+}
+
+

--- a/regression/esbmc/bitwise2/test.desc
+++ b/regression/esbmc/bitwise2/test.desc
@@ -1,5 +1,5 @@
 CORE
-main.py
+main.c
 --z3 --ir --no-simplify --multi-property
 VERIFICATION FAILED
 result != 6

--- a/regression/esbmc/bitwise2/test.desc
+++ b/regression/esbmc/bitwise2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.py
+--z3 --ir --no-simplify --multi-property
+VERIFICATION FAILED
+result != 6
+result != 5
+result != 0
+result != ~5
+result != 255

--- a/regression/esbmc/bitwise3/main.c
+++ b/regression/esbmc/bitwise3/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdio.h>
+
+// Function to perform boolean NXOR (XNOR)
+int bool_nxor(int a, int b) {
+    return !(a ^ b);
+}
+
+// Function to perform bitwise NXOR (XNOR) on integers
+int int_nxor(int a, int b) {
+    return ~(a ^ b);
+}
+
+void test_nxor() {
+    // Boolean NXOR test cases
+    assert(bool_nxor(0, 0) == 1);
+    assert(bool_nxor(0, 1) == 0);
+    assert(bool_nxor(1, 0) == 0);
+    assert(bool_nxor(1, 1) == 1);
+
+    // Integer NXOR test cases
+    assert(int_nxor(0b1100, 0b1010) == ~(0b1100 ^ 0b1010));
+    assert(int_nxor(0xF0F0, 0x0F0F) == ~(0xF0F0 ^ 0x0F0F));
+    assert(int_nxor(123, 456) == ~(123 ^ 456));
+    assert(int_nxor(-5, 3) == ~(-5 ^ 3));
+    assert(int_nxor(0, 0) == ~0);
+    
+    printf("All NXOR tests passed!\n");
+}
+
+int main() {
+    test_nxor();
+    return 0;
+}

--- a/regression/esbmc/bitwise3/test.desc
+++ b/regression/esbmc/bitwise3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/bitwise4/main.c
+++ b/regression/esbmc/bitwise4/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdio.h>
+
+// Function to perform boolean NXOR (XNOR)
+int bool_nxor(int a, int b) {
+    return !(a ^ b);
+}
+
+// Function to perform bitwise NXOR (XNOR) on integers
+int int_nxor(int a, int b) {
+    return ~(a ^ b);
+}
+
+void test_nxor() {
+    // Boolean NXOR test cases
+    assert(bool_nxor(0, 0) != 1);
+    assert(bool_nxor(0, 1) != 0);
+    assert(bool_nxor(1, 0) != 0);
+    assert(bool_nxor(1, 1) != 1);
+
+    // Integer NXOR test cases
+    assert(int_nxor(0b1100, 0b1010) != ~(0b1100 ^ 0b1010));
+    assert(int_nxor(0xF0F0, 0x0F0F) != ~(0xF0F0 ^ 0x0F0F));
+    assert(int_nxor(123, 456) != ~(123 ^ 456));
+    assert(int_nxor(-5, 3) != ~(-5 ^ 3));
+    assert(int_nxor(0, 0) != ~0);
+    
+    printf("All NXOR tests passed!\n");
+}
+
+int main() {
+    test_nxor();
+    return 0;
+}

--- a/regression/esbmc/bitwise4/test.desc
+++ b/regression/esbmc/bitwise4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --z3 --ir --no-simplify --multi-property
-$VERIFICATION FAILED^
+^VERIFICATION FAILED$

--- a/regression/esbmc/bitwise4/test.desc
+++ b/regression/esbmc/bitwise4/test.desc
@@ -2,12 +2,12 @@ CORE
 main.c
 --z3 --ir --no-simplify --multi-property
 VERIFICATION FAILED
-return_value$_int_nxor$9 != ~0
-return_value$_int_nxor$8 != ~(-5 ^ 3)
-return_value$_int_nxor$7 != ~(123 ^ 456)
-return_value$_int_nxor$6 != ~(61680 ^ 3855)
-return_value$_int_nxor$5 != ~(12 ^ 10)
-return_value$_bool_nxor$4 != 1
-return_value$_bool_nxor$3 != 0
-return_value$_bool_nxor$2 != 0
-return_value$_bool_nxor$1 != 1
+!= ~0
+!= ~(-5 ^ 3)
+!= ~(123 ^ 456)
+!= ~(61680 ^ 3855)
+!= ~(12 ^ 10)
+!= 1
+!= 0
+!= 0
+!= 1

--- a/regression/esbmc/bitwise4/test.desc
+++ b/regression/esbmc/bitwise4/test.desc
@@ -1,13 +1,4 @@
 CORE
 main.c
 --z3 --ir --no-simplify --multi-property
-VERIFICATION FAILED
-!= ~0
-!= ~(-5 ^ 3)
-!= ~(123 ^ 456)
-!= ~(61680 ^ 3855)
-!= ~(12 ^ 10)
-!= 1
-!= 0
-!= 0
-!= 1
+$VERIFICATION FAILED^

--- a/regression/esbmc/bitwise4/test.desc
+++ b/regression/esbmc/bitwise4/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--z3 --ir --no-simplify --multi-property
+VERIFICATION FAILED
+return_value$_int_nxor$9 != ~0
+return_value$_int_nxor$8 != ~(-5 ^ 3)
+return_value$_int_nxor$7 != ~(123 ^ 456)
+return_value$_int_nxor$6 != ~(61680 ^ 3855)
+return_value$_int_nxor$5 != ~(12 ^ 10)
+return_value$_bool_nxor$4 != 1
+return_value$_bool_nxor$3 != 0
+return_value$_bool_nxor$2 != 0
+return_value$_bool_nxor$1 != 1

--- a/regression/esbmc/bitwise5/main.c
+++ b/regression/esbmc/bitwise5/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <stdio.h>
+
+// Function to compute NOR operation
+typedef int (*nor_func)(int, int);
+
+int int_nor(int a, int b) {
+    return ~(a | b);
+}
+
+void test_nor(nor_func func) {
+    // Test cases
+    assert(func(0, 0) == ~0);
+    assert(func(0, 1) == ~1);
+    assert(func(1, 0) == ~1);
+    assert(func(1, 1) == ~1);
+    assert(func(5, 3) == ~(5 | 3));
+    assert(func(123, 456) == ~(123 | 456));
+    assert(func(0xF0F0, 0x0F0F) == ~(0xF0F0 | 0x0F0F));
+    assert(func(0b1100, 0b1010) == ~(0b1100 | 0b1010));
+    
+    printf("All NOR tests passed.\n");
+}
+
+int main() {
+    test_nor(int_nor);
+    return 0;
+}

--- a/regression/esbmc/bitwise5/test.desc
+++ b/regression/esbmc/bitwise5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/bitwise6/main.c
+++ b/regression/esbmc/bitwise6/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <stdio.h>
+
+// Function to compute NOR operation
+typedef int (*nor_func)(int, int);
+
+int int_nor(int a, int b) {
+    return ~(a | b);
+}
+
+void test_nor(nor_func func) {
+    // Test cases
+    assert(func(0, 0) != ~0);
+    assert(func(0, 1) != ~1);
+    assert(func(1, 0) != ~1);
+    assert(func(1, 1) != ~1);
+    assert(func(5, 3) != ~(5 | 3));
+    assert(func(123, 456) != ~(123 | 456));
+    assert(func(0xF0F0, 0x0F0F) != ~(0xF0F0 | 0x0F0F));
+    assert(func(0b1100, 0b1010) != ~(0b1100 | 0b1010));
+    
+    printf("All NOR tests passed.\n");
+}
+
+int main() {
+    test_nor(int_nor);
+    return 0;
+}

--- a/regression/esbmc/bitwise6/test.desc
+++ b/regression/esbmc/bitwise6/test.desc
@@ -1,10 +1,4 @@
 CORE
 main.c
 --z3 --ir --no-simplify --multi-property
-VERIFICATION FAILED
-!= ~(12 | 10)
-!= ~(61680 | 3855)
-!= ~0
-!= ~1
-!= ~(5 | 3)
-!= ~(123 | 456)
+^VERIFICATION FAILED$

--- a/regression/esbmc/bitwise6/test.desc
+++ b/regression/esbmc/bitwise6/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--z3 --ir --no-simplify --multi-property
+VERIFICATION FAILED
+!= ~(12 | 10)
+!= ~(61680 | 3855)
+!= ~0
+!= ~1
+!= ~(5 | 3)
+!= ~(123 | 456)

--- a/regression/esbmc/bitwise7/main.c
+++ b/regression/esbmc/bitwise7/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+    // Test AND operation
+    assert((1 & 1) == 1); // 1 AND 1 should be 1
+    assert((1 & 0) == 0); // 1 AND 0 should be 0
+    assert((0 & 1) == 0); // 0 AND 1 should be 0
+    assert((0 & 0) == 0); // 0 AND 0 should be 0
+    
+    printf("AND operation tests passed.\n");
+    return 0;
+}

--- a/regression/esbmc/bitwise7/test.desc
+++ b/regression/esbmc/bitwise7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/bitwise8/main.c
+++ b/regression/esbmc/bitwise8/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+    // Test AND operation
+    assert((1 & 1) != 1); // 1 AND 1 should be 1
+    assert((1 & 0) != 0); // 1 AND 0 should be 0
+    assert((0 & 1) != 0); // 0 AND 1 should be 0
+    assert((0 & 0) != 0); // 0 AND 0 should be 0
+    
+    printf("AND operation tests passed.\n");
+    return 0;
+}

--- a/regression/esbmc/bitwise8/test.desc
+++ b/regression/esbmc/bitwise8/test.desc
@@ -1,8 +1,4 @@
 CORE
 main.c
 --z3 --ir --no-simplify --multi-property
-VERIFICATION FAILED
-(1 & 1) != 1
-(1 & 0) != 0
-(0 & 1) != 0
-(0 & 0) != 0
+$VERIFICATION FAILED^

--- a/regression/esbmc/bitwise8/test.desc
+++ b/regression/esbmc/bitwise8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --z3 --ir --no-simplify --multi-property
-$VERIFICATION FAILED^
+^VERIFICATION FAILED$

--- a/regression/esbmc/bitwise8/test.desc
+++ b/regression/esbmc/bitwise8/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--z3 --ir --no-simplify --multi-property
+VERIFICATION FAILED
+(1 & 1) != 1
+(1 & 0) != 0
+(0 & 1) != 0
+(0 & 0) != 0

--- a/regression/esbmc/bitwise9/main.c
+++ b/regression/esbmc/bitwise9/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int my_nand(int a, int b) {
+    return !(a & b);  // NAND is the negation of AND
+}
+
+int main() {
+    // Test NAND operation
+    assert(my_nand(1, 1) == 0); // 1 NAND 1 should be 0
+    assert(my_nand(1, 0) == 1); // 1 NAND 0 should be 1
+    assert(my_nand(0, 1) == 1); // 0 NAND 1 should be 1
+    assert(my_nand(0, 0) == 1); // 0 NAND 0 should be 1
+    return 0;
+}
+

--- a/regression/esbmc/bitwise9/test.desc
+++ b/regression/esbmc/bitwise9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1174,8 +1174,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitnxor_id:
   {
-    assert(!int_encoding);
-    a = mk_bvnxor(args[0], args[1]);
+    if (int_encoding)
+      a = mk_not(mk_xor(args[0], args[1]));
+    else
+      a = mk_bvnxor(args[0], args[1]);
     break;
   }
   case expr2t::bitnot_id:

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1148,8 +1148,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitor_id:
   {
-    assert(!int_encoding);
-    a = mk_bvor(args[0], args[1]);
+    if (int_encoding)
+      a = mk_or(args[0], args[1]);
+    else
+      a = mk_bvor(args[0], args[1]);
     break;
   }
   case expr2t::bitxor_id:
@@ -1168,8 +1170,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitnor_id:
   {
-    assert(!int_encoding);
-    a = mk_bvnor(args[0], args[1]);
+    if (int_encoding)
+      a = mk_not(mk_or(args[0], args[1]));
+    else
+      a = mk_bvnor(args[0], args[1]);
     break;
   }
   case expr2t::bitnxor_id:

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1142,8 +1142,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitand_id:
   {
-    assert(!int_encoding);
-    a = mk_bvand(args[0], args[1]);
+    if (int_encoding)
+      a = mk_and(args[0], args[1]);
+    else
+      a = mk_bvand(args[0], args[1]);
     break;
   }
   case expr2t::bitor_id:
@@ -1164,8 +1166,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitnand_id:
   {
-    assert(!int_encoding);
-    a = mk_bvnand(args[0], args[1]);
+    if (int_encoding)
+      a = mk_not(mk_and(args[0], args[1]));
+    else
+      a = mk_bvnand(args[0], args[1]);
     break;
   }
   case expr2t::bitnor_id:

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1142,58 +1142,37 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitand_id:
   {
-    if (int_encoding)
-      a = mk_and(args[0], args[1]);
-    else
-      a = mk_bvand(args[0], args[1]);
+    a = mk_bvand(args[0], args[1]);
     break;
   }
   case expr2t::bitor_id:
   {
-    if (int_encoding)
-      a = mk_or(args[0], args[1]);
-    else
-      a = mk_bvor(args[0], args[1]);
+    a = mk_bvor(args[0], args[1]);
     break;
   }
   case expr2t::bitxor_id:
   {
-    if (int_encoding)
-      a = mk_xor(args[0], args[1]);
-    else
-      a = mk_bvxor(args[0], args[1]);
+    a = mk_bvxor(args[0], args[1]);
     break;
   }
   case expr2t::bitnand_id:
   {
-    if (int_encoding)
-      a = mk_not(mk_and(args[0], args[1]));
-    else
-      a = mk_bvnand(args[0], args[1]);
+    a = mk_bvnand(args[0], args[1]);
     break;
   }
   case expr2t::bitnor_id:
   {
-    if (int_encoding)
-      a = mk_not(mk_or(args[0], args[1]));
-    else
-      a = mk_bvnor(args[0], args[1]);
+    a = mk_bvnor(args[0], args[1]);
     break;
   }
   case expr2t::bitnxor_id:
   {
-    if (int_encoding)
-      a = mk_not(mk_xor(args[0], args[1]));
-    else
-      a = mk_bvnxor(args[0], args[1]);
+    a = mk_bvnxor(args[0], args[1]);
     break;
   }
   case expr2t::bitnot_id:
   {
-    if (int_encoding)
-      a = mk_not(args[0]);
-    else
-      a = mk_bvnot(args[0]);
+    a = mk_bvnot(args[0]);
     break;
   }
   case expr2t::not_id:

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1140,6 +1140,12 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     a = mk_implies(args[0], args[1]);
     break;
   }
+  /* According to the SMT-lib, LIRA focuses on arithmetic operations
+     involving integers and reals. Still, it does not inherently handle
+     bitwise operations, as these fall under the domain of bit-vector theories.
+     Here, we combine LIRA and bitwise operations (such as &, |, ^)
+     in a way that aligns with arithmetic constraints.
+  */
   case expr2t::bitand_id:
   {
     a = mk_bvand(args[0], args[1]);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1154,8 +1154,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitxor_id:
   {
-    assert(!int_encoding);
-    a = mk_bvxor(args[0], args[1]);
+    if (int_encoding)
+      a = mk_xor(args[0], args[1]);
+    else
+      a = mk_bvxor(args[0], args[1]);
     break;
   }
   case expr2t::bitnand_id:
@@ -1178,8 +1180,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::bitnot_id:
   {
-    assert(!int_encoding);
-    a = mk_bvnot(args[0]);
+    if (int_encoding)
+      a = mk_not(args[0]);
+    else
+      a = mk_bvnot(args[0]);
     break;
   }
   case expr2t::not_id:

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -383,7 +383,7 @@ smt_astt z3_convt::mk_bvnot(smt_astt a)
 {
   if (int_encoding)
   {
-    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
+    assert(a->sort->id == SMT_SORT_INT);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     // Get the signedbv bit-width
     size_t bit_width = signed_size_type2()->get_width();
@@ -405,8 +405,7 @@ smt_astt z3_convt::mk_bvnot(smt_astt a)
 smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
 {
   assert(
-    (a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
-    (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
+    (a->sort->id == SMT_SORT_INT) || (b->sort->id == SMT_SORT_INT) ||
     (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
     !(to_solver_smt_ast<z3_smt_ast>(a)->a ^
@@ -417,8 +416,7 @@ smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
 smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(
-    (a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
-    (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
+    (a->sort->id == SMT_SORT_INT) || (b->sort->id == SMT_SORT_INT) ||
     (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
     !(to_solver_smt_ast<z3_smt_ast>(a)->a |
@@ -429,8 +427,7 @@ smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 smt_astt z3_convt::mk_bvnand(smt_astt a, smt_astt b)
 {
   assert(
-    (a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
-    (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
+    (a->sort->id == SMT_SORT_INT) || (b->sort->id == SMT_SORT_INT) ||
     (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
     !(to_solver_smt_ast<z3_smt_ast>(a)->a &
@@ -442,8 +439,7 @@ smt_astt z3_convt::mk_bvxor(smt_astt a, smt_astt b)
 {
   if (int_encoding)
   {
-    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
-    assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
+    assert(a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
     // Get the signedbv bit-width
@@ -473,8 +469,7 @@ smt_astt z3_convt::mk_bvor(smt_astt a, smt_astt b)
 {
   if (int_encoding)
   {
-    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
-    assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
+    assert(a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
     // Get the signedbv bit-width
@@ -504,8 +499,7 @@ smt_astt z3_convt::mk_bvand(smt_astt a, smt_astt b)
 {
   if (int_encoding)
   {
-    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
-    assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
+    assert(a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
     // Get the signed bit-width

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -404,7 +404,8 @@ smt_astt z3_convt::mk_bvnot(smt_astt a)
 
 smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
 {
-  assert((a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
+  assert(
+    (a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
     (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
     (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
@@ -415,7 +416,8 @@ smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
-  assert((a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
+  assert(
+    (a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
     (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
     (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
@@ -426,18 +428,19 @@ smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_bvnand(smt_astt a, smt_astt b)
 {
-  assert((a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
+  assert(
+    (a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
     (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
     (a->sort->get_data_width() == b->sort->get_data_width()));
-    return new_ast(
-      !(to_solver_smt_ast<z3_smt_ast>(a)->a &
-        to_solver_smt_ast<z3_smt_ast>(b)->a),
-      a->sort);
+  return new_ast(
+    !(to_solver_smt_ast<z3_smt_ast>(a)->a &
+      to_solver_smt_ast<z3_smt_ast>(b)->a),
+    a->sort);
 }
 
 smt_astt z3_convt::mk_bvxor(smt_astt a, smt_astt b)
 {
-  if(int_encoding)
+  if (int_encoding)
   {
     assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
     assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
@@ -460,7 +463,8 @@ smt_astt z3_convt::mk_bvxor(smt_astt a, smt_astt b)
     assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
     assert(a->sort->get_data_width() == b->sort->get_data_width());
     return new_ast(
-      (to_solver_smt_ast<z3_smt_ast>(a)->a ^ to_solver_smt_ast<z3_smt_ast>(b)->a),
+      (to_solver_smt_ast<z3_smt_ast>(a)->a ^
+       to_solver_smt_ast<z3_smt_ast>(b)->a),
       a->sort);
   }
 }
@@ -483,7 +487,6 @@ smt_astt z3_convt::mk_bvor(smt_astt a, smt_astt b)
     // Convert result back to integer
     z3::expr int_or = z3::bv2int(or_bv, true); // 'true' = signed conversion
     return new_ast(int_or, mk_int_sort());
-
   }
   else
   {
@@ -491,7 +494,8 @@ smt_astt z3_convt::mk_bvor(smt_astt a, smt_astt b)
     assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
     assert(a->sort->get_data_width() == b->sort->get_data_width());
     return new_ast(
-      (to_solver_smt_ast<z3_smt_ast>(a)->a | to_solver_smt_ast<z3_smt_ast>(b)->a),
+      (to_solver_smt_ast<z3_smt_ast>(a)->a |
+       to_solver_smt_ast<z3_smt_ast>(b)->a),
       a->sort);
   }
 }
@@ -519,12 +523,12 @@ smt_astt z3_convt::mk_bvand(smt_astt a, smt_astt b)
   {
     assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
     assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-    assert(a->sort->get_data_width() == b->sort->get_data_width());    
+    assert(a->sort->get_data_width() == b->sort->get_data_width());
     return new_ast(
-      (to_solver_smt_ast<z3_smt_ast>(a)->a & to_solver_smt_ast<z3_smt_ast>(b)->a),
+      (to_solver_smt_ast<z3_smt_ast>(a)->a &
+       to_solver_smt_ast<z3_smt_ast>(b)->a),
       a->sort);
   }
-
 }
 
 smt_astt z3_convt::mk_implies(smt_astt a, smt_astt b)
@@ -554,7 +558,7 @@ smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     (to_solver_smt_ast<z3_smt_ast>(a)->a ||
-    to_solver_smt_ast<z3_smt_ast>(b)->a),
+     to_solver_smt_ast<z3_smt_ast>(b)->a),
     boolean_sort);
 }
 
@@ -563,7 +567,7 @@ smt_astt z3_convt::mk_and(smt_astt a, smt_astt b)
   assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
   return new_ast(
     (to_solver_smt_ast<z3_smt_ast>(a)->a &&
-    to_solver_smt_ast<z3_smt_ast>(b)->a),
+     to_solver_smt_ast<z3_smt_ast>(b)->a),
     boolean_sort);
 }
 

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -495,7 +495,6 @@ smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
   assert(
     (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL) ||
     (a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT));
-  
   if (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL)
   {
     return new_ast(

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -381,15 +381,32 @@ smt_astt z3_convt::mk_bvneg(smt_astt a)
 
 smt_astt z3_convt::mk_bvnot(smt_astt a)
 {
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  return new_ast((~to_solver_smt_ast<z3_smt_ast>(a)->a), a->sort);
+  if (int_encoding)
+  {
+    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
+    z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
+    // Get the signedbv bit-width
+    size_t bit_width = signed_size_type2()->get_width();
+    // Convert integer to bit-vector
+    z3::expr a_bv = z3::int2bv(bit_width, a_expr);
+    // Apply bitwise NOT (~x)
+    z3::expr not_bv = ~a_bv;
+    // Convert back to integer
+    z3::expr int_not = z3::bv2int(not_bv, true); // 'true' = signed conversion
+    return new_ast(int_not, mk_int_sort());
+  }
+  else
+  {
+    assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+    return new_ast((~to_solver_smt_ast<z3_smt_ast>(a)->a), a->sort);
+  }
 }
 
 smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
 {
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  assert((a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
+    (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
+    (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
     !(to_solver_smt_ast<z3_smt_ast>(a)->a ^
       to_solver_smt_ast<z3_smt_ast>(b)->a),
@@ -398,9 +415,9 @@ smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
+  assert((a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
+    (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
+    (a->sort->get_data_width() == b->sort->get_data_width()));
   return new_ast(
     !(to_solver_smt_ast<z3_smt_ast>(a)->a |
       to_solver_smt_ast<z3_smt_ast>(b)->a),
@@ -409,72 +426,21 @@ smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_bvnand(smt_astt a, smt_astt b)
 {
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    !(to_solver_smt_ast<z3_smt_ast>(a)->a &
-      to_solver_smt_ast<z3_smt_ast>(b)->a),
-    a->sort);
+  assert((a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL) ||
+    (b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL) ||
+    (a->sort->get_data_width() == b->sort->get_data_width()));
+    return new_ast(
+      !(to_solver_smt_ast<z3_smt_ast>(a)->a &
+        to_solver_smt_ast<z3_smt_ast>(b)->a),
+      a->sort);
 }
 
 smt_astt z3_convt::mk_bvxor(smt_astt a, smt_astt b)
 {
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    (to_solver_smt_ast<z3_smt_ast>(a)->a ^ to_solver_smt_ast<z3_smt_ast>(b)->a),
-    a->sort);
-}
-
-smt_astt z3_convt::mk_bvor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    (to_solver_smt_ast<z3_smt_ast>(a)->a | to_solver_smt_ast<z3_smt_ast>(b)->a),
-    a->sort);
-}
-
-smt_astt z3_convt::mk_bvand(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    (to_solver_smt_ast<z3_smt_ast>(a)->a & to_solver_smt_ast<z3_smt_ast>(b)->a),
-    a->sort);
-}
-
-smt_astt z3_convt::mk_implies(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
-  return new_ast(
-    implies(
-      to_solver_smt_ast<z3_smt_ast>(a)->a, to_solver_smt_ast<z3_smt_ast>(b)->a),
-    boolean_sort);
-}
-
-smt_astt z3_convt::mk_xor(smt_astt a, smt_astt b)
-{
-  assert(
-    (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL) ||
-    (a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT));
-  if (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL)
+  if(int_encoding)
   {
-    return new_ast(
-      z3::to_expr(
-        z3_ctx,
-        Z3_mk_xor(
-          z3_ctx,
-          to_solver_smt_ast<z3_smt_ast>(a)->a,
-          to_solver_smt_ast<z3_smt_ast>(b)->a)),
-      boolean_sort);
-  }
-  else
-  {
+    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
+    assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
     // Get the signedbv bit-width
@@ -488,22 +454,23 @@ smt_astt z3_convt::mk_xor(smt_astt a, smt_astt b)
     z3::expr int_xor = z3::bv2int(xor_bv, true); // 'true' = signed conversion
     return new_ast(int_xor, mk_int_sort());
   }
-}
-
-smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
-{
-  assert(
-    (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL) ||
-    (a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT));
-  if (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL)
-  {
-    return new_ast(
-      (to_solver_smt_ast<z3_smt_ast>(a)->a ||
-       to_solver_smt_ast<z3_smt_ast>(b)->a),
-      boolean_sort);
-  }
   else
   {
+    assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+    assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+    assert(a->sort->get_data_width() == b->sort->get_data_width());
+    return new_ast(
+      (to_solver_smt_ast<z3_smt_ast>(a)->a ^ to_solver_smt_ast<z3_smt_ast>(b)->a),
+      a->sort);
+  }
+}
+
+smt_astt z3_convt::mk_bvor(smt_astt a, smt_astt b)
+{
+  if (int_encoding)
+  {
+    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
+    assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
     // Get the signedbv bit-width
@@ -516,23 +483,25 @@ smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
     // Convert result back to integer
     z3::expr int_or = z3::bv2int(or_bv, true); // 'true' = signed conversion
     return new_ast(int_or, mk_int_sort());
-  }
-}
 
-smt_astt z3_convt::mk_and(smt_astt a, smt_astt b)
-{
-  assert(
-    (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL) ||
-    (a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT));
-  if (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL)
-  {
-    return new_ast(
-      (to_solver_smt_ast<z3_smt_ast>(a)->a &&
-       to_solver_smt_ast<z3_smt_ast>(b)->a),
-      boolean_sort);
   }
   else
   {
+    assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+    assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+    assert(a->sort->get_data_width() == b->sort->get_data_width());
+    return new_ast(
+      (to_solver_smt_ast<z3_smt_ast>(a)->a | to_solver_smt_ast<z3_smt_ast>(b)->a),
+      a->sort);
+  }
+}
+
+smt_astt z3_convt::mk_bvand(smt_astt a, smt_astt b)
+{
+  if (int_encoding)
+  {
+    assert(a->sort->id == SMT_SORT_INT || a->sort->id == SMT_SORT_REAL);
+    assert(b->sort->id == SMT_SORT_INT || b->sort->id == SMT_SORT_REAL);
     z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
     z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
     // Get the signed bit-width
@@ -546,26 +515,62 @@ smt_astt z3_convt::mk_and(smt_astt a, smt_astt b)
     z3::expr int_and = z3::bv2int(and_bv, true); // 'true' = signed conversion
     return new_ast(int_and, mk_int_sort());
   }
+  else
+  {
+    assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
+    assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
+    assert(a->sort->get_data_width() == b->sort->get_data_width());    
+    return new_ast(
+      (to_solver_smt_ast<z3_smt_ast>(a)->a & to_solver_smt_ast<z3_smt_ast>(b)->a),
+      a->sort);
+  }
+
+}
+
+smt_astt z3_convt::mk_implies(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    implies(
+      to_solver_smt_ast<z3_smt_ast>(a)->a, to_solver_smt_ast<z3_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt z3_convt::mk_xor(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    z3::to_expr(
+      z3_ctx,
+      Z3_mk_xor(
+        z3_ctx,
+        to_solver_smt_ast<z3_smt_ast>(a)->a,
+        to_solver_smt_ast<z3_smt_ast>(b)->a)),
+    boolean_sort);
+}
+
+smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    (to_solver_smt_ast<z3_smt_ast>(a)->a ||
+    to_solver_smt_ast<z3_smt_ast>(b)->a),
+    boolean_sort);
+}
+
+smt_astt z3_convt::mk_and(smt_astt a, smt_astt b)
+{
+  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
+  return new_ast(
+    (to_solver_smt_ast<z3_smt_ast>(a)->a &&
+    to_solver_smt_ast<z3_smt_ast>(b)->a),
+    boolean_sort);
 }
 
 smt_astt z3_convt::mk_not(smt_astt a)
 {
-  assert(a->sort->id == SMT_SORT_BOOL || a->sort->id == SMT_SORT_INT);
-  if (a->sort->id == SMT_SORT_BOOL)
-    return new_ast(!to_solver_smt_ast<z3_smt_ast>(a)->a, boolean_sort);
-  else
-  {
-    z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
-    // Get the signedbv bit-width
-    size_t bit_width = signed_size_type2()->get_width();
-    // Convert integer to bit-vector
-    z3::expr a_bv = z3::int2bv(bit_width, a_expr);
-    // Apply bitwise NOT (~x)
-    z3::expr not_bv = ~a_bv;
-    // Convert back to integer
-    z3::expr int_not = z3::bv2int(not_bv, true); // 'true' = signed conversion
-    return new_ast(int_not, mk_int_sort());
-  }
+  assert(a->sort->id == SMT_SORT_BOOL);
+  return new_ast(!to_solver_smt_ast<z3_smt_ast>(a)->a, boolean_sort);
 }
 
 smt_astt z3_convt::mk_lt(smt_astt a, smt_astt b)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -492,11 +492,36 @@ smt_astt z3_convt::mk_xor(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
 {
-  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
-  return new_ast(
-    (to_solver_smt_ast<z3_smt_ast>(a)->a ||
-     to_solver_smt_ast<z3_smt_ast>(b)->a),
-    boolean_sort);
+  assert(
+    (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL) ||
+    (a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT));
+  
+  if (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL)
+  {
+    return new_ast(
+      z3::to_expr(
+        z3_ctx,
+        Z3_mk_xor(
+          z3_ctx,
+          to_solver_smt_ast<z3_smt_ast>(a)->a,
+          to_solver_smt_ast<z3_smt_ast>(b)->a)),
+      boolean_sort);
+  }
+  else
+  {
+    z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
+    z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
+    // Get the signedbv bit-width
+    size_t bit_width = signed_size_type2()->get_width();
+    // Convert integers to bit-vectors
+    z3::expr a_bv = z3::int2bv(bit_width, a_expr);
+    z3::expr b_bv = z3::int2bv(bit_width, b_expr);
+    // Perform bitwise OR operation
+    z3::expr or_bv = a_bv | b_bv; // Equivalent to mk_bvor
+    // Convert result back to integer
+    z3::expr int_or = z3::bv2int(or_bv, true); // 'true' = signed conversion
+    return new_ast(int_or, mk_int_sort());
+  }
 }
 
 smt_astt z3_convt::mk_and(smt_astt a, smt_astt b)

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -459,15 +459,41 @@ smt_astt z3_convt::mk_implies(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_xor(smt_astt a, smt_astt b)
 {
-  assert(a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL);
-  return new_ast(
-    z3::to_expr(
-      z3_ctx,
-      Z3_mk_xor(
+  if (a->sort->id == SMT_SORT_BOOL && b->sort->id == SMT_SORT_BOOL)
+  {
+    return new_ast(
+      z3::to_expr(
         z3_ctx,
-        to_solver_smt_ast<z3_smt_ast>(a)->a,
-        to_solver_smt_ast<z3_smt_ast>(b)->a)),
-    boolean_sort);
+        Z3_mk_xor(
+          z3_ctx,
+          to_solver_smt_ast<z3_smt_ast>(a)->a,
+          to_solver_smt_ast<z3_smt_ast>(b)->a)),
+      boolean_sort);
+  }
+  else if (a->sort->id == SMT_SORT_INT && b->sort->id == SMT_SORT_INT)
+  {
+    z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
+    z3::expr b_expr = to_solver_smt_ast<z3_smt_ast>(b)->a;
+
+    // Get the signedbv bit-width
+    size_t bit_width = signed_size_type2()->get_width();
+
+    // Convert integers to bit-vectors
+    z3::expr a_bv = z3::int2bv(bit_width, a_expr);
+    z3::expr b_bv = z3::int2bv(bit_width, b_expr);
+
+    // Perform bitwise XOR using the correct syntax
+    z3::expr xor_bv = a_bv ^ b_bv;  // Equivalent to mk_bvxor
+
+    // Convert result back to integer
+    z3::expr int_xor = z3::bv2int(xor_bv, true); // 'true' = signed conversion
+
+    return new_ast(int_xor, mk_int_sort());
+  }
+  else
+  {
+    throw "Unsupported sort in mk_xor";
+  }
 }
 
 smt_astt z3_convt::mk_or(smt_astt a, smt_astt b)
@@ -490,8 +516,32 @@ smt_astt z3_convt::mk_and(smt_astt a, smt_astt b)
 
 smt_astt z3_convt::mk_not(smt_astt a)
 {
-  assert(a->sort->id == SMT_SORT_BOOL);
-  return new_ast(!to_solver_smt_ast<z3_smt_ast>(a)->a, boolean_sort);
+  if (a->sort->id == SMT_SORT_BOOL)
+  {
+    return new_ast(!to_solver_smt_ast<z3_smt_ast>(a)->a, boolean_sort);
+  }
+  else if (a->sort->id == SMT_SORT_INT)
+  {
+    z3::expr a_expr = to_solver_smt_ast<z3_smt_ast>(a)->a;
+
+    // Get the signedbv bit-width
+    size_t bit_width = signed_size_type2()->get_width();
+
+    // Convert integer to bit-vector
+    z3::expr a_bv = z3::int2bv(bit_width, a_expr);
+
+    // Apply bitwise NOT (~x)
+    z3::expr not_bv = ~a_bv;
+
+    // Convert back to integer
+    z3::expr int_not = z3::bv2int(not_bv, true); // 'true' = signed conversion
+
+    return new_ast(int_not, mk_int_sort());
+  }
+  else
+  {
+    throw "Unsupported sort in mk_not";
+  }
 }
 
 smt_astt z3_convt::mk_lt(smt_astt a, smt_astt b)


### PR DESCRIPTION
This PR refactors our bitwise operations handling and enhances our SMT conversion functions to better support integer and boolean types. In particular, it introduces more consistent handling for boolean and integer types and improves compatibility with the Z3 solver's bit-vector operations.
- [X] bitnot_id
- [X] bitxor_id
- [x] bitand_id
- [x] bitor_id
- [x] bitnand_id
- [x] bitnor_id
- [x] bitnxor_id

This PR (30s): 

````
Statistics:          33569 Files
  correct:           18073
    correct true:    10743
    correct false:    7330
  incorrect:            40
    incorrect true:     13
    incorrect false:    27
  unknown:           15456
  Score:             27968 (max: 55885)

https://github.com/esbmc/esbmc/actions/runs/13956944037
````

Master (30s):

````
Statistics:          33569 Files
  correct:           18075
    correct true:    10743
    correct false:    7332
  incorrect:            40
    incorrect true:     13
    incorrect false:    27
  unknown:           15454
  Score:             27970 (max: 55885)

https://github.com/esbmc/esbmc/actions/runs/13906715936
````