### PR TITLE
Disabled broken solvers for benchexec CI

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -165,7 +165,7 @@ do
     C) BASE_ARGS="$BASE_ARGS -DESBMC_SVCOMP=ON"
        SOLVER_FLAGS="\
           -DENABLE_BOOLECTOR=On \
-          -DENABLE_YICES=ON \
+          -DENABLE_YICES=OFF \
           -DENABLE_CVC4=OFF \
           -DENABLE_BITWUZLA=On \
           -DENABLE_Z3=On \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -167,7 +167,7 @@ do
           -DENABLE_BOOLECTOR=On \
           -DENABLE_YICES=OFF \
           -DENABLE_CVC4=OFF \
-          -DENABLE_BITWUZLA=On \
+          -DENABLE_BITWUZLA=OFF \
           -DENABLE_Z3=On \
           -DENABLE_MATHSAT=ON \
           -DENABLE_GOTO_CONTRACTOR=On \


### PR DESCRIPTION
Yices and Bitwuzla are not building on benchexec CI runs. The crashes seems to be related to GMP.

Lets avoid it for now and enable again when it is working.