### PR TITLE
[smt] Fix BigInt to double conversion warnings for very small rationals

### DIFF
--- a/regression/floats/underflow17/main.c
+++ b/regression/floats/underflow17/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+
+int main() 
+{
+    double x = nondet_double();
+    double y = nondet_double();
+
+    __ESBMC_assume(x > 0.0 && x < 1.0e-154);
+    __ESBMC_assume(y > 0.0 && y < 1.0e-154);
+
+    double result = x * y;
+
+    // Underflow check
+    assert(result > 0.0);
+
+    return 0;
+}

--- a/regression/floats/underflow17/test.desc
+++ b/regression/floats/underflow17/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir
+^WARNING: BigInt as_string\(\) failed for very small rational - returning minimal positive value$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1,4 +1,5 @@
 #include "irep2/irep2_expr.h"
+#include <cfloat>
 #include <iomanip>
 #include <set>
 #include <solvers/prop/literal.h>

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2841,58 +2841,69 @@ double smt_convt::convert_rational_to_double(
   size_t den_len = strnlen(den_buffer.data(), BUFFER_SIZE);
 
   // Handle the case where as_string() fails for very small numbers
-  if (num_len == 0 || den_len == 0) 
+  if (num_len == 0 || den_len == 0)
   {
-    bool num_positive = !numerator.is_zero(); // Assumes non-zero means some value exists
+    bool num_positive =
+      !numerator.is_zero(); // Assumes non-zero means some value exists
     bool den_positive = !denominator.is_zero();
-    
-    if (num_positive && den_positive) 
+
+    if (num_positive && den_positive)
     {
       // This likely represents a very small positive rational number
       // that's too small for string conversion but should be > 0
       // Return a very small positive value instead of 0.0
-      log_warning("BigInt as_string() failed for very small rational - returning minimal positive value");
+      log_warning(
+        "BigInt as_string() failed for very small rational - returning minimal "
+        "positive value");
       return DBL_MIN; // Smallest positive normalized double
-    } 
-    else 
+    }
+    else
     {
       log_warning("BigInt as_string() failed and cannot determine sign");
       return 0.0;
     }
   }
 
-  if (num_len >= BUFFER_SIZE - 1 || den_len >= BUFFER_SIZE - 1) 
+  if (num_len >= BUFFER_SIZE - 1 || den_len >= BUFFER_SIZE - 1)
   {
-    log_warning("BigInt to string conversion may have been truncated - buffer too small");
+    log_warning(
+      "BigInt to string conversion may have been truncated - buffer too small");
     return 0.0;
   }
 
-  try {
+  try
+  {
     double num_val = std::stod(num_buffer.data());
     double den_val = std::stod(den_buffer.data());
-    
-    if (den_val == 0.0) 
+
+    if (den_val == 0.0)
     {
       log_warning("Denominator converted to 0.0 despite non-zero BigInt");
       return 0.0;
     }
-    
+
     double result = num_val / den_val;
-    
+
     // Handle underflow in the division result
-    if (result == 0.0 && num_val != 0.0) 
+    if (result == 0.0 && num_val != 0.0)
     {
       // The division underflowed to zero, but we know the rational is non-zero
       // Return a minimal positive value to preserve the sign
-      log_warning("Division result underflowed - returning minimal positive value");
+      log_warning(
+        "Division result underflowed - returning minimal positive value");
       return DBL_MIN;
     }
-    
+
     return result;
   }
-  catch (const std::exception &e) {
-    log_warning("Failed to convert BigInt strings to double: numerator='%s', denominator='%s', error: %s",
-                num_buffer.data(), den_buffer.data(), e.what());
+  catch (const std::exception &e)
+  {
+    log_warning(
+      "Failed to convert BigInt strings to double: numerator='%s', "
+      "denominator='%s', error: %s",
+      num_buffer.data(),
+      den_buffer.data(),
+      e.what());
     return 0.0;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2599.

Handle `as_string()` failure for numbers < 1e-154 by detecting empty buffers and returning `DBL_MIN` for positive rationals instead of 0.0. Eliminates "numerator=, denominator=" warning messages and improves mathematical correctness for underflow scenarios.