### PR TITLE
[c++] fix namespace collision in functional header

### DIFF
--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -47,13 +47,13 @@ private:
   Callable func;
 
 public:
-  explicit callable_wrapper(Callable &&f) : func(std::forward<Callable>(f))
+  explicit callable_wrapper(Callable &&f) : func(::std::forward<Callable>(f))
   {
   }
 
   int invoke(int a, int b) const override
   {
-    if constexpr (std::is_invocable_v<Callable, int, int>)
+    if constexpr (::std::is_invocable_v<Callable, int, int>)
     {
       return func(a, b);
     }
@@ -66,7 +66,7 @@ public:
 
   int invoke(int a) const override
   {
-    if constexpr (std::is_invocable_v<Callable, int>)
+    if constexpr (::std::is_invocable_v<Callable, int>)
     {
       return func(a);
     }
@@ -79,7 +79,7 @@ public:
 
   bool invoke_bool(int a, int b) const override
   {
-    if constexpr (std::is_invocable_r_v<bool, Callable, int, int>)
+    if constexpr (::std::is_invocable_r_v<bool, Callable, int, int>)
     {
       return func(a, b);
     }
@@ -92,7 +92,7 @@ public:
 
   bool invoke_bool(int a) const override
   {
-    if constexpr (std::is_invocable_r_v<bool, Callable, int>)
+    if constexpr (::std::is_invocable_r_v<bool, Callable, int>)
     {
       return func(a);
     }
@@ -159,7 +159,7 @@ public:
   Ret operator()(Args... args) const
   {
     assert(func != nullptr);
-    return func->invoke(std::forward<Args>(args)...);
+    return func->invoke(::std::forward<Args>(args)...);
   }
 
   explicit operator bool() const noexcept
@@ -186,7 +186,7 @@ inline size_t __esbmc_deterministic_hash(size_t key)
 template <typename SignedInt>
 inline size_t __esbmc_hash_signed_int(SignedInt key)
 {
-  using Unsigned = typename std::make_unsigned<SignedInt>::type;
+  using Unsigned = typename ::std::make_unsigned<SignedInt>::type;
   return __esbmc_deterministic_hash(
     static_cast<size_t>(static_cast<Unsigned>(key)));
 }
@@ -432,9 +432,9 @@ struct hash<const char *>
 
 // Specialization for std::string
 template <>
-struct hash<std::string>
+struct hash<::std::string>
 {
-  size_t operator()(const std::string &key) const
+  size_t operator()(const ::std::string &key) const
   {
     // Simple deterministic string hash using polynomial rolling hash
     size_t hash_value = 0;
@@ -640,7 +640,7 @@ struct bit_not
 template <typename Func, typename... Args>
 decltype(auto) invoke(Func &&f, Args &&...args)
 {
-  return forward<Func>(f)(forward<Args>(args)...);
+  return ::std::forward<Func>(f)(::std::forward<Args>(args)...);
 }
 
 } // namespace std


### PR DESCRIPTION
This PR replaces unqualified `std::` references with `::std::` to resolve parsing errors where ESBMC incorrectly looks up standard library features in `__shedskin__::std` (https://github.com/shedskin/shedskin/blob/master/shedskin/lib/builtin/hash.hpp) instead of the `global ::std` namespace.

````
ESBMC version 7.9.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing main.cpp
In file included from main.cpp:1:
In file included from ./builtin.hpp:223:
In file included from ./builtin/hash.hpp:5:
/tmp/esbmc-cpp-headers-ba1b-0202-35ea/functional:50:50: error: no template named 'forward' in namespace '__shedskin__::std'; did you mean '::std::forward'?
  explicit callable_wrapper(Callable &&f) : func(std::forward<Callable>(f))
                                                 ^~~~~
/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/move.h:77:5: note: '::std::forward' declared here
    forward(typename std::remove_reference<_Tp>::type& __t) noexcept
    ^
In file included from main.cpp:1:
In file included from ./builtin.hpp:223:
In file included from ./builtin/hash.hpp:5:
/tmp/esbmc-cpp-headers-ba1b-0202-35ea/functional:50:50: error: no template named 'forward' in namespace '__shedskin__::std'; did you mean '::std::forward'?
  explicit callable_wrapper(Callable &&f) : func(std::forward<Callable>(f))
````