### PR TITLE
[CI] Integrate cheribsd-riscv64 system root

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -21,13 +21,6 @@ jobs:
     runs-on: ${{ inputs.operating-system }}
     steps:
     - uses: actions/checkout@v4
-    - name: Add apt.llvm.org repository
-      run: |
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc &&
-        source /etc/os-release &&
-        sudo add-apt-repository -y "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-16 main" &&
-        sudo apt-get update
-      if: ${{ startsWith(inputs.operating-system, 'ubuntu-') }}
     - name: Build ESBMC
       run: ./scripts/build.sh ${{ inputs.build-flags }}
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,10 +62,10 @@ jobs:
 
   build-cheri:
     uses: ./.github/workflows/build-unix.yml
-    name: CHERI llvm-17 build
+    name: static CHERI llvm-17 build
     with:
       operating-system: ubuntu-22.04
-      build-flags: '-b DebugOpt -x -S ON'
+      build-flags: '-b DebugOpt -x'
       testing: false
 
     # Check project with clang-format

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,6 @@ error() {
 ubuntu_setup () {
     # Tested on ubuntu 22.04
     PKGS="\
-        clang-$CLANG_VERSION clang-tidy-$CLANG_VERSION \
         python-is-python3 csmith python3 \
         git ccache unzip wget curl libcsmith-dev gperf \
         libgmp-dev cmake bison flex g++-multilib linux-libc-dev \

--- a/scripts/cmake/ExternalDependencies.cmake
+++ b/scripts/cmake/ExternalDependencies.cmake
@@ -32,4 +32,9 @@ if(ESBMC_CHERI_CLANG)
     set(ESBMC_CHERI_HYBRID_SYSROOT ${cheri_sysroot_SOURCE_DIR})
     set(ESBMC_CHERI_PURECAP_SYSROOT ${cheri_sysroot_SOURCE_DIR})
   endif()
+
+  # CHERI Clang AST: ignore other frontend
+  unset(ENABLE_PYTHON_FRONTEND CACHE)
+  unset(ENABLE_SOLIDITY_FRONTEND CACHE)
+  unset(ENABLE_JIMPLE_FRONTEND CACHE)
 endif()

--- a/scripts/cmake/ExternalDependencies.cmake
+++ b/scripts/cmake/ExternalDependencies.cmake
@@ -23,4 +23,13 @@ if(ESBMC_CHERI_CLANG)
                      ${cheri_compressed_cap_BINARY_DIR}
                      EXCLUDE_FROM_ALL)
   endif()
+
+  if(ESBMC_CHERI AND DOWNLOAD_DEPENDENCIES AND ("${ESBMC_CHERI_HYBRID_SYSROOT}" STREQUAL ""))
+    FetchContent_Declare(cheri_sysroot
+     URL https://github.com/XLiZHI/esbmc/releases/download/v17/sysroot-riscv64-purecap.zip)
+    FetchContent_MakeAvailable(cheri_sysroot)
+
+    set(ESBMC_CHERI_HYBRID_SYSROOT ${cheri_sysroot_SOURCE_DIR})
+    set(ESBMC_CHERI_PURECAP_SYSROOT ${cheri_sysroot_SOURCE_DIR})
+  endif()
 endif()


### PR DESCRIPTION
The build on GitHub runner using cheribuild took too long and exceeded the runner's hard disk capacity.

Currently I have uploaded the cheribsd SDK built locally and hope it works as expected. ;)