### PR TITLE
[python] add __ESBMC_rounding_mode initialization to match C frontend behavior

### DIFF
--- a/regression/python/power15/test.desc
+++ b/regression/python/power15/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 5 --no-slice
 ^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4699,7 +4699,7 @@ void python_converter::add_intrinsic_assignments(code_blockt &block)
   // Add assignment for intrinsic variable to match C frontend behavior
   locationt location;
   location.set_file("esbmc_intrinsics.h");
-  
+
   // ASSIGN __ESBMC_rounding_mode = 0;
   {
     symbol_exprt rounding_symbol("c:@__ESBMC_rounding_mode", int_type());

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -107,6 +107,8 @@ private:
 
   void load_c_intrisics();
 
+  void add_intrinsic_assignments(code_blockt &block);
+
   void get_var_assign(const nlohmann::json &ast_node, codet &target_block);
 
   typet


### PR DESCRIPTION
This PR adds `add_esbmc_initialization()` to initialize the intrinsic variable `__ESBMC_rounding_mode`. This missing assignment was causing Python programs to skip essential runtime setup, leading to inconsistent behavior between C and Python verification.

For this Python program:

````python
a = 4
b = 0.5
assert a ** b == 2.0
````

ESBMC was producing (check the rounding_mode debug below):

````
$ esbmc main.py --unwind 4 --no-slice
ESBMC version 7.10.0 64-bit x86_64 Linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing main.py
Converting
rounding_mode: 0
....
Symex completed in: 0.391s (1552 assignments)
Slicing time: 0.002s (removed 0 assignments)
Generated 72 VCC(s), 6 remaining after simplification (1552 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 1.775s
Solving with solver Boolector 3.2.2
Runtime decision procedure: 3.511s
Building error trace
rounding_mode: -2147483648
esbmc: /home/lucas/ESBMC_Project/esbmc/src/util/ieee_float.cpp:694: void ieee_floatt::divide_and_round(BigInt&, const BigInt&): Assertion `false' failed.
````

With this PR, ESBMC now produces:

````
$ esbmc main.py --unwind 4 --no-slice
ESBMC version 7.10.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing main.py
Converting
Generating GOTO Program
GOTO program creation time: 1.534s
GOTO program processing time: 0.022s
....
Symex completed in: 0.101s (310 assignments)
Slicing time: 0.000s (removed 0 assignments)
Generated 17 VCC(s), 2 remaining after simplification (310 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.301s
Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.672s
Building error trace

[Counterexample]


State 1 file esbmc_intrinsics.h thread 0
----------------------------------------------------
  rounding_mode = 0 (00000000 00000000 00000000 00000000)

State 70 file /home/lucas/ESBMC_Project/esbmc/src/c2goto/library/libm/exp.c line 133 column 3 function log2 thread 0
----------------------------------------------------
  xm = ieee_sqrt
  * type: floatbv
      * width: 64
      * f: 52
  * operands:
    0: constant
        * type: floatbv
            * width: 64
            * f: 52
        * value: 0011111111110000000000000000000000000000000000000000000000000000
  * rounding_mode: constant
      * type: signedbv
          * width: 32
      * value: 00000000000000000000000000000000

Violated property:
  file main.py line 3 column 0
  assertion
  return_value$_pow$1 == 2.000000


VERIFICATION FAILED
````