### PR TITLE
[smt] add IEEE 754 compliance for floating-point operations in real encoding

### DIFF
--- a/regression/esbmc/github_2572/test.desc
+++ b/regression/esbmc/github_2572/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --z3 --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2572_2/test.desc
+++ b/regression/esbmc/github_2572_2/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --z3 --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/floats/underflow1/main.c
+++ b/regression/floats/underflow1/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+ 
+int main() {
+    double x = nondet_double();
+    double y = nondet_double();
+ 
+    __ESBMC_assume(x > 0.0 && x < 1.0e-154);
+    __ESBMC_assume(y > 0.0 && y < 1.0e-154);
+ 
+    double result = x * y;
+ 
+    // Underflow check
+    assert(result > 0.0);  
+ 
+    return 0;
+}

--- a/regression/floats/underflow1/test.desc
+++ b/regression/floats/underflow1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow10/main.c
+++ b/regression/floats/underflow10/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <float.h>
+
+int main() {
+  double a = DBL_TRUE_MIN * 2;
+  double b = DBL_TRUE_MIN;
+  double result = a - b;
+
+  assert(result > 0.0);
+  return 0;
+}
+

--- a/regression/floats/underflow10/test.desc
+++ b/regression/floats/underflow10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/underflow11/main.c
+++ b/regression/floats/underflow11/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <float.h>
+
+int main() {
+  double small = DBL_MIN;
+  double large = 1e+308;
+  double result = small / large;
+
+  assert(result > 0.0); // Likely underflows to subnormal or 0.0
+  return 0;
+}
+

--- a/regression/floats/underflow11/test.desc
+++ b/regression/floats/underflow11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow12/main.c
+++ b/regression/floats/underflow12/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <float.h>
+
+int main() 
+{
+  double x = DBL_MIN;
+  double y = -DBL_MIN;
+  double result = x + y;
+
+  assert(result > 0.0); // Fails: exact zero due to cancellation
+  return 0;
+}

--- a/regression/floats/underflow12/test.desc
+++ b/regression/floats/underflow12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow13/main.c
+++ b/regression/floats/underflow13/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <float.h>
+
+int main() 
+{
+    double subnormal1 = DBL_TRUE_MIN * 2;
+    double subnormal2 = DBL_TRUE_MIN * 3;
+    double result = subnormal1 * subnormal2;
+    
+    assert(result > 0.0); // May underflow to zero
+    return 0;
+}
+

--- a/regression/floats/underflow13/test.desc
+++ b/regression/floats/underflow13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow14/main.c
+++ b/regression/floats/underflow14/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <float.h>
+
+int main() 
+{
+    double subnormal = DBL_TRUE_MIN * 100;
+    double large = 1e+100;
+    double result = subnormal / large;
+    
+    assert(result > 0.0); // Likely underflows to zero
+    return 0;
+}

--- a/regression/floats/underflow14/test.desc
+++ b/regression/floats/underflow14/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow15/main.c
+++ b/regression/floats/underflow15/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <float.h>
+
+int main() 
+{
+    double subnormal1 = DBL_TRUE_MIN * 5;
+    double subnormal2 = DBL_TRUE_MIN * 4;
+    double result = subnormal1 - subnormal2;
+    
+    assert(result == DBL_TRUE_MIN); // Should equal DBL_TRUE_MIN
+    return 0;
+}

--- a/regression/floats/underflow15/test.desc
+++ b/regression/floats/underflow15/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/underflow16/main.c
+++ b/regression/floats/underflow16/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+int main() 
+{
+    double x = -1e-200;
+    double y = -1e-200;
+    double result = x * y; // Should be positive due to sign rules
+    
+    assert(result > 0.0); // (-) * (-) = (+), but may underflow to 0
+    return 0;
+}

--- a/regression/floats/underflow16/test.desc
+++ b/regression/floats/underflow16/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow2/main.c
+++ b/regression/floats/underflow2/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main() 
+{
+  double x = 1e-200, y = 1e-200;
+  double result1 = x * y;        // Underflows to 0.0
+  assert(result1 > 0.0);         // FAILS - underflow
+  return 0;
+}

--- a/regression/floats/underflow2/test.desc
+++ b/regression/floats/underflow2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow3/main.c
+++ b/regression/floats/underflow3/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main() 
+{
+  double z = 1e-200;
+  double result2 = z + z;
+  assert(result2 > 1e+309);      
+  return 0;
+}

--- a/regression/floats/underflow3/test.desc
+++ b/regression/floats/underflow3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow4/main.c
+++ b/regression/floats/underflow4/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main() 
+{
+  double x = 1e-200, z = 1e+200;
+  double result3 = x / z;        // Underflows to 0.0
+  assert(result3 > 0.0);         // FAILS - underflow
+  return 0;
+}

--- a/regression/floats/underflow4/test.desc
+++ b/regression/floats/underflow4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow5/main.c
+++ b/regression/floats/underflow5/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+int main()
+{
+  float z = 1e30f;
+  float result2 = z * z;        // Overflows in single precision
+  assert(result2 < 1e40f);      // FAILS - single precision overflow
+
+  return 0;
+}
+

--- a/regression/floats/underflow5/test.desc
+++ b/regression/floats/underflow5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow6/main.c
+++ b/regression/floats/underflow6/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main()
+{
+  double a = 1e-200, b = 1e-200;
+  double result3 = a * b;       // Underflows to 0.0
+  assert(result3 > 0.0);        // FAILS - double precision underflow
+  return 0;
+}
+

--- a/regression/floats/underflow6/test.desc
+++ b/regression/floats/underflow6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow7/main.c
+++ b/regression/floats/underflow7/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main()
+{
+  float x = 1e-154, y = 1e-154;
+  float result = x * y;
+  assert(result > 0.0);
+  return 0;
+}

--- a/regression/floats/underflow7/test.desc
+++ b/regression/floats/underflow7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow8/main.c
+++ b/regression/floats/underflow8/main.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+ 
+int main() {
+    double x = nondet_double();
+    double y = nondet_double();
+ 
+    __ESBMC_assume(x > 0.0 && x < 1.0e-154);
+    __ESBMC_assume(y > 0.0 && y < 1.0e-154);
+ 
+    double product = x * y;
+    double ulp;
+ 
+    if (product < DBL_MIN) {
+        // Force underflow
+        product = nondet_double();
+        __ESBMC_assume(product == 0.0);
+        ulp = DBL_MIN * 0x1p-52;
+    } else {
+        ulp = product * 0x1p-52;
+    }
+ 
+    // Model IEEE-754 rounding error
+    double rounding_error = nondet_double();
+    __ESBMC_assume(rounding_error >= -ulp/2 && rounding_error <= ulp/2);
+ 
+    double result = product + rounding_error;
+ 
+    // Underflow check
+    assert(result > 0.0);
+ 
+    return 0;
+}
+

--- a/regression/floats/underflow8/test.desc
+++ b/regression/floats/underflow8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/regression/floats/underflow9/main.c
+++ b/regression/floats/underflow9/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <float.h>
+
+int main() {
+  double x = DBL_TRUE_MIN; // Smallest positive subnormal double
+  double y = 0.5;
+  double z = x * y;
+
+  assert(z > 0.0); // Fails: gradual underflow
+  return 0;
+}
+

--- a/regression/floats/underflow9/test.desc
+++ b/regression/floats/underflow9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -254,6 +254,48 @@ smt_astt smt_convt::convert_assign(const expr2tc &expr)
   return side2;
 }
 
+smt_astt smt_convt::get_zero_real()
+{
+  // Returns SMT representation of zero (0.0)
+  return mk_smt_real("0");
+}
+
+smt_astt smt_convt::get_double_min_normal()
+{
+  // IEEE 754 double precision minimum normal positive value (2^-1022)
+  return mk_smt_real("2.2250738585072014e-308");
+}
+
+smt_astt smt_convt::get_double_min_subnormal()
+{
+  // IEEE 754 double precision minimum positive subnormal value (2^-1074)
+  return mk_smt_real("4.9406564584124654e-324");
+}
+
+smt_astt smt_convt::get_double_max_normal()
+{
+  // IEEE 754 double precision maximum normal positive value (~(2-2^-52)*2^1023)
+  return mk_smt_real("1.7976931348623157e+308");
+}
+
+smt_astt smt_convt::get_single_min_normal()
+{
+  // IEEE 754 single precision minimum normal positive value (2^-126)
+  return mk_smt_real("1.1754943508222875e-38");
+}
+
+smt_astt smt_convt::get_single_min_subnormal()
+{
+  // IEEE 754 single precision minimum positive subnormal value (2^-149)
+  return mk_smt_real("1.4012984643248171e-45");
+}
+
+smt_astt smt_convt::get_single_max_normal()
+{
+  // IEEE 754 single precision maximum normal positive value (~(2-2^-23)*2^127)
+  return mk_smt_real("3.4028234663852886e+38");
+}
+
 // Apply IEEE 754 semantics to a real arithmetic result
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
@@ -271,17 +313,16 @@ smt_astt smt_convt::apply_ieee754_semantics(
   // IEEE 754 double precision (64-bit): 11 exponent bits, 52 fraction bits
   if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
   {
-    min_normal = mk_smt_real("2.2250738585072014e-308");    // 2^(-1022)
-    min_subnormal = mk_smt_real("4.9406564584124654e-324"); // 2^(-1074)
-    max_normal =
-      mk_smt_real("1.7976931348623157e+308"); // ~(2-2^(-52)) * 2^1023
+    min_normal = get_double_min_normal();
+    min_subnormal = get_double_min_subnormal();
+    max_normal = get_double_max_normal();
   }
   // IEEE 754 single precision (32-bit): 8 exponent bits, 23 fraction bits
   else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
   {
-    min_normal = mk_smt_real("1.1754943508222875e-38");    // 2^(-126)
-    min_subnormal = mk_smt_real("1.4012984643248171e-45"); // 2^(-149)
-    max_normal = mk_smt_real("3.4028234663852886e+38"); // ~(2-2^(-23)) * 2^127
+    min_normal = get_single_min_normal();
+    min_subnormal = get_single_min_subnormal();
+    max_normal = get_single_max_normal();
   }
   // Unsupported format - return original result
   else
@@ -293,18 +334,19 @@ smt_astt smt_convt::apply_ieee754_semantics(
     return real_result;
   }
 
-  smt_astt zero = mk_smt_real("0.0");
-
   // Get absolute value of result
-  smt_astt abs_result =
-    mk_ite(mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+  smt_astt abs_result = mk_ite(
+    mk_lt(real_result, get_zero_real()),
+    mk_sub(get_zero_real(), real_result),
+    real_result);
 
   // Check for overflow
   smt_astt overflows = mk_gt(abs_result, max_normal);
 
   // Check for underflow to zero
-  smt_astt underflows_to_zero =
-    mk_and(mk_lt(abs_result, min_subnormal), mk_not(mk_eq(real_result, zero)));
+  smt_astt underflows_to_zero = mk_and(
+    mk_lt(abs_result, min_subnormal),
+    mk_not(mk_eq(real_result, get_zero_real())));
 
   // If we have a special zero check (like for multiplication), use it
   if (operand_zero_check)
@@ -318,21 +360,22 @@ smt_astt smt_convt::apply_ieee754_semantics(
   // Use the appropriate subnormal step for the format
   smt_astt subnormal_step =
     (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
-      ? mk_smt_real("4.9406564584124654e-324")
-      :                                      // Double precision
-      mk_smt_real("1.4012984643248171e-45"); // Single precision
+      ? get_double_min_subnormal()  // Double precision
+      : get_single_min_subnormal(); // Single precision
   smt_astt quotient = mk_div(abs_result, subnormal_step);
   smt_astt rounded_quotient = mk_add(quotient, mk_smt_real("0.5"));
   smt_astt subnormal_magnitude = mk_mul(rounded_quotient, subnormal_step);
 
   smt_astt subnormal_result = mk_ite(
-    mk_lt(real_result, zero),
-    mk_sub(zero, subnormal_magnitude),
+    mk_lt(real_result, get_zero_real()),
+    mk_sub(get_zero_real(), subnormal_magnitude),
     subnormal_magnitude);
 
   // Overflow result (approximate infinity)
-  smt_astt overflow_result =
-    mk_ite(mk_lt(real_result, zero), mk_sub(zero, max_normal), max_normal);
+  smt_astt overflow_result = mk_ite(
+    mk_lt(real_result, get_zero_real()),
+    mk_sub(get_zero_real(), max_normal),
+    max_normal);
 
   // Apply IEEE 754 semantics with priority: overflow > underflow > subnormal > normal
   smt_astt ieee_result = mk_ite(
@@ -340,12 +383,12 @@ smt_astt smt_convt::apply_ieee754_semantics(
     overflow_result,
     mk_ite(
       underflows_to_zero,
-      zero,
+      get_zero_real(),
       mk_ite(is_subnormal, subnormal_result, real_result)));
 
   // Handle special operand zero case for multiplication
   if (operand_zero_check)
-    return mk_ite(operand_zero_check, zero, ieee_result);
+    return mk_ite(operand_zero_check, get_zero_real(), ieee_result);
 
   return ieee_result;
 }
@@ -691,8 +734,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     {
       smt_astt side1 = convert_ast(to_ieee_div2t(expr).side_1);
       smt_astt side2 = convert_ast(to_ieee_div2t(expr).side_2);
-      smt_astt zero = mk_smt_real("0.0");
-      smt_astt div_by_zero = mk_eq(side2, zero);
+      smt_astt div_by_zero = mk_eq(side2, get_zero_real());
 
       // Handle division by zero specially
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
@@ -708,17 +750,16 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
          fbv_type.fraction == single_spec.f)) // Single precision
       {
         // Get the appropriate max value for infinity approximation
-        smt_astt max_val =
-          (fbv_type.exponent == double_spec.e &&
-           fbv_type.fraction == double_spec.f)
-            ? mk_smt_real("1.7976931348623157e+308") // Double precision max
-            : mk_smt_real("3.4028234663852886e+38"); // Single precision max
+        smt_astt max_val = (fbv_type.exponent == double_spec.e &&
+                            fbv_type.fraction == double_spec.f)
+                             ? get_double_max_normal()  // Double precision max
+                             : get_single_max_normal(); // Single precision max
 
         // Return signed infinity for division by zero
         smt_astt inf_result = mk_ite(
-          mk_lt(side1, zero),
-          mk_sub(zero, max_val), // -infinity (approximate)
-          max_val                // +infinity (approximate)
+          mk_lt(side1, get_zero_real()),
+          mk_sub(get_zero_real(), max_val), // -infinity (approximate)
+          max_val                           // +infinity (approximate)
         );
 
         smt_astt real_result = mk_div(side1, side2);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -711,8 +711,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         smt_astt max_val =
           (fbv_type.exponent == double_spec.e &&
            fbv_type.fraction == double_spec.f)
-            ? mk_smt_real("1.7976931348623157e+308")
-            :                                      // Double precision max
+            ? mk_smt_real("1.7976931348623157e+308") // Double precision max
+            :
             mk_smt_real("3.4028234663852886e+38"); // Single precision max
 
         // Return signed infinity for division by zero

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -255,90 +255,85 @@ smt_astt smt_convt::convert_assign(const expr2tc &expr)
 }
 
 // Apply IEEE 754 semantics to a real arithmetic result
-smt_astt smt_convt::apply_ieee754_semantics(smt_astt real_result, const floatbv_type2t &fbv_type, 
-                                            smt_astt operand_zero_check) 
+smt_astt smt_convt::apply_ieee754_semantics(
+  smt_astt real_result,
+  const floatbv_type2t &fbv_type,
+  smt_astt operand_zero_check)
 {
   unsigned int fraction_bits = fbv_type.fraction;
   unsigned int exponent_bits = fbv_type.exponent;
-  
+
   auto double_spec = ieee_float_spect::double_precision();
   auto single_spec = ieee_float_spect::single_precision();
 
   smt_astt min_normal, min_subnormal, max_normal;
-  
+
   // IEEE 754 double precision (64-bit): 11 exponent bits, 52 fraction bits
   if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
   {
-    min_normal = mk_smt_real("2.2250738585072014e-308");     // 2^(-1022)
-    min_subnormal = mk_smt_real("4.9406564584124654e-324");  // 2^(-1074)
-    max_normal = mk_smt_real("1.7976931348623157e+308");     // ~(2-2^(-52)) * 2^1023
+    min_normal = mk_smt_real("2.2250738585072014e-308");    // 2^(-1022)
+    min_subnormal = mk_smt_real("4.9406564584124654e-324"); // 2^(-1074)
+    max_normal =
+      mk_smt_real("1.7976931348623157e+308"); // ~(2-2^(-52)) * 2^1023
   }
-  // IEEE 754 single precision (32-bit): 8 exponent bits, 23 fraction bits  
+  // IEEE 754 single precision (32-bit): 8 exponent bits, 23 fraction bits
   else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
   {
-    min_normal = mk_smt_real("1.1754943508222875e-38");      // 2^(-126)
-    min_subnormal = mk_smt_real("1.4012984643248171e-45");   // 2^(-149)
-    max_normal = mk_smt_real("3.4028234663852886e+38");      // ~(2-2^(-23)) * 2^127
+    min_normal = mk_smt_real("1.1754943508222875e-38");    // 2^(-126)
+    min_subnormal = mk_smt_real("1.4012984643248171e-45"); // 2^(-149)
+    max_normal = mk_smt_real("3.4028234663852886e+38"); // ~(2-2^(-23)) * 2^127
   }
   // Unsupported format - return original result
-  else 
+  else
   {
     log_warning(
       "Unsupported IEEE 754 format: exponent bits = {}, fraction bits = {}",
-      exponent_bits, fraction_bits);
+      exponent_bits,
+      fraction_bits);
     return real_result;
   }
-  
+
   smt_astt zero = mk_smt_real("0.0");
-  
+
   // Get absolute value of result
-  smt_astt abs_result = mk_ite(
-    mk_lt(real_result, zero),
-    mk_sub(zero, real_result),
-    real_result
-  );
-  
+  smt_astt abs_result =
+    mk_ite(mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
   // Check for overflow
   smt_astt overflows = mk_gt(abs_result, max_normal);
-  
+
   // Check for underflow to zero
-  smt_astt underflows_to_zero = mk_and(
-    mk_lt(abs_result, min_subnormal),
-    mk_not(mk_eq(real_result, zero))
-  );
-  
+  smt_astt underflows_to_zero =
+    mk_and(mk_lt(abs_result, min_subnormal), mk_not(mk_eq(real_result, zero)));
+
   // If we have a special zero check (like for multiplication), use it
   if (operand_zero_check)
     underflows_to_zero = mk_and(underflows_to_zero, mk_not(operand_zero_check));
-  
+
   // Check if result is in subnormal range
-  smt_astt is_subnormal = mk_and(
-    mk_ge(abs_result, min_subnormal),
-    mk_lt(abs_result, min_normal)
-  );
-  
+  smt_astt is_subnormal =
+    mk_and(mk_ge(abs_result, min_subnormal), mk_lt(abs_result, min_normal));
+
   // Handle subnormal rounding (simplified round-to-nearest)
   // Use the appropriate subnormal step for the format
-  smt_astt subnormal_step = (exponent_bits == double_spec.e  && fraction_bits == double_spec.f) ? 
-    mk_smt_real("4.9406564584124654e-324") :  // Double precision
-    mk_smt_real("1.4012984643248171e-45");    // Single precision
+  smt_astt subnormal_step =
+    (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      ? mk_smt_real("4.9406564584124654e-324")
+      :                                      // Double precision
+      mk_smt_real("1.4012984643248171e-45"); // Single precision
   smt_astt quotient = mk_div(abs_result, subnormal_step);
   smt_astt rounded_quotient = mk_add(quotient, mk_smt_real("0.5"));
   smt_astt subnormal_magnitude = mk_mul(rounded_quotient, subnormal_step);
-  
+
   smt_astt subnormal_result = mk_ite(
     mk_lt(real_result, zero),
     mk_sub(zero, subnormal_magnitude),
-    subnormal_magnitude
-  );
-  
+    subnormal_magnitude);
+
   // Overflow result (approximate infinity)
-  smt_astt overflow_result = mk_ite(
-    mk_lt(real_result, zero),
-    mk_sub(zero, max_normal),
-    max_normal
-  );
-  
+  smt_astt overflow_result =
+    mk_ite(mk_lt(real_result, zero), mk_sub(zero, max_normal), max_normal);
+
   // Apply IEEE 754 semantics with priority: overflow > underflow > subnormal > normal
   smt_astt ieee_result = mk_ite(
     overflows,
@@ -346,18 +341,12 @@ smt_astt smt_convt::apply_ieee754_semantics(smt_astt real_result, const floatbv_
     mk_ite(
       underflows_to_zero,
       zero,
-      mk_ite(
-        is_subnormal,
-        subnormal_result,
-        real_result
-      )
-    )
-  );
-  
+      mk_ite(is_subnormal, subnormal_result, real_result)));
+
   // Handle special operand zero case for multiplication
   if (operand_zero_check)
     return mk_ite(operand_zero_check, zero, ieee_result);
-  
+
   return ieee_result;
 }
 
@@ -635,7 +624,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt side1 = convert_ast(to_ieee_add2t(expr).side_1);
       smt_astt side2 = convert_ast(to_ieee_add2t(expr).side_2);
       smt_astt real_result = mk_add(side1, side2);
-      
+
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
     }
@@ -657,7 +646,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt side1 = convert_ast(to_ieee_sub2t(expr).side_1);
       smt_astt side2 = convert_ast(to_ieee_sub2t(expr).side_2);
       smt_astt real_result = mk_sub(side1, side2);
-      
+
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
     }
@@ -678,11 +667,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt side1 = convert_ast(to_ieee_mul2t(expr).side_1);
       smt_astt side2 = convert_ast(to_ieee_mul2t(expr).side_2);
       smt_astt real_result = mk_mul(side1, side2);
-      
+
       // Special handling for multiplication: check if either operand is zero
       smt_astt zero = mk_smt_real("0.0");
       smt_astt operand_is_zero = mk_or(mk_eq(side1, zero), mk_eq(side2, zero));
-      
+
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       a = apply_ieee754_semantics(real_result, fbv_type, operand_is_zero);
     }
@@ -704,7 +693,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt side2 = convert_ast(to_ieee_div2t(expr).side_2);
       smt_astt zero = mk_smt_real("0.0");
       smt_astt div_by_zero = mk_eq(side2, zero);
-      
+
       // Handle division by zero specially
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
 
@@ -712,31 +701,40 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       auto single_spec = ieee_float_spect::single_precision();
 
       // Check if we support this IEEE 754 format
-      if ((fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f) ||  // Double precision
-          (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f))    // Single precision
-      {  
+      if (
+        (fbv_type.exponent == double_spec.e &&
+         fbv_type.fraction == double_spec.f) || // Double precision
+        (fbv_type.exponent == single_spec.e &&
+         fbv_type.fraction == single_spec.f)) // Single precision
+      {
         // Get the appropriate max value for infinity approximation
-        smt_astt max_val = (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f) ?
-          mk_smt_real("1.7976931348623157e+308") :   // Double precision max
-          mk_smt_real("3.4028234663852886e+38");     // Single precision max
-        
+        smt_astt max_val =
+          (fbv_type.exponent == double_spec.e &&
+           fbv_type.fraction == double_spec.f)
+            ? mk_smt_real("1.7976931348623157e+308")
+            :                                      // Double precision max
+            mk_smt_real("3.4028234663852886e+38"); // Single precision max
+
         // Return signed infinity for division by zero
         smt_astt inf_result = mk_ite(
           mk_lt(side1, zero),
-          mk_sub(zero, max_val),  // -infinity (approximate)
-          max_val                 // +infinity (approximate)
+          mk_sub(zero, max_val), // -infinity (approximate)
+          max_val                // +infinity (approximate)
         );
-        
+
         smt_astt real_result = mk_div(side1, side2);
-        smt_astt ieee_result = apply_ieee754_semantics(real_result, fbv_type, nullptr);
-        
+        smt_astt ieee_result =
+          apply_ieee754_semantics(real_result, fbv_type, nullptr);
+
         a = mk_ite(div_by_zero, inf_result, ieee_result);
       }
-      else 
+      else
       {
         log_error(
-          "Unsupported IEEE 754 format for division: exponent bits = {}, fraction bits = {}",
-          fbv_type.exponent, fbv_type.fraction);
+          "Unsupported IEEE 754 format for division: exponent bits = {}, "
+          "fraction bits = {}",
+          fbv_type.exponent,
+          fbv_type.fraction);
         abort();
       }
     }
@@ -757,12 +755,12 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt val1 = convert_ast(to_ieee_fma2t(expr).value_1);
       smt_astt val2 = convert_ast(to_ieee_fma2t(expr).value_2);
       smt_astt val3 = convert_ast(to_ieee_fma2t(expr).value_3);
-      
+
       // Fused multiply-add: (val1 * val2) + val3
       // In true FMA, the intermediate result isn't rounded
       smt_astt intermediate = mk_mul(val1, val2);
       smt_astt real_result = mk_add(intermediate, val3);
-      
+
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
     }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -712,8 +712,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           (fbv_type.exponent == double_spec.e &&
            fbv_type.fraction == double_spec.f)
             ? mk_smt_real("1.7976931348623157e+308") // Double precision max
-            :
-            mk_smt_real("3.4028234663852886e+38"); // Single precision max
+            : mk_smt_real("3.4028234663852886e+38"); // Single precision max
 
         // Return signed infinity for division by zero
         smt_astt inf_result = mk_ite(

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -416,6 +416,21 @@ public:
    *  @return The newly created terminal smt_ast of this real. */
   virtual smt_astt mk_smt_real(const std::string &str) = 0;
 
+  // Returns SMT AST representing real zero
+  smt_astt get_zero_real();
+  // Returns SMT AST representing double precision minimum normal value (2^-1022)
+  smt_astt get_double_min_normal();
+  // Returns SMT AST representing double precision minimum subnormal value (2^-1074)
+  smt_astt get_double_min_subnormal();
+  // Returns SMT AST representing double precision maximum normal value (~1.7976931348623157e+308)
+  smt_astt get_double_max_normal();
+  // Returns SMT AST representing single precision minimum normal value (2^-126)
+  smt_astt get_single_min_normal();
+  // Returns SMT AST representing single precision minimum subnormal value (2^-149)
+  smt_astt get_single_min_subnormal();
+  // Returns SMT AST representing single precision maximum normal value (~3.4028234663852886e+38)
+  smt_astt get_single_max_normal();
+
   /** Create a bitvector.
    *  @param theint Integer representation of the bitvector. Any excess bits
    *         in the stored integer should be ignored.

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -545,8 +545,10 @@ public:
    *         (e.g., multiplication where either operand is zero should yield zero
    *         regardless of the other operand, even if it would cause underflow)
    *  @return SMT AST representing the result with IEEE 754 semantics applied */
-  virtual smt_astt apply_ieee754_semantics(smt_astt real_result, const floatbv_type2t &fbv_type, 
-                                         smt_astt operand_zero_check = nullptr);
+  virtual smt_astt apply_ieee754_semantics(
+    smt_astt real_result,
+    const floatbv_type2t &fbv_type,
+    smt_astt operand_zero_check = nullptr);
 
   /** Method to dump the SMT formula */
   virtual std::string dump_smt();

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -530,6 +530,22 @@ public:
    *  @return Boolean valued AST representing whether an overflow occurs. */
   virtual smt_astt overflow_neg(const expr2tc &expr);
 
+/** Applies IEEE 754 floating-point semantics to a real arithmetic result.
+   *  Handles overflow, underflow, and subnormal number behaviors that are
+   *  missing when using integer/real encoding for floating-point operations.
+   *  For double precision (64-bit), this includes: overflow to ±max_normal
+   *  (~±1.798e+308), underflow to zero for results smaller than min_subnormal
+   *  (~4.941e-324), and proper quantization of subnormal numbers in the range
+   *  [min_subnormal, min_normal). For non-double precision formats, returns
+   *  the original result unchanged.
+   *  @param real_result The result of exact real arithmetic operation
+   *  @param fbv_type The floating-point type information (exponent/fraction bits)
+   *  @param operand_zero_check Optional boolean AST for special zero handling
+   *         (e.g., multiplication where either operand is zero should yield zero
+   *         regardless of the other operand, even if it would cause underflow)
+   *  @return SMT AST representing the result with IEEE 754 semantics applied */
+  virtual smt_astt apply_ieee754_semantics(smt_astt real_result, const floatbv_type2t &fbv_type, 
+                                         smt_astt operand_zero_check = nullptr);
   /** Method to dump the SMT formula */
   virtual std::string dump_smt();
 

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -530,14 +530,15 @@ public:
    *  @return Boolean valued AST representing whether an overflow occurs. */
   virtual smt_astt overflow_neg(const expr2tc &expr);
 
-/** Applies IEEE 754 floating-point semantics to a real arithmetic result.
+  /** Applies IEEE 754 floating-point semantics to a real arithmetic result.
    *  Handles overflow, underflow, and subnormal number behaviors that are
    *  missing when using integer/real encoding for floating-point operations.
-   *  For double precision (64-bit), this includes: overflow to ±max_normal
-   *  (~±1.798e+308), underflow to zero for results smaller than min_subnormal
-   *  (~4.941e-324), and proper quantization of subnormal numbers in the range
-   *  [min_subnormal, min_normal). For non-double precision formats, returns
-   *  the original result unchanged.
+   *  Supports both IEEE 754 single precision (32-bit: 8 exponent, 23 fraction)
+   *  and double precision (64-bit: 11 exponent, 52 fraction) formats.
+   *  For double precision: overflow to ±1.798e+308, underflow below 4.941e-324,
+   *  subnormal range [4.941e-324, 2.225e-308). For single precision: overflow
+   *  to ±3.403e+38, underflow below 1.401e-45, subnormal range [1.401e-45, 1.175e-38).
+   *  Other formats return the original result unchanged.
    *  @param real_result The result of exact real arithmetic operation
    *  @param fbv_type The floating-point type information (exponent/fraction bits)
    *  @param operand_zero_check Optional boolean AST for special zero handling
@@ -546,6 +547,7 @@ public:
    *  @return SMT AST representing the result with IEEE 754 semantics applied */
   virtual smt_astt apply_ieee754_semantics(smt_astt real_result, const floatbv_type2t &fbv_type, 
                                          smt_astt operand_zero_check = nullptr);
+
   /** Method to dump the SMT formula */
   virtual std::string dump_smt();
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2590.

This PR implements IEEE 754 underflow, overflow, and subnormal number handling for floating-point operations (add, sub, mul, div, fma) when using integer/real encoding mode. Previously, these operations were treated as exact real arithmetic,
missing IEEE 754 behaviors such as underflow to zero.


