### PR TITLE
[python] Add floor/ceil Operational Models and Regression Tests

### DIFF
--- a/regression/python/floor_ceil1/main.py
+++ b/regression/python/floor_ceil1/main.py
@@ -1,0 +1,20 @@
+import math
+
+# Positive numbers
+assert math.floor(3.7) == 3
+assert math.ceil(3.7) == 4
+
+# Negative numbers
+assert math.floor(-3.7) == -4
+assert math.ceil(-3.7) == -3
+
+# Zero
+assert math.floor(0.0) == 0
+assert math.ceil(0.0) == 0
+
+# Integers (should stay the same)
+assert math.floor(5.0) == 5
+assert math.ceil(5.0) == 5
+assert math.floor(-5.0) == -5
+assert math.ceil(-5.0) == -5
+

--- a/regression/python/floor_ceil1/test.desc
+++ b/regression/python/floor_ceil1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil1_fail/main.py
+++ b/regression/python/floor_ceil1_fail/main.py
@@ -1,0 +1,5 @@
+import math
+
+assert math.floor(3.7) == 4
+assert math.ceil(-3.7) == -3.1
+

--- a/regression/python/floor_ceil1_fail/test.desc
+++ b/regression/python/floor_ceil1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/regression/python/floor_ceil2/main.py
+++ b/regression/python/floor_ceil2/main.py
@@ -1,0 +1,13 @@
+import math
+
+# Very small fractional values
+assert math.floor(0.0001) == 0
+assert math.ceil(0.0001) == 1
+assert math.floor(-0.0001) == -1
+assert math.ceil(-0.0001) == 0
+
+# Large values
+assert math.floor(1e12 + 0.9) == 1000000000000
+assert math.ceil(1e12 + 0.1) == 1000000000001
+assert math.floor(-1e12 - 0.1) == -1000000000001
+assert math.ceil(-1e12 - 0.9) == -1000000000000

--- a/regression/python/floor_ceil2/test.desc
+++ b/regression/python/floor_ceil2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil2_fail/main.py
+++ b/regression/python/floor_ceil2_fail/main.py
@@ -1,0 +1,5 @@
+import math
+
+# Very small fractional values
+assert math.floor(0.0001) == -1
+assert math.ceil(0.0001) == 2

--- a/regression/python/floor_ceil2_fail/test.desc
+++ b/regression/python/floor_ceil2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/regression/python/floor_ceil3/main.py
+++ b/regression/python/floor_ceil3/main.py
@@ -1,0 +1,14 @@
+import math
+
+# Positive integer boundary
+assert math.floor(1.0) == 1
+assert math.ceil(1.0) == 1
+
+# Negative integer boundary
+assert math.floor(-1.0) == -1
+assert math.ceil(-1.0) == -1
+
+# Zero boundary
+assert math.floor(0.0) == 0
+assert math.ceil(0.0) == 0
+

--- a/regression/python/floor_ceil3/test.desc
+++ b/regression/python/floor_ceil3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil3_fail/main.py
+++ b/regression/python/floor_ceil3_fail/main.py
@@ -1,0 +1,8 @@
+import math
+
+# Infinity
+assert math.floor(float("inf")) == 1
+assert math.ceil(float("inf")) == 1
+assert math.floor(float("-inf")) == 1
+assert math.ceil(float("-inf")) == 1
+

--- a/regression/python/floor_ceil3_fail/test.desc
+++ b/regression/python/floor_ceil3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/regression/python/floor_ceil4/main.py
+++ b/regression/python/floor_ceil4/main.py
@@ -1,0 +1,13 @@
+import math
+
+# Very small positive/negative values
+assert math.floor(1e-10) == 0
+assert math.ceil(1e-10) == 1
+assert math.floor(-1e-10) == -1
+assert math.ceil(-1e-10) == 0
+    
+# Values near zero
+assert math.floor(0.5) == 0
+assert math.ceil(0.5) == 1
+assert math.floor(-0.5) == -1
+assert math.ceil(-0.5) == 0

--- a/regression/python/floor_ceil4/test.desc
+++ b/regression/python/floor_ceil4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil5/main.py
+++ b/regression/python/floor_ceil5/main.py
@@ -1,0 +1,12 @@
+import math
+
+# Just below 3
+x = 2.9999999999999
+assert math.floor(x) == 2
+assert math.ceil(x) == 3
+
+# Just below -2
+y = -2.0000000000001
+assert math.floor(y) == -3
+assert math.ceil(y) == -2
+

--- a/regression/python/floor_ceil5/test.desc
+++ b/regression/python/floor_ceil5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil6/main.py
+++ b/regression/python/floor_ceil6/main.py
@@ -1,0 +1,12 @@
+# regression/python/floor_ceil_boundary_above/main.py
+import math
+
+# Just above 3
+x = 3.0000000000001
+assert math.floor(x) == 3
+assert math.ceil(x) == 4
+
+# Just above -2
+y = -1.9999999999999
+assert math.floor(y) == -2
+assert math.ceil(y) == -1

--- a/regression/python/floor_ceil6/test.desc
+++ b/regression/python/floor_ceil6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil_nan_fail/main.py
+++ b/regression/python/floor_ceil_nan_fail/main.py
@@ -1,0 +1,7 @@
+import math
+
+# NaN should not be a valid input
+x = float("nan")
+assert math.floor(x) == 0  # This should FAIL
+assert math.ceil(x) == 0   # This should FAIL
+

--- a/regression/python/floor_ceil_nan_fail/test.desc
+++ b/regression/python/floor_ceil_nan_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -42,3 +42,39 @@ def comb(n: int, k: int) -> int:
         result = result * (n - i) // (i + 1)
         i = i + 1
     return result
+
+def isinf(x: float) -> bool:
+    return __ESBMC_isinf(x)
+
+def isnan(x: float) -> bool:
+    return __ESBMC_isnan(x)
+
+def floor(x: float) -> int:
+    # infinity and NaN inputs cause assertion failures
+    # since they cannot be converted to integers.
+    assert not isinf(x), "Input cannot be infinity"
+    assert not isnan(x), "Input cannot be NaN"
+
+    if x >= 0:
+        return int(x)
+    else:
+        int_x: int = int(x)
+        if x == int_x:
+            return int_x
+        else:
+            return int_x - 1
+
+def ceil(x: float) -> int:
+    # infinity and NaN inputs cause assertion failures 
+    # since they cannot be converted to integers.
+    assert not isinf(x), "Input cannot be infinity"
+    assert not isnan(x), "Input cannot be NaN"
+
+    if x <= 0:
+        return int(x)
+    else:
+        int_x: int = int(x)
+        if x == int_x:
+            return int_x
+        else:
+            return int_x + 1

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -65,7 +65,7 @@ def floor(x: float) -> int:
             return int_x - 1
 
 def ceil(x: float) -> int:
-    # infinity and NaN inputs cause assertion failures 
+    # infinity and NaN inputs cause assertion failures
     # since they cannot be converted to integers.
     assert not isinf(x), "Input cannot be infinity"
     assert not isnan(x), "Input cannot be NaN"


### PR DESCRIPTION
This PR introduces operational models for `math. Floor` and `math. Ceil` in the Python frontend. It also adds regression tests to validate correct behavior across a variety of inputs.