### PR TITLE
[c++] fix map::insert() to accept temporary pair objects

### DIFF
--- a/regression/esbmc-cpp/cpp/ch21_9/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_9/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_insert1/test.desc
+++ b/regression/esbmc-cpp/map/map_insert1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_insert1_bug/test.desc
+++ b/regression/esbmc-cpp/map/map_insert1_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 4 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/map/map_string_class-2/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/map/map_string_class-3/test.desc
+++ b/regression/esbmc-cpp/map/map_string_class-3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 3 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/map
+++ b/src/cpp/library/map
@@ -981,7 +981,7 @@ public:
     x = tmp;
   }
 
-  pair<iterator, bool> insert(value_type &val)
+  pair<iterator, bool> insert(const value_type &val)
   {
     unsigned int s = this->_size;
     pair<iterator, bool> _pair;


### PR DESCRIPTION
This PR changes `map::insert(value_type &val)` to `map::insert(const value_type &val)` to allow binding to rvalue references. This fixes compilation errors when inserting temporary pair objects such as `mymap.insert(pair<char,int>('a', 100));`.
