### PR TITLE
[symex] assume assertions after checking to strengthen path conditions (EXPERIMENTAL!!!)

### DIFF
--- a/regression/esbmc-unix2/20_flex/test.desc
+++ b/regression/esbmc-unix2/20_flex/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --unwind 1 --ir --z3
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/20_flex/test.desc
+++ b/regression/esbmc-unix2/20_flex/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --unwind 1 --ir --z3
 ^VERIFICATION FAILED$

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -89,11 +89,14 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
   // add assertion to the target equation
   assertion(new_expr, msg);
   
-  // add assumption for the claim
-  // provides additional constraints that help with unit propagation
-  // helps the solver make better branching decisions
-  // reduces the search space for subsequent assertions
-  assume(new_expr);
+  // add assumption for the claim to:
+  // - provide additional constraints that help with unit propagation
+  // - help the solver make better branching decisions
+  // - reduce the search space for subsequent assertions
+  if (!options.get_bool_option("multi-property") && 
+    (options.get_bool_option("incremental-bmc") || 
+    options.get_bool_option("k-induction")))
+    assume(new_expr);
 }
 
 void goto_symext::assertion(

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -88,21 +88,12 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
 
   // add assertion to the target equation
   assertion(new_expr, msg);
-
-  // Convert asserts in assumes, if it's not the last loop iteration
-  // This is a common technique in k-induction to strengthen the induction hypothesis.
-  // also, don't convert assertions added by the bidirectional search
-  if (
-    inductive_step && first_loop && !cur_state->source.pc->inductive_assertion)
-  {
-    // Fetch the current loop iteration count
-    BigInt unwind = cur_state->loop_iterations[first_loop];
-    if (unwind < max_unwind - 1)
-    {
-      assume(claim_expr);
-      return;
-    }
-  }
+  
+  // add assumption for the claim
+  // provides additional constraints that help with unit propagation
+  // helps the solver make better branching decisions
+  // reduces the search space for subsequent assertions
+  assume(new_expr);
 }
 
 void goto_symext::assertion(

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -70,7 +70,7 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
   expr2tc new_expr = claim_expr;
   cur_state->rename(new_expr);
 
-  // simplify the renamed expression to potentially optimize the claim
+  // Simplify the renamed expression to potentially optimize the claim
   do_simplify(new_expr);
 
   if (is_true(new_expr))
@@ -86,18 +86,23 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
     check_incremental(new_expr, msg))
     return; // Verification succeeded, no further action needed
 
-  // add assertion to the target equation
+  // Add assertion to the target equation
   assertion(new_expr, msg);
 
-  // add assumption for the claim to:
-  // - provide additional constraints that help with unit propagation
-  // - help the solver make better branching decisions
-  // - reduce the search space for subsequent assertions
+  // Add assumption for the claim to:
+  // - Provide additional constraints that help with unit propagation
+  // - Help the solver make better branching decisions
+  // - Reduce the search space for subsequent assertions
   if (
     !options.get_bool_option("multi-property") &&
-    (options.get_bool_option("incremental-bmc") ||
-     options.get_bool_option("k-induction")))
+    options.get_bool_option("k-induction"))
+  {
+    // Base case and forward condition:
+    // Proven assertions become assumptions for the next step
+    // Inductive step:
+    // Each assertion immediately strengthens the induction hypothesis
     assume(new_expr);
+  }
 }
 
 void goto_symext::assertion(

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -88,14 +88,15 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
 
   // add assertion to the target equation
   assertion(new_expr, msg);
-  
+
   // add assumption for the claim to:
   // - provide additional constraints that help with unit propagation
   // - help the solver make better branching decisions
   // - reduce the search space for subsequent assertions
-  if (!options.get_bool_option("multi-property") && 
-    (options.get_bool_option("incremental-bmc") || 
-    options.get_bool_option("k-induction")))
+  if (
+    !options.get_bool_option("multi-property") &&
+    (options.get_bool_option("incremental-bmc") ||
+     options.get_bool_option("k-induction")))
     assume(new_expr);
 }
 


### PR DESCRIPTION
This PR adds `assume(new_expr)` after `assertion(new_expr, msg)` to strengthen path conditions with proven properties. This appears to facilitate improved SMT solver constraint propagation and path pruning. The approach seems particularly effective for k-induction, where each proven assertion serves as an assumption for subsequent verification steps, enabling the SMT solver to eliminate infeasible paths earlier in the search. In particular:
- Base case: Proven assertions become assumptions for the next step
- Inductive step: Each assertion immediately strengthens the induction hypothesis
- Solver can eliminate infeasible paths much faster

Performance improvements on k-induction regression test suites:
- K-induction: 18.5% faster (2344→1909 sec*proc)
- Total regression: 12.3% faster (3823→3353 sec*proc)
- Real time: 10.7% faster (956→853 sec)