### PR TITLE
[c++] fix STL operator overload resolution errors in ostream, sstream and string headers

### DIFF
--- a/regression/esbmc-cpp/stream/sstream_str_long/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_long/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -91,6 +91,14 @@ inline ostream &operator<<(ostream &o, unsigned long val)
   return o;
 }
 #endif
+inline ostream &operator<<(ostream &o, long long val)
+{
+  return o;
+}
+inline ostream &operator<<(ostream &o, unsigned long long val)
+{
+  return o;
+}
 inline ostream &operator<<(ostream &o, float val)
 {
   return o;

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -187,6 +187,18 @@ inline ostream &flush(ostream &os)
 {
   return os.flush();
 }
+
+inline ostream& boolalpha(ostream& os) {
+  // In a real implementation this would set a flag
+  // For ESBMC verification, just return the stream
+  return os;
+}
+
+inline ostream &operator<<(ostream &o, ostream& (*manip)(ostream&))
+{
+  return manip(o);
+}
+
 } // namespace std
 
 #endif

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -188,9 +188,8 @@ inline ostream &flush(ostream &os)
   return os.flush();
 }
 
-inline ostream& boolalpha(ostream& os) {
-  // In a real implementation this would set a flag
-  // For ESBMC verification, just return the stream
+inline ostream& boolalpha(ostream& os) 
+{
   return os;
 }
 

--- a/src/cpp/library/sstream
+++ b/src/cpp/library/sstream
@@ -111,6 +111,14 @@ public:
     return *this;
   }
 
+  ostream &operator<<(unsigned long val)
+  {
+    char *temp = new char[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
   ostream &operator<<(float val)
   {
     char *temp = new char[NUM_SIZE];

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -424,7 +424,7 @@ public:
   string &operator=(const char *s);
   string &operator=(char c);
   string &operator=(const string &str);
-  string &operator+=(string &s);
+  string &operator+=(const string &s);
   string &operator+=(const char *s);
   string &operator+=(char s);
   //TODO: operator+
@@ -1411,7 +1411,7 @@ __ESBMC_HIDE:
  return next;
  }
  */
-string &string::operator+=(string &s)
+string &string::operator+=(const string &s)
 {
 __ESBMC_HIDE:
   __ESBMC_assert(s.str != NULL, "The parameter must to be different than NULL");


### PR DESCRIPTION
This PR fixes multiple compilation errors in ESBMC's C++ standard library headers caused by incomplete or incompatible operator overloads:

- fix ostream ambiguous overload error for long long types: 
- fix operator+= temporary binding and add boolalpha manipulator.
- add missing unsigned long operator<< to stringstream class.
