### PR TITLE
[multi-property] fix clear verifired claims

### DIFF
--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -65,10 +65,8 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
     // Run cache if user has specified the option
     if (options.get_bool_option("cache-asserts"))
       // Store the set between runs
-      algorithms.emplace_back(
-        std::make_unique<assertion_cache>(
-          config.ssa_caching_db,
-          !options.get_bool_option("forward-condition")));
+      algorithms.emplace_back(std::make_unique<assertion_cache>(
+        config.ssa_caching_db, !options.get_bool_option("forward-condition")));
 
     if (opts.get_bool_option("ssa-features-dump"))
       algorithms.emplace_back(std::make_unique<ssa_features>());
@@ -1237,8 +1235,9 @@ int bmct::ltl_run_thread(symex_target_equationt &equation) const
   return ltl_res_good;
 }
 
-smt_convt::resultt
-bmct::multi_property_check(const symex_target_equationt &eq, size_t remaining_claims)
+smt_convt::resultt bmct::multi_property_check(
+  const symex_target_equationt &eq,
+  size_t remaining_claims)
 {
   // As of now, it only makes sense to do this for the base-case
   assert(
@@ -1327,8 +1326,7 @@ bmct::multi_property_check(const symex_target_equationt &eq, size_t remaining_cl
                        &fail_fast_cnt,
                        &bs,
                        &fc,
-                       &is](const size_t &i)
-  {
+                       &is](const size_t &i) {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1238,7 +1238,7 @@ int bmct::ltl_run_thread(symex_target_equationt &equation) const
 }
 
 smt_convt::resultt
-bmct::multi_property_check(symex_target_equationt &eq, size_t remaining_claims)
+bmct::multi_property_check(const symex_target_equationt &eq, size_t remaining_claims)
 {
   // As of now, it only makes sense to do this for the base-case
   assert(

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -378,7 +378,7 @@ void bmct::clear_verified_claims_in_ssa(
   }
 }
 
-void bmct::clear_verified_claims_in_ssa_in_goto(
+void bmct::clear_verified_claims_in_goto(
   const claim_slicer &claim,
   const bool &is_goto_cov)
 {
@@ -1358,7 +1358,7 @@ smt_convt::resultt bmct::multi_property_check(
     if (verified_claims.count(claim_sig))
     {
       clear_verified_claims_in_ssa(local_eq, claim, is_goto_cov);
-      clear_verified_claims_in_ssa_in_goto(claim, is_goto_cov);
+      clear_verified_claims_in_goto(claim, is_goto_cov);
       is_verified = true;
     }
 
@@ -1444,7 +1444,7 @@ smt_convt::resultt bmct::multi_property_check(
       if (!is_keep_verified && (bs || fc || is))
       {
         clear_verified_claims_in_ssa(local_eq, claim, is_goto_cov);
-        clear_verified_claims_in_ssa_in_goto(claim, is_goto_cov);
+        clear_verified_claims_in_goto(claim, is_goto_cov);
       }
     }
     else if (solver_result == smt_convt::P_UNSATISFIABLE)
@@ -1454,7 +1454,7 @@ smt_convt::resultt bmct::multi_property_check(
       if (!is_keep_verified && !bs)
       {
         clear_verified_claims_in_ssa(local_eq, claim, is_goto_cov);
-        clear_verified_claims_in_ssa_in_goto(claim, is_goto_cov);
+        clear_verified_claims_in_goto(claim, is_goto_cov);
       }
   };
 

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -76,8 +76,9 @@ protected:
 
   int ltl_run_thread(symex_target_equationt &equation) const;
 
-  smt_convt::resultt
-  multi_property_check(const symex_target_equationt &eq, size_t remaining_claims);
+  smt_convt::resultt multi_property_check(
+    const symex_target_equationt &eq,
+    size_t remaining_claims);
 
   std::vector<std::unique_ptr<ssa_step_algorithm>> algorithms;
 

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -91,7 +91,7 @@ protected:
     symex_target_equationt &local_eq,
     const claim_slicer &claim,
     const bool &is_goto_cov);
-  void clear_verified_claims_in_ssa_in_goto(
+  void clear_verified_claims_in_goto(
     const claim_slicer &claim,
     const bool &is_goto_cov);
 

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -77,7 +77,7 @@ protected:
   int ltl_run_thread(symex_target_equationt &equation) const;
 
   smt_convt::resultt
-  multi_property_check(symex_target_equationt &eq, size_t remaining_claims);
+  multi_property_check(const symex_target_equationt &eq, size_t remaining_claims);
 
   std::vector<std::unique_ptr<ssa_step_algorithm>> algorithms;
 

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -76,9 +76,8 @@ protected:
 
   int ltl_run_thread(symex_target_equationt &equation) const;
 
-  smt_convt::resultt multi_property_check(
-    const symex_target_equationt &eq,
-    size_t remaining_claims);
+  smt_convt::resultt
+  multi_property_check(symex_target_equationt &eq, size_t remaining_claims);
 
   std::vector<std::unique_ptr<ssa_step_algorithm>> algorithms;
 
@@ -87,8 +86,13 @@ protected:
     symex_target_equationt &eq) const;
 
   // for multi-property
-  void
-  clear_verified_claims(const claim_slicer &claim, const bool &is_goto_cov);
+  void clear_verified_claims_in_ssa(
+    symex_target_equationt &local_eq,
+    const claim_slicer &claim,
+    const bool &is_goto_cov);
+  void clear_verified_claims_in_ssa_in_goto(
+    const claim_slicer &claim,
+    const bool &is_goto_cov);
 
   virtual void report_multi_property_trace(
     const smt_convt::resultt &res,


### PR DESCRIPTION
```
int main()
{
    int x = 0;

    assert(x < 0);
    while(++x<10)
        assert(x<5);
}
```


Bug fix for things like:
![c763974dd391c17a9c261774f6520c0e](https://github.com/user-attachments/assets/11a6d87a-ff9d-41b1-8190-b241e71bf716)

where `1` should be true, but still got verified as failed.

```sh
# before
Properties: 6 verified, √3 skipped, X3 failed
# after
Properties: 6 verified, √4 skipped, X2 failed
```