### PR TITLE
[C verification] fix external var init

### DIFF
--- a/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex5-recursive/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 2 --no-unwinding-assertions --error-label ERROR --depth 125 --timeout 900
+--unwind 2 --no-unwinding-assertions --error-label ERROR --depth 130 --timeout 900
 
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_2569/main.c
+++ b/regression/esbmc/github_2569/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+extern int x;
+int main(int argc, char **argv)
+{
+  if (nondet_int())
+  {
+    argc = 3;
+  }
+  else
+  {
+    argc = 2;
+  }
+  if (argc > 5)
+  {
+    x = 42;
+  }
+  assert(x == 42);
+}

--- a/regression/esbmc/github_2569/test.desc
+++ b/regression/esbmc/github_2569/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -517,7 +517,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
                       (!vd.isExternallyVisible() && !vd.hasGlobalStorage());
 
   if (
-    symbol.static_lifetime && !symbol.is_extern &&
+    symbol.static_lifetime &&
     (!vd.hasInit() || is_aggregate_type(vd.getType())))
   {
     // the type might contains symbolic types,
@@ -525,8 +525,17 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
     // Initialize with zero value, if the symbol has initial value,
     // it will be added later on in this method
-    symbol.value = gen_zero(get_complete_type(t, ns), true);
-    symbol.value.zero_initializer(true);
+    if (symbol.is_extern)
+    {
+      exprt value = exprt("sideeffect", get_complete_type(t, ns));
+      value.statement("nondet");
+      symbol.value = value;
+    }
+    else
+    {
+      symbol.value = gen_zero(get_complete_type(t, ns), true);
+      symbol.value.zero_initializer(true);
+    }
   }
 
   symbolt *added_symbol = nullptr;

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -172,7 +172,6 @@ protected:
    *  merges in the future to handle each path thats taken.
    *  @param old_guard Renamed guard on this jump occuring.
    */
-  bool goto_guard_warning = true;
   virtual void symex_goto(const expr2tc &old_guard);
 
   /**


### PR DESCRIPTION
In this PR:
1. Assign nondet to the uninitialized external variable.
2. I think constant propagation is still very important for assume.

` ASSIGN x=NONDET(signed int);`
