### PR TITLE
[python] add helper functions for range-loops

### DIFF
--- a/regression/python/range19_2/main.py
+++ b/regression/python/range19_2/main.py
@@ -1,0 +1,17 @@
+import random
+
+result:int = 0
+
+def factorial (n: int) -> int:
+  if n < 0:
+    assert(0)
+  
+  result = 1
+  
+  for i in range (1, n + 1):
+    result *= i
+  
+  return result
+
+x:int = 4
+assert factorial (x) == 24

--- a/regression/python/range19_2/test.desc
+++ b/regression/python/range19_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range19_2_fail/main.py
+++ b/regression/python/range19_2_fail/main.py
@@ -1,0 +1,17 @@
+import random
+
+result:int = 0
+
+def factorial (n: int) -> int:
+  if n < 0:
+    assert(0)
+  
+  result = 1
+  
+  for i in range (1, n + 1):
+    result *= i
+  
+  return result
+
+x:int = 4
+assert factorial (x) == 25

--- a/regression/python/range19_2_fail/test.desc
+++ b/regression/python/range19_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/range19_fail/main.py
+++ b/regression/python/range19_fail/main.py
@@ -1,0 +1,17 @@
+import random
+
+result:int = 0
+
+def factorial (n: int) -> int:
+  if n < 0:
+    assert(0)
+  
+  result = 1
+  
+  for i in range (1, n + 1):
+    result *= i
+  
+  return result
+
+x:int = random.randint(1, 16383)
+assert factorial (x) < 0

--- a/regression/python/range19_fail/test.desc
+++ b/regression/python/range19_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$


### PR DESCRIPTION
This PR extends the Python frontend preprocessor to handle range-based loops by injecting helper functions that model range semantics.