### PR TITLE
[Concurrency] Don't terminate thread in pthread_exit

### DIFF
--- a/regression/esbmc-cpp/unordered_map/basic_insert_fail/test.desc
+++ b/regression/esbmc-cpp/unordered_map/basic_insert_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---incremental-bmc
+--incremental-bmc --z3
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/03_use_if/test.desc
+++ b/regression/esbmc-unix/03_use_if/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---no-por --context-bound 4 -Wno-error=implicit-function-declaration
+--no-por --context-bound 6 -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix/pthread_exit/main.c
+++ b/regression/esbmc-unix/pthread_exit/main.c
@@ -1,0 +1,9 @@
+#include<assert.h>
+#include <pthread.h>
+
+int main() {
+        int exit = __VERIFIER_nondet_int();
+        //__VERIFIER_assume(exit == 0);
+        if(exit) pthread_exit(0);
+        assert(0);
+}

--- a/regression/esbmc-unix/pthread_exit/test.desc
+++ b/regression/esbmc-unix/pthread_exit/test.desc
@@ -1,0 +1,3 @@
+CORE
+main.c
+^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/01_pthread64/test.desc
+++ b/regression/esbmc-unix2/01_pthread64/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---incremental-bmc --context-bound 2 -Wno-error=implicit-function-declaration
+--unwind 2 --no-unwinding-assertions --context-bound 2 -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$

--- a/regression/esbmc-unix2/01_pthread64/test.desc
+++ b/regression/esbmc-unix2/01_pthread64/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---unwind 2 --no-unwinding-assertions --context-bound 2 -Wno-error=implicit-function-declaration
+--unwind 2 --no-unwinding-assertions --context-bound 3 -Wno-error=implicit-function-declaration
 ^VERIFICATION FAILED$

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -252,12 +252,10 @@ __ESBMC_HIDE:;
   // to the reader.
   __ESBMC_assume(__ESBMC_blocked_threads_count == 0);
 
-  // Terminate thread
-  __ESBMC_terminate_thread();
-  __ESBMC_atomic_end();
-
   // Ensure that there is no subsequent execution path
   __ESBMC_assume(0);
+  
+  __ESBMC_atomic_end();
 }
 #pragma clang diagnostic pop
 

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -253,7 +253,7 @@ __ESBMC_HIDE:;
   __ESBMC_assume(__ESBMC_blocked_threads_count == 0);  
   __ESBMC_atomic_end();
 
-    // Ensure that there is no subsequent execution path
+  // Ensure that there is no subsequent execution path
   __ESBMC_assume(0);
 }
 #pragma clang diagnostic pop

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -250,12 +250,11 @@ __ESBMC_HIDE:;
   // A thread terminating during a search for a deadlock means there's no
   // deadlock or it can be found down a different path. Proof left as exercise
   // to the reader.
-  __ESBMC_assume(__ESBMC_blocked_threads_count == 0);
-
-  // Ensure that there is no subsequent execution path
-  __ESBMC_assume(0);
-  
+  __ESBMC_assume(__ESBMC_blocked_threads_count == 0);  
   __ESBMC_atomic_end();
+
+    // Ensure that there is no subsequent execution path
+  __ESBMC_assume(0);
 }
 #pragma clang diagnostic pop
 

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -29,14 +29,14 @@ void __ESBMC_set_thread_internal_data(
 #define __ESBMC_rwlock_writer(a) ((a)->__writer)
 
 /* Global tracking data. Should all initialize to 0 / false */
-__attribute__((
-  annotate("__ESBMC_inf_size"))) _Bool __ESBMC_pthread_thread_running[1];
+__attribute__((annotate("__ESBMC_inf_size")))
+_Bool __ESBMC_pthread_thread_running[1];
 
-__attribute__((
-  annotate("__ESBMC_inf_size"))) _Bool __ESBMC_pthread_thread_ended[1];
+__attribute__((annotate("__ESBMC_inf_size")))
+_Bool __ESBMC_pthread_thread_ended[1];
 
-__attribute__((
-  annotate("__ESBMC_inf_size"))) _Bool __ESBMC_pthread_thread_detach[1];
+__attribute__((annotate("__ESBMC_inf_size")))
+_Bool __ESBMC_pthread_thread_detach[1];
 
 __attribute__((
   annotate("__ESBMC_inf_size"))) void *__ESBMC_pthread_end_values[1];
@@ -250,7 +250,7 @@ __ESBMC_HIDE:;
   // A thread terminating during a search for a deadlock means there's no
   // deadlock or it can be found down a different path. Proof left as exercise
   // to the reader.
-  __ESBMC_assume(__ESBMC_blocked_threads_count == 0);  
+  __ESBMC_assume(__ESBMC_blocked_threads_count == 0);
   __ESBMC_atomic_end();
 
   // Ensure that there is no subsequent execution path

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -29,14 +29,14 @@ void __ESBMC_set_thread_internal_data(
 #define __ESBMC_rwlock_writer(a) ((a)->__writer)
 
 /* Global tracking data. Should all initialize to 0 / false */
-__attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_pthread_thread_running[1];
+__attribute__((
+  annotate("__ESBMC_inf_size"))) _Bool __ESBMC_pthread_thread_running[1];
 
-__attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_pthread_thread_ended[1];
+__attribute__((
+  annotate("__ESBMC_inf_size"))) _Bool __ESBMC_pthread_thread_ended[1];
 
-__attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_pthread_thread_detach[1];
+__attribute__((
+  annotate("__ESBMC_inf_size"))) _Bool __ESBMC_pthread_thread_detach[1];
 
 __attribute__((
   annotate("__ESBMC_inf_size"))) void *__ESBMC_pthread_end_values[1];

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -848,7 +848,7 @@ void goto_symext::intrinsic_spawn_thread(
 
 void goto_symext::intrinsic_terminate_thread(reachability_treet &art)
 {
-    art.get_cur_state().end_thread();
+  art.get_cur_state().end_thread();
   // No need to force a context switch; an ended thread will cause the run to
   // end and the switcher to be invoked.
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -848,7 +848,8 @@ void goto_symext::intrinsic_spawn_thread(
 
 void goto_symext::intrinsic_terminate_thread(reachability_treet &art)
 {
-  art.get_cur_state().end_thread();
+  if(art.get_cur_state().cur_state->guard.is_true())
+    art.get_cur_state().end_thread();
   // No need to force a context switch; an ended thread will cause the run to
   // end and the switcher to be invoked.
 }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -848,7 +848,6 @@ void goto_symext::intrinsic_spawn_thread(
 
 void goto_symext::intrinsic_terminate_thread(reachability_treet &art)
 {
-  if(art.get_cur_state().cur_state->guard.is_true())
     art.get_cur_state().end_thread();
   // No need to force a context switch; an ended thread will cause the run to
   // end and the switcher to be invoked.


### PR DESCRIPTION
This PR fixes #2737 

We only mark a thread has ended at the end of the thread. In `pthread_exit() ` we can just use `assume(0)`  at the end to cut further execution in this thread.

This PR:
https://github.com/esbmc/esbmc/actions/runs/17470662298/job/49619645540
```
Statistics:           3179 Files
  correct:            1783
    correct true:     1327
    correct false:     456
  incorrect:            35
    incorrect true:     17
    incorrect false:    18
  unknown:            1361
  Score:              2278 (max: 5725)
```

Master:
https://github.com/esbmc/esbmc/actions/runs/17466249770/job/49604469493
```
Statistics:           3179 Files
  correct:            1783
    correct true:     1327
    correct false:     456
  incorrect:            35
    incorrect true:     17
    incorrect false:    18
  unknown:            1361
  Score:              2278 (max: 5725)
```