### PR TITLE
Consider the guard when dealing with sideeffects

### DIFF
--- a/regression/esbmc/realloc7/main.c
+++ b/regression/esbmc/realloc7/main.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  int *a = (int *)malloc(sizeof(int));
+
+  int *temp = realloc(a, 2 * sizeof(int));
+  a = temp;
+
+  free(a);
+  return 0;
+}

--- a/regression/esbmc/realloc7/test.desc
+++ b/regression/esbmc/realloc7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-realloc-success --force-malloc-success --memory-leak-check
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -86,10 +86,10 @@ void goto_symext::symex_realloc(
   std::list<std::pair<expr2tc, expr2tc>> result_list;
   for (auto &item : internal_deref_items)
   {
-    expr2tc guard = item.guard;
+    expr2tc g = item.guard;
     cur_state->rename_address(item.object);
-    cur_state->guard.guard_expr(guard);
-    target->renumber(guard, item.object, realloc_size, cur_state->source);
+    cur_state->guard.guard_expr(g);
+    target->renumber(g, item.object, realloc_size, cur_state->source);
     type2tc new_ptr = pointer_type2tc(item.object->type);
     expr2tc addrof = address_of2tc(new_ptr, item.object);
     result_list.emplace_back(addrof, item.guard);
@@ -279,9 +279,9 @@ expr2tc goto_symext::symex_mem(
   expr2tc ptr_obj = pointer_object2tc(pointer_type2(), ptr_rhs);
 
   if (size_is_one)
-    track_new_pointer(ptr_obj, new_type);
+    track_new_pointer(ptr_obj, new_type, guard);
   else
-    track_new_pointer(ptr_obj, new_type, size);
+    track_new_pointer(ptr_obj, new_type, guard, size);
 
   alloc_guard.append(guard);
   dynamic_memory.emplace_back(

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -546,7 +546,10 @@ protected:
    * This function does not return any value; it modifies the symbolic execution state
    * based on the side effect encountered.
    */
-  void handle_sideeffect(const expr2tc &lhs, const sideeffect2t &effect);
+  void handle_sideeffect(
+    const expr2tc &lhs,
+    const sideeffect2t &effect,
+    const guardt &guard);
 
   /**
    * Handle conditional expressions (if2t) in the symbolic execution.
@@ -557,7 +560,10 @@ protected:
    * 
    * This function returns true if there is a sideeffect.
    */
-  bool handle_conditional(const expr2tc &lhs, const if2t &if_effect);
+  bool handle_conditional(
+    const expr2tc &lhs,
+    const if2t &if_effect,
+    const guardt &guard);
 
   /**
    *  Make symbolic assignment.
@@ -773,31 +779,50 @@ protected:
     const bool hidden);
 
   /** Symbolic implementation of malloc. */
-  expr2tc symex_malloc(const expr2tc &lhs, const sideeffect2t &code);
+  expr2tc symex_malloc(
+    const expr2tc &lhs,
+    const sideeffect2t &code,
+    const guardt &guard);
   /** Implementation of realloc. */
-  void symex_realloc(const expr2tc &lhs, const sideeffect2t &code);
+  void symex_realloc(
+    const expr2tc &lhs,
+    const sideeffect2t &code,
+    const guardt &guard);
   /** Symbolic implementation of alloca. */
-  expr2tc symex_alloca(const expr2tc &lhs, const sideeffect2t &code);
+  expr2tc symex_alloca(
+    const expr2tc &lhs,
+    const sideeffect2t &code,
+    const guardt &guard);
   /** Wrapper around for alloca and malloc. */
-  expr2tc
-  symex_mem(const bool is_malloc, const expr2tc &lhs, const sideeffect2t &code);
+  expr2tc symex_mem(
+    const bool is_malloc,
+    const expr2tc &lhs,
+    const sideeffect2t &code,
+    const guardt &guard);
   /** Pointer modelling update function */
   void track_new_pointer(
     const expr2tc &ptr_obj,
     const type2tc &new_type,
+    const guardt &guard,
     const expr2tc &size = expr2tc());
   /** Symbolic implementation of free */
   void symex_free(const expr2tc &expr);
   /** Symbolic implementation of c++'s delete. */
   void symex_cpp_delete(const expr2tc &code);
   /** Symbolic implementation of c++'s new. */
-  void symex_cpp_new(const expr2tc &lhs, const sideeffect2t &code);
+  void symex_cpp_new(
+    const expr2tc &lhs,
+    const sideeffect2t &code,
+    const guardt &guard);
   /** Symbolic implementation of printf */
   void symex_printf(const expr2tc &lhs, expr2tc &code);
   /** Symbolic implementation of scanf and fscanf */
   void symex_input(const code_function_call2t &expr);
   /** Symbolic implementation of va_arg */
-  void symex_va_arg(const expr2tc &lhs, const sideeffect2t &code);
+  void symex_va_arg(
+    const expr2tc &lhs,
+    const sideeffect2t &code,
+    const guardt &guard);
 
   /**
    *  Replace nondet func calls with nondeterminism.

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -132,25 +132,26 @@ void goto_symext::do_simplify(expr2tc &expr)
 // Handle side effects
 void goto_symext::handle_sideeffect(
   const expr2tc &lhs,
-  const sideeffect2t &effect)
+  const sideeffect2t &effect,
+  const guardt &guard)
 {
   switch (effect.kind)
   {
   case sideeffect2t::cpp_new:
   case sideeffect2t::cpp_new_arr:
-    symex_cpp_new(lhs, effect);
+    symex_cpp_new(lhs, effect, guard);
     break;
   case sideeffect2t::realloc:
-    symex_realloc(lhs, effect);
+    symex_realloc(lhs, effect, guard);
     break;
   case sideeffect2t::malloc:
-    symex_malloc(lhs, effect);
+    symex_malloc(lhs, effect, guard);
     break;
   case sideeffect2t::alloca:
-    symex_alloca(lhs, effect);
+    symex_alloca(lhs, effect, guard);
     break;
   case sideeffect2t::va_arg:
-    symex_va_arg(lhs, effect);
+    symex_va_arg(lhs, effect, guard);
     break;
   case sideeffect2t::printf2:
     // Do nothing for printf
@@ -161,23 +162,31 @@ void goto_symext::handle_sideeffect(
 }
 
 // Handle conditional expressions (if2t)
-bool goto_symext::handle_conditional(const expr2tc &lhs, const if2t &if_effect)
+bool goto_symext::handle_conditional(
+  const expr2tc &lhs,
+  const if2t &if_effect,
+  const guardt &guard)
 {
   bool has_sideeffect = false;
+  const expr2tc &cond = if_effect.cond;
   const expr2tc &true_value = if_effect.true_value;
   const expr2tc &false_value = if_effect.false_value;
 
   // Handle true_value side effects
   if (is_sideeffect2t(true_value))
   {
-    handle_sideeffect(lhs, to_sideeffect2t(true_value));
+    guardt g(guard);
+    g.add(cond);
+    handle_sideeffect(lhs, to_sideeffect2t(true_value), g);
     has_sideeffect = true;
   }
 
   // Handle false_value side effects
   if (is_sideeffect2t(false_value))
   {
-    handle_sideeffect(lhs, to_sideeffect2t(false_value));
+    guardt g(guard);
+    g.add(not2tc(cond));
+    handle_sideeffect(lhs, to_sideeffect2t(false_value), g);
     has_sideeffect = true;
   }
 
@@ -228,7 +237,7 @@ void goto_symext::symex_assign(
   // Handle sideeffect2t (side effects) expressions
   if (is_sideeffect2t(rhs))
   {
-    handle_sideeffect(lhs, to_sideeffect2t(rhs));
+    handle_sideeffect(lhs, to_sideeffect2t(rhs), guard);
     return;
   }
 
@@ -236,7 +245,7 @@ void goto_symext::symex_assign(
   if (is_if2t(rhs))
   {
     const if2t &if_effect = to_if2t(rhs);
-    if (handle_conditional(lhs, if_effect))
+    if (handle_conditional(lhs, if_effect, guard))
       return;
   }
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -142,7 +142,7 @@ void goto_symext::handle_sideeffect(
     symex_cpp_new(lhs, effect, guard);
     break;
   case sideeffect2t::realloc:
-    symex_realloc(lhs, effect, guard);
+    symex_realloc(lhs, effect, guardt());
     break;
   case sideeffect2t::malloc:
     symex_malloc(lhs, effect, guard);


### PR DESCRIPTION
This is one of the known problems:

1. The current guard needs to be taken into account when dealing with memory allocation, especially in if expressions.
2. There is something wrong with our realloc operation that causes out of bound. This is because we only adjust the bound in the track new pointer, while nothing changes in the dynamic object. I tried to modify the symbol directly, but at the SMT level there was a bit width mismatch.

Should we rethink the implementation of realloc, perhaps malloc and memcpy would be a good approach instead?