### PR TITLE
[python] fix import handling for referenced classes and mixed import styles

### DIFF
--- a/regression/python/import-multi-files/l.py
+++ b/regression/python/import-multi-files/l.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, x: int) -> int:
+        return x + 1
+
+class Bar:
+    def __init__(self) -> None:
+        pass
+        
+    def bar(self, x: str) -> bool:
+       return x == "bar"
+
+def create(t: str) -> Any:
+    if t == "foo":
+        return Foo()
+    elif t == "bar":
+        return Bar()
+    else:
+        raise Exception("Unknown type")

--- a/regression/python/import-multi-files/main.py
+++ b/regression/python/import-multi-files/main.py
@@ -1,0 +1,4 @@
+from l import create, Foo
+
+o1: Foo = create("foo")
+assert o1.foo(4) == 5

--- a/regression/python/import-multi-files/test.desc
+++ b/regression/python/import-multi-files/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-multi-files2/l.py
+++ b/regression/python/import-multi-files2/l.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, x: int) -> int:
+        return x + 1
+
+class Bar:
+    def __init__(self) -> None:
+        pass
+        
+    def bar(self, x: str) -> bool:
+       return x == "bar"
+
+def create(t: str) -> Any:
+    if t == "foo":
+        return Foo()
+    elif t == "bar":
+        return Bar()
+    else:
+        raise Exception("Unknown type")

--- a/regression/python/import-multi-files2/main.py
+++ b/regression/python/import-multi-files2/main.py
@@ -1,0 +1,5 @@
+import l
+from l import Foo, Bar
+
+o1: Foo = l.create("foo")
+assert o1.foo(4) == 5

--- a/regression/python/import-multi-files2/test.desc
+++ b/regression/python/import-multi-files2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2856.

This PR fixes two related issues with Python import processing:
1) Missing referenced classes in selective imports. When importing a function that references other classes, those classes were not included in the generated AST if not explicitly imported.
2) Conflicting import statements for the same module. When both 'import module' and 'from module import X' were used for the same module, the second import would overwrite the first.