### PR TITLE
[python] add support for python built-in function handling

### DIFF
--- a/regression/python/builtin1/main.py
+++ b/regression/python/builtin1/main.py
@@ -1,0 +1,6 @@
+def test_abs(x: int) -> int:
+    result = abs(x)
+    length = len([1, 2, 3])
+    return result + length
+
+assert test_abs(-5) == 8  # abs(-5) + len([1,2,3]) = 5 + 3 = 8

--- a/regression/python/builtin1/test.desc
+++ b/regression/python/builtin1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/builtin1_fail/main.py
+++ b/regression/python/builtin1_fail/main.py
@@ -1,0 +1,6 @@
+def test_abs(x: int) -> int:
+    result = abs(x)
+    length = len([1, 2, 3, 10])
+    return result + length
+
+assert test_abs(-5) == 8  # abs(-5) + len([1,2,3]) = 5 + 3 = 8

--- a/regression/python/builtin1_fail/main.py
+++ b/regression/python/builtin1_fail/main.py
@@ -3,4 +3,4 @@ def test_abs(x: int) -> int:
     length = len([1, 2, 3, 10])
     return result + length
 
-assert test_abs(-5) == 8  # abs(-5) + len([1,2,3]) = 5 + 3 = 8
+assert test_abs(-5) == 8  # should fail

--- a/regression/python/builtin1_fail/test.desc
+++ b/regression/python/builtin1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/builtin2/main.py
+++ b/regression/python/builtin2/main.py
@@ -1,0 +1,6 @@
+def test_chr_ord() -> bool:
+    char_code = ord('A')  # Should be 65
+    back_to_char = chr(char_code)
+    return back_to_char == 'A' and char_code == 65
+
+assert test_chr_ord() == True

--- a/regression/python/builtin2/test.desc
+++ b/regression/python/builtin2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/builtin2_fail/main.py
+++ b/regression/python/builtin2_fail/main.py
@@ -1,0 +1,6 @@
+def test_chr_ord() -> bool:
+    char_code = ord('B')  # Should be 65
+    back_to_char = chr(char_code)
+    return back_to_char == 'A' and char_code == 65
+
+assert test_chr_ord() == True

--- a/regression/python/builtin2_fail/main.py
+++ b/regression/python/builtin2_fail/main.py
@@ -1,5 +1,5 @@
 def test_chr_ord() -> bool:
-    char_code = ord('B')  # Should be 65
+    char_code = ord('B')  # Should be 66
     back_to_char = chr(char_code)
     return back_to_char == 'A' and char_code == 65
 

--- a/regression/python/builtin2_fail/test.desc
+++ b/regression/python/builtin2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/list12/main.py
+++ b/regression/python/list12/main.py
@@ -1,0 +1,10 @@
+def sum_while(n: list[int]) -> int:
+    l = len(n)
+    i = 0
+    s = 0
+    while i < l:
+        s += n[i]
+        i += 1
+    return s
+
+assert sum_while([1, 2]) == 3

--- a/regression/python/list12/test.desc
+++ b/regression/python/list12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list12_fail/main.py
+++ b/regression/python/list12_fail/main.py
@@ -1,0 +1,10 @@
+def sum_while(n: list[int]) -> int:
+    l = len(n)
+    i = 0
+    s = 0
+    while i < l:
+        s += n[i]
+        i += 1
+    return s
+
+assert sum_while([1, 2]) == 2

--- a/regression/python/list12_fail/test.desc
+++ b/regression/python/list12_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -861,8 +861,7 @@ private:
     element.erase("type_comment");
 
     // Update value fields with the correct offsets
-    auto update_offsets = [&inferred_type](Json &value)
-    {
+    auto update_offsets = [&inferred_type](Json &value) {
       value["col_offset"] =
         value["col_offset"].template get<int>() + inferred_type.size() + 1;
       value["end_col_offset"] =

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -15,6 +15,80 @@ enum class InferResult
   UNKNOWN,
 };
 
+// Handle Python built-in functions
+static const std::map<std::string, std::string> builtin_functions = {
+  // Type conversion functions
+  {"int", "int"},
+  {"float", "float"},
+  {"str", "str"},
+  {"bool", "bool"},
+  {"list", "list"},
+  {"dict", "dict"},
+  {"set", "set"},
+  {"tuple", "tuple"},
+
+  // Numeric functions
+  {"abs", "int"},   // Can return int or float, but int is common case
+  {"round", "int"}, // Can return int or float
+  {"min", "Any"},   // Type depends on input
+  {"max", "Any"},   // Type depends on input
+  {"sum", "int"},   // Can return int or float, but int is common case
+  {"pow", "int"},   // Can return int or float
+
+  // Sequence functions
+  {"len", "int"},
+  {"range", "range"},
+  {"enumerate", "enumerate"},
+  {"zip", "zip"},
+  {"reversed", "reversed"},
+  {"sorted", "list"},
+
+  // I/O functions
+  {"print", "NoneType"},
+  {"input", "str"},
+  {"open", "file"},
+
+  // Utility functions
+  {"isinstance", "bool"},
+  {"issubclass", "bool"},
+  {"hasattr", "bool"},
+  {"getattr", "Any"},
+  {"setattr", "NoneType"},
+  {"delattr", "NoneType"},
+  {"callable", "bool"},
+  {"id", "int"},
+  {"hash", "int"},
+  {"repr", "str"},
+  {"ascii", "str"},
+  {"ord", "int"},
+  {"chr", "str"},
+  {"bin", "str"},
+  {"oct", "str"},
+  {"hex", "str"},
+  {"format", "str"},
+
+  // Iteration functions
+  {"iter", "iterator"},
+  {"next", "Any"},
+  {"all", "bool"},
+  {"any", "bool"},
+  {"filter", "filter"},
+  {"map", "map"},
+
+  // Variable functions
+  {"vars", "dict"},
+  {"dir", "list"},
+  {"globals", "dict"},
+  {"locals", "dict"},
+
+  // Execution functions
+  {"eval", "Any"},
+  {"exec", "NoneType"},
+  {"compile", "code"},
+
+  // Import functions
+  {"__import__", "module"}};
+
 template <class Json>
 class python_annotation
 {
@@ -352,6 +426,13 @@ private:
     }
     catch (std::runtime_error &)
     {
+    }
+
+    // Check if the function is a built-in function
+    auto it = builtin_functions.find(func_name);
+    if (it != builtin_functions.end())
+    {
+      return it->second;
     }
 
     std::ostringstream oss;
@@ -780,7 +861,8 @@ private:
     element.erase("type_comment");
 
     // Update value fields with the correct offsets
-    auto update_offsets = [&inferred_type](Json &value) {
+    auto update_offsets = [&inferred_type](Json &value)
+    {
       value["col_offset"] =
         value["col_offset"].template get<int>() + inferred_type.size() + 1;
       value["end_col_offset"] =

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -311,15 +311,18 @@ void python_converter::promote_int_to_float(exprt &op, const typet &target_type)
 }
 
 // Helper function to get numeric width from type
-size_t get_type_width(const typet &type) {
+size_t get_type_width(const typet &type)
+{
   // First try to parse width directly
-  try {
+  try
+  {
     return std::stoi(type.width().c_str());
   }
-  catch (const std::exception &) {
+  catch (const std::exception &)
+  {
     // If direct parsing fails, try to infer from type name
     std::string type_str = type.width().as_string();
-    
+
     // Handle common Python/ESBMC type mappings
     if (type_str == "int" || type_str == "int32")
       return 32;
@@ -339,15 +342,18 @@ size_t get_type_width(const typet &type) {
     // Try to extract number from string like "int32", "uint64", etc.
     std::regex width_regex(R"(\d+)");
     std::smatch match;
-    if (std::regex_search(type_str, match, width_regex)) {
-      try {
+    if (std::regex_search(type_str, match, width_regex))
+    {
+      try
+      {
         return std::stoi(match.str());
       }
-      catch (const std::exception &) {
+      catch (const std::exception &)
+      {
         // Fall through to default
       }
     }
-    
+
     // Default to 32 for unknown types
     return 32;
   }


### PR DESCRIPTION
This PR enhances the Python frontend by:
- Adding support for inferring the types of several Python built-in functions.
- Implementing regression test cases to validate the correct behavior of these built-ins under verification.
- Improving robustness in type width inference during type adjustments.