### PR TITLE
[CI] fix YAPF checkout for PR from fork repo

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,7 +108,7 @@ jobs:
         - name: Checkout PR branch (not merge ref)
           uses: actions/checkout@v4
           with:
-            ref: ${{ github.head_ref }}
+            ref: ${{ github.event.pull_request.head.sha }}
             fetch-depth: 0
             persist-credentials: true
 


### PR DESCRIPTION
The CI failed because there were some formatting issues in the previous push. Not related to this PR.