### PR TITLE
[c++] fix stringstream compilation errors

### DIFF
--- a/regression/esbmc-cpp/stream/sstream_str_int/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_int/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_short/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_short/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/sstream
+++ b/src/cpp/library/sstream
@@ -71,15 +71,14 @@ public:
     return _string;
   }
 
-  ostream &operator<<(string &val)
+  ostream &operator<<(const string &val)
   {
-    _string.append(val);
+    _string.append(val.c_str());
     return *this;
   }
 
-  ostream &operator<<(bool &val)
+  ostream &operator<<(bool val)
   {
-    char temp;
     if (val)
       _string.append("1");
     else
@@ -87,7 +86,17 @@ public:
     return *this;
   }
 
-  ostream &operator<<(short &val)
+  ostream &operator<<(void* val)
+  {
+    char *temp = new char[NUM_SIZE];
+    // Convert pointer to string representation (hexadecimal)
+    // For simplicity, just convert the pointer value to decimal
+    itoa((long)val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(short val)
   {
     char *temp = new char[NUM_SIZE];
     itoa(val, temp, DEC);
@@ -95,7 +104,7 @@ public:
     return *this;
   }
 
-  ostream &operator<<(long &val)
+  ostream &operator<<(int val)
   {
     char *temp = new char[NUM_SIZE];
     itoa(val, temp, DEC);
@@ -103,7 +112,23 @@ public:
     return *this;
   }
 
-  ostream &operator<<(unsigned int &val)
+  ostream &operator<<(long val)
+  {
+    char *temp = new char[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(unsigned short val)
+  {
+    char *temp = new char[NUM_SIZE];
+    itoa(val, temp, DEC);
+    _string.append(temp);
+    return *this;
+  }
+
+  ostream &operator<<(unsigned int val)
   {
     char *temp = new char[NUM_SIZE];
     itoa(val, temp, DEC);
@@ -157,31 +182,21 @@ public:
     return *this;
   }
 
-  ostream &operator<<(char &val)
+  ostream &operator<<(char val)
   {
     _string.append(&val, 1);
     return *this;
   }
 
-  ostream &operator<<(unsigned char &val)
+  ostream &operator<<(unsigned char val)
   {
     _string.append(reinterpret_cast<const char *>(&val), 1);
     return *this;
   }
 
-  ostream &operator<<(char *val)
+  ostream &operator<<(const char *val)
   {
-    int tam = strlen(val);
-    _string.append(val, tam);
-    return *this;
-  }
-
-  ostream &operator<<(unsigned short &val)
-  {
-    char *temp = new char[NUM_SIZE];
-    itoa(val, temp, DEC);
-    _string.append(temp);
-    _string._size = strlen(_string.str) + strlen(temp);
+    _string.append(val);
     return *this;
   }
 };


### PR DESCRIPTION
This PR fixes compilation failures when using `stringstream` with integer types due to ambiguity between global ostream operators and stringstream members. In particular, this PR

- Adds missing `operator<<(int val)` to resolve ambiguous overload errors
- Adds missing `operator<<(void* val)` to resolve ambiguity with bool operator  
- Fixes parameter types: use pass-by-value for primitives instead of references
- Fixes `const string& append' by using 'c_str()' method for ESBMC compatibility
- Makes string and char* parameters const-correct