### PR TITLE
[c++] fix deque reverse iterator bugs

### DIFF
--- a/regression/esbmc-cpp/deque/deque_arithmetic/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_arithmetic/main.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    for (int i = 1; i <= 5; i++) {
+        mydeque.push_back(i);
+    }
+    
+    auto rit = mydeque.rbegin();
+    
+    // Test operator+
+    auto rit2 = rit + 2;
+    assert(*rit == 5);   // Original unchanged
+    assert(*rit2 == 3);  // Moved 2 positions backward
+    
+    // Test operator-
+    auto rit3 = rit2 - 1;
+    assert(*rit3 == 4);  // Moved 1 position forward
+    
+    // Test operator+=
+    rit += 3;
+    assert(*rit == 2);   // Moved 3 positions backward
+    
+    // Test operator-=
+    rit -= 1;
+    assert(*rit == 3);   // Moved 1 position forward
+    
+    cout << "Arithmetic tests passed!" << endl;
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_arithmetic/test.desc
+++ b/regression/esbmc-cpp/deque/deque_arithmetic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --overflow-check --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_arithmetic_bug/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_arithmetic_bug/main.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    for (int i = 1; i <= 5; i++) {
+        mydeque.push_back(i);
+    }
+    
+    auto rit = mydeque.rbegin();
+    
+    // Test operator+
+    auto rit2 = rit + 2;
+    assert(*rit == 5);   // Original unchanged
+    assert(*rit2 == 3);  // Moved 2 positions backward
+    
+    // Test operator-
+    auto rit3 = rit2 - 1;
+    assert(*rit3 == 4);  // Moved 1 position forward
+    
+    // Test operator+=
+    rit += 3;
+    assert(*rit == 2);   // Moved 3 positions backward
+    
+    // Test operator-=
+    rit -= 1;
+    assert(*rit != 3);   // it should fail
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_arithmetic_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_arithmetic_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --overflow-check --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_basic_reverse/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_basic_reverse/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    deque<int>::reverse_iterator rit;
+    
+    for (int i = 1; i <= 5; i++) {
+        mydeque.push_back(i);
+    }
+    
+    cout << "mydeque contains:";
+    rit = mydeque.rbegin();
+    while (rit < mydeque.rend()) {
+        cout << " " << *rit;
+        ++rit;
+    }
+    
+    assert(rit == mydeque.rend());
+    cout << endl;
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_basic_reverse/test.desc
+++ b/regression/esbmc-cpp/deque/deque_basic_reverse/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --overflow-check --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_basic_reverse_bug/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_basic_reverse_bug/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    deque<int>::reverse_iterator rit;
+    
+    for (int i = 1; i <= 5; i++) {
+        mydeque.push_back(i);
+    }
+    
+    cout << "mydeque contains:";
+    rit = mydeque.rbegin();
+    while (rit < mydeque.rend()) {
+        cout << " " << *rit;
+        ++rit;
+    }
+    
+    assert(rit != mydeque.rend());
+    cout << endl;
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_basic_reverse_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_basic_reverse_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_comparison/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_comparison/main.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    for (int i = 1; i <= 3; i++) {
+        mydeque.push_back(i);
+    }
+    
+    auto rit1 = mydeque.rbegin();
+    auto rit2 = mydeque.rbegin();
+    auto rend = mydeque.rend();
+    
+    // Test equality
+    assert(rit1 == rit2);
+    assert(!(rit1 != rit2));
+    
+    // Test inequality with rend
+    assert(rit1 != rend);
+    assert(!(rit1 == rend));
+    
+    // Test ordering
+    assert(rit1 < rend);
+    assert(!(rend < rit1));
+    assert(rit1 <= rend);
+    assert(rend >= rit1);
+    
+    cout << "All comparison tests passed!" << endl;
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_comparison/test.desc
+++ b/regression/esbmc-cpp/deque/deque_comparison/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --overflow-check --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_comparison_bug/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_comparison_bug/main.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    for (int i = 1; i <= 3; i++) {
+        mydeque.push_back(i);
+    }
+    
+    auto rit1 = mydeque.rbegin();
+    auto rit2 = mydeque.rbegin();
+    auto rend = mydeque.rend();
+    
+    // Test equality
+    assert(rit1 == rit2);
+    assert(!(rit1 != rit2));
+    
+    // Test inequality with rend
+    assert(rit1 != rend);
+    assert(!(rit1 == rend));
+    
+    // Test ordering
+    assert(rit1 < rend);
+    assert(!(rend < rit1));
+    assert(rit1 <= rend);
+    assert(rend == rit1); // it should fail
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_comparison_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_comparison_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 4 --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_edge_cases/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_edge_cases/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    // Test empty deque
+    deque<int> empty_deque;
+    assert(empty_deque.rbegin() == empty_deque.rend());
+    
+    // Test single element
+    deque<int> single_deque;
+    single_deque.push_back(42);
+    
+    auto rit = single_deque.rbegin();
+    assert(*rit == 42);
+    assert(rit != single_deque.rend());
+    
+    ++rit;
+    assert(rit == single_deque.rend());
+    
+    cout << "Edge case tests passed!" << endl;
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_edge_cases/test.desc
+++ b/regression/esbmc-cpp/deque/deque_edge_cases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --overflow-check --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_edge_cases_bug/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_edge_cases_bug/main.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    // Test empty deque
+    deque<int> empty_deque;
+    assert(empty_deque.rbegin() == empty_deque.rend());
+    
+    // Test single element
+    deque<int> single_deque;
+    single_deque.push_back(42);
+    
+    auto rit = single_deque.rbegin();
+    assert(*rit == 42);
+    assert(rit != single_deque.rend());
+    
+    ++rit;
+    assert(rit != single_deque.rend()); // it should fail
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_edge_cases_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_edge_cases_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --overflow-check --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_increment/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_increment/main.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    for (int i = 1; i <= 4; i++) {
+        mydeque.push_back(i);
+    }
+    
+    auto rit1 = mydeque.rbegin();
+    auto rit2 = mydeque.rbegin();
+    
+    // Test pre-increment
+    int val1 = *rit1;  // Should be 4
+    ++rit1;
+    int val2 = *rit1;  // Should be 3
+    
+    // Test post-increment
+    int val3 = *(rit2++);  // Should be 4, then rit2 moves
+    int val4 = *rit2;      // Should be 3
+    
+    assert(val1 == 4);
+    assert(val2 == 3);
+    assert(val3 == 4);
+    assert(val4 == 3);
+    assert(rit1 == rit2);  // Both should point to same position
+    
+    cout << "Increment tests passed!" << endl;
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_increment/test.desc
+++ b/regression/esbmc-cpp/deque/deque_increment/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5 --overflow-check --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_increment_bug/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_increment_bug/main.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    for (int i = 1; i <= 4; i++) {
+        mydeque.push_back(i);
+    }
+    
+    auto rit1 = mydeque.rbegin();
+    auto rit2 = mydeque.rbegin();
+    
+    // Test pre-increment
+    int val1 = *rit1;  // Should be 4
+    ++rit1;
+    int val2 = *rit1;  // Should be 3
+    
+    // Test post-increment
+    int val3 = *(rit2++);  // Should be 4, then rit2 moves
+    int val4 = *rit2;      // Should be 3
+    
+    assert(val1 == 4);
+    assert(val2 == 3);
+    assert(val3 == 4);
+    assert(val4 == 3);
+    assert(rit1 != rit2);  // It shouls fail since both should point to same position
+    
+    return 0;
+}
+

--- a/regression/esbmc-cpp/deque/deque_increment_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_increment_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5 --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_rbegin/test.desc
+++ b/regression/esbmc-cpp/deque/deque_rbegin/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_rend/test.desc
+++ b/regression/esbmc-cpp/deque/deque_rend/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_stress/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_stress/main.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    const int SIZE = 20;
+    
+    // Fill with values 1 to SIZE
+    for (int i = 1; i <= SIZE; i++) {
+        mydeque.push_back(i);
+    }
+    
+    // Reverse iterate and verify values
+    int expected = SIZE;
+    for (auto rit = mydeque.rbegin(); rit != mydeque.rend(); ++rit) {
+        assert(*rit == expected);
+        expected--;
+    }
+    
+    assert(expected == 0); // Should have processed all elements
+    
+    cout << "Stress test with " << SIZE << " elements passed!" << endl;
+    return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_stress/test.desc
+++ b/regression/esbmc-cpp/deque/deque_stress/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 21 --overflow-check --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_stress_bug/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_stress_bug/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <deque>
+#include <cassert>
+using namespace std;
+
+int main() {
+    deque<int> mydeque;
+    const int SIZE = 20;
+    
+    // Fill with values 1 to SIZE
+    for (int i = 1; i <= SIZE; i++) {
+        mydeque.push_back(i);
+    }
+    
+    // Reverse iterate and verify values
+    int expected = SIZE;
+    for (auto rit = mydeque.rbegin(); rit != mydeque.rend(); ++rit) {
+        assert(*rit == expected);
+        expected--;
+    }
+    
+    assert(expected == 1); // it should fail     
+    
+    return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_stress_bug/test.desc
+++ b/regression/esbmc-cpp/deque/deque_stress_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 21 --overflow-check --timeout 900
+^VERIFICATION FAILED$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -8,7 +8,6 @@
 
 namespace std
 {
-
 template <class T>
 class deque
 {
@@ -69,7 +68,7 @@ public:
     iterator operator++(int)
     {
       iterator temp = *this;
-      ++(*this);  // Use the pre-increment operator
+      ++(*this); // Use the pre-increment operator
       return temp;
     }
     iterator &operator--()
@@ -258,42 +257,106 @@ public:
       return *this;
     }
 
-    T *operator->();
+    T *operator->()
+    {
+      return pointer;
+    }
 
     T &operator*()
     {
       return *pointer;
     }
 
-    reverse_iterator &operator++();
-    reverse_iterator operator++(int n)
+    // Pre-increment: move backwards through the container
+    reverse_iterator &operator++()
     {
-      reverse_iterator buffer;
-      buffer.pointer = pointer;
-      buffer.pos = pos;
-      buffer.vec_pos = vec_pos;
-      pointer -= sizeof(T);
-      pos--;
+      --pointer;
+      --pos;
+      return *this;
+    }
+
+    // Post-increment: move backwards through the container
+    reverse_iterator operator++(int)
+    {
+      reverse_iterator buffer = *this;
+      --pointer;
+      --pos;
       return buffer;
     }
 
-    reverse_iterator &operator--();
-    reverse_iterator operator--(int);
+    // Pre-decrement: move forwards through the container
+    reverse_iterator &operator--()
+    {
+      ++pointer;
+      ++pos;
+      return *this;
+    }
 
-    bool operator==(const reverse_iterator &) const;
-    bool operator!=(const reverse_iterator &) const;
+    // Post-decrement: move forwards through the container
+    reverse_iterator operator--(int)
+    {
+      reverse_iterator buffer = *this;
+      ++pointer;
+      ++pos;
+      return buffer;
+    }
 
-    bool operator<(const reverse_iterator &) const;
-    bool operator>(const reverse_iterator &) const;
+    // Comparison operators - compare pointers
+    bool operator==(const reverse_iterator &i) const
+    {
+      return (pointer == i.pointer);
+    }
 
-    bool operator<=(const reverse_iterator &) const;
-    bool operator>=(const reverse_iterator &) const;
+    bool operator!=(const reverse_iterator &i) const
+    {
+      return (pointer != i.pointer);
+    }
 
-    reverse_iterator operator+(int) const;
-    reverse_iterator operator-(int) const;
+    bool operator<(const reverse_iterator &i) const
+    {
+      // For reverse iterators, < means greater pointer address
+      // because we're going backwards
+      return (pointer > i.pointer);
+    }
 
-    reverse_iterator &operator+=(int);
-    reverse_iterator &operator-=(int);
+    bool operator>(const reverse_iterator &i) const
+    {
+      return (pointer < i.pointer);
+    }
+
+    bool operator<=(const reverse_iterator &i) const
+    {
+      return (pointer >= i.pointer);
+    }
+
+    bool operator>=(const reverse_iterator &i) const
+    {
+      return (pointer <= i.pointer);
+    }
+
+    reverse_iterator operator+(int n) const
+    {
+      return reverse_iterator(pointer - n, pos - n, vec_pos);
+    }
+
+    reverse_iterator operator-(int n) const
+    {
+      return reverse_iterator(pointer + n, pos + n, vec_pos);
+    }
+
+    reverse_iterator &operator+=(int n)
+    {
+      pointer -= n;
+      pos -= n;
+      return *this;
+    }
+
+    reverse_iterator &operator-=(int n)
+    {
+      pointer += n;
+      pos += n;
+      return *this;
+    }
   };
 
   class const_reverse_iterator
@@ -476,17 +539,18 @@ public:
   reverse_iterator rbegin()
   {
     reverse_iterator buffer;
-    buffer.pointer = buf + _size;
+    buffer.pointer = buf + _size; // Points to last element
     buffer.pos = _size;
     buffer.vec_pos = buf;
     return buffer;
   }
   const_reverse_iterator rbegin() const;
+
   reverse_iterator rend()
   {
     reverse_iterator buffer;
     buf[0] = T();
-    buffer.pointer = buf;
+    buffer.pointer = buf; // Points to position before first element
     buffer.pos = 0;
     buffer.vec_pos = buf;
     return buffer;
@@ -677,16 +741,6 @@ public:
     }
     verify_capacity();
   }
-
-  //	void insert(iterator position, iterator first, iterator last){
-  //		int i = _size;
-  //		int aux;
-  //		while(first!=last){
-  //			insert(position++, *first);
-  //			first++;
-  //		}
-  //		verify_capacity();
-  //	}
 
   template <class Iterator1, class Iterator2>
   void insert(Iterator1 position, Iterator2 first, Iterator2 last)

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -249,6 +249,12 @@ public:
     reverse_iterator()
     {
     }
+    reverse_iterator(T *ppointer, int ppos, T *pvec_pos)
+    {
+      pointer = ppointer;
+      pos = ppos;
+      vec_pos = pvec_pos;
+    }
     reverse_iterator &operator=(const reverse_iterator &i)
     {
       pointer = i.pointer;


### PR DESCRIPTION
This PR fixes incorrect pointer arithmetic, missing operator implementations, and wrong comparison logic that caused verification failures in reverse iterator loops and `rbegin()`/`rend()` usage.