### PR TITLE
[python] fix string slicing semantics and extend regression coverage

### DIFF
--- a/regression/python/string-indexing/main.py
+++ b/regression/python/string-indexing/main.py
@@ -1,0 +1,4 @@
+foo = "abc:xyz:123"
+assert foo.startswith("abc:")
+# Ensure "xyz" is present after the colon
+assert foo[4:7] == "xyz"

--- a/regression/python/string-indexing/test.desc
+++ b/regression/python/string-indexing/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing2/main.py
+++ b/regression/python/string-indexing2/main.py
@@ -1,0 +1,6 @@
+foo = "abc:xyz:123"
+
+assert foo.startswith("abc:")
+assert foo[4:7] == "xyz"
+assert foo[8:] == "123"
+assert foo[-3:] == "123"

--- a/regression/python/string-indexing2/test.desc
+++ b/regression/python/string-indexing2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing2_fail/main.py
+++ b/regression/python/string-indexing2_fail/main.py
@@ -1,0 +1,6 @@
+foo = "abc:xyz:123"
+
+assert foo.startswith("abc:")
+assert foo[4:7] == "xyzz"
+assert foo[8:] == "1232"
+assert foo[-3:] == "1232"

--- a/regression/python/string-indexing2_fail/test.desc
+++ b/regression/python/string-indexing2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties\: 11 verified \✓ 8 passed, \✗ 3 failed$

--- a/regression/python/string-indexing3_fail/main.py
+++ b/regression/python/string-indexing3_fail/main.py
@@ -1,0 +1,5 @@
+foo = "abc:xyz:123"
+
+assert foo.startswith("abc:")
+assert foo[4:7] == "zzz"
+

--- a/regression/python/string-indexing3_fail/test.desc
+++ b/regression/python/string-indexing3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/string-indexing4/main.py
+++ b/regression/python/string-indexing4/main.py
@@ -1,0 +1,11 @@
+foo = "abc:xyz:123"
+
+assert foo.startswith("abc:")
+assert foo[4:7] == "xyz"
+assert foo[8:] == "123"
+assert foo[-3:] == "123"
+
+assert foo[:4] == "abc:"
+assert foo[4:] == "xyz:123"
+assert foo[:3] == "abc"
+assert foo[-7:-4] == "xyz"

--- a/regression/python/string-indexing4/test.desc
+++ b/regression/python/string-indexing4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing4_fail/main.py
+++ b/regression/python/string-indexing4_fail/main.py
@@ -1,0 +1,3 @@
+foo = "abc:xyz:123"
+assert foo[0:0] == "a"        # Should be empty
+assert foo[::2] == "abc"      # Wrong step slicing

--- a/regression/python/string-indexing4_fail/test.desc
+++ b/regression/python/string-indexing4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties\: 4 verified \✓ 2 passed, \✗ 2 failed$

--- a/regression/python/string-indexing_fail/main.py
+++ b/regression/python/string-indexing_fail/main.py
@@ -1,0 +1,3 @@
+foo = "abc:xyz:123"
+assert foo.startswith("abc:")
+assert foo[4:7] == "xayz"

--- a/regression/python/string-indexing_fail/test.desc
+++ b/regression/python/string-indexing_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -355,11 +355,18 @@ exprt python_list::handle_range_slice(
   const size_t lower_bound = slice_node["lower"]["value"].get<size_t>();
   const size_t upper_bound = slice_node["upper"]["value"].get<size_t>();
 
-  for (size_t i = lower_bound; i < upper_bound; ++i)
+  // Only update type map for actual lists (not strings or other types)
+  if (
+    !list_node.is_null() && list_node.contains("value") &&
+    list_node["value"].contains("elts") &&
+    list_node["value"]["elts"].is_array())
   {
-    const exprt element = converter_.get_expr(list_node["value"]["elts"][i]);
-    list_type_map[sliced_list.id.as_string()].push_back(
-      std::make_pair(element.identifier().as_string(), element.type()));
+    for (size_t i = lower_bound; i < upper_bound; ++i)
+    {
+      const exprt element = converter_.get_expr(list_node["value"]["elts"][i]);
+      list_type_map[sliced_list.id.as_string()].push_back(
+        std::make_pair(element.identifier().as_string(), element.type()));
+    }
   }
 
   return symbol_expr(sliced_list);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -301,7 +301,7 @@ exprt python_list::handle_range_slice(
     if (src_type.subtype() == char_type())
       logical_len = minus_exprt(array_len, gen_one(size_type()));
 
-    // Helper lambda to process slice bounds (handles null, negative indices)
+    // Process slice bounds (handles null, negative indices)
     auto process_bound =
       [&](const std::string &bound_name, const exprt &default_value) -> exprt {
       if (!slice_node.contains(bound_name) || slice_node[bound_name].is_null())
@@ -378,7 +378,7 @@ exprt python_list::handle_range_slice(
   symbolt &sliced_list = create_list();
   const locationt location = converter_.get_location_from_decl(list_value_);
 
-  // Helper to safely get bound expressions (handles null/missing)
+  // Get bound expressions (handles null/missing)
   auto get_list_bound = [&](const std::string &bound_name) -> exprt {
     if (slice_node.contains(bound_name) && !slice_node[bound_name].is_null())
       return converter_.get_expr(slice_node[bound_name]);
@@ -423,7 +423,9 @@ exprt python_list::handle_range_slice(
   const symbolt *push_func =
     converter_.symbol_table().find_symbol("c:list.c@F@list_push_object");
   if (!push_func)
+  {
     throw std::runtime_error("Push function symbol not found");
+  }
 
   side_effect_expr_function_callt push_call;
   push_call.function() = symbol_expr(*push_func);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2835.

This PR updates the Python frontend to correctly handle string slicing in accordance with Python’s semantics, and introduces new regression tests to validate slicing behavior across multiple scenarios.

Future work: Python slicing supports a third argument, the step or stride (e.g., [::2]). This PR only handles the two-argument slice ([lower: upper]); this is a missing piece of full Python slicing support!

