### PR TITLE
[python] add support for __name__ built-in variable

### DIFF
--- a/regression/python/main-function/main.py
+++ b/regression/python/main-function/main.py
@@ -1,0 +1,6 @@
+def main():
+    """Main function that runs the program."""
+    assert True
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/main-function/test.desc
+++ b/regression/python/main-function/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-function_fail/main.py
+++ b/regression/python/main-function_fail/main.py
@@ -1,0 +1,6 @@
+def main():
+    """Main function that runs the program."""
+    assert False
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/main-function_fail/test.desc
+++ b/regression/python/main-function_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/main-if-guard/main.py
+++ b/regression/python/main-if-guard/main.py
@@ -1,0 +1,10 @@
+def main():
+    """Main function that only runs if __name__ == '__main__'."""
+    if __name__ == "__main__":
+        assert True
+    else:
+        # This should never happen in the main module
+        assert False
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/main-if-guard/test.desc
+++ b/regression/python/main-if-guard/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-if-guard_fail/main.py
+++ b/regression/python/main-if-guard_fail/main.py
@@ -1,0 +1,10 @@
+def main():
+    """Main function that will fail if __name__ == '__main__'."""
+    if __name__ == "__main__":
+        # This should trigger a verification failure
+        assert False
+    else:
+        assert True
+
+if __name__ == "__main__":
+    main()

--- a/regression/python/main-if-guard_fail/test.desc
+++ b/regression/python/main-if-guard_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/main-import/main.py
+++ b/regression/python/main-import/main.py
@@ -1,0 +1,1 @@
+import other

--- a/regression/python/main-import/other.py
+++ b/regression/python/main-import/other.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+  assert False

--- a/regression/python/main-import/test.desc
+++ b/regression/python/main-import/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-import_fail/main.py
+++ b/regression/python/main-import_fail/main.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+  assert False

--- a/regression/python/main-import_fail/test.desc
+++ b/regression/python/main-import_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3903,6 +3903,8 @@ void python_converter::load_c_intrisics()
   add_global_static_variable(symbol_table_, type2, "__ESBMC_alloc_size");
 }
 
+///  Only addresses __name__; other Python built-ins such as
+/// __file__, __doc__, __package__ are unsupported
 void python_converter::create_builtin_symbols()
 {
   // Create __name__ symbol

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -273,6 +273,8 @@ private:
     const nlohmann::json &method_body,
     struct_typet &clazz);
 
+  void create_builtin_symbols();
+
   symbolt *find_function_in_base_classes(
     const std::string &class_name,
     const std::string &symbol_id,


### PR DESCRIPTION
This PR fixes crash when Python code references the `__name__` built-in variable, commonly used in "if __name__ == '__main__':" patterns. The converter now automatically creates the `__name__` symbol with value "__main__" during initialization.