### PR TITLE
[Parallel Solving] GitHub #2619 output fix

### DIFF
--- a/regression/esbmc/github_2619/main.c
+++ b/regression/esbmc/github_2619/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+int main()
+{
+  int arr[1];
+  arr[3] = 10;
+  for (int i = 0; i < 10; i++)
+  {
+    assert(1 == 0);
+  }
+}

--- a/regression/esbmc/github_2619/test.desc
+++ b/regression/esbmc/github_2619/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--parallel-solving --k-induction
+2 failed$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -395,6 +395,7 @@ void bmct::clear_verified_claims_in_goto(
   {
     for (auto &instr : func.second.body.instructions)
     {
+      std::lock_guard lock(instr.instruction_mutex);
       if (!instr.is_assert())
         continue;
 

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -395,7 +395,7 @@ void bmct::clear_verified_claims_in_goto(
   {
     for (auto &instr : func.second.body.instructions)
     {
-      std::lock_guard lock(instr.instruction_mutex);
+      std::lock_guard lock(instr.clear_claims_mutex);
       if (!instr.is_assert())
         continue;
 

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -476,7 +476,6 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   // parallel solving activates "--multi-property"
   if (cmdline.isset("parallel-solving"))
   {
-    options.set_option("result-only", true);
     options.set_option("base-case", true);
     options.set_option("multi-property", true);
   }
@@ -1833,7 +1832,7 @@ bool esbmc_parseoptionst::process_goto_program(
   {
     namespacet ns(context);
 
-    bool is_mul = cmdline.isset("multi-property");
+    bool is_mul = cmdline.isset("multi-property") || cmdline.isset("parallel-solving");
     is_coverage = cmdline.isset("assertion-coverage") ||
                   cmdline.isset("assertion-coverage-claims") ||
                   cmdline.isset("condition-coverage") ||

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1832,7 +1832,8 @@ bool esbmc_parseoptionst::process_goto_program(
   {
     namespacet ns(context);
 
-    bool is_mul = cmdline.isset("multi-property") || cmdline.isset("parallel-solving");
+    bool is_mul =
+      cmdline.isset("multi-property") || cmdline.isset("parallel-solving");
     is_coverage = cmdline.isset("assertion-coverage") ||
                   cmdline.isset("assertion-coverage-claims") ||
                   cmdline.isset("condition-coverage") ||

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -359,45 +359,36 @@ public:
       guard = gen_true_expr();
     }
 
-    instructiont(const instructiont& other)
-    : code(other.code),
-      function(other.function),
-      location(other.location),
-      type(other.type),
-      guard(other.guard),
-      // `targets` list is intentionally not copied. The `copy_from` function
-      // is responsible for creating new instructions and then fixing up the
-      // target iterators to point within the new list.
-      labels(other.labels),
-      inductive_step_instruction(other.inductive_step_instruction),
-      inductive_assertion(other.inductive_assertion),
-      location_number(other.location_number),
-      loop_number(other.loop_number),
-      target_number(other.target_number),
-      scope_id(other.scope_id),
-      parent_scope_id(other.parent_scope_id)
+    instructiont(const instructiont &other)
+      : code(other.code),
+        function(other.function),
+        location(other.location),
+        type(other.type),
+        guard(other.guard),
+        labels(other.labels),
+        inductive_step_instruction(other.inductive_step_instruction),
+        inductive_assertion(other.inductive_assertion),
+        location_number(other.location_number),
+        loop_number(other.loop_number),
+        target_number(other.target_number),
+        scope_id(other.scope_id),
+        parent_scope_id(other.parent_scope_id)
     {
-        // The `instruction_mutex` is NOT copied. The new object's mutex
-        // is default-initialized to a fresh, unlocked state.
+      // instruction_mutex is not copied
     }
 
-    // 3. Custom Copy Assignment Operator (NEW)
-    instructiont& operator=(const instructiont& other)
+    instructiont &operator=(const instructiont &other)
     {
       if (this == &other)
         return *this;
 
-      // Lock our own mutex to make the assignment operation safe.
       std::lock_guard<std::mutex> lock(instruction_mutex);
 
-      // Copy data members. Do not touch the mutex itself.
       code = other.code;
       function = other.function;
       location = other.location;
       type = other.type;
       guard = other.guard;
-      // As with the copy constructor, `copy_from` will fix the targets.
-      // Clearing them here is the safest approach.
       targets.clear();
       labels = other.labels;
       inductive_step_instruction = other.inductive_step_instruction;
@@ -411,34 +402,33 @@ public:
       return *this;
     }
 
-    // 4. Custom Move Constructor (from previous fix)
-    instructiont(instructiont&& other) noexcept
-        : code(std::move(other.code)),
-          function(std::move(other.function)),
-          location(std::move(other.location)),
-          type(other.type),
-          guard(std::move(other.guard)),
-          targets(std::move(other.targets)),
-          labels(std::move(other.labels)),
-          inductive_step_instruction(other.inductive_step_instruction),
-          inductive_assertion(other.inductive_assertion),
-          location_number(other.location_number),
-          loop_number(other.loop_number),
-          target_number(other.target_number),
-          scope_id(other.scope_id),
-          parent_scope_id(other.parent_scope_id)
+    instructiont(instructiont &&other)
+      : code(std::move(other.code)),
+        function(std::move(other.function)),
+        location(std::move(other.location)),
+        type(other.type),
+        guard(std::move(other.guard)),
+        targets(std::move(other.targets)),
+        labels(std::move(other.labels)),
+        inductive_step_instruction(other.inductive_step_instruction),
+        inductive_assertion(other.inductive_assertion),
+        location_number(other.location_number),
+        loop_number(other.loop_number),
+        target_number(other.target_number),
+        scope_id(other.scope_id),
+        parent_scope_id(other.parent_scope_id)
     {
-        // The mutex is not moved; the new object gets its own.
     }
 
-    // 5. Custom Move Assignment Operator (from previous fix)
-    instructiont& operator=(instructiont&& other) noexcept
+    instructiont &operator=(instructiont &&other)
     {
       if (this != &other)
       {
         std::lock(instruction_mutex, other.instruction_mutex);
-        std::lock_guard<std::mutex> lhs_lock(instruction_mutex, std::adopt_lock);
-        std::lock_guard<std::mutex> rhs_lock(other.instruction_mutex, std::adopt_lock);
+        std::lock_guard<std::mutex> lhs_lock(
+          instruction_mutex, std::adopt_lock);
+        std::lock_guard<std::mutex> rhs_lock(
+          other.instruction_mutex, std::adopt_lock);
 
         code = std::move(other.code);
         function = std::move(other.function);

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -88,7 +88,7 @@ public:
   class instructiont
   {
   public:
-    mutable std::recursive_mutex instruction_mutex;
+    mutable std::mutex clear_claims_mutex;
 
     expr2tc code;
 
@@ -151,7 +151,6 @@ public:
     //! clear the node
     inline void clear(goto_program_instruction_typet _type)
     {
-      std::lock_guard lock(instruction_mutex);
       type = _type;
       targets.clear();
       guard = gen_true_expr();
@@ -366,8 +365,8 @@ public:
         location(other.location),
         type(other.type),
         guard(other.guard),
-        labels(other.labels),
         targets(other.targets),
+        labels(other.labels),
         inductive_step_instruction(other.inductive_step_instruction),
         inductive_assertion(other.inductive_assertion),
         location_number(other.location_number),
@@ -414,7 +413,6 @@ public:
     {
       if (this == &instruction)
         return;
-      std::scoped_lock lock(instruction_mutex, instruction.instruction_mutex);
 
       instruction.code.swap(code);
       instruction.location.swap(location);

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -10,7 +10,6 @@
 #include <util/location.h>
 #include <util/namespace.h>
 #include <util/std_code.h>
-#include <mutex>
 
 #define forall_goto_program_instructions(it, program)                          \
   for (goto_programt::instructionst::const_iterator it =                       \

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -10,6 +10,7 @@
 #include <util/location.h>
 #include <util/namespace.h>
 #include <util/std_code.h>
+#include <mutex>
 
 #define forall_goto_program_instructions(it, program)                          \
   for (goto_programt::instructionst::const_iterator it =                       \
@@ -87,6 +88,8 @@ public:
   class instructiont
   {
   public:
+    std::mutex instruction_mutex;
+
     expr2tc code;
 
     //! function this belongs to
@@ -354,6 +357,105 @@ public:
         target_number(unsigned(-1))
     {
       guard = gen_true_expr();
+    }
+
+    instructiont(const instructiont& other)
+    : code(other.code),
+      function(other.function),
+      location(other.location),
+      type(other.type),
+      guard(other.guard),
+      // `targets` list is intentionally not copied. The `copy_from` function
+      // is responsible for creating new instructions and then fixing up the
+      // target iterators to point within the new list.
+      labels(other.labels),
+      inductive_step_instruction(other.inductive_step_instruction),
+      inductive_assertion(other.inductive_assertion),
+      location_number(other.location_number),
+      loop_number(other.loop_number),
+      target_number(other.target_number),
+      scope_id(other.scope_id),
+      parent_scope_id(other.parent_scope_id)
+    {
+        // The `instruction_mutex` is NOT copied. The new object's mutex
+        // is default-initialized to a fresh, unlocked state.
+    }
+
+    // 3. Custom Copy Assignment Operator (NEW)
+    instructiont& operator=(const instructiont& other)
+    {
+      if (this == &other)
+        return *this;
+
+      // Lock our own mutex to make the assignment operation safe.
+      std::lock_guard<std::mutex> lock(instruction_mutex);
+
+      // Copy data members. Do not touch the mutex itself.
+      code = other.code;
+      function = other.function;
+      location = other.location;
+      type = other.type;
+      guard = other.guard;
+      // As with the copy constructor, `copy_from` will fix the targets.
+      // Clearing them here is the safest approach.
+      targets.clear();
+      labels = other.labels;
+      inductive_step_instruction = other.inductive_step_instruction;
+      inductive_assertion = other.inductive_assertion;
+      location_number = other.location_number;
+      loop_number = other.loop_number;
+      target_number = other.target_number;
+      scope_id = other.scope_id;
+      parent_scope_id = other.parent_scope_id;
+
+      return *this;
+    }
+
+    // 4. Custom Move Constructor (from previous fix)
+    instructiont(instructiont&& other) noexcept
+        : code(std::move(other.code)),
+          function(std::move(other.function)),
+          location(std::move(other.location)),
+          type(other.type),
+          guard(std::move(other.guard)),
+          targets(std::move(other.targets)),
+          labels(std::move(other.labels)),
+          inductive_step_instruction(other.inductive_step_instruction),
+          inductive_assertion(other.inductive_assertion),
+          location_number(other.location_number),
+          loop_number(other.loop_number),
+          target_number(other.target_number),
+          scope_id(other.scope_id),
+          parent_scope_id(other.parent_scope_id)
+    {
+        // The mutex is not moved; the new object gets its own.
+    }
+
+    // 5. Custom Move Assignment Operator (from previous fix)
+    instructiont& operator=(instructiont&& other) noexcept
+    {
+      if (this != &other)
+      {
+        std::lock(instruction_mutex, other.instruction_mutex);
+        std::lock_guard<std::mutex> lhs_lock(instruction_mutex, std::adopt_lock);
+        std::lock_guard<std::mutex> rhs_lock(other.instruction_mutex, std::adopt_lock);
+
+        code = std::move(other.code);
+        function = std::move(other.function);
+        location = std::move(other.location);
+        type = other.type;
+        guard = std::move(other.guard);
+        targets = std::move(other.targets);
+        labels = std::move(other.labels);
+        inductive_step_instruction = other.inductive_step_instruction;
+        inductive_assertion = other.inductive_assertion;
+        location_number = other.location_number;
+        loop_number = other.loop_number;
+        target_number = other.target_number;
+        scope_id = other.scope_id;
+        parent_scope_id = other.parent_scope_id;
+      }
+      return *this;
     }
 
     //! swap two instructions

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -176,6 +176,7 @@ void goto_symext::symex_step(reachability_treet &art)
   assert(!cur_state->call_stack.empty());
 
   const goto_programt::instructiont &instruction = *cur_state->source.pc;
+  std::lock_guard lock(instruction.instruction_mutex);
 
   // depth exceeded?
   {

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -176,7 +176,6 @@ void goto_symext::symex_step(reachability_treet &art)
   assert(!cur_state->call_stack.empty());
 
   const goto_programt::instructiont &instruction = *cur_state->source.pc;
-  std::lock_guard lock(instruction.instruction_mutex);
 
   // depth exceeded?
   {


### PR DESCRIPTION
#2619 is fixed by the change to esbmc_parseoptions.cpp. Parallel-solving enables multi-property on the options object but is_mul only checks the command line arguments.

The rest of the changes fix a race condition introduced by removing result-only from parallel-solving by default to be in line with multi-property.