### PR TITLE
[python] consolidate string handling into string_builder class

### DIFF
--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(pythonfrontend STATIC
             function_call_expr.cpp
             numpy_call_expr.cpp
             function_call_builder.cpp
+            string_builder.cpp
             ${CMAKE_SOURCE_DIR}/src/ansi-c/parse_float.cpp
             ${CMAKE_SOURCE_DIR}/src/ansi-c/convert_float_literal.cpp)
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -952,9 +952,10 @@ private:
     const auto &value_type = element["value"]["_type"];
 
     // Handle subscript of string constant (e.g., "hello"[0] returns str)
-    if (value_type == "Subscript" &&
-        element["value"]["value"]["_type"] == "Constant" &&
-        element["value"]["value"]["value"].is_string())
+    if (
+      value_type == "Subscript" &&
+      element["value"]["value"]["_type"] == "Constant" &&
+      element["value"]["value"]["value"].is_string())
     {
       return "str";
     }

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -18,6 +18,7 @@ class function_id;
 class symbol_id;
 class function_call_expr;
 class type_handler;
+class string_builder;
 
 class python_converter
 {
@@ -27,7 +28,11 @@ public:
     const nlohmann::json *ast,
     const global_scope &gs);
 
+  ~python_converter();
+
   void convert();
+
+  string_builder &get_string_builder();
 
   const nlohmann::json &ast() const
   {
@@ -39,10 +44,14 @@ public:
     return symbol_table_;
   }
 
-  const type_handler &get_type_handler() const
+  type_handler &get_type_handler()
   {
     return type_handler_;
   }
+
+  bool is_zero_length_array(const exprt &expr);
+
+  void ensure_string_array(exprt &expr);
 
   const std::string &python_file() const
   {
@@ -147,10 +156,6 @@ private:
   exprt handle_power_operator(exprt base, exprt exp);
 
   exprt build_power_expression(const exprt &base, const BigInt &exp);
-
-  bool is_zero_length_array(const exprt &expr);
-
-  void ensure_string_array(exprt &expr);
 
   BigInt get_string_size(const exprt &expr);
 
@@ -402,6 +407,7 @@ private:
   const nlohmann::json *ast_json;
   const global_scope &global_scope_;
   type_handler type_handler_;
+  string_builder *string_builder_;
   symbol_generator sym_generator_;
 
   namespacet ns;

--- a/src/python-frontend/string_builder.cpp
+++ b/src/python-frontend/string_builder.cpp
@@ -1,0 +1,262 @@
+#include "string_builder.h"
+#include "python_converter.h"
+#include "type_handler.h"
+#include <util/arith_tools.h>
+#include <util/std_code.h>
+#include <util/expr_util.h>
+
+string_builder::string_builder(python_converter &converter)
+  : converter_(converter)
+{
+}
+
+contextt &string_builder::get_symbol_table() const
+{
+  return converter_.symbol_table();
+}
+
+type_handler &string_builder::get_type_handler()
+{
+  return converter_.get_type_handler();
+}
+
+exprt string_builder::make_null_terminator()
+{
+  BigInt zero(0);
+  return constant_exprt(
+    integer2binary(zero, 8), integer2string(zero), char_type());
+}
+
+exprt string_builder::make_char_constant(unsigned char ch)
+{
+  BigInt char_val(ch);
+  return constant_exprt(
+    integer2binary(char_val, 8), integer2string(char_val), char_type());
+}
+
+std::vector<exprt> string_builder::extract_string_chars(
+  const exprt &expr,
+  const nlohmann::json &json_node)
+{
+  std::vector<exprt> chars;
+
+  // Handle JSON string constants first
+  if (
+    !json_node.is_null() && json_node.contains("_type") &&
+    json_node["_type"] == "Constant" && json_node.contains("value"))
+  {
+    std::string str_value = json_node["value"].get<std::string>();
+    chars.reserve(str_value.size());
+    for (char c : str_value)
+    {
+      if (c == 0)
+        break;
+      chars.push_back(make_char_constant(static_cast<unsigned char>(c)));
+    }
+    return chars;
+  }
+
+  // Handle symbol expressions
+  if (expr.is_symbol())
+  {
+    symbolt *symbol =
+      get_symbol_table().find_symbol(expr.identifier().as_string());
+    if (
+      symbol && symbol->value.is_constant() && symbol->value.type().is_array())
+    {
+      for (size_t i = 0; i < symbol->value.operands().size(); ++i)
+      {
+        const exprt &ch = symbol->value.operands()[i];
+        if (ch.is_constant())
+        {
+          try
+          {
+            BigInt char_val =
+              binary2integer(ch.value().as_string(), ch.type().is_signedbv());
+            if (char_val == 0)
+              break;
+            chars.push_back(ch);
+          }
+          catch (...)
+          {
+            chars.push_back(ch);
+          }
+        }
+      }
+    }
+    return chars;
+  }
+
+  // Handle constant arrays
+  if (expr.is_constant() && expr.type().is_array())
+  {
+    for (size_t i = 0; i < expr.operands().size(); ++i)
+    {
+      const exprt &ch = expr.operands()[i];
+      if (ch.is_constant())
+      {
+        try
+        {
+          BigInt char_val =
+            binary2integer(ch.value().as_string(), ch.type().is_signedbv());
+          if (char_val == 0)
+            break;
+          chars.push_back(ch);
+        }
+        catch (...)
+        {
+          chars.push_back(ch);
+        }
+      }
+    }
+    return chars;
+  }
+
+  // Handle single character constants
+  if (
+    expr.is_constant() &&
+    (expr.type().is_signedbv() || expr.type().is_unsignedbv()))
+  {
+    try
+    {
+      BigInt char_val =
+        binary2integer(expr.value().as_string(), expr.type().is_signedbv());
+      if (char_val != 0)
+        chars.push_back(expr);
+    }
+    catch (...)
+    {
+      chars.push_back(expr);
+    }
+  }
+
+  return chars;
+}
+
+exprt string_builder::build_null_terminated_string(
+  const std::vector<exprt> &chars)
+{
+  // Calculate total size including null terminator
+  size_t total_size = chars.size() + 1;
+
+  // Create array type and expression
+  typet string_type = get_type_handler().build_array(char_type(), total_size);
+  exprt result = constant_exprt(
+    array_typet(char_type(), from_integer(total_size, size_type())));
+  result.type() = string_type;
+  result.operands().resize(total_size);
+
+  // Copy characters
+  for (size_t i = 0; i < chars.size(); ++i)
+    result.operands().at(i) = chars[i];
+
+  // Add null terminator
+  result.operands().at(chars.size()) = make_null_terminator();
+
+  return result;
+}
+
+exprt string_builder::build_string_literal(const std::string &str)
+{
+  std::vector<exprt> chars;
+  chars.reserve(str.size());
+  for (char c : str)
+    chars.push_back(make_char_constant(static_cast<unsigned char>(c)));
+
+  return build_null_terminated_string(chars);
+}
+
+exprt string_builder::build_byte_string(const std::vector<uint8_t> &bytes)
+{
+  std::vector<exprt> chars;
+  chars.reserve(bytes.size());
+  for (uint8_t byte : bytes)
+    chars.push_back(make_char_constant(byte));
+
+  return build_null_terminated_string(chars);
+}
+
+exprt string_builder::ensure_null_terminated_string(exprt &e)
+{
+  // Already a proper string array - return as is
+  if (e.type().is_array() && e.type().subtype() == char_type())
+    return e;
+
+  // Single character constant - convert to null-terminated string
+  if (e.is_constant() && (e.type().is_signedbv() || e.type().is_unsignedbv()))
+  {
+    BigInt char_val =
+      binary2integer(e.value().as_string(), e.type().is_signedbv());
+
+    std::vector<exprt> chars;
+    chars.push_back(
+      make_char_constant(static_cast<unsigned char>(char_val.to_uint64())));
+    return build_null_terminated_string(chars);
+  }
+
+  // For other types, fallback to converter's ensure_string_array
+  converter_.ensure_string_array(e);
+  return e;
+}
+
+exprt string_builder::concatenate_strings(
+  const exprt &lhs,
+  const exprt &rhs,
+  const nlohmann::json &left,
+  const nlohmann::json &right)
+{
+  // Handle edge cases with empty strings
+  bool lhs_is_empty =
+    converter_.is_zero_length_array(lhs) ||
+    (lhs.is_constant() && lhs.type().is_array() && lhs.operands().size() <= 1);
+  bool rhs_is_empty =
+    converter_.is_zero_length_array(rhs) ||
+    (rhs.is_constant() && rhs.type().is_array() && rhs.operands().size() <= 1);
+
+  if (lhs_is_empty && rhs_is_empty)
+    return lhs;
+  if (lhs_is_empty && !rhs_is_empty)
+    return rhs;
+  if (!lhs_is_empty && rhs_is_empty)
+    return lhs;
+
+  // Extract characters from both operands
+  std::vector<exprt> lhs_chars = extract_string_chars(lhs, left);
+  std::vector<exprt> rhs_chars = extract_string_chars(rhs, right);
+
+  // Combine character vectors
+  std::vector<exprt> combined_chars;
+  combined_chars.reserve(lhs_chars.size() + rhs_chars.size());
+  combined_chars.insert(
+    combined_chars.end(), lhs_chars.begin(), lhs_chars.end());
+  combined_chars.insert(
+    combined_chars.end(), rhs_chars.begin(), rhs_chars.end());
+
+  // Build null-terminated result
+  return build_null_terminated_string(combined_chars);
+}
+
+exprt string_builder::build_raw_byte_array(const std::vector<uint8_t> &bytes)
+{
+  // Get the proper bytes type from type_handler
+  typet bytes_type = get_type_handler().get_typet("bytes", bytes.size());
+
+  // Create zero-initialized array
+  exprt result = gen_zero(bytes_type);
+
+  // Get the element type from the bytes type's subtype
+  const typet &element_type = bytes_type.subtype();
+
+  // Copy bytes using the proper element type and width
+  for (size_t i = 0; i < bytes.size(); ++i)
+  {
+    uint8_t byte = bytes[i];
+    exprt byte_value = constant_exprt(
+      integer2binary(BigInt(byte), bv_width(element_type)),
+      integer2string(BigInt(byte)),
+      element_type);
+    result.operands().at(i) = byte_value;
+  }
+
+  return result;
+}

--- a/src/python-frontend/string_builder.h
+++ b/src/python-frontend/string_builder.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <util/expr.h>
+#include <util/type.h>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <string>
+#include <cstdint>
+
+// Forward declaration
+class python_converter;
+class type_handler;
+class contextt;
+
+/// Helper class for building and manipulating string expressions in Python frontend
+/// Handles null-termination, character extraction, and string concatenation
+class string_builder
+{
+public:
+  explicit string_builder(python_converter &converter);
+
+  /// Create a null terminator character constant
+  exprt make_null_terminator();
+
+  /// Create a character constant from a byte value
+  exprt make_char_constant(unsigned char ch);
+
+  /// Extract characters from an expression, stopping at null terminator
+  /// Returns a vector of character expressions (without null terminator)
+  std::vector<exprt> extract_string_chars(
+    const exprt &expr,
+    const nlohmann::json &json_node = nlohmann::json());
+
+  /// Create a null-terminated string array from a vector of character expressions
+  exprt build_null_terminated_string(const std::vector<exprt> &chars);
+
+  /// Create a null-terminated string from a std::string
+  exprt build_string_literal(const std::string &str);
+
+  /// Create a null-terminated string from a vector of bytes
+  exprt build_byte_string(const std::vector<uint8_t> &bytes);
+
+  /// Ensure an expression is a null-terminated string
+  /// Converts single characters or promotes to proper string arrays
+  exprt ensure_null_terminated_string(exprt &e);
+
+  /// Concatenate two string expressions with proper null-termination
+  exprt concatenate_strings(
+    const exprt &lhs,
+    const exprt &rhs,
+    const nlohmann::json &left = nlohmann::json(),
+    const nlohmann::json &right = nlohmann::json());
+
+  /// Create a raw byte array without null termination (for Python bytes literals)
+  exprt build_raw_byte_array(const std::vector<uint8_t> &bytes);
+
+private:
+  python_converter &converter_;
+  contextt &get_symbol_table() const;
+  type_handler &get_type_handler();
+};


### PR DESCRIPTION
This PR extracts duplicated string null-termination, character extraction, and concatenation logic from `python_converter` into a dedicated `string_builder` helper class to centralize string operation logic, similar to the existing `type_handler` pattern.

This makes the following changes:
- Add `string_builder.h/cpp` with methods for string literal creation, null-termination, and concatenation.
- Update `python_converter` to use `string_builder` for all string operations.
- Simplify `get_literal()` and `handle_string_concatenation()` implementations.