### PR TITLE
Fix symbol dependencies system for Python frontend

### DIFF
--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -357,7 +357,8 @@ void add_cprover_library(contextt &context, const languaget *language)
        * have these dependencies already available in symbol_deps.
        * Therefore add dependencies that result from this new symbol
        */
-      if (language && language->id() == "python") {
+      if (language && language->id() == "python")
+      {
         generate_symbol_deps(s->id, s->value, symbol_deps);
         generate_symbol_deps(s->id, s->type, symbol_deps);
       }

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -88,6 +88,8 @@ static const struct buffer
 #endif
 };
 
+// The goto reader will only pick up symbols for these functions and their dependencies
+// This is a Python-specific whitelist invoked when you use set_functions_to_read
 const static std::vector<std::string> python_c_models = {
   "strncmp",
   "strcmp",
@@ -147,28 +149,37 @@ static void generate_symbol_deps(
   {
     type = std::pair<irep_idt, irep_idt>(name, irep.identifier());
     deps.insert(type);
-    return;
+
+    /* Cannot return here just yet
+     * Symbol identifier may point to variable identifier
+     * Further traversal needed to find type identifier if exists
+     */
   }
 
   forall_irep (irep_it, irep.get_sub())
   {
-    if (irep_it->id() == "symbol")
-    {
-      type = std::pair<irep_idt, irep_idt>(name, irep_it->identifier());
-      deps.insert(type);
-      generate_symbol_deps(name, *irep_it, deps);
-    }
-    else if (irep_it->id() == "argument")
+    if (irep_it->id() == "argument")
     {
       type = std::pair<irep_idt, irep_idt>(name, irep_it->cmt_identifier());
       deps.insert(type);
     }
     else
     {
+      /* Even if symbol & identifier found, further traversal might be needed for type identifier
+       * Continue traversing to find symbol dependencies
+       * The subcall will add the symbol identifier before traversing named and unnamed ireps so does not need to be done explicitly here
+       */
       generate_symbol_deps(name, *irep_it, deps);
     }
   }
 
+  /* The case where symbol identifier is reached but there are more nested type symbols
+   * has only been seen so far when these higher-level symbols are unnamed ireps.
+   *        (in particular inside an "operands" named_irep the layer above that)
+   * Therefore named_irep iterator should be able to terminate on named_irep symbols
+   * If there are future symbol resolution issues, consider changing this to also keep traversing
+   *        For debugging, you can look at the nested structure via irept::pretty()
+   */
   forall_named_irep (irep_it, irep.get_named_sub())
   {
     if (irep_it->second.id() == "symbol")
@@ -251,10 +262,19 @@ void add_cprover_library(contextt &context, const languaget *language)
   if (language && language->id() == "python")
     goto_reader.set_functions_to_read(python_c_models);
 
+  /* Python: actively has a function filter
+   *    - not everything makes it into new_ctx
+   *    - ignored symbols go into ignored_ctx
+   * Other languages: no function filter
+   *    - everything makes it into new_ctx
+   *    - ignored_ctx empty
+   */
+  contextt ignored_ctx;
   if (goto_reader.read_goto_binary_array(
-        clib->start, clib->size, new_ctx, goto_functions))
+        clib->start, clib->size, new_ctx, ignored_ctx, goto_functions))
     abort();
 
+  // Traverse symbols and get dependencies from both their nested types and values
   new_ctx.foreach_operand([&symbol_deps](const symbolt &s) {
     generate_symbol_deps(s.id, s.value, symbol_deps);
     generate_symbol_deps(s.id, s.type, symbol_deps);
@@ -274,10 +294,11 @@ void add_cprover_library(contextt &context, const languaget *language)
     dstring("pthread_join"), dstring("pthread_join_noswitch"));
   symbol_deps.insert(joincheck);
 
-  /* The code just pulled into store_ctx might use other symbols in the C
-   * library. So, repeatedly search for new C library symbols that we use but
-   * haven't pulled in, then pull them in. We finish when we've made a pass
-   * that adds no new symbols. */
+  /* Iterate through the new_ctx symbols, figure out which ones to go into store_ctx
+   *    For Python this is everything: new_ctx already has a filtering layer
+   *    For other frontends, only add symbols that exist already in context but value empty
+   * store_ctx is what actually gets merged into the existing, final context
+   */
 
   new_ctx.foreach_operand(
     [&context, &store_ctx, &symbol_deps, &to_include, &language](
@@ -288,15 +309,40 @@ void add_cprover_library(contextt &context, const languaget *language)
         (symbol != nullptr && symbol->value.is_nil()))
       {
         store_ctx.add(s);
+
+        // ingest_symbol takes this added symbol and goes through symbol_deps
+        // it only moves dependencies from symbol_deps to to_include
+        //    if they're dependencies for a symbol that is definitely being included
+        //    (i.e. in store_ctx)
         ingest_symbol(s.id, symbol_deps, to_include);
       }
     });
 
+  /* Now iterate through the dependencies that we know we want to add (due to ingest_symbol filter)
+   * These will be symbols that didn't make it into store_ctx
+   * 
+   * For Python:
+   *    - symbols that didn't make it into store_ctx didn't make it because they're not in new_ctx
+   *    - they will be found in ignored_ctx
+   * 
+   * For other frontends:
+   *    - every symbol made it into new_ctx (no ignored_ctx)
+   *    - not every symbol made it into store_ctx from new_ctx
+   *    - they will be found in new_ctx
+   */
   for (std::list<irep_idt>::const_iterator nameit = to_include.begin();
        nameit != to_include.end();
        nameit++)
   {
-    symbolt *s = new_ctx.find_symbol(*nameit);
+    symbolt *s;
+
+    // Look in the appropriate place for this symbol
+    if ((language && language->id() == "python")){
+      s = ignored_ctx.find_symbol(*nameit);
+    } else{
+      s = new_ctx.find_symbol(*nameit);
+    }
+
     if (s != nullptr)
     {
       store_ctx.add(*s);
@@ -304,6 +350,7 @@ void add_cprover_library(contextt &context, const languaget *language)
     }
   }
 
+  // Bring store_ctx symbols into context
   if (c_link(context, store_ctx, "<built-in-library>"))
   {
     // Merging failed

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -300,23 +300,25 @@ void add_cprover_library(contextt &context, const languaget *language)
    * store_ctx is what actually gets merged into the existing, final context
    */
 
-  new_ctx.foreach_operand(
-    [&context, &store_ctx, &symbol_deps, &to_include, &language](
-      const symbolt &s) {
-      const symbolt *symbol = context.find_symbol(s.id);
-      if (
-        (language && language->id() == "python") ||
-        (symbol != nullptr && symbol->value.is_nil()))
-      {
-        store_ctx.add(s);
+  new_ctx.foreach_operand([&context,
+                           &store_ctx,
+                           &symbol_deps,
+                           &to_include,
+                           &language](const symbolt &s) {
+    const symbolt *symbol = context.find_symbol(s.id);
+    if (
+      (language && language->id() == "python") ||
+      (symbol != nullptr && symbol->value.is_nil()))
+    {
+      store_ctx.add(s);
 
-        // ingest_symbol takes this added symbol and goes through symbol_deps
-        // it only moves dependencies from symbol_deps to to_include
-        //    if they're dependencies for a symbol that is definitely being included
-        //    (i.e. in store_ctx)
-        ingest_symbol(s.id, symbol_deps, to_include);
-      }
-    });
+      // ingest_symbol takes this added symbol and goes through symbol_deps
+      // it only moves dependencies from symbol_deps to to_include
+      //    if they're dependencies for a symbol that is definitely being included
+      //    (i.e. in store_ctx)
+      ingest_symbol(s.id, symbol_deps, to_include);
+    }
+  });
 
   /* Now iterate through the dependencies that we know we want to add (due to ingest_symbol filter)
    * These will be symbols that didn't make it into store_ctx
@@ -337,9 +339,12 @@ void add_cprover_library(contextt &context, const languaget *language)
     symbolt *s;
 
     // Look in the appropriate place for this symbol
-    if ((language && language->id() == "python")){
+    if ((language && language->id() == "python"))
+    {
       s = ignored_ctx.find_symbol(*nameit);
-    } else{
+    }
+    else
+    {
       s = new_ctx.find_symbol(*nameit);
     }
 

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -351,6 +351,17 @@ void add_cprover_library(contextt &context, const languaget *language)
     if (s != nullptr)
     {
       store_ctx.add(*s);
+
+      /* Python frontend hasn't looked for dependencies for symbols that aren't in
+       * the function whitelist, (since they're not put in new_ctx); other frontends
+       * have these dependencies already available in symbol_deps.
+       * Therefore add dependencies that result from this new symbol
+       */
+      if (language && language->id() == "python") {
+        generate_symbol_deps(s->id, s->value, symbol_deps);
+        generate_symbol_deps(s->id, s->type, symbol_deps);
+      }
+
       ingest_symbol(*nameit, symbol_deps, to_include);
     }
   }

--- a/src/goto-programs/goto_binary_reader.cpp
+++ b/src/goto-programs/goto_binary_reader.cpp
@@ -10,11 +10,12 @@ bool goto_binary_reader::read_goto_binary_array(
   const void *data,
   size_t size,
   contextt &context,
+  contextt &ignored,
   goto_functionst &dest)
 {
   using namespace boost::iostreams;
   stream<array_source> src(static_cast<const char *>(data), size);
-  return read_bin_goto_object(src, "", context, functions, dest);
+  return read_bin_goto_object(src, "", context, ignored, function_set, dest);
 }
 
 bool goto_binary_reader::read_goto_binary(

--- a/src/goto-programs/goto_binary_reader.h
+++ b/src/goto-programs/goto_binary_reader.h
@@ -14,11 +14,12 @@ public:
     const void *data,
     size_t size,
     contextt &context,
+    contextt &ignored,
     goto_functionst &dest);
 
   void set_functions_to_read(const std::vector<std::string> &funcs)
   {
-    functions = funcs;
+    function_set.insert(funcs.begin(), funcs.end());
   }
 
   bool read_goto_binary(
@@ -27,5 +28,6 @@ public:
     goto_functionst &dest);
 
 private:
-  std::vector<std::string> functions; // functions to read
+  // whitelist (if not empty) of functions to read symbols of
+  std::unordered_set<std::string> function_set;
 };

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -84,18 +84,21 @@ bool read_bin_goto_object(
     }
 
     // Add functions only from the list if there is a whitelist
-    if (!function_set.empty()) {
+    if (!function_set.empty())
+    {
       const auto &fname = symbol.get_function_name();
-      
+
       // Symbol is not in the function set
-      if (function_set.find(id2string(fname)) == function_set.end()) {
+      if (function_set.find(id2string(fname)) == function_set.end())
+      {
         // Keep this symbol in case we end up needing it as a dependency later on
         ignored.add(symbol);
         continue; // skip to next symbol
       }
     }
 
-    context.add(symbol); // add symbol if no function whitelist or in function whitelist
+    context.add(
+      symbol); // add symbol if no function whitelist or in function whitelist
   }
 
   assert(migrate_namespace_lookup);
@@ -123,7 +126,10 @@ bool read_bin_goto_object(
   contextt &context,
   goto_functionst &goto_functions)
 {
-  contextt empt_ignored; // empty context to put ignored symbols in; will not be used since empty function filter
-  std::unordered_set<std::string> empt_function_set; // empty function filter; no function whitelist
-  return read_bin_goto_object(in, filename, context, empt_ignored, empt_function_set, goto_functions);
+  contextt
+    empt_ignored; // empty context to put ignored symbols in; will not be used since empty function filter
+  std::unordered_set<std::string>
+    empt_function_set; // empty function filter; no function whitelist
+  return read_bin_goto_object(
+    in, filename, context, empt_ignored, empt_function_set, goto_functions);
 }

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -13,7 +13,8 @@ bool read_bin_goto_object(
   std::istream &in,
   const std::string &filename,
   contextt &context,
-  std::vector<std::string> &functions,
+  contextt &ignored,
+  std::unordered_set<std::string> &function_set,
   goto_functionst &goto_functions)
 {
   std::ostringstream str;
@@ -82,16 +83,19 @@ bool read_bin_goto_object(
         to_code_type(symbol.type);
     }
 
-    // Add functions only from the list
-    if (!functions.empty())
-    {
-      auto it = std::find(
-        functions.begin(), functions.end(), symbol.get_function_name().c_str());
-      if (it == functions.end())
-        continue;
+    // Add functions only from the list if there is a whitelist
+    if (!function_set.empty()) {
+      const auto &fname = symbol.get_function_name();
+      
+      // Symbol is not in the function set
+      if (function_set.find(id2string(fname)) == function_set.end()) {
+        // Keep this symbol in case we end up needing it as a dependency later on
+        ignored.add(symbol);
+        continue; // skip to next symbol
+      }
     }
 
-    context.add(symbol);
+    context.add(symbol); // add symbol if no function whitelist or in function whitelist
   }
 
   assert(migrate_namespace_lookup);
@@ -119,6 +123,7 @@ bool read_bin_goto_object(
   contextt &context,
   goto_functionst &goto_functions)
 {
-  std::vector<std::string> empty;
-  return read_bin_goto_object(in, filename, context, empty, goto_functions);
+  contextt empt_ignored; // empty context to put ignored symbols in; will not be used since empty function filter
+  std::unordered_set<std::string> empt_function_set; // empty function filter; no function whitelist
+  return read_bin_goto_object(in, filename, context, empt_ignored, empt_function_set, goto_functions);
 }

--- a/src/goto-programs/read_bin_goto_object.h
+++ b/src/goto-programs/read_bin_goto_object.h
@@ -19,7 +19,8 @@ bool read_bin_goto_object(
   std::istream &in,
   const std::string &filename,
   contextt &context,
-  std::vector<std::string> &functions,
+  contextt &ignored,
+  std::unordered_set<std::string> &function_set,
   goto_functionst &goto_functions);
 
 #endif /*READ_BIN_GOTO_OBJECT_H_*/


### PR DESCRIPTION
The Python frontend generates its symbol dependencies slightly differently to other frontends, as it has a function whitelist that it selectively pulls in symbols based on.

The old implementation was broken for a few reasons:
- Not traversing the irep tree far enough to find type symbols (specifically for C structs found in the OM libraries)
- Non-function symbols were discarded by the Python function filter, even if they could be potential dependencies later on
- Dependency symbols were looked for in new_ctx when Python already pulls in all of new_ctx

This PR changes the symbol dependencies system to fix these issues, while preserving functionality for the other frontends.
This allows C operational models containing structs to work on the Python frontend without type symbol issues.