### PR TITLE
[python] Add support for string operations ('in' operator, startswith(), and endswith() methods)

### DIFF
--- a/regression/python/string-endswith/main.py
+++ b/regression/python/string-endswith/main.py
@@ -1,0 +1,36 @@
+s = "foo"
+
+b: bool = s.startswith("f")
+assert b
+b = s.startswith("l")
+assert not b
+assert s.startswith("fo")
+assert not s.startswith("oo")
+
+b = s.endswith("o")
+assert b
+b = s.endswith("x")
+assert not b
+assert s.endswith("oo")
+assert not s.endswith("fo")
+
+empty = ""
+assert empty.startswith("")
+assert not empty.startswith("a")
+assert empty.endswith("")
+assert not empty.endswith("a")
+
+prefix = "f"
+assert s.startswith(prefix)
+suffix = "o"
+assert s.endswith(suffix)
+
+assert s.startswith("foo")
+assert s.endswith("foo")
+
+single = "x"
+assert single.startswith("x")
+assert single.endswith("x")
+assert not single.startswith("y")
+assert not single.endswith("y")
+

--- a/regression/python/string-endswith/test.desc
+++ b/regression/python/string-endswith/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-in/main.py
+++ b/regression/python/string-in/main.py
@@ -1,0 +1,22 @@
+s = "foo"
+b: bool = "f" in s
+assert b
+
+b = "l" in s
+assert not b
+
+t = "needle in haystack"
+c: bool = "needle" in t
+assert c
+
+c = "neddle" in t
+assert not c
+
+x = "hello world"
+y = "world"
+assert y in x
+assert not "mars" in x
+
+empty = ""
+assert not "x" in empty
+assert "" in "abc"

--- a/regression/python/string-in/test.desc
+++ b/regression/python/string-in/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-startswith/main.py
+++ b/regression/python/string-startswith/main.py
@@ -1,0 +1,18 @@
+s = "foo"
+
+b: bool = s.startswith("f")
+assert b
+
+b = s.startswith("l")
+assert not b
+
+assert s.startswith("fo")
+assert not s.startswith("oo")
+
+empty = ""
+assert empty.startswith("")
+assert not empty.startswith("a")
+
+prefix = "f"
+assert s.startswith(prefix)
+

--- a/regression/python/string-startswith/test.desc
+++ b/regression/python/string-startswith/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -121,7 +121,7 @@ const static std::vector<std::string> python_c_models = {
   "matmul",       "pow",
   "log",          "pow_by_squaring",
   "log2",         "ldexp",
-  "log1p_taylor"};
+  "log1p_taylor", "strstr"};
 
 } // namespace
 

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -236,7 +236,6 @@ exprt function_call_builder::build() const
   if (function_id.get_function() == "__ESBMC_len_single_char")
     return from_integer(1, int_type());
 
-  // Handle startswith() method
   if (call_["func"]["_type"] == "Attribute")
   {
     std::string method_name = call_["func"]["attr"].get<std::string>();
@@ -252,6 +251,19 @@ exprt function_call_builder::build() const
       locationt loc = converter_.get_location_from_decl(call_);
 
       return converter_.handle_string_startswith(obj_expr, prefix_arg, loc);
+    }
+
+    if (method_name == "endswith")
+    {
+      exprt obj_expr = converter_.get_expr(call_["func"]["value"]);
+
+      if (call_["args"].size() != 1)
+        throw std::runtime_error("endswith() requires exactly one argument");
+
+      exprt suffix_arg = converter_.get_expr(call_["args"][0]);
+      locationt loc = converter_.get_location_from_decl(call_);
+
+      return converter_.handle_string_endswith(obj_expr, suffix_arg, loc);
     }
   }
 

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -236,6 +236,25 @@ exprt function_call_builder::build() const
   if (function_id.get_function() == "__ESBMC_len_single_char")
     return from_integer(1, int_type());
 
+  // Handle startswith() method
+  if (call_["func"]["_type"] == "Attribute")
+  {
+    std::string method_name = call_["func"]["attr"].get<std::string>();
+
+    if (method_name == "startswith")
+    {
+      exprt obj_expr = converter_.get_expr(call_["func"]["value"]);
+
+      if (call_["args"].size() != 1)
+        throw std::runtime_error("startswith() requires exactly one argument");
+
+      exprt prefix_arg = converter_.get_expr(call_["args"][0]);
+      locationt loc = converter_.get_location_from_decl(call_);
+
+      return converter_.handle_string_startswith(obj_expr, prefix_arg, loc);
+    }
+  }
+
   // Add assume and len functions to symbol table
   if (is_assume_call(function_id) || is_len_call(function_id))
   {

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -255,6 +255,13 @@ private:
     const nlohmann::json &right,
     const nlohmann::json &element);
 
+  exprt handle_string_membership(
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &element);
+
+  exprt ensure_null_terminated_string(exprt &e);
+
   symbolt &create_tmp_symbol(
     const nlohmann::json &element,
     const std::string var_name,

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -262,6 +262,11 @@ private:
 
   exprt ensure_null_terminated_string(exprt &e);
 
+  exprt handle_string_startswith(
+    const exprt &string_obj,
+    const exprt &prefix_arg,
+    const locationt &location);
+
   symbolt &create_tmp_symbol(
     const nlohmann::json &element,
     const std::string var_name,

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -267,6 +267,11 @@ private:
     const exprt &prefix_arg,
     const locationt &location);
 
+  exprt handle_string_endswith(
+    const exprt &string_obj,
+    const exprt &suffix_arg,
+    const locationt &location);
+
   symbolt &create_tmp_symbol(
     const nlohmann::json &element,
     const std::string var_name,


### PR DESCRIPTION
Fixes #2826.

This PR implements Python's string membership and prefix/suffix testing operations:

1. **'in' operator** for substring testing (e.g., `"o" in "foo"`)
2. **str.startswith()** method for prefix checking (e.g., `"foo".startswith("f")`)
3. **str.endswith()** method for suffix checking (e.g., `"foo".endswith("oo")`)

This PR makes the following changes:

1) String Membership ('in' operator)
* Added `in` mapping to `operator_map`.
* Implemented `handle_string_membership()` to convert substring checks to `strstr()` calls with NULL pointer comparison.
* Integrated membership test handling into `get_binary_operator_expr()`.

2) String Prefix Testing (startswith())
* Implemented `handle_string_startswith()` to convert prefix checks to `strncmp()` calls with proper length calculation.
* Added method interception in `function_call_builder` before generic symbol lookup.

3) String Suffix Testing (endswith())
* Implemented `handle_string_endswith()` to convert suffix checks to `strncmp()` calls with pointer arithmetic.
* Uses pointer `offset (str + (str_len - suffix_len))` to compare the end portion of the string.

4) Shared Infrastructure
* Implemented `ensure_null_terminated_string()` as a reusable helper method for converting single characters and expressions to proper null-terminated C strings.

Future work: Reuse `ensure_null_terminated_string()` to ensure consistency throughout the Python frontend to convert single characters and expressions to proper null-terminated C strings.

Thanks to @zhassan-aws for reporting this issue.