### PR TITLE
[python] Fix a string conversion when char is used with ord/chr functions

### DIFF
--- a/regression/python/string23/main.py
+++ b/regression/python/string23/main.py
@@ -1,0 +1,5 @@
+def is_foo(a: str) -> bool:
+    return a == "foo"
+
+e = is_foo("foo")
+assert e

--- a/regression/python/string23/test.desc
+++ b/regression/python/string23/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string23_fail/main.py
+++ b/regression/python/string23_fail/main.py
@@ -1,0 +1,5 @@
+def is_foo(a: str) -> bool:
+    return a != "foo"
+
+e = is_foo("foo")
+assert e

--- a/regression/python/string23_fail/test.desc
+++ b/regression/python/string23_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1545,8 +1545,9 @@ exprt python_converter::handle_type_mismatches(
     return nil_exprt();
   }
 
-  // Mixed types (array vs non-array) = not equal
-  return gen_boolean(op == "NotEq");
+  // Mixed types (array vs non-array)
+  // Let strcmp handle the comparison
+  return nil_exprt();
 }
 
 exprt python_converter::handle_string_comparison(


### PR DESCRIPTION
## Problem
String variables declared with `str` type annotation were being automatically converted to character arrays even when used with `ord()`/`chr()` functions, causing type compatibility segment fault.

## Solution
- Add pre-scan phase to identify variables used as arguments to `ord()`/`chr()` functions with single character
- Skip automatic string array conversion for these variables to maintain single character representation

## Changes
- Added `prescan_ord_chr_usage()` method to scan AST for ord/chr function calls since the adding ord_type is after the comparison. I think there could be some better solution with changing the ord and chr operations assignment. 
- The current scan AST to check the format char + ord/chr could be not efficient.
- Added `ord_chr_used_variables` set to track single char used with ord/chr
- Modified string literal assignment logic in `get_var_assign()` to skip array conversion when variable is used with ord/chr

## Known Issues
This previous fix #2768  introduces a regression break in ternary_string case. The `ternary_string` fails in this minimal format:

```python
whitespace: str = " "
space_check: str = "space" if whitespace == " " else "no_space"
assert space_check == "space"
```

**Root cause**: The single-character representation compai propagates to `space_check` during modifying on single character comparsion, causing:
- Missing `\0` terminator leads to infinite loops in string operations (guessing)
- `len(space_check)` function would also fail

This PR did not fix this problem yet, should use some way to put the null character back to the end of the assgined array or refine the modifying on single character comparsion. 

## Testing
- ✅ Fixes: `regression/python/ord-var/` 
- ❌ Breaks: `ternary_string` test case
