### PR TITLE
[smt] fix crash in convert_bitcast when converting float to bv in int_encoding mode

### DIFF
--- a/regression/esbmc/github_2579/main.c
+++ b/regression/esbmc/github_2579/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdint.h>
+
+union mix {
+  float f;
+  uint32_t i;
+};
+
+int f00 (float a, float b) {
+  float sum = a + b;
+  union mix m;
+  m.f = sum;
+  assert(m.i != 0x80000000);
+
+  return 1;
+}
+
+int main (void) {
+  // The sum should be a positive zero,
+  // unless we round towards minus infinity.
+  f00(-0x1.6b890ep+29, 0x1.6b890ep+29);
+  return 0;
+}

--- a/regression/esbmc/github_2579/test.desc
+++ b/regression/esbmc/github_2579/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2579_1/main.c
+++ b/regression/esbmc/github_2579_1/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdint.h>
+
+union mix {
+  float f;
+  uint32_t i;
+};
+
+int f00 (float a, float b) {
+  float sum = a + b;
+  union mix m;
+  m.f = sum;
+  assert(m.i == 0x80000000);
+
+  return 1;
+}
+
+int main (void) {
+  // The sum should be a positive zero,
+  // unless we round towards minus infinity.
+  f00(-0x1.6b890ep+29, 0x1.6b890ep+29);
+  return 0;
+}

--- a/regression/esbmc/github_2579_1/test.desc
+++ b/regression/esbmc/github_2579_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--z3 --ir
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -158,6 +158,12 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
   }
   else if (is_bv_type(to_type))
   {
+    // When int_encoding is true, floating point types are represented
+    // as reals in the SMT solver, but fp_api expects bitvectors.
+    // Fall back to value-based conversion.
+    if (int_encoding && is_floatbv_type(from))
+      return convert_ast(typecast2tc(to_type, from));
+
     if (is_floatbv_type(from))
       return fp_api->mk_from_fp_to_bv(convert_ast(from));
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2579.

When `int_encoding` is enabled, floating point values are represented as reals in the SMT solver, but `fp_api->mk_from_fp_to_bv` expects bitvectors. This caused an assertion failure in `get_significand_width()` when processing union types that bitcast floats to integers.

Add `int_encoding` check before `fp_api->mk_from_fp_to_bv` call and fall back to value-based conversion using `typecast2tc`, similar to the existing fix for integer types.

Fixes crash with union { float f; uint32_t i; } in integer/real arithmetic mode.