### PR TITLE
[c++] fix iterator memory safety issues in string model

### DIFF
--- a/regression/esbmc-cpp/string/string_erase_2/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 30 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_erase_final/test.desc
+++ b/regression/esbmc-cpp/string/string_erase_final/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 30 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_insert_6/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_6/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 50 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_insert_7/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 50 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_insert_final/test.desc
+++ b/regression/esbmc-cpp/string/string_insert_final/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 50 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_replace_7/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 25 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_replace_8/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_8/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 25 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_replace_9/test.desc
+++ b/regression/esbmc-cpp/string/string_replace_9/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 25 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -170,7 +170,7 @@ public:
     CC_DIAGNOSTIC_PUSH()
     DO_PRAGMA(GCC diagnostic ignored "-Wreturn-stack-address")
 
-    iterator &operator-(int n) const
+    iterator operator-(int n) const
     {
       iterator buffer;
       buffer.pointer = pointer - sizeof(char) * n;
@@ -179,7 +179,7 @@ public:
       return buffer;
     }
 
-    iterator &operator+(int n) const
+    iterator operator+(int n) const
     {
       iterator buffer;
       buffer.pointer = pointer + sizeof(char) * n;
@@ -192,35 +192,27 @@ public:
     //It's like "++c"
     iterator &operator++()
     {
-      iterator buffer;
-      buffer.pointer = pointer;
-      buffer.pos = pos;
       pointer = pointer + sizeof(char);
       pos++;
-      return buffer;
+      return *this;
     }
 
     //operator increases pointer address and returns new value
     //It's like "c++"
     iterator operator++(int _b)
     {
-      iterator buffer;
-      buffer.pointer = pointer + sizeof(char);
-      buffer.pos++;
-      pos++;
+      iterator buffer = *this;
       pointer = pointer + sizeof(char);
+      pos++;
       return buffer;
     }
     //operator decreases pointer address, but returns old value.
     //It's like "--c"
     iterator &operator--()
     {
-      iterator buffer;
-      buffer.pointer = pointer;
-      buffer.pos = pos;
       pointer = pointer - sizeof(char);
       pos--;
-      return buffer;
+      return *this;
     }
 
     CC_DIAGNOSTIC_POP()
@@ -229,11 +221,9 @@ public:
     //It's like "c--"
     iterator operator--(int _b)
     {
-      iterator buffer;
-      buffer.pointer = pointer + sizeof(char);
-      buffer.pos--;
-      pos--;
+      iterator buffer = *this;
       pointer = pointer - sizeof(char);
+      pos--;
       return buffer;
     }
 
@@ -313,22 +303,18 @@ public:
 
     iterator &operator+=(int n)
     {
-      iterator buffer;
-      buffer = buffer + n;
       pointer = pointer + sizeof(char) * n;
       pos += n;
-      return buffer;
+      return *this;
     }
 
     //operator subtracts n positions on pointer address, and returns its address value
 
     iterator operator-=(int n)
     {
-      iterator buffer;
-      buffer = buffer - n;
       pointer = pointer - sizeof(char) * n;
-      pos += n;
-      return buffer;
+      pos -= n;
+      return *this;
     }
 
     CC_DIAGNOSTIC_POP()
@@ -377,24 +363,37 @@ public:
     DO_PRAGMA(GCC diagnostic ignored "-Wreturn-stack-address")
 
     //operator subtracts n positions on pointer address of this
-    const_iterator &operator-(int n) const
+    const_iterator operator-(int n) const
     {
       const_iterator buffer;
       buffer.pointer = pointer - sizeof(char) * n;
+      buffer.pos = pos - n;
       return buffer;
     }
 
-    const_iterator &operator+(int n) const
+    const_iterator operator+(int n) const
     {
       const_iterator buffer;
       buffer.pointer = pointer + sizeof(char) * n;
+      buffer.pos = pos + n;
       return buffer;
     }
 
     CC_DIAGNOSTIC_POP()
 
-    const_iterator &operator++();
-    const_iterator operator++(int);
+    const_iterator &operator++()
+    {
+      pointer = pointer + sizeof(char);
+      pos++;
+      return *this;
+    }
+    const_iterator operator++(int)
+    {
+      const_iterator buffer = *this;
+      pointer = pointer + sizeof(char);
+      pos++;
+      return buffer;
+    }
 
     //operator returns true if both members point to the same address
     //returns false if not happen


### PR DESCRIPTION
This PR fixes memory safety issues in `basic_string iterator` and `const_iterator` implementations that were causing dereference failures when iterators were used.

Issues fixed:
- Iterator arithmetic operators (`operator+`, `operator-`) were returning references to local variables instead of returning by value, causing use-after-free bugs;
- Pre-increment/decrement operators were returning references to temporary objects instead of modifying and returning `*this`;
- Post-increment/decrement operators had incorrect semantics;
- Compound assignment operators were not returning `*this`.