### PR TITLE
[python] fix symbol table type update in string concatenation compound assignment

### DIFF
--- a/regression/python/concat3/main.py
+++ b/regression/python/concat3/main.py
@@ -1,0 +1,3 @@
+s: str = ""
+s += "a"
+assert len(s) == 1

--- a/regression/python/concat3/test.desc
+++ b/regression/python/concat3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat3_fail/main.py
+++ b/regression/python/concat3_fail/main.py
@@ -1,0 +1,3 @@
+s: str = ""
+s += "a"
+assert len(s) != 1

--- a/regression/python/concat3_fail/test.desc
+++ b/regression/python/concat3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/concat4/main.py
+++ b/regression/python/concat4/main.py
@@ -1,0 +1,3 @@
+str4 = "test"
+str4 += "ing"
+assert str4 == "testing"

--- a/regression/python/concat4/test.desc
+++ b/regression/python/concat4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat4_fail/main.py
+++ b/regression/python/concat4_fail/main.py
@@ -1,0 +1,3 @@
+str4 = "test"
+str4 += "ing"
+assert str4 == "testing1"

--- a/regression/python/concat4_fail/test.desc
+++ b/regression/python/concat4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/concat5/main.py
+++ b/regression/python/concat5/main.py
@@ -1,0 +1,6 @@
+t: str = "foo"
+s: str = "bar"
+s += t
+assert s == "barfoo"
+assert len(s) == 6
+

--- a/regression/python/concat5/test.desc
+++ b/regression/python/concat5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat5_fail/main.py
+++ b/regression/python/concat5_fail/main.py
@@ -1,0 +1,6 @@
+t: str = "foo"
+s: str = "bar"
+s += t
+assert s == "foobar"
+assert len(s) == 7
+

--- a/regression/python/concat5_fail/test.desc
+++ b/regression/python/concat5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties\: 4 verified \✓ 2 passed, \✗ 2 failed$

--- a/regression/python/concat6/main.py
+++ b/regression/python/concat6/main.py
@@ -1,0 +1,4 @@
+s: str = "hi"
+s += "!"
+assert len(s) == 3
+

--- a/regression/python/concat6/test.desc
+++ b/regression/python/concat6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat6_fail/main.py
+++ b/regression/python/concat6_fail/main.py
@@ -1,0 +1,4 @@
+s: str = "hi"
+s += "!"
+assert len(s) != 3  # should FAIL
+

--- a/regression/python/concat6_fail/test.desc
+++ b/regression/python/concat6_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/concat7/main.py
+++ b/regression/python/concat7/main.py
@@ -1,0 +1,4 @@
+s: str = "foo"
+s += "bar"
+assert s == "foobar"
+

--- a/regression/python/concat7/test.desc
+++ b/regression/python/concat7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat7_fail/main.py
+++ b/regression/python/concat7_fail/main.py
@@ -1,0 +1,4 @@
+s: str = "foo"
+s += "bar"
+assert s == "foobar!"  # should FAIL
+

--- a/regression/python/concat7_fail/test.desc
+++ b/regression/python/concat7_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2755.

This PR updates symbol type and value when string concatenation in compound assignment (+=) creates arrays with different sizes. Fixes verification failures where len() returned incorrect values after concatenation.