### PR TITLE
[C verification] improve the relation simplification

### DIFF
--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -73,15 +73,13 @@ expr2tc expr2t::simplify() const
     // An operand has been changed; clone ourselves and update.
     expr2tc new_us = clone();
     std::list<expr2tc>::iterator it2 = newoperands.begin();
-    new_us->Foreach_operand(
-      [&it2](expr2tc &e)
-      {
-        if (!*it2)
-          ; // No change in operand;
-        else
-          e = *it2; // Operand changed; overwrite with new one.
-        it2++;
-      });
+    new_us->Foreach_operand([&it2](expr2tc &e) {
+      if (!*it2)
+        ; // No change in operand;
+      else
+        e = *it2; // Operand changed; overwrite with new one.
+      it2++;
+    });
 
     // Finally, attempt simplification again.
     expr2tc tmp = new_us->do_simplify();
@@ -134,8 +132,8 @@ static void fetch_ops_from_this_type(
 {
   if (expr->expr_id == id)
   {
-    expr->foreach_operand([&ops, id](const expr2tc &e)
-                          { fetch_ops_from_this_type(ops, id, e); });
+    expr->foreach_operand(
+      [&ops, id](const expr2tc &e) { fetch_ops_from_this_type(ops, id, e); });
   }
   else
   {
@@ -164,8 +162,9 @@ static bool rebalance_associative_tree(
   // faster than stringly stuff.
 
   // Extract immediate operands
-  expr.foreach_operand([&ops, &expr](const expr2tc &e)
-                       { fetch_ops_from_this_type(ops, expr.expr_id, e); });
+  expr.foreach_operand([&ops, &expr](const expr2tc &e) {
+    fetch_ops_from_this_type(ops, expr.expr_id, e);
+  });
 
   // Are there enough constant values in there?
   unsigned int const_values = 0;
@@ -295,10 +294,11 @@ static expr2tc simplify_arith_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -306,10 +306,11 @@ static expr2tc simplify_arith_2ops(
   else if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -325,7 +326,7 @@ static expr2tc simplify_arith_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -336,10 +337,11 @@ static expr2tc simplify_arith_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_bool2t;
+      (bool (*)(const expr2tc &)) & is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
-    { return to_constant_bool2t(c).value; };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
+      return to_constant_bool2t(c).value;
+    };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -362,8 +364,9 @@ struct Addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      { return add2tc(t, e1, e2); };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+        return add2tc(t, e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -438,8 +441,7 @@ expr2tc add2t::do_simplify() const
 
   // Attempt associative simplification
   std::function<expr2tc(const expr2tc &arg1, const expr2tc &arg2)> add_wrapper =
-    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc
-  {
+    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc {
     expr2tc a = arg1, b = arg2;
     type2tc t = common_arith_op2_type(a, b);
     return add2tc(t, a, b);
@@ -460,8 +462,9 @@ struct Subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      { return sub2tc(t, e1, e2); };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+        return sub2tc(t, e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -514,8 +517,9 @@ struct Multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      { return mul2tc(t, e1, e2); };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+        return mul2tc(t, e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -579,8 +583,7 @@ struct DivModtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-      {
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
         if constexpr (Div)
           return div2tc(t, e1, e2);
         else
@@ -1152,10 +1155,11 @@ static expr2tc simplify_logic_2ops(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1163,7 +1167,7 @@ static expr2tc simplify_logic_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1174,11 +1178,12 @@ static expr2tc simplify_logic_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1186,10 +1191,11 @@ static expr2tc simplify_logic_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_bool2t;
+      (bool (*)(const expr2tc &)) & is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
-    { return to_constant_bool2t(c).value; };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
+      return to_constant_bool2t(c).value;
+    };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1454,9 +1460,8 @@ static expr2tc do_bit_munge_operation(
   if (side_1 != simplified_side_1 || side_2 != simplified_side_2)
     return typecast_check_return(
       type,
-      expr2tc(
-        std::make_shared<constructor>(
-          type, simplified_side_1, simplified_side_2)));
+      expr2tc(std::make_shared<constructor>(
+        type, simplified_side_1, simplified_side_2)));
 
   return expr2tc();
 }
@@ -1468,8 +1473,9 @@ expr2tc bitand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitand2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitand2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1483,8 +1489,9 @@ expr2tc bitor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1498,8 +1505,9 @@ expr2tc bitxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitxor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitxor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1513,8 +1521,9 @@ expr2tc bitnand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitnand2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitnand2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1528,8 +1537,9 @@ expr2tc bitnor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitnor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitnor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1543,8 +1553,9 @@ expr2tc bitnxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return bitnxor2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return bitnxor2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1575,8 +1586,9 @@ expr2tc shl2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return shl2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return shl2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1589,8 +1601,9 @@ expr2tc lshr2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return lshr2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return lshr2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1599,8 +1612,7 @@ expr2tc lshr2t::do_simplify() const
 
 expr2tc ashr2t::do_simplify() const
 {
-  auto op = [](uint64_t op1, uint64_t op2)
-  {
+  auto op = [](uint64_t op1, uint64_t op2) {
     /* simulating the arithmetic right shift in C++ requires LHS to be signed */
     return (int64_t)op1 >> op2;
   };
@@ -1608,8 +1620,9 @@ expr2tc ashr2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
-    { return ashr2tc(t, e1, e2); };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      return ashr2tc(t, e1, e2);
+    };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1918,7 +1931,7 @@ static expr2tc simplify_relations(
       // address = pointer + offset
       // When the pointer objects are the same, comparing the addresses is equivalent
       // to comparing the offsets.
-      // (&x + 1 == &x + 2) => (1 == 2) => false 
+      // (&x + 1 == &x + 2) => (1 == 2) => false
       add2t lhs = to_add2t(simplied_side_1);
       add2t rhs = to_add2t(simplied_side_2);
 
@@ -1962,10 +1975,11 @@ static expr2tc simplify_relations(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_int2t;
+      (bool (*)(const expr2tc &)) & is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
-    { return to_constant_int2t(c).value; };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
+      return to_constant_int2t(c).value;
+    };
 
     simpl_res = TFunctor<BigInt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1973,7 +1987,7 @@ static expr2tc simplify_relations(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1984,11 +1998,12 @@ static expr2tc simplify_relations(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1996,8 +2011,7 @@ static expr2tc simplify_relations(
   else if (is_pointer_type(simplied_side_1) || is_pointer_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      [&](const expr2tc &t) -> bool
-    {
+      [&](const expr2tc &t) -> bool {
       if (is_pointer_type(t) && is_symbol2t(t))
       {
         symbol2t s = to_symbol2t(t);
@@ -2007,8 +2021,9 @@ static expr2tc simplify_relations(
       return false;
     };
 
-    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int
-    { return 0xbadbeef; };
+    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int {
+      return 0xbadbeef;
+    };
 
     simpl_res = TFunctor<int>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2041,11 +2056,12 @@ static expr2tc simplify_floatbv_relations(
     if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
     {
       std::function<bool(const expr2tc &)> is_constant =
-        (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+        (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
       std::function<ieee_floatt &(expr2tc &)> get_value =
-        [](expr2tc &c) -> ieee_floatt &
-      { return to_constant_floatbv2t(c).value; };
+        [](expr2tc &c) -> ieee_floatt & {
+        return to_constant_floatbv2t(c).value;
+      };
 
       simpl_res = TFunctor<ieee_floatt>::simplify(
         simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2108,8 +2124,9 @@ struct Equalitytor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc, expr2tc e1, expr2tc e2)
-      { return equality2tc(e1, e2); };
+      auto op = [](type2tc, expr2tc e1, expr2tc e2) {
+        return equality2tc(e1, e2);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2712,9 +2729,8 @@ static expr2tc simplify_floatbv_2ops(
     // Were we able to simplify the sides?
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
-      expr2tc new_op(
-        std::make_shared<constructor>(
-          type, simplied_side_1, simplied_side_2, rounding_mode));
+      expr2tc new_op(std::make_shared<constructor>(
+        type, simplied_side_1, simplied_side_2, rounding_mode));
 
       return typecast_check_return(type, new_op);
     }
@@ -2727,11 +2743,12 @@ static expr2tc simplify_floatbv_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2739,11 +2756,12 @@ static expr2tc simplify_floatbv_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
+      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt &
-    { return to_constant_floatbv2t(c).value; };
+      [](expr2tc &c) -> ieee_floatt & {
+      return to_constant_floatbv2t(c).value;
+    };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2767,8 +2785,9 @@ struct IEEE_addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_add2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_add2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2812,8 +2831,9 @@ struct IEEE_subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_sub2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_sub2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the subtraction
@@ -2856,8 +2876,9 @@ struct IEEE_multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_mul2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_mul2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2900,8 +2921,9 @@ struct IEEE_divtor
   {
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
-      { return ieee_div2tc(t, e1, e2, rm); };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
+        return ieee_div2tc(t, e1, e2, rm);
+      };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the division

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -73,13 +73,15 @@ expr2tc expr2t::simplify() const
     // An operand has been changed; clone ourselves and update.
     expr2tc new_us = clone();
     std::list<expr2tc>::iterator it2 = newoperands.begin();
-    new_us->Foreach_operand([&it2](expr2tc &e) {
-      if (!*it2)
-        ; // No change in operand;
-      else
-        e = *it2; // Operand changed; overwrite with new one.
-      it2++;
-    });
+    new_us->Foreach_operand(
+      [&it2](expr2tc &e)
+      {
+        if (!*it2)
+          ; // No change in operand;
+        else
+          e = *it2; // Operand changed; overwrite with new one.
+        it2++;
+      });
 
     // Finally, attempt simplification again.
     expr2tc tmp = new_us->do_simplify();
@@ -132,8 +134,8 @@ static void fetch_ops_from_this_type(
 {
   if (expr->expr_id == id)
   {
-    expr->foreach_operand(
-      [&ops, id](const expr2tc &e) { fetch_ops_from_this_type(ops, id, e); });
+    expr->foreach_operand([&ops, id](const expr2tc &e)
+                          { fetch_ops_from_this_type(ops, id, e); });
   }
   else
   {
@@ -162,9 +164,8 @@ static bool rebalance_associative_tree(
   // faster than stringly stuff.
 
   // Extract immediate operands
-  expr.foreach_operand([&ops, &expr](const expr2tc &e) {
-    fetch_ops_from_this_type(ops, expr.expr_id, e);
-  });
+  expr.foreach_operand([&ops, &expr](const expr2tc &e)
+                       { fetch_ops_from_this_type(ops, expr.expr_id, e); });
 
   // Are there enough constant values in there?
   unsigned int const_values = 0;
@@ -294,11 +295,10 @@ static expr2tc simplify_arith_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -306,11 +306,10 @@ static expr2tc simplify_arith_2ops(
   else if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -326,7 +325,7 @@ static expr2tc simplify_arith_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -337,11 +336,10 @@ static expr2tc simplify_arith_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_bool2t;
+      (bool (*)(const expr2tc &))&is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
-      return to_constant_bool2t(c).value;
-    };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
+    { return to_constant_bool2t(c).value; };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -364,9 +362,8 @@ struct Addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-        return add2tc(t, e1, e2);
-      };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      { return add2tc(t, e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -441,7 +438,8 @@ expr2tc add2t::do_simplify() const
 
   // Attempt associative simplification
   std::function<expr2tc(const expr2tc &arg1, const expr2tc &arg2)> add_wrapper =
-    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc {
+    [](const expr2tc &arg1, const expr2tc &arg2) -> expr2tc
+  {
     expr2tc a = arg1, b = arg2;
     type2tc t = common_arith_op2_type(a, b);
     return add2tc(t, a, b);
@@ -462,9 +460,8 @@ struct Subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-        return sub2tc(t, e1, e2);
-      };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      { return sub2tc(t, e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -517,9 +514,8 @@ struct Multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-        return mul2tc(t, e1, e2);
-      };
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      { return mul2tc(t, e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -583,7 +579,8 @@ struct DivModtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
+      auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+      {
         if constexpr (Div)
           return div2tc(t, e1, e2);
         else
@@ -1155,11 +1152,10 @@ static expr2tc simplify_logic_2ops(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1167,7 +1163,7 @@ static expr2tc simplify_logic_2ops(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1178,12 +1174,11 @@ static expr2tc simplify_logic_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1191,11 +1186,10 @@ static expr2tc simplify_logic_2ops(
   else if (is_bool_type(simplied_side_1) || is_bool_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_bool2t;
+      (bool (*)(const expr2tc &))&is_constant_bool2t;
 
-    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool & {
-      return to_constant_bool2t(c).value;
-    };
+    std::function<bool &(expr2tc &)> get_value = [](expr2tc &c) -> bool &
+    { return to_constant_bool2t(c).value; };
 
     simpl_res = TFunctor<bool>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1460,8 +1454,9 @@ static expr2tc do_bit_munge_operation(
   if (side_1 != simplified_side_1 || side_2 != simplified_side_2)
     return typecast_check_return(
       type,
-      expr2tc(std::make_shared<constructor>(
-        type, simplified_side_1, simplified_side_2)));
+      expr2tc(
+        std::make_shared<constructor>(
+          type, simplified_side_1, simplified_side_2)));
 
   return expr2tc();
 }
@@ -1473,9 +1468,8 @@ expr2tc bitand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitand2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitand2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1489,9 +1483,8 @@ expr2tc bitor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1505,9 +1498,8 @@ expr2tc bitxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitxor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitxor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1521,9 +1513,8 @@ expr2tc bitnand2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnand2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitnand2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1537,9 +1528,8 @@ expr2tc bitnor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitnor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1553,9 +1543,8 @@ expr2tc bitnxor2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnxor2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return bitnxor2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1586,9 +1575,8 @@ expr2tc shl2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return shl2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return shl2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1601,9 +1589,8 @@ expr2tc lshr2t::do_simplify() const
 
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return lshr2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return lshr2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1612,7 +1599,8 @@ expr2tc lshr2t::do_simplify() const
 
 expr2tc ashr2t::do_simplify() const
 {
-  auto op = [](uint64_t op1, uint64_t op2) {
+  auto op = [](uint64_t op1, uint64_t op2)
+  {
     /* simulating the arithmetic right shift in C++ requires LHS to be signed */
     return (int64_t)op1 >> op2;
   };
@@ -1620,9 +1608,8 @@ expr2tc ashr2t::do_simplify() const
   // Is a vector operation ? Apply the op
   if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
   {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return ashr2tc(t, e1, e2);
-    };
+    auto op = [](type2tc t, expr2tc e1, expr2tc e2)
+    { return ashr2tc(t, e1, e2); };
     return distribute_vector_operation(op, side_1, side_2);
   }
 
@@ -1923,8 +1910,15 @@ static expr2tc simplify_relations(
 
       return typecast_check_return(type, new_op);
     }
-    else if (is_add2t(simplied_side_1) && is_add2t(simplied_side_2))
+    else if (
+      is_add2t(simplied_side_1) && is_add2t(simplied_side_2) &&
+      is_pointer_type(simplied_side_1) && is_pointer_type(simplied_side_2))
     {
+      // Simplification of pointer comparison:
+      // address = pointer + offset
+      // When the pointer objects are the same, comparing the addresses is equivalent
+      // to comparing the offsets.
+      // (&x + 1 == &x + 2) => (1 == 2) => false 
       add2t lhs = to_add2t(simplied_side_1);
       add2t rhs = to_add2t(simplied_side_2);
 
@@ -1968,11 +1962,10 @@ static expr2tc simplify_relations(
   if (is_bv_type(simplied_side_1) || is_bv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_int2t;
+      (bool (*)(const expr2tc &))&is_constant_int2t;
 
-    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt & {
-      return to_constant_int2t(c).value;
-    };
+    std::function<BigInt &(expr2tc &)> get_value = [](expr2tc &c) -> BigInt &
+    { return to_constant_int2t(c).value; };
 
     simpl_res = TFunctor<BigInt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -1980,7 +1973,7 @@ static expr2tc simplify_relations(
   else if (is_fixedbv_type(simplied_side_1) || is_fixedbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_fixedbv2t;
+      (bool (*)(const expr2tc &))&is_constant_fixedbv2t;
 
     std::function<fixedbvt &(expr2tc &)> get_value =
       [](expr2tc &c) -> fixedbvt & { return to_constant_fixedbv2t(c).value; };
@@ -1991,12 +1984,11 @@ static expr2tc simplify_relations(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt &>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2004,7 +1996,8 @@ static expr2tc simplify_relations(
   else if (is_pointer_type(simplied_side_1) || is_pointer_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      [&](const expr2tc &t) -> bool {
+      [&](const expr2tc &t) -> bool
+    {
       if (is_pointer_type(t) && is_symbol2t(t))
       {
         symbol2t s = to_symbol2t(t);
@@ -2014,9 +2007,8 @@ static expr2tc simplify_relations(
       return false;
     };
 
-    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int {
-      return 0xbadbeef;
-    };
+    std::function<int(expr2tc &)> get_value = [](expr2tc &) -> int
+    { return 0xbadbeef; };
 
     simpl_res = TFunctor<int>::simplify(
       simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2049,12 +2041,11 @@ static expr2tc simplify_floatbv_relations(
     if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
     {
       std::function<bool(const expr2tc &)> is_constant =
-        (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+        (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
       std::function<ieee_floatt &(expr2tc &)> get_value =
-        [](expr2tc &c) -> ieee_floatt & {
-        return to_constant_floatbv2t(c).value;
-      };
+        [](expr2tc &c) -> ieee_floatt &
+      { return to_constant_floatbv2t(c).value; };
 
       simpl_res = TFunctor<ieee_floatt>::simplify(
         simplied_side_1, simplied_side_2, is_constant, get_value);
@@ -2117,9 +2108,8 @@ struct Equalitytor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [](type2tc, expr2tc e1, expr2tc e2) {
-        return equality2tc(e1, e2);
-      };
+      auto op = [](type2tc, expr2tc e1, expr2tc e2)
+      { return equality2tc(e1, e2); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2722,8 +2712,9 @@ static expr2tc simplify_floatbv_2ops(
     // Were we able to simplify the sides?
     if ((side_1 != simplied_side_1) || (side_2 != simplied_side_2))
     {
-      expr2tc new_op(std::make_shared<constructor>(
-        type, simplied_side_1, simplied_side_2, rounding_mode));
+      expr2tc new_op(
+        std::make_shared<constructor>(
+          type, simplied_side_1, simplied_side_2, rounding_mode));
 
       return typecast_check_return(type, new_op);
     }
@@ -2736,12 +2727,11 @@ static expr2tc simplify_floatbv_2ops(
   if (is_vector_type(type))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2749,12 +2739,11 @@ static expr2tc simplify_floatbv_2ops(
   else if (is_floatbv_type(simplied_side_1) || is_floatbv_type(simplied_side_2))
   {
     std::function<bool(const expr2tc &)> is_constant =
-      (bool (*)(const expr2tc &)) & is_constant_floatbv2t;
+      (bool (*)(const expr2tc &))&is_constant_floatbv2t;
 
     std::function<ieee_floatt &(expr2tc &)> get_value =
-      [](expr2tc &c) -> ieee_floatt & {
-      return to_constant_floatbv2t(c).value;
-    };
+      [](expr2tc &c) -> ieee_floatt &
+    { return to_constant_floatbv2t(c).value; };
 
     simpl_res = TFunctor<ieee_floatt>::simplify(
       simplied_side_1, simplied_side_2, rounding_mode, is_constant, get_value);
@@ -2778,9 +2767,8 @@ struct IEEE_addtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_add2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_add2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2824,9 +2812,8 @@ struct IEEE_subtor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_sub2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_sub2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the subtraction
@@ -2869,9 +2856,8 @@ struct IEEE_multor
     // Is a vector operation ? Apply the op
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_mul2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_mul2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
 
@@ -2914,9 +2900,8 @@ struct IEEE_divtor
   {
     if (is_constant_vector2t(op1) || is_constant_vector2t(op2))
     {
-      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2) {
-        return ieee_div2tc(t, e1, e2, rm);
-      };
+      auto op = [rm](type2tc t, expr2tc e1, expr2tc e2)
+      { return ieee_div2tc(t, e1, e2, rm); };
       return distribute_vector_operation(op, op1, op2);
     }
     // Two constants? Simplify to result of the division

--- a/src/util/simplify_expr2.cpp
+++ b/src/util/simplify_expr2.cpp
@@ -1923,6 +1923,42 @@ static expr2tc simplify_relations(
 
       return typecast_check_return(type, new_op);
     }
+    else if (is_add2t(simplied_side_1) && is_add2t(simplied_side_2))
+    {
+      add2t lhs = to_add2t(simplied_side_1);
+      add2t rhs = to_add2t(simplied_side_2);
+
+      if (
+        lhs.side_1 == rhs.side_1 && is_constant(lhs.side_2) &&
+        is_constant(rhs.side_2))
+      {
+        expr2tc new_op(std::make_shared<constructor>(lhs.side_2, rhs.side_2));
+        return typecast_check_return(type, new_op);
+      }
+      else if (
+        lhs.side_2 == rhs.side_2 && is_constant(lhs.side_1) &&
+        is_constant(rhs.side_1))
+      {
+        expr2tc new_op(std::make_shared<constructor>(lhs.side_1, rhs.side_1));
+        return typecast_check_return(type, new_op);
+      }
+      else if (
+        lhs.side_1 == rhs.side_2 && is_constant(lhs.side_2) &&
+        is_constant(rhs.side_1))
+      {
+        expr2tc new_op(std::make_shared<constructor>(lhs.side_2, rhs.side_1));
+        return typecast_check_return(type, new_op);
+      }
+      else if (
+        lhs.side_2 == rhs.side_1 && is_constant(lhs.side_1) &&
+        is_constant(rhs.side_2))
+      {
+        expr2tc new_op(std::make_shared<constructor>(lhs.side_1, rhs.side_2));
+        return typecast_check_return(type, new_op);
+      }
+
+      return expr2tc();
+    }
 
     return expr2tc();
   }


### PR DESCRIPTION
During symbolic execution, ESBMC cannot compare addresses/pointers. 

The pointer objects/offsets are all defined at the SMT level:
https://github.com/esbmc/esbmc/blob/master/src/solvers/smt/smt_memspace.cpp

This results in the situation where if there is a pointer/address comparison in the GOTO guard, the boundaries cannot be determined.

The following is the underlying principle of the range-based for loop in C++, although it is much simpler:
```c
int main()
{
    int arr[5] = {0,0,0,0,0};
    int *p = arr;
    int *end = arr + 5;

    while (p != end)
    {
        assert(*p == 0);
        p++;
    }
}
```
This PR:
```c
ESBMC version 7.10.0 64-bit x86_64 linux
Target: 64-bit little-endian x86_64-unknown-linux with esbmclibc
Parsing main3.c
Converting
Generating GOTO Program
GOTO program creation time: 0.358s
GOTO program processing time: 0.001s
Starting Bounded Model Checking
Unwinding loop 2 iteration 1   file main3.c line 7 column 5 function main
Unwinding loop 2 iteration 2   file main3.c line 7 column 5 function main
Unwinding loop 2 iteration 3   file main3.c line 7 column 5 function main
Unwinding loop 2 iteration 4   file main3.c line 7 column 5 function main
Unwinding loop 2 iteration 5   file main3.c line 7 column 5 function main
Symex completed in: 0.007s (21 assignments)
Slicing time: 0.000s (removed 20 assignments)
Generated 15 VCC(s), 0 remaining after simplification (1 assignments)
BMC program time: 0.007s

VERIFICATION SUCCESSFUL
```
