### PR TITLE
[smt] default to Z3 solver when using --ir option

### DIFF
--- a/regression/floats/Float24/main.c
+++ b/regression/floats/Float24/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  float a, b, _a=a, _b=b;
+  __ESBMC_assume(a==1 && b==2);
+  assert(a!=b);
+}

--- a/regression/floats/Float24/test.desc
+++ b/regression/floats/Float24/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv --ir
+^Using integer\/real arithmetic mode; defaulting to Z3$

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -113,10 +113,14 @@ pick_solver(std::string &solver_name, const optionst &options)
     }
     else
     {
-      log_warning("Z3 not available for integer/real arithmetic mode; using default solver");
+      log_warning(
+        "Z3 not available for integer/real arithmetic mode; using default "
+        "solver");
     }
 #else
-    log_warning("Z3 not built into this version of ESBMC; using default solver for integer/real mode");
+    log_warning(
+      "Z3 not built into this version of ESBMC; using default solver for "
+      "integer/real mode");
 #endif
   }
   if (solver_name == "")

--- a/src/solvers/solve.cpp
+++ b/src/solvers/solve.cpp
@@ -102,6 +102,23 @@ pick_solver(std::string &solver_name, const optionst &options)
   if (solver_name == "")
     solver_name = options.get_option("default-solver");
 
+  // Check for --ir option and default to Z3 for integer/real arithmetic
+  if (solver_name == "" && options.get_bool_option("ir"))
+  {
+#ifdef Z3
+    if (esbmc_solvers.count("z3"))
+    {
+      log_status("Using integer/real arithmetic mode; defaulting to Z3");
+      solver_name = "z3";
+    }
+    else
+    {
+      log_warning("Z3 not available for integer/real arithmetic mode; using default solver");
+    }
+#else
+    log_warning("Z3 not built into this version of ESBMC; using default solver for integer/real mode");
+#endif
+  }
   if (solver_name == "")
     solver_name = pick_default_solver();
 


### PR DESCRIPTION
Automatically select Z3 for integer/real arithmetic mode due to its superior support for these operations. Maintains user override capabilities and graceful fallback when Z3 unavailable.