### PR TITLE
[c++] added basic std::unordered_map support

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -107,6 +107,7 @@ set(REGRESSIONS_CPP03 esbmc-cpp/cpp
                       esbmc-cpp/deque
                       esbmc-cpp/list
                       esbmc-cpp/map
+                      esbmc-cpp/unordered_map
                       esbmc-cpp/multimap
                       esbmc-cpp/multiset
                       esbmc-cpp/priority_queue

--- a/regression/esbmc-cpp/Makefile
+++ b/regression/esbmc-cpp/Makefile
@@ -16,6 +16,7 @@ set := set
 multimap := multimap
 multiset := multiset
 unordered_set := unordered_set
+unordered_map := unordered_map
 
 # Clean
 ifneq ($(filter clean,$(MAKECMDGOALS)),)
@@ -30,13 +31,13 @@ endif
 llvm: all
 
 # Make them all
-all: $(algorithm) $(cpp) $(inheritance) $(stream)  $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set)
+all: $(algorithm) $(cpp) $(inheritance) $(stream)  $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map)
 
-$(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set)  $(multimap) $(multiset) $(string) $(unordered_set):
+$(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set)  $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map):
 	$(MAKE) --directory=$@ $(TARGET)
 
 #Make only STL directories
-stl: $(algorithm) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(unordered_set)
+stl: $(algorithm) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(unordered_set) $(unordered_map)
 
 # Make each directory
 algorithm: $(algorithm)
@@ -56,7 +57,8 @@ set: $(set)
 multimap: $(multimap)
 multiset: $(multiset)
 unordered_set: $(unordered_set)
+unordered_map: $(unordered_map)
 
 # Allow parallel make
 
-.PHONY: all $(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set)
+.PHONY: all $(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map)

--- a/regression/esbmc-cpp/OM_sanity_checks/unordered_map/main.cpp
+++ b/regression/esbmc-cpp/OM_sanity_checks/unordered_map/main.cpp
@@ -1,0 +1,4 @@
+#include <unordered_map>
+int main () {
+  return 0;
+}

--- a/regression/esbmc-cpp/OM_sanity_checks/unordered_map/test.desc
+++ b/regression/esbmc-cpp/OM_sanity_checks/unordered_map/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+ --timeout 900
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/Makefile
+++ b/regression/esbmc-cpp/unordered_map/Makefile
@@ -1,0 +1,40 @@
+default: tests.log
+
+test:
+	@./test.pl
+
+tests.log: test.pl
+	@./test.pl
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/main.cpp" "$$dir/main.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			rm -f "$$dir/main.out"; \
+		fi; \
+	done;
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			rm -f "$$dir/smt*.tmp"; \
+		fi; \
+	done;
+	find . -name *.*~ | xargs rm -f
+	find . -name *.out | xargs rm -f
+	find . -name *.smt | xargs rm -f
+	find . -name txt | xargs rm -f
+	find . -name *.txt | xargs rm -f
+	find . -name *.log | xargs rm -f
+	find . -name *.trace | xargs rm -f
+	find . -name *.o | xargs rm -f
+	find . -name *.bc | xargs rm -f
+	find . -name *.ll | xargs rm -f
+	find . -name *.c | xargs rm -f
+	find . -name *.dat | xargs rm -f
+	find . -name *.report | xargs rm -f
+	rm -f tests.log	

--- a/regression/esbmc-cpp/unordered_map/basic_insert/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/basic_insert/main.cpp
@@ -1,0 +1,25 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+
+    // Test initial state
+    assert(m.empty());
+    assert(m.size() == 0);
+
+    // Test insertion
+    auto result = m.insert({42, "hello"});
+    assert(result.second == true);  // Should be inserted
+    assert(m.size() == 1);
+    assert(!m.empty());
+
+    // Test duplicate insertion
+    auto result2 = m.insert({42, "world"});
+    assert(result2.second == false); // Should not be inserted
+    assert(m.size() == 1);
+    assert(m[42] == "hello"); // Original value preserved
+
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/basic_insert/test.desc
+++ b/regression/esbmc-cpp/unordered_map/basic_insert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/basic_insert2/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/basic_insert2/main.cpp
@@ -1,0 +1,34 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+    m.insert({10, "ten"});
+    m.insert({20, "twenty"});
+    m.insert({30, "thirty"});
+
+    // Test find existing elements
+    auto it1 = m.find(20);
+    assert(it1 != m.end());
+    assert(it1->first == 20);
+    assert(it1->second == "twenty");
+
+    // Test find non-existing element
+    auto it2 = m.find(99);
+    assert(it2 == m.end());
+
+    // Test count
+    assert(m.count(10) == 1);
+    assert(m.count(99) == 0);
+
+    // Test contains (C++20 feature)
+    assert(m.contains(30) == true);
+    assert(m.contains(99) == false);
+
+    // Test operator[]
+    assert(m[10] == "ten");
+    assert(m[20] == "twenty");
+
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/basic_insert2/test.desc
+++ b/regression/esbmc-cpp/unordered_map/basic_insert2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/basic_insert2_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/basic_insert2_fail/main.cpp
@@ -1,0 +1,34 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+    m.insert({10, "ten"});
+    m.insert({20, "twenty"});
+    m.insert({30, "thirty"});
+
+    // Test find existing elements
+    auto it1 = m.find(20);
+    assert(it1 != m.end());
+    assert(it1->first == 20);
+    assert(it1->second == "twenty");
+
+    // Test find non-existing element
+    auto it2 = m.find(99);
+    assert(it2 == m.end());
+
+    // Test count
+    assert(m.count(10) == 0); // should fail
+    assert(m.count(99) == 0);
+
+    // Test contains (C++20 feature)
+    assert(m.contains(30) == true);
+    assert(m.contains(99) == false);
+
+    // Test operator[]
+    assert(m[10] == "ten");
+    assert(m[20] == "twenty");
+
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/basic_insert2_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/basic_insert2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/basic_insert_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/basic_insert_fail/main.cpp
@@ -1,0 +1,25 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+
+    // Test initial state
+    assert(m.empty());
+    assert(m.size() == 0);
+
+    // Test insertion
+    auto result = m.insert({42, "hello"});
+    assert(result.second == true);  // Should be inserted
+    assert(m.size() == 1);
+    assert(!m.empty());
+
+    // Test duplicate insertion
+    auto result2 = m.insert({42, "world"});
+    assert(result2.second == false); // Should not be inserted
+    assert(m.size() == 1);
+    assert(m[42] == "hello1"); // should fail
+
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/basic_insert_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/basic_insert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/copy_move/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/copy_move/main.cpp
@@ -1,0 +1,15 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m1;
+    m1.insert({1, "one"});
+    std::unordered_map<int, std::string> m2(m1);
+    assert(m2.size() == 1);
+    assert(m2.contains(1));
+    assert(m2[1] == "one");
+    assert(m1 == m2);
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/copy_move/test.desc
+++ b/regression/esbmc-cpp/unordered_map/copy_move/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/copy_move2/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/copy_move2/main.cpp
@@ -1,0 +1,41 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m1;
+    m1.insert({1, "on"});
+    m1.insert({2, "tw"});
+    m1.insert({3, "th"});
+
+    // Test copy constructor
+    std::unordered_map<int, std::string> m2(m1);
+    assert(m2.size() == 3);
+    assert(m2.contains(1));
+    assert(m2.contains(2));
+    assert(m2.contains(3));
+    assert(m2[1] == "on");
+    assert(m1 == m2);
+
+    // Test copy assignment
+    std::unordered_map<int, std::string> m3;
+    m3 = m1;
+    assert(m3.size() == 3);
+    assert(m1 == m3);
+
+    // Test move constructor
+    std::unordered_map<int, std::string> m4(std::move(m2));
+    assert(m4.size() == 3);
+    assert(m4.contains(1));
+    assert(m4[1] == "on");
+    // m2 is in valid but unspecified state
+
+    // Test move assignment
+    std::unordered_map<int, std::string> m5;
+    m5 = std::move(m3);
+    assert(m5.size() == 3);
+    assert(m5.contains(1));
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/copy_move2/test.desc
+++ b/regression/esbmc-cpp/unordered_map/copy_move2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --goto-unwind
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/copy_move2_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/copy_move2_fail/main.cpp
@@ -1,0 +1,41 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m1;
+    m1.insert({1, "on"});
+    m1.insert({2, "tw"});
+    m1.insert({3, "th"});
+
+    // Test copy constructor
+    std::unordered_map<int, std::string> m2(m1);
+    assert(m2.size() == 3);
+    assert(m2.contains(1));
+    assert(m2.contains(2));
+    assert(m2.contains(3));
+    assert(m2[1] == "one");
+    assert(m1 == m2);
+
+    // Test copy assignment
+    std::unordered_map<int, std::string> m3;
+    m3 = m1;
+    assert(m3.size() == 3);
+    assert(m1 == m3);
+
+    // Test move constructor
+    std::unordered_map<int, std::string> m4(std::move(m2));
+    assert(m4.size() == 3);
+    assert(m4.contains(1));
+    assert(m4[1] == "on");
+    // m2 is in valid but unspecified state
+
+    // Test move assignment
+    std::unordered_map<int, std::string> m5;
+    m5 = std::move(m3);
+    assert(m5.size() == 3);
+    assert(m5.contains(1));
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/copy_move2_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/copy_move2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 8 --goto-unwind
+--unwind 4 --goto-unwind
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/copy_move3_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/copy_move3_fail/main.cpp
@@ -1,0 +1,13 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m1;
+    m1.insert({1, "one"});
+    std::unordered_map<int, std::string> m2(m1);
+    assert(m2.size() == 1);
+    assert(m2.contains(2)); // should fail
+    assert(m1 == m2);
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/copy_move3_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/copy_move3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 8 --goto-unwind
+--unwind 4 --goto-unwind
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/copy_move_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/copy_move_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m1;
+    m1.insert({1, "one"});
+    std::unordered_map<int, std::string> m2(m1);
+    assert(m2.size() == 0);
+    assert(m2.contains(1));
+    assert(m2[1] == "one");
+    assert(m1 == m2);
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/copy_move_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/copy_move_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/emplace/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/emplace/main.cpp
@@ -1,0 +1,35 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+
+    // Test emplace
+    auto result1 = m.emplace(42, "he");
+    assert(result1.second == true);
+    assert(m.size() == 1);
+    assert(m.contains(42));
+    assert(m[42] == "he");
+
+    // Test emplace duplicate
+    auto result2 = m.emplace(42, "wo");
+    assert(result2.second == false);
+    assert(m.size() == 1);
+    assert(m[42] == "he"); // Original value preserved
+
+    // Test try_emplace
+    auto result3 = m.try_emplace(100, "hu");
+    assert(result3.second == true);
+    assert(m.size() == 2);
+    assert(m.contains(100));
+    assert(m[100] == "hu");
+
+    // Test try_emplace duplicate
+    auto result4 = m.try_emplace(100, "di");
+    assert(result4.second == false);
+    assert(m[100] == "hu"); // Original value preserved
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/emplace/test.desc
+++ b/regression/esbmc-cpp/unordered_map/emplace/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --goto-unwind --no-bounds-check --no-pointer-check --no-div-by-zero-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/emplace_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/emplace_fail/main.cpp
@@ -1,0 +1,35 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+
+    // Test emplace
+    auto result1 = m.emplace(42, "he");
+    assert(result1.second == true);
+    assert(m.size() == 1);
+    assert(m.contains(42));
+    assert(m[42] == "he");
+
+    // Test emplace duplicate
+    auto result2 = m.emplace(42, "wo");
+    assert(result2.second == false);
+    assert(m.size() == 1);
+    assert(m[42] == "he"); // Original value preserved
+
+    // Test try_emplace
+    auto result3 = m.try_emplace(100, "hu");
+    assert(result3.second == true);
+    assert(m.size() == 3); // should fail
+    assert(m.contains(100));
+    assert(m[100] == "hu");
+
+    // Test try_emplace duplicate
+    auto result4 = m.try_emplace(100, "di");
+    assert(result4.second == false);
+    assert(m[100] == "hu"); // Original value preserved
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/emplace_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/emplace_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --goto-unwind --no-bounds-check --no-pointer-check --no-div-by-zero-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/emplace_fail2/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/emplace_fail2/main.cpp
@@ -1,0 +1,29 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+
+    // Test emplace
+    auto result1 = m.emplace(42, "he");
+    assert(result1.second == true);
+    assert(m.size() == 1);
+    assert(m.contains(42));
+    assert(m[42] == "he");
+
+    // Test emplace duplicate
+    auto result2 = m.emplace(42, "wo");
+    assert(result2.second == false);
+    assert(m.size() == 1);
+
+    // Test try_emplace
+    auto result3 = m.try_emplace(100, "hu");
+    assert(result3.second == true);
+    assert(m.size() == 2);
+    assert(m.contains(100));
+    assert(m[100] == "th"); // should fail
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/emplace_fail2/test.desc
+++ b/regression/esbmc-cpp/unordered_map/emplace_fail2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 8 --goto-unwind --no-bounds-check --no-pointer-check --no-div-by-zero-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/equality/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/equality/main.cpp
@@ -1,0 +1,34 @@
+#include <unordered_map>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, int> m1;
+    std::unordered_map<int, int> m2;
+
+    // Test empty maps equality
+    assert(m1 == m2);
+    assert(!(m1 != m2));
+
+    // Test after insertion
+    m1[1] = 1;
+    m1[2] = 2;
+    
+    m2[2] = 2;
+    m2[1] = 1;
+
+    assert(m1 == m2); // Order shouldn't matter
+    assert(!(m1 != m2));
+
+    // Test different values
+    m2[1] = 3;
+    assert(!(m1 == m2));
+    assert(m1 != m2);
+
+    // Test different sizes
+    m2[1] = 1; // Fix the value
+    m2[3] = 3;
+    assert(!(m1 == m2));
+    assert(m1 != m2);
+
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/equality/test.desc
+++ b/regression/esbmc-cpp/unordered_map/equality/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --goto-unwind
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/equality_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/equality_fail/main.cpp
@@ -1,0 +1,34 @@
+#include <unordered_map>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, int> m1;
+    std::unordered_map<int, int> m2;
+
+    // Test empty maps equality
+    assert(m1 == m2);
+    assert(!(m1 != m2));
+
+    // Test after insertion
+    m1[1] = 1;
+    m1[2] = 2;
+    
+    m2[2] = 2;
+    m2[1] = 1;
+
+    assert(m1 == m2); // Order shouldn't matter
+    assert(!(m1 != m2));
+
+    // Test different values
+    m2[1] = 3;
+    assert(!(m1 == m2));
+    assert(m1 != m2);
+
+    // Test different sizes
+    m2[1] = 1; // Fix the value
+    m2[3] = 3;
+    assert(!(m1 == m2));
+    assert(m1 == m2); // should fail
+
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/equality_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/equality_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --goto-unwind
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/erase/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/erase/main.cpp
@@ -1,0 +1,37 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, int> m;
+    m.insert({10, 1});
+    m.insert({20, 2});
+    m.insert({30, 3});
+    m.insert({40, 4});
+
+    // Test erase by key
+    std::size_t erased = m.erase(20);
+    assert(erased == 1);
+    assert(m.size() == 3);
+    assert(m.count(20) == 0);
+
+    // Test erase non-existing key
+    std::size_t erased2 = m.erase(99);
+    assert(erased2 == 0);
+    assert(m.size() == 3);
+    
+    // Test erase by iterator
+    auto it = m.find(30);
+    assert(it != m.end());
+    auto next_it = m.erase(it);
+    assert(m.size() == 2);
+    assert(m.count(30) == 0);
+
+    // Test clear
+    m.clear();
+    assert(m.empty());
+    assert(m.size() == 0);
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/erase/test.desc
+++ b/regression/esbmc-cpp/unordered_map/erase/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --goto-unwind
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/erase_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/erase_fail/main.cpp
@@ -1,0 +1,37 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, int> m;
+    m.insert({10, 1});
+    m.insert({20, 2});
+    m.insert({30, 3});
+    m.insert({40, 4});
+
+    // Test erase by key
+    std::size_t erased = m.erase(20);
+    assert(erased == 1);
+    assert(m.size() == 3);
+    assert(m.count(20) == 0);
+
+    // Test erase non-existing key
+    std::size_t erased2 = m.erase(99);
+    assert(erased2 == 0);
+    assert(m.size() == 3);
+    
+    // Test erase by iterator
+    auto it = m.find(30);
+    assert(it != m.end());
+    auto next_it = m.erase(it);
+    assert(m.size() == 2);
+    assert(m.count(30) == 0);
+
+    // Test clear
+    m.clear();
+    assert(!m.empty());
+    assert(m.size() == 0);
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/erase_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/erase_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 8 --goto-unwind
+--unwind 4 --goto-unwind
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/insert2_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/insert2_fail/main.cpp
@@ -1,0 +1,31 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+    m.insert({10, "ten"});
+    m.insert({20, "twenty"});
+    m.insert({30, "thirty"});
+
+    // Test find existing elements
+    auto it1 = m.find(20);
+    assert(it1 != m.end());
+    assert(it1->first == 20);
+    assert(it1->second == "twenty");
+
+    // Test find non-existing element
+    auto it2 = m.find(99);
+    assert(it2 == m.end());
+
+    // Test count
+    assert(m.count(10) == 1);
+    assert(m.count(99) == 0);
+
+    // Test contains (C++20 feature)
+    assert(m.contains(31) == true); // should fail
+    assert(m.contains(99) == false);
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/insert2_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/insert2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/insert_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/insert_fail/main.cpp
@@ -1,0 +1,25 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+
+    // Test initial state
+    assert(m.empty());
+    assert(m.size() == 0);
+
+    // Test insertion
+    auto result = m.insert({42, "hello"});
+    assert(result.second == true);  // Should be inserted
+    assert(m.size() == 1);
+    assert(!m.empty());
+
+    // Test duplicate insertion
+    auto result2 = m.insert({42, "world"});
+    assert(result2.second == false); // Should not be inserted
+    assert(m.size() == 2); // should fail!
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/insert_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/insert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/unordered_map/set_map/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/set_map/main.cpp
@@ -1,0 +1,64 @@
+#include <unordered_map>
+#include <unordered_set>
+#include <iostream>
+#include <cassert>
+
+int main()
+{
+    // Example 1: Track unique student IDs using unordered_set
+    std::unordered_set<int> student_ids;
+    
+    // Add some student IDs
+    student_ids.insert(101);
+    student_ids.insert(102);
+    student_ids.insert(103);
+    student_ids.insert(101); // Duplicate - won't be added
+    // Assertion: Should have exactly 3 unique elements
+    assert(student_ids.size() == 3);
+    assert(!student_ids.empty());
+    
+    // Check if a student ID exists
+    auto found_it = student_ids.find(102);
+    assert(found_it != student_ids.end()); // Should find student 102
+    assert(student_ids.count(102) == 1);   // Alternative check
+    assert(student_ids.contains(102));     // C++20 style check    
+    // Check for non-existent student
+    auto not_found_it = student_ids.find(999);
+    assert(not_found_it == student_ids.end()); // Should not find student 999
+    assert(student_ids.count(999) == 0);
+    assert(!student_ids.contains(999));
+    
+    // Example 2: Map student IDs to their grades using unordered_map
+    std::unordered_map<int, int> student_grades;
+    
+    // Assign grades
+    student_grades[101] = 10;
+    student_grades[102] = 9;
+    student_grades[103] = 8;
+    student_grades[104] = 7;
+    
+    // Assertions: Should have exactly 4 graded students
+    assert(student_grades.size() == 4);
+    assert(!student_grades.empty());
+    
+    // Verify specific grades
+    assert(student_grades[101] == 10);
+    assert(student_grades[102] == 9);
+    assert(student_grades[103] == 8);
+    assert(student_grades[104] == 7);
+    
+    // Look up a specific grade
+    auto grade_it = student_grades.find(102);
+    assert(grade_it != student_grades.end()); // Should find student 102
+    assert(grade_it->second == 9);          // Should have grade 'B'
+    assert(student_grades.count(102) == 1);   // Alternative check
+    assert(student_grades.contains(102));     // C++20 style check
+    
+    // Check for non-existent student in grades
+    auto no_grade_it = student_grades.find(999);
+    assert(no_grade_it == student_grades.end()); // Should not find student 999
+    assert(student_grades.count(999) == 0);
+    assert(!student_grades.contains(999));
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/unordered_map/set_map/test.desc
+++ b/regression/esbmc-cpp/unordered_map/set_map/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -354,6 +354,7 @@ TEST_SUITES = [
     "esbmc-cpp/inheritance_bringup",
     "esbmc-cpp/list",
     "esbmc-cpp/map",
+    "esbmc-cpp/unordered_map",
     "esbmc-cpp/multimap",
     "esbmc-cpp/multiset",
     "esbmc-cpp/unordered_set",

--- a/src/cpp/library/unordered_map
+++ b/src/cpp/library/unordered_map
@@ -1,0 +1,564 @@
+#ifndef ESBMC_UNORDERED_MAP_H
+#define ESBMC_UNORDERED_MAP_H
+
+#include <utility>
+#include <new>
+
+namespace std {
+
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t)-1)
+#endif
+
+// Simple hash function for keys
+template<typename T>
+struct esbmc_hash {
+    size_t operator()(const T& key) const {
+        return static_cast<size_t>(key);
+    }
+};
+
+// Simple equality comparison for keys
+template<typename T>
+struct esbmc_equal_to {
+    bool operator()(const T& lhs, const T& rhs) const {
+        return lhs == rhs;
+    }
+};
+
+// Simple forward iterator tag
+struct esbmc_forward_iterator_tag {};
+
+// Forward declaration
+template<typename Key, typename Value, typename Hash = esbmc_hash<Key>, 
+         typename KeyEqual = esbmc_equal_to<Key>>
+class unordered_map;
+
+// Iterator for unordered_map
+template<typename Key, typename Value, typename Hash, typename KeyEqual>
+class esbmc_unordered_map_iterator {
+public:
+    typedef std::pair<Key, Value> value_type;  // Note: using non-const Key
+    typedef value_type& reference;
+    typedef value_type* pointer;
+    typedef ptrdiff_t difference_type;
+    typedef esbmc_forward_iterator_tag iterator_category;
+
+    // Grant friend access to unordered_map
+    friend class unordered_map<Key, Value, Hash, KeyEqual>;
+
+private:
+    value_type* data_;
+    size_t pos_;
+    size_t size_;
+
+public:
+    // Constructors
+    esbmc_unordered_map_iterator() : data_(nullptr), pos_(0), size_(0) {}
+    
+    esbmc_unordered_map_iterator(value_type* data, size_t position, size_t size)
+        : data_(data), pos_(position), size_(size) {}
+
+    // Dereference operators
+    reference operator*() const {
+        return data_[pos_];
+    }
+    
+    pointer operator->() const {
+        return &data_[pos_];
+    }
+
+    // Increment operators
+    esbmc_unordered_map_iterator& operator++() {
+        if (pos_ < size_) {
+            ++pos_;
+        }
+        return *this;
+    }
+    
+    esbmc_unordered_map_iterator operator++(int) {
+        esbmc_unordered_map_iterator temp = *this;
+        ++(*this);
+        return temp;
+    }
+
+    // Comparison operators
+    bool operator==(const esbmc_unordered_map_iterator& other) const {
+        return data_ == other.data_ && pos_ == other.pos_;
+    }
+    
+    bool operator!=(const esbmc_unordered_map_iterator& other) const {
+        return !(*this == other);
+    }
+};
+
+// Const iterator for unordered_map
+template<typename Key, typename Value, typename Hash, typename KeyEqual>
+class esbmc_unordered_map_const_iterator {
+public:
+    typedef std::pair<Key, Value> value_type;  // Note: using non-const Key
+    typedef const value_type& reference;
+    typedef const value_type* pointer;
+    typedef ptrdiff_t difference_type;
+    typedef esbmc_forward_iterator_tag iterator_category;
+
+    // Grant friend access to unordered_map
+    friend class unordered_map<Key, Value, Hash, KeyEqual>;
+
+private:
+    const value_type* data_;
+    size_t pos_;
+    size_t size_;
+
+public:
+    // Constructors
+    esbmc_unordered_map_const_iterator() : data_(nullptr), pos_(0), size_(0) {}
+    
+    esbmc_unordered_map_const_iterator(const value_type* data, size_t position, size_t size)
+        : data_(data), pos_(position), size_(size) {}
+    
+    // Conversion from non-const iterator
+    esbmc_unordered_map_const_iterator(const esbmc_unordered_map_iterator<Key, Value, Hash, KeyEqual>& other)
+        : data_(other.data_), pos_(other.pos_), size_(other.size_) {}
+
+    // Dereference operators
+    reference operator*() const {
+        return data_[pos_];
+    }
+    
+    pointer operator->() const {
+        return &data_[pos_];
+    }
+
+    // Increment operators
+    esbmc_unordered_map_const_iterator& operator++() {
+        if (pos_ < size_) {
+            ++pos_;
+        }
+        return *this;
+    }
+    
+    esbmc_unordered_map_const_iterator operator++(int) {
+        esbmc_unordered_map_const_iterator temp = *this;
+        ++(*this);
+        return temp;
+    }
+
+    // Comparison operators
+    bool operator==(const esbmc_unordered_map_const_iterator& other) const {
+        return data_ == other.data_ && pos_ == other.pos_;
+    }
+    
+    bool operator!=(const esbmc_unordered_map_const_iterator& other) const {
+        return !(*this == other);
+    }
+};
+
+// Simple unordered_map implementation using fixed-size array
+template<typename Key, typename Value, typename Hash, typename KeyEqual>
+class unordered_map {
+public:
+    // Type definitions
+    typedef Key key_type;
+    typedef Value mapped_type;
+    // Note: using non-const Key for ESBMC compatibility
+    typedef std::pair<Key, Value> value_type;
+    typedef Hash hasher;
+    typedef KeyEqual key_equal;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+    typedef value_type* pointer;
+    typedef const value_type* const_pointer;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+    
+    typedef esbmc_unordered_map_iterator<Key, Value, Hash, KeyEqual> iterator;
+    typedef esbmc_unordered_map_const_iterator<Key, Value, Hash, KeyEqual> const_iterator;
+
+private:
+    // Simple fixed-size array storage
+    static const size_t MAX_SIZE = 1024; // Small size for verification
+    value_type data_[MAX_SIZE];
+    size_type size_;
+    hasher hash_function_;
+    key_equal equal_function_;
+
+    // Find index of key, or MAX_SIZE if not found
+    size_type find_index(const Key& key) const {
+        for (size_type i = 0; i < size_; ++i) {
+            if (equal_function_(data_[i].first, key)) {
+                return i;
+            }
+        }
+        return MAX_SIZE;
+    }
+
+public:
+    // Constructors
+    unordered_map() : size_(0) {}
+    
+    explicit unordered_map(size_type /*bucket_count*/) : size_(0) {}
+    
+    // Iterator range constructor
+    template<typename InputIterator>
+    unordered_map(InputIterator first, InputIterator last) : size_(0) {
+        insert(first, last);
+    }
+    
+    // Copy constructor
+    unordered_map(const unordered_map& other) 
+        : size_(other.size_), hash_function_(other.hash_function_), 
+          equal_function_(other.equal_function_) {
+        for (size_type i = 0; i < size_; ++i) {
+            data_[i] = other.data_[i];
+        }
+    }
+    
+    // Move constructor
+    // Move constructor
+    unordered_map(unordered_map&& other) noexcept
+        : size_(other.size_), hash_function_(other.hash_function_), 
+          equal_function_(other.equal_function_) {
+        for (size_type i = 0; i < size_; ++i) {
+            data_[i] = other.data_[i];
+        }
+        other.size_ = 0;
+    }
+
+    // Assignment operators
+    unordered_map& operator=(const unordered_map& other) {
+        if (this != &other) {
+            size_ = other.size_;
+            hash_function_ = other.hash_function_;
+            equal_function_ = other.equal_function_;
+            for (size_type i = 0; i < size_; ++i) {
+                data_[i] = other.data_[i];
+            }
+        }
+        return *this;
+    }
+    
+    unordered_map& operator=(unordered_map&& other) noexcept {
+        if (this != &other) {
+            size_ = other.size_;
+            hash_function_ = other.hash_function_;
+            equal_function_ = other.equal_function_;
+            for (size_type i = 0; i < size_; ++i) {
+                data_[i] = other.data_[i];
+            }
+            other.size_ = 0;
+        }
+        return *this;
+    }
+
+    // Iterators
+    iterator begin() {
+        return iterator(data_, 0, size_);
+    }
+    
+    const_iterator begin() const {
+        return const_iterator(data_, 0, size_);
+    }
+    
+    iterator end() {
+        return iterator(data_, size_, size_);
+    }
+    
+    const_iterator end() const {
+        return const_iterator(data_, size_, size_);
+    }
+    
+    const_iterator cbegin() const {
+        return begin();
+    }
+    
+    const_iterator cend() const {
+        return end();
+    }
+
+    // Capacity
+    bool empty() const noexcept {
+        return size_ == 0;
+    }
+    
+    size_type size() const noexcept {
+        return size_;
+    }
+    
+    size_type max_size() const noexcept {
+        return MAX_SIZE;
+    }
+
+    // Element access
+    
+    // Access with bounds checking
+    Value& at(const Key& key) {
+        size_type idx = find_index(key);
+        if (idx == MAX_SIZE) {
+            // In real implementation, this would throw std::out_of_range
+            // For ESBMC, we'll return a reference to a static default value
+            static Value default_value = Value();
+            return default_value;
+        }
+        return data_[idx].second;
+    }
+    
+    const Value& at(const Key& key) const {
+        size_type idx = find_index(key);
+        if (idx == MAX_SIZE) {
+            // In real implementation, this would throw std::out_of_range
+            static const Value default_value = Value();
+            return default_value;
+        }
+        return data_[idx].second;
+    }
+    
+    // Access without bounds checking (insert if not found)
+    Value& operator[](const Key& key) {
+        size_type idx = find_index(key);
+        if (idx != MAX_SIZE) {
+            return data_[idx].second;
+        }
+        
+        // Insert with default value if not found and space available
+        if (size_ < MAX_SIZE) {
+            data_[size_] = std::make_pair(key, Value());
+            return data_[size_++].second;
+        }
+        
+        // Array full - return reference to static default
+        static Value default_value = Value();
+        return default_value;
+    }
+
+    // Modifiers
+    
+    // Insert pair
+    std::pair<iterator, bool> insert(const value_type& pair) {
+        size_type idx = find_index(pair.first);
+        if (idx != MAX_SIZE) {
+            // Already exists
+            return std::make_pair(iterator(data_, idx, size_), false);
+        }
+        
+        if (size_ >= MAX_SIZE) {
+            // Array full
+            return std::make_pair(end(), false);
+        }
+        
+        // Insert new element
+        data_[size_] = pair;
+        iterator result(data_, size_, size_ + 1);
+        ++size_;
+        return std::make_pair(result, true);
+    }
+    
+    // Insert with move semantics
+    std::pair<iterator, bool> insert(value_type&& pair) {
+        return insert(pair);
+    }
+    
+    // Insert range
+    template<typename InputIterator>
+    void insert(InputIterator first, InputIterator last) {
+        for (InputIterator it = first; it != last; ++it) {
+            insert(*it);
+        }
+    }
+    
+    // Insert or assign
+    std::pair<iterator, bool> insert_or_assign(const Key& key, const Value& value) {
+        size_type idx = find_index(key);
+        if (idx != MAX_SIZE) {
+            // Key exists, update value
+            data_[idx].second = value;
+            return std::make_pair(iterator(data_, idx, size_), false);
+        }
+        
+        // Key doesn't exist, insert new pair
+        return insert(std::make_pair(key, value));
+    }
+    
+    // Emplace
+    template<typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        value_type pair(args...);
+        return insert(pair);
+    }
+    
+    // Try emplace
+    template<typename... Args>
+    std::pair<iterator, bool> try_emplace(const Key& key, Args&&... args) {
+        size_type idx = find_index(key);
+        if (idx != MAX_SIZE) {
+            // Key already exists
+            return std::make_pair(iterator(data_, idx, size_), false);
+        }
+        
+        if (size_ >= MAX_SIZE) {
+            // Array full
+            return std::make_pair(end(), false);
+        }
+        
+        // Construct new element
+        data_[size_] = std::make_pair(key, Value(args...));
+        iterator result(data_, size_, size_ + 1);
+        ++size_;
+        return std::make_pair(result, true);
+    }
+    
+    // Erase by key
+    size_type erase(const Key& key) {
+        size_type idx = find_index(key);
+        if (idx == MAX_SIZE) {
+            return 0; // Not found
+        }
+        
+        // Destroy the element
+        data_[idx].~value_type();
+        
+        // Shift elements down
+        for (size_type i = idx; i < size_ - 1; ++i) {
+            new (&data_[i]) value_type(data_[i + 1].first, data_[i + 1].second);
+            data_[i + 1].~value_type();
+        }
+        --size_;
+        return 1;
+    }
+    
+    // Erase by iterator
+    iterator erase(const_iterator position) {
+        if (position == end()) {
+            return end();
+        }
+        
+        // Calculate index from iterator position
+        size_type idx = position.pos_;
+        if (idx >= size_) {
+            return end();
+        }
+        
+        // Destroy the element
+        data_[idx].~value_type();
+        
+        // Shift elements down
+        for (size_type i = idx; i < size_ - 1; ++i) {
+            new (&data_[i]) value_type(data_[i + 1].first, data_[i + 1].second);
+            data_[i + 1].~value_type();
+        }
+        --size_;
+        
+        // Return iterator to next element (or end if we removed the last)
+        return iterator(data_, idx, size_);
+    }
+    
+    // Erase range
+    iterator erase(const_iterator first, const_iterator last) {
+        if (first == last) {
+            return iterator(data_, first.pos_, size_);
+        }
+        
+        // Simple implementation: erase elements one by one
+        iterator current(data_, first.pos_, size_);
+        while (current != end() && current.pos_ < last.pos_) {
+            current = erase(current);
+        }
+        return current;
+    }
+    
+    // Clear all elements
+    void clear() noexcept {
+        for (size_type i = 0; i < size_; ++i) {
+            data_[i].~value_type();
+        }
+        size_ = 0;
+    }
+
+    // Lookup operations
+    
+    // Find element
+    iterator find(const Key& key) {
+        size_type idx = find_index(key);
+        if (idx != MAX_SIZE) {
+            return iterator(data_, idx, size_);
+        }
+        return end();
+    }
+    
+    const_iterator find(const Key& key) const {
+        size_type idx = find_index(key);
+        if (idx != MAX_SIZE) {
+            return const_iterator(data_, idx, size_);
+        }
+        return end();
+    }
+    
+    // Count occurrences (0 or 1 for map)
+    size_type count(const Key& key) const {
+        return find_index(key) != MAX_SIZE ? 1 : 0;
+    }
+    
+    // Check if key exists (C++20)
+    bool contains(const Key& key) const {
+        return find_index(key) != MAX_SIZE;
+    }
+
+    // Bucket interface
+    size_type bucket_count() const noexcept {
+        return 1;
+    }
+    
+    size_type bucket_size(size_type /*bucket_index*/) const {
+        return size_;
+    }
+    
+    size_type bucket(const Key& /*key*/) const {
+        return 0;
+    }
+
+    // Hash policy
+    double load_factor() const noexcept {
+        return static_cast<double>(size_) / MAX_SIZE;
+    }
+    
+    double max_load_factor() const noexcept {
+        return 1.0;
+    }
+    
+    void reserve(size_type /*count*/) {
+        // No-op for fixed-size array
+    }
+
+    // Observers
+    hasher hash_function() const {
+        return hash_function_;
+    }
+    
+    key_equal key_eq() const {
+        return equal_function_;
+    }
+
+    // Comparison operators
+    bool operator==(const unordered_map& other) const {
+        if (size_ != other.size_) {
+            return false;
+        }
+        
+        // Check that all key-value pairs in this map exist in other
+        for (size_type i = 0; i < size_; ++i) {
+            const_iterator it = other.find(data_[i].first);
+            if (it == other.end() || !(it->second == data_[i].second)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    bool operator!=(const unordered_map& other) const {
+        return !(*this == other);
+    }
+};
+
+} // namespace std
+
+#endif // ESBMC_UNORDERED_MAP_H

--- a/src/cpp/library/unordered_map
+++ b/src/cpp/library/unordered_map
@@ -26,9 +26,6 @@ struct esbmc_equal_to {
     }
 };
 
-// Simple forward iterator tag
-struct esbmc_forward_iterator_tag {};
-
 // Forward declaration
 template<typename Key, typename Value, typename Hash = esbmc_hash<Key>, 
          typename KeyEqual = esbmc_equal_to<Key>>
@@ -38,21 +35,20 @@ class unordered_map;
 template<typename Key, typename Value, typename Hash, typename KeyEqual>
 class esbmc_unordered_map_iterator {
 public:
-    typedef std::pair<Key, Value> value_type;  // Note: using non-const Key
+    // Note: using non-const Key
+    typedef std::pair<Key, Value> value_type;
     typedef value_type& reference;
     typedef value_type* pointer;
     typedef ptrdiff_t difference_type;
-    typedef esbmc_forward_iterator_tag iterator_category;
 
     // Grant friend access to unordered_map
     friend class unordered_map<Key, Value, Hash, KeyEqual>;
 
-private:
+    // Make members public for compatibility
     value_type* data_;
     size_t pos_;
     size_t size_;
 
-public:
     // Constructors
     esbmc_unordered_map_iterator() : data_(nullptr), pos_(0), size_(0) {}
     
@@ -96,21 +92,20 @@ public:
 template<typename Key, typename Value, typename Hash, typename KeyEqual>
 class esbmc_unordered_map_const_iterator {
 public:
-    typedef std::pair<Key, Value> value_type;  // Note: using non-const Key
+    // Note: using non-const Key
+    typedef std::pair<Key, Value> value_type;
     typedef const value_type& reference;
     typedef const value_type* pointer;
     typedef ptrdiff_t difference_type;
-    typedef esbmc_forward_iterator_tag iterator_category;
 
     // Grant friend access to unordered_map
     friend class unordered_map<Key, Value, Hash, KeyEqual>;
 
-private:
+    // Make members public for compatibility
     const value_type* data_;
     size_t pos_;
     size_t size_;
 
-public:
     // Constructors
     esbmc_unordered_map_const_iterator() : data_(nullptr), pos_(0), size_(0) {}
     
@@ -161,7 +156,7 @@ public:
     // Type definitions
     typedef Key key_type;
     typedef Value mapped_type;
-    // Note: using non-const Key for ESBMC compatibility
+    // Note: using non-const Key for compatibility
     typedef std::pair<Key, Value> value_type;
     typedef Hash hasher;
     typedef KeyEqual key_equal;
@@ -214,7 +209,6 @@ public:
         }
     }
     
-    // Move constructor
     // Move constructor
     unordered_map(unordered_map&& other) noexcept
         : size_(other.size_), hash_function_(other.hash_function_), 
@@ -296,7 +290,7 @@ public:
         size_type idx = find_index(key);
         if (idx == MAX_SIZE) {
             // In real implementation, this would throw std::out_of_range
-            // For ESBMC, we'll return a reference to a static default value
+            // Here, we'll return a reference to a static default value
             static Value default_value = Value();
             return default_value;
         }
@@ -414,13 +408,9 @@ public:
             return 0; // Not found
         }
         
-        // Destroy the element
-        data_[idx].~value_type();
-        
         // Shift elements down
         for (size_type i = idx; i < size_ - 1; ++i) {
-            new (&data_[i]) value_type(data_[i + 1].first, data_[i + 1].second);
-            data_[i + 1].~value_type();
+            data_[i] = data_[i + 1];
         }
         --size_;
         return 1;
@@ -438,13 +428,9 @@ public:
             return end();
         }
         
-        // Destroy the element
-        data_[idx].~value_type();
-        
         // Shift elements down
         for (size_type i = idx; i < size_ - 1; ++i) {
-            new (&data_[i]) value_type(data_[i + 1].first, data_[i + 1].second);
-            data_[i + 1].~value_type();
+            data_[i] = data_[i + 1];
         }
         --size_;
         
@@ -458,19 +444,29 @@ public:
             return iterator(data_, first.pos_, size_);
         }
         
-        // Simple implementation: erase elements one by one
-        iterator current(data_, first.pos_, size_);
-        while (current != end() && current.pos_ < last.pos_) {
-            current = erase(current);
+        // Erase elements one by one from the beginning
+        // Since we're shifting elements, we need to be careful about indices
+        size_type start_idx = first.pos_;
+        size_type end_idx = last.pos_;
+        
+        if (end_idx > size_) {
+            end_idx = size_;
         }
-        return current;
+        
+        // Number of elements to remove
+        size_type num_to_remove = end_idx - start_idx;
+        
+        // Shift remaining elements down
+        for (size_type i = start_idx; i + num_to_remove < size_; ++i) {
+            data_[i] = data_[i + num_to_remove];
+        }
+        
+        size_ -= num_to_remove;
+        return iterator(data_, start_idx, size_);
     }
     
     // Clear all elements
     void clear() noexcept {
-        for (size_type i = 0; i < size_; ++i) {
-            data_[i].~value_type();
-        }
         size_ = 0;
     }
 

--- a/src/cpp/library/unordered_map
+++ b/src/cpp/library/unordered_map
@@ -2,7 +2,6 @@
 #define ESBMC_UNORDERED_MAP_H
 
 #include <utility>
-#include <new>
 
 namespace std {
 
@@ -12,7 +11,7 @@ namespace std {
 
 // Simple hash function for keys
 template<typename T>
-struct esbmc_hash {
+struct esbmc_um_hash {
     size_t operator()(const T& key) const {
         return static_cast<size_t>(key);
     }
@@ -20,15 +19,15 @@ struct esbmc_hash {
 
 // Simple equality comparison for keys
 template<typename T>
-struct esbmc_equal_to {
+struct esbmc_um_equal_to {
     bool operator()(const T& lhs, const T& rhs) const {
         return lhs == rhs;
     }
 };
 
 // Forward declaration
-template<typename Key, typename Value, typename Hash = esbmc_hash<Key>, 
-         typename KeyEqual = esbmc_equal_to<Key>>
+template<typename Key, typename Value, typename Hash = esbmc_um_hash<Key>, 
+         typename KeyEqual = esbmc_um_equal_to<Key>>
 class unordered_map;
 
 // Iterator for unordered_map


### PR DESCRIPTION
This PR introduces initial support for `std::unordered_map` in our C++ model, along with corresponding regression tests to validate its correctness and error detection capabilities. The support includes a simplified internal implementation suitable for bounded model checking, and test cases to ensure expected behavior.