### PR TITLE
[c++] fix string assignment operator

### DIFF
--- a/regression/esbmc-cpp/unordered_map/element_access/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/element_access/main.cpp
@@ -1,0 +1,41 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+    
+    // Test operator[] for insertion
+    m[1] = "one";
+    m[2] = "two";
+    assert(m.size() == 2);
+    assert(m[1] == "one");
+    assert(m[2] == "two");
+
+    // Test operator[] for modification
+    m[1] = "ONE";
+    assert(m[1] == "ONE");
+    assert(m.size() == 2);
+
+    // Test operator[] with default construction
+    std::string& val = m[99];
+    assert(val == ""); // Default constructed string
+    assert(m.size() == 3);
+
+    // Test at() for existing elements
+    assert(m.at(1) == "ONE");
+    assert(m.at(2) == "two");
+
+    // Test insert_or_assign
+    auto result1 = m.insert_or_assign(1, "one again");
+    assert(result1.second == false); // Key existed
+    assert(m[1] == "one again");
+
+    auto result2 = m.insert_or_assign(50, "fifty");
+    assert(result2.second == true); // New key
+    assert(m[50] == "fifty");
+    assert(m.size() == 4);
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/element_access/test.desc
+++ b/regression/esbmc-cpp/unordered_map/element_access/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-bounds-check --no-pointer-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/unordered_map/element_access_fail/main.cpp
+++ b/regression/esbmc-cpp/unordered_map/element_access_fail/main.cpp
@@ -1,0 +1,41 @@
+#include <unordered_map>
+#include <string>
+#include <cassert>
+
+int main() {
+    std::unordered_map<int, std::string> m;
+    
+    // Test operator[] for insertion
+    m[1] = "one";
+    m[2] = "two";
+    assert(m.size() == 2);
+    assert(m[1] == "one");
+    assert(m[2] == "two");
+
+    // Test operator[] for modification
+    m[1] = "ONE";
+    assert(m[1] == "ONE");
+    assert(m.size() == 2);
+
+    // Test operator[] with default construction
+    std::string& val = m[99];
+    assert(val == ""); // Default constructed string
+    assert(m.size() == 3);
+
+    // Test at() for existing elements
+    assert(m.at(1) == "ONE");
+    assert(m.at(2) == "two");
+
+    // Test insert_or_assign
+    auto result1 = m.insert_or_assign(1, "one again");
+    assert(result1.second == false); // Key existed
+    assert(m[1] == "one|again"); // should fail
+
+    auto result2 = m.insert_or_assign(50, "fifty");
+    assert(result2.second == true); // New key
+    assert(m[50] == "fifty");
+    assert(m.size() == 4);
+
+    return 0;
+}
+

--- a/regression/esbmc-cpp/unordered_map/element_access_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/element_access_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-bounds-check --no-pointer-check
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2,6 +2,7 @@
 #define STL_STRING
 
 #include "definitions.h"
+#include "algorithm"
 #include "cstring"
 #include "cstdio"
 #include "cassert"
@@ -1307,31 +1308,23 @@ bool string::empty() const
 
 string &string::operator=(const string &str)
 {
-  int i, len;
-  this->_size = str.length();
-  this->str = new char[this->_size + 1];
-  len = str.length();
-  for (i = 0; i < len; i++)
-  {
-    this->str[i] = str.str[i];
-  }
-  this->str[i] = '\0';
+__ESBMC_HIDE:  
+  // Create temporary copy
+  string temp(str);  // Use copy constructor
+  // Swap with current object
+  std::swap(this->str, temp.str);
+  std::swap(this->_size, temp._size);
   return *this;
 }
 
 string &string::operator=(string &str)
 {
-  //	__ESBMC_HIDE: __ESBMC_assert(str.str != NULL,
-  //		"The parameter must to be different than NULL");
-  int i, len;
-  this->_size = str.size();
-  this->str = new char[this->_size + 1];
-  len = str.size();
-  for (i = 0; i < len; i++)
-  {
-    this->str[i] = str.str[i];
-  }
-  this->str[i] = '\0';
+__ESBMC_HIDE:  
+  // Create temporary copy
+  string temp(str);  // Use copy constructor
+  // Swap with current object
+  std::swap(this->str, temp.str);
+  std::swap(this->_size, temp._size);
   return *this;
 }
 


### PR DESCRIPTION
Apply copy-and-swap idiom to prevent memory leaks and ensure exception safety.

This gives some speedup for the unordered_map regression suite:

Before:

![image](https://github.com/user-attachments/assets/4df954a9-b70e-406b-8e82-0e8cd1b2cef7)


After:

![image](https://github.com/user-attachments/assets/b1d71409-ffc4-40bc-a401-44ac3cca9df4)
