### PR TITLE
Slice unused array updates

### DIFF
--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -103,19 +103,20 @@ void symex_slicet::run_on_assignment(
           return;
       }
     }
+
+    const symbol2t &lhs = to_symbol2t(SSA_step.lhs);
+    auto it = indexes.find(lhs.get_symbol_name());
     // WITH(symbol[constant_index] := constant_value)
     if (
       is_with2t(SSA_step.rhs) &&
       is_symbol2t(to_with2t(SSA_step.rhs).source_value) &&
       is_constant_int2t(to_with2t(SSA_step.rhs).update_field))
     {
-      const symbol2t &lhs = to_symbol2t(SSA_step.lhs);
       const with2t &with = to_with2t(SSA_step.rhs);
       const symbol2t &rhs_symbol = to_symbol2t(with.source_value);
       const constant_int2t &rhs_index = to_constant_int2t(with.update_field);
 
       // Is lhs in the watch list?
-      auto it = indexes.find(lhs.get_symbol_name());
       if (it != indexes.end())
       {
         // Found an array in the dependency list! Its guard should be added to the dependency list
@@ -144,6 +145,14 @@ void symex_slicet::run_on_assignment(
         }
         return;
       }
+    }
+
+    // We might be trying to initialize an array in a weird way
+    if (it != indexes.end())
+    {
+      get_symbols<true>(SSA_step.guard);
+      get_symbols<true>(SSA_step.rhs);
+      return;
     }
 
     // we don't really need it

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -11,12 +11,31 @@ template <bool Add>
 bool symex_slicet::get_symbols(const expr2tc &expr)
 {
   bool res = false;
+
+  /* Array slicer, extract dependencies of the form arr_symbol[constant_index]
+     Needs to come before the symbols as it short circuits.
+     This should be safe as if some symbolic index is eventually added, it will go to the next case. So the full symbol will go to the dependency tree
+   */
+  if (is_index2t(expr))
+  {
+    const index2t &index = to_index2t(expr);
+    if (is_symbol2t(index.source_value) && is_constant_number(index.index))
+    {
+      const symbol2t &s = to_symbol2t(index.source_value);
+      const constant_int2t &i = to_constant_int2t(index.index);
+      if constexpr (Add)
+        return indexes[s.get_symbol_name()].insert(i.as_ulong()).second;
+    }
+  }
+
   // Recursively look if any of the operands has a inner symbol
-  expr->foreach_operand([this, &res](const expr2tc &e) {
-    if (!is_nil_expr(e))
-      res |= get_symbols<Add>(e);
-    return res;
-  });
+  expr->foreach_operand(
+    [this, &res](const expr2tc &e)
+    {
+      if (!is_nil_expr(e))
+        res |= get_symbols<Add>(e);
+      return res;
+    });
 
   if (!is_symbol2t(expr))
     return res;
@@ -82,6 +101,48 @@ void symex_slicet::run_on_assignment(
         auto &sym = to_symbol2t(expr);
         if (has_prefix(sym.thename.as_string(), "nondet$"))
           return;
+      }
+    }
+    // WITH(symbol[constant_index] := constant_value)
+    if (
+      is_with2t(SSA_step.rhs) &&
+      is_symbol2t(to_with2t(SSA_step.rhs).source_value) &&
+      is_constant_int2t(to_with2t(SSA_step.rhs).update_field))
+    {
+      const symbol2t &lhs = to_symbol2t(SSA_step.lhs);
+      const with2t &with = to_with2t(SSA_step.rhs);
+      const symbol2t &rhs_symbol = to_symbol2t(with.source_value);
+      const constant_int2t &rhs_index = to_constant_int2t(with.update_field);
+
+      // Is lhs in the watch list?
+      auto it = indexes.find(lhs.get_symbol_name());
+      if (it != indexes.end())
+      {
+        // Found an array in the dependency list! Its guard should be added to the dependency list
+        get_symbols<true>(SSA_step.guard);
+
+        // Is this updating a watched index?
+        if (it->second.count(rhs_index.as_ulong()) > 0)
+        {
+          // Add next array as a dependency and remove one index.
+          indexes[rhs_symbol.get_symbol_name()] = it->second;
+          indexes[rhs_symbol.get_symbol_name()].erase(rhs_index.as_ulong());
+
+          // Finally, the update_value becomes a dependency as well
+          get_symbols<true>(with.update_value);
+        }
+        else
+        {
+          log_debug(
+            "slice",
+            "slice ignoring update to array {} at index {}",
+            rhs_symbol.get_symbol_name(),
+            rhs_index.as_ulong());
+          // Don't need the update, transform into ID and propagate dependences
+          SSA_step.cond = equality2tc(SSA_step.lhs, with.source_value);
+          indexes[rhs_symbol.get_symbol_name()] = it->second;
+        }
+        return;
       }
     }
 

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -19,7 +19,7 @@ bool symex_slicet::get_symbols(const expr2tc &expr)
   if (is_index2t(expr))
   {
     const index2t &index = to_index2t(expr);
-    if (is_symbol2t(index.source_value) && is_constant_number(index.index))
+    if (is_symbol2t(index.source_value) && is_constant_number(index.index) && !to_constant_int2t(index.index).value.is_negative() )
     {
       const symbol2t &s = to_symbol2t(index.source_value);
       const constant_int2t &i = to_constant_int2t(index.index);
@@ -110,7 +110,8 @@ void symex_slicet::run_on_assignment(
     if (
       is_with2t(SSA_step.rhs) &&
       is_symbol2t(to_with2t(SSA_step.rhs).source_value) &&
-      is_constant_int2t(to_with2t(SSA_step.rhs).update_field))
+	is_constant_int2t(to_with2t(SSA_step.rhs).update_field) &&
+	!to_constant_int2t(to_with2t(SSA_step.rhs).update_field).value.is_negative())
     {
       const with2t &with = to_with2t(SSA_step.rhs);
       const symbol2t &rhs_symbol = to_symbol2t(with.source_value);

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -19,7 +19,9 @@ bool symex_slicet::get_symbols(const expr2tc &expr)
   if (is_index2t(expr))
   {
     const index2t &index = to_index2t(expr);
-    if (is_symbol2t(index.source_value) && is_constant_number(index.index) && !to_constant_int2t(index.index).value.is_negative() )
+    if (
+      is_symbol2t(index.source_value) && is_constant_number(index.index) &&
+      !to_constant_int2t(index.index).value.is_negative())
     {
       const symbol2t &s = to_symbol2t(index.source_value);
       const constant_int2t &i = to_constant_int2t(index.index);
@@ -29,13 +31,11 @@ bool symex_slicet::get_symbols(const expr2tc &expr)
   }
 
   // Recursively look if any of the operands has a inner symbol
-  expr->foreach_operand(
-    [this, &res](const expr2tc &e)
-    {
-      if (!is_nil_expr(e))
-        res |= get_symbols<Add>(e);
-      return res;
-    });
+  expr->foreach_operand([this, &res](const expr2tc &e) {
+    if (!is_nil_expr(e))
+      res |= get_symbols<Add>(e);
+    return res;
+  });
 
   if (!is_symbol2t(expr))
     return res;
@@ -110,8 +110,9 @@ void symex_slicet::run_on_assignment(
     if (
       is_with2t(SSA_step.rhs) &&
       is_symbol2t(to_with2t(SSA_step.rhs).source_value) &&
-	is_constant_int2t(to_with2t(SSA_step.rhs).update_field) &&
-	!to_constant_int2t(to_with2t(SSA_step.rhs).update_field).value.is_negative())
+      is_constant_int2t(to_with2t(SSA_step.rhs).update_field) &&
+      !to_constant_int2t(to_with2t(SSA_step.rhs).update_field)
+         .value.is_negative())
     {
       const with2t &with = to_with2t(SSA_step.rhs);
       const symbol2t &rhs_symbol = to_symbol2t(with.source_value);

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -119,9 +119,9 @@ public:
    */
   std::unordered_set<std::string> depends;
 
-/**
+  /**
  * Hold a map of array symbols and indexes. All other indexes can be cut */
-std::unordered_map<std::string, std::unordered_set<size_t>> indexes;
+  std::unordered_map<std::string, std::unordered_set<size_t>> indexes;
 
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 

--- a/src/goto-symex/slice.h
+++ b/src/goto-symex/slice.h
@@ -119,6 +119,10 @@ public:
    */
   std::unordered_set<std::string> depends;
 
+/**
+ * Hold a map of array symbols and indexes. All other indexes can be cut */
+std::unordered_map<std::string, std::unordered_set<size_t>> indexes;
+
   static expr2tc get_nondet_symbol(const expr2tc &expr);
 
   /**


### PR DESCRIPTION
Solvers such as Z3 can struggle when we have a huge amount of needless array updates (see https://github.com/Z3Prover/z3/issues/7134#issuecomment-1957258357).  For example, this program:

```c
#define N 10000
int main()
{
  int myarray[N];

  for (int i = 0; i < N; i++)
    myarray[i] = i;

  __ESBMC_assert(myarray[5] == 5, "should pass");
  
}
```

Even though we only care about the index 5, we generate a huge update chain in the SSA:

```
...

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#10000 == (myarray?1!0&0#9999 WITH [9998:=9998])

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#10001 == (myarray?1!0&0#10000 WITH [9999:=9999])

Thread 0 file test.c line 9 column 3 function main
ASSERT
execution_statet::\guard_exec?0!0 => myarray?1!0&0#10001[5] == 5
should pass
```

Even though Z3 updated a fix for this, it is still not on pair with Boolector. We can, however, do this preprocessing locally. By updating the slicer with two new rules:

1. Add a new dependency track for arrays and indexes.
2. Only keep WITH operations that change the tracked index. Otherwise, replace it with the updated array.

We still keep tons of identities now, which most solvers can deal very easily. For example, for the previous program. We now have:

```
...

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#6 == myarray?1!0&0#5

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#7 == (myarray?1!0&0#6 WITH [5:=5])

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#8 == myarray?1!0&0#7

...

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#10000 == myarray?1!0&0#9999

Thread 0 file test.c line 7 column 5 function main
ASSIGNMENT ()
myarray?1!0&0#10001 == myarray?1!0&0#10000

Thread 0 file test.c line 9 column 3 function main
ASSERT
execution_statet::\guard_exec?0!0 => myarray?1!0&0#10001[5] == 5
should pass
```

Before this patch, Z3 would take 0.38s for this program.
With this patch, Z3 now takes 0.08s.
