### PR TITLE
[Parallel Solving] Data race in goto trace

### DIFF
--- a/regression/parallel-solving/forester-heap-reduction/main.i
+++ b/regression/parallel-solving/forester-heap-reduction/main.i
@@ -1,0 +1,5 @@
+a() { __assert_fail("", "", 2, __PRETTY_FUNCTION__); }
+main() {
+  a();
+  a();
+}

--- a/regression/parallel-solving/forester-heap-reduction/test.desc
+++ b/regression/parallel-solving/forester-heap-reduction/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.i
+--parallel-solving -Wno-error=implicit-int -Wno-error=return-type
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -395,7 +395,7 @@ void bmct::clear_verified_claims_in_goto(
   {
     for (auto &instr : func.second.body.instructions)
     {
-      std::lock_guard lock(instr.clear_claims_mutex);
+      std::lock_guard lock(instr.type_mutex);
       if (!instr.is_assert())
         continue;
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -87,7 +87,7 @@ public:
   class instructiont
   {
   public:
-    mutable std::mutex clear_claims_mutex;
+    mutable std::mutex type_mutex;
 
     expr2tc code;
 
@@ -374,7 +374,7 @@ public:
         scope_id(other.scope_id),
         parent_scope_id(other.parent_scope_id)
     {
-      // instruction_mutex is not copied
+      // type_mutex is not copied
     }
 
     instructiont &operator=(const instructiont &other)

--- a/src/goto-symex/goto_trace.cpp
+++ b/src/goto-symex/goto_trace.cpp
@@ -478,6 +478,7 @@ void show_goto_trace(
 
   for (const auto &step : goto_trace.steps)
   {
+    std::lock_guard lock(step.pc->type_mutex);
     // we only care about the counter example, which is only triggered by assert steps. Ignore all other steps.
     if (cex_only && step.type != goto_trace_stept::ASSERT)
       continue;


### PR DESCRIPTION
Previously step type could be changed from ASSERT to SKIP by a different thread during the goto trace. This PR reuses a mutex for the same problem in bmc and renames the mutex. 