### PR TITLE
[goto-symex] fix unexpected handler

### DIFF
--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_03_bug/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_03_bug/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
+++ b/regression/esbmc-cpp/try_catch/try-catch_unexpected_04/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900 --std c++03
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -912,6 +912,8 @@ protected:
 
   /** Flag to indicate if we are go into the unexpected flow. */
   bool inside_unexpected;
+  /** Store the unexpected function end */
+  irep_idt unexpected_end;
 
   /** Disable return value optimization */
   bool no_return_value_opt;

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -263,9 +263,7 @@ bool goto_symext::unexpected_handler()
 
     // Call the function
     symex_function_call(the_call);
-    // TODO: implement rethrow
-    std::string msg = std::string("Unexpected exceptions");
-    claim(gen_false_expr(), msg);
+    unexpected_end = handler->value.identifier();
     return true;
   }
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -198,8 +198,15 @@ void goto_symext::symex_step(reachability_treet &art)
     break;
 
   case END_FUNCTION:
-    symex_end_of_function();
+    if (
+      inside_unexpected &&
+      unexpected_end == cur_state->source.pc->function.as_string())
+    {
+      std::string msg = std::string("Unexpected exceptions");
+      claim(gen_false_expr(), msg);
+    }
 
+    symex_end_of_function();
     if (!stack_catch.empty())
     {
       // Get to the correct try (always the last one)


### PR DESCRIPTION
Improve the unexpected handler's behavior:

1. The handler terminates without a proper throw, which violates the assertion.
2. The desc of one TC is wrong.