### PR TITLE
[python] Handling hasttr()

### DIFF
--- a/regression/python/has-attr/main.py
+++ b/regression/python/has-attr/main.py
@@ -1,0 +1,7 @@
+class Foo:
+    pass
+
+f = Foo()
+f.x = 10
+assert hasattr(f, 'x')
+assert hasattr(f, 'y') == False

--- a/regression/python/has-attr/main.py
+++ b/regression/python/has-attr/main.py
@@ -3,5 +3,5 @@ class Foo:
 
 f = Foo()
 f.x = 10
-assert hasattr(f, 'x')
+assert hasattr(f, 'x') == True
 assert hasattr(f, 'y') == False

--- a/regression/python/has-attr/test.desc
+++ b/regression/python/has-attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -86,6 +86,8 @@ private:
 
   exprt handle_isinstance() const;
 
+  exprt handle_hasattr() const;
+
   /*
    * Handles str-to-int conversions (e.g., int('65')) by reconstructing
    * the string value from a symbol's internal representation and


### PR DESCRIPTION
We have a mapping from objects to a list of attributes in the `python_converter`. I am handling the `hasattr(obj, 'attrname')` function by using this map to check whether an attribute belongs to an object.