### PR TITLE
[smt] support floating-point equality semantics in real encoding mode (EXPERIMENTAL!)

### DIFF
--- a/regression/esbmc/github_660_z3/main.c
+++ b/regression/esbmc/github_660_z3/main.c
@@ -1,3 +1,5 @@
+#include <assert.h>
+
 int main()
 {
   double d = nondet_double();

--- a/regression/esbmc/github_660_z3/test.desc
+++ b/regression/esbmc/github_660_z3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir --z3 -Wno-error=implicit-function-declaration
-^VERIFICATION SUCCESSFUL$
+--ir --z3
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding-fail/main.c
+++ b/regression/esbmc/real-encoding-fail/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  assert(x == x);
+  return 0;
+}

--- a/regression/esbmc/real-encoding-fail/test.desc
+++ b/regression/esbmc/real-encoding-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding/main.c
+++ b/regression/esbmc/real-encoding/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  __VERIFIER_assume(x > 0);
+  assert(x != 0);
+  return 0;
+}

--- a/regression/esbmc/real-encoding/test.desc
+++ b/regression/esbmc/real-encoding/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/real-encoding2-fail/main.c
+++ b/regression/esbmc/real-encoding2-fail/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+ 
+int main()
+{
+  float a = nondet_float(), b = nondet_float();
+  assert(a == b);
+  return 0;
+}

--- a/regression/esbmc/real-encoding2-fail/test.desc
+++ b/regression/esbmc/real-encoding2-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding2/main.c
+++ b/regression/esbmc/real-encoding2/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  float x = NAN;
+  _Bool y = nondet_bool();
+
+  if (y)
+    assert(x != x); // should hold
+
+  assert (y==0 || y==1); 
+
+  return 0;
+}
+

--- a/regression/esbmc/real-encoding2/test.desc
+++ b/regression/esbmc/real-encoding2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/real-encoding3-fail/main.c
+++ b/regression/esbmc/real-encoding3-fail/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  assert(!isnan(x)); // x might be NaN
+}
+

--- a/regression/esbmc/real-encoding3-fail/test.desc
+++ b/regression/esbmc/real-encoding3-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding3/main.c
+++ b/regression/esbmc/real-encoding3/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  __VERIFIER_assume(x == 1.0f); // not NaN
+  assert(!isnan(x));
+}
+

--- a/regression/esbmc/real-encoding3/test.desc
+++ b/regression/esbmc/real-encoding3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/real-encoding4-fail/main.c
+++ b/regression/esbmc/real-encoding4-fail/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  float x = NAN;
+  float y = 1.0f;
+  assert(x == y);  // Should fail: NaN != 1.0f
+  return 0;
+}

--- a/regression/esbmc/real-encoding4-fail/test.desc
+++ b/regression/esbmc/real-encoding4-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding4/main.c
+++ b/regression/esbmc/real-encoding4/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  float x = NAN;
+  assert(x != x);  // Should pass: NaN != NaN is true
+  return 0;
+}

--- a/regression/esbmc/real-encoding4/test.desc
+++ b/regression/esbmc/real-encoding4/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/real-encoding5-fail/main.c
+++ b/regression/esbmc/real-encoding5-fail/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  float x = NAN;
+  float y = NAN;
+  _Bool z = nondet_bool();
+
+  if (z) 
+    assert(x == y); // Should fail: NaN != NaN even if both are NaN
+
+  assert (z == 0 || z == 1);
+  return 0;
+}

--- a/regression/esbmc/real-encoding5-fail/test.desc
+++ b/regression/esbmc/real-encoding5-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding5/main.c
+++ b/regression/esbmc/real-encoding5/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <math.h>
+
+int main()
+{
+  float x = NAN;
+  float y = NAN;
+  _Bool z = nondet_bool();
+
+  if (z) 
+    assert(x != y);  // Should pass: NaN != NaN is true
+
+  assert (z == 0 || z == 1);
+  return 0;
+}

--- a/regression/esbmc/real-encoding5/test.desc
+++ b/regression/esbmc/real-encoding5/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/real-encoding6-fail/main.c
+++ b/regression/esbmc/real-encoding6-fail/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  __VERIFIER_assume(isnan(x));  // Assume x is NaN
+  assert(x == x);  // Should fail: NaN != NaN
+  return 0;
+}

--- a/regression/esbmc/real-encoding6-fail/test.desc
+++ b/regression/esbmc/real-encoding6-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding6/main.c
+++ b/regression/esbmc/real-encoding6/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  __VERIFIER_assume(!isnan(x));  // Assume x is not NaN
+  assert(x == x);  // Should pass: non-NaN == itself
+  return 0;
+}

--- a/regression/esbmc/real-encoding6/test.desc
+++ b/regression/esbmc/real-encoding6/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/real-encoding7-fail/main.c
+++ b/regression/esbmc/real-encoding7-fail/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  float y = nondet_float();
+  
+  __VERIFIER_assume(isnan(x));
+  __VERIFIER_assume(!isnan(y));
+  
+  assert((x == x) || (x == y));  // Should fail: both are false
+  return 0;
+}

--- a/regression/esbmc/real-encoding7-fail/test.desc
+++ b/regression/esbmc/real-encoding7-fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.c
+--z3 --ir
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/real-encoding7/main.c
+++ b/regression/esbmc/real-encoding7/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <math.h>
+
+float nondet_float();
+
+int main()
+{
+  float x = nondet_float();
+  float y = nondet_float();
+  
+  __VERIFIER_assume(isnan(x));
+  __VERIFIER_assume(!isnan(y));
+  
+  assert((x != x) && (y == y));  // Should pass: both are true
+  return 0;
+}

--- a/regression/esbmc/real-encoding7/test.desc
+++ b/regression/esbmc/real-encoding7/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --ir
+
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -881,14 +881,38 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
      *       them properly according to the input language.
      */
 
-    auto eq = to_equality2t(expr);
+     auto eq = to_equality2t(expr);
 
-    if (
-      is_floatbv_type(eq.side_1) && is_floatbv_type(eq.side_2) && !int_encoding)
-      a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
-    else
-      a = args[0]->eq(this, args[1]);
-    break;
+     if (is_floatbv_type(eq.side_1) && is_floatbv_type(eq.side_2))
+     {
+       if (!int_encoding)
+       {
+         // Bit-vector mode: use IEEE-compliant floating-point equality
+         a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
+       }
+       else
+       {
+         // Real arithmetic mode: manually implement IEEE 754 semantics
+         // IEEE 754: x == y is false if either x or y is NaN
+         smt_astt normal_eq = args[0]->eq(this, args[1]);
+    
+         // Create isnan2t expressions before calling convert_is_nan
+         expr2tc isnan_side1 = isnan2tc(eq.side_1);
+         expr2tc isnan_side2 = isnan2tc(eq.side_2);
+    
+         smt_astt x_not_nan = mk_not(convert_is_nan(isnan_side1));
+         smt_astt y_not_nan = mk_not(convert_is_nan(isnan_side2));
+    
+         // (x == y) && !isnan(x) && !isnan(y)
+         a = mk_and(normal_eq, mk_and(x_not_nan, y_not_nan));
+       }
+     }
+     else
+     {
+       // Non-floating point types
+       a = args[0]->eq(this, args[1]);
+     }
+     break;
   }
   case expr2t::notequal_id:
   {
@@ -1596,13 +1620,24 @@ smt_astt smt_convt::mk_fresh(
 smt_astt smt_convt::convert_is_nan(const expr2tc &expr)
 {
   const isnan2t &isnan = to_isnan2t(expr);
-
-  // Anything other than floats will never be NaNs
-  if (!is_floatbv_type(isnan.value) || int_encoding)
-    return mk_smt_bool(false);
+  // Only floating-point types can be NaN
+  if (!is_floatbv_type(isnan.value))
+    return mk_smt_bool(false); // Safe default for non-float types
 
   smt_astt operand = convert_ast(isnan.value);
-  return fp_api->mk_smt_fpbv_is_nan(operand);
+
+  if (int_encoding)
+  {
+    // In real arithmetic, IEEE NaN is not representable natively.
+    // The only known property of NaN: it is not equal to itself.
+    // So we simulate isnan(x) with x != x
+    return mk_not(mk_neq(operand, operand));
+  }
+  else
+  {
+    // In bit-vector encoding, use IEEE-compliant bit-level check
+    return fp_api->mk_smt_fpbv_is_nan(operand);
+  }
 }
 
 smt_astt smt_convt::convert_is_inf(const expr2tc &expr)

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -881,38 +881,38 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
      *       them properly according to the input language.
      */
 
-     auto eq = to_equality2t(expr);
+    auto eq = to_equality2t(expr);
 
-     if (is_floatbv_type(eq.side_1) && is_floatbv_type(eq.side_2))
-     {
-       if (!int_encoding)
-       {
-         // Bit-vector mode: use IEEE-compliant floating-point equality
-         a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
-       }
-       else
-       {
-         // Real arithmetic mode: manually implement IEEE 754 semantics
-         // IEEE 754: x == y is false if either x or y is NaN
-         smt_astt normal_eq = args[0]->eq(this, args[1]);
-    
-         // Create isnan2t expressions before calling convert_is_nan
-         expr2tc isnan_side1 = isnan2tc(eq.side_1);
-         expr2tc isnan_side2 = isnan2tc(eq.side_2);
-    
-         smt_astt x_not_nan = mk_not(convert_is_nan(isnan_side1));
-         smt_astt y_not_nan = mk_not(convert_is_nan(isnan_side2));
-    
-         // (x == y) && !isnan(x) && !isnan(y)
-         a = mk_and(normal_eq, mk_and(x_not_nan, y_not_nan));
-       }
-     }
-     else
-     {
-       // Non-floating point types
-       a = args[0]->eq(this, args[1]);
-     }
-     break;
+    if (is_floatbv_type(eq.side_1) && is_floatbv_type(eq.side_2))
+    {
+      if (!int_encoding)
+      {
+        // Bit-vector mode: use IEEE-compliant floating-point equality
+        a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
+      }
+      else
+      {
+        // Real arithmetic mode: manually implement IEEE 754 semantics
+        // IEEE 754: x == y is false if either x or y is NaN
+        smt_astt normal_eq = args[0]->eq(this, args[1]);
+
+        // Create isnan2t expressions before calling convert_is_nan
+        expr2tc isnan_side1 = isnan2tc(eq.side_1);
+        expr2tc isnan_side2 = isnan2tc(eq.side_2);
+
+        smt_astt x_not_nan = mk_not(convert_is_nan(isnan_side1));
+        smt_astt y_not_nan = mk_not(convert_is_nan(isnan_side2));
+
+        // (x == y) && !isnan(x) && !isnan(y)
+        a = mk_and(normal_eq, mk_and(x_not_nan, y_not_nan));
+      }
+    }
+    else
+    {
+      // Non-floating point types
+      a = args[0]->eq(this, args[1]);
+    }
+    break;
   }
   case expr2t::notequal_id:
   {


### PR DESCRIPTION
This PR tries to propose support for IEEE 754 floating-point semantics in `--ir` (real arithmetic) mode. In real encoding mode, ESBMC now explicitly checks for NaN and ensures that equality only holds when both operands are equal and neither is NaN. Additionally, in real encoding mode, `isnan(x)` is now simulated as `x != x`, reflecting IEEE 754 behavior. In bit-vector mode, the existing IEEE-compliant `fpbv_is_nan` logic remains unchanged.