### PR TITLE
[c++] add deterministic hash specializations for std::hash

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -118,6 +118,7 @@ set(REGRESSIONS_CPP03 esbmc-cpp/cpp
                       esbmc-cpp/unix
                       esbmc-cpp/vector
                       esbmc-cpp/try_catch
+                      esbmc-cpp/functional
                       )
 # list of C++11 test suites
 set(REGRESSIONS_CPP11 esbmc-cpp11/cpp

--- a/regression/esbmc-cpp/Makefile
+++ b/regression/esbmc-cpp/Makefile
@@ -17,6 +17,7 @@ multimap := multimap
 multiset := multiset
 unordered_set := unordered_set
 unordered_map := unordered_map
+functional := functional
 
 # Clean
 ifneq ($(filter clean,$(MAKECMDGOALS)),)
@@ -31,13 +32,13 @@ endif
 llvm: all
 
 # Make them all
-all: $(algorithm) $(cpp) $(inheritance) $(stream)  $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map)
+all: $(algorithm) $(cpp) $(inheritance) $(stream)  $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map) $(functional)
 
-$(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set)  $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map):
+$(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set)  $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map) $(functional):
 	$(MAKE) --directory=$@ $(TARGET)
 
 #Make only STL directories
-stl: $(algorithm) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(unordered_set) $(unordered_map)
+stl: $(algorithm) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(unordered_set) $(unordered_map) $(functional)
 
 # Make each directory
 algorithm: $(algorithm)
@@ -58,7 +59,8 @@ multimap: $(multimap)
 multiset: $(multiset)
 unordered_set: $(unordered_set)
 unordered_map: $(unordered_map)
+functional : $(functional)
 
 # Allow parallel make
 
-.PHONY: all $(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map)
+.PHONY: all $(algorithm) $(cpp) $(inheritance) $(stream) $(trycatch) $(vector) $(deque) $(list) $(stack) $(queue) $(priority_queue) $(map) $(set) $(multimap) $(multiset) $(string) $(unordered_set) $(unordered_map) $(functional)

--- a/regression/esbmc-cpp/functional/Makefile
+++ b/regression/esbmc-cpp/functional/Makefile
@@ -1,0 +1,40 @@
+default: tests.log
+
+test:
+	@./test.pl
+
+tests.log: test.pl
+	@./test.pl
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/main.cpp" "$$dir/main.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			rm -f "$$dir/main.out"; \
+		fi; \
+	done;
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			rm -f "$$dir/smt*.tmp"; \
+		fi; \
+	done;
+	find . -name *.*~ | xargs rm -f
+	find . -name *.out | xargs rm -f
+	find . -name *.smt | xargs rm -f
+	find . -name txt | xargs rm -f
+	find . -name *.txt | xargs rm -f
+	find . -name *.log | xargs rm -f
+	find . -name *.trace | xargs rm -f
+	find . -name *.o | xargs rm -f
+	find . -name *.bc | xargs rm -f
+	find . -name *.ll | xargs rm -f
+	find . -name *.c | xargs rm -f
+	find . -name *.dat | xargs rm -f
+	find . -name *.report | xargs rm -f
+	rm -f tests.log	

--- a/regression/esbmc-cpp/functional/basic/main.cpp
+++ b/regression/esbmc-cpp/functional/basic/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+#include <functional>  // For std::hash
+#include <climits>     // For INT_MAX and INT_MIN
+
+int main()
+{
+  std::hash<int> hasher;
+  // Test with various integer values
+  std::size_t hash1 = hasher(42);
+  std::size_t hash2 = hasher(-17);
+  std::size_t hash3 = hasher(0);
+  std::size_t hash4 = hasher(INT_MAX);
+  std::size_t hash5 = hasher(INT_MIN);
+  // Basic sanity checks - results should be valid size_t values
+  assert(hash1 >= 0);  // Always true for size_t
+  assert(hash2 >= 0);
+  assert(hash3 >= 0);
+  assert(hash4 >= 0);
+  assert(hash5 >= 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/functional/basic/test.desc
+++ b/regression/esbmc-cpp/functional/basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/basic2/main.cpp
+++ b/regression/esbmc-cpp/functional/basic2/main.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+#include <functional>
+#include <climits>
+
+int main()
+{
+  std::hash<unsigned int> hasher;
+    
+  std::size_t hash1 = hasher(42U);
+  std::size_t hash2 = hasher(0U);
+  std::size_t hash3 = hasher(UINT_MAX);
+    
+  assert(hash1 >= 0);
+  assert(hash2 >= 0);
+  assert(hash3 >= 0);
+    
+  return 0;
+}
+

--- a/regression/esbmc-cpp/functional/basic2/test.desc
+++ b/regression/esbmc-cpp/functional/basic2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/basic3/main.cpp
+++ b/regression/esbmc-cpp/functional/basic3/main.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+#include <functional>
+
+int main() 
+{
+  std::hash<bool> hasher;
+    
+  size_t hash_true = hasher(true);
+  size_t hash_false = hasher(false);
+    
+  // Our model specifies that true->1, false->0
+  assert(hash_true == 1);
+  assert(hash_false == 0);
+    
+  // They should be different
+  assert(hash_true != hash_false);
+    
+  return 0;
+}
+

--- a/regression/esbmc-cpp/functional/basic3/test.desc
+++ b/regression/esbmc-cpp/functional/basic3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/boundary-values/main.cpp
+++ b/regression/esbmc-cpp/functional/boundary-values/main.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <functional>
+#include <climits>
+#include <cfloat>
+
+int main() {
+    // Integer boundary tests
+    std::hash<int> int_hasher;
+    std::hash<long> long_hasher;
+    std::hash<short> short_hasher;
+    std::hash<char> char_hasher;
+    
+    // Test integer boundaries
+    std::size_t hash_int_max = int_hasher(INT_MAX);
+    std::size_t hash_int_min = int_hasher(INT_MIN);
+    std::size_t hash_zero = int_hasher(0);
+    std::size_t hash_neg_one = int_hasher(-1);
+    std::size_t hash_one = int_hasher(1);
+    
+    // Test long boundaries
+    std::size_t hash_long_max = long_hasher(LONG_MAX);
+    std::size_t hash_long_min = long_hasher(LONG_MIN);
+    
+    // Test short boundaries
+    std::size_t hash_short_max = short_hasher(SHRT_MAX);
+    std::size_t hash_short_min = short_hasher(SHRT_MIN);
+    
+    // Test char boundaries
+    std::size_t hash_char_max = char_hasher(CHAR_MAX);
+    std::size_t hash_char_min = char_hasher(CHAR_MIN);
+    
+    // Determinism tests
+    assert(int_hasher(INT_MAX) == hash_int_max);
+    assert(int_hasher(INT_MIN) == hash_int_min);
+    assert(long_hasher(LONG_MAX) == hash_long_max);
+    assert(short_hasher(SHRT_MAX) == hash_short_max);
+    assert(char_hasher(CHAR_MAX) == hash_char_max);
+    
+    // All should be valid
+    assert(hash_int_max >= 0);
+    assert(hash_int_min >= 0);
+    assert(hash_long_max >= 0);
+    assert(hash_short_max >= 0);
+    assert(hash_char_max >= 0);
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/boundary-values/test.desc
+++ b/regression/esbmc-cpp/functional/boundary-values/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/char-edge-cases/main.cpp
+++ b/regression/esbmc-cpp/functional/char-edge-cases/main.cpp
@@ -1,0 +1,54 @@
+#include <cassert>
+#include <functional>
+
+int main() {
+    std::hash<char> char_hasher;
+    std::hash<unsigned char> uchar_hasher;
+    std::hash<wchar_t> wchar_hasher;
+    
+    // Test ASCII control characters
+    std::size_t hash_null = char_hasher('\0');
+    std::size_t hash_tab = char_hasher('\t');
+    std::size_t hash_newline = char_hasher('\n');
+    std::size_t hash_cr = char_hasher('\r');
+    std::size_t hash_esc = char_hasher('\033');
+    std::size_t hash_del = char_hasher('\177');
+    
+    // Test printable characters
+    std::size_t hash_space = char_hasher(' ');
+    std::size_t hash_exclaim = char_hasher('!');
+    std::size_t hash_tilde = char_hasher('~');
+    std::size_t hash_a = char_hasher('a');
+    std::size_t hash_A = char_hasher('A');
+    std::size_t hash_0 = char_hasher('0');
+    std::size_t hash_9 = char_hasher('9');
+    
+    // Test unsigned char boundaries
+    std::size_t hash_uchar_0 = uchar_hasher(0);
+    std::size_t hash_uchar_255 = uchar_hasher(255);
+    
+    // Test wide characters
+    std::size_t hash_wchar_0 = wchar_hasher(L'\0');
+    std::size_t hash_wchar_a = wchar_hasher(L'a');
+    std::size_t hash_wchar_unicode = wchar_hasher(L'é');
+    
+    // Test determinism
+    assert(char_hasher('\0') == hash_null);
+    assert(char_hasher('\n') == hash_newline);
+    assert(char_hasher('a') == hash_a);
+    assert(char_hasher('A') == hash_A);
+    assert(uchar_hasher(255) == hash_uchar_255);
+    assert(wchar_hasher(L'é') == hash_wchar_unicode);
+    
+    // Test that different characters give different hashes
+    assert(hash_a != hash_A);  // Case sensitivity
+    assert(hash_0 != hash_9);  // Different digits
+    assert(hash_space != hash_tab);  // Different whitespace
+    
+    // All should be valid
+    assert(hash_null >= 0);
+    assert(hash_wchar_unicode >= 0);  // ← Fixed: was hash_unicode
+    assert(hash_uchar_255 >= 0);
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/char-edge-cases/test.desc
+++ b/regression/esbmc-cpp/functional/char-edge-cases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/float-edge-cases/main.cpp
+++ b/regression/esbmc-cpp/functional/float-edge-cases/main.cpp
@@ -1,0 +1,56 @@
+#include <cassert>
+#include <functional>
+#include <cmath>
+#include <cfloat>
+
+int main() {
+    std::hash<float> float_hasher;
+    std::hash<double> double_hasher;
+    
+    // Test special float values
+    std::size_t hash_nan = float_hasher(nan(""));  // Use global nan instead of std::nan
+    std::size_t hash_zero = float_hasher(0.0f);
+    std::size_t hash_neg_zero = float_hasher(-0.0f);
+    std::size_t hash_min = float_hasher(FLT_MIN);
+    std::size_t hash_max = float_hasher(FLT_MAX);
+    std::size_t hash_epsilon = float_hasher(FLT_EPSILON);
+    
+    // Test subnormal numbers
+    std::size_t hash_denorm_min = float_hasher(FLT_TRUE_MIN);
+    
+    // Test double precision values
+    std::size_t hash_double_max = double_hasher(DBL_MAX);
+    std::size_t hash_double_min = double_hasher(DBL_MIN);
+    std::size_t hash_double_epsilon = double_hasher(DBL_EPSILON);
+    
+    // Test very small and very large values
+    std::size_t hash_tiny = float_hasher(1e-30f);
+    std::size_t hash_huge = float_hasher(1e30f);
+    
+    // Determinism tests for special values
+    assert(float_hasher(0.0f) == hash_zero);
+    assert(float_hasher(FLT_MAX) == hash_max);
+    assert(double_hasher(DBL_MAX) == hash_double_max);
+    
+    // NaN special case - NaN != NaN, but hash should be deterministic
+    assert(float_hasher(nan("")) == hash_nan);
+    
+    // Test that +0.0 and -0.0 might have same or different hashes
+    // (implementation defined, but should be deterministic)
+    assert(float_hasher(0.0f) == hash_zero);
+    assert(float_hasher(-0.0f) == hash_neg_zero);
+    
+    // Test determinism for various values
+    assert(float_hasher(1e-30f) == hash_tiny);
+    assert(float_hasher(1e30f) == hash_huge);
+    assert(float_hasher(FLT_EPSILON) == hash_epsilon);
+    
+    // All should be valid (size_t is always >= 0)
+    assert(hash_nan >= 0);
+    assert(hash_max >= 0);
+    assert(hash_double_max >= 0);
+    assert(hash_tiny >= 0);
+    assert(hash_huge >= 0);
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/float-edge-cases/test.desc
+++ b/regression/esbmc-cpp/functional/float-edge-cases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/float-edge-cases_fail/main.cpp
+++ b/regression/esbmc-cpp/functional/float-edge-cases_fail/main.cpp
@@ -1,0 +1,56 @@
+#include <cassert>
+#include <functional>
+#include <cmath>
+#include <cfloat>
+
+int main() {
+    std::hash<float> float_hasher;
+    std::hash<double> double_hasher;
+    
+    // Test special float values
+    std::size_t hash_nan = float_hasher(nan(""));  // Use global nan instead of std::nan
+    std::size_t hash_zero = float_hasher(0.0f);
+    std::size_t hash_neg_zero = float_hasher(-0.0f);
+    std::size_t hash_min = float_hasher(FLT_MIN);
+    std::size_t hash_max = float_hasher(FLT_MAX);
+    std::size_t hash_epsilon = float_hasher(FLT_EPSILON);
+    
+    // Test subnormal numbers
+    std::size_t hash_denorm_min = float_hasher(FLT_TRUE_MIN);
+    
+    // Test double precision values
+    std::size_t hash_double_max = double_hasher(DBL_MAX);
+    std::size_t hash_double_min = double_hasher(DBL_MIN);
+    std::size_t hash_double_epsilon = double_hasher(DBL_EPSILON);
+    
+    // Test very small and very large values
+    std::size_t hash_tiny = float_hasher(1e-30f);
+    std::size_t hash_huge = float_hasher(1e30f);
+    
+    // Determinism tests for special values
+    assert(float_hasher(0.0f) == hash_zero);
+    assert(float_hasher(FLT_MAX) == hash_max);
+    assert(double_hasher(DBL_MAX) == hash_double_max);
+    
+    // NaN special case - NaN != NaN, but hash should be deterministic
+    assert(float_hasher(nan("")) == hash_nan);
+    
+    // Test that +0.0 and -0.0 might have same or different hashes
+    // (implementation defined, but should be deterministic)
+    assert(float_hasher(0.0f) == hash_zero);
+    assert(float_hasher(-0.0f) == hash_neg_zero);
+    
+    // Test determinism for various values
+    assert(float_hasher(1e-30f) == hash_tiny);
+    assert(float_hasher(1e30f) == hash_huge);
+    assert(float_hasher(FLT_EPSILON) == hash_epsilon);
+    
+    // All should be valid (size_t is always >= 0)
+    assert(hash_nan < 1); // should fail
+    assert(hash_max >= 0);
+    assert(hash_double_max >= 0);
+    assert(hash_tiny >= 0);
+    assert(hash_huge >= 0);
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/float-edge-cases_fail/test.desc
+++ b/regression/esbmc-cpp/functional/float-edge-cases_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/functional/hash-distribution/main.cpp
+++ b/regression/esbmc-cpp/functional/hash-distribution/main.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <functional>
+#include <set>
+
+int main() {
+    std::hash<int> hasher;
+    std::set<std::size_t> hash_values;
+    
+    // Test consecutive integers (should have good distribution)
+    for(int i = 0; i < 100; ++i) {
+        std::size_t hash_val = hasher(i);
+        assert(hash_val >= 0);
+        
+        // Check determinism
+        assert(hasher(i) == hash_val);
+        
+        // Collect for distribution check
+        hash_values.insert(hash_val);
+    }
+    
+    // Test that we don't have too many collisions
+    // (This is probabilistic, but with 100 values we should have
+    // a reasonable number of unique hashes)
+    assert(hash_values.size() > 50);  // At least 50% unique
+    
+    // Test some specific patterns that might cause collisions
+    int pattern1 = 0x12345678;
+    int pattern2 = 0x87654321;
+    int pattern3 = 0x11111111;
+    int pattern4 = 0x22222222;
+    
+    std::size_t hash_p1 = hasher(pattern1);
+    std::size_t hash_p2 = hasher(pattern2);
+    std::size_t hash_p3 = hasher(pattern3);
+    std::size_t hash_p4 = hasher(pattern4);
+    
+    // These patterns should ideally produce different hashes
+    assert(hash_p1 != hash_p2);
+    assert(hash_p3 != hash_p4);
+    
+    // Test bit patterns that might be problematic
+    assert(hasher(0x00000000) != hasher(0xFFFFFFFF));
+    assert(hasher(0x55555555) != hasher(0xAAAAAAAA));
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/functional/hash-distribution/test.desc
+++ b/regression/esbmc-cpp/functional/hash-distribution/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 12 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/hash/main.cpp
+++ b/regression/esbmc-cpp/functional/hash/main.cpp
@@ -1,0 +1,112 @@
+#include <cassert>
+#include <functional>
+
+int main() {
+    std::hash<int> hasher;
+    
+    // Test sequential values around zero
+    for (int i = -10; i <= 10; i++) {
+        std::size_t hash_i = hasher(i);
+        std::size_t hash_i_repeat = hasher(i);
+        
+        // Test determinism for each value
+        assert(hash_i == hash_i_repeat);
+        assert(hash_i >= 0);  // All hashes should be valid
+        
+        // Test multiple calls for same value
+        for (int j = 0; j < 3; j++) {
+            assert(hasher(i) == hash_i);
+        }
+    }
+    
+    // Test larger sequential values
+    for (int i = 100; i <= 110; i++) {
+        std::size_t hash_i = hasher(i);
+        assert(hasher(i) == hash_i);  // Determinism
+        assert(hash_i >= 0);
+    }
+    
+    // Test negative sequential values
+    for (int i = -110; i <= -100; i++) {
+        std::size_t hash_i = hasher(i);
+        assert(hasher(i) == hash_i);  // Determinism
+        assert(hash_i >= 0);
+    }
+    
+    // Test repeated calls with same value (stress test)
+    int stress_value = 12345;
+    std::size_t stress_hash = hasher(stress_value);
+    
+    for (int i = 0; i < 20; i++) {
+        assert(hasher(stress_value) == stress_hash);
+    }
+    
+    // Test char sequential values
+    std::hash<char> char_hasher;
+    
+    // Test ASCII digit range
+    for (char c = '0'; c <= '9'; c++) {
+        std::size_t hash_c = char_hasher(c);
+        assert(char_hasher(c) == hash_c);
+        assert(hash_c >= 0);
+    }
+    
+    // Test ASCII uppercase range
+    for (char c = 'A'; c <= 'Z'; c++) {
+        std::size_t hash_c = char_hasher(c);
+        assert(char_hasher(c) == hash_c);
+        assert(hash_c >= 0);
+    }
+    
+    // Test ASCII lowercase range
+    for (char c = 'a'; c <= 'z'; c++) {
+        std::size_t hash_c = char_hasher(c);
+        assert(char_hasher(c) == hash_c);
+        assert(hash_c >= 0);
+    }
+    
+    // Test bool stress (limited values but multiple calls)
+    std::hash<bool> bool_hasher;
+    
+    for (int i = 0; i < 10; i++) {
+        assert(bool_hasher(true) == 1);
+        assert(bool_hasher(false) == 0);
+        assert(bool_hasher(true) != bool_hasher(false));
+    }
+    
+    // Test unsigned int with sequential values
+    std::hash<unsigned int> uint_hasher;
+    
+    for (unsigned int i = 0U; i <= 20U; i++) {
+        std::size_t hash_i = uint_hasher(i);
+        assert(uint_hasher(i) == hash_i);
+        assert(hash_i >= 0);
+    }
+    
+    // Test large unsigned values
+    unsigned int large_base = 1000000U;
+    for (unsigned int i = large_base; i <= large_base + 10U; i++) {
+        std::size_t hash_i = uint_hasher(i);
+        assert(uint_hasher(i) == hash_i);
+        assert(hash_i >= 0);
+    }
+    
+    // Test pointer stress with null
+    std::hash<int*> ptr_hasher;
+    
+    for (int i = 0; i < 5; i++) {
+        assert(ptr_hasher(nullptr) == ptr_hasher(nullptr));
+    }
+    
+    // Test multiple pointers to same value
+    int shared_val = 999;
+    int* ptr1 = &shared_val;
+    int* ptr2 = &shared_val;
+    
+    for (int i = 0; i < 5; i++) {
+        assert(ptr_hasher(ptr1) == ptr_hasher(ptr2));
+        assert(ptr_hasher(&shared_val) == ptr_hasher(ptr1));
+    }
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/hash/test.desc
+++ b/regression/esbmc-cpp/functional/hash/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/hash_fail/main.cpp
+++ b/regression/esbmc-cpp/functional/hash_fail/main.cpp
@@ -1,0 +1,112 @@
+#include <cassert>
+#include <functional>
+
+int main() {
+    std::hash<int> hasher;
+    
+    // Test sequential values around zero
+    for (int i = -10; i <= 10; i++) {
+        std::size_t hash_i = hasher(i);
+        std::size_t hash_i_repeat = hasher(i);
+        
+        // Test determinism for each value
+        assert(hash_i == hash_i_repeat);
+        assert(hash_i >= 0);  // All hashes should be valid
+        
+        // Test multiple calls for same value
+        for (int j = 0; j < 3; j++) {
+            assert(hasher(i) == hash_i);
+        }
+    }
+    
+    // Test larger sequential values
+    for (int i = 100; i <= 110; i++) {
+        std::size_t hash_i = hasher(i);
+        assert(hasher(i) == hash_i);  // Determinism
+        assert(hash_i >= 0);
+    }
+    
+    // Test negative sequential values
+    for (int i = -110; i <= -100; i++) {
+        std::size_t hash_i = hasher(i);
+        assert(hasher(i) == hash_i);  // Determinism
+        assert(hash_i >= 0);
+    }
+    
+    // Test repeated calls with same value (stress test)
+    int stress_value = 12345;
+    std::size_t stress_hash = hasher(stress_value);
+    
+    for (int i = 0; i < 20; i++) {
+        assert(hasher(stress_value) != stress_hash); // should fail
+    }
+    
+    // Test char sequential values
+    std::hash<char> char_hasher;
+    
+    // Test ASCII digit range
+    for (char c = '0'; c <= '9'; c++) {
+        std::size_t hash_c = char_hasher(c);
+        assert(char_hasher(c) == hash_c);
+        assert(hash_c >= 0);
+    }
+    
+    // Test ASCII uppercase range
+    for (char c = 'A'; c <= 'Z'; c++) {
+        std::size_t hash_c = char_hasher(c);
+        assert(char_hasher(c) == hash_c);
+        assert(hash_c >= 0);
+    }
+    
+    // Test ASCII lowercase range
+    for (char c = 'a'; c <= 'z'; c++) {
+        std::size_t hash_c = char_hasher(c);
+        assert(char_hasher(c) == hash_c);
+        assert(hash_c >= 0);
+    }
+    
+    // Test bool stress (limited values but multiple calls)
+    std::hash<bool> bool_hasher;
+    
+    for (int i = 0; i < 10; i++) {
+        assert(bool_hasher(true) == 1);
+        assert(bool_hasher(false) == 0);
+        assert(bool_hasher(true) != bool_hasher(false));
+    }
+    
+    // Test unsigned int with sequential values
+    std::hash<unsigned int> uint_hasher;
+    
+    for (unsigned int i = 0U; i <= 20U; i++) {
+        std::size_t hash_i = uint_hasher(i);
+        assert(uint_hasher(i) == hash_i);
+        assert(hash_i >= 0);
+    }
+    
+    // Test large unsigned values
+    unsigned int large_base = 1000000U;
+    for (unsigned int i = large_base; i <= large_base + 10U; i++) {
+        std::size_t hash_i = uint_hasher(i);
+        assert(uint_hasher(i) == hash_i);
+        assert(hash_i >= 0);
+    }
+    
+    // Test pointer stress with null
+    std::hash<int*> ptr_hasher;
+    
+    for (int i = 0; i < 5; i++) {
+        assert(ptr_hasher(nullptr) == ptr_hasher(nullptr));
+    }
+    
+    // Test multiple pointers to same value
+    int shared_val = 999;
+    int* ptr1 = &shared_val;
+    int* ptr2 = &shared_val;
+    
+    for (int i = 0; i < 5; i++) {
+        assert(ptr_hasher(ptr1) == ptr_hasher(ptr2));
+        assert(ptr_hasher(&shared_val) == ptr_hasher(ptr1));
+    }
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/hash_fail/test.desc
+++ b/regression/esbmc-cpp/functional/hash_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/functional/large-numbers/main.cpp
+++ b/regression/esbmc-cpp/functional/large-numbers/main.cpp
@@ -1,0 +1,48 @@
+#include <cassert>
+#include <functional>
+#include <climits>
+
+int main() {
+    std::hash<long long> ll_hasher;
+    std::hash<unsigned long long> ull_hasher;
+    std::hash<size_t> size_hasher;
+    
+    // Test very large numbers
+    long long large_positive = LLONG_MAX;
+    long long large_negative = LLONG_MIN;
+    unsigned long long max_unsigned = ULLONG_MAX;
+    
+    std::size_t hash_large_pos = ll_hasher(large_positive);
+    std::size_t hash_large_neg = ll_hasher(large_negative);
+    std::size_t hash_max_unsigned = ull_hasher(max_unsigned);
+    
+    // Test numbers near overflow boundaries
+    std::size_t hash_near_max1 = ll_hasher(LLONG_MAX - 1);
+    std::size_t hash_near_max2 = ll_hasher(LLONG_MAX - 2);
+    std::size_t hash_near_min1 = ll_hasher(LLONG_MIN + 1);
+    std::size_t hash_near_min2 = ll_hasher(LLONG_MIN + 2);
+    
+    // Test size_t boundaries
+    std::size_t hash_size_max = size_hasher(SIZE_MAX);
+    std::size_t hash_size_zero = size_hasher(0);
+    
+    // Test determinism
+    assert(ll_hasher(LLONG_MAX) == hash_large_pos);
+    assert(ll_hasher(LLONG_MIN) == hash_large_neg);
+    assert(ull_hasher(ULLONG_MAX) == hash_max_unsigned);
+    assert(size_hasher(SIZE_MAX) == hash_size_max);
+    
+    // Test that boundary values produce different hashes
+    assert(hash_large_pos != hash_large_neg);
+    assert(hash_near_max1 != hash_near_max2);
+    assert(hash_near_min1 != hash_near_min2);
+    
+    // All should be valid
+    assert(hash_large_pos >= 0);
+    assert(hash_large_neg >= 0);
+    assert(hash_max_unsigned >= 0);
+    assert(hash_size_max >= 0);
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/functional/large-numbers/test.desc
+++ b/regression/esbmc-cpp/functional/large-numbers/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/pointer-edge-cases/main.cpp
+++ b/regression/esbmc-cpp/functional/pointer-edge-cases/main.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+#include <functional>
+
+int main() {
+    std::hash<void*> ptr_hasher;
+    std::hash<int*> int_ptr_hasher;
+    
+    // Test null pointer
+    void* null_ptr = nullptr;
+    std::size_t hash_null = ptr_hasher(null_ptr);
+    
+    // Test valid pointers
+    int value = 42;
+    int* int_ptr = &value;
+    void* void_ptr = &value;
+    
+    std::size_t hash_int_ptr = int_ptr_hasher(int_ptr);
+    std::size_t hash_void_ptr = ptr_hasher(void_ptr);
+    
+    // Test determinism
+    assert(ptr_hasher(nullptr) == hash_null);
+    assert(int_ptr_hasher(&value) == hash_int_ptr);
+    assert(ptr_hasher(&value) == hash_void_ptr);
+    
+    // Test that same address gives same hash
+    int* another_ptr = &value;
+    assert(int_ptr_hasher(another_ptr) == hash_int_ptr);
+    
+    // All should be valid
+    assert(hash_null >= 0);
+    assert(hash_int_ptr >= 0);
+    assert(hash_void_ptr >= 0);
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/functional/pointer-edge-cases/test.desc
+++ b/regression/esbmc-cpp/functional/pointer-edge-cases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/power-of-two/main.cpp
+++ b/regression/esbmc-cpp/functional/power-of-two/main.cpp
@@ -1,0 +1,95 @@
+#include <cassert>
+#include <functional>
+
+int main() {
+    std::hash<int> hasher;
+    
+    // Test powers of 2 (common edge cases for hash functions)
+    std::size_t hash_1 = hasher(1);          // 2^0
+    std::size_t hash_2 = hasher(2);          // 2^1
+    std::size_t hash_4 = hasher(4);          // 2^2
+    std::size_t hash_8 = hasher(8);          // 2^3
+    std::size_t hash_16 = hasher(16);        // 2^4
+    std::size_t hash_32 = hasher(32);        // 2^5
+    std::size_t hash_64 = hasher(64);        // 2^6
+    std::size_t hash_128 = hasher(128);      // 2^7
+    std::size_t hash_256 = hasher(256);      // 2^8
+    std::size_t hash_512 = hasher(512);      // 2^9
+    std::size_t hash_1024 = hasher(1024);    // 2^10
+    std::size_t hash_2048 = hasher(2048);    // 2^11
+    std::size_t hash_4096 = hasher(4096);    // 2^12
+    
+    // Test determinism for powers of 2
+    assert(hasher(1) == hash_1);
+    assert(hasher(2) == hash_2);
+    assert(hasher(16) == hash_16);
+    assert(hasher(256) == hash_256);
+    assert(hasher(1024) == hash_1024);
+    assert(hasher(4096) == hash_4096);
+    
+    // Test negative powers of 2
+    std::size_t hash_neg_1 = hasher(-1);
+    std::size_t hash_neg_2 = hasher(-2);
+    std::size_t hash_neg_4 = hasher(-4);
+    std::size_t hash_neg_8 = hasher(-8);
+    std::size_t hash_neg_16 = hasher(-16);
+    std::size_t hash_neg_32 = hasher(-32);
+    std::size_t hash_neg_64 = hasher(-64);
+    std::size_t hash_neg_128 = hasher(-128);
+    std::size_t hash_neg_256 = hasher(-256);
+    std::size_t hash_neg_512 = hasher(-512);
+    std::size_t hash_neg_1024 = hasher(-1024);
+    
+    // Test determinism for negative powers of 2
+    assert(hasher(-1) == hash_neg_1);
+    assert(hasher(-2) == hash_neg_2);
+    assert(hasher(-16) == hash_neg_16);
+    assert(hasher(-256) == hash_neg_256);
+    assert(hasher(-1024) == hash_neg_1024);
+    
+    // Test powers of 2 minus 1 (also common edge cases)
+    std::size_t hash_3 = hasher(3);          // 2^2 - 1
+    std::size_t hash_7 = hasher(7);          // 2^3 - 1
+    std::size_t hash_15 = hasher(15);        // 2^4 - 1
+    std::size_t hash_31 = hasher(31);        // 2^5 - 1
+    std::size_t hash_63 = hasher(63);        // 2^6 - 1
+    std::size_t hash_127 = hasher(127);      // 2^7 - 1
+    std::size_t hash_255 = hasher(255);      // 2^8 - 1
+    std::size_t hash_511 = hasher(511);      // 2^9 - 1
+    std::size_t hash_1023 = hasher(1023);    // 2^10 - 1
+    
+    // Test determinism for powers of 2 minus 1
+    assert(hasher(3) == hash_3);
+    assert(hasher(7) == hash_7);
+    assert(hasher(15) == hash_15);
+    assert(hasher(31) == hash_31);
+    assert(hasher(127) == hash_127);
+    assert(hasher(255) == hash_255);
+    assert(hasher(1023) == hash_1023);
+    
+    // Test unsigned int with large powers of 2
+    std::hash<unsigned int> uint_hasher;
+    
+    std::size_t hash_65536 = uint_hasher(65536U);      // 2^16
+    std::size_t hash_131072 = uint_hasher(131072U);    // 2^17
+    std::size_t hash_262144 = uint_hasher(262144U);    // 2^18
+    std::size_t hash_524288 = uint_hasher(524288U);    // 2^19
+    std::size_t hash_1048576 = uint_hasher(1048576U);  // 2^20
+    
+    // Test determinism
+    assert(uint_hasher(65536U) == hash_65536);
+    assert(uint_hasher(1048576U) == hash_1048576);
+    
+    // Test zero (which is also a power of 2 in some sense: 2^0 * 0)
+    std::size_t hash_zero = hasher(0);
+    assert(hasher(0) == hash_zero);
+    
+    // All hashes should be valid
+    assert(hash_1 >= 0);
+    assert(hash_256 >= 0);
+    assert(hash_neg_128 >= 0);
+    assert(hash_65536 >= 0);
+    assert(hash_zero >= 0);
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/power-of-two/test.desc
+++ b/regression/esbmc-cpp/functional/power-of-two/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/functional/power-of-two_fail/main.cpp
+++ b/regression/esbmc-cpp/functional/power-of-two_fail/main.cpp
@@ -1,0 +1,95 @@
+#include <cassert>
+#include <functional>
+
+int main() {
+    std::hash<int> hasher;
+    
+    // Test powers of 2 (common edge cases for hash functions)
+    std::size_t hash_1 = hasher(1);          // 2^0
+    std::size_t hash_2 = hasher(2);          // 2^1
+    std::size_t hash_4 = hasher(4);          // 2^2
+    std::size_t hash_8 = hasher(8);          // 2^3
+    std::size_t hash_16 = hasher(16);        // 2^4
+    std::size_t hash_32 = hasher(32);        // 2^5
+    std::size_t hash_64 = hasher(64);        // 2^6
+    std::size_t hash_128 = hasher(128);      // 2^7
+    std::size_t hash_256 = hasher(256);      // 2^8
+    std::size_t hash_512 = hasher(512);      // 2^9
+    std::size_t hash_1024 = hasher(1024);    // 2^10
+    std::size_t hash_2048 = hasher(2048);    // 2^11
+    std::size_t hash_4096 = hasher(4096);    // 2^12
+    
+    // Test determinism for powers of 2
+    assert(hasher(1) == hash_1);
+    assert(hasher(2) == hash_2);
+    assert(hasher(16) == hash_16);
+    assert(hasher(256) == hash_256);
+    assert(hasher(1024) == hash_1024);
+    assert(hasher(4096) == hash_4096);
+    
+    // Test negative powers of 2
+    std::size_t hash_neg_1 = hasher(-1);
+    std::size_t hash_neg_2 = hasher(-2);
+    std::size_t hash_neg_4 = hasher(-4);
+    std::size_t hash_neg_8 = hasher(-8);
+    std::size_t hash_neg_16 = hasher(-16);
+    std::size_t hash_neg_32 = hasher(-32);
+    std::size_t hash_neg_64 = hasher(-64);
+    std::size_t hash_neg_128 = hasher(-128);
+    std::size_t hash_neg_256 = hasher(-256);
+    std::size_t hash_neg_512 = hasher(-512);
+    std::size_t hash_neg_1024 = hasher(-1024);
+    
+    // Test determinism for negative powers of 2
+    assert(hasher(-1) == hash_neg_1);
+    assert(hasher(-2) == hash_neg_2);
+    assert(hasher(-16) == hash_neg_16);
+    assert(hasher(-256) == hash_neg_256);
+    assert(hasher(-1024) == hash_neg_1024);
+    
+    // Test powers of 2 minus 1 (also common edge cases)
+    std::size_t hash_3 = hasher(3);          // 2^2 - 1
+    std::size_t hash_7 = hasher(7);          // 2^3 - 1
+    std::size_t hash_15 = hasher(15);        // 2^4 - 1
+    std::size_t hash_31 = hasher(31);        // 2^5 - 1
+    std::size_t hash_63 = hasher(63);        // 2^6 - 1
+    std::size_t hash_127 = hasher(127);      // 2^7 - 1
+    std::size_t hash_255 = hasher(255);      // 2^8 - 1
+    std::size_t hash_511 = hasher(511);      // 2^9 - 1
+    std::size_t hash_1023 = hasher(1023);    // 2^10 - 1
+    
+    // Test determinism for powers of 2 minus 1
+    assert(hasher(3) == hash_3);
+    assert(hasher(7) == hash_3); // should fail
+    assert(hasher(15) == hash_15);
+    assert(hasher(31) == hash_31);
+    assert(hasher(127) == hash_127);
+    assert(hasher(255) == hash_255);
+    assert(hasher(1023) == hash_1023);
+    
+    // Test unsigned int with large powers of 2
+    std::hash<unsigned int> uint_hasher;
+    
+    std::size_t hash_65536 = uint_hasher(65536U);      // 2^16
+    std::size_t hash_131072 = uint_hasher(131072U);    // 2^17
+    std::size_t hash_262144 = uint_hasher(262144U);    // 2^18
+    std::size_t hash_524288 = uint_hasher(524288U);    // 2^19
+    std::size_t hash_1048576 = uint_hasher(1048576U);  // 2^20
+    
+    // Test determinism
+    assert(uint_hasher(65536U) == hash_65536);
+    assert(uint_hasher(1048576U) == hash_1048576);
+    
+    // Test zero (which is also a power of 2 in some sense: 2^0 * 0)
+    std::size_t hash_zero = hasher(0);
+    assert(hasher(0) == hash_zero);
+    
+    // All hashes should be valid
+    assert(hash_1 >= 0);
+    assert(hash_256 >= 0);
+    assert(hash_neg_128 >= 0);
+    assert(hash_65536 >= 0);
+    assert(hash_zero >= 0);
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/functional/power-of-two_fail/test.desc
+++ b/regression/esbmc-cpp/functional/power-of-two_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/functional/string-edge-cases/main.cpp
+++ b/regression/esbmc-cpp/functional/string-edge-cases/main.cpp
@@ -1,0 +1,53 @@
+#include <cassert>
+#include <functional>
+#include <string>
+
+int main() {
+    std::hash<std::string> string_hasher;
+    std::hash<const char*> cstr_hasher;
+    
+    // Test various string edge cases
+    std::string empty_str = "";
+    std::string single_char = "a";
+    std::string null_char = std::string(1, '\0');
+    std::string spaces = "   ";
+    std::string newlines = "\n\r\t";
+    std::string very_long = std::string(1000, 'x');
+    std::string unicode = "héllo wørld";
+    std::string special_chars = "!@#$%^&*()";
+    std::string numbers = "1234567890";
+    std::string mixed = "Hello123!";
+    
+    // Get hashes
+    std::size_t hash_empty = string_hasher(empty_str);
+    std::size_t hash_single = string_hasher(single_char);
+    std::size_t hash_null = string_hasher(null_char);
+    std::size_t hash_spaces = string_hasher(spaces);
+    std::size_t hash_newlines = string_hasher(newlines);
+    std::size_t hash_long = string_hasher(very_long);
+    std::size_t hash_unicode = string_hasher(unicode);
+    std::size_t hash_special = string_hasher(special_chars);
+    std::size_t hash_numbers = string_hasher(numbers);
+    std::size_t hash_mixed = string_hasher(mixed);
+    
+    // Test determinism
+    assert(string_hasher("") == hash_empty);
+    assert(string_hasher("a") == hash_single);
+    assert(string_hasher("   ") == hash_spaces);
+    assert(string_hasher(very_long) == hash_long);
+    assert(string_hasher("1234567890") == hash_numbers);
+    
+    // Test that different strings produce different hashes
+    // (not guaranteed by standard, but likely for these cases)
+    assert(hash_empty != hash_single);
+    assert(hash_single != hash_spaces);
+    assert(hash_numbers != hash_mixed);
+    
+    // All should be valid
+    assert(hash_empty >= 0);
+    assert(hash_long >= 0);
+    assert(hash_unicode >= 0);
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/functional/string-edge-cases/test.desc
+++ b/regression/esbmc-cpp/functional/string-edge-cases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -369,6 +369,7 @@ TEST_SUITES = [
     "esbmc-cpp/template",
     "esbmc-cpp/unix",
     "esbmc-cpp/vector",
+    "esbmc-cpp/functional",
     "esbmc-cpp11/constructors",
     "esbmc-cpp11/cpp",
     "esbmc-cpp11/new-delete",

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -2,65 +2,102 @@
 #define STL_FUNCTIONAL
 
 #include <cassert>
-#include <utility>  // std::forward
+#include <utility> // std::forward
 #include <cstddef>
 #include <type_traits>
-#include <cstdint>  // for uint32_t, uint64_t
-#include <cmath>    // for INFINITY
-#include <string>   // for std::string
+#include <cstdint> // for uint32_t, uint64_t
+#include <cmath>   // for INFINITY
+#include <string>  // for std::string
 
-namespace std {
+namespace std
+{
 
 // Base class for callable objects
-class callable_base {
+class callable_base
+{
 public:
   virtual ~callable_base() = default;
-  virtual int invoke(int, int) const { assert(false); return 0; }
-  virtual int invoke(int) const { assert(false); return 0; }
-  virtual bool invoke_bool(int, int) const { assert(false); return false; }
-  virtual bool invoke_bool(int) const { assert(false); return false; }
+  virtual int invoke(int, int) const
+  {
+    assert(false);
+    return 0;
+  }
+  virtual int invoke(int) const
+  {
+    assert(false);
+    return 0;
+  }
+  virtual bool invoke_bool(int, int) const
+  {
+    assert(false);
+    return false;
+  }
+  virtual bool invoke_bool(int) const
+  {
+    assert(false);
+    return false;
+  }
 };
 
 // Wrapper for callable types (function pointers, lambdas, functors)
 template <typename Callable>
-class callable_wrapper : public callable_base {
+class callable_wrapper : public callable_base
+{
 private:
   Callable func;
 
 public:
-  explicit callable_wrapper(Callable&& f) : func(std::forward<Callable>(f)) {}
+  explicit callable_wrapper(Callable &&f) : func(std::forward<Callable>(f))
+  {
+  }
 
-  int invoke(int a, int b) const override {
-    if constexpr (std::is_invocable_v<Callable, int, int>) {
+  int invoke(int a, int b) const override
+  {
+    if constexpr (std::is_invocable_v<Callable, int, int>)
+    {
       return func(a, b);
-    } else {
+    }
+    else
+    {
       assert(false);
       return 0;
     }
   }
 
-  int invoke(int a) const override {
-    if constexpr (std::is_invocable_v<Callable, int>) {
+  int invoke(int a) const override
+  {
+    if constexpr (std::is_invocable_v<Callable, int>)
+    {
       return func(a);
-    } else {
+    }
+    else
+    {
       assert(false);
       return 0;
     }
   }
 
-  bool invoke_bool(int a, int b) const override {
-    if constexpr (std::is_invocable_r_v<bool, Callable, int, int>) {
+  bool invoke_bool(int a, int b) const override
+  {
+    if constexpr (std::is_invocable_r_v<bool, Callable, int, int>)
+    {
       return func(a, b);
-    } else {
+    }
+    else
+    {
       assert(false);
       return false;
     }
   }
 
-  bool invoke_bool(int a) const override {
-    if constexpr (std::is_invocable_r_v<bool, Callable, int>) {
+  bool invoke_bool(int a) const override
+  {
+    if constexpr (std::is_invocable_r_v<bool, Callable, int>)
+    {
       return func(a);
-    } else {
+    }
+    else
+    {
       assert(false);
       return false;
     }
@@ -72,34 +109,41 @@ template <typename Signature>
 class function;
 
 template <typename Ret, typename... Args>
-class function<Ret(Args...)> {
+class function<Ret(Args...)>
+{
 private:
-  callable_base* func = nullptr;
+  callable_base *func = nullptr;
 
 public:
   function() = default;
 
-  function(Ret (*f)(Args...)) {
-    if (f) {
+  function(Ret (*f)(Args...))
+  {
+    if (f)
+    {
       func = new callable_wrapper<Ret (*)(Args...)>(move(f));
     }
   }
 
   template <typename Callable>
-  function(Callable f) {
+  function(Callable f)
+  {
     func = new callable_wrapper<Callable>(move(f));
   }
 
-  function(const function& other) = delete;
-  function& operator=(const function& other) = delete;
+  function(const function &other) = delete;
+  function &operator=(const function &other) = delete;
 
-  function(function&& other) noexcept {
+  function(function &&other) noexcept
+  {
     func = other.func;
     other.func = nullptr;
   }
 
-  function& operator=(function&& other) noexcept {
-    if (this != &other) {
+  function &operator=(function &&other) noexcept
+  {
+    if (this != &other)
+    {
       delete func;
       func = other.func;
       other.func = nullptr;
@@ -107,290 +151,311 @@ public:
     return *this;
   }
 
-  ~function() {
+  ~function()
+  {
     delete func;
   }
 
-  Ret operator()(Args... args) const {
+  Ret operator()(Args... args) const
+  {
     assert(func != nullptr);
     return func->invoke(std::forward<Args>(args)...);
   }
 
-  explicit operator bool() const noexcept {
+  explicit operator bool() const noexcept
+  {
     return func != nullptr;
   }
 };
 
 // Deterministic hash value generator using simple mathematical function
 // This ensures determinism while still providing hash-like distribution
-inline size_t __esbmc_deterministic_hash(size_t key) {
-    // Simple hash function that's deterministic
-    // Uses bit manipulation to create pseudo-random distribution
-    key ^= key >> 16;
-    key *= 0x85ebca6b;
-    key ^= key >> 13;
-    key *= 0xc2b2ae35;
-    key ^= key >> 16;
-    return key;
+inline size_t __esbmc_deterministic_hash(size_t key)
+{
+  // Simple hash function that's deterministic
+  // Uses bit manipulation to create pseudo-random distribution
+  key ^= key >> 16;
+  key *= 0x85ebca6b;
+  key ^= key >> 13;
+  key *= 0xc2b2ae35;
+  key ^= key >> 16;
+  return key;
 }
 
 // Helper function to handle signed integer hashing consistently
-template<typename SignedInt>
-inline size_t __esbmc_hash_signed_int(SignedInt key) {
-    // Convert to size_t safely
-    size_t unsigned_key = static_cast<size_t>(key);
-    
-    // Handle negative numbers by flipping high bit
-    if (key < 0) {
-        unsigned_key = ~unsigned_key + 1;  // Two's complement
-    }
-    
-    return __esbmc_deterministic_hash(unsigned_key);
+template <typename SignedInt>
+inline size_t __esbmc_hash_signed_int(SignedInt key)
+{
+  using Unsigned = typename std::make_unsigned<SignedInt>::type;
+  return __esbmc_deterministic_hash(
+    static_cast<size_t>(static_cast<Unsigned>(key)));
 }
 
 // Helper function for unsigned integer hashing
-template<typename UnsignedInt>
-inline size_t __esbmc_hash_unsigned_int(UnsignedInt key) {
-    size_t unsigned_key = static_cast<size_t>(key);
-    return __esbmc_deterministic_hash(unsigned_key);
+template <typename UnsignedInt>
+inline size_t __esbmc_hash_unsigned_int(UnsignedInt key)
+{
+  size_t unsigned_key = static_cast<size_t>(key);
+  return __esbmc_deterministic_hash(unsigned_key);
 }
 
 // Primary template for std::hash
-template<typename T>
-struct hash {
-    // Default hash is undefined for non-specialized types
-    size_t operator()(const T& key) const = delete;
+template <typename T>
+struct hash
+{
+  // Default hash is undefined for non-specialized types
+  size_t operator()(const T &key) const = delete;
 };
 
 // Specialization for bool
-template<>
-struct hash<bool> {
-    size_t operator()(bool key) const {
-        // Simple deterministic mapping for bool
-        return key ? 1 : 0;
-    }
+template <>
+struct hash<bool>
+{
+  size_t operator()(bool key) const
+  {
+    // Simple deterministic mapping for bool
+    return key ? 1 : 0;
+  }
 };
 
 // Specializations for character types
-template<>
-struct hash<char> {
-    size_t operator()(char key) const {
-        // Convert char to unsigned and hash
-        size_t unsigned_key = static_cast<unsigned char>(key);
-        return __esbmc_deterministic_hash(unsigned_key);
-    }
+template <>
+struct hash<char>
+{
+  size_t operator()(char key) const
+  {
+    // Convert char to unsigned and hash
+    size_t unsigned_key = static_cast<unsigned char>(key);
+    return __esbmc_deterministic_hash(unsigned_key);
+  }
 };
 
-template<>
-struct hash<signed char> {
-    size_t operator()(signed char key) const {
-        return __esbmc_hash_signed_int(key);
-    }
+template <>
+struct hash<signed char>
+{
+  size_t operator()(signed char key) const
+  {
+    return __esbmc_hash_signed_int(key);
+  }
 };
 
-template<>
-struct hash<unsigned char> {
-    size_t operator()(unsigned char key) const {
-        return __esbmc_hash_unsigned_int(key);
-    }
+template <>
+struct hash<unsigned char>
+{
+  size_t operator()(unsigned char key) const
+  {
+    return __esbmc_hash_unsigned_int(key);
+  }
 };
 
 // Specialization for wchar_t
-template<>
-struct hash<wchar_t> {
-    size_t operator()(wchar_t key) const {
-        // Convert wchar_t to size_t and hash
-        size_t unsigned_key = static_cast<size_t>(key);
-        return __esbmc_deterministic_hash(unsigned_key);
-    }
+template <>
+struct hash<wchar_t>
+{
+  size_t operator()(wchar_t key) const
+  {
+    // Convert wchar_t to size_t and hash
+    size_t unsigned_key = static_cast<size_t>(key);
+    return __esbmc_deterministic_hash(unsigned_key);
+  }
 };
 
 // Specializations for short integer types
-template<>
-struct hash<short> {
-    size_t operator()(short key) const {
-        return __esbmc_hash_signed_int(key);
-    }
+template <>
+struct hash<short>
+{
+  size_t operator()(short key) const
+  {
+    return __esbmc_hash_signed_int(key);
+  }
 };
 
-template<>
-struct hash<unsigned short> {
-    size_t operator()(unsigned short key) const {
-        return __esbmc_hash_unsigned_int(key);
-    }
+template <>
+struct hash<unsigned short>
+{
+  size_t operator()(unsigned short key) const
+  {
+    return __esbmc_hash_unsigned_int(key);
+  }
 };
 
 // Specializations for int types
-template<>
-struct hash<int> {
-    size_t operator()(int key) const {
-        return __esbmc_hash_signed_int(key);
-    }
+template <>
+struct hash<int>
+{
+  size_t operator()(int key) const
+  {
+    return __esbmc_hash_signed_int(key);
+  }
 };
 
-template<>
-struct hash<unsigned int> {
-    size_t operator()(unsigned int key) const {
-        return __esbmc_hash_unsigned_int(key);
-    }
+template <>
+struct hash<unsigned int>
+{
+  size_t operator()(unsigned int key) const
+  {
+    return __esbmc_hash_unsigned_int(key);
+  }
 };
 
 // Specializations for long types
-template<>
-struct hash<long> {
-    size_t operator()(long key) const {
-        return __esbmc_hash_signed_int(key);
-    }
+template <>
+struct hash<long>
+{
+  size_t operator()(long key) const
+  {
+    return __esbmc_hash_signed_int(key);
+  }
 };
 
-template<>
-struct hash<unsigned long> {
-    size_t operator()(unsigned long key) const {
-        return __esbmc_hash_unsigned_int(key);
-    }
+template <>
+struct hash<unsigned long>
+{
+  size_t operator()(unsigned long key) const
+  {
+    return __esbmc_hash_unsigned_int(key);
+  }
 };
 
 // Specializations for long long types
-template<>
-struct hash<long long> {
-    size_t operator()(long long key) const {
-        return __esbmc_hash_signed_int(key);
-    }
+template <>
+struct hash<long long>
+{
+  size_t operator()(long long key) const
+  {
+    return __esbmc_hash_signed_int(key);
+  }
 };
 
-template<>
-struct hash<unsigned long long> {
-    size_t operator()(unsigned long long key) const {
-        return __esbmc_hash_unsigned_int(key);
-    }
+template <>
+struct hash<unsigned long long>
+{
+  size_t operator()(unsigned long long key) const
+  {
+    return __esbmc_hash_unsigned_int(key);
+  }
 };
 
 // Specialization for size_t (only if different from unsigned long)
 #if !defined(__SIZEOF_SIZE_T__) || (__SIZEOF_SIZE_T__ != __SIZEOF_LONG__)
-template<>
-struct hash<size_t> {
-    size_t operator()(size_t key) const {
-        return __esbmc_deterministic_hash(key);
-    }
+template <>
+struct hash<size_t>
+{
+  size_t operator()(size_t key) const
+  {
+    return __esbmc_deterministic_hash(key);
+  }
 };
 #endif
 
 // Specializations for floating point types
-template<>
-struct hash<float> {
-    size_t operator()(float key) const {
-        // Handle special floating point values
-        if (key != key) {  // NaN check
-            return __esbmc_deterministic_hash(0xFFFFFFFF);  // Consistent NaN hash
-        }
-        if (key == 0.0f) {  // Handle +0.0 and -0.0 as same
-            return __esbmc_deterministic_hash(0);
-        }
-        
-        // For normal values, use bit representation
-        union { float f; uint32_t i; } u;
-        u.f = key;
-        return __esbmc_deterministic_hash(static_cast<size_t>(u.i));
+template <>
+struct hash<float>
+{
+  size_t operator()(float key) const
+  {
+    // Handle special floating point values
+    if (key != key)
+    {                                                // NaN check
+      return __esbmc_deterministic_hash(0xFFFFFFFF); // Consistent NaN hash
     }
+    if (key == 0.0f)
+    { // Handle +0.0 and -0.0 as same
+      return __esbmc_deterministic_hash(0);
+    }
+
+    // For normal values, use bit representation
+    union
+    {
+      float f;
+      uint32_t i;
+    } u;
+    u.f = key;
+    return __esbmc_deterministic_hash(static_cast<size_t>(u.i));
+  }
 };
 
-template<>
-struct hash<double> {
-    size_t operator()(double key) const {
-        // Handle special floating point values
-        if (key != key) {  // NaN check
-            return __esbmc_deterministic_hash(0xFFFFFFFFFFFFFFFF);  // Consistent NaN hash
-        }
-        if (key == 0.0) {  // Handle +0.0 and -0.0 as same
-            return __esbmc_deterministic_hash(0);
-        }
-        
-        // For normal values, use bit representation
-        union { double d; uint64_t i; } u;
-        u.d = key;
-        return __esbmc_deterministic_hash(static_cast<size_t>(u.i));
+template <>
+struct hash<double>
+{
+  size_t operator()(double key) const
+  {
+    // Handle special floating point values
+    if (key != key)
+    { // NaN check
+      return __esbmc_deterministic_hash(
+        0xFFFFFFFFFFFFFFFF); // Consistent NaN hash
     }
+    if (key == 0.0)
+    { // Handle +0.0 and -0.0 as same
+      return __esbmc_deterministic_hash(0);
+    }
+
+    // For normal values, use bit representation
+    union
+    {
+      double d;
+      uint64_t i;
+    } u;
+    u.d = key;
+    return __esbmc_deterministic_hash(static_cast<size_t>(u.i));
+  }
 };
 
 // Specialization for pointer types
-template<typename T>
-struct hash<T*> {
-    size_t operator()(T* key) const {
-        // Convert pointer to size_t and hash
-        size_t ptr_value = reinterpret_cast<size_t>(key);
-        return __esbmc_deterministic_hash(ptr_value);
-    }
+template <typename T>
+struct hash<T *>
+{
+  size_t operator()(T *key) const
+  {
+    // Convert pointer to size_t and hash
+    size_t ptr_value = reinterpret_cast<size_t>(key);
+    return __esbmc_deterministic_hash(ptr_value);
+  }
 };
 
 // Specialization for C-strings
-template<>
-struct hash<const char*> {
-    size_t operator()(const char* key) const {
-        // Basic null check
-        assert(key != nullptr);
-        
-        // For deterministic verification, use pointer address as hash
-        // This ensures same pointer gives same hash, different pointers give different hashes
-        size_t ptr_hash = reinterpret_cast<size_t>(key);
-        return __esbmc_deterministic_hash(ptr_hash);
-    }
+template <>
+struct hash<const char *>
+{
+  size_t operator()(const char *key) const
+  {
+    // Basic null check
+    assert(key != nullptr);
+
+    // For deterministic verification, use pointer address as hash
+    // This ensures same pointer gives same hash, different pointers give different hashes
+    size_t ptr_hash = reinterpret_cast<size_t>(key);
+    return __esbmc_deterministic_hash(ptr_hash);
+  }
 };
 
 // Specialization for std::string
-template<>
-struct hash<std::string> {
-    size_t operator()(const std::string& key) const {
-        // Simple deterministic string hash using polynomial rolling hash
-        size_t hash_value = 0;
-        const size_t prime = 31;
-        
-        // Use c_str() to access characters in a const-compatible way
-        const char* str = key.c_str();
-        for (size_t i = 0; i < key.length(); ++i) {
-            hash_value = hash_value * prime + static_cast<size_t>(static_cast<unsigned char>(str[i]));
-        }
-        
-        return __esbmc_deterministic_hash(hash_value);
+template <>
+struct hash<std::string>
+{
+  size_t operator()(const std::string &key) const
+  {
+    // Simple deterministic string hash using polynomial rolling hash
+    size_t hash_value = 0;
+    const size_t prime = 31;
+
+    // Use c_str() to access characters in a const-compatible way
+    const char *str = key.c_str();
+    for (size_t i = 0; i < key.length(); ++i)
+    {
+      hash_value = hash_value * prime +
+                   static_cast<size_t>(static_cast<unsigned char>(str[i]));
     }
+
+    return __esbmc_deterministic_hash(hash_value);
+  }
 };
-
-// Utility functions for testing
-template<typename T>
-bool verify_hash_determinism(const T& value) {
-    hash<T> hasher;
-    size_t hash1 = hasher(value);
-    size_t hash2 = hasher(value);
-    
-    // Should always be equal due to deterministic implementation
-    assert(hash1 == hash2);
-    return hash1 == hash2;
-}
-
-template<typename T>
-void verify_hash_basic_properties(const T& value1, const T& value2) {
-    hash<T> hasher;
-    
-    // Equal values should produce equal hashes
-    if (value1 == value2) {
-        assert(hasher(value1) == hasher(value2));
-    }
-    
-    // Function should not crash on valid inputs
-    size_t hash1 = hasher(value1);
-    size_t hash2 = hasher(value2);
-    
-    // Hashes should be valid (always true for size_t)
-    assert(hash1 >= 0);
-    assert(hash2 >= 0);
-    
-    // Test determinism
-    assert(hasher(value1) == hash1);
-    assert(hasher(value2) == hash2);
-}
 
 // Legacy binary_function class template (for compatibility)
 template <typename Arg1, typename Arg2, typename Result>
-struct binary_function {
+struct binary_function
+{
   using first_argument_type = Arg1;
   using second_argument_type = Arg2;
   using result_type = Result;
@@ -398,126 +463,186 @@ struct binary_function {
 
 // Arithmetic Operations
 template <typename T = int>
-struct plus {
-  constexpr T operator()(const T& a, const T& b) const { return a + b; }
+struct plus
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a + b;
+  }
 };
 
 template <typename T = int>
-struct minus {
-  constexpr T operator()(const T& a, const T& b) const { return a - b; }
+struct minus
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a - b;
+  }
 };
 
 template <typename T = int>
-struct multiplies {
-  constexpr T operator()(const T& a, const T& b) const { return a * b; }
+struct multiplies
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a * b;
+  }
 };
 
 template <typename T = int>
-struct divides {
-  constexpr T operator()(const T& a, const T& b) const { return a / b; }
+struct divides
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a / b;
+  }
 };
 
 template <typename T = int>
-struct modulus {
-  constexpr T operator()(const T& a, const T& b) const { return a % b; }
+struct modulus
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a % b;
+  }
 };
 
 template <typename T = int>
-struct negate {
-  constexpr T operator()(const T& a) const { return -a; }
+struct negate
+{
+  constexpr T operator()(const T &a) const
+  {
+    return -a;
+  }
 };
 
 // Comparison Operations
 template <typename T = int>
-struct equal_to {
-  constexpr bool operator()(const T& a, const T& b) const { return a == b; }
+struct equal_to
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a == b;
+  }
 };
 
 template <typename T = int>
-struct not_equal_to {
-  constexpr bool operator()(const T& a, const T& b) const { return a != b; }
+struct not_equal_to
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a != b;
+  }
 };
 
 template <typename T = int>
-struct greater {
-  constexpr bool operator()(const T& a, const T& b) const { return a > b; }
+struct greater
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a > b;
+  }
 };
 
 template <typename T = int>
-struct less {
-  constexpr bool operator()(const T& a, const T& b) const { return a < b; }
+struct less
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a < b;
+  }
 };
 
 template <typename T = int>
-struct greater_equal {
-  constexpr bool operator()(const T& a, const T& b) const { return a >= b; }
+struct greater_equal
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a >= b;
+  }
 };
 
 template <typename T = int>
-struct less_equal {
-  constexpr bool operator()(const T& a, const T& b) const { return a <= b; }
+struct less_equal
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a <= b;
+  }
 };
 
 // Logical Operations
 template <typename T = bool>
-struct logical_and {
-  constexpr bool operator()(const T& a, const T& b) const { return a && b; }
+struct logical_and
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a && b;
+  }
 };
 
 template <typename T = bool>
-struct logical_or {
-  constexpr bool operator()(const T& a, const T& b) const { return a || b; }
+struct logical_or
+{
+  constexpr bool operator()(const T &a, const T &b) const
+  {
+    return a || b;
+  }
 };
 
 template <typename T = bool>
-struct logical_not {
-  constexpr bool operator()(const T& a) const { return !a; }
+struct logical_not
+{
+  constexpr bool operator()(const T &a) const
+  {
+    return !a;
+  }
 };
 
 // Bitwise Operations
 template <typename T = int>
-struct bit_and {
-  constexpr T operator()(const T& a, const T& b) const { return a & b; }
+struct bit_and
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a & b;
+  }
 };
 
 template <typename T = int>
-struct bit_or {
-  constexpr T operator()(const T& a, const T& b) const { return a | b; }
+struct bit_or
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a | b;
+  }
 };
 
 template <typename T = int>
-struct bit_xor {
-  constexpr T operator()(const T& a, const T& b) const { return a ^ b; }
+struct bit_xor
+{
+  constexpr T operator()(const T &a, const T &b) const
+  {
+    return a ^ b;
+  }
 };
 
 template <typename T = int>
-struct bit_not {
-  constexpr T operator()(const T& a) const { return ~a; }
+struct bit_not
+{
+  constexpr T operator()(const T &a) const
+  {
+    return ~a;
+  }
 };
 
 // Simplified std::invoke model
 template <typename Func, typename... Args>
-decltype(auto) invoke(Func&& f, Args&&... args) {
+decltype(auto) invoke(Func &&f, Args &&...args)
+{
   return forward<Func>(f)(forward<Args>(args)...);
 }
 
 } // namespace std
-
-// Simple verification helper macros
-#define VERIFY_HASH_DETERMINISM(type, value) \
-    do { \
-        std::hash<type> h; \
-        size_t h1 = h(value); \
-        size_t h2 = h(value); \
-        assert(h1 == h2); \
-    } while(0)
-
-#define VERIFY_HASH_EQUALITY(type, val1, val2) \
-    do { \
-        if ((val1) == (val2)) { \
-            std::hash<type> h; \
-            assert(h(val1) == h(val2)); \
-        } \
-    } while(0)
 
 #endif // STL_FUNCTIONAL

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -3,6 +3,11 @@
 
 #include <cassert>
 #include <utility>  // std::forward
+#include <cstddef>
+#include <type_traits>
+#include <cstdint>  // for uint32_t, uint64_t
+#include <cmath>    // for INFINITY
+#include <string>   // for std::string
 
 namespace std {
 
@@ -115,6 +120,273 @@ public:
     return func != nullptr;
   }
 };
+
+// Deterministic hash value generator using simple mathematical function
+// This ensures determinism while still providing hash-like distribution
+inline size_t __esbmc_deterministic_hash(size_t key) {
+    // Simple hash function that's deterministic
+    // Uses bit manipulation to create pseudo-random distribution
+    key ^= key >> 16;
+    key *= 0x85ebca6b;
+    key ^= key >> 13;
+    key *= 0xc2b2ae35;
+    key ^= key >> 16;
+    return key;
+}
+
+// Helper function to handle signed integer hashing consistently
+template<typename SignedInt>
+inline size_t __esbmc_hash_signed_int(SignedInt key) {
+    // Convert to size_t safely
+    size_t unsigned_key = static_cast<size_t>(key);
+    
+    // Handle negative numbers by flipping high bit
+    if (key < 0) {
+        unsigned_key = ~unsigned_key + 1;  // Two's complement
+    }
+    
+    return __esbmc_deterministic_hash(unsigned_key);
+}
+
+// Helper function for unsigned integer hashing
+template<typename UnsignedInt>
+inline size_t __esbmc_hash_unsigned_int(UnsignedInt key) {
+    size_t unsigned_key = static_cast<size_t>(key);
+    return __esbmc_deterministic_hash(unsigned_key);
+}
+
+// Primary template for std::hash
+template<typename T>
+struct hash {
+    // Default hash is undefined for non-specialized types
+    size_t operator()(const T& key) const = delete;
+};
+
+// Specialization for bool
+template<>
+struct hash<bool> {
+    size_t operator()(bool key) const {
+        // Simple deterministic mapping for bool
+        return key ? 1 : 0;
+    }
+};
+
+// Specializations for character types
+template<>
+struct hash<char> {
+    size_t operator()(char key) const {
+        // Convert char to unsigned and hash
+        size_t unsigned_key = static_cast<unsigned char>(key);
+        return __esbmc_deterministic_hash(unsigned_key);
+    }
+};
+
+template<>
+struct hash<signed char> {
+    size_t operator()(signed char key) const {
+        return __esbmc_hash_signed_int(key);
+    }
+};
+
+template<>
+struct hash<unsigned char> {
+    size_t operator()(unsigned char key) const {
+        return __esbmc_hash_unsigned_int(key);
+    }
+};
+
+// Specialization for wchar_t
+template<>
+struct hash<wchar_t> {
+    size_t operator()(wchar_t key) const {
+        // Convert wchar_t to size_t and hash
+        size_t unsigned_key = static_cast<size_t>(key);
+        return __esbmc_deterministic_hash(unsigned_key);
+    }
+};
+
+// Specializations for short integer types
+template<>
+struct hash<short> {
+    size_t operator()(short key) const {
+        return __esbmc_hash_signed_int(key);
+    }
+};
+
+template<>
+struct hash<unsigned short> {
+    size_t operator()(unsigned short key) const {
+        return __esbmc_hash_unsigned_int(key);
+    }
+};
+
+// Specializations for int types
+template<>
+struct hash<int> {
+    size_t operator()(int key) const {
+        return __esbmc_hash_signed_int(key);
+    }
+};
+
+template<>
+struct hash<unsigned int> {
+    size_t operator()(unsigned int key) const {
+        return __esbmc_hash_unsigned_int(key);
+    }
+};
+
+// Specializations for long types
+template<>
+struct hash<long> {
+    size_t operator()(long key) const {
+        return __esbmc_hash_signed_int(key);
+    }
+};
+
+template<>
+struct hash<unsigned long> {
+    size_t operator()(unsigned long key) const {
+        return __esbmc_hash_unsigned_int(key);
+    }
+};
+
+// Specializations for long long types
+template<>
+struct hash<long long> {
+    size_t operator()(long long key) const {
+        return __esbmc_hash_signed_int(key);
+    }
+};
+
+template<>
+struct hash<unsigned long long> {
+    size_t operator()(unsigned long long key) const {
+        return __esbmc_hash_unsigned_int(key);
+    }
+};
+
+// Specialization for size_t (only if different from unsigned long)
+#if !defined(__SIZEOF_SIZE_T__) || (__SIZEOF_SIZE_T__ != __SIZEOF_LONG__)
+template<>
+struct hash<size_t> {
+    size_t operator()(size_t key) const {
+        return __esbmc_deterministic_hash(key);
+    }
+};
+#endif
+
+// Specializations for floating point types
+template<>
+struct hash<float> {
+    size_t operator()(float key) const {
+        // Handle special floating point values
+        if (key != key) {  // NaN check
+            return __esbmc_deterministic_hash(0xFFFFFFFF);  // Consistent NaN hash
+        }
+        if (key == 0.0f) {  // Handle +0.0 and -0.0 as same
+            return __esbmc_deterministic_hash(0);
+        }
+        
+        // For normal values, use bit representation
+        union { float f; uint32_t i; } u;
+        u.f = key;
+        return __esbmc_deterministic_hash(static_cast<size_t>(u.i));
+    }
+};
+
+template<>
+struct hash<double> {
+    size_t operator()(double key) const {
+        // Handle special floating point values
+        if (key != key) {  // NaN check
+            return __esbmc_deterministic_hash(0xFFFFFFFFFFFFFFFF);  // Consistent NaN hash
+        }
+        if (key == 0.0) {  // Handle +0.0 and -0.0 as same
+            return __esbmc_deterministic_hash(0);
+        }
+        
+        // For normal values, use bit representation
+        union { double d; uint64_t i; } u;
+        u.d = key;
+        return __esbmc_deterministic_hash(static_cast<size_t>(u.i));
+    }
+};
+
+// Specialization for pointer types
+template<typename T>
+struct hash<T*> {
+    size_t operator()(T* key) const {
+        // Convert pointer to size_t and hash
+        size_t ptr_value = reinterpret_cast<size_t>(key);
+        return __esbmc_deterministic_hash(ptr_value);
+    }
+};
+
+// Specialization for C-strings
+template<>
+struct hash<const char*> {
+    size_t operator()(const char* key) const {
+        // Basic null check
+        assert(key != nullptr);
+        
+        // For deterministic verification, use pointer address as hash
+        // This ensures same pointer gives same hash, different pointers give different hashes
+        size_t ptr_hash = reinterpret_cast<size_t>(key);
+        return __esbmc_deterministic_hash(ptr_hash);
+    }
+};
+
+// Specialization for std::string
+template<>
+struct hash<std::string> {
+    size_t operator()(const std::string& key) const {
+        // Simple deterministic string hash using polynomial rolling hash
+        size_t hash_value = 0;
+        const size_t prime = 31;
+        
+        // Use c_str() to access characters in a const-compatible way
+        const char* str = key.c_str();
+        for (size_t i = 0; i < key.length(); ++i) {
+            hash_value = hash_value * prime + static_cast<size_t>(static_cast<unsigned char>(str[i]));
+        }
+        
+        return __esbmc_deterministic_hash(hash_value);
+    }
+};
+
+// Utility functions for testing
+template<typename T>
+bool verify_hash_determinism(const T& value) {
+    hash<T> hasher;
+    size_t hash1 = hasher(value);
+    size_t hash2 = hasher(value);
+    
+    // Should always be equal due to deterministic implementation
+    assert(hash1 == hash2);
+    return hash1 == hash2;
+}
+
+template<typename T>
+void verify_hash_basic_properties(const T& value1, const T& value2) {
+    hash<T> hasher;
+    
+    // Equal values should produce equal hashes
+    if (value1 == value2) {
+        assert(hasher(value1) == hasher(value2));
+    }
+    
+    // Function should not crash on valid inputs
+    size_t hash1 = hasher(value1);
+    size_t hash2 = hasher(value2);
+    
+    // Hashes should be valid (always true for size_t)
+    assert(hash1 >= 0);
+    assert(hash2 >= 0);
+    
+    // Test determinism
+    assert(hasher(value1) == hash1);
+    assert(hasher(value2) == hash2);
+}
 
 // Legacy binary_function class template (for compatibility)
 template <typename Arg1, typename Arg2, typename Result>
@@ -230,5 +502,22 @@ decltype(auto) invoke(Func&& f, Args&&... args) {
 }
 
 } // namespace std
+
+// Simple verification helper macros
+#define VERIFY_HASH_DETERMINISM(type, value) \
+    do { \
+        std::hash<type> h; \
+        size_t h1 = h(value); \
+        size_t h2 = h(value); \
+        assert(h1 == h2); \
+    } while(0)
+
+#define VERIFY_HASH_EQUALITY(type, val1, val2) \
+    do { \
+        if ((val1) == (val2)) { \
+            std::hash<type> h; \
+            assert(h(val1) == h(val2)); \
+        } \
+    } while(0)
 
 #endif // STL_FUNCTIONAL


### PR DESCRIPTION
This PR adds a set of deterministic and type-safe `std::hash` specializations to `functional`. These implementations aim to ensure platform-independent, deterministic behavior across supported fundamental types, including integral, floating point, pointer, and string types.