### PR TITLE
[python] Add support for hex() built-in function

### DIFF
--- a/regression/python/casting20/main.py
+++ b/regression/python/casting20/main.py
@@ -1,6 +1,3 @@
-a = '60'
-b = '5'
-
 # Hexadecimal conversion
 assert hex(60) == '0x3c'
 assert hex(5) == '0x5'

--- a/regression/python/casting20/main.py
+++ b/regression/python/casting20/main.py
@@ -1,0 +1,6 @@
+a = '60'
+b = '5'
+
+# Hexadecimal conversion
+assert hex(60) == '0x3c'
+assert hex(5) == '0x5'

--- a/regression/python/casting20/test.desc
+++ b/regression/python/casting20/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting21/main.py
+++ b/regression/python/casting21/main.py
@@ -1,0 +1,2 @@
+# Hexadecimal conversion
+assert hex(60) == '0x3a'

--- a/regression/python/casting21/test.desc
+++ b/regression/python/casting21/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/casting22/main.py
+++ b/regression/python/casting22/main.py
@@ -1,0 +1,6 @@
+a = '60'
+b = '5'
+
+# Hexadecimal conversion
+assert hex(a) == '0x3c'
+assert hex(b) == '0x5'

--- a/regression/python/casting22/test.desc
+++ b/regression/python/casting22/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: TypeError: hex\(\) argument must be an integer$

--- a/regression/python/casting23/main.py
+++ b/regression/python/casting23/main.py
@@ -1,0 +1,6 @@
+# Valid hexadecimal conversion
+assert hex(0) == '0x0'
+assert hex(1) == '0x1'
+assert hex(255) == '0xff'
+assert hex(-1) == '-0x1'
+assert hex(-42) == '-0x2a'

--- a/regression/python/casting23/test.desc
+++ b/regression/python/casting23/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting24/main.py
+++ b/regression/python/casting24/main.py
@@ -1,0 +1,2 @@
+# Invalid: float passed to hex()
+assert hex(3.14) == '0x3'

--- a/regression/python/casting24/test.desc
+++ b/regression/python/casting24/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: TypeError: hex\(\) argument must be an integer$

--- a/regression/python/casting25/main.py
+++ b/regression/python/casting25/main.py
@@ -1,0 +1,2 @@
+# Invalid: string passed to hex()
+assert hex("123") == '0x7b'

--- a/regression/python/casting25/test.desc
+++ b/regression/python/casting25/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: TypeError: hex\(\) argument must be an integer$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -93,6 +93,12 @@ exprt function_call_expr::build_nondet_call() const
   return rhs;
 }
 
+void function_call_expr::handle_int_to_float(nlohmann::json &arg) const
+{
+  int value = arg["value"].get<int>();
+  arg["value"] = static_cast<double>(value);
+}
+
 exprt function_call_expr::handle_hex(nlohmann::json &arg) const
 {
   long long int_value = 0;
@@ -157,6 +163,10 @@ exprt function_call_expr::build_constant_from_arg() const
 
   // Handle float(): convert int to float
   else if (func_name == "float" && arg["value"].is_number_integer())
+    handle_int_to_float(arg);
+
+  // Handle float(): convert int to float
+  else if (func_name == "float" && arg["value"].is_number_integer())
   {
     int arg_value = arg["value"].get<int>();
     arg["value"] = static_cast<double>(arg_value);
@@ -218,6 +228,7 @@ exprt function_call_expr::build_constant_from_arg() const
     arg_size = 1;
   }
 
+  // Handle hex: Handles hexadecimal string arguments
   else if (func_name == "hex")
     return handle_hex(arg);
 

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -191,7 +191,8 @@ exprt function_call_expr::build_constant_from_arg() const
       const auto &op = arg["op"];
       const auto &operand = arg["operand"];
 
-      if (op["_type"] == "USub" && operand.contains("value") &&
+      if (
+        op["_type"] == "USub" && operand.contains("value") &&
         operand["value"].is_number_integer())
       {
         is_negative = true;
@@ -212,8 +213,8 @@ exprt function_call_expr::build_constant_from_arg() const
 
     // Build Python-style hex string: 0x<hex> or -0x<hex>
     std::ostringstream oss;
-    oss << (is_negative ? "-0x" : "0x")
-      << std::hex << std::nouppercase << std::llabs(int_value);
+    oss << (is_negative ? "-0x" : "0x") << std::hex << std::nouppercase
+        << std::llabs(int_value);
     const std::string hex_str = oss.str();
 
     // Build string constant expression
@@ -223,7 +224,6 @@ exprt function_call_expr::build_constant_from_arg() const
 
     return expr;
   }
-
 
   // Construct expression with appropriate type
   typet t = type_handler_.get_typet(func_name, arg_size);

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -220,6 +220,7 @@ exprt function_call_expr::build_constant_from_arg() const
   typet t = type_handler_.get_typet(func_name, arg_size);
   exprt expr = converter_.get_expr(arg);
   expr.type() = t;
+  
   return expr;
 }
 

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -224,13 +224,6 @@ exprt function_call_expr::build_constant_from_arg() const
   else if (func_name == "float" && arg["value"].is_number_integer())
     handle_int_to_float(arg);
 
-  // Handle float(): convert int to float
-  else if (func_name == "float" && arg["value"].is_number_integer())
-  {
-    int arg_value = arg["value"].get<int>();
-    arg["value"] = static_cast<double>(arg_value);
-  }
-
   // Handle chr(): convert integer to single-character string
   else if (func_name == "chr")
     handle_chr(arg);

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -103,8 +103,9 @@ exprt function_call_expr::handle_hex(nlohmann::json &arg) const
     const auto &op = arg["op"];
     const auto &operand = arg["operand"];
 
-    if (op["_type"] == "USub" && operand.contains("value") &&
-        operand["value"].is_number_integer())
+    if (
+      op["_type"] == "USub" && operand.contains("value") &&
+      operand["value"].is_number_integer())
     {
       is_negative = true;
       int_value = operand["value"].get<long long>();

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -93,6 +93,14 @@ exprt function_call_expr::build_nondet_call() const
   return rhs;
 }
 
+size_t function_call_expr::handle_str(nlohmann::json &arg) const
+{
+  if (!arg.contains("value") || !arg["value"].is_string())
+    throw std::runtime_error("TypeError: str() expects a string argument");
+
+  return arg["value"].get<std::string>().size();
+}
+
 void function_call_expr::handle_float_to_int(nlohmann::json &arg) const
 {
   double value = arg["value"].get<double>();
@@ -206,13 +214,7 @@ exprt function_call_expr::build_constant_from_arg() const
 
   // Handle str(): determine size of the resulting string constant
   if (func_name == "str")
-  {
-    if (!arg.contains("value") || !arg["value"].is_string())
-      throw std::runtime_error("TypeError: str() expects a string argument");
-
-    const std::string &s = arg["value"].get<std::string>();
-    arg_size = s.size();
-  }
+    arg_size = handle_str(arg);
 
   // Handle int(): convert float to int
   else if (func_name == "int" && arg["value"].is_number_float())

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -219,17 +219,7 @@ exprt function_call_expr::build_constant_from_arg() const
     // Build string constant expression
     typet t = type_handler_.get_typet("str", hex_str.size());
     std::vector<uint8_t> string_literal(hex_str.begin(), hex_str.end());
-    typet &char_type = t.subtype();
-    exprt expr = gen_zero(t);
-
-    for (unsigned int i = 0; i < string_literal.size(); ++i)
-    {
-      exprt char_value = constant_exprt(
-        integer2binary(BigInt(string_literal[i]), bv_width(char_type)),
-        integer2string(BigInt(string_literal[i])),
-        char_type);
-      expr.operands().at(i) = char_value;
-    }
+    exprt expr = converter_.make_char_array_expr(string_literal, t);
 
     return expr;
   }

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -182,7 +182,6 @@ exprt function_call_expr::build_constant_from_arg() const
   // Handle hex(): convert int to hexadecimal string with "0x" prefix
   else if (func_name == "hex")
   {
-    printf("passou em 185\n");
     int int_value = 0;
     bool is_negative = false;
 
@@ -220,7 +219,7 @@ exprt function_call_expr::build_constant_from_arg() const
   typet t = type_handler_.get_typet(func_name, arg_size);
   exprt expr = converter_.get_expr(arg);
   expr.type() = t;
-  
+
   return expr;
 }
 

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -93,6 +93,12 @@ exprt function_call_expr::build_nondet_call() const
   return rhs;
 }
 
+void function_call_expr::handle_float_to_int(nlohmann::json &arg) const
+{
+  double value = arg["value"].get<double>();
+  arg["value"] = static_cast<int>(value);
+}
+
 void function_call_expr::handle_int_to_float(nlohmann::json &arg) const
 {
   int value = arg["value"].get<int>();
@@ -156,10 +162,7 @@ exprt function_call_expr::build_constant_from_arg() const
 
   // Handle int(): convert float to int
   else if (func_name == "int" && arg["value"].is_number_float())
-  {
-    double arg_value = arg["value"].get<double>();
-    arg["value"] = static_cast<int>(arg_value);
-  }
+    handle_float_to_int(arg);
 
   // Handle float(): convert int to float
   else if (func_name == "float" && arg["value"].is_number_integer())

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -75,6 +75,12 @@ private:
   void handle_int_to_float(nlohmann::json &arg) const;
 
   /*
+   * Handles chr(int) conversions by creating a single-character
+   * string expression from an integer.
+   */
+  void handle_chr(nlohmann::json &arg) const;
+
+  /*
    * Handles hexadecimal string arguments (e.g., hex(255) -> "0xff")
    * by building a constant expression representing the string.
    */

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -63,6 +63,12 @@ private:
   std::string get_object_name() const;
 
   /*
+   * Handles string arguments (e.g., str("abc")) by converting them
+   * into character array expressions.
+   */
+  size_t handle_str(nlohmann::json &arg) const;
+
+  /*
    * Handles float-to-int conversions (e.g., int(3.14)) by generating
    * the appropriate cast expression.
    */

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -63,6 +63,12 @@ private:
   std::string get_object_name() const;
 
   /*
+   * Handles int-to-float conversions (e.g., float(3)) by generating
+   * the appropriate cast expression.
+   */
+  void handle_int_to_float(nlohmann::json &arg) const;
+
+  /*
    * Handles hexadecimal string arguments (e.g., hex(255) -> "0xff")
    * by building a constant expression representing the string.
    */

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -62,6 +62,12 @@ private:
    */
   std::string get_object_name() const;
 
+  /*
+   * Handles hexadecimal string arguments (e.g., hex(255) -> "0xff")
+   * by building a constant expression representing the string.
+   */
+  exprt handle_hex(nlohmann::json &arg) const;
+
 protected:
   symbol_id function_id_;
   const nlohmann::json &call_;

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -63,6 +63,12 @@ private:
   std::string get_object_name() const;
 
   /*
+   * Handles float-to-int conversions (e.g., int(3.14)) by generating
+   * the appropriate cast expression.
+   */
+  void handle_float_to_int(nlohmann::json &arg) const;
+
+  /*
    * Handles int-to-float conversions (e.g., float(3)) by generating
    * the appropriate cast expression.
    */

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -964,7 +964,7 @@ exprt python_converter::get_literal(const nlohmann::json &element)
     typet &char_type = t.subtype();
 
     // Fill the array with character values
-    for (unsigned int i = 0; i < string_literal.size(); ++i)
+    for (size_t i = 0; i < string_literal.size(); ++i)
     {
       uint8_t ch = string_literal[i];
       exprt char_value = constant_exprt(
@@ -977,9 +977,9 @@ exprt python_converter::get_literal(const nlohmann::json &element)
     return expr;
   }
 
-  // If none of the above matched, throw an error
-  throw std::runtime_error(
-    "Unsupported literal type or malformed value: " + value.dump());
+  // If none of the above matched, log an error and return empty expression
+  log_error("Unsupported literal type or malformed value: {}", value.dump());
+  return exprt();
 }
 
 exprt python_converter::get_expr(const nlohmann::json &element)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -885,7 +885,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
   return call_builder.build();
 }
 
-exprt python_converter::make_char_array_expr(const std::vector<unsigned char> &string_literal, const typet &t)
+exprt python_converter::make_char_array_expr(
+  const std::vector<unsigned char> &string_literal,
+  const typet &t)
 {
   exprt expr = gen_zero(t);
   const typet &char_type = t.subtype();
@@ -923,9 +925,9 @@ exprt python_converter::make_char_array_expr(const std::vector<unsigned char> &s
 exprt python_converter::get_literal(const nlohmann::json &element)
 {
   // Determine the source of the literal's value.
-  const auto &value = (element["_type"] == "UnaryOp") ?
-                        element["operand"]["value"] :
-                        element["value"];
+  const auto &value = (element["_type"] == "UnaryOp")
+                        ? element["operand"]["value"]
+                        : element["value"];
 
   // Handle integer literals (int)
   if (value.is_number_integer())
@@ -939,7 +941,8 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   if (value.is_number_float())
   {
     exprt expr;
-    convert_float_literal(value.dump(), expr);  // `value.dump()` converts it to string
+    convert_float_literal(
+      value.dump(), expr); // `value.dump()` converts it to string
     return expr;
   }
 
@@ -952,10 +955,11 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   }
 
   // Handle empty strings or docstrings (often beginning with a newline)
-  if (value.is_string() && !value.get<std::string>().empty() &&
-      value.get<std::string>()[0] == '\n')
+  if (
+    value.is_string() && !value.get<std::string>().empty() &&
+    value.get<std::string>()[0] == '\n')
   {
-    return exprt();  // Return empty expression
+    return exprt(); // Return empty expression
   }
 
   // Handle string or byte literals

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -885,6 +885,24 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
   return call_builder.build();
 }
 
+exprt python_converter::make_char_array_expr(const std::vector<unsigned char> &string_literal, const typet &t)
+{
+  exprt expr = gen_zero(t);
+  const typet &char_type = t.subtype();
+
+  for (size_t i = 0; i < string_literal.size(); ++i)
+  {
+    uint8_t ch = string_literal[i];
+    exprt char_value = constant_exprt(
+      integer2binary(BigInt(ch), bv_width(char_type)),
+      integer2string(BigInt(ch)),
+      char_type);
+    expr.operands().at(i) = char_value;
+  }
+
+  return expr;
+}
+
 /// Convert a Python AST literal element to an expression.
 /// This function handles various Python 3 literal types, including:
 ///   - Integers (e.g., `42`)
@@ -959,20 +977,7 @@ exprt python_converter::get_literal(const nlohmann::json &element)
       string_literal.assign(str_val.begin(), str_val.end());
     }
 
-    // Create zero-initialized array expression
-    exprt expr = gen_zero(t);
-    typet &char_type = t.subtype();
-
-    // Fill the array with character values
-    for (size_t i = 0; i < string_literal.size(); ++i)
-    {
-      uint8_t ch = string_literal[i];
-      exprt char_value = constant_exprt(
-        integer2binary(BigInt(ch), bv_width(char_type)),
-        integer2string(BigInt(ch)),
-        char_type);
-      expr.operands().at(i) = char_value;
-    }
+    exprt expr = make_char_array_expr(string_literal, t);
 
     return expr;
   }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -977,9 +977,7 @@ exprt python_converter::get_literal(const nlohmann::json &element)
     return expr;
   }
 
-  // If none of the above matched, log an error and return empty expression
-  log_error("Unsupported literal type or malformed value: {}", value.dump());
-  return exprt();
+  throw std::runtime_error("Unsupported literal " + value.get<std::string>());
 }
 
 exprt python_converter::get_expr(const nlohmann::json &element)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -119,6 +119,8 @@ private:
 
   exprt get_function_call(const nlohmann::json &ast_block);
 
+  exprt make_char_array_expr(const std::vector<unsigned char> &string_literal, const typet &t);
+
   exprt get_literal(const nlohmann::json &element);
 
   exprt get_block(const nlohmann::json &ast_block);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -119,7 +119,9 @@ private:
 
   exprt get_function_call(const nlohmann::json &ast_block);
 
-  exprt make_char_array_expr(const std::vector<unsigned char> &string_literal, const typet &t);
+  exprt make_char_array_expr(
+    const std::vector<unsigned char> &string_literal,
+    const typet &t);
 
   exprt get_literal(const nlohmann::json &element);
 

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -129,7 +129,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     // or consider modelling it with string_constantt.
     return build_array(long_long_int_type(), type_size);
   }
-  if (ast_type == "str" || ast_type == "chr")
+  if (ast_type == "str" || ast_type == "chr" || ast_type == "hex")
   {
     if (type_size == 1)
     {

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -43,7 +43,7 @@ public:
   {
     return (
       name == "int" || name == "float" || name == "bool" || name == "str" ||
-      name == "chr");
+      name == "chr" || name == "hex");
   }
 
   static bool is_consensus_type(const std::string &name)


### PR DESCRIPTION
This PR fully supports the Python built-in hex() function in our ESBMC Python frontend. It includes AST handling, type resolution, and string construction for hexadecimal string representations of integers.