### PR TITLE
[python] refactor string comparison

### DIFF
--- a/regression/python/string22/main.py
+++ b/regression/python/string22/main.py
@@ -1,0 +1,195 @@
+# Test Case 1: Basic String Equality
+def test_basic_string_equality() -> None:
+    """Test basic string equality comparisons"""
+    a: str = "hello"
+    b: str = "hello"
+    c: str = "world"
+    
+    assert a == b  # Should be True
+    assert a != c  # Should be True
+    assert not (a == c)  # Should be True
+
+test_basic_string_equality()
+
+# Test Case 2: Single Character Comparisons  
+def test_single_characters() -> None:
+    """Test single character comparisons"""
+    char1: str = "a"
+    char2: str = "a" 
+    char3: str = "b"
+    
+    assert char1 == char2  # Should be True
+    assert char1 != char3  # Should be True
+
+test_single_characters()
+
+# Test Case 3: Empty String Comparisons
+def test_empty_strings() -> None:
+    """Test empty string comparisons"""
+    empty1: str = ""
+    empty2: str = ""
+    non_empty: str = "test"
+    
+    assert empty1 == empty2  # Should be True
+    assert empty1 != non_empty  # Should be True
+
+test_empty_strings()
+
+# Test Case 4: String Concatenation and Comparison
+def test_string_concatenation() -> None:
+    """Test string concatenation with comparisons"""
+    part1: str = "hello"
+    part2: str = " world"
+    combined: str = part1 + part2
+    expected: str = "hello world"
+    
+    assert combined == expected  # Should be True
+
+test_string_concatenation()
+
+# Test Case 5: Mixed Length Strings
+def test_mixed_length_strings() -> None:
+    """Test strings of different lengths"""
+    short: str = "hi"
+    long: str = "hello world"
+    
+    assert short != long  # Should be True
+    assert len(short) != len(long)  # Should be True
+
+test_mixed_length_strings()
+
+# Test Case 6: Special Characters
+def test_special_characters() -> None:
+    """Test strings with special characters"""
+    special1: str = "hello\n"
+    special2: str = "hello\n"
+    normal: str = "hello"
+    
+    assert special1 == special2  # Should be True
+    assert special1 != normal  # Should be True
+
+test_special_characters()
+
+# Test Case 7: Numeric String Comparisons
+def test_numeric_strings() -> None:
+    """Test strings containing numbers"""
+    num1: str = "123"
+    num2: str = "123"
+    num3: str = "456"
+    
+    assert num1 == num2  # Should be True
+    assert num1 != num3  # Should be True
+
+test_numeric_strings()
+
+# Test Case 8: Case Sensitivity
+def test_case_sensitivity() -> None:
+    """Test case sensitive string comparisons"""
+    lower: str = "hello"
+    upper: str = "HELLO"
+    mixed: str = "Hello"
+    
+    assert lower != upper  # Should be True
+    assert lower != mixed  # Should be True
+    assert upper != mixed  # Should be True
+
+test_case_sensitivity()
+
+# Test Case 9: Whitespace Strings
+def test_whitespace_strings() -> None:
+    """Test strings with whitespace"""
+    with_space: str = "hello world"
+    without_space: str = "helloworld"
+    just_space: str = " "
+    empty: str = ""
+    
+    assert with_space != without_space  # Should be True
+    assert just_space != empty  # Should be True
+
+test_whitespace_strings()
+
+# Test Case 10: String Assignment and Comparison
+def test_string_assignments() -> None:
+    """Test string assignments and subsequent comparisons"""
+    original: str = "test string"
+    copy: str = original
+    different: str = "other string"
+    
+    assert original == copy  # Should be True
+    assert original != different  # Should be True
+    
+    # Modify copy and test
+    copy = "modified"
+    assert original != copy  # Should be True
+
+test_string_assignments()
+
+# Test Case 11: Multiple Equality Checks
+def test_multiple_equality() -> None:
+    """Test multiple equality operations in sequence"""
+    a: str = "same"
+    b: str = "same"
+    c: str = "same"
+    d: str = "different"
+    
+    assert a == b == c  # Should be True
+    assert not (a == b == d)  # Should be True
+
+test_multiple_equality()
+
+# Test Case 12: Edge Case - Very Short Strings
+def test_very_short_strings() -> None:
+    """Test very short strings including single chars"""
+    single1: str = "x"
+    single2: str = "x"
+    single3: str = "y"
+    
+    assert single1 == single2  # Should be True
+    assert single1 != single3  # Should be True
+
+test_very_short_strings()
+
+# Test Case 13: Longer Strings
+def test_longer_strings() -> None:
+    """Test longer string comparisons"""
+    long1: str = "This is a longer string for testing purposes"
+    long2: str = "This is a longer string for testing purposes"
+    long3: str = "This is a different longer string for testing"
+    
+    assert long1 == long2  # Should be True
+    assert long1 != long3  # Should be True
+
+test_longer_strings()
+
+# Test Case 14: String Comparison in Conditional
+def test_string_conditional() -> None:
+    """Test string comparison in conditional statements"""
+    user_input: str = "yes"
+    
+    if user_input == "yes":
+        result: bool = True
+    else:
+        result: bool = False
+    
+    assert result  # Should be True
+
+test_string_conditional()
+
+# Test Case 15: String Comparison with Variables
+def test_string_variables() -> None:
+    """Test string comparisons with different variable types"""
+    constant: str = "constant"
+    variable: str = "constant"
+    
+    # Test variable comparison
+    assert constant == variable  # Should be True
+    
+    # Modify variable
+    variable = "changed"
+    assert constant != variable  # Should be True
+
+test_string_variables()
+
+assert "a" == "a"   # True
+assert "a" != "b"   # True
+assert "a" != "ab"  # True

--- a/regression/python/string22/test.desc
+++ b/regression/python/string22/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string22_fail/main.py
+++ b/regression/python/string22_fail/main.py
@@ -7,7 +7,7 @@ def test_basic_string_equality() -> None:
     
     assert a == b  # Should be True
     assert a != c  # Should be True
-    assert not (a == c)  # Should be True
+    assert (a == c)  # Should be False
 
 test_basic_string_equality()
 
@@ -19,7 +19,7 @@ def test_single_characters() -> None:
     char3: str = "b"
     
     assert char1 == char2  # Should be True
-    assert char1 != char3  # Should be True
+    assert char1 == char3  # Should be False
 
 test_single_characters()
 
@@ -31,7 +31,7 @@ def test_empty_strings() -> None:
     non_empty: str = "test"
     
     assert empty1 == empty2  # Should be True
-    assert empty1 != non_empty  # Should be True
+    assert empty1 == non_empty  # Should be False
 
 test_empty_strings()
 
@@ -43,7 +43,7 @@ def test_string_concatenation() -> None:
     combined: str = part1 + part2
     expected: str = "hello world"
     
-    assert combined == expected  # Should be True
+    assert combined != expected  # Should be False
 
 test_string_concatenation()
 
@@ -54,7 +54,7 @@ def test_mixed_length_strings() -> None:
     long: str = "hello world"
     
     assert short != long  # Should be True
-    assert len(short) != len(long)  # Should be True
+    assert len(short) == len(long)  # Should be False
 
 test_mixed_length_strings()
 
@@ -66,7 +66,7 @@ def test_special_characters() -> None:
     normal: str = "hello"
     
     assert special1 == special2  # Should be True
-    assert special1 != normal  # Should be True
+    assert special1 == normal  # Should be False
 
 test_special_characters()
 
@@ -78,7 +78,7 @@ def test_numeric_strings() -> None:
     num3: str = "456"
     
     assert num1 == num2  # Should be True
-    assert num1 != num3  # Should be True
+    assert num1 == num3  # Should be False
 
 test_numeric_strings()
 
@@ -89,7 +89,7 @@ def test_case_sensitivity() -> None:
     upper: str = "HELLO"
     mixed: str = "Hello"
     
-    assert lower != upper  # Should be True
+    assert lower == upper  # Should be False
     assert lower != mixed  # Should be True
     assert upper != mixed  # Should be True
 
@@ -104,7 +104,7 @@ def test_whitespace_strings() -> None:
     empty: str = ""
     
     assert with_space != without_space  # Should be True
-    assert just_space != empty  # Should be True
+    assert just_space == empty  # Should be False
 
 test_whitespace_strings()
 
@@ -120,7 +120,7 @@ def test_string_assignments() -> None:
     
     # Modify copy and test
     copy = "modified"
-    assert original != copy  # Should be True
+    assert original == copy  # Should be False
 
 test_string_assignments()
 
@@ -133,7 +133,7 @@ def test_multiple_equality() -> None:
     d: str = "different"
     
     assert a == b == c  # Should be True
-    assert not (a == b == d)  # Should be True
+    assert not (a != b == d)  # Should be False
 
 test_multiple_equality()
 
@@ -145,7 +145,7 @@ def test_very_short_strings() -> None:
     single3: str = "y"
     
     assert single1 == single2  # Should be True
-    assert single1 != single3  # Should be True
+    assert single1 == single3  # Should be False
 
 test_very_short_strings()
 
@@ -157,7 +157,7 @@ def test_longer_strings() -> None:
     long3: str = "This is a different longer string for testing"
     
     assert long1 == long2  # Should be True
-    assert long1 != long3  # Should be True
+    assert long1 == long3  # Should be False
 
 test_longer_strings()
 
@@ -171,7 +171,7 @@ def test_string_conditional() -> None:
     else:
         result: bool = False
     
-    assert result  # Should be True
+    assert not result  # Should be False
 
 test_string_conditional()
 
@@ -186,7 +186,7 @@ def test_string_variables() -> None:
     
     # Modify variable
     variable = "changed"
-    assert constant != variable  # Should be True
+    assert constant == variable  # Should be False
 
 test_string_variables()
 
@@ -212,7 +212,7 @@ def test_escape_sequences() -> None:
     quote3: str = "He said 'hello'"
     
     assert quote1 == quote2  # Should be True
-    assert quote1 != quote3  # Should be True
+    assert quote1 == quote3  # Should be False
 
 # Test Case 17: Whitespace Variations
 def test_whitespace_variations() -> None:
@@ -233,7 +233,7 @@ def test_whitespace_variations() -> None:
     mixed: str = " \t "
     
     assert spaces != tabs  # Should be True
-    assert spaces != mixed  # Should be True
+    assert spaces == mixed  # Should be False
 
 # Test Case 18: String Indexing Comparisons
 def test_string_indexing() -> None:
@@ -241,7 +241,7 @@ def test_string_indexing() -> None:
     text: str = "hello"
     
     assert text[0] == "h"  # Should be True
-    assert text[1] == "e"  # Should be True
+    assert text[1] != "e"  # Should be False
     assert text[0] != "e"  # Should be True
 
 test_string_indexing()
@@ -262,7 +262,7 @@ def test_null_and_special_chars() -> None:
     ascii_only: str = "cafe"
     
     assert special1 == special2  # Should be True
-    assert special1 != ascii_only  # Should be True
+    assert special1 == ascii_only  # Should be False
 
 test_null_and_special_chars()
 
@@ -279,7 +279,7 @@ def test_leading_trailing_whitespace() -> None:
     assert normal != both  # Should be True
     assert leading != trailing  # Should be True
     assert leading != both  # Should be True
-    assert trailing != both  # Should be True
+    assert trailing == both  # Should be False
 
 # Test Case 21: Complex Equality Chains
 def test_complex_equality_chains() -> None:
@@ -292,7 +292,7 @@ def test_complex_equality_chains() -> None:
     # Mixed chain with inequality
     assert (a == b) and (b != c) and (c != d)  # Should be True
     assert not (a == b == c)  # Should be True
-    assert a == b == d  # Should be True
+    assert a == b != d  # Should be False
 
 test_complex_equality_chains()
 
@@ -314,7 +314,7 @@ def test_empty_vs_whitespace_detailed() -> None:
     # All should be different from each other
     assert single_space != single_tab  # Should be True
     assert single_space != single_newline  # Should be True
-    assert single_tab != single_newline  # Should be True
+    assert single_tab == single_newline  # Should be False
 
 # Test Case 23: Case Variations with Unicode
 def test_unicode_case_variations() -> None:
@@ -329,10 +329,10 @@ def test_unicode_case_variations() -> None:
     unicode_lower: str = "héllo"
     unicode_mixed: str = "Héllo"
     
-    assert unicode_lower != unicode_mixed  # Should be True
+    assert unicode_lower == unicode_mixed  # Should be False
 
 test_unicode_case_variations()
 
-assert "a" == "a"   # True
-assert "a" != "b"   # True
-assert "a" != "ab"  # True
+assert "a" != "a"   # False
+assert "a" == "b"   # False
+assert "a" == "ab"  # False

--- a/regression/python/string22_fail/test.desc
+++ b/regression/python/string22_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties\: 336 verified \✓ 315 passed, \✗ 21 failed$

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -240,6 +240,23 @@ private:
 
   void handle_float_division(exprt &lhs, exprt &rhs, exprt &bin_expr) const;
 
+  std::pair<exprt, exprt>
+  resolve_comparison_operands_internal(const exprt &lhs, const exprt &rhs);
+  bool
+  has_unsupported_side_effects_internal(const exprt &lhs, const exprt &rhs);
+  exprt compare_constants_internal(
+    const std::string &op,
+    const exprt &lhs,
+    const exprt &rhs);
+  exprt handle_indexed_comparison_internal(
+    const std::string &op,
+    const exprt &lhs,
+    const exprt &rhs);
+  exprt handle_type_mismatches(
+    const std::string &op,
+    const exprt &lhs,
+    const exprt &rhs);
+
   void get_attributes_from_self(
     const nlohmann::json &method_body,
     struct_typet &clazz);


### PR DESCRIPTION
This PR improves our Python frontend's string comparison handling by refactoring the `handle_string_comparison` method into a modular system that handles Python's type semantics and prevents crashes during GOTO program generation.