### PR TITLE
[solidity] fix regression

### DIFF
--- a/regression/esbmc-solidity/bytes_16/contract.sol
+++ b/regression/esbmc-solidity/bytes_16/contract.sol
@@ -1,14 +1,16 @@
 pragma solidity >=0.5.0;
 
 contract Base {
-    constructor() {}
+    constructor() public { }
 
     function test() public {
         bytes3 data3 = 0;
         assert(data3 == hex"00");
+        assert(data3 == "00");
         assert(data3 == 0x00);
     }
 }
+
 contract Dreive {
     Base x = new Base();
 


### PR DESCRIPTION
Fix the regression contract code. The AST was correct, which is why the regression test did not fail