### PR TITLE
[python] fix array-to-pointer decay for keyword arguments in function calls

### DIFF
--- a/regression/python/github_2839/main.py
+++ b/regression/python/github_2839/main.py
@@ -1,0 +1,5 @@
+def is_foo(a: str) -> bool:
+    return a == "foo"
+
+e = is_foo(a="foo")
+assert e

--- a/regression/python/github_2839/test.desc
+++ b/regression/python/github_2839/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2839_fail/main.py
+++ b/regression/python/github_2839_fail/main.py
@@ -1,0 +1,5 @@
+def is_foo(a: str) -> bool:
+    return a != "foo"
+
+e = is_foo(a="foo")
+assert e

--- a/regression/python/github_2839_fail/test.desc
+++ b/regression/python/github_2839_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2687,6 +2687,11 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           func_symbol->name.as_string());
       }
 
+      // Convert array to pointer to match parameter type
+      const typet &param_type = params[it->second].type();
+      if (arg_expr.type().is_array() && param_type.is_pointer())
+        arg_expr = get_array_base_address(arg_expr);
+
       args[it->second] = arg_expr;
     }
   };


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2839.

This PR applies array-to-pointer conversion when keyword arguments are arrays, but function parameters expect pointers. It fixes `argument type mismatch` crash when passing string literals as keyword arguments (e.g., `func(arg="foo")`).