### PR TITLE
[C verification] redesign of realloc

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -296,6 +296,7 @@ void goto_convertt::do_realloc(
   realloc_expr.statement("realloc");
   realloc_expr.copy_to_operands(arguments[0]);
   realloc_expr.cmt_size(arguments[1]);
+  realloc_expr.cmt_type(alloc_type);
   realloc_expr.location() = function.location();
 
   // Use conditional expression: (ptr == NULL) ? malloc(size) : realloc(ptr, size)

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -118,7 +118,7 @@ void goto_symext::symex_realloc(
   unsigned int sz_tgt = type_byte_size_bits(tgt->type).to_uint64();
 
   // if realloc size less than original, cut the original
-  // Otherwise we will concatenate: SIZE 2 to 3 
+  // Otherwise we will concatenate: SIZE 2 to 3
   // new obj {nondet, nondet, nondet}
   // {1, 2} + {nondet} -> {1, 2, nondet}
   // TODO: We should have an efficient array copy that use byte_extract.
@@ -127,10 +127,16 @@ void goto_symext::symex_realloc(
   {
     unsigned int sz_min = std::min(sz_result, sz_tgt);
     expr2tc ex_result = extract2tc(
-      get_uint_type(sz_min), bitcast2tc(get_uint_type(sz_result), result), sz_min - 1, 0);
+      get_uint_type(sz_min),
+      bitcast2tc(get_uint_type(sz_result), result),
+      sz_min - 1,
+      0);
 
     expr2tc ex_tgt = extract2tc(
-      get_uint_type(sz_min), bitcast2tc(get_uint_type(sz_tgt), tgt), sz_min - 1, 0);
+      get_uint_type(sz_min),
+      bitcast2tc(get_uint_type(sz_tgt), tgt),
+      sz_min - 1,
+      0);
 
     symex_assign(code_assign2tc(ex_tgt, ex_result), true, guard);
   }
@@ -498,13 +504,11 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     new_rhs.operands.erase(new_rhs.operands.begin());
 
   std::list<expr2tc> args;
-  new_rhs.foreach_operand(
-    [this, &args](const expr2tc &e)
-    {
-      expr2tc tmp = e;
-      do_simplify(tmp);
-      args.push_back(tmp);
-    });
+  new_rhs.foreach_operand([this, &args](const expr2tc &e) {
+    expr2tc tmp = e;
+    do_simplify(tmp);
+    args.push_back(tmp);
+  });
 
   if (!is_nil_expr(lhs))
   {
@@ -1742,12 +1746,10 @@ void goto_symext::replace_races_check(expr2tc &expr)
 
   // replace RACE_CHECK(&x) with __ESBMC_races_flag[&x]
   // recursion is needed for this case: !RACE_CHECK(&x)
-  expr->Foreach_operand(
-    [this](expr2tc &e)
-    {
-      if (!is_nil_expr(e))
-        replace_races_check(e);
-    });
+  expr->Foreach_operand([this](expr2tc &e) {
+    if (!is_nil_expr(e))
+      replace_races_check(e);
+  });
 
   if (is_races_check2t(expr))
   {

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -795,7 +795,7 @@ protected:
     const guardt &guard);
   /** Wrapper around for alloca and malloc. */
   expr2tc symex_mem(
-    const bool is_malloc,
+    const sideeffect2t::allockind &kind,
     const expr2tc &lhs,
     const sideeffect2t &code,
     const guardt &guard);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -283,16 +283,6 @@ void goto_symex_statet::rename_address(expr2tc &expr)
     type2tc origtype = expr->type;
     top().level1.rename(expr);
     fixup_renamed_type(expr, origtype);
-
-    // Realloc hacks: The l1 name may need to change slightly when we realloc
-    // a pointer, so that l2 renaming still points at the same piece of data,
-    // but so that the address compares differently to previous address-of's.
-    // Do this by bumping the l2 number in the l1 name, if it's been realloc'd.
-    if (realloc_map.find(expr) != realloc_map.end())
-    {
-      symbol2t &sym = to_symbol2t(expr);
-      sym.level2_num = realloc_map[expr];
-    }
   }
   else if (is_index2t(expr))
   {

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -463,11 +463,6 @@ public:
 
   /** Namespace to work with. */
   const namespacet &ns;
-
-  /** Map of what pointer values have been realloc'd, and what their new
-   *  realloc number is. No need for special consideration when merging states
-   *  at phi nodes: the renumbering update itself is guarded at the SMT layer.*/
-  std::map<expr2tc, unsigned> realloc_map;
 };
 
 #endif

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -142,7 +142,7 @@ void goto_symext::handle_sideeffect(
     symex_cpp_new(lhs, effect, guard);
     break;
   case sideeffect2t::realloc:
-    symex_realloc(lhs, effect, guardt());
+    symex_realloc(lhs, effect, guard);
     break;
   case sideeffect2t::malloc:
     symex_malloc(lhs, effect, guard);


### PR DESCRIPTION
This PR splits realloc into malloc and internally implemented array copy.

There might be a new implementation of memcpy, and I think it might be possible to reuse the same code.