### PR TITLE
[python] Add AssertionError to ESBMC-Python exception operational model

### DIFF
--- a/regression/python/AssertionError1/main.py
+++ b/regression/python/AssertionError1/main.py
@@ -1,0 +1,10 @@
+x = 10
+y = 5
+
+try:
+    assert x > y, f"Assertion failed: {x} is not greater than {y}"
+except AssertionError as e:
+    print("Caught an AssertionError:", e)
+
+print("Program continues running after handling the error.")
+

--- a/regression/python/AssertionError1/test.desc
+++ b/regression/python/AssertionError1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/AssertionError1_fail/main.py
+++ b/regression/python/AssertionError1_fail/main.py
@@ -1,0 +1,10 @@
+x = 5
+y = 10
+
+try:
+    assert x > y, f"Assertion failed: {x} is not greater than {y}"
+except AssertionError as e:
+    print("Caught an AssertionError:", e)
+
+print("Program continues running after handling the error.")
+

--- a/regression/python/AssertionError1_fail/test.desc
+++ b/regression/python/AssertionError1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/AssertionError2/main.py
+++ b/regression/python/AssertionError2/main.py
@@ -1,0 +1,12 @@
+import random
+
+x = random.randint(10,100)
+y = random.randint(1, 9)
+
+try:
+    assert x > y, f"Assertion failed: {x} is not greater than {y}"
+except AssertionError as e:
+    print("Caught an AssertionError:", e)
+
+print("Program continues running after handling the error.")
+

--- a/regression/python/AssertionError2/test.desc
+++ b/regression/python/AssertionError2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/AssertionError2_fail/main.py
+++ b/regression/python/AssertionError2_fail/main.py
@@ -1,0 +1,12 @@
+import random
+
+x = random.randint(1,1000)
+y = random.randint(1, 1000)
+
+try:
+    assert x > y, f"Assertion failed: {x} is not greater than {y}"
+except AssertionError as e:
+    print("Caught an AssertionError:", e)
+
+print("Program continues running after handling the error.")
+

--- a/regression/python/AssertionError2_fail/test.desc
+++ b/regression/python/AssertionError2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/insertion3/main.py
+++ b/regression/python/insertion3/main.py
@@ -1,0 +1,49 @@
+import random
+
+def insertion_sort(arr: list[int]):
+    # Traverse from 1 to len(arr)
+    for i in range(1, len(arr)):
+        key = arr[i]  # The current element to insert
+        j: int = i - 1
+
+        # Move elements of arr[0..i-1], that are greater than key,
+        # to one position ahead of their current position
+        while j >= 0 and key < arr[j]:
+            arr[j + 1] = arr[j]
+            j -= 1
+
+        # Place the key in its correct position
+        arr[j + 1] = key
+
+        # Assertion: prefix [0..i] should be sorted after each iteration
+        k = 0
+        while k < i:
+            try:
+                assert arr[k] <= arr[k + 1], f"Array not sorted at step {i}: {arr}"
+            except AssertionError as e:
+                print("Assertion failed:", e)
+                return arr
+            k += 1
+
+    # Final assertion: entire array is sorted
+    k = 0
+    while k < len(arr) - 1:
+        try:
+            assert arr[k] <= arr[k + 1], f"Final array not sorted: {arr}"
+        except AssertionError as e:
+            print("Final check failed:", e)
+            return arr
+        k += 1
+
+    return arr
+
+
+# Example usage
+x = random.randint(1,1000)
+y = random.randint(1,1000)
+z = random.randint(1,1000)
+nums = [x, y, z]
+print("Unsorted:", nums)
+sorted_nums = insertion_sort(nums)
+print("Sorted:", sorted_nums)
+

--- a/regression/python/insertion3/test.desc
+++ b/regression/python/insertion3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/insertion3_fail/main.py
+++ b/regression/python/insertion3_fail/main.py
@@ -1,0 +1,49 @@
+import random
+
+def insertion_sort(arr: list[int]):
+    # Traverse from 1 to len(arr)
+    for i in range(1, len(arr)):
+        key = arr[i]  # The current element to insert
+        j: int = i - 1
+
+        # Move elements of arr[0..i-1], that are greater than key,
+        # to one position ahead of their current position
+        while j > 0 and key < arr[j]:
+            arr[j + 1] = arr[j]
+            j -= 1
+
+        # Place the key in its correct position
+        arr[j + 1] = key
+
+        # Assertion: prefix [0..i] should be sorted after each iteration
+        k = 0
+        while k < i:
+            try:
+                assert arr[k] <= arr[k + 1], f"Array not sorted at step {i}: {arr}"
+            except AssertionError as e:
+                print("Assertion failed:", e)
+                return arr
+            k += 1
+
+    # Final assertion: entire array is sorted
+    k = 0
+    while k < len(arr) - 1:
+        try:
+            assert arr[k] <= arr[k + 1], f"Final array not sorted: {arr}"
+        except AssertionError as e:
+            print("Final check failed:", e)
+            return arr
+        k += 1
+
+    return arr
+
+
+# Example usage
+x = random.randint(1,1000)
+y = random.randint(1,1000)
+z = random.randint(1,1000)
+nums = [x, y, z]
+print("Unsorted:", nums)
+sorted_nums = insertion_sort(nums)
+print("Sorted:", sorted_nums)
+

--- a/regression/python/insertion3_fail/main.py
+++ b/regression/python/insertion3_fail/main.py
@@ -8,7 +8,7 @@ def insertion_sort(arr: list[int]):
 
         # Move elements of arr[0..i-1], that are greater than key,
         # to one position ahead of their current position
-        while j > 0 and key < arr[j]:
+        while j > 0 and key < arr[j]: # BUG: it should be j>=0 instead of j>0 
             arr[j + 1] = arr[j]
             j -= 1
 

--- a/regression/python/insertion3_fail/test.desc
+++ b/regression/python/insertion3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -6,6 +6,8 @@ all_passed=true
 
 # List of directories to ignore
 ignored_dirs=(
+  "AssertionError1_fail"
+  "AssertionError2_fail"
   "branch_coverage-fail"
   "built-in-functions"
   "constants"
@@ -29,6 +31,7 @@ ignored_dirs=(
   "input5_fail"
   "input6"
   "insertion_fail"
+  "insertion3_fail"
   "jpl"
   "list9"
   "list10"

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -57,6 +57,7 @@ class ZeroDivisionError(BaseException):
     def __str__(self) -> str:
         return self.message
 
+
 class AssertionError(BaseException):
     message: str = ""
 

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -56,3 +56,12 @@ class ZeroDivisionError(BaseException):
 
     def __str__(self) -> str:
         return self.message
+
+class AssertionError(BaseException):
+    message: str = ""
+
+    def __init__(self, message: str):
+        self.message: str = message
+
+    def __str__(self) -> str:
+        return self.message

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -89,7 +89,7 @@ public:
     return (
       name == "BaseException" || name == "ValueError" || name == "TypeError" ||
       name == "IndexError" || name == "KeyError" ||
-      name == "ZeroDivisionError");
+      name == "ZeroDivisionError" || name == "AssertionError");
   }
 
   static bool is_c_model_func(const std::string &func_name)


### PR DESCRIPTION
This PR:

- Extends exception hierarchy to support Python assert statements
- Fixes "Unknown or unsupported AST type: AssertionError" warning
- Resolves segmentation fault when analyzing code with try-except blocks catching AssertionError
- Follows existing pattern for exception class implementation

This enables ESBMC-Python to properly model and verify Python programs that use assertions with exception handling.