### PR TITLE
[libm] Fix incorrect ln(1+x) Maclaurin series in exp.c

### DIFF
--- a/src/c2goto/library/libm/exp.c
+++ b/src/c2goto/library/libm/exp.c
@@ -12,8 +12,8 @@ static double expm1_taylor(double x)
   acc += (smd *= x / 4);
   acc += (smd *= x / 5);
   acc += (smd *= x / 6);
-  // acc += (smd *= x / 7);
-  // acc += (smd *= x / 8);
+  acc += (smd *= x / 7);
+  acc += (smd *= x / 8);
   return acc;
 }
 
@@ -66,12 +66,12 @@ static double log1p_taylor(double x)
   double acc = x;
   double smd = x;
   acc += (smd *= x) / -2;
-  acc += (smd *= x) / -3;
+  acc += (smd *= x) / 3;
   acc += (smd *= x) / -4;
-  acc += (smd *= x) / -5;
+  acc += (smd *= x) / 5;
   acc += (smd *= x) / -6;
-  // acc += (smd *= x) / -7;
-  // acc += (smd *= x) / -8;
+  acc += (smd *= x) / 7;
+  acc += (smd *= x) / -8;
   return acc;
 }
 

--- a/src/c2goto/library/libm/exp.c
+++ b/src/c2goto/library/libm/exp.c
@@ -61,15 +61,15 @@ double exp(double x)
 
 static double log1p_taylor(double x)
 {
-  /* Compute truncated Taylor series of ln(x+1) around 0:
-   * x - x^2/2! + x^3/3! - x^4/4! + ... +- x^n/n! */
+  /* Compute truncated Taylor series of ln(1+x) around 0:
+   * x - x^2/2 + x^3/3 - x^4/4 + ... +- x^n/n */
   double acc = x;
   double smd = x;
-  acc += (smd *= x / -2);
-  acc += (smd *= x / -3);
-  acc += (smd *= x / -4);
-  acc += (smd *= x / -5);
-  // acc += (smd *= x / -6);
+  acc += (smd *= x) / -2;
+  acc += (smd *= x) / -3;
+  acc += (smd *= x) / -4;
+  acc += (smd *= x) / -5;
+  acc += (smd *= x) / -6;
   // acc += (smd *= x / -7);
   // acc += (smd *= x / -8);
   return acc;

--- a/src/c2goto/library/libm/exp.c
+++ b/src/c2goto/library/libm/exp.c
@@ -70,8 +70,8 @@ static double log1p_taylor(double x)
   acc += (smd *= x) / -4;
   acc += (smd *= x) / -5;
   acc += (smd *= x) / -6;
-  // acc += (smd *= x / -7);
-  // acc += (smd *= x / -8);
+  // acc += (smd *= x) / -7;
+  // acc += (smd *= x) / -8;
   return acc;
 }
 


### PR DESCRIPTION
Currently working on fixing the Python frontend's issues with handling fractional exponents; in the process I noticed that exp.c is returning incorrect results due to an incorrect Maclaurin series expansion for ln(1+x).

In code it was ln(1+x) = x - x^2/2! + x^3/3! - x^4/4! + ... +- x^n/n!
In reality it is ln(1+x) = x - x^2/2 + x^3/3 - x^4/4 + ... +- x^n/n

This has been corrected, and the Taylor terms for both the exp and log Taylor series now go up to x^8 for more precise results (this can be scaled back if needed).

Further PRs will aim to continue fixing the Python frontend's support for fractional exponents.