### PR TITLE
[smt] fix bitcast crash with integer/real encoding for int-to-float conversions

### DIFF
--- a/regression/esbmc/github_2573/main.c
+++ b/regression/esbmc/github_2573/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int main()
+{
+  unsigned int i;
+  i=0;
+  
+  float *p;
+  p=(float *)&i;
+  
+  float f=*p;
+  
+  assert(f==0.0);
+}

--- a/regression/esbmc/github_2573/test.desc
+++ b/regression/esbmc/github_2573/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2573_1/main.c
+++ b/regression/esbmc/github_2573_1/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+int main()
+{
+  unsigned int i;
+  i=0;
+  
+  float *p;
+  p=(float *)&i;
+  
+  float f=*p;
+  
+  assert(f==0.1);
+}

--- a/regression/esbmc/github_2573_1/test.desc
+++ b/regression/esbmc/github_2573_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -136,6 +136,14 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
     if (is_struct_type(new_from) || is_array_type(new_from))
       new_from = flatten_to_bitvector(new_from);
 
+    // When int_encoding is true, integer types are represented as integers
+    // in the SMT solver, but fp_api expects bitvectors. Fall back to value-based conversion.
+    if (int_encoding && (is_signedbv_type(new_from) || is_unsignedbv_type(new_from)))
+    {
+      // Fall back to value-based conversion instead of bit-pattern conversion
+      return convert_ast(typecast2tc(to_type, new_from));
+    }
+
     // from bitvectors should go through the fp api
     if (is_bv_type(new_from) || is_union_type(new_from))
       return fp_api->mk_from_bv_to_fp(

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -138,7 +138,9 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
 
     // When int_encoding is true, integer types are represented as integers
     // in the SMT solver, but fp_api expects bitvectors. Fall back to value-based conversion.
-    if (int_encoding && (is_signedbv_type(new_from) || is_unsignedbv_type(new_from)))
+    if (
+      int_encoding &&
+      (is_signedbv_type(new_from) || is_unsignedbv_type(new_from)))
     {
       // Fall back to value-based conversion instead of bit-pattern conversion
       return convert_ast(typecast2tc(to_type, new_from));


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2573.

When `int_encoding` is enabled, integers are represented as mathematical  integers in the SMT solver rather than bitvectors. This caused crashes in `convert_bitcast()` when converting from integer types to floating-point because `fp_api->mk_from_bv_to_fp()` expects bitvector inputs.

The fix detects integer types under `int_encoding` mode and falls back to value-based conversion using `typecast2tc()` instead of attempting bit-pattern conversion through the floating-point API.

Fixes crash: "Z3 error bv then fp sort expected encountered".