### PR TITLE
[python] Subscript Type Inference & Regression Tests

### DIFF
--- a/regression/python/problem4/main.py
+++ b/regression/python/problem4/main.py
@@ -1,0 +1,15 @@
+def minimumCoins_v1(prices: list[int]) -> int:
+    n = len(prices)
+    if not n: return 0
+    elif n == 1: return prices[0]
+    #dp = [float("inf")] * n
+    dp = [1, 2, 3]
+    for j in range(2):
+        dp[j] = prices[0]
+    for i in range(1, n):
+        price = dp[i - 1] + prices[i]
+        for j in range(i, min(n, (i + 1) * 2)):
+            dp[j] = min(dp[j], price)
+    return dp[-1]
+
+assert minimumCoins_v1([1, 2, 3]) == 3

--- a/regression/python/problem4/test.desc
+++ b/regression/python/problem4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/problem4_fail/main.py
+++ b/regression/python/problem4_fail/main.py
@@ -1,0 +1,15 @@
+def minimumCoins_v1(prices: list[int]) -> int:
+    n = len(prices)
+    if not n: return 0
+    elif n == 1: return prices[0]
+    #dp = [float("inf")] * n
+    dp = [1, 2, 3]
+    for j in range(2):
+        dp[j] = prices[0]
+    for i in range(1, n):
+        price = dp[i - 1] + prices[i]
+        for j in range(i, min(n, (i + 1) * 2)):
+            dp[j] = min(dp[j], price)
+    return dp[-1]
+
+assert minimumCoins_v1([1, 2, 3]) == 2

--- a/regression/python/problem4_fail/test.desc
+++ b/regression/python/problem4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -341,55 +341,26 @@ private:
       else if (lhs["_type"] == "Subscript")
       {
         // Handle subscript operations like dp[i-1], prices[i], etc.
-        if (lhs.contains("value") && lhs["value"]["_type"] == "Name")
+        const std::string &var_name = lhs["value"]["id"];
+        Json var_node =
+          json_utils::find_var_decl(var_name, get_current_func_name(), ast_);
+
+        if (!var_node.empty())
         {
-          const std::string &var_name = lhs["value"]["id"];
+          const std::string &var_type = var_node["annotation"]["id"];
 
-          // Find the variable declaration
-          Json var_node = find_annotated_assign(var_name, body["body"]);
-
-          // If not found in current scope, search in current function body
-          if (var_node.empty() && current_func != nullptr)
-            var_node = find_annotated_assign(var_name, (*current_func)["body"]);
-
-          // Check function parameters if not found in function body
-          if (
-            var_node.empty() && current_func != nullptr &&
-            (*current_func).contains("args"))
+          // For list[T], return T. For other types, return the type itself
+          if (var_type == "list")
           {
-            var_node =
-              find_annotated_assign(var_name, (*current_func)["args"]["args"]);
-          }
-
-          // Check function args in body
-          if (var_node.empty() && body.contains("args"))
-            var_node = find_annotated_assign(var_name, body["args"]["args"]);
-
-          // Check global scope
-          if (var_node.empty())
-            var_node = find_annotated_assign(var_name, ast_["body"]);
-
-          if (!var_node.empty())
-          {
-            const std::string &var_type = var_node["annotation"]["id"];
-
-            // For list[T], return T. For other types, return the type itself
-            if (var_type == "list")
+            // Try to get subtype from list initialization
+            if (var_node.contains("value") && !var_node["value"].is_null())
             {
-              // Try to get subtype from list initialization
-              if (var_node.contains("value") && !var_node["value"].is_null())
-              {
-                std::string subtype = get_list_subtype(var_node["value"]);
-                type = subtype.empty() ? "Any" : subtype;
-              }
-              else
-              {
-                type = "Any"; // Unknown list element type
-              }
+              std::string subtype = get_list_subtype(var_node["value"]);
+              type = subtype.empty() ? "Any" : subtype;
             }
             else
             {
-              type = var_type;
+              type = "Any"; // Unknown list element type
             }
           }
         }


### PR DESCRIPTION
This PR extends the Python frontend to handle subscript operations (e.g., dp[i-1], prices[i]) during type inference. It also introduces new regression tests to validate the correctness of this feature, using both successful and failing verification scenarios.