### PR TITLE
[Parallel-Solving] String Container fix for #2618

### DIFF
--- a/regression/esbmc/github_2618/main.c
+++ b/regression/esbmc/github_2618/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+struct InnerStruct {
+  char innerValue[10];
+};
+
+int main() {
+  struct InnerStruct array[2];
+
+  strcpy(array[0].innerValue, "20");
+  strcpy(array[1].innerValue, "40");
+
+  for (int i = 0; i < 2; i++) {
+    int innerValue = atoi(array[i].innerValue);
+    assert(innerValue == 40);
+  }
+
+  return 0;
+}

--- a/regression/esbmc/github_2618/test.desc
+++ b/regression/esbmc/github_2618/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--parallel-solving --k-induction
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -69,10 +69,8 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
     // Run cache if user has specified the option
     if (options.get_bool_option("cache-asserts"))
       // Store the set between runs
-      algorithms.emplace_back(
-        std::make_unique<assertion_cache>(
-          config.ssa_caching_db,
-          !options.get_bool_option("forward-condition")));
+      algorithms.emplace_back(std::make_unique<assertion_cache>(
+        config.ssa_caching_db, !options.get_bool_option("forward-condition")));
 
     if (opts.get_bool_option("ssa-features-dump"))
       algorithms.emplace_back(std::make_unique<ssa_features>());
@@ -1349,8 +1347,7 @@ smt_convt::resultt bmct::multi_property_check(
                        &bs,
                        &fc,
                        &is,
-                       &is_color](const size_t &i)
-  {
+                       &is_color](const size_t &i) {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;
@@ -1413,10 +1410,9 @@ smt_convt::resultt bmct::multi_property_check(
     std::unique_ptr<smt_convt> runtime_solver(create_solver("", ns, options));
 
     // Store solver name initially but not again
-    std::call_once(
-      summary.solver_name_flag,
-      [&]() { summary.solver_name = runtime_solver->solver_text(); });
-
+    std::call_once(summary.solver_name_flag, [&]() {
+      summary.solver_name = runtime_solver->solver_text();
+    });
     log_status(
       "Solving claim '{}' with solver {}",
       claim.claim_msg,

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -69,8 +69,10 @@ bmct::bmct(goto_functionst &funcs, optionst &opts, contextt &_context)
     // Run cache if user has specified the option
     if (options.get_bool_option("cache-asserts"))
       // Store the set between runs
-      algorithms.emplace_back(std::make_unique<assertion_cache>(
-        config.ssa_caching_db, !options.get_bool_option("forward-condition")));
+      algorithms.emplace_back(
+        std::make_unique<assertion_cache>(
+          config.ssa_caching_db,
+          !options.get_bool_option("forward-condition")));
 
     if (opts.get_bool_option("ssa-features-dump"))
       algorithms.emplace_back(std::make_unique<ssa_features>());
@@ -1347,7 +1349,8 @@ smt_convt::resultt bmct::multi_property_check(
                        &bs,
                        &fc,
                        &is,
-                       &is_color](const size_t &i) {
+                       &is_color](const size_t &i)
+  {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;
@@ -1409,9 +1412,10 @@ smt_convt::resultt bmct::multi_property_check(
     // Initialize a solver
     std::unique_ptr<smt_convt> runtime_solver(create_solver("", ns, options));
 
-    // Store solver name
-    if (summary.solver_name.empty())
-      summary.solver_name = runtime_solver->solver_text();
+    // Store solver name initially but not again
+    std::call_once(
+      summary.solver_name_flag,
+      [&]() { summary.solver_name = runtime_solver->solver_text(); });
 
     log_status(
       "Solving claim '{}' with solver {}",

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -122,6 +122,7 @@ private:
     std::atomic<size_t> failed_properties = 0;
     std::atomic<double> total_time_s = 0.0;
     std::string solver_name;
+    std::once_flag solver_name_flag;
   };
 
   void report_simple_summary(const SimpleSummary &summary) const;

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -28,6 +28,13 @@ unsigned string_containert::get(const char *s)
   }
 
   std::unique_lock lock(string_container_mutex);
+  //Recheck after acquiring sole lock
+  hash_tablet::iterator it = hash_table.find(string_ptr);
+  if (it != hash_table.end())
+  {
+    return it->second;
+  }
+
   size_t r = hash_table.size();
 
   // these are stable
@@ -55,6 +62,13 @@ unsigned string_containert::get(const std::string &s)
   }
 
   std::unique_lock lock(string_container_mutex);
+  //Recheck after acquiring sole lock
+  hash_tablet::iterator it = hash_table.find(string_ptr);
+  if (it != hash_table.end())
+  {
+    return it->second;
+  }
+
   size_t r = hash_table.size();
 
   // these are stable


### PR DESCRIPTION
Fixes #2618 

Added Double-Checked Locking to string container to avoid race condition when two threads are trying to add the same string to the cache.

Also adds thread safe way of updating the solver name once.
