### PR TITLE
[Concurrency] Fix goto guard and data races in incremental smt mode

### DIFF
--- a/regression/esbmc-unix/00_race28/main.c
+++ b/regression/esbmc-unix/00_race28/main.c
@@ -1,0 +1,14 @@
+#include <pthread.h>
+#include <assert.h>
+
+int data1, data2;
+void *t_fun(void *arg) {
+  data1 = 5;
+  return ((void *)0);
+}
+int main () {
+  pthread_t id;
+  pthread_create(&id,((void *)0),t_fun,((void *)0));
+  data2 = 8;
+  return 0;
+}

--- a/regression/esbmc-unix/00_race28/test.desc
+++ b/regression/esbmc-unix/00_race28/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--context-bound 1 --no-slice --data-races
+^VERIFICATION SUCCESSFUL$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -256,7 +256,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
                  check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
-    command_line += " --no-por --context-bound 3 --smt-symex-guard --z3 "
+    command_line += " --no-por --context-bound 3 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -256,7 +256,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
                  check_if_benchmark_contains_pthread(benchmark))
 
   if concurrency:
-    command_line += " --no-por --context-bound 3 "
+    command_line += " --no-por --context-bound 3 --smt-symex-guard --z3 "
     #command_line += "--no-slice " # TODO: Witness validation is only working without slicing
 
   # Add witness arg

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -23,6 +23,9 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   bool new_guard_false = (is_false(new_guard) || cur_state->guard.is_false());
   bool new_guard_true = is_true(new_guard);
 
+  // new_guard_false = TRUE means that the guard is false, 
+  // new_guard_true = TRUE means that the guard is true.
+  // And if both variables are not TRUE we need to ask the solver whether the guard holds.
   if (
     !new_guard_false && !new_guard_true &&
     options.get_bool_option("smt-symex-guard"))
@@ -41,8 +44,8 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
     }
     catch (runtime_encoded_equationt::dual_unsat_exception &e)
     {
-      // Assumptions mean that the guard is never satisfiable as true or false,
-      // basically means we can't say for sure the guard must be false.
+      // If reach here it means both guard G and !G are unsatisfiable,
+      // basically means we can't prove the guard must be true or must be false.
       new_guard_false = false;
     }
   }

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -23,7 +23,7 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   bool new_guard_false = (is_false(new_guard) || cur_state->guard.is_false());
   bool new_guard_true = is_true(new_guard);
 
-  if (!new_guard_false && options.get_bool_option("smt-symex-guard"))
+  if (!new_guard_false && !new_guard_true && options.get_bool_option("smt-symex-guard"))
   {
     auto rte = std::dynamic_pointer_cast<runtime_encoded_equationt>(target);
 
@@ -40,9 +40,8 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
     catch (runtime_encoded_equationt::dual_unsat_exception &e)
     {
       // Assumptions mean that the guard is never satisfiable as true or false,
-      // basically means we've assume'd away the possibility of hitting this
-      // point.
-      new_guard_false = true;
+      // basically means we can't say for sure the guard must be false.
+      new_guard_false = false;
     }
   }
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -23,7 +23,9 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   bool new_guard_false = (is_false(new_guard) || cur_state->guard.is_false());
   bool new_guard_true = is_true(new_guard);
 
-  if (!new_guard_false && !new_guard_true && options.get_bool_option("smt-symex-guard"))
+  if (
+    !new_guard_false && !new_guard_true &&
+    options.get_bool_option("smt-symex-guard"))
   {
     auto rte = std::dynamic_pointer_cast<runtime_encoded_equationt>(target);
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -23,7 +23,7 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   bool new_guard_false = (is_false(new_guard) || cur_state->guard.is_false());
   bool new_guard_true = is_true(new_guard);
 
-  // new_guard_false = TRUE means that the guard is false, 
+  // new_guard_false = TRUE means that the guard is false,
   // new_guard_true = TRUE means that the guard is true.
   // And if both variables are not TRUE we need to ask the solver whether the guard holds.
   if (

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1526,10 +1526,9 @@ smt_astt smt_convt::convert_terminal(const expr2tc &expr)
     if (sym.thename == "c:@__ESBMC_alloc")
       current_valid_objects_sym = expr;
 
-    if (sym.thename == "c:@__ESBMC_is_dynamic"){
+    if (sym.thename == "c:@__ESBMC_is_dynamic")
       cur_dynamic = expr;
-      expr.get()->dump();
-    }
+
     // Special case for tuple symbols
     if (is_tuple_ast_type(expr))
       return tuple_api->mk_tuple_symbol(

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1526,6 +1526,10 @@ smt_astt smt_convt::convert_terminal(const expr2tc &expr)
     if (sym.thename == "c:@__ESBMC_alloc")
       current_valid_objects_sym = expr;
 
+    if (sym.thename == "c:@__ESBMC_is_dynamic"){
+      cur_dynamic = expr;
+      expr.get()->dump();
+    }
     // Special case for tuple symbols
     if (is_tuple_ast_type(expr))
       return tuple_api->mk_tuple_symbol(

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -836,6 +836,10 @@ public:
    */
   expr2tc current_valid_objects_sym;
 
+  /** Holds the `__ESBMC_is_dynamic` symbol convert_terminal() was last invoked with.
+   */
+  expr2tc cur_dynamic;
+
   // XXX - push-pop will break here.
   typedef std::map<std::string, smt_astt> renumber_mapt;
   std::vector<renumber_mapt> renumber_map;

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -452,11 +452,12 @@ void smt_convt::finalize_pointer_chain(unsigned int objnum)
       expr2tc alive =
         index2tc(get_bool_type(), current_valid_objects_sym, gen_ulong(j));
 
-      // Tong: "alive" is only changed when the pointer is dynamic from malloc/free.
-      // And it's value is always false for some pointers that represent race-flags.
-      // However usually this issue will not be exposed because the slicer has sliced
-      // away "alive", but it's exposed in no-slice and incremental-smt.
-      // For now we just modify for races check.
+      // Tong: When dynamic object gets registered/freed in __ESBMC_alloc by
+      // symex_malloc()/symex_free(), the alloc bit "alive" is assigned to 1/0.
+      // However in dataraces check we introduce infinite array to store the address of
+      // shared objects, and if they are not dynamically managed by symex_malloc()/symex_free(),
+      // and it's alloc bit is always 0 by default.
+      // For now we just modify races check.
 
       if (options.get_bool_option("data-races-check") && cur_dynamic)
       {

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -455,7 +455,7 @@ void smt_convt::finalize_pointer_chain(unsigned int objnum)
       // Tong: "alive" is only changed when the pointer is dynamic from malloc/free.
       // And it's value is always false for some pointers that represent race-flags.
       // However usually this issue will not be exposed because the slicer has sliced
-      // away "alive", but it's exposed in no-slice and incremental-smt. 
+      // away "alive", but it's exposed in no-slice and incremental-smt.
       // For now we just modify for races check.
 
       if (options.get_bool_option("data-races-check") && cur_dynamic)

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -455,7 +455,7 @@ void smt_convt::finalize_pointer_chain(unsigned int objnum)
       // Tong: "alive" is only changed when the pointer is dynamic from malloc/free.
       // And it's value is always false for some pointers that represent race-flags.
       // However usually this issue will not be exposed because the slicer has sliced
-      // away "alive", but it's expoosed in no-slice and incremental-smt. 
+      // away "alive", but it's exposed in no-slice and incremental-smt. 
       // For now we just modify for races check.
 
       if (options.get_bool_option("data-races-check") && cur_dynamic)


### PR DESCRIPTION
This PR fixes two bugs:

1. #2518 
2. Incremental SMT when checking goto guards `--smt-symex-guard`

This PR with 30s:
https://github.com/esbmc/esbmc/actions/runs/15911847379

```
Statistics:           3179 Files
  correct:            1122
    correct true:      742
    correct false:     380
  incorrect:            23
    incorrect true:     11
    incorrect false:    12
  unknown:            2034
  Score:              1320 (max: 5725)
```

Master with 30s:
https://github.com/esbmc/esbmc/actions/runs/15911811039

```
Statistics:           3179 Files
  correct:            1109
    correct true:      729
    correct false:     380
  incorrect:            23
    incorrect true:     11
    incorrect false:    12
  unknown:            2047
  Score:              1294 (max: 5725)
```


This PR with` --smt-symex-guard --z3` 30s: 
https://github.com/esbmc/esbmc/actions/runs/15910258278

```
Statistics:           3179 Files
  correct:            1091
    correct true:      718
    correct false:     373
  incorrect:            22
    incorrect true:     10
    incorrect false:    12
  unknown:            2066
  Score:              1297 (max: 5725)

```
Master with `--smt-symex-guard --z3` 30s:
https://github.com/esbmc/esbmc/actions/runs/15903831256

```
Statistics:           3179 Files
  correct:            1032
    correct true:      644
    correct false:     388
  incorrect:           200
    incorrect true:      8
    incorrect false:   192
  unknown:            1947
  Score:             -1652 (max: 5725)
```