### PR TITLE
[python] add support for bytes literals and indexing

### DIFF
--- a/regression/python/bytes2-fail/main.py
+++ b/regression/python/bytes2-fail/main.py
@@ -1,0 +1,4 @@
+single = b'A'
+assert len(single) == 2
+assert single[0] == 65  # ASCII value of 'A'
+assert single[-1] == 65  # Negative indexing

--- a/regression/python/bytes2-fail/test.desc
+++ b/regression/python/bytes2-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/bytes2/main.py
+++ b/regression/python/bytes2/main.py
@@ -1,0 +1,4 @@
+single = b'A'
+assert len(single) == 1
+assert single[0] == 65  # ASCII value of 'A'
+assert single[-1] == 65  # Negative indexing

--- a/regression/python/bytes2/main.py
+++ b/regression/python/bytes2/main.py
@@ -1,4 +1,4 @@
 single = b'A'
 assert len(single) == 1
 assert single[0] == 65  # ASCII value of 'A'
-assert single[-1] == 65  # Negative indexing
+assert single[-1] == 65  # Negative indexing works, -1 refers to the last element (same as index 0 here)

--- a/regression/python/bytes2/test.desc
+++ b/regression/python/bytes2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes3/main.py
+++ b/regression/python/bytes3/main.py
@@ -1,0 +1,4 @@
+data = b'Hello'
+assert data[-1] == 111  # 'o'
+assert data[-2] == 108  # 'l'
+assert data[-5] == 72   # 'H'

--- a/regression/python/bytes3/test.desc
+++ b/regression/python/bytes3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes4-fail/main.py
+++ b/regression/python/bytes4-fail/main.py
@@ -1,0 +1,6 @@
+data = b'\x00\x01\x02\x00'
+assert len(data) == 4
+assert data[0] == 0
+assert data[1] == 2
+assert data[2] == 2
+assert data[3] == 0

--- a/regression/python/bytes4-fail/test.desc
+++ b/regression/python/bytes4-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/bytes4/main.py
+++ b/regression/python/bytes4/main.py
@@ -1,0 +1,6 @@
+data = b'\x00\x01\x02\x00'
+assert len(data) == 4
+assert data[0] == 0
+assert data[1] == 1
+assert data[2] == 2
+assert data[3] == 0

--- a/regression/python/bytes4/test.desc
+++ b/regression/python/bytes4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes5/main.py
+++ b/regression/python/bytes5/main.py
@@ -1,0 +1,5 @@
+data = b'ABC'
+values = [65, 66, 67]  # ASCII values
+
+for i in range(len(data)):
+    assert data[i] == values[i]

--- a/regression/python/bytes5/test.desc
+++ b/regression/python/bytes5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes5_fail/main.py
+++ b/regression/python/bytes5_fail/main.py
@@ -1,0 +1,5 @@
+data = b'ABC'
+values = [65, 66, 66]  # ASCII values
+
+for i in range(len(data)):
+    assert data[i] == values[i]

--- a/regression/python/bytes5_fail/test.desc
+++ b/regression/python/bytes5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -31,8 +31,7 @@ static const std::unordered_map<std::string, std::string> operator_map = {
   {"rshift", "ashr"},   {"usub", "unary-"},   {"eq", "="},
   {"lt", "<"},          {"lte", "<="},        {"noteq", "notequal"},
   {"gt", ">"},          {"gte", ">="},        {"and", "and"},
-  {"or", "or"},         {"not", "not"},       {"uadd", "unary+"}
-};
+  {"or", "or"},         {"not", "not"},       {"uadd", "unary+"}};
 
 static const std::unordered_map<std::string, StatementType> statement_map = {
   {"AnnAssign", StatementType::VARIABLE_ASSIGN},
@@ -1274,8 +1273,9 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   }
 
   // Handle single-character string as char literal
-  if (value.is_string() && value.get<std::string>().size() == 1 && 
-      !is_bytes_literal(element))
+  if (
+    value.is_string() && value.get<std::string>().size() == 1 &&
+    !is_bytes_literal(element))
   {
     const std::string &str = value.get<std::string>();
     typet t = type_handler_.get_typet("str", str.size());
@@ -1302,7 +1302,8 @@ exprt python_converter::get_literal(const nlohmann::json &element)
       // Handle bytes literal - check for encoded_bytes field first
       if (element.contains("encoded_bytes"))
       {
-        string_literal = base64_decode(element["encoded_bytes"].get<std::string>());
+        string_literal =
+          base64_decode(element["encoded_bytes"].get<std::string>());
       }
       else
       {
@@ -1310,7 +1311,7 @@ exprt python_converter::get_literal(const nlohmann::json &element)
         const std::string &str_val = value.get<std::string>();
         string_literal.assign(str_val.begin(), str_val.end());
       }
-      
+
       // Set appropriate bytes type
       t = type_handler_.get_typet("bytes", string_literal.size());
     }
@@ -1335,20 +1336,21 @@ bool python_converter::is_bytes_literal(const nlohmann::json &element)
   // Check if element has encoded_bytes field (explicit bytes)
   if (element.contains("encoded_bytes"))
     return true;
-    
+
   // Check if element has bytes type annotation
-  if (element.contains("annotation") && element["annotation"].contains("id") &&
-      element["annotation"]["id"] == "bytes")
+  if (
+    element.contains("annotation") && element["annotation"].contains("id") &&
+    element["annotation"]["id"] == "bytes")
     return true;
-    
+
   // Check if element has a parent context indicating bytes
   if (element.contains("kind") && element["kind"] == "bytes")
     return true;
-    
+
   // Check if this is part of a bytes assignment/initialization
   if (current_element_type.id() == "bytes")
     return true;
-    
+
   // Check if this is an array of uint8 (bytes representation)
   if (current_element_type.id() == "array")
   {
@@ -1357,16 +1359,19 @@ bool python_converter::is_bytes_literal(const nlohmann::json &element)
     {
       // Convert dstring width to integer
       const irep_idt &width_str = subtype.width();
-      try {
+      try
+      {
         int width = std::stoi(width_str.as_string());
         if (width == 8)
           return true;
-      } catch (const std::exception&) {
+      }
+      catch (const std::exception &)
+      {
         // If conversion fails, continue with other checks
       }
     }
   }
-    
+
   return false;
 }
 
@@ -1663,12 +1668,15 @@ size_t get_type_size(const nlohmann::json &ast_node)
   if (ast_node["value"].contains("value"))
   {
     // Handle bytes literals
-    if (ast_node.contains("annotation") && ast_node["annotation"].contains("id") &&
-        ast_node["annotation"]["id"] == "bytes")
+    if (
+      ast_node.contains("annotation") &&
+      ast_node["annotation"].contains("id") &&
+      ast_node["annotation"]["id"] == "bytes")
     {
       if (ast_node["value"].contains("encoded_bytes"))
       {
-        const std::string &str = ast_node["value"]["encoded_bytes"].get<std::string>();
+        const std::string &str =
+          ast_node["value"]["encoded_bytes"].get<std::string>();
         std::vector<uint8_t> decoded = base64_decode(str);
         type_size = decoded.size();
       }
@@ -1695,7 +1703,9 @@ size_t get_type_size(const nlohmann::json &ast_node)
     type_size = ast_node["value"]["elts"].size();
   }
   // Handle cases where size cannot be determined from AST structure
-  else if (ast_node["value"].contains("value") && ast_node["value"]["value"].is_string())
+  else if (
+    ast_node["value"].contains("value") &&
+    ast_node["value"]["value"].is_string())
   {
     // Fallback for direct string values
     type_size = ast_node["value"]["value"].get<std::string>().size();

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1274,7 +1274,8 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   }
 
   // Handle single-character string as char literal
-  if (value.is_string() && value.get<std::string>().size() == 1)
+  if (value.is_string() && value.get<std::string>().size() == 1 && 
+      !is_bytes_literal(element))
   {
     const std::string &str = value.get<std::string>();
     typet t = type_handler_.get_typet("str", str.size());
@@ -1284,7 +1285,7 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   // Handle empty strings or docstrings (often beginning with a newline)
   if (
     value.is_string() && !value.get<std::string>().empty() &&
-    value.get<std::string>()[0] == '\n')
+    value.get<std::string>()[0] == '\n' && !is_bytes_literal(element))
   {
     return exprt(); // Return empty expression
   }
@@ -1295,11 +1296,23 @@ exprt python_converter::get_literal(const nlohmann::json &element)
     typet t = current_element_type;
     std::vector<uint8_t> string_literal;
 
-    // Detect and decode "bytes" literal from encoded base64 content
-    if (element.contains("encoded_bytes"))
+    // Check if this is a bytes literal
+    if (is_bytes_literal(element))
     {
-      string_literal =
-        base64_decode(element["encoded_bytes"].get<std::string>());
+      // Handle bytes literal - check for encoded_bytes field first
+      if (element.contains("encoded_bytes"))
+      {
+        string_literal = base64_decode(element["encoded_bytes"].get<std::string>());
+      }
+      else
+      {
+        // Handle direct bytes literal (e.g., b'A')
+        const std::string &str_val = value.get<std::string>();
+        string_literal.assign(str_val.begin(), str_val.end());
+      }
+      
+      // Set appropriate bytes type
+      t = type_handler_.get_typet("bytes", string_literal.size());
     }
     else // Handle Python str literals
     {
@@ -1314,6 +1327,47 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   }
 
   throw std::runtime_error("Unsupported literal " + value.get<std::string>());
+}
+
+// Helper function to detect bytes literals
+bool python_converter::is_bytes_literal(const nlohmann::json &element)
+{
+  // Check if element has encoded_bytes field (explicit bytes)
+  if (element.contains("encoded_bytes"))
+    return true;
+    
+  // Check if element has bytes type annotation
+  if (element.contains("annotation") && element["annotation"].contains("id") &&
+      element["annotation"]["id"] == "bytes")
+    return true;
+    
+  // Check if element has a parent context indicating bytes
+  if (element.contains("kind") && element["kind"] == "bytes")
+    return true;
+    
+  // Check if this is part of a bytes assignment/initialization
+  if (current_element_type.id() == "bytes")
+    return true;
+    
+  // Check if this is an array of uint8 (bytes representation)
+  if (current_element_type.id() == "array")
+  {
+    const typet &subtype = current_element_type.subtype();
+    if (subtype.id() == "unsignedbv")
+    {
+      // Convert dstring width to integer
+      const irep_idt &width_str = subtype.width();
+      try {
+        int width = std::stoi(width_str.as_string());
+        if (width == 8)
+          return true;
+      } catch (const std::exception&) {
+        // If conversion fails, continue with other checks
+      }
+    }
+  }
+    
+  return false;
 }
 
 exprt python_converter::get_expr(const nlohmann::json &element)
@@ -1608,12 +1662,21 @@ size_t get_type_size(const nlohmann::json &ast_node)
   size_t type_size = 0;
   if (ast_node["value"].contains("value"))
   {
-    if (ast_node["annotation"]["id"] == "bytes")
+    // Handle bytes literals
+    if (ast_node.contains("annotation") && ast_node["annotation"].contains("id") &&
+        ast_node["annotation"]["id"] == "bytes")
     {
-      const std::string &str =
-        ast_node["value"]["encoded_bytes"].get<std::string>();
-      std::vector<uint8_t> decoded = base64_decode(str);
-      type_size = decoded.size();
+      if (ast_node["value"].contains("encoded_bytes"))
+      {
+        const std::string &str = ast_node["value"]["encoded_bytes"].get<std::string>();
+        std::vector<uint8_t> decoded = base64_decode(str);
+        type_size = decoded.size();
+      }
+      else if (ast_node["value"]["value"].is_string())
+      {
+        // Direct bytes literal like b'A'
+        type_size = ast_node["value"]["value"].get<std::string>().size();
+      }
     }
     else if (ast_node["value"]["value"].is_string())
       type_size = ast_node["value"]["value"].get<std::string>().size();
@@ -1623,11 +1686,19 @@ size_t get_type_size(const nlohmann::json &ast_node)
     ast_node["value"]["args"].size() > 0 &&
     ast_node["value"]["args"][0].contains("value") &&
     ast_node["value"]["args"][0]["value"].is_string())
+  {
     type_size = ast_node["value"]["args"][0]["value"].get<std::string>().size();
+  }
   else if (
     ast_node["value"].contains("_type") && ast_node["value"]["_type"] == "List")
   {
     type_size = ast_node["value"]["elts"].size();
+  }
+  // Handle cases where size cannot be determined from AST structure
+  else if (ast_node["value"].contains("value") && ast_node["value"]["value"].is_string())
+  {
+    // Fallback for direct string values
+    type_size = ast_node["value"]["value"].get<std::string>().size();
   }
 
   return type_size;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -128,6 +128,8 @@ private:
 
   BigInt get_string_size(const exprt &expr);
 
+  bool is_bytes_literal(const nlohmann::json &element);
+
   exprt handle_string_concatenation(
     const exprt &lhs,
     const exprt &rhs,


### PR DESCRIPTION
This PR extends the ESBMC Python frontend to support Python bytes literals, including correct handling of their type, size, and indexing semantics. This enhancement includes updates to the AST conversion logic, additional test coverage for both correct and failing cases, and a new helper method to identify bytes literals in the AST.