### PR TITLE
[python-frontend] add support for PEP 604 union syntax: int | bool

### DIFF
--- a/regression/python/union4/main.py
+++ b/regression/python/union4/main.py
@@ -1,0 +1,7 @@
+def returns_union(b: bool) -> int | bool:
+    if b:
+        return 1
+    else:
+        return False
+
+assert returns_union(True) == 1

--- a/regression/python/union4/test.desc
+++ b/regression/python/union4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/union4_fail/main.py
+++ b/regression/python/union4_fail/main.py
@@ -1,0 +1,7 @@
+def returns_union(b: bool) -> int | bool:
+    if b:
+        return 1
+    else:
+        return False
+
+assert returns_union(True) == 0

--- a/regression/python/union4_fail/test.desc
+++ b/regression/python/union4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/union5/main.py
+++ b/regression/python/union5/main.py
@@ -1,0 +1,4 @@
+def f() -> int | bool | float:
+    return 1.0
+
+assert f() == 1.0

--- a/regression/python/union5/test.desc
+++ b/regression/python/union5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/union5_fail/main.py
+++ b/regression/python/union5_fail/main.py
@@ -1,0 +1,4 @@
+def f() -> int | bool | float:
+    return 1.0
+
+assert f() != 1.0

--- a/regression/python/union5_fail/test.desc
+++ b/regression/python/union5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/union6/main.py
+++ b/regression/python/union6/main.py
@@ -1,0 +1,4 @@
+def f() -> int | int | bool:
+    return False
+
+assert not f()

--- a/regression/python/union6/test.desc
+++ b/regression/python/union6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/union6_fail/main.py
+++ b/regression/python/union6_fail/main.py
@@ -1,0 +1,4 @@
+def f() -> int | int | bool:
+    return False
+
+assert f()

--- a/regression/python/union6_fail/test.desc
+++ b/regression/python/union6_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/module_manager.cpp
+++ b/src/python-frontend/module_manager.cpp
@@ -39,7 +39,10 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
         if (node["returns"].is_null())
           continue;
 
-        if (node["returns"]["_type"] == "Subscript")
+        // Handle PEP 604 union syntax: int | bool
+        if (node["returns"]["_type"] == "BinOp")
+          f.return_type_ = "Union";
+        else if (node["returns"]["_type"] == "Subscript")
           f.return_type_ = node["returns"]["value"]["id"];
         else if (node["returns"]["_type"] == "Tuple")
           f.return_type_ = "Tuple";

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4423,6 +4423,16 @@ void python_converter::get_function_definition(
         type_handler_.get_typet(return_type.get<std::string>());
     }
   }
+  else if (return_node["_type"] == "BinOp")
+  {
+    // Handle PEP 604 union syntax: int | bool
+    TypeFlags flags = type_utils::extract_binop_union_types(return_node);
+    type.return_type() =
+      type_utils::select_widest_type(flags, pointer_typet(empty_typet()));
+
+    if (!flags.has_float && !flags.has_int && !flags.has_bool)
+      log_warning("Union with no recognized types, defaulting to pointer");
+  }
   else if (return_node["_type"] == "Tuple")
   {
     // Handle tuple return types such as (int, str)

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -181,7 +181,7 @@ public:
     return default_type;
   }
 
-  // Extract type flags from Union annotation slice: Union[int, bool]
+  // Extract type flags from Union annotation slice
   static TypeFlags extract_union_types(const nlohmann::json &slice)
   {
     TypeFlags flags;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2842.

This PR adds support for Python union type annotations using Python 3.10+ PEP 604 pipe syntax.
