### PR TITLE
[python] add support for transforming general python for loops over iterables 

### DIFF
--- a/regression/python/for-loop10/main.py
+++ b/regression/python/for-loop10/main.py
@@ -1,0 +1,5 @@
+word = "test"
+length = 0
+for letter in word:
+    length = length + 1
+assert length == 4

--- a/regression/python/for-loop10/test.desc
+++ b/regression/python/for-loop10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop11/main.py
+++ b/regression/python/for-loop11/main.py
@@ -1,0 +1,10 @@
+word = [1, 2, 3, 4, 5]
+even_count = 0
+odd_count = 0
+for item in word:
+    if item % 2 == 0:
+        even_count = even_count + 1
+    else:
+        odd_count = odd_count + 1
+assert even_count == 2
+assert odd_count == 3

--- a/regression/python/for-loop11/test.desc
+++ b/regression/python/for-loop11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop12/main.py
+++ b/regression/python/for-loop12/main.py
@@ -1,0 +1,7 @@
+nums = [1, 2, 3, 4, 5]
+found = False
+for n in nums:
+    if n == 3:
+        found = True
+        break
+assert found

--- a/regression/python/for-loop12/test.desc
+++ b/regression/python/for-loop12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop12_fail/main.py
+++ b/regression/python/for-loop12_fail/main.py
@@ -1,0 +1,6 @@
+word = [10, 20, 30, 40]
+found = False
+for item in word:
+    if item == 50:  # 50 is not in the list
+        found = True
+assert found  # This will fail

--- a/regression/python/for-loop12_fail/test.desc
+++ b/regression/python/for-loop12_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/for-loop13/main.py
+++ b/regression/python/for-loop13/main.py
@@ -1,0 +1,7 @@
+nums = [1, 2, 3, 4, 5]
+total = 0
+for n in nums:
+    if n % 2 == 0:
+        continue
+    total += n
+assert total == 9  # 1 + 3 + 5

--- a/regression/python/for-loop13/test.desc
+++ b/regression/python/for-loop13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop14/main.py
+++ b/regression/python/for-loop14/main.py
@@ -1,0 +1,5 @@
+word = ""
+length = 0
+for letter in word:
+    length += 1
+assert length == 0

--- a/regression/python/for-loop14/test.desc
+++ b/regression/python/for-loop14/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop15/main.py
+++ b/regression/python/for-loop15/main.py
@@ -1,0 +1,4 @@
+total = 0
+for i in range(5):
+    total += i
+assert total == 10  # 0+1+2+3+4

--- a/regression/python/for-loop15/test.desc
+++ b/regression/python/for-loop15/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop16_fail/main.py
+++ b/regression/python/for-loop16_fail/main.py
@@ -1,0 +1,5 @@
+word = "loop"
+length = 0
+for letter in word:
+    length += 1
+assert length == 5  # Incorrect, should be 4

--- a/regression/python/for-loop16_fail/test.desc
+++ b/regression/python/for-loop16_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/for-loop2/main.py
+++ b/regression/python/for-loop2/main.py
@@ -1,0 +1,3 @@
+word = [1, 2, 3]
+for letter in word:
+    assert letter == 1 or letter == 2 or letter == 3

--- a/regression/python/for-loop2/test.desc
+++ b/regression/python/for-loop2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop2_fail/main.py
+++ b/regression/python/for-loop2_fail/main.py
@@ -1,0 +1,3 @@
+word = [1, 2, 3]
+for letter in word:
+    assert letter == 1 or letter == 3

--- a/regression/python/for-loop2_fail/test.desc
+++ b/regression/python/for-loop2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/for-loop3/main.py
+++ b/regression/python/for-loop3/main.py
@@ -1,0 +1,3 @@
+word = "Python"
+for letter in word:
+    assert letter == 'P' or letter == 'y' or letter == 't' or letter == 'h' or letter == 'o' or letter == 'n'

--- a/regression/python/for-loop3/test.desc
+++ b/regression/python/for-loop3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop3_fail/main.py
+++ b/regression/python/for-loop3_fail/main.py
@@ -1,0 +1,3 @@
+word = "Python"
+for letter in word:
+    assert letter == 'p' or letter == 'y' or letter == 't' or letter == 'h' or letter == 'o' or letter == 'n'

--- a/regression/python/for-loop3_fail/test.desc
+++ b/regression/python/for-loop3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/for-loop4/main.py
+++ b/regression/python/for-loop4/main.py
@@ -1,0 +1,6 @@
+word = [1]
+found_any = True
+if len(word)!=0:
+    for letter in word:
+        found_any = False
+assert not found_any

--- a/regression/python/for-loop4/test.desc
+++ b/regression/python/for-loop4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop5/main.py
+++ b/regression/python/for-loop5/main.py
@@ -1,0 +1,3 @@
+word = [42]
+for letter in word:
+    assert letter == 42

--- a/regression/python/for-loop5/test.desc
+++ b/regression/python/for-loop5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop6/main.py
+++ b/regression/python/for-loop6/main.py
@@ -1,0 +1,3 @@
+word = "Abc"
+for letter in word:
+    assert letter == "A" or letter == "b" or letter == "c"

--- a/regression/python/for-loop6/test.desc
+++ b/regression/python/for-loop6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop7_fail/main.py
+++ b/regression/python/for-loop7_fail/main.py
@@ -1,0 +1,5 @@
+word = [1, 2, 3, 4, 5]
+sum_val = 0
+for item in word:
+    sum_val = sum_val + item
+assert sum_val == 20  # Should be 15

--- a/regression/python/for-loop7_fail/test.desc
+++ b/regression/python/for-loop7_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/for-loop8_fail/main.py
+++ b/regression/python/for-loop8_fail/main.py
@@ -1,0 +1,3 @@
+word = "Hello"
+for letter in word:
+    assert letter != 'e'  # Will fail when letter == 'e'

--- a/regression/python/for-loop8_fail/test.desc
+++ b/regression/python/for-loop8_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/for-loop9/main.py
+++ b/regression/python/for-loop9/main.py
@@ -1,0 +1,5 @@
+word = [10, 20, 30]
+count = 0
+for item in word:
+    count = count + 1
+assert count == 3

--- a/regression/python/for-loop9/test.desc
+++ b/regression/python/for-loop9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1,16 +1,44 @@
 import ast
 
 class Preprocessor(ast.NodeTransformer):
-    def __init__(self,module_name):
+    def __init__(self, module_name):
         # Initialize with an empty target name
         self.target_name = ""
         self.functionDefaults = {}
         self.functionParams = {}
         self.module_name = module_name # for errors
+        self.is_range_loop = False  # Track if we're in a range loop transformation
 
+    def ensure_all_locations(self, node, source_node=None, line=1, col=0):
+        """Recursively ensure all nodes in an AST tree have location information"""
+        if source_node:
+            line = getattr(source_node, 'lineno', 1)
+            col = getattr(source_node, 'col_offset', 0)
+        
+        # Ensure current node has location info
+        if not hasattr(node, 'lineno') or node.lineno is None:
+            node.lineno = line
+        if not hasattr(node, 'col_offset') or node.col_offset is None:
+            node.col_offset = col
+        
+        # Recursively apply to all child nodes
+        for child in ast.iter_child_nodes(node):
+            self.ensure_all_locations(child, source_node, line, col)
+        
+        return node
 
-    def generate_variable_copy(self, node_name:str, argument:ast.arg, default_val):
-        target = ast.Name(id=f"ESBMC_DEFAULT_{node_name}_{argument.arg}",ctx=ast.Store())
+    def create_name_node(self, name_id, ctx, source_node=None):
+        """Create a Name node with proper location info"""
+        node = ast.Name(id=name_id, ctx=ctx)
+        return self.ensure_all_locations(node, source_node)
+
+    def create_constant_node(self, value, source_node=None):
+        """Create a Constant node with proper location info"""
+        node = ast.Constant(value=value)
+        return self.ensure_all_locations(node, source_node)
+
+    def generate_variable_copy(self, node_name: str, argument: ast.arg, default_val):
+        target = ast.Name(id=f"ESBMC_DEFAULT_{node_name}_{argument.arg}", ctx=ast.Store())
         assign_node = ast.AnnAssign(
             target=target,
             annotation=argument.annotation,
@@ -18,130 +46,264 @@ class Preprocessor(ast.NodeTransformer):
             simple=1
         )
         return assign_node, target
-    # for-range statements such as:
-    #
-    #   for x in range(1, 5, 1):
-    #     print(x)
-    #
-    # are transformed into a corresponding while loop with the following structure:
-    #
-    #   def ESBMC_range_next_(curr: int, step: int) -> int:
-    #     return curr + step
-    #
-    #   def ESBMC_range_has_next_(curr: int, end: int, step: int) -> bool:
-    #     return curr + step <= end
-    #
-    #   start = 1  # start value is copied from the first parameter of range call
-    #   has_next:bool = ESBMC_range_has_next_(1, 5, 1) # ESBMC_range_has_next_ parameters copied from range call
-    #   while has_next == True:
-    #     print(start)
-    #     start = ESBMC_range_next_(start, 1)
-    #     has_next = ESBMC_range_has_next_(start, 5, 1)
 
     def visit_For(self, node):
-        # Transformation from for to while if the iterator is range
-        if isinstance(node.iter, ast.Call) and isinstance(node.iter.func, ast.Name) and node.iter.func.id == "range":
+        """
+        Transform for loops into while loops.
+        Handles both range() calls and general iterables (strings, lists, etc.)
+        """
+        # First, recursively visit any nested nodes
+        node = self.generic_visit(node)
+        
+        # Check if iter is a Call to range
+        is_range_call = (isinstance(node.iter, ast.Call) and 
+                        isinstance(node.iter.func, ast.Name) and 
+                        node.iter.func.id == "range")
+        
+        if is_range_call:
+            # Handle range-based for loops
+            self.is_range_loop = True
+            result = self._transform_range_for(node)
+            self.is_range_loop = False
+            return result
+        else:
+            # Handle general iteration over iterables (strings, lists, etc.)
+            self.is_range_loop = False
+            return self._transform_iterable_for(node)
 
-            if len(node.iter.args) > 1:
-                start = node.iter.args[0]  # Start of the range
-                end = node.iter.args[1]    # End of the range
-            elif len(node.iter.args) == 1:
-                start = ast.Constant(value=0)
-                end = node.iter.args[0]
+    def _transform_range_for(self, node):
+        """Transform range-based for loops to while loops"""
+        if len(node.iter.args) > 1:
+            start = node.iter.args[0]  # Start of the range
+            end = node.iter.args[1]    # End of the range
+        elif len(node.iter.args) == 1:
+            start = ast.Constant(value=0)
+            end = node.iter.args[0]
 
-            # Check if step is provided in range, otherwise default to 1
-            if len(node.iter.args) > 2:
-                step = node.iter.args[2]
+        # Check if step is provided in range, otherwise default to 1
+        if len(node.iter.args) > 2:
+            step = node.iter.args[2]
+        else:
+            step = ast.Constant(value=1)
+
+        # Step validation - Python raises ValueError if step == 0
+        step_validation = ast.Assert(
+            test=ast.Compare(
+            left=step,
+            ops=[ast.NotEq()],
+            comparators=[ast.Constant(value=0)]
+            ),
+            msg=ast.Constant(value="range() arg 3 must not be zero")
+        )
+
+        # Create assignment for the start variable
+        start_assign = ast.AnnAssign(
+            target=ast.Name(id='start', ctx=ast.Store()),
+            annotation=ast.Name(id='int', ctx=ast.Load()),
+            value=start,
+            simple=1
+        )
+
+        # Create call to ESBMC_range_has_next_ function for the range
+        has_next_call = ast.Call(
+            func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()),
+            args=[start, end, step],
+            keywords=[]
+        )
+
+        # Create assignment for the has_next variable
+        has_next_assign = ast.AnnAssign(
+            target=ast.Name(id='has_next', ctx=ast.Store()),
+            annotation=ast.Name(id='bool', ctx=ast.Load()),
+            value=has_next_call,
+            simple=1
+        )
+
+        # Create condition for the while loop
+        has_next_name = ast.Name(id='has_next', ctx=ast.Load())
+        while_cond = ast.Compare(
+            left=has_next_name,
+            ops=[ast.Eq()],
+            comparators=[ast.Constant(value=True)]
+        )
+
+        # Transform the body of the for loop
+        transformed_body = []
+        old_target_name = self.target_name
+        self.target_name = node.target.id # Store the target variable name for replacement
+        
+        for statement in node.body:
+            transformed_statement = self.visit(statement)
+            if isinstance(transformed_statement, list):
+                transformed_body.extend(transformed_statement)
             else:
-                step = ast.Constant(value=1)
+                transformed_body.append(transformed_statement)
+        self.target_name = old_target_name
 
-            # Step validation - Python raises ValueError if step == 0
-            step_validation = ast.Assert(
-                test=ast.Compare(
-                left=step,
-                ops=[ast.NotEq()],
-                comparators=[ast.Constant(value=0)]
-                ),
-                msg=ast.Constant(value="range() arg 3 must not be zero")
-            )
-
-            # Create assignment for the start variable
-            start_assign = ast.AnnAssign(
-                target=ast.Name(id='start', ctx=ast.Store()),
-                annotation=ast.Name(id='int', ctx=ast.Load()),
-                value=start,
-                simple=1
-            )
-
-            # Create call to ESBMC_range_has_next_ function for the range
-            has_next_call = ast.Call(
-                func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()),
-                args=[start, end, step],
-                keywords=[]
-            )
-
-            # Create assignment for the has_next variable
-            has_next_assign = ast.AnnAssign(
-                target=ast.Name(id='has_next', ctx=ast.Store()),
-                annotation=ast.Name(id='bool', ctx=ast.Load()),
-                value=has_next_call,
-                simple=1
-            )
-
-            # Create condition for the while loop
-            has_next_name = ast.Name(id='has_next', ctx=ast.Load())
-            while_cond = ast.Compare(
-                left=has_next_name,
-                ops=[ast.Eq()],
-                comparators=[ast.Constant(value=True)]
-            )
-
-            # Transform the body of the for loop
-            transformed_body = []
-            self.target_name = node.target.id # Store the target variable name for replacement
-            for statement in node.body:
-                transformed_body.append(self.visit(statement))
-
-            # Create the body of the while loop, including updating the start and has_next variables
-            while_body = transformed_body + [
-                ast.Assign(
-                    targets=[ast.Name(id='start', ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Name(id='ESBMC_range_next_', ctx=ast.Load()),
-                        args=[ast.Name(id='start', ctx=ast.Load()), step],
-                        keywords=[]
-                    )
-                ),
-                ast.Assign(
-                    targets=[has_next_name],
-                    value=ast.Call(
-                        func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()),
-                        args=[ast.Name(id='start', ctx=ast.Load()), end, step],
-                        keywords=[]
-                    )
+        # Create the body of the while loop, including updating the start and has_next variables
+        while_body = transformed_body + [
+            ast.Assign(
+                targets=[ast.Name(id='start', ctx=ast.Store())],
+                value=ast.Call(
+                    func=ast.Name(id='ESBMC_range_next_', ctx=ast.Load()),
+                    args=[ast.Name(id='start', ctx=ast.Load()), step],
+                    keywords=[]
                 )
-            ]
-
-            # Create the while statement
-            while_stmt = ast.While(
-                test=while_cond,
-                body=while_body,
-                orelse=[]
+            ),
+            ast.Assign(
+                targets=[has_next_name],
+                value=ast.Call(
+                    func=ast.Name(id='ESBMC_range_has_next_', ctx=ast.Load()),
+                    args=[ast.Name(id='start', ctx=ast.Load()), end, step],
+                    keywords=[]
+                )
             )
+        ]
 
-            # Return the transformed statements
-            return [step_validation, start_assign, has_next_assign, while_stmt]
+        # Create the while statement
+        while_stmt = ast.While(
+            test=while_cond,
+            body=while_body,
+            orelse=[]
+        )
 
-        return node
+        # Return the transformed statements
+        return [step_validation, start_assign, has_next_assign, while_stmt]
+
+    def _transform_iterable_for(self, node):
+        """
+        Transform general iterable for loops to while loops.
+        
+        Transforms:
+            for item in iterable:
+                body
+        Into:
+            ESBMC_iter: str = iterable
+            ESBMC_index: int = 0
+            ESBMC_length: int = len(ESBMC_iter)
+            while ESBMC_index < ESBMC_length:
+                item: str = ESBMC_iter[ESBMC_index]
+                body
+                ESBMC_index: int = ESBMC_index + 1
+        """
+        # Handle the target variable name
+        if hasattr(node.target, 'id'):
+            target_var_name = node.target.id
+        else:
+            target_var_name = 'ESBMC_loop_var'
+
+        # Create assignment for the iterable variable
+        iter_target = self.create_name_node('ESBMC_iter', ast.Store(), node)
+        str_annotation = self.create_name_node('str', ast.Load(), node)
+        iter_assign = ast.AnnAssign(
+            target=iter_target,
+            annotation=str_annotation,
+            value=node.iter,
+            simple=1
+        )
+        self.ensure_all_locations(iter_assign, node)
+
+        # Create assignment for the index variable
+        index_target = self.create_name_node('ESBMC_index', ast.Store(), node)
+        index_value = self.create_constant_node(0, node)
+        int_annotation = self.create_name_node('int', ast.Load(), node)
+        index_assign = ast.AnnAssign(
+            target=index_target,
+            annotation=int_annotation,
+            value=index_value,
+            simple=1
+        )
+        self.ensure_all_locations(index_assign, node)
+
+        # Create assignment for the length variable
+        length_target = self.create_name_node('ESBMC_length', ast.Store(), node)
+        len_func = self.create_name_node('len', ast.Load(), node)
+        iter_arg = self.create_name_node('ESBMC_iter', ast.Load(), node)
+        len_call = ast.Call(func=len_func, args=[iter_arg], keywords=[])
+        self.ensure_all_locations(len_call, node)
+        int_annotation2 = self.create_name_node('int', ast.Load(), node)
+        length_assign = ast.AnnAssign(
+            target=length_target,
+            annotation=int_annotation2,
+            value=len_call,
+            simple=1
+        )
+        self.ensure_all_locations(length_assign, node)
+
+        # Create condition for the while loop
+        index_left = self.create_name_node('ESBMC_index', ast.Load(), node)
+        length_right = self.create_name_node('ESBMC_length', ast.Load(), node)
+        lt_op = ast.Lt()
+        self.ensure_all_locations(lt_op, node)
+        while_cond = ast.Compare(left=index_left, ops=[lt_op], comparators=[length_right])
+        self.ensure_all_locations(while_cond, node)
+
+        # Add assignment to get current item from iterable
+        item_target = self.create_name_node(target_var_name, ast.Store(), node)
+        iter_value = self.create_name_node('ESBMC_iter', ast.Load(), node)
+        index_slice = self.create_name_node('ESBMC_index', ast.Load(), node)
+        subscript = ast.Subscript(value=iter_value, slice=index_slice, ctx=ast.Load())
+        self.ensure_all_locations(subscript, node)
+        str_annotation_item = self.create_name_node('str', ast.Load(), node)
+        item_assign = ast.AnnAssign(
+            target=item_target,
+            annotation=str_annotation_item,
+            value=subscript,
+            simple=1
+        )
+        self.ensure_all_locations(item_assign, node)
+
+        # Transform the body of the for loop
+        transformed_body = [item_assign]
+        
+        # Transform the original body statements
+        for statement in node.body:
+            transformed_statement = self.visit(statement)
+            if isinstance(transformed_statement, list):
+                transformed_body.extend(transformed_statement)
+            else:
+                transformed_body.append(transformed_statement)
+
+        # Add increment of index
+        inc_target = self.create_name_node('ESBMC_index', ast.Store(), node)
+        inc_left = self.create_name_node('ESBMC_index', ast.Load(), node)
+        inc_right = self.create_constant_node(1, node)
+        add_op = ast.Add()
+        self.ensure_all_locations(add_op, node)
+        inc_binop = ast.BinOp(left=inc_left, op=add_op, right=inc_right)
+        self.ensure_all_locations(inc_binop, node)
+        int_annotation_inc = self.create_name_node('int', ast.Load(), node)
+        index_increment = ast.AnnAssign(
+            target=inc_target,
+            annotation=int_annotation_inc,
+            value=inc_binop,
+            simple=1
+        )
+        self.ensure_all_locations(index_increment, node)
+        transformed_body.append(index_increment)
+
+        # Create the while statement
+        while_stmt = ast.While(test=while_cond, body=transformed_body, orelse=[])
+        self.ensure_all_locations(while_stmt, node)
+
+        result = [iter_assign, index_assign, length_assign, while_stmt]
+        
+        # Ensure all nodes in the result have proper location info
+        for stmt in result:
+            self.ensure_all_locations(stmt, node)
+            ast.fix_missing_locations(stmt)
+        
+        return result
 
     def visit_Name(self, node):
-        # Replace variable names as needed in the for to while transformation
-        if node.id == self.target_name:
+        """Replace variable names as needed in range-based for to while transformation"""
+        # Replace variable names ONLY for range-based loops, not iterable loops
+        if self.is_range_loop and node.id == self.target_name:
             node.id = 'start'  # Replace the variable name with 'start'
         return node
 
-    # This method is responsible for visiting and transforming Call nodes in the AST.
     def visit_Call(self, node):
+        """Transform function calls and handle default arguments"""
         # Transformation for int.from_bytes calls
         if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name) and node.func.value.id == "int" and node.func.attr == "from_bytes":
             # Replace 'big' argument with True and anything else with False
@@ -184,11 +346,11 @@ class Preprocessor(ast.NodeTransformer):
                 print(f"* file: {self.module_name}\n* line {node.lineno}\n* function: {functionName}\n* column: {node.col_offset} ")
                 break # breaking means not enough arguments, solver should reject
 
-
         self.generic_visit(node)
         return node # transformed node
 
     def visit_FunctionDef(self, node):
+        """Handle function definitions and extract default parameter values"""
         # Preserve order of parameters
         self.functionParams[node.name] = [i.arg for i in node.args.args]
 

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -73,12 +73,12 @@ class Preprocessor(ast.NodeTransformer):
         """
         # First, recursively visit any nested nodes
         node = self.generic_visit(node)
-        
+
         # Check if iter is a Call to range
         is_range_call = (isinstance(node.iter, ast.Call) and
                         isinstance(node.iter.func, ast.Name) and
                         node.iter.func.id == "range")
-        
+
         if is_range_call:
             # Handle range-based for loops
             self.is_range_loop = True
@@ -150,7 +150,7 @@ class Preprocessor(ast.NodeTransformer):
         transformed_body = []
         old_target_name = self.target_name
         self.target_name = node.target.id # Store the target variable name for replacement
-        
+
         for statement in node.body:
             transformed_statement = self.visit(statement)
             if isinstance(transformed_statement, list):
@@ -192,7 +192,7 @@ class Preprocessor(ast.NodeTransformer):
     def _transform_iterable_for(self, node):
         """
         Transform general iterable for loops to while loops.
-        
+
         Handles continue statements correctly by placing index increment
         at the beginning of the loop body, not the end.
         """
@@ -240,7 +240,7 @@ class Preprocessor(ast.NodeTransformer):
         )
         self.ensure_all_locations(length_assign, node)
 
-        # Create condition for the while loop
+        # Create a condition for the while loop
         index_left = self.create_name_node('ESBMC_index', ast.Load(), node)
         length_right = self.create_name_node('ESBMC_length', ast.Load(), node)
         lt_op = ast.Lt()
@@ -283,7 +283,7 @@ class Preprocessor(ast.NodeTransformer):
         # Transform the body of the for loop
         # Order: item_assign, index_increment, then original body
         transformed_body = [item_assign, index_increment]
-        
+
         # Transform the original body statements
         for statement in node.body:
             transformed_statement = self.visit(statement)
@@ -297,12 +297,12 @@ class Preprocessor(ast.NodeTransformer):
         self.ensure_all_locations(while_stmt, node)
 
         result = [iter_assign, index_assign, length_assign, while_stmt]
-        
+
         # Ensure all nodes in the result have proper location info
         for stmt in result:
             self.ensure_all_locations(stmt, node)
             ast.fix_missing_locations(stmt)
-        
+
         return result
 
     def visit_Name(self, node):

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -14,7 +14,7 @@ class Preprocessor(ast.NodeTransformer):
         if source_node:
             line = getattr(source_node, 'lineno', 1)
             col = getattr(source_node, 'col_offset', 0)
-        
+
         # Ensure current node has location info
         if not hasattr(node, 'lineno') or node.lineno is None:
             node.lineno = line
@@ -46,7 +46,6 @@ class Preprocessor(ast.NodeTransformer):
             simple=1
         )
         return assign_node, target
-
     # for-range statements such as:
     #
     #   for x in range(1, 5, 1):
@@ -76,8 +75,8 @@ class Preprocessor(ast.NodeTransformer):
         node = self.generic_visit(node)
         
         # Check if iter is a Call to range
-        is_range_call = (isinstance(node.iter, ast.Call) and 
-                        isinstance(node.iter.func, ast.Name) and 
+        is_range_call = (isinstance(node.iter, ast.Call) and
+                        isinstance(node.iter.func, ast.Name) and
                         node.iter.func.id == "range")
         
         if is_range_call:

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -20,11 +20,11 @@ class Preprocessor(ast.NodeTransformer):
             node.lineno = line
         if not hasattr(node, 'col_offset') or node.col_offset is None:
             node.col_offset = col
-        
+
         # Recursively apply to all child nodes
         for child in ast.iter_child_nodes(node):
             self.ensure_all_locations(child, source_node, line, col)
-        
+
         return node
 
     def create_name_node(self, name_id, ctx, source_node=None):


### PR DESCRIPTION
This PR enhances the Python frontend of ESBMC by introducing support for general for loops over iterable types (e.g., strings and lists), in addition to the previously supported range()-based loops.