### PR TITLE
[Solidity] Change default setting from 'bound' to 'unbound'

### DIFF
--- a/regression/esbmc-solidity/address_bind_1/test.desc
+++ b/regression/esbmc-solidity/address_bind_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Base --k-induction --no-standard-check
+--sol contract.sol --contract Base --k-induction --no-standard-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_2/test.desc
+++ b/regression/esbmc-solidity/address_bind_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Base --k-induction --no-standard-check
+--sol contract.sol --contract Base --k-induction --no-standard-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_3/test.desc
+++ b/regression/esbmc-solidity/address_bind_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Base --k-induction --no-standard-check
+--sol contract.sol --contract Base --k-induction --no-standard-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_4/test.desc
+++ b/regression/esbmc-solidity/address_bind_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Base --k-induction --no-standard-check
+--sol contract.sol --contract Base --k-induction --no-standard-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_5/test.desc
+++ b/regression/esbmc-solidity/address_bind_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Base --k-induction --no-standard-check
+--sol contract.sol --contract Base --k-induction --no-standard-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_6/test.desc
+++ b/regression/esbmc-solidity/address_bind_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_7/test.desc
+++ b/regression/esbmc-solidity/address_bind_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/address_bind_8/test.desc
+++ b/regression/esbmc-solidity/address_bind_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/bytes_1/test.desc
+++ b/regression/esbmc-solidity/bytes_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract Dreive --sol contract.sol --k-induction --no-standard-checks
+--contract Dreive --sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/bytes_2/test.desc
+++ b/regression/esbmc-solidity/bytes_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/bytes_3/test.desc
+++ b/regression/esbmc-solidity/bytes_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract Dreive --sol contract.sol --k-induction
+--contract Dreive --sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/bytes_4/test.desc
+++ b/regression/esbmc-solidity/bytes_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract Dreive --sol contract.sol --k-induction --no-standard-checks
+--contract Dreive --sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/bytes_5/test.desc
+++ b/regression/esbmc-solidity/bytes_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract Base --sol contract.sol --unwind 4 --no-unwinding-assertions   --no-standard-checks
+--contract Base --sol contract.sol --unwind 4 --no-unwinding-assertions   --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/bytes_6/test.desc
+++ b/regression/esbmc-solidity/bytes_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol  --unwind 4 --no-unwinding-assertions  --no-standard-checks
+--sol contract.sol  --unwind 4 --no-unwinding-assertions  --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/call_5/test.desc
+++ b/regression/esbmc-solidity/call_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --no-standard-checks --unwind 3 --no-unwinding-assertions --contract Reproduction
+--sol contract.sol --no-standard-checks --unwind 3 --no-unwinding-assertions --contract Reproduction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/constructor_1/test.desc
+++ b/regression/esbmc-solidity/constructor_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 2 --no-unwinding-assertions --no-standard-checks
+--sol contract.sol --unwind 2 --no-unwinding-assertions --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/constructor_2/test.desc
+++ b/regression/esbmc-solidity/constructor_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 2 --no-unwinding-assertions --no-standard-checks
+--sol contract.sol --unwind 2 --no-unwinding-assertions --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/constructor_3/test.desc
+++ b/regression/esbmc-solidity/constructor_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract Derive --sol contract.sol --unwind 3 --no-unwinding-assertions
+--contract Derive --sol contract.sol --unwind 3 --no-unwinding-assertions --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/constructor_4/test.desc
+++ b/regression/esbmc-solidity/constructor_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract DD --sol contract.sol --k-induction --no-standard-checks
+--contract DD --sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/constructor_5/test.desc
+++ b/regression/esbmc-solidity/constructor_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function D --contract DD --sol contract.sol --k-induction
+--function D --contract DD --sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/constructor_6/test.desc
+++ b/regression/esbmc-solidity/constructor_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function DD --contract DD --sol contract.sol --k-induction
+--function DD --contract DD --sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/contract_var_1/test.desc
+++ b/regression/esbmc-solidity/contract_var_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/contract_var_2/test.desc
+++ b/regression/esbmc-solidity/contract_var_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/contract_var_3/test.desc
+++ b/regression/esbmc-solidity/contract_var_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract UserContract
+--sol contract.sol --k-induction --contract UserContract --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/doftcoin_2/test.desc
+++ b/regression/esbmc-solidity/doftcoin_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --incremental-bmc --no-standard-checks --unsigned-overflow-check
+--sol contract.sol --contract Reproduction --incremental-bmc --no-standard-checks --unsigned-overflow-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/func_sig_1/test.desc
+++ b/regression/esbmc-solidity/func_sig_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract C --no-standard-checks
+--sol contract.sol --k-induction --contract C --no-standard-checks --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/func_sig_2/test.desc
+++ b/regression/esbmc-solidity/func_sig_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --no-standard-checks --unwind 4 --no-unwinding-assertions
+--sol contract.sol --contract C --no-standard-checks --unwind 4 --no-unwinding-assertions --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/func_sig_3/test.desc
+++ b/regression/esbmc-solidity/func_sig_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract C --no-standard-checks
+--sol contract.sol --k-induction --contract C --no-standard-checks --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/func_sig_4/test.desc
+++ b/regression/esbmc-solidity/func_sig_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --no-standard-checks --unwind 5 --no-unwinding-assertions
+--sol contract.sol --contract C --no-standard-checks --unwind 5 --no-unwinding-assertions --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/func_sig_5/test.desc
+++ b/regression/esbmc-solidity/func_sig_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --no-standard-checks --unwind 5 --no-unwinding-assertions
+--sol contract.sol --contract C --no-standard-checks --unwind 5 --no-unwinding-assertions --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/func_sig_6/test.desc
+++ b/regression/esbmc-solidity/func_sig_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --no-standard-checks --unwind 5 --no-unwinding-assertions
+--sol contract.sol --contract C --no-standard-checks --unwind 5 --no-unwinding-assertions --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/function_overload_1/test.desc
+++ b/regression/esbmc-solidity/function_overload_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 function_overload.solast
---function test_overload --sol function_overload.sol --no-standard-checks --k-induction
+--function test_overload --sol function_overload.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/function_overload_1_fail/test.desc
+++ b/regression/esbmc-solidity/function_overload_1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 function_overload.solast
---function test_overload --sol function_overload.sol  --k-induction
+--function test_overload --sol function_overload.sol  --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/function_overload_2/test.desc
+++ b/regression/esbmc-solidity/function_overload_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 function_overload.solast
---function test_overload --sol function_overload.sol --no-standard-checks  --k-induction
+--function test_overload --sol function_overload.sol --no-standard-checks  --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/function_overload_2_fail/test.desc
+++ b/regression/esbmc-solidity/function_overload_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 function_overload.solast
---function test_overload --sol function_overload.sol  --k-induction
+--function test_overload --sol function_overload.sol  --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_1/test.desc
+++ b/regression/esbmc-solidity/import_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_10/test.desc
+++ b/regression/esbmc-solidity/import_10/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_11/test.desc
+++ b/regression/esbmc-solidity/import_11/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract DD --no-standard-checks
+--sol contract.sol --k-induction --contract DD --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_12/test.desc
+++ b/regression/esbmc-solidity/import_12/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function func_array_loop --sol contract.sol --k-induction
+--function func_array_loop --sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_13/test.desc
+++ b/regression/esbmc-solidity/import_13/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_14/test.desc
+++ b/regression/esbmc-solidity/import_14/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_15/test.desc
+++ b/regression/esbmc-solidity/import_15/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --incremental-bmc --no-standard-checks --contract A --base-k-step 2
+--sol contract.sol --incremental-bmc --no-standard-checks --contract A --base-k-step 2 --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_16/test.desc
+++ b/regression/esbmc-solidity/import_16/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract2.solast
---sol contract2.sol --k-induction
+--sol contract2.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_17/test.desc
+++ b/regression/esbmc-solidity/import_17/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract3.solast
---sol contract3.sol --k-induction
+--sol contract3.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_2/test.desc
+++ b/regression/esbmc-solidity/import_2/test.desc
@@ -1,4 +1,4 @@
 FUTURE
 contract.solast
---sol contract.sol --k-induction  --base-k-step 2 --no-standard-checks
+--sol contract.sol --k-induction  --base-k-step 2 --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_3/test.desc
+++ b/regression/esbmc-solidity/import_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_4/test.desc
+++ b/regression/esbmc-solidity/import_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast 
---sol contract.sol --k-induction --overflow-check
+--sol contract.sol --k-induction --overflow-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_5/test.desc
+++ b/regression/esbmc-solidity/import_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function Derive --contract Derive --sol contract.sol --k-induction
+--function Derive --contract Derive --sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/import_6/test.desc
+++ b/regression/esbmc-solidity/import_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_7/test.desc
+++ b/regression/esbmc-solidity/import_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_8/test.desc
+++ b/regression/esbmc-solidity/import_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/import_9/test.desc
+++ b/regression/esbmc-solidity/import_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Base --k-induction --no-standard-check
+--sol contract.sol --contract Base --k-induction --no-standard-check --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_1/test.desc
+++ b/regression/esbmc-solidity/inheritance_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast
---function test_override --sol inheritance.sol --no-standard-checks --k-induction
+--function test_override --sol inheritance.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_10/test.desc
+++ b/regression/esbmc-solidity/inheritance_10/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction  --no-standard-checks
+--sol contract.sol --k-induction  --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_11/test.desc
+++ b/regression/esbmc-solidity/inheritance_11/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction 
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_12/test.desc
+++ b/regression/esbmc-solidity/inheritance_12/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks --contract Derived2
+--sol contract.sol --k-induction --no-standard-checks --contract Derived2 --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_1_fail/test.desc
+++ b/regression/esbmc-solidity/inheritance_1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast
---function test_override --sol inheritance.sol --k-induction
+--function test_override --sol inheritance.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_2/test.desc
+++ b/regression/esbmc-solidity/inheritance_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast 
---sol inheritance.sol --no-standard-checks --k-induction
+--sol inheritance.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_2_fail/test.desc
+++ b/regression/esbmc-solidity/inheritance_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast 
---function test_inheritance --sol inheritance.sol --k-induction
+--function test_inheritance --sol inheritance.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_3/test.desc
+++ b/regression/esbmc-solidity/inheritance_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast 
---function test_override --sol inheritance.sol --no-standard-checks --k-induction
+--function test_override --sol inheritance.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_3_fail/test.desc
+++ b/regression/esbmc-solidity/inheritance_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast 
---function test_override --sol inheritance.sol --k-induction
+--function test_override --sol inheritance.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_4/test.desc
+++ b/regression/esbmc-solidity/inheritance_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 inheritance.solast
---function test_inheritance --sol inheritance.sol --no-standard-checks --k-induction
+--function test_inheritance --sol inheritance.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_5/test.desc
+++ b/regression/esbmc-solidity/inheritance_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --k-induction --no-standard-checks
+--sol contract.sol --contract C --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_5_fail/test.desc
+++ b/regression/esbmc-solidity/inheritance_5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract C --k-induction --no-standard-checks
+--sol contract.sol --contract C --k-induction --no-standard-checks --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_6/test.desc
+++ b/regression/esbmc-solidity/inheritance_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract caller  --unwind 1 --no-unwinding-assertions --no-standard-check
+--sol contract.sol --contract caller  --unwind 1 --no-unwinding-assertions --no-standard-check --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_7/test.desc
+++ b/regression/esbmc-solidity/inheritance_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/inheritance_7_fail/test.desc
+++ b/regression/esbmc-solidity/inheritance_7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_8/test.desc
+++ b/regression/esbmc-solidity/inheritance_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract Base
+--sol contract.sol --k-induction --contract Base --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/inheritance_9/test.desc
+++ b/regression/esbmc-solidity/inheritance_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract DD --no-standard-checks
+--sol contract.sol --k-induction --contract DD --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_1/test.desc
+++ b/regression/esbmc-solidity/mapping_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 3 --no-unwinding-assertions   --z3 --no-standard-checks
+--sol contract.sol --unwind 3 --no-unwinding-assertions   --z3 --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_10/test.desc
+++ b/regression/esbmc-solidity/mapping_10/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 7 --no-unwinding-assertions   --no-standard-checks
+--sol contract.sol --unwind 7 --no-unwinding-assertions   --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_11/test.desc
+++ b/regression/esbmc-solidity/mapping_11/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 4 --no-unwinding-assertions --no-standard-checks
+--sol contract.sol --unwind 4 --no-unwinding-assertions --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_12/test.desc
+++ b/regression/esbmc-solidity/mapping_12/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/mapping_13/test.desc
+++ b/regression/esbmc-solidity/mapping_13/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 3 --no-unwinding-assertions
+--sol contract.sol --unwind 3 --no-unwinding-assertions --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_14/test.desc
+++ b/regression/esbmc-solidity/mapping_14/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract Derived 
+--sol contract.sol --k-induction --contract Derived --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_15/test.desc
+++ b/regression/esbmc-solidity/mapping_15/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract Derived --unbound
+--sol contract.sol --k-induction --contract Derived --unbound 
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/mapping_16/test.desc
+++ b/regression/esbmc-solidity/mapping_16/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --contract Derived 
+--sol contract.sol --k-induction --contract Derived --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/mapping_2/test.desc
+++ b/regression/esbmc-solidity/mapping_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --no-standard-checks --incremental-bmc --contract Base
+--sol contract.sol --no-standard-checks --incremental-bmc --contract Base --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/mapping_3/test.desc
+++ b/regression/esbmc-solidity/mapping_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 3 --no-unwinding-assertions   --contract Base --no-standard-checks
+--sol contract.sol --unwind 3 --no-unwinding-assertions   --contract Base --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_4/test.desc
+++ b/regression/esbmc-solidity/mapping_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 3 --no-unwinding-assertions   --contract Base2  --no-standard-checks
+--sol contract.sol --unwind 3 --no-unwinding-assertions   --contract Base2  --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_5/test.desc
+++ b/regression/esbmc-solidity/mapping_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks --contract Base
+--sol contract.sol --k-induction --no-standard-checks --contract Base --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/mapping_6/test.desc
+++ b/regression/esbmc-solidity/mapping_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 3 --no-unwinding-assertions   --no-standard-checks
+--sol contract.sol --unwind 3 --no-unwinding-assertions   --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_7/test.desc
+++ b/regression/esbmc-solidity/mapping_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --unwind 3 --no-unwinding-assertions   --no-simplify --no-standard-checks
+--sol contract.sol --unwind 3 --no-unwinding-assertions   --no-simplify --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/mapping_8/test.desc
+++ b/regression/esbmc-solidity/mapping_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks --contract Base
+--sol contract.sol --k-induction --no-standard-checks --contract Base --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/mapping_9/test.desc
+++ b/regression/esbmc-solidity/mapping_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks --contract Base 
+--sol contract.sol --k-induction --no-standard-checks --contract Base --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/multiple_contracts_1/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 mul.solast
---function func_array_loop --sol mul.sol --k-induction
+--function func_array_loop --sol mul.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/multiple_contracts_2/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 mul.solast
---function empty --contract A --sol mul.sol --no-standard-checks --k-induction
+--function empty --contract A --sol mul.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/multiple_contracts_5/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 mul.solast
---function test --contract Base --sol mul.sol --no-standard-checks --k-induction
+--function test --contract Base --sol mul.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/multiple_contracts_6/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 mul.solast
---function test --contract Derived --sol mul.sol  --k-induction
+--function test --contract Derived --sol mul.sol  --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/multiple_contracts_7/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 mul.solast
---function test --contract Base --sol mul.sol --incremental-bmc
+--function test --contract Base --sol mul.sol --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/multiple_contracts_8/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 mul.solast
---function test --contract Derived --sol mul.sol --incremental-bmc
+--function test --contract Derived --sol mul.sol --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/multiple_contracts_9/test.desc
+++ b/regression/esbmc-solidity/multiple_contracts_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract "Derived Base" --sol contract.sol --k-induction
+--contract "Derived Base" --sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/op_binary_1/test.desc
+++ b/regression/esbmc-solidity/op_binary_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --no-standard-checks --k-induction
+--function test_op --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_binary_2/test.desc
+++ b/regression/esbmc-solidity/op_binary_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --no-standard-checks --k-induction
+--function test_op --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_binary_3/test.desc
+++ b/regression/esbmc-solidity/op_binary_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --no-standard-checks --k-induction
+--function test_op --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_binary_4/test.desc
+++ b/regression/esbmc-solidity/op_binary_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --incremental-bmc
+--function test_op --sol contract.sol --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/op_binary_5/test.desc
+++ b/regression/esbmc-solidity/op_binary_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function comp --sol contract.sol --k-induction --no-standard-checks
+--function comp --sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_binary_6/test.desc
+++ b/regression/esbmc-solidity/op_binary_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/op_binary_7/test.desc
+++ b/regression/esbmc-solidity/op_binary_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_unary_1/test.desc
+++ b/regression/esbmc-solidity/op_unary_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --no-standard-checks --k-induction
+--function test_op --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_unary_2/test.desc
+++ b/regression/esbmc-solidity/op_unary_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --no-standard-checks --k-induction
+--function test_op --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/op_unary_3/test.desc
+++ b/regression/esbmc-solidity/op_unary_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_op --sol contract.sol --incremental-bmc
+--function test_op --sol contract.sol --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_1/test.desc
+++ b/regression/esbmc-solidity/reentrance_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --incremental-bmc
+--sol contract.sol --contract Reproduction --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_10/test.desc
+++ b/regression/esbmc-solidity/reentrance_10/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --k-induction --no-standard-checks
+--sol contract.sol --contract Reproduction --k-induction --no-standard-checks --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_13/test.desc
+++ b/regression/esbmc-solidity/reentrance_13/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --no-standard-checks --incremental-bmc
+--sol contract.sol --contract Reproduction --no-standard-checks --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_2/test.desc
+++ b/regression/esbmc-solidity/reentrance_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --k-induction
+--sol contract.sol --contract Reproduction --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_3/test.desc
+++ b/regression/esbmc-solidity/reentrance_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --k-induction
+--sol contract.sol --contract Reproduction --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_4/test.desc
+++ b/regression/esbmc-solidity/reentrance_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --k-induction
+--sol contract.sol --contract Reproduction --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_6/test.desc
+++ b/regression/esbmc-solidity/reentrance_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --incremental-bmc
+--sol contract.sol --contract Reproduction --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_7/test.desc
+++ b/regression/esbmc-solidity/reentrance_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --incremental-bmc
+--sol contract.sol --contract Reproduction --incremental-bmc --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_8/test.desc
+++ b/regression/esbmc-solidity/reentrance_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --k-induction
+--sol contract.sol --contract Reproduction --k-induction --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/reentrance_9/test.desc
+++ b/regression/esbmc-solidity/reentrance_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --contract Reproduction --k-induction --reentry-check --no-standard-checks
+--sol contract.sol --contract Reproduction --k-induction --reentry-check --no-standard-checks --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/return_1/test.desc
+++ b/regression/esbmc-solidity/return_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function getResult --sol contract.sol --no-standard-checks --k-induction
+--function getResult --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/return_3/test.desc
+++ b/regression/esbmc-solidity/return_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks
+--sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/return_4/test.desc
+++ b/regression/esbmc-solidity/return_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_return --sol contract.sol --no-standard-checks --k-induction
+--function test_return --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/return_5/test.desc
+++ b/regression/esbmc-solidity/return_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---function test_return --sol contract.sol --no-standard-checks --k-induction
+--function test_return --sol contract.sol --no-standard-checks --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/return_6/test.desc
+++ b/regression/esbmc-solidity/return_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---contract call --sol contract.sol --k-induction --no-standard-checks
+--contract call --sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/transfer_send_1/test.desc
+++ b/regression/esbmc-solidity/transfer_send_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction
+--sol contract.sol --k-induction --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/transfer_send_2/test.desc
+++ b/regression/esbmc-solidity/transfer_send_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---sol contract.sol --k-induction --no-standard-checks --contract TestTransfer
+--sol contract.sol --k-induction --no-standard-checks --contract TestTransfer --bound
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/unbound_2/test.desc
+++ b/regression/esbmc-solidity/unbound_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---incremental-bmc --unbound --sol contract.sol 
+--incremental-bmc --unbound --sol contract.sol
 ^VERIFICATION FAILED$

--- a/regression/esbmc-solidity/unbound_3/test.desc
+++ b/regression/esbmc-solidity/unbound_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---k-induction --no-standard-checks --sol contract.sol   
+--k-induction --no-standard-checks --sol contract.sol  --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/unbound_7/test.desc
+++ b/regression/esbmc-solidity/unbound_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 contract.solast
---no-standard-checks --sol contract.sol --unwind 3 --no-unwinding-assertions
+--no-standard-checks --sol contract.sol --unwind 3 --no-unwinding-assertions --bound
 ^VERIFICATION SUCCESSFUL$

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -46,7 +46,7 @@ solidity_convertert::solidity_convertert(
     member_entity_scope({}),
     initializers(code_blockt()),
     aux_counter(0),
-    is_bound(true),
+    is_bound(false),
     is_reentry_check(false),
     is_pointer_check(true),
     nondet_bool_expr(),
@@ -56,10 +56,10 @@ solidity_convertert::solidity_convertert(
   contract_contents.assign(
     (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
 
-  // bound setting - default value is true
-  const std::string unbound = config.options.get_option("unbound");
-  if (!unbound.empty())
-    is_bound = false;
+  // bound setting - default value is false
+  const std::string bound = config.options.get_option("bound");
+  if (!bound.empty())
+    is_bound = true;
 
   const std::string reentry_check = config.options.get_option("reentry-check");
   if (!reentry_check.empty())


### PR DESCRIPTION
This PR changes the default verification command from 'bound' to 'unbound'.