### PR TITLE
[Parallel Solving] Data race in irep2

### DIFF
--- a/regression/parallel-solving/array_tiling/main.c
+++ b/regression/parallel-solving/array_tiling/main.c
@@ -1,0 +1,9 @@
+b, c;
+main()
+{
+  long *a = malloc(b);
+  a[c] = a[c];
+  if (a[c])
+  d:
+    reach_error();
+}

--- a/regression/parallel-solving/array_tiling/test.desc
+++ b/regression/parallel-solving/array_tiling/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--parallel-solving --parallel-solving --k-induction --max-k-step 5 --Wno-error=implicit-int
+^VERIFICATION UNKNOWN$

--- a/regression/parallel-solving/array_tiling/test.desc
+++ b/regression/parallel-solving/array_tiling/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---parallel-solving --parallel-solving --k-induction --max-k-step 5 --Wno-error=implicit-int
+--parallel-solving --parallel-solving --k-induction --max-k-step 5 -Wno-error=implicit-int
 ^VERIFICATION UNKNOWN$

--- a/regression/parallel-solving/array_tiling/test.desc
+++ b/regression/parallel-solving/array_tiling/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---parallel-solving --parallel-solving --k-induction --max-k-step 5 -Wno-error=implicit-int
+--parallel-solving --k-induction --max-k-step 5 -Wno-error=implicit-int
 ^VERIFICATION UNKNOWN$

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -132,8 +132,10 @@ expr2t::expr2t(const type2tc &_type, expr_ids id)
 }
 
 expr2t::expr2t(const expr2t &ref)
-  : expr_id(ref.expr_id), type(ref.type), crc_val(ref.crc_val)
+  : expr_id(ref.expr_id), type(ref.type)
 {
+  std::lock_guard lock(ref.crc_mutex);
+  crc_val = ref.crc_val;
 }
 
 bool expr2t::operator==(const expr2t &ref) const

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -131,8 +131,7 @@ expr2t::expr2t(const type2tc &_type, expr_ids id)
 {
 }
 
-expr2t::expr2t(const expr2t &ref)
-  : expr_id(ref.expr_id), type(ref.type)
+expr2t::expr2t(const expr2t &ref) : expr_id(ref.expr_id), type(ref.type)
 {
   std::lock_guard lock(ref.crc_mutex);
   crc_val = ref.crc_val;


### PR DESCRIPTION
crc_mutex in the irep2 class did not cover the copy constructor. If do_crc is called on object A and object B copy constructed from object A at the same time a data race occurs on the crc_val.

Adding the crc_mutex to the copy constructor avoid this.