### PR TITLE
[python] Fix import for fully qualified names

### DIFF
--- a/regression/python/import-fully-qualified-fail/main.py
+++ b/regression/python/import-fully-qualified-fail/main.py
@@ -1,0 +1,3 @@
+from other.other import ok
+
+fail()

--- a/regression/python/import-fully-qualified-fail/other/other.py
+++ b/regression/python/import-fully-qualified-fail/other/other.py
@@ -1,0 +1,5 @@
+def ok() -> None:
+    assert True
+
+def fail() -> None:
+    assert False

--- a/regression/python/import-fully-qualified-fail/test.desc
+++ b/regression/python/import-fully-qualified-fail/test.desc
@@ -1,0 +1,3 @@
+CORE
+main.py
+^WARNING\: Undefined function: fail$

--- a/regression/python/import-fully-qualified/main.py
+++ b/regression/python/import-fully-qualified/main.py
@@ -1,0 +1,3 @@
+from other.other import ok
+
+ok()

--- a/regression/python/import-fully-qualified/other/other.py
+++ b/regression/python/import-fully-qualified/other/other.py
@@ -1,0 +1,5 @@
+def ok() -> None:
+    assert True
+
+def fail() -> None:
+    assert False

--- a/regression/python/import-fully-qualified/test.desc
+++ b/regression/python/import-fully-qualified/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(pythonfrontend STATIC
             python_list.cpp
             pythonastgen.c
             module_manager.cpp
+            module_locator.cpp
             symbol_id.cpp
             type_handler.cpp
             function_call_expr.cpp

--- a/src/python-frontend/module_locator.cpp
+++ b/src/python-frontend/module_locator.cpp
@@ -1,0 +1,50 @@
+#include <module_locator.h>
+#include <boost/filesystem.hpp>
+
+namespace bfs = boost::filesystem;
+
+module_locator::module_locator(std::string output_dir)
+  : out_dir_(std::move(output_dir))
+{
+}
+
+std::vector<std::string> module_locator::split(const std::string &s, char delim)
+{
+  std::vector<std::string> out;
+  std::string cur;
+  for (char c : s)
+  {
+    if (c == delim)
+    {
+      if (!cur.empty())
+        out.push_back(cur);
+      cur.clear();
+    }
+    else
+    {
+      cur.push_back(c);
+    }
+  }
+  if (!cur.empty())
+    out.push_back(cur);
+  return out;
+}
+
+std::string
+module_locator::module_path(const std::string &qualified_module) const
+{
+  const auto parts = split(qualified_module, '.');
+  bfs::path p(out_dir_);
+  if (parts.empty())
+    return (p / (qualified_module + ".json")).string();
+  for (size_t i = 0; i + 1 < parts.size(); ++i)
+    p /= parts[i];
+  p /= parts.back() + std::string(".json");
+  return p.string();
+}
+
+std::ifstream
+module_locator::open_module_file(const std::string &qualified_module) const
+{
+  return std::ifstream(module_path(qualified_module));
+}

--- a/src/python-frontend/module_locator.h
+++ b/src/python-frontend/module_locator.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <fstream>
+#include <vector>
+
+class module_locator
+{
+public:
+  explicit module_locator(std::string output_dir);
+
+  /**
+    * @brief Computes the canonical file path for a qualified module name.
+    *        Example: "a.b.c" -> "<out_dir>/a/b/c.ext".
+    */
+  std::string module_path(const std::string &qualified_module) const;
+
+  /**
+    * @brief Opens the module file for reading.
+    *        Does not throw; callers should check `is_open()`.
+    */
+  std::ifstream open_module_file(const std::string &qualified_module) const;
+
+private:
+  static std::vector<std::string> split(const std::string &s, char delim);
+
+  std::string out_dir_;
+};

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -18,9 +18,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#include <iomanip>
 #include <fstream>
+#include <iomanip>
 #include <regex>
+#include <stdexcept>
 #include <sstream>
 #include <unordered_map>
 
@@ -4997,6 +4998,8 @@ void python_converter::convert()
         module_path << (*ast_json)["ast_output_dir"].get<std::string>() << "/"
                     << module_name << ".json";
         std::ifstream imported_file(module_path.str());
+        if (!imported_file.is_open())
+          throw std::runtime_error("Cannot open file: " + module_path.str());
         imported_file >> imported_module_json;
 
         current_python_file =

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4,6 +4,7 @@
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/function_call_builder.h>
 #include <python-frontend/python_list.h>
+#include <python-frontend/module_locator.h>
 #include <ansi-c/convert_float_literal.h>
 #include <util/std_code.h>
 #include <util/c_types.h>
@@ -4986,6 +4987,8 @@ void python_converter::convert()
   else
   {
     // Convert imported modules
+    module_locator locator((*ast_json)["ast_output_dir"].get<std::string>());
+
     for (const auto &elem : (*ast_json)["body"])
     {
       if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
@@ -4997,9 +5000,14 @@ void python_converter::convert()
         std::stringstream module_path;
         module_path << (*ast_json)["ast_output_dir"].get<std::string>() << "/"
                     << module_name << ".json";
-        std::ifstream imported_file(module_path.str());
+
+        std::ifstream imported_file = locator.open_module_file(module_name);
         if (!imported_file.is_open())
-          throw std::runtime_error("Cannot open file: " + module_path.str());
+        {
+          throw std::runtime_error(
+            "Cannot open file: " + locator.module_path(module_name));
+        }
+
         imported_file >> imported_module_json;
 
         current_python_file =


### PR DESCRIPTION
This PR adds support for handling imports that use fully qualified module names, such as:
`from my_module.myfile import a, b, c`