### PR TITLE
[python] enable strict type checking with mypy

### DIFF
--- a/regression/python/missing-return14_fail/main.py
+++ b/regression/python/missing-return14_fail/main.py
@@ -1,0 +1,14 @@
+import random
+
+def lambda_test(x: int) -> int:
+    # Lambda that might return None
+    process = lambda n: n * 2 if n > 0 else None
+    
+    if x > 0:
+        result = process(x)
+        return result if result is not None else 0
+    else:
+        return -1
+
+x = random.randint(0,10)
+result = lambda_test(x)

--- a/regression/python/missing-return14_fail/test.desc
+++ b/regression/python/missing-return14_fail/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -45,6 +45,7 @@ ignored_dirs=(
   "missing-return11_fail"
   "missing-return12_fail"
   "missing-return13_fail"
+  "missing-return14_fail"
   "random1"
   "random1-fail"
   "random2-fail"

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -253,7 +253,7 @@ def main():
 
     # Type checking input program with mypy
     result = subprocess.run(
-    ["mypy", filename],
+    ["mypy", "--strict", filename],
     capture_output=True,
     text=True)
 


### PR DESCRIPTION
This PR Invokes mypy with `--strict` in parser.py so that missing return statements and other type safety issues are properly detected. This ensures broken annotations (e.g., functions annotated to return int but returning None) are caught during analysis.

For this Python program:

````python
import random

def lambda_test(x: int) -> int:
    # Lambda that might return None
    process = lambda n: n * 2 if n > 0 else None

    if x > 0:
        result = process(x)
        return result if result is not None else 0
    else:
        return -1

x = random.randint(0,10)
result = lambda_test(x)
````

ESBMC now produces:

````
ESBMC version 7.10.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing main.py

Type checking warning:
main.py:8: error: Call to untyped function (unknown) in typed context
main.py:9: error: Returning Any from function declared to return "int"
Found 2 errors in 1 file (checked 1 source file)

Converting
Generating GOTO Program
GOTO program creation time: 1.568s
GOTO program processing time: 0.016s
Starting Bounded Model Checking
Symex completed in: 0.004s (13 assignments)
Slicing time: 0.000s (removed 11 assignments)
Generated 1 VCC(s), 0 remaining after simplification (2 assignments)
BMC program time: 0.005s

VERIFICATION SUCCESSFUL
````

The support for detecting missing return statements in lamba expression will come with another PR eventually :-)