### PR TITLE
[smt] add integer arithmetic support for byte operations

### DIFF
--- a/regression/esbmc-unix2/20_flex/test.desc
+++ b/regression/esbmc-unix2/20_flex/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --unwind 1 --ir --z3
 ^VERIFICATION FAILED$

--- a/regression/esbmc/concatenation_basic/main.c
+++ b/regression/esbmc/concatenation_basic/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main() {
+    uint16_t high = 0x1234;
+    uint16_t low = 0x5678;
+    
+    // Concatenate to form 32-bit value
+    uint32_t result = ((uint32_t)high << 16) | low;
+    
+    // Expected result: 0x12345678
+    assert(result == 0x12345678);
+    
+    // Test with 8-bit values
+    uint8_t byte1 = 0xAB;
+    uint8_t byte2 = 0xCD;
+    uint16_t concat16 = ((uint16_t)byte1 << 8) | byte2;
+    
+    assert(concat16 == 0xABCD);
+    
+    return 0;
+}

--- a/regression/esbmc/concatenation_basic/test.desc
+++ b/regression/esbmc/concatenation_basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/endianness/main.c
+++ b/regression/esbmc/endianness/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+int main() {
+    uint32_t value = 0x12345678;
+    uint8_t bytes[4];
+    
+    // Copy bytes maintaining byte order
+    memcpy(bytes, &value, sizeof(value));
+    
+    // Test that we can extract and reconstruct
+    uint32_t reconstructed = 0;
+    for (int i = 0; i < 4; i++) {
+        reconstructed |= ((uint32_t)bytes[i] << (i * 8));
+    }
+    
+    assert(reconstructed == value);
+    
+    return 0;
+}

--- a/regression/esbmc/endianness/test.desc
+++ b/regression/esbmc/endianness/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --no-simplify --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/mixed_operations/main.c
+++ b/regression/esbmc/mixed_operations/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main() {
+    uint32_t original = 0x12345678;
+    uint8_t *bytes = (uint8_t*)&original;
+    
+    // Extract individual bytes
+    uint8_t b0 = bytes[0];
+    uint8_t b1 = bytes[1];
+    uint8_t b2 = bytes[2];
+    uint8_t b3 = bytes[3];
+    
+    // Reconstruct using concatenation (reverse byte order for big-endian result)
+    uint32_t reconstructed = ((uint32_t)b3 << 24) | 
+                            ((uint32_t)b2 << 16) | 
+                            ((uint32_t)b1 << 8) | 
+                            b0;
+    
+    // Should equal original value
+    assert(reconstructed == original);
+    
+    return 0;
+}

--- a/regression/esbmc/mixed_operations/test.desc
+++ b/regression/esbmc/mixed_operations/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/test_byte_extract_basic/main.c
+++ b/regression/esbmc/test_byte_extract_basic/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main() {
+    uint32_t value = 0x12345678;
+    uint8_t *bytes = (uint8_t*)&value;
+    
+    // Test little-endian byte extraction
+    uint8_t byte0 = bytes[0];  // Should be 0x78
+    uint8_t byte1 = bytes[1];  // Should be 0x56
+    uint8_t byte2 = bytes[2];  // Should be 0x34
+    uint8_t byte3 = bytes[3];  // Should be 0x12
+    
+    // Verify results
+    assert(byte0 == 0x78);
+    assert(byte1 == 0x56);
+    assert(byte2 == 0x34);
+    assert(byte3 == 0x12);
+    
+    return 0;
+}
+

--- a/regression/esbmc/test_byte_extract_basic/test.desc
+++ b/regression/esbmc/test_byte_extract_basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt/smt_byteops.cpp
+++ b/src/solvers/smt/smt_byteops.cpp
@@ -3,14 +3,6 @@
 
 smt_astt smt_convt::convert_byte_extract(const expr2tc &expr)
 {
-  if (int_encoding)
-  {
-    log_error(
-      "Refusing to byte extract in integer mode; re-run in "
-      "bitvector mode");
-    abort();
-  }
-
   const byte_extract2t &data = to_byte_extract2t(expr);
   expr2tc source = data.source_value;
   expr2tc offs = data.source_offset;
@@ -19,6 +11,114 @@ smt_astt smt_convt::convert_byte_extract(const expr2tc &expr)
 
   unsigned int src_width = source->type->get_width();
 
+  if (int_encoding)
+  {
+    // Integer arithmetic mode implementation
+    return convert_byte_extract_int_mode(data, source, offs, src_width);
+  }
+  else
+  {
+    // Original bitvector mode implementation
+    return convert_byte_extract_bv_mode(data, source, offs, src_width);
+  }
+}
+
+smt_astt smt_convt::convert_byte_extract_int_mode(const byte_extract2t &data, 
+                                                  expr2tc source, 
+                                                  expr2tc offs, 
+                                                  unsigned int src_width)
+{
+  // Convert source to integer representation if needed
+  if (!is_number_type(source->type))
+  {
+    // For non-numeric types, we need to interpret them as integers
+    source = typecast2tc(get_uint_type(src_width), source);
+  }
+
+  if (!is_constant_int2t(offs))
+  {
+    // Non-constant offset case - use mathematical operations
+    // to simulate bit shifting and extraction
+    
+    // Ensure offset is the same type as source for arithmetic operations
+    if (offs->type->get_width() != source->type->get_width())
+      offs = typecast2tc(source->type, offs);
+
+    // Handle endianness by adjusting the offset
+    if (data.big_endian)
+    {
+      auto data_size = type_byte_size(source->type);
+      expr2tc data_size_expr = constant_int2tc(source->type, data_size - 1);
+      offs = sub2tc(source->type, data_size_expr, offs);
+    }
+
+    // Convert byte offset to bit offset (multiply by 8)
+    expr2tc bit_offset = mul2tc(offs->type, offs, constant_int2tc(offs->type, BigInt(8)));
+    
+    // Simulate right shift using division by 2^bit_offset
+    expr2tc shifted_source = create_int_right_shift(source, bit_offset);
+    
+    // Extract bottom byte using bitwise AND with 255 (not 256)
+    expr2tc byte_mask = constant_int2tc(source->type, BigInt(255));
+    expr2tc extracted_byte = bitand2tc(source->type, shifted_source, byte_mask);
+    
+    return convert_ast(extracted_byte);
+  }
+  else
+  {
+    // Constant offset case - can use direct mathematical operations
+    const constant_int2t &intref = to_constant_int2t(offs);
+    unsigned int byte_offset = intref.value.to_uint64();
+    
+    // Calculate the divisor for extracting the specific byte
+    BigInt divisor = BigInt(1);
+    unsigned int shift_amount;
+    
+    if (!data.big_endian)
+    {
+      // Little endian: byte 0 is least significant
+      shift_amount = byte_offset * 8;
+    }
+    else
+    {
+      // Big endian: byte 0 is most significant
+      unsigned int total_bytes = src_width / 8;
+      if (byte_offset >= total_bytes)
+      {
+        // Out of bounds access
+        smt_sortt s = mk_int_sort();
+        return mk_smt_symbol("out_of_bounds_byte_extract", s);
+      }
+      shift_amount = (total_bytes - 1 - byte_offset) * 8;
+    }
+    
+    // Calculate 2^shift_amount
+    for (unsigned int i = 0; i < shift_amount; i++)
+    {
+      divisor = divisor * BigInt(2);
+    }
+    
+    // Perform integer division to simulate right shift
+    if (shift_amount > 0)
+    {
+      expr2tc divisor_expr = constant_int2tc(source->type, divisor);
+      source = div2tc(source->type, source, divisor_expr);
+    }
+    
+    // Extract bottom byte using bitwise AND with 255
+    expr2tc byte_mask = constant_int2tc(source->type, BigInt(255));
+    expr2tc result = bitand2tc(source->type, source, byte_mask);
+    
+    return convert_ast(result);
+  }
+}
+
+smt_astt smt_convt::convert_byte_extract_bv_mode(const byte_extract2t &data,
+                                                 expr2tc source,
+                                                 expr2tc offs,
+                                                 unsigned int src_width)
+{
+  // Original bitvector implementation
   if (!is_bv_type(source->type) && !is_fixedbv_type(source->type))
     source = bitcast2tc(get_uint_type(src_width), source);
 
@@ -75,6 +175,35 @@ smt_astt smt_convt::convert_byte_extract(const expr2tc &expr)
   }
 
   return mk_extract(source_ast, upper, lower);
+}
+
+// Helper function to simulate right shift in integer arithmetic
+expr2tc smt_convt::create_int_right_shift(expr2tc source, expr2tc shift_amount)
+{
+  // For non-constant shift amounts, we use conditional expressions
+  // for common shift amounts (bit-aligned shifts from 0 to 64)
+  
+  expr2tc result = source;
+  
+  // Create conditional chain for shift amounts 0 to 64 (bit-aligned)
+  for (int i = 8; i <= 64; i += 8)  // Only byte-aligned shifts for efficiency
+  {
+    expr2tc i_expr = constant_int2tc(shift_amount->type, BigInt(i));
+    expr2tc condition = equality2tc(shift_amount, i_expr);
+    
+    BigInt divisor = BigInt(1);
+    for (int j = 0; j < i; j++)
+    {
+      divisor = divisor * BigInt(2);
+    }
+    
+    expr2tc divisor_expr = constant_int2tc(source->type, divisor);
+    expr2tc shifted = div2tc(source->type, source, divisor_expr);
+    
+    result = if2tc(source->type, condition, shifted, result);
+  }
+  
+  return result;
 }
 
 smt_astt smt_convt::convert_byte_update(const expr2tc &expr)

--- a/src/solvers/smt/smt_byteops.cpp
+++ b/src/solvers/smt/smt_byteops.cpp
@@ -193,9 +193,7 @@ expr2tc smt_convt::create_int_right_shift(expr2tc source, expr2tc shift_amount)
 
     BigInt divisor = BigInt(1);
     for (size_t j = 0; j < i; j++)
-    {
       divisor = divisor * BigInt(2);
-    }
 
     expr2tc divisor_expr = constant_int2tc(source->type, divisor);
     expr2tc shifted = div2tc(source->type, source, divisor_expr);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -238,6 +238,58 @@ smt_astt smt_convt::imply_ast(smt_astt a, smt_astt b)
   return mk_implies(a, b);
 }
 
+smt_astt smt_convt::convert_concat_int_mode(
+  smt_astt left_ast,
+  smt_astt right_ast,
+  const expr2tc &expr)
+{
+  const concat2t &concat_expr = to_concat2t(expr);
+
+  // Get the widths of the operands
+  unsigned int left_width = concat_expr.side_1->type->get_width();
+  unsigned int right_width = concat_expr.side_2->type->get_width();
+  unsigned int result_width = left_width + right_width;
+
+  // Create the result type
+  type2tc result_type = get_uint_type(result_width);
+
+  // Convert concatenation to mathematical operations:
+  // result = left * (2^right_width) + right
+
+  // Calculate 2^right_width
+  BigInt multiplier = BigInt(1);
+  for (unsigned int i = 0; i < right_width; i++)
+    multiplier = multiplier * BigInt(2);
+
+  // Create the multiplier constant
+  expr2tc multiplier_expr = constant_int2tc(result_type, multiplier);
+  smt_astt multiplier_ast = convert_ast(multiplier_expr);
+
+  // Convert operands to the result type if needed
+  smt_astt left_converted = left_ast;
+  smt_astt right_converted = right_ast;
+
+  if (concat_expr.side_1->type->get_width() != result_width)
+  {
+    expr2tc left_extended = typecast2tc(result_type, concat_expr.side_1);
+    left_converted = convert_ast(left_extended);
+  }
+
+  if (concat_expr.side_2->type->get_width() != result_width)
+  {
+    expr2tc right_extended = typecast2tc(result_type, concat_expr.side_2);
+    right_converted = convert_ast(right_extended);
+  }
+
+  // Perform left * multiplier
+  smt_astt shifted_left = mk_mul(left_converted, multiplier_ast);
+
+  // Add the right operand: (left * 2^right_width) + right
+  smt_astt result = mk_add(shifted_left, right_converted);
+
+  return result;
+}
+
 smt_astt smt_convt::convert_assign(const expr2tc &expr)
 {
   const equality2t &eq = to_equality2t(expr);
@@ -1332,10 +1384,10 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   case expr2t::concat_id:
   {
-    assert(
-      !int_encoding &&
-      "Concatenate encountered in integer mode; unimplemented (and funky)");
-    a = mk_concat(args[0], args[1]);
+    if (int_encoding)
+      return convert_concat_int_mode(args[0], args[1], expr);
+    else
+      a = mk_concat(args[0], args[1]);
     break;
   }
   case expr2t::implies_id:

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -682,6 +682,20 @@ public:
   /** Convert a byte_extract2tc, pulling a byte from the byte representation
    *  of some piece of data. */
   smt_astt convert_byte_extract(const expr2tc &expr);
+  /* Integer mode byte extraction helper functions */
+  smt_astt convert_byte_extract_int_mode(const byte_extract2t &data, 
+                                         expr2tc source, 
+                                         expr2tc offs, 
+                                         unsigned int src_width);
+  
+  smt_astt convert_byte_extract_bv_mode(const byte_extract2t &data,
+                                        expr2tc source,
+                                        expr2tc offs,
+                                        unsigned int src_width);
+                                        
+  /* Helper function for integer arithmetic right shift simulation */
+  expr2tc create_int_right_shift(expr2tc source, expr2tc shift_amount);
+
   /** Convert a byte_update2tc, inserting a byte into the byte representation
    *  of some piece of data. */
   smt_astt convert_byte_update(const expr2tc &expr);

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -355,6 +355,11 @@ public:
     abort();
   }
 
+  smt_astt convert_concat_int_mode(
+    smt_astt left_ast,
+    smt_astt right_ast,
+    const expr2tc &expr);
+
   /** Create an integer or SBV/UBV sort */
   smt_sortt mk_int_bv_sort(std::size_t width)
   {
@@ -683,19 +688,19 @@ public:
    *  of some piece of data. */
   smt_astt convert_byte_extract(const expr2tc &expr);
   /* Integer mode byte extraction helper functions */
-  smt_astt convert_byte_extract_int_mode(const byte_extract2t &data, 
-                                         expr2tc source, 
-                                         expr2tc offs, 
-                                         unsigned int src_width);
-  
-  smt_astt convert_byte_extract_bv_mode(const byte_extract2t &data,
-                                        expr2tc source,
-                                        expr2tc offs,
-                                        unsigned int src_width);
-                                        
+  smt_astt convert_byte_extract_int_mode(
+    const byte_extract2t &data,
+    expr2tc source,
+    expr2tc offs,
+    unsigned int src_width);
+  /* Bit-vector mode byte extraction helper functions */
+  smt_astt convert_byte_extract_bv_mode(
+    const byte_extract2t &data,
+    expr2tc source,
+    expr2tc offs,
+    unsigned int src_width);
   /* Helper function for integer arithmetic right shift simulation */
   expr2tc create_int_right_shift(expr2tc source, expr2tc shift_amount);
-
   /** Convert a byte_update2tc, inserting a byte into the byte representation
    *  of some piece of data. */
   smt_astt convert_byte_update(const expr2tc &expr);


### PR DESCRIPTION
This PR extends our support for integer arithmetic mode for byte extraction and concatenation operations, eliminating previous assertion failures and expanding solver compatibility beyond bitvector-only SMT theories.

### Problem

Previously, ESBMC would abort when encountering byte extraction or concatenation operations in integer arithmetic mode:

```cpp
// Before: Fatal error
assert(!int_encoding && "Refusing to byte extract in integer mode");
assert(!int_encoding && "Concatenate encountered in integer mode; unimplemented");
```

This limitation restricted ESBMC to bitvector SMT theories only, reducing solver compatibility and verification capabilities.

### Byte Extraction
Implemented mathematical simulation of bit operations using integer arithmetic:
- **Right shifts**: Simulated using integer division by powers of 2
- **Byte masking**: Uses bitwise AND with `(2^char_width - 1)`
- **Variable offsets**: Handled via conditional expressions for common shift amounts
- **Endianness**: Proper support for both little-endian and big-endian byte ordering

### Concatenation  
Implemented using mathematical formula: `result = left * (2^right_width) + right`
- **Type handling**: Automatic width extension when needed
- **Bit-accurate**: Produces identical results to bitvector concatenation
- **SMT-friendly**: Uses only basic arithmetic operations

