### PR TITLE
[smt] fix signbit crash with integer/real encoding for floating-point values

### DIFF
--- a/regression/esbmc/github_2572/main.c
+++ b/regression/esbmc/github_2572/main.c
@@ -1,0 +1,12 @@
+#include<math.h>
+
+int main()
+{
+  double f, f2;
+  // the following rely on f not being a NaN or Infinity
+  __ESBMC_assume(!isnan(f2));
+  __ESBMC_assume(!isinf(f2));
+  f=f2;
+  assert(0+f==f);
+}
+

--- a/regression/esbmc/github_2572/test.desc
+++ b/regression/esbmc/github_2572/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2572_1/main.c
+++ b/regression/esbmc/github_2572_1/main.c
@@ -1,0 +1,12 @@
+#include<math.h>
+
+int main()
+{
+  double f, f2;
+  // the following rely on f not being a NaN or Infinity
+  __ESBMC_assume(!isnan(f2));
+  __ESBMC_assume(!isinf(f2));
+  f=f2;
+  assert(0+f==-f);
+}
+

--- a/regression/esbmc/github_2572_1/test.desc
+++ b/regression/esbmc/github_2572_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_2572_2/main.c
+++ b/regression/esbmc/github_2572_2/main.c
@@ -1,0 +1,66 @@
+#include<math.h>
+#include <assert.h>
+
+int main()
+{
+  double f, f2;
+  // the following rely on f not being a NaN or Infinity
+  __ESBMC_assume(!isnan(f2));
+  __ESBMC_assume(!isinf(f2));
+  f=f2;
+  
+  // addition
+  assert(100.0+10==110);
+  assert(0+f==f);
+  assert(f+0==f);
+  assert(100+0.5==100.5);
+  assert(0.0+0.0+f==f);
+  
+  // subtraction
+  assert(100.0-10==90);
+  assert(0-f==-f);
+  assert(f-0==f);
+  assert(100-0.5==99.5);
+  assert(0.0-0.0-f==-f);
+
+  // unary minus
+  assert(-(-100.0)==100);
+  assert(-(1-2.0)==1);
+  assert(-(-f)==f);
+
+  // multiplication
+  assert(100.0*10==1000);
+  assert(0*f==0);
+  assert(f*0==0);
+  assert(100*0.5==50);
+
+  // division
+  assert(100.0/1.0==100);
+  assert(100.1/1.0==100.1);
+  assert(100.0/2.0==50);
+  assert(100.0/0.5==200);
+  assert(0/1.0==0);
+  
+  // conversion
+  assert(((double)(float)100)==100.0);
+  assert(((unsigned int)100.0)==100.0);
+  assert(100.0);
+  assert(!0.0);
+  assert((int)0.5==0);
+  assert((int)0.49==0);
+  assert((int)-1.5==-1);
+  assert((int)-10.49==-10);
+  
+  // relations
+  assert(1.0<2.5);
+  assert(1.0<=2.5);
+  assert(1.01<=1.01);
+  assert(2.5>1.0);
+  assert(2.5>=1.0);
+  assert(1.01>=1.01);
+  assert(!(1.0>=2.5));
+  assert(!(1.0>2.5));
+  assert(1.0!=2.5);
+
+  return 0;
+}

--- a/regression/esbmc/github_2572_2/test.desc
+++ b/regression/esbmc/github_2572_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1654,7 +1654,7 @@ smt_astt smt_convt::convert_signbit(const expr2tc &expr)
   auto value = convert_ast(signbit.operand);
 
   smt_astt is_neg;
-  
+
   if (int_encoding)
   {
     // In integer/real encoding mode, floating-point values are represented as reals

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1653,9 +1653,21 @@ smt_astt smt_convt::convert_signbit(const expr2tc &expr)
   // Extract the top bit
   auto value = convert_ast(signbit.operand);
 
-  const auto width = value->sort->get_data_width();
-  smt_astt is_neg =
-    mk_eq(mk_extract(value, width - 1, width - 1), mk_smt_bv(BigInt(1), 1));
+  smt_astt is_neg;
+  
+  if (int_encoding)
+  {
+    // In integer/real encoding mode, floating-point values are represented as reals
+    // We can't extract bits, so check the sign mathematically
+    is_neg = mk_lt(value, mk_smt_real("0"));
+  }
+  else
+  {
+    // In bitvector mode, extract the sign bit
+    const auto width = value->sort->get_data_width();
+    is_neg =
+      mk_eq(mk_extract(value, width - 1, width - 1), mk_smt_bv(BigInt(1), 1));
+  }
 
   // If it's true, return 1. Return 0, othewise.
   return mk_ite(


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2572.

When `int_encoding` is enabled, use mathematical comparison instead of bit extraction since floating-point values are represented as reals.

Fixes: "Z3 error bit-vector size must be greater than zero encountered".