### PR TITLE
[CI] improve auto commit

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -92,10 +92,10 @@ jobs:
       run: rm -rf clang*
     # Commit all changed files back to the repository
     - uses: stefanzweifel/git-auto-commit-action@v5
-      if: ${{ ! startsWith(github.head_ref, 'fb/') }}
+      if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     - name: Throws error if changes were made
       run: git diff --exit-code --ignore-cr-at-eol
-      if: ${{ startsWith(github.head_ref, 'fb/') }}
+      if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
 
   cmake-lint:
     name: Check CMake modules


### PR DESCRIPTION
Improve the code style check CI:

Only branches in the ESBMC repository will trigger the auto commit, because git commit does not have permission to modify other repositories.

Otherwise, we show the corresponding code, throw an error.