### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         vcpkg.exe update
         cd C:/vcpkg
-        git.exe pull
+        git.exe checkout 2025.03.19
         .\bootstrap-vcpkg.bat
     - name: Make git use LF only
       run: |


### PR DESCRIPTION
Known: vcpkg was recently updated, causing the win build to fail. (boost 1.88.0 https://www.boost.org/users/history/version_1_88_0.html) 

According to the error message:
```
C:\vcpkg\installed\x64-windows-static\include\boost\asio\detail\socket_types.hpp(24,1): error C1189: #error:  WinSock.h has already been included [D:\a\esbmc\esbmc\build\src\python-frontend\pythonfrontend.vcxproj]
  (compiling source file '../../../src/python-frontend/python_language.cpp')
```

It looks like there's a dependency conflict in the python frontend. I tried a few flags to avoid it but failed:
`  add_compile_definitions(NOMINMAX=1 _WINSOCKAPI_=1)`

To get CI working for now, I think we'll go back to the previous version.