### PR TITLE
[python] Fix string comparison between pointer and array types

### DIFF
--- a/regression/python/string23/main.py
+++ b/regression/python/string23/main.py
@@ -1,0 +1,5 @@
+def is_foo(a: str) -> bool:
+    return a == "foo"
+
+e = is_foo("foo")
+assert e

--- a/regression/python/string23/test.desc
+++ b/regression/python/string23/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string23_fail/main.py
+++ b/regression/python/string23_fail/main.py
@@ -1,0 +1,5 @@
+def is_foo(a: str) -> bool:
+    return a != "foo"
+
+e = is_foo("foo")
+assert e

--- a/regression/python/string23_fail/test.desc
+++ b/regression/python/string23_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1545,8 +1545,9 @@ exprt python_converter::handle_type_mismatches(
     return nil_exprt();
   }
 
-  // Mixed types (array vs non-array) = not equal
-  return gen_boolean(op == "NotEq");
+  // Mixed types (array vs non-array)
+  // Let strcmp handle the comparison
+  return nil_exprt();
 }
 
 exprt python_converter::handle_string_comparison(


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2840.

The `handle_type_mismatches` function incorrectly treated pointer-to-char and array-of-char as incompatible types, causing string comparisons to fail without invoking `strcmp`.