### PR TITLE
[SMT solver] Updated Bitwuzla from v0.7.0 to v0.8.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,7 +21,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.4           |
 | Z3        | no       | 4.13.3          |
-| Bitwuzla  | no       | 0.7.0           |
+| Bitwuzla  | no       | 0.8.0           |
 
 The version requirements are stable but can change between releases.
 
@@ -275,7 +275,7 @@ We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
 Linux/macOS:
-git clone --depth=1 --branch=0.7.0 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
+git clone --depth=1 --branch=0.8.0 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
 ```
 
 For more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
             NAME bitwuzla
             DOWNLOAD_ONLY YES
             GITHUB_REPOSITORY bitwuzla/bitwuzla
-            GIT_TAG 0.7.0)
+            GIT_TAG 0.8.0)
 	  
 	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
         message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -56,7 +56,12 @@ if(ENABLE_BITWUZLA)
     target_include_directories(solverbitw
             PRIVATE ${Boost_INCLUDE_DIRS}
             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-    target_link_libraries(solverbitw fmt::fmt PkgConfig::Bitwuzla)
+
+    find_library(GMP_LIB gmp)
+    if(NOT GMP_LIB)
+        message(FATAL_ERROR "gmp not found")
+    endif()
+    target_link_libraries(solverbitw fmt::fmt PkgConfig::Bitwuzla ${GMP_LIB})
 
     target_link_libraries(solvers INTERFACE solverbitw)
 


### PR DESCRIPTION
SV-COMP runs for 30s with bitwuzla 0.7.0 and 0.8.0:

Master (30s - v0.7.0): https://github.com/esbmc/esbmc/actions/runs/15238003592

This PR (30s - v0.8.0): https://github.com/esbmc/esbmc/actions/runs/15238006243