### PR TITLE
[multi-property] Verify properties individually using claim.cstr

### DIFF
--- a/regression/esbmc-cpp/cpp/multi-property/main.cpp
+++ b/regression/esbmc-cpp/cpp/multi-property/main.cpp
@@ -1,0 +1,16 @@
+#include <cstdlib>
+
+int* make_array(int n) {
+  if (n <= 0) return NULL;
+  int *arr = (int *) malloc(n * sizeof(int));
+  for (int i = 0; i <= n; i++) {
+    arr[i] = i;
+  }
+  return arr;
+}
+
+int main()
+{
+  make_array(nondet_int());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/multi-property/test.desc
+++ b/regression/esbmc-cpp/cpp/multi-property/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--multi-property --unwind 10
+^  dereference failure\: NULL pointer$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1477,7 +1477,10 @@ smt_convt::resultt bmct::multi_property_check(
       else
       {
         std::lock_guard lock(reached_claims_mutex);
-        reached_claims.emplace(claim.claim_cstr);
+        if (is_goto_cov)
+          reached_claims.emplace(claim_sig);
+        else
+          reached_claims.emplace(claim.claim_cstr);
       }
 
       // update cex number

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1371,7 +1371,7 @@ smt_convt::resultt bmct::multi_property_check(
       // C++20 reached_mul_claims.contains
       is_verified = reached_mul_claims.count(claim_sig) ? true : false;
     else
-      is_verified = reached_claims.count(claim_sig) ? true : false;
+      is_verified = reached_claims.count(claim.claim_cstr) ? true : false;
     if (is_assert_cov && is_verified)
     {
       // insert to the multiset before skipping the verification process
@@ -1379,7 +1379,7 @@ smt_convt::resultt bmct::multi_property_check(
       reached_mul_claims.emplace(claim_sig);
     }
 
-    if (verified_claims.count(claim_sig))
+    if (verified_claims.count(claim.claim_cstr))
     {
       clear_verified_claims_in_ssa(local_eq, claim, is_goto_cov);
       clear_verified_claims_in_goto(claim, is_goto_cov);
@@ -1415,7 +1415,7 @@ smt_convt::resultt bmct::multi_property_check(
     });
     log_status(
       "Solving claim '{}' with solver {}",
-      claim.claim_msg,
+      claim.claim_cstr,
       runtime_solver->solver_text());
 
     // Save current instance with timing
@@ -1468,7 +1468,7 @@ smt_convt::resultt bmct::multi_property_check(
       goto_tracet goto_trace;
       build_goto_trace(local_eq, *runtime_solver, goto_trace, is_compact_trace);
 
-      // Store claim_sig
+      // Store claim signature
       if (is_assert_cov)
       {
         std::lock_guard lock(reached_mul_claims_mutex);
@@ -1477,7 +1477,7 @@ smt_convt::resultt bmct::multi_property_check(
       else
       {
         std::lock_guard lock(reached_claims_mutex);
-        reached_claims.emplace(claim_sig);
+        reached_claims.emplace(claim.claim_cstr);
       }
 
       // update cex number


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2654.

Use claim.cstr to access property and location information for individual property verification before determining whether to skip properties. This ensures more accurate validation by checking each property's specific constraints.

Before this PR:

````
ESBMC version 7.10.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
[PROGRESS] Parsing ex1.cpp
[PROGRESS] Converting
[PROGRESS] Generating GOTO Program
GOTO program creation time: 0.651s
GOTO program processing time: 0.009s
[PROGRESS] Starting Bounded Model Checking
Unwinding loop 14 iteration 1   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 2   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 3   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 4   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 5   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 6   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 7   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 8   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 9   file ex1.cpp line 6 column 3 function make_array
Not unwinding loop 14 iteration 10   file ex1.cpp line 6 column 3 function make_array
Symex completed in: 0.057s (134 assignments)
Slicing time: 0.002s (removed 83 assignments)
Generated 31 VCC(s), 31 remaining after simplification (51 assignments)
No solver specified; defaulting to Boolector
Slicing time: 0.000s (removed 6 assignments)
No solver specified; defaulting to Boolector
Solving claim '1' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.004s
✗ FAILED: 'unwinding assertion loop 14 at file ex1.cpp line 6 column 3 function make_array'

[Counterexample]


State 1 file ex1.cpp line 6 column 3 function make_array thread 0
----------------------------------------------------
Violated property:
  file ex1.cpp line 6 column 3 function make_array
  unwinding assertion loop 14

Slicing time: 0.000s (removed 2 assignments)
No solver specified; defaulting to Boolector
Solving claim '1' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.019s
✗ FAILED: 'dereference failure: array bounds violated at file ex1.cpp line 7 column 5 function make_array'

[Counterexample]


State 1 file ex1.cpp line 5 column 3 function make_array thread 0
----------------------------------------------------
  arr = (signed int *)(&dynamic_3_array[0])

State 2 file ex1.cpp line 7 column 5 function make_array thread 0
----------------------------------------------------
Violated property:
  file ex1.cpp line 7 column 5 function make_array
  dereference failure: array bounds violated

Properties: 31 verified, ✓ 29 skipped, ✗ 2 failed
Solver: Boolector 3.2.2 • Decision procedure total time: 0.025s • Avg: 0.000s/property

VERIFICATION FAILED
````

This PR:

````
ESBMC version 7.10.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
[PROGRESS] Parsing ex1.cpp
[PROGRESS] Converting
[PROGRESS] Generating GOTO Program
GOTO program creation time: 0.614s
GOTO program processing time: 0.009s
[PROGRESS] Starting Bounded Model Checking
Unwinding loop 14 iteration 1   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 2   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 3   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 4   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 5   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 6   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 7   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 8   file ex1.cpp line 6 column 3 function make_array
Unwinding loop 14 iteration 9   file ex1.cpp line 6 column 3 function make_array
Not unwinding loop 14 iteration 10   file ex1.cpp line 6 column 3 function make_array
Symex completed in: 0.059s (134 assignments)
Slicing time: 0.002s (removed 83 assignments)
Generated 31 VCC(s), 31 remaining after simplification (51 assignments)
No solver specified; defaulting to Boolector
Slicing time: 0.000s (removed 6 assignments)
No solver specified; defaulting to Boolector
Solving claim 'unwinding assertion loop 14 at file ex1.cpp line 6 column 3 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.003s
✗ FAILED: 'unwinding assertion loop 14 at file ex1.cpp line 6 column 3 function make_array'

[Counterexample]


State 1 file ex1.cpp line 6 column 3 function make_array thread 0
----------------------------------------------------
Violated property:
  file ex1.cpp line 6 column 3 function make_array
  unwinding assertion loop 14

Slicing time: 0.002s (removed 2 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: array bounds violated at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.003s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.018s
✗ FAILED: 'dereference failure: array bounds violated at file ex1.cpp line 7 column 5 function make_array'

[Counterexample]


State 1 file ex1.cpp line 5 column 3 function make_array thread 0
----------------------------------------------------
  arr = (signed int *)(&dynamic_3_array[0])

State 2 file ex1.cpp line 7 column 5 function make_array thread 0
----------------------------------------------------
Violated property:
  file ex1.cpp line 7 column 5 function make_array
  dereference failure: array bounds violated

Slicing time: 0.000s (removed 9 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: NULL pointer at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.027s
✗ FAILED: 'dereference failure: NULL pointer at file ex1.cpp line 7 column 5 function make_array'

[Counterexample]


State 1 file ex1.cpp line 5 column 3 function make_array thread 0
----------------------------------------------------
  arr = (signed int *)0

State 2 file ex1.cpp line 7 column 5 function make_array thread 0
----------------------------------------------------
Violated property:
  file ex1.cpp line 7 column 5 function make_array
  dereference failure: NULL pointer

Slicing time: 0.000s (removed 8 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.002s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.002s (removed 9 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.002s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.000s (removed 10 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.002s (removed 11 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.000s (removed 7 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.003s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.000s (removed 6 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.002s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.000s (removed 5 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.003s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.000s (removed 4 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.003s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.002s (removed 3 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Slicing time: 0.000s (removed 2 assignments)
No solver specified; defaulting to Boolector
Solving claim 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array' with solver Boolector 3.2.2
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.002s
[PROGRESS] Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
✓ PASSED: 'dereference failure: invalidated dynamic object at file ex1.cpp line 7 column 5 function make_array'
Properties: 31 verified ✓ 10 passed, ✓ 18 skipped, ✗ 3 failed
Solver: Boolector 3.2.2 • Decision procedure total time: 0.068s • Avg: 0.003s/property

VERIFICATION FAILED
````
