### PR TITLE
Recognising "global" declarations in ESBMC-Python

### DIFF
--- a/regression/python/global-decl-fail/main.py
+++ b/regression/python/global-decl-fail/main.py
@@ -1,0 +1,7 @@
+x = 10
+
+def modify():
+    x = x + 1
+    global x
+  
+modify()

--- a/regression/python/global-decl-fail/test.desc
+++ b/regression/python/global-decl-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/global-decl-fail/test.desc
+++ b/regression/python/global-decl-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-^VERIFICATION FAILED$
+^ERROR: Variable x in function modify is uninitialized.$

--- a/regression/python/global-decl/main.py
+++ b/regression/python/global-decl/main.py
@@ -1,0 +1,8 @@
+x = 10
+
+def modify():
+    global x
+    x = x + 1
+  
+modify()
+assert(x == 11)

--- a/regression/python/global-decl/test.desc
+++ b/regression/python/global-decl/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/global-no-decl-fail/main.py
+++ b/regression/python/global-no-decl-fail/main.py
@@ -1,0 +1,6 @@
+x = 10
+
+def modify():
+    x = x + 1
+  
+modify()

--- a/regression/python/global-no-decl-fail/test.desc
+++ b/regression/python/global-no-decl-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/global-no-decl-fail/test.desc
+++ b/regression/python/global-no-decl-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-^VERIFICATION FAILED$
+^ERROR: Variable x in function modify is uninitialized.$

--- a/regression/python/global-no-decl-fail2/main.py
+++ b/regression/python/global-no-decl-fail2/main.py
@@ -1,0 +1,7 @@
+x = 10
+
+def modify():
+    y = x
+    x = 10
+  
+modify()

--- a/regression/python/global-no-decl-fail2/test.desc
+++ b/regression/python/global-no-decl-fail2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/global-no-decl-fail2/test.desc
+++ b/regression/python/global-no-decl-fail2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-^VERIFICATION FAILED$
+^ERROR: Variable x in function modify is uninitialized.$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2215,11 +2215,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     }
 
     // Tracks global reads within a function
-    if (element["_type"] == "Name" && sid.to_string().find("@C") == std::string::npos && sid.to_string().find("@F") != std::string::npos
-      && is_right && !symbol_table_.find_symbol(sid.to_string().c_str()))
-      {
-        local_loads.push_back(sid.to_string());
-      }
+    if (
+      element["_type"] == "Name" &&
+      sid.to_string().find("@C") == std::string::npos &&
+      sid.to_string().find("@F") != std::string::npos && is_right &&
+      !symbol_table_.find_symbol(sid.to_string().c_str()))
+    {
+      local_loads.push_back(sid.to_string());
+    }
     break;
   }
   case ExpressionType::FUNC_CALL:
@@ -2429,12 +2432,16 @@ void python_converter::get_var_assign(
 
     // Process RHS before LHS if code is in a Function, to update local_load
     exprt rhs;
-    if (sid.to_string().find("@F") != std::string::npos && sid.to_string().find("@C") == std::string::npos)
+    if (
+      sid.to_string().find("@F") != std::string::npos &&
+      sid.to_string().find("@C") == std::string::npos)
     {
       is_right = true;
       if (!ast_node["value"].is_null())
       {
-        if (ast_node["_type"] != "Call") // Test cases showed that some types cannot be processed here
+        if (
+          ast_node["_type"] !=
+          "Call") // Test cases showed that some types cannot be processed here
         {
           rhs = get_expr(ast_node["value"]);
         }
@@ -2449,7 +2456,7 @@ void python_converter::get_var_assign(
 
     bool is_global = false;
 
-    for(std::string& s  : global_declarations)
+    for (std::string &s : global_declarations)
     {
       if (s == sid.global_to_string())
       {
@@ -2472,17 +2479,21 @@ void python_converter::get_var_assign(
         location_begin,
         current_element_type);
       symbol.lvalue = true;
-      symbol.static_lifetime = (current_class_name_ == "" && current_func_name_ == "") ? true : false;
+      symbol.static_lifetime =
+        (current_class_name_ == "" && current_func_name_ == "") ? true : false;
       symbol.file_local = true;
       symbol.is_extern = false;
 
       lhs_symbol = symbol_table_.move_symbol_to_context(symbol);
     }
 
-    for(std::string& s  : local_loads)
+    for (std::string &s : local_loads)
     {
-      if (lhs_symbol->id.as_string() == s) {
-        throw std::runtime_error("Variable " + sid.get_object() + " in function " + current_func_name_ + " is uninitialized.");
+      if (lhs_symbol->id.as_string() == s)
+      {
+        throw std::runtime_error(
+          "Variable " + sid.get_object() + " in function " +
+          current_func_name_ + " is uninitialized.");
       }
       continue;
     }
@@ -2510,7 +2521,7 @@ void python_converter::get_var_assign(
 
     bool is_global = false;
 
-    for(std::string& s  : global_declarations)
+    for (std::string &s : global_declarations)
     {
       if (s == sid.global_to_string())
       {

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -281,4 +281,8 @@ private:
   std::map<std::string, std::set<std::string>> instance_attr_map;
   // Map imported modules to their corresponding paths
   std::unordered_map<std::string, std::string> imported_modules;
+
+  std::vector<std::string> global_declarations;
+  std::vector<std::string> local_loads;
+  bool is_right = false;
 };

--- a/src/python-frontend/symbol_id.cpp
+++ b/src/python-frontend/symbol_id.cpp
@@ -29,6 +29,17 @@ std::string symbol_id::to_string() const
   return ss.str();
 }
 
+std::string symbol_id::global_to_string() const
+{
+  std::stringstream ss;
+  ss << prefix_ << filename_;
+
+  if (!object_.empty())
+    ss << "@" << object_;
+
+  return ss.str();
+}
+
 void symbol_id::clear()
 {
   filename_.clear();

--- a/src/python-frontend/symbol_id.h
+++ b/src/python-frontend/symbol_id.h
@@ -57,9 +57,16 @@ public:
     return filename_;
   }
 
+  const std::string &get_object() const
+  {
+    return object_;
+  }
+
   void clear();
 
   std::string to_string() const;
+
+  std::string global_to_string() const;
 
 private:
   std::string filename_;

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -20,6 +20,7 @@ enum class StatementType
   CONTINUE,
   RAISE,
   UNKNOWN,
+  GLOBAL
 };
 
 enum class ExpressionType
@@ -33,7 +34,7 @@ enum class ExpressionType
   SUBSCRIPT,
   VARIABLE_REF,
   LIST,
-  UNKNOWN,
+  UNKNOWN
 };
 
 class type_utils


### PR DESCRIPTION
The changes made allows for ESBMC-Python to recognise the "global" keyword. 4 new tests were written to ensure that ESBMC-Python produces the correct verification results/errors as Python does.

Notably, all symbols generated had their static_lifetime flag set to false regardless of scope prior to this pull request. I had changed it to only be false if the variable is within a class or a function.