### PR TITLE
[python] Handle ord(): convert single-character string to integer Unicode code point

### DIFF
--- a/regression/python/casting28/main.py
+++ b/regression/python/casting28/main.py
@@ -1,0 +1,2 @@
+assert ord('<') == 60
+assert ord('5') == 53

--- a/regression/python/casting28/main.py
+++ b/regression/python/casting28/main.py
@@ -2,3 +2,7 @@ assert ord('<') == 60
 assert ord('5') == 53
 assert ord('A') == 65
 assert ord('a') == 97
+assert ord('\n') == 10
+assert ord('€') == 8364  # Euro sign, UTF-8 multibyte
+assert ord('ÿ') == 255   # Latin-1 character
+assert ord('\u20AC') == 8364  # Euro sign using Unicode escape

--- a/regression/python/casting28/main.py
+++ b/regression/python/casting28/main.py
@@ -1,2 +1,4 @@
 assert ord('<') == 60
 assert ord('5') == 53
+assert ord('A') == 65
+assert ord('a') == 97

--- a/regression/python/casting28/test.desc
+++ b/regression/python/casting28/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting28_fail/main.py
+++ b/regression/python/casting28_fail/main.py
@@ -1,0 +1,2 @@
+assert ord('<') != 60
+assert ord('5') != 53

--- a/regression/python/casting28_fail/main.py
+++ b/regression/python/casting28_fail/main.py
@@ -1,2 +1,5 @@
-assert ord('<') != 60
-assert ord('5') != 53
+assert ord('<') != 60     # Incorrect: will fail
+assert ord('5') != 53     # Incorrect: will fail
+assert ord('A') != 65     # Incorrect: will fail
+assert ord('€') != 8364   # Incorrect: will fail
+assert ord('a') == 66     # Incorrect: should be 97

--- a/regression/python/casting28_fail/test.desc
+++ b/regression/python/casting28_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -274,12 +274,14 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
   if (arg.contains("value") && arg["value"].is_string())
   {
     const std::string &s = arg["value"].get<std::string>();
-    const unsigned char* bytes = reinterpret_cast<const unsigned char*>(s.c_str());
+    const unsigned char *bytes =
+      reinterpret_cast<const unsigned char *>(s.c_str());
     size_t length = s.length();
 
     if (length == 0)
     {
-      throw std::runtime_error("TypeError: ord() expected a character, but string of length 0 found");
+      throw std::runtime_error(
+        "TypeError: ord() expected a character, but string of length 0 found");
     }
 
     // Manual UTF-8 decoding
@@ -287,7 +289,8 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     {
       // 1-byte ASCII
       if (length != 1)
-        throw std::runtime_error("TypeError: ord() expected a single character");
+        throw std::runtime_error(
+          "TypeError: ord() expected a single character");
 
       code_point = bytes[0];
     }
@@ -295,35 +298,35 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     {
       // 2-byte sequence
       if (length != 2)
-        throw std::runtime_error("TypeError: ord() expected a single character");
+        throw std::runtime_error(
+          "TypeError: ord() expected a single character");
 
-      code_point = ((bytes[0] & 0x1F) << 6) |
-                   (bytes[1] & 0x3F);
+      code_point = ((bytes[0] & 0x1F) << 6) | (bytes[1] & 0x3F);
     }
     else if ((bytes[0] & 0xF0) == 0xE0)
     {
       // 3-byte sequence
       if (length != 3)
-        throw std::runtime_error("TypeError: ord() expected a single character");
+        throw std::runtime_error(
+          "TypeError: ord() expected a single character");
 
-      code_point = ((bytes[0] & 0x0F) << 12) |
-                   ((bytes[1] & 0x3F) << 6) |
+      code_point = ((bytes[0] & 0x0F) << 12) | ((bytes[1] & 0x3F) << 6) |
                    (bytes[2] & 0x3F);
     }
     else if ((bytes[0] & 0xF8) == 0xF0)
     {
       // 4-byte sequence
       if (length != 4)
-        throw std::runtime_error("TypeError: ord() expected a single character");
+        throw std::runtime_error(
+          "TypeError: ord() expected a single character");
 
-      code_point = ((bytes[0] & 0x07) << 18) |
-                   ((bytes[1] & 0x3F) << 12) |
-                   ((bytes[2] & 0x3F) << 6) |
-                   (bytes[3] & 0x3F);
+      code_point = ((bytes[0] & 0x07) << 18) | ((bytes[1] & 0x3F) << 12) |
+                   ((bytes[2] & 0x3F) << 6) | (bytes[3] & 0x3F);
     }
     else
     {
-      throw std::runtime_error("ValueError: ord() received invalid UTF-8 input");
+      throw std::runtime_error(
+        "ValueError: ord() received invalid UTF-8 input");
     }
   }
   else

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -106,6 +106,12 @@ private:
    */
   exprt handle_oct(nlohmann::json &arg) const;
 
+  /*
+   * Handles ord(str) conversions by extracting the Unicode code point
+   * (as an integer) from a single-character string expression.
+   */
+  exprt handle_ord(nlohmann::json &arg) const;
+
 protected:
   symbol_id function_id_;
   const nlohmann::json &call_;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1465,8 +1465,8 @@ void python_converter::get_var_assign(
     if (lhs_symbol)
     {
       if (
-        lhs_type == "str" || lhs_type == "chr" || lhs_type == "ord" || lhs_type == "list" ||
-        rhs.type().is_array())
+        lhs_type == "str" || lhs_type == "chr" || lhs_type == "ord" ||
+        lhs_type == "list" || rhs.type().is_array())
       {
         /* When a string is assigned the result of a concatenation, we initially
          * create the LHS type as a zero-size array: "current_element_type = get_typet(lhs_type, type_size);"

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1465,7 +1465,7 @@ void python_converter::get_var_assign(
     if (lhs_symbol)
     {
       if (
-        lhs_type == "str" || lhs_type == "chr" || lhs_type == "list" ||
+        lhs_type == "str" || lhs_type == "chr" || lhs_type == "ord" || lhs_type == "list" ||
         rhs.type().is_array())
       {
         /* When a string is assigned the result of a concatenation, we initially

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -174,10 +174,11 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   // str: immutable sequences of Unicode characters
   // chr(): returns a 1-character string
   // hex(): returns string representation of integer in hex
-  // oct() — Converts an integer to a lowercase octal string
+  // oct(): Converts an integer to a lowercase octal string
+  // - ord(): Converts a 1-character string to its Unicode code point (as integer)
   if (
     ast_type == "str" || ast_type == "chr" || ast_type == "hex" ||
-    ast_type == "oct")
+    ast_type == "oct" || ast_type == "ord")
   {
     if (type_size == 1)
     {

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -175,7 +175,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   // chr(): returns a 1-character string
   // hex(): returns string representation of integer in hex
   // oct(): Converts an integer to a lowercase octal string
-  // - ord(): Converts a 1-character string to its Unicode code point (as integer)
+  // ord(): Converts a 1-character string to its Unicode code point (as integer)
   if (
     ast_type == "str" || ast_type == "chr" || ast_type == "hex" ||
     ast_type == "oct" || ast_type == "ord")

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -43,7 +43,7 @@ public:
   {
     return (
       name == "int" || name == "float" || name == "bool" || name == "str" ||
-      name == "chr" || name == "hex" || name == "oct");
+      name == "chr" || name == "hex" || name == "oct" || name == "ord");
   }
 
   static bool is_consensus_type(const std::string &name)


### PR DESCRIPTION
This PR implements the `ord()` built-in function as described in the Python documentation (https://docs.python.org/3/library/functions.html#ord):


_"Given a string representing one Unicode character, return an integer representing the Unicode code point of that character. For example, ord('a') returns the integer 97 and ord('€') (Euro sign) returns 8364. This is the inverse of [chr()](https://docs.python.org/3/library/functions.html#chr)."_