### PR TITLE
[smt] fix typecast handling for float-int conversions in integer encoding mode

### DIFF
--- a/regression/esbmc/github_2560/main.c
+++ b/regression/esbmc/github_2560/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+int main()
+{
+  float f;
+  double d;
+  unsigned char x;
+
+  d = f;
+
+  if (f == x)
+    assert(d == x);
+}

--- a/regression/esbmc/github_2560/test.desc
+++ b/regression/esbmc/github_2560/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2560_fail/main.c
+++ b/regression/esbmc/github_2560_fail/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+int main()
+{
+  float f;
+  double d;
+  unsigned char x;
+
+  d = f;
+
+  if (f == x)
+    assert(d != x);
+}

--- a/regression/esbmc/github_2560_fail/test.desc
+++ b/regression/esbmc/github_2560_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -690,6 +690,40 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
     return convert_ast(cast.from);
   }
 
+  // Handle float-to-integer conversions when int_encoding is enabled
+  if (
+    int_encoding && is_floatbv_type(cast.from->type) &&
+    (is_bv_type(cast.type) || is_fixedbv_type(cast.type)))
+  {
+    // Convert float to real, then to integer
+    smt_astt from_real = convert_ast(cast.from);
+
+    // Convert real to integer using appropriate SMT operation
+    if (is_signedbv_type(cast.type))
+    {
+      return round_real_to_int(from_real);
+    }
+    else
+    {
+      // For unsigned types, ensure non-negative conversion
+      smt_astt int_val = round_real_to_int(from_real);
+      smt_astt zero = mk_smt_int(BigInt(0));
+      smt_astt is_negative = mk_lt(int_val, zero);
+      return mk_ite(is_negative, zero, int_val);
+    }
+  }
+
+  // Handle integer-to-float conversions when int_encoding is enabled
+  if (
+    int_encoding &&
+    (is_bv_type(cast.from->type) || is_fixedbv_type(cast.from->type)) &&
+    is_floatbv_type(cast.type))
+  {
+    // Convert integer to real (which represents float in int_encoding mode)
+    smt_astt from_int = convert_ast(cast.from);
+    return mk_int2real(from_int);
+  }
+
   if (cast.type == cast.from->type)
     return convert_ast(cast.from);
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2560.

Fix assertion failure in `smt_ast.h` when converting between floating-point and integer types while using integer encoding. The original code only handled float-to-float conversions but failed on mixed float/integer typecasts.

Changes:
- Add proper float-to-integer conversion using `round_real_to_int()`
- Add integer-to-float conversion using `mk_int2real()`
- Handle unsigned integer clamping to prevent negative values
- Ensure type consistency in SMT encoding for mixed arithmetic

Fixes core dump in programs with float-integer comparisons such as:  `float f; unsigned char x; if (f == x) assert(d == x);`