### PR TITLE
[python] Fix forward reference handling in function calls

### DIFF
--- a/regression/python/forward-declaration/main.py
+++ b/regression/python/forward-declaration/main.py
@@ -1,0 +1,7 @@
+def func1():
+    func0()
+
+def func0():
+    assert True
+
+func1()

--- a/regression/python/forward-declaration/test.desc
+++ b/regression/python/forward-declaration/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/forward-declaration_fail/main.py
+++ b/regression/python/forward-declaration_fail/main.py
@@ -1,0 +1,7 @@
+def func1():
+    func0()
+
+def func0():
+    assert False
+
+func1()

--- a/regression/python/forward-declaration_fail/test.desc
+++ b/regression/python/forward-declaration_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1258,41 +1258,8 @@ exprt function_call_expr::get()
         // by searching the AST directly
         bool is_forward_reference = false;
 
-        // Lambda to recursively search for FunctionDef nodes
-        std::function<bool(const nlohmann::json &)> search_ast =
-          [&](const nlohmann::json &node) -> bool {
-          if (!node.is_object())
-            return false;
-
-          // Check if this is a function definition with matching name
-          if (
-            node.contains("_type") && node["_type"] == "FunctionDef" &&
-            node.contains("name") && node["name"] == func_name)
-          {
-            return true;
-          }
-
-          // Recursively search all child nodes
-          for (const auto &[key, value] : node.items())
-          {
-            if (value.is_array())
-            {
-              for (const auto &item : value)
-              {
-                if (search_ast(item))
-                  return true;
-              }
-            }
-            else if (value.is_object())
-            {
-              if (search_ast(value))
-                return true;
-            }
-          }
-          return false;
-        };
-
-        is_forward_reference = search_ast(converter_.ast());
+        is_forward_reference =
+          json_utils::search_function_in_ast(converter_.ast(), func_name);
 
         if (is_forward_reference)
         {

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -10,6 +10,40 @@
 namespace json_utils
 {
 template <typename JsonType>
+bool search_function_in_ast(const JsonType &node, const std::string &func_name)
+{
+  if (!node.is_object())
+    return false;
+
+  // Check if this is a function definition with matching name
+  if (
+    node.contains("_type") && node["_type"] == "FunctionDef" &&
+    node.contains("name") && node["name"] == func_name)
+  {
+    return true;
+  }
+
+  // Recursively search all child nodes
+  for (const auto &[key, value] : node.items())
+  {
+    if (value.is_array())
+    {
+      for (const auto &item : value)
+      {
+        if (search_function_in_ast(item, func_name))
+          return true;
+      }
+    }
+    else if (value.is_object())
+    {
+      if (search_function_in_ast(value, func_name))
+        return true;
+    }
+  }
+  return false;
+}
+
+template <typename JsonType>
 JsonType find_class(const JsonType &ast_json, const std::string &class_name)
 {
   auto it =


### PR DESCRIPTION
Previously, function calls to forward-declared functions returned empty expressions, causing those calls to be ignored during verification. This fix distinguishes between forward references (functions defined in the current Python source) and external functions by searching the AST.

Forward references now generate proper function call expressions that can be resolved in later compilation phases, ensuring all user-defined function calls are properly verified.

Fixes the issue where assertions in forward-referenced functions were not being checked, leading to false verification success.