### PR TITLE
[goto-symex] Fix static output_count scoping in symex_target_equationt

### DIFF
--- a/regression/parallel-solving/pthread_mutex_init/main.c
+++ b/regression/parallel-solving/pthread_mutex_init/main.c
@@ -1,0 +1,6 @@
+int a;
+main()
+{
+  pthread_mutex_init();
+  printf(a);
+}

--- a/regression/parallel-solving/pthread_mutex_init/test.desc
+++ b/regression/parallel-solving/pthread_mutex_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--parallel-solving -Wno-error=implicit-int -Wno-error=int-conversion -Wno-error=format-security
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -148,7 +148,6 @@ void symex_target_equationt::convert_internal_step(
   smt_convt::ast_vec &assertions,
   SSA_stept &step)
 {
-  static unsigned output_count = 0; // Temporary hack; should become scoped.
   smt_astt true_val = smt_conv.convert_ast(gen_true_expr());
   smt_astt false_val = smt_conv.convert_ast(gen_false_expr());
 

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -20,7 +20,7 @@ class symex_target_equationt : public symex_targett
 public:
   class SSA_stept;
 
-  symex_target_equationt(const namespacet &_ns) : ns(_ns)
+  symex_target_equationt(const namespacet &_ns) : ns(_ns), output_count(0)
   {
     debug_print = config.options.get_bool_option("symex-ssa-trace");
     ssa_trace = config.options.get_bool_option("ssa-trace");
@@ -188,6 +188,7 @@ public:
   void clear()
   {
     SSA_steps.clear();
+    output_count = 0;
   }
 
   unsigned int clear_assertions();
@@ -208,6 +209,7 @@ protected:
   bool debug_print;
   bool ssa_trace;
   bool ssa_smt_trace;
+  unsigned output_count;
 
 private:
   void debug_print_step(const SSA_stept &step) const;


### PR DESCRIPTION
This PR replace static `unsigned output_count` with an instance member variable in `symex_target_equationt` class. This fixes thread safety issues and ensures each equation instance maintains its own counter state. In particular, this PR:

- Adds `output_count` as protected member variable
- Initializes in constructor  
- Resets counter in `clear()` method
- Removes global state sharing between instances