### PR TITLE
[bmc] add colored summary and results for multi-property verification

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1511,10 +1511,10 @@ void bmct::report_simple_summary(const SimpleSummary &summary) const
 
   std::ostringstream timing_oss;
   timing_oss << "Solver: " << summary.solver_name
-             << " • Decision procedure total time: " << time2string(summary.total_time_s)
-             << "s"
-             << " • Avg: " << std::fixed << std::setprecision(1) << time2string(avg_time)
-             << "s/property";
+             << " • Decision procedure total time: "
+             << time2string(summary.total_time_s) << "s"
+             << " • Avg: " << std::fixed << std::setprecision(1)
+             << time2string(avg_time) << "s/property";
 
   // Output the summary
   log_result("{}", properties_oss.str());

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1503,7 +1503,7 @@ void bmct::report_simple_summary(const SimpleSummary &summary) const
     properties_oss << " " << GREEN << "✓ " << summary.passed_properties
                    << " passed" << RESET;
 
-    if (summary.skipped_properties > 0)
+  if (summary.skipped_properties > 0)
     properties_oss << ", " << GREEN << "✓ " << summary.skipped_properties
                    << " skipped" << RESET;
 

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1350,7 +1350,10 @@ smt_convt::resultt bmct::multi_property_check(
 
     // skip if we have already verified
     if (is_verified && !is_keep_verified)
+    {
+      ++summary.skipped_properties;
       return;
+    }
 
     // Slice
     if (!options.get_bool_option("no-slice"))
@@ -1499,6 +1502,10 @@ void bmct::report_simple_summary(const SimpleSummary &summary) const
   if (summary.passed_properties > 0)
     properties_oss << " " << GREEN << "✓ " << summary.passed_properties
                    << " passed" << RESET;
+
+    if (summary.skipped_properties > 0)
+    properties_oss << ", " << GREEN << "✓ " << summary.skipped_properties
+                   << " skipped" << RESET;
 
   if (summary.failed_properties > 0)
     properties_oss << ", " << RED << "✗ " << summary.failed_properties

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -113,6 +113,7 @@ private:
   {
     size_t total_properties = 0;
     size_t passed_properties = 0;
+    size_t skipped_properties = 0;
     size_t failed_properties = 0;
     double total_time_s = 0.0;
     std::string solver_name;

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -107,6 +107,18 @@ protected:
     const bool &is_branch_func_cov,
     const std::unordered_set<std::string> &reached_claims,
     const std::unordered_multiset<std::string> &reached_mul_claims);
+
+private:
+  struct SimpleSummary
+  {
+    size_t total_properties = 0;
+    size_t passed_properties = 0;
+    size_t failed_properties = 0;
+    double total_time_s = 0.0;
+    std::string solver_name;
+  };
+
+  void report_simple_summary(const SimpleSummary &summary) const;
 };
 
 void report_coverage(


### PR DESCRIPTION
This PR:
- Shows colored ✓/✗ indicators for individual claim results
- Displays summary with pass/fail counts, timing, and solver info
- Uses green for passed claims, red for failures

Here is the output for VERIFICATION FAILED:

![image](https://github.com/user-attachments/assets/c0557eed-828b-4f75-958f-6bafe8e96599)


![image](https://github.com/user-attachments/assets/aa379c2a-6d96-451b-87b8-d6c6468d1661)


VERIFICATION SUCCESSFUL:

![image](https://github.com/user-attachments/assets/4fe6d30c-6b04-4df7-a273-30af5acf8ebd)
