### PR TITLE
[Build] Update fuzzing build configuration

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -411,3 +411,14 @@ passing the CMake flags
 ```
 e.g. the 'path' should point to `$HOME/cheri/output/sdk/sysroot-riscv64-purecap`. As for the `sysroot-riscv64-purecap` part, you may want to use a diffrent directory if you used a different variant in the `cheribuild.py` command above.
 
+# ESBMC Fuzzing Tests
+
+ESBMC has a number of fuzzing test targets which are used with libFuzzer to test parts of ESBMC. Building these targets require additional CMake configuration.
+
+Using Clang to build the fuzzing targets is required due to the included libFuzzer support. Clang must therefore be install and CMake configured to use Clang to build ESBMC. One way to do this is to pass the following options to CMake:
+```
+-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+```
+Note that passing these options to CMake for the first time will result the CMake cache being deleted, possibly requiring some variables to be reset.
+
+Fuzzing tests must also be enabled with `-DENABLE_FUZZER=1` before building.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -415,10 +415,10 @@ e.g. the 'path' should point to `$HOME/cheri/output/sdk/sysroot-riscv64-purecap`
 
 ESBMC has a number of fuzzing test targets which are used with libFuzzer to test parts of ESBMC. Building these targets require additional CMake configuration.
 
-Using Clang to build the fuzzing targets is required due to the included libFuzzer support. Clang must therefore be install and CMake configured to use Clang to build ESBMC. One way to do this is to pass the following options to CMake:
+Using Clang to build the fuzzing targets is required due to the included libFuzzer support. Clang must therefore be installed and CMake configured to use Clang to build ESBMC. One way to do this is to pass the following options to CMake:
 ```
 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 ```
-Note that passing these options to CMake for the first time will result the CMake cache being deleted, possibly requiring some variables to be reset.
+Note that passing these options to CMake for the first time will result in the CMake cache being deleted, possibly requiring some variables to be reset.
 
 Fuzzing tests must also be enabled with `-DENABLE_FUZZER=1` before building.

--- a/scripts/cmake/TestConfiguration.cmake
+++ b/scripts/cmake/TestConfiguration.cmake
@@ -42,8 +42,10 @@ function (new_fuzz_test TARGET SRC LIBS)
   endif()
   add_executable(${TARGET} ${SRC})
   add_test(NAME ${TARGET}-Fuzz COMMAND ${TARGET} -runs=6500000)
-  target_compile_options(${TARGET} PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>)
-  target_link_libraries(${TARGET} PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer> ${LIBS})
+  target_compile_options(${TARGET} PRIVATE $<$<COMPILE_LANG_AND_ID:C,Clang>:-g -O1 -fsanitize=fuzzer>
+                                           $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-g -O1 -fsanitize=fuzzer>)
+  target_link_libraries(${TARGET} PRIVATE $<$<LINK_LANG_AND_ID:C,Clang>:-fsanitize=fuzzer> ${LIBS}
+                                          $<$<LINK_LANG_AND_ID:CXX,Clang>:-fsanitize=fuzzer> ${LIBS})
 endfunction()
 
 # Add a new Fuzz based test (this will execute less runs)
@@ -53,6 +55,8 @@ function (new_fast_fuzz_test TARGET SRC LIBS)
   endif()
   add_executable(${TARGET} ${SRC})
   add_test(NAME ${TARGET}-Fuzz COMMAND ${TARGET} -runs=1000)
-  target_compile_options(${TARGET} PRIVATE $<$<C_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>)
-  target_link_libraries(${TARGET} PRIVATE $<$<C_COMPILER_ID:Clang>:-fsanitize=fuzzer> ${LIBS})
+  target_compile_options(${TARGET} PRIVATE $<$<COMPILE_LANG_AND_ID:C,Clang>:-g -O1 -fsanitize=fuzzer>
+                                           $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-g -O1 -fsanitize=fuzzer>)
+  target_link_libraries(${TARGET} PRIVATE $<$<LINK_LANG_AND_ID:C,Clang>:-fsanitize=fuzzer> ${LIBS}
+                                          $<$<LINK_LANG_AND_ID:CXX,Clang>:-fsanitize=fuzzer> ${LIBS})
 endfunction()


### PR DESCRIPTION
This PR fixes building fuzzing targets when CMake is configured to use Clang as a C++ compiler but not as a C compiler. Also adds some initial documentation for building fuzzing targets.