### PR TITLE
[c++] fix multiset constructor ambiguity

### DIFF
--- a/regression/esbmc-cpp/multiset/multiset-construct-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-construct-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-construct/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-construct/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-count/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-count/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-destructor-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-destructor-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-destructor/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-destructor/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-empty-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-empty-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-insert-with-iterators/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-insert-with-iterators/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-key_comp-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-key_comp-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-key_comp/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-key_comp/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-max_size-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-max_size-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-max_size/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-max_size/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-size/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-size/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-swap-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-swap-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-swap/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-swap/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/multiset/multiset-value_comp-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-value_comp-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-value_comp/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-value_comp/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -372,7 +372,7 @@ public:
   };
 
   // construct/copy/destroy:
-  explicit multiset(const Compare &comp = Compare()) : _size(0)
+  explicit multiset(const Compare &comp) : _size(0) 
   {
   }
 


### PR DESCRIPTION
Split ambiguous constructor with default parameter into separate default and explicit constructors to resolve parsing conflicts.