### PR TITLE
[c++] fix deque iterator increment operators binding to temporary

### DIFF
--- a/regression/esbmc-cpp/deque/deque_insert/test.desc
+++ b/regression/esbmc-cpp/deque/deque_insert/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_insert_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_insert_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_resize_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_resize_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -62,13 +62,16 @@ public:
 
     iterator &operator++()
     {
-      return iterator(++pointer, ++pos, vec_pos);
+      ++pointer;
+      ++pos;
+      return *this;
     }
-    iterator operator++(int b)
+    iterator operator++(int)
     {
-      return iterator(pointer++, pos++, vec_pos);
+      iterator temp = *this;
+      ++(*this);  // Use the pre-increment operator
+      return temp;
     }
-
     iterator &operator--()
     {
       return iterator(--pointer, --pos, vec_pos);


### PR DESCRIPTION
This PR replaces temporary iterator construction in `operator++()` with proper in-place modification and returns *this to resolve compilation errors.