### PR TITLE
[goto-contractor] handle missing interval data in goto_contractor

### DIFF
--- a/regression/goto-contractor/github_2662/main.c
+++ b/regression/goto-contractor/github_2662/main.c
@@ -1,0 +1,16 @@
+#include<assert.h>
+
+int main(){
+ int x=1, y=0;
+
+ while(y <1000 &&__VERIFIER_nondet_int())
+ {
+   x=x+y;
+   y=y+1;
+ }
+
+ assert(x >= y);
+
+ return 0;
+}
+

--- a/regression/goto-contractor/github_2662/test.desc
+++ b/regression/goto-contractor/github_2662/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-analysis --goto-contractor --incremental-bmc
+^VERIFICATION UNKNOWN$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -386,6 +386,7 @@ TEST_SUITES = [
     "Interval-analysis-ibex-contractor",
     "jimple",
     "k-induction",
+    "goto-contractor",
     "k-induction-parallel",
     "termination"
     "linux",

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -56,7 +56,22 @@ void goto_contractort::get_intervals(
         while (it != map.var_map.end())
         {
           auto var_name = to_symbol2t(it->second.getSymbol()).get_symbol_name();
-          auto _new_interval = interval_analysis[i_it].intervals->at(var_name);
+
+          // Check if the variable exists in the intervals map before accessing
+          auto intervals_map = interval_analysis[i_it].intervals;
+          if (intervals_map->find(var_name) == intervals_map->end())
+          {
+            // Variable not found in interval analysis for this location
+            log_debug(
+              "contractor",
+              "Variable {} not found in interval analysis at location {}",
+              var_name,
+              i_it->location_number);
+            it++;
+            continue;
+          }
+
+          auto _new_interval = intervals_map->at(var_name);
           if (_new_interval.index() != 0)
           {
             it++;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2662.

Prevent `std::out_of_range` crash by checking if variables exist in the interval analysis map before accessing them. Add a fallback for missing interval data at specific program locations.