### PR TITLE
[cpp] add missing priority_queue constructor and comparator support

### DIFF
--- a/regression/esbmc-cpp/priority_queue/priority_queue_constructor-2/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_constructor-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/priority_queue/priority_queue_constructor_bug-2/test.desc
+++ b/regression/esbmc-cpp/priority_queue/priority_queue_constructor_bug-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/template/priority_queue_constructor-2/test.desc
+++ b/regression/esbmc-cpp/template/priority_queue_constructor-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/template/priority_queue_constructor_bug-2/test.desc
+++ b/regression/esbmc-cpp/template/priority_queue_constructor_bug-2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/cpp/library/queue
+++ b/src/cpp/library/queue
@@ -37,13 +37,15 @@ public:
   {
   }
 
-  priority_queue(T &x, T &y) : _size(0), head(0), tail(0), comp(Compare())
+  template <typename Iterator>
+  priority_queue(
+    Iterator begin,
+    Iterator end,
+    const Compare &compare = Compare())
+    : _size(0), head(0), tail(0), comp(compare)
   {
-  }
-  priority_queue(T *x, T *y) : _size(0), head(0), tail(0), comp(Compare())
-  {
-    for (; x != y; x++)
-      this->push(*x);
+    for (auto it = begin; it != end; ++it)
+      this->push(*it);
   }
 
   void push(const T &x)

--- a/src/cpp/library/queue
+++ b/src/cpp/library/queue
@@ -8,40 +8,50 @@
 
 namespace std
 {
-
 #define QUEUE_CAPACITY 1000
 
 template <
   class T,
   class Container = vector<T>,
-  class Compare = less<typename Container::value_type> >
+  class Compare = less<typename Container::value_type>>
 class priority_queue
 {
   T buf[QUEUE_CAPACITY];
   size_t _size;
   T head;
   T tail;
+  Compare comp; // Store the comparator
 
 public:
-  priority_queue() : _size(0), head(0), tail(0)
+  priority_queue() : _size(0), head(0), tail(0), comp(Compare())
   {
   }
-  priority_queue(T &x, T &y) : _size(0), head(0), tail(0)
+
+  // Constructor that takes const reference (handles temporaries)
+  priority_queue(const Compare &x) : _size(0), head(0), tail(0), comp(x)
   {
   }
-  priority_queue(T *x, T *y) : _size(0), head(0), tail(0)
+
+  // Constructor that takes reference (for existing code)
+  priority_queue(Compare &x) : _size(0), head(0), tail(0), comp(x)
+  {
+  }
+
+  priority_queue(T &x, T &y) : _size(0), head(0), tail(0), comp(Compare())
+  {
+  }
+  priority_queue(T *x, T *y) : _size(0), head(0), tail(0), comp(Compare())
   {
     for (; x != y; x++)
       this->push(*x);
   }
-  priority_queue(Compare &x)
-  {
-  }
+
   void push(const T &x)
   {
     size_t i = 0;
     T tmp = x, y;
-    while ((x < this->buf[i]) && (i != this->_size))
+    // Use the comparator instead of hardcoded comparison
+    while ((comp(x, this->buf[i])) && (i != this->_size))
     {
       i++;
     }
@@ -93,7 +103,7 @@ public:
   }
 };
 
-template <class T, class Container = deque<T> >
+template <class T, class Container = deque<T>>
 class queue
 {
   T buf[QUEUE_CAPACITY];


### PR DESCRIPTION
Fixes parsing errors in ESBMC when constructing `priority_queue` with custom comparison functors passed as temporaries, In particular, this PR:

- Adds constructor taking `const Compare&` to handle temporary comparator objects
- Stores and use the Compare instance in `priority_queue` operations
- Replaces hardcoded comparison in `push()` with custom comparator
- Resolves compilation errors when using custom comparators such as `mycomparison()`
