### PR TITLE
[python] improve type inference for typing. Any

### DIFF
--- a/regression/python/github_2843/main.py
+++ b/regression/python/github_2843/main.py
@@ -1,0 +1,15 @@
+import random
+
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x == 4:
+        return True
+    elif x == 2:
+        return True
+    else:
+        return 3
+
+x = random.randint(0, 10)
+y = foo(x)
+assert y == True or y == 3

--- a/regression/python/github_2843/test.desc
+++ b/regression/python/github_2843/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_2/main.py
+++ b/regression/python/github_2843_2/main.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x == 4:
+        return True
+    else:
+        return 5
+
+assert foo(4) == True
+assert foo(0) == 5

--- a/regression/python/github_2843_2/test.desc
+++ b/regression/python/github_2843_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_2_fail/main.py
+++ b/regression/python/github_2843_2_fail/main.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x == 4:
+        return True
+    else:
+        return 5
+
+assert foo(4) != True
+assert foo(0) != 5

--- a/regression/python/github_2843_2_fail/test.desc
+++ b/regression/python/github_2843_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties\: 2 verified, \✗ 2 failed$

--- a/regression/python/github_2843_3/main.py
+++ b/regression/python/github_2843_3/main.py
@@ -1,0 +1,12 @@
+import random
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x > 0:
+        return 3.14
+    else:
+        return 5
+
+x = random.randint(-10,10)
+
+assert foo(x) == 3.14 or foo(x) == 5

--- a/regression/python/github_2843_3/test.desc
+++ b/regression/python/github_2843_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_4/main.py
+++ b/regression/python/github_2843_4/main.py
@@ -1,0 +1,12 @@
+import random
+
+from typing import Any
+def foo(x: int) -> Any:
+    if x > 0:
+        return 3.14
+    else:
+        return 5
+
+x = random.randint(-10,10)
+
+assert foo(x) == 3.14 or foo(x) == 5

--- a/regression/python/github_2843_4/test.desc
+++ b/regression/python/github_2843_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_4_fail/main.py
+++ b/regression/python/github_2843_4_fail/main.py
@@ -1,0 +1,13 @@
+import random
+
+from typing import Any
+def foo(x: int) -> Any:
+    if x > 0:
+        return 3.14
+    else:
+        return 5
+
+x = random.randint(-10,10)
+
+assert foo(x) != 3.14 
+assert foo(x) != 5

--- a/regression/python/github_2843_4_fail/test.desc
+++ b/regression/python/github_2843_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties\: 2 verified, \✗ 2 failed$

--- a/regression/python/github_2843_5/main.py
+++ b/regression/python/github_2843_5/main.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x == 4:
+        return True
+    elif x == 2:
+        return "Any"
+    else:
+        return 5
+
+assert foo(4) == True
+assert foo(0) == 5
+assert foo(2) == "Any"

--- a/regression/python/github_2843_5/test.desc
+++ b/regression/python/github_2843_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR\: Unsupported return type \'string\' detected$

--- a/regression/python/github_2843_6/main.py
+++ b/regression/python/github_2843_6/main.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x > 0:
+        return x + 1
+    else:
+        return x - 1
+
+assert foo(2) == 3
+assert foo(-2) == -3

--- a/regression/python/github_2843_6/test.desc
+++ b/regression/python/github_2843_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_7/main.py
+++ b/regression/python/github_2843_7/main.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+def foo(x: float) -> Any:
+    if x > 0:
+        return x + 1
+    else:
+        return x - 1
+
+assert foo(2.1) == 3.1
+assert foo(-2.1) == -3.1

--- a/regression/python/github_2843_7/test.desc
+++ b/regression/python/github_2843_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_fail/main.py
+++ b/regression/python/github_2843_fail/main.py
@@ -1,0 +1,15 @@
+import random
+
+from typing import Any
+
+def foo(x: int) -> Any:
+    if x == 4:
+        return True
+    elif x == 2:
+        return True
+    else:
+        return 3
+
+x = random.randint(0, 10)
+y = foo(x)
+assert y == True or y == 2

--- a/regression/python/github_2843_fail/test.desc
+++ b/regression/python/github_2843_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -19,6 +19,8 @@ ignored_dirs=(
   "enumerate15_fail"
   "func-no-params-types-fail"
   "function-option-fail"
+  "github_2843_fail"
+  "github_2843_4_fail"
   "global"
   "integer_squareroot_fail"
   "int_from_bytes"

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4313,8 +4313,8 @@ void python_converter::get_function_definition(
         type.return_type() = bool_type();
       else
       {
-        log_warning("Default to int sice no type could be inferred");
-        type.return_type() = int_type();
+        log_warning("Default to double sice no type could be inferred");
+        type.return_type() = double_type();
       }
     }
     // Handles list types

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -202,7 +202,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   const
 {
   if (ast_type == "Any")
-    return empty_typet();
+    return pointer_typet(empty_typet());
 
   // Handle empty string - return empty type without error message
   // This can occur when no type annotation is provided or for internal use


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2843.

This PR improves the handling of `typing. Any` in our Python frontend by:
- Representing Any as a `pointer(empty_type)` instead of a bare `empty_typet`.
- The frontend will now scan the function's body for return statements and infer the most appropriate concrete type (bool, int, or float) based on the returned constant literals.
- Adding multiple regression tests to verify success and failure cases