### PR TITLE
[smt] add rational value extraction for floating-point counterexamples in int_encoding mode

### DIFF
--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2620,30 +2620,37 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
   }
 }
 
-double smt_convt::convert_rational_to_double(const BigInt &numerator, const BigInt &denominator)
+double smt_convt::convert_rational_to_double(
+  const BigInt &numerator,
+  const BigInt &denominator)
 {
   size_t buffer_size = 1024;
-  
+
   std::vector<char> num_buffer(buffer_size);
   std::vector<char> den_buffer(buffer_size);
-  
+
   numerator.as_string(num_buffer.data(), buffer_size, 10);
   denominator.as_string(den_buffer.data(), buffer_size, 10);
-  
+
   // Check for buffer overflow
   size_t num_len = strlen(num_buffer.data());
   size_t den_len = strlen(den_buffer.data());
-  
-  if (num_len >= buffer_size - 1 || den_len >= buffer_size - 1) {
-    log_warning("BigInt to string conversion may have been truncated - buffer too small");
+
+  if (num_len >= buffer_size - 1 || den_len >= buffer_size - 1)
+  {
+    log_warning(
+      "BigInt to string conversion may have been truncated - buffer too small");
     return 0.0; // Safer to return 0 than use truncated data
   }
-  
-  try {
+
+  try
+  {
     double num_val = std::stod(num_buffer.data());
     double den_val = std::stod(den_buffer.data());
     return (den_val != 0.0) ? num_val / den_val : 0.0;
-  } catch (const std::exception &) {
+  }
+  catch (const std::exception &)
+  {
     return 0.0;
   }
 }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2640,7 +2640,7 @@ double smt_convt::convert_rational_to_double(
   {
     log_warning(
       "BigInt to string conversion may have been truncated - buffer too small");
-    return 0.0; // Safer to return 0 than use truncated data
+    return 0.0;
   }
 
   try

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2549,15 +2549,23 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
 
         if (type_width == ieee_float_spect::single_precision().width())
         {
+          // Single precision (32-bit float)
           ieee_floatt ieee_val(ieee_float_spect::single_precision());
           ieee_val.from_float(static_cast<float>(value));
           return constant_floatbv2tc(ieee_val);
         }
-        else
+        else if (type_width == ieee_float_spect::double_precision().width())
         {
+          // Double precision (64-bit double)
           ieee_floatt ieee_val(ieee_float_spect::double_precision());
           ieee_val.from_double(value);
           return constant_floatbv2tc(ieee_val);
+        }
+        else
+        {
+          log_error(
+            "Unsupported floatbv width ({}) for rational conversion",
+            type_width);
         }
       }
       return expr2tc();

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2622,7 +2622,6 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
 
 double smt_convt::convert_rational_to_double(const BigInt &numerator, const BigInt &denominator)
 {
-  // Can handle very large BigInt values
   size_t buffer_size = 1024;
   
   std::vector<char> num_buffer(buffer_size);
@@ -2630,6 +2629,15 @@ double smt_convt::convert_rational_to_double(const BigInt &numerator, const BigI
   
   numerator.as_string(num_buffer.data(), buffer_size, 10);
   denominator.as_string(den_buffer.data(), buffer_size, 10);
+  
+  // Check for buffer overflow
+  size_t num_len = strlen(num_buffer.data());
+  size_t den_len = strlen(den_buffer.data());
+  
+  if (num_len >= buffer_size - 1 || den_len >= buffer_size - 1) {
+    log_warning("BigInt to string conversion may have been truncated - buffer too small");
+    return 0.0; // Safer to return 0 than use truncated data
+  }
   
   try {
     double num_val = std::stod(num_buffer.data());

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2542,18 +2542,18 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
     if (int_encoding)
     {
       BigInt numerator, denominator;
-      if (get_rational(a, numerator, denominator)) 
+      if (get_rational(a, numerator, denominator))
       {
         double value = convert_rational_to_double(numerator, denominator);
         unsigned int type_width = type->get_width();
-      
-        if (type_width == ieee_float_spect::single_precision().width()) 
+
+        if (type_width == ieee_float_spect::single_precision().width())
         {
           ieee_floatt ieee_val(ieee_float_spect::single_precision());
           ieee_val.from_float(static_cast<float>(value));
           return constant_floatbv2tc(ieee_val);
-        } 
-        else 
+        }
+        else
         {
           ieee_floatt ieee_val(ieee_float_spect::double_precision());
           ieee_val.from_double(value);
@@ -2612,19 +2612,24 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
   }
 }
 
-double smt_convt::convert_rational_to_double(const BigInt &numerator, const BigInt &denominator)
+double smt_convt::convert_rational_to_double(
+  const BigInt &numerator,
+  const BigInt &denominator)
 {
   char num_buffer[256];
   char den_buffer[256];
-  
+
   numerator.as_string(num_buffer, sizeof(num_buffer), 10);
   denominator.as_string(den_buffer, sizeof(den_buffer), 10);
-  
-  try {
+
+  try
+  {
     double num_val = std::stod(std::string(num_buffer));
     double den_val = std::stod(std::string(den_buffer));
     return (den_val != 0.0) ? num_val / den_val : 0.0;
-  } catch (const std::exception &) {
+  }
+  catch (const std::exception &)
+  {
     return 0.0; // Fallback value
   }
 }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2620,25 +2620,23 @@ expr2tc smt_convt::get_by_ast(const type2tc &type, smt_astt a)
   }
 }
 
-double smt_convt::convert_rational_to_double(
-  const BigInt &numerator,
-  const BigInt &denominator)
+double smt_convt::convert_rational_to_double(const BigInt &numerator, const BigInt &denominator)
 {
-  char num_buffer[256];
-  char den_buffer[256];
-
-  numerator.as_string(num_buffer, sizeof(num_buffer), 10);
-  denominator.as_string(den_buffer, sizeof(den_buffer), 10);
-
-  try
-  {
-    double num_val = std::stod(std::string(num_buffer));
-    double den_val = std::stod(std::string(den_buffer));
+  // Can handle very large BigInt values
+  size_t buffer_size = 1024;
+  
+  std::vector<char> num_buffer(buffer_size);
+  std::vector<char> den_buffer(buffer_size);
+  
+  numerator.as_string(num_buffer.data(), buffer_size, 10);
+  denominator.as_string(den_buffer.data(), buffer_size, 10);
+  
+  try {
+    double num_val = std::stod(num_buffer.data());
+    double den_val = std::stod(den_buffer.data());
     return (den_val != 0.0) ? num_val / den_val : 0.0;
-  }
-  catch (const std::exception &)
-  {
-    return 0.0; // Fallback value
+  } catch (const std::exception &) {
+    return 0.0;
   }
 }
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2624,19 +2624,23 @@ double smt_convt::convert_rational_to_double(
   const BigInt &numerator,
   const BigInt &denominator)
 {
-  size_t buffer_size = 1024;
+  constexpr size_t BUFFER_SIZE = 1024;
 
-  std::vector<char> num_buffer(buffer_size);
-  std::vector<char> den_buffer(buffer_size);
+  std::vector<char> num_buffer(BUFFER_SIZE, '\0');
+  std::vector<char> den_buffer(BUFFER_SIZE, '\0');
 
-  numerator.as_string(num_buffer.data(), buffer_size, 10);
-  denominator.as_string(den_buffer.data(), buffer_size, 10);
+  numerator.as_string(num_buffer.data(), BUFFER_SIZE, 10);
+  denominator.as_string(den_buffer.data(), BUFFER_SIZE, 10);
 
-  // Check for buffer overflow
-  size_t num_len = strlen(num_buffer.data());
-  size_t den_len = strlen(den_buffer.data());
+  // Force null termination to prevent over-read
+  num_buffer[BUFFER_SIZE - 1] = '\0';
+  den_buffer[BUFFER_SIZE - 1] = '\0';
 
-  if (num_len >= buffer_size - 1 || den_len >= buffer_size - 1)
+  // Use bounded string length check
+  size_t num_len = strnlen(num_buffer.data(), BUFFER_SIZE);
+  size_t den_len = strnlen(den_buffer.data(), BUFFER_SIZE);
+
+  if (num_len >= BUFFER_SIZE - 1 || den_len >= BUFFER_SIZE - 1)
   {
     log_warning(
       "BigInt to string conversion may have been truncated - buffer too small");

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -254,6 +254,19 @@ public:
    *  @return Expression representation of a's value */
   expr2tc get_by_value(const type2tc &type, BigInt value);
 
+  /** Extract the assignment to a rational/real value from the SMT solvers model.
+   *  Used in integer/real arithmetic mode to get floating point values.
+   *  @param a The AST whose value we wish to know.
+   *  @param numerator Output parameter for the numerator of the rational.
+   *  @param denominator Output parameter for the denominator of the rational.
+   *  @return True if the rational value was successfully extracted, false otherwise. */
+   virtual bool get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
+  {
+    // Default implementation returns false - solver-specific implementations should override this
+    (void)a; (void)numerator; (void)denominator;
+    return false;
+  }
+
   /** Fetch a satisfying assignment from the solver. If a previous call to
    *  dec_solve returned satisfiable, then the solver has a set of assignments
    *  to symbols / variables used in the formula. This method retrieves the
@@ -859,6 +872,9 @@ public:
   // Workaround for integer shifts. This is an array of the powers of two,
   // up to 2^64.
   smt_astt int_shift_op_array;
+
+private:
+  double convert_rational_to_double(const BigInt &numerator, const BigInt &denominator);
 };
 
 /** Given an array type, create a type2tc representing its domain. */

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -260,10 +260,12 @@ public:
    *  @param numerator Output parameter for the numerator of the rational.
    *  @param denominator Output parameter for the denominator of the rational.
    *  @return True if the rational value was successfully extracted, false otherwise. */
-   virtual bool get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
+  virtual bool get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
   {
     // Default implementation returns false - solver-specific implementations should override this
-    (void)a; (void)numerator; (void)denominator;
+    (void)a;
+    (void)numerator;
+    (void)denominator;
     return false;
   }
 
@@ -874,7 +876,9 @@ public:
   smt_astt int_shift_op_array;
 
 private:
-  double convert_rational_to_double(const BigInt &numerator, const BigInt &denominator);
+  double convert_rational_to_double(
+    const BigInt &numerator,
+    const BigInt &denominator);
 };
 
 /** Given an array type, create a type2tc representing its domain. */

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1321,28 +1321,29 @@ BigInt z3_convt::get_bv(smt_astt a, bool is_signed)
 bool z3_convt::get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
 {
   const z3_smt_ast *za = static_cast<const z3_smt_ast *>(a);
-  
+
   // First check if this is a numeral (constant value)
-  if (Z3_get_ast_kind(z3_ctx, za->a) == Z3_NUMERAL_AST) 
+  if (Z3_get_ast_kind(z3_ctx, za->a) == Z3_NUMERAL_AST)
   {
     Z3_string str = Z3_get_numeral_string(z3_ctx, za->a);
     if (str != nullptr)
       return parse_rational_bigint(str, numerator, denominator);
-  } 
-  else 
+  }
+  else
   {
     // It's not a numeral, need to evaluate it in the model
     // Get the current model from Z3 solver
     Z3_model current_model = Z3_solver_get_model(z3_ctx, solver);
-    if (current_model != nullptr) 
+    if (current_model != nullptr)
     {
       Z3_ast evaluated;
-      bool eval_success = Z3_model_eval(z3_ctx, current_model, za->a, true, &evaluated);
-      
-      if (eval_success && evaluated != nullptr) 
+      bool eval_success =
+        Z3_model_eval(z3_ctx, current_model, za->a, true, &evaluated);
+
+      if (eval_success && evaluated != nullptr)
       {
         // Check if the evaluated result is a numeral
-        if (Z3_get_ast_kind(z3_ctx, evaluated) == Z3_NUMERAL_AST) 
+        if (Z3_get_ast_kind(z3_ctx, evaluated) == Z3_NUMERAL_AST)
         {
           Z3_string str = Z3_get_numeral_string(z3_ctx, evaluated);
           if (str != nullptr)
@@ -1351,25 +1352,28 @@ bool z3_convt::get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
       }
     }
   }
-  
+
   return false;
 }
 
-bool z3_convt::parse_rational_bigint(Z3_string str, BigInt &numerator, BigInt &denominator)
+bool z3_convt::parse_rational_bigint(
+  Z3_string str,
+  BigInt &numerator,
+  BigInt &denominator)
 {
   std::string value_str(str);
-  
-  if (value_str.find('/') != std::string::npos) 
+
+  if (value_str.find('/') != std::string::npos)
   {
     // Parse rational "numerator/denominator"
     size_t slash_pos = value_str.find('/');
     std::string num_str = value_str.substr(0, slash_pos);
     std::string den_str = value_str.substr(slash_pos + 1);
-    
+
     numerator = BigInt(num_str.c_str());
     denominator = BigInt(den_str.c_str());
-  } 
-  else 
+  }
+  else
   {
     // Integer value - denominator is 1
     numerator = BigInt(value_str.c_str());

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1318,6 +1318,66 @@ BigInt z3_convt::get_bv(smt_astt a, bool is_signed)
   return binary2integer(bin, is_signed);
 }
 
+bool z3_convt::get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
+{
+  const z3_smt_ast *za = static_cast<const z3_smt_ast *>(a);
+  
+  // First check if this is a numeral (constant value)
+  if (Z3_get_ast_kind(z3_ctx, za->a) == Z3_NUMERAL_AST) 
+  {
+    Z3_string str = Z3_get_numeral_string(z3_ctx, za->a);
+    if (str != nullptr)
+      return parse_rational_bigint(str, numerator, denominator);
+  } 
+  else 
+  {
+    // It's not a numeral, need to evaluate it in the model
+    // Get the current model from Z3 solver
+    Z3_model current_model = Z3_solver_get_model(z3_ctx, solver);
+    if (current_model != nullptr) 
+    {
+      Z3_ast evaluated;
+      bool eval_success = Z3_model_eval(z3_ctx, current_model, za->a, true, &evaluated);
+      
+      if (eval_success && evaluated != nullptr) 
+      {
+        // Check if the evaluated result is a numeral
+        if (Z3_get_ast_kind(z3_ctx, evaluated) == Z3_NUMERAL_AST) 
+        {
+          Z3_string str = Z3_get_numeral_string(z3_ctx, evaluated);
+          if (str != nullptr)
+            return parse_rational_bigint(str, numerator, denominator);
+        }
+      }
+    }
+  }
+  
+  return false;
+}
+
+bool z3_convt::parse_rational_bigint(Z3_string str, BigInt &numerator, BigInt &denominator)
+{
+  std::string value_str(str);
+  
+  if (value_str.find('/') != std::string::npos) 
+  {
+    // Parse rational "numerator/denominator"
+    size_t slash_pos = value_str.find('/');
+    std::string num_str = value_str.substr(0, slash_pos);
+    std::string den_str = value_str.substr(slash_pos + 1);
+    
+    numerator = BigInt(num_str.c_str());
+    denominator = BigInt(den_str.c_str());
+  } 
+  else 
+  {
+    // Integer value - denominator is 1
+    numerator = BigInt(value_str.c_str());
+    denominator = BigInt("1");
+  }
+  return true;
+}
+
 ieee_floatt z3_convt::get_fpbv(smt_astt a)
 {
   const z3_smt_ast *za = to_solver_smt_ast<z3_smt_ast>(a);

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1348,8 +1348,9 @@ bool z3_convt::get_rational(smt_astt a, BigInt &numerator, BigInt &denominator)
       bool eval_success =
         Z3_model_eval(z3_ctx, current_model, za->a, true, &evaluated);
 
-      if (eval_success && evaluated != nullptr &&
-          Z3_get_ast_kind(z3_ctx, evaluated) == Z3_NUMERAL_AST)
+      if (
+        eval_success && evaluated != nullptr &&
+        Z3_get_ast_kind(z3_ctx, evaluated) == Z3_NUMERAL_AST)
       {
         int64_t num, den;
         if (Z3_get_numeral_rational_int64(z3_ctx, evaluated, &num, &den))

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -1378,10 +1378,10 @@ bool z3_convt::parse_rational_bigint(
 {
   std::string value_str(str);
 
-  if (value_str.find('/') != std::string::npos)
+  size_t slash_pos = value_str.find('/');
+  if (slash_pos != std::string::npos)
   {
     // Parse rational "numerator/denominator"
-    size_t slash_pos = value_str.find('/');
     std::string num_str = value_str.substr(0, slash_pos);
     std::string den_str = value_str.substr(slash_pos + 1);
 

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -39,7 +39,8 @@ public:
   bool get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   ieee_floatt get_fpbv(smt_astt a) override;
-  bool get_rational(smt_astt a, BigInt &numerator, BigInt &denominator) override;
+  bool
+  get_rational(smt_astt a, BigInt &numerator, BigInt &denominator) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
     override;
 
@@ -211,7 +212,8 @@ public:
 
 private:
   void print_smt_formulae(std::ostream &dest);
-  bool parse_rational_bigint(Z3_string str, BigInt &numerator, BigInt &denominator);
+  bool
+  parse_rational_bigint(Z3_string str, BigInt &numerator, BigInt &denominator);
 
 public:
   virtual void output_smt();

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -39,6 +39,7 @@ public:
   bool get_bool(smt_astt a) override;
   BigInt get_bv(smt_astt a, bool is_signed) override;
   ieee_floatt get_fpbv(smt_astt a) override;
+  bool get_rational(smt_astt a, BigInt &numerator, BigInt &denominator) override;
   expr2tc get_array_elem(smt_astt array, uint64_t index, const type2tc &subtype)
     override;
 
@@ -210,6 +211,7 @@ public:
 
 private:
   void print_smt_formulae(std::ostream &dest);
+  bool parse_rational_bigint(Z3_string str, BigInt &numerator, BigInt &denominator);
 
 public:
   virtual void output_smt();


### PR DESCRIPTION
In integer/real arithmetic mode, floating point values are represented as rational numbers in the SMT solver, but `get_by_ast()` was returning empty expressions, causing counterexamples to show "(assignment removed)" instead of actual values.

Changes:
- Add virtual `get_rational()` method to `smt_convt` interface.
- Implement rational-to-floating-point conversion in get_by_ast() for floatbv types.
- Provide default implementation that return false (to be overridden by solvers).

This enables the proper display of floating-point variable values in counterexamples when using integer/real arithmetic mode. Solver-specific implementations of the new virtual method is required for each SMT backend. However, I have implemented it for Z3 only here.