### PR TITLE
[python] add os.mkdir, os.rmdir, and OSError hierarchy

### DIFF
--- a/regression/python/import-os/main.py
+++ b/regression/python/import-os/main.py
@@ -1,8 +1,9 @@
 import os
-from os import listdir, popen, makedirs, remove
+from os import listdir, popen, makedirs, mkdir, rmdir, remove
 
 p = "/tmp/foo/"
 f = "/tmp/foo/bar.txt"
+q = "/tmp/baz"
 
 popen("ls /tmp")
 makedirs(p, exist_ok=True)
@@ -12,3 +13,12 @@ exists = os.path.exists(f)
 base = os.path.basename(f)
 if exists:
   remove(f)
+
+exists = os.path.exists(q)
+if exists:
+  rmdir(q)
+
+try:
+  mkdir(q)
+except FileExistsError:
+  print("FileExistsError")

--- a/regression/python/import-os_fail/main.py
+++ b/regression/python/import-os_fail/main.py
@@ -1,0 +1,24 @@
+import os
+from os import listdir, popen, makedirs, mkdir, rmdir, remove
+
+p = "/tmp/foo/"
+f = "/tmp/foo/bar.txt"
+q = "/tmp/baz"
+
+popen("ls /tmp")
+makedirs(p, exist_ok=True)
+listdir(p)
+
+exists = os.path.exists(f)
+base = os.path.basename(f)
+if exists:
+  remove(f)
+
+exists = os.path.exists(q)
+if exists:
+  rmdir(q)
+
+try:
+  rmdir(f)
+except OSError:
+  assert False

--- a/regression/python/import-os_fail/test.desc
+++ b/regression/python/import-os_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -102,10 +102,10 @@ class OSError(Exception):
 class FileNotFoundError(OSError):
     """Raised when a file or directory is not found"""
     message: str = ""
-    
+
     def __init__(self, message: str = "File not found"):
         self.message: str = message
-    
+
     def __str__(self) -> str:
         return self.message
 
@@ -113,10 +113,10 @@ class FileNotFoundError(OSError):
 class FileExistsError(OSError):
     """Raised when trying to create a file or directory that already exists"""
     message: str = ""
-    
+
     def __init__(self, message: str = "File exists"):
         self.message: str = message
-    
+
     def __str__(self) -> str:
         return self.message
 
@@ -124,9 +124,9 @@ class FileExistsError(OSError):
 class PermissionError(OSError):
     """Raised when an operation lacks the necessary permissions"""
     message: str = ""
-    
+
     def __init__(self, message: str = "Permission denied"):
         self.message: str = message
-    
+
     def __str__(self) -> str:
         return self.message

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -86,3 +86,47 @@ class NameError(BaseException):
 
     def __str__(self) -> str:
         return self.message
+
+
+class OSError(Exception):
+    """Base class for I/O related errors"""
+    message: str = ""
+
+    def __init__(self, message: str = "OS error"):
+        self.message: str = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class FileNotFoundError(OSError):
+    """Raised when a file or directory is not found"""
+    message: str = ""
+    
+    def __init__(self, message: str = "File not found"):
+        self.message: str = message
+    
+    def __str__(self) -> str:
+        return self.message
+
+
+class FileExistsError(OSError):
+    """Raised when trying to create a file or directory that already exists"""
+    message: str = ""
+    
+    def __init__(self, message: str = "File exists"):
+        self.message: str = message
+    
+    def __str__(self) -> str:
+        return self.message
+
+
+class PermissionError(OSError):
+    """Raised when an operation lacks the necessary permissions"""
+    message: str = ""
+    
+    def __init__(self, message: str = "Permission denied"):
+        self.message: str = message
+    
+    def __str__(self) -> str:
+        return self.message

--- a/src/python-frontend/models/os.py
+++ b/src/python-frontend/models/os.py
@@ -15,4 +15,18 @@ def makedirs(path: str) -> None:
 
 
 def remove(path: str) -> None:
-    pass
+    file_exists: bool = nondet_bool()
+    if not file_exists:
+        raise FileNotFoundError("No such file or directory")
+
+
+def mkdir(path: str) -> None:
+    dir_not_exists: bool = nondet_bool()
+    if not dir_not_exists:
+        raise FileExistsError("Directory already exists")
+
+
+def rmdir(path: str) -> None:
+    is_empty: bool = nondet_bool()
+    if not is_empty:
+        raise OSError("Directory not empty")

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -90,7 +90,8 @@ public:
       name == "BaseException" || name == "Exception" || name == "ValueError" ||
       name == "TypeError" || name == "IndexError" || name == "KeyError" ||
       name == "ZeroDivisionError" || name == "AssertionError" ||
-      name == "NameError");
+      name == "NameError" || name == "OSError" || name == "FileNotFoundError" ||
+      name == "FileExistsError" || name == "PermissionError");
   }
 
   static bool is_c_model_func(const std::string &func_name)


### PR DESCRIPTION
This PR extends the Python frontend with new filesystem functions and exception classes to improve compatibility with Python’s os module.

Future Work:
- Replace nondeterministic stubs with a symbolic filesystem model to maintain path existence and state across calls.
- Add tests for PermissionError and more failure cases.
- Align exception messages and semantics more closely with CPython.
