### PR TITLE
[C ++ verification] add reference adjustments to pre/post - inc/dec 

### DIFF
--- a/regression/esbmc-cpp11/reference/Reference7-preincrement-struct-fail/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference7-preincrement-struct-fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --std c++11 
 

--- a/regression/esbmc-cpp11/reference/Reference7-preincrement-struct/test.desc
+++ b/regression/esbmc-cpp11/reference/Reference7-preincrement-struct/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --std c++11 
 

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -222,6 +222,7 @@ void clang_c_adjust::adjust_side_effect(side_effect_exprt &expr)
       statement == "preincrement" || statement == "predecrement" ||
       statement == "postincrement" || statement == "postdecrement")
     {
+      adjust_reference(expr);
     }
     else if (has_prefix(id2string(statement), "assign"))
     {


### PR DESCRIPTION
Fix #2172
```cpp
#include <assert.h>

int main()
{
  int other = 0;
  struct nested
  {
    int &y;
  };
  nested n{other};
  assert(++(n.y) == 1);
}
```

goto before:
```c
        // 19 file main6.cpp line 11 column 10 function main
        ASSIGN n.y=n.y + 1;
        // 20 file main6.cpp line 11 column 3 function main
        ASSERT n.y == 1 // assertion ++(n.y) == 1
```

This PR:
```c
        // 19 file main6.cpp line 11 column 10 function main
        ASSIGN *n.y=*n.y + 1;
        // 20 file main6.cpp line 11 column 3 function main
        ASSERT *n.y == 1 // assertion ++(n.y) == 1
```
