### PR TITLE
[Parallel Solving] Data Race in irep2 cont

### DIFF
--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -50,9 +50,11 @@ type2t::type2t(type_ids id) : type_id(id), crc_val(0)
 {
 }
 
-type2t::type2t(const type2t &ref) : type_id(ref.type_id), crc_val(ref.crc_val)
+type2t::type2t(const type2t &ref) : type_id(ref.type_id)
 // NOTE: crc_mutex not mentioned here so fresh mutex is created.
 {
+  std::lock_guard lock(ref.crc_mutex);
+  crc_val = ref.crc_val;
 }
 
 bool type2t::operator==(const type2t &ref) const


### PR DESCRIPTION
Issue fixed in https://github.com/esbmc/esbmc/pull/2680 still occurs about 1 in 20 times due to missing a lock for crc_val. Searched all the files to crc_val references and this should be all.