### PR TITLE
[python] fix boost::process compilation on macOS

### DIFF
--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -16,11 +16,11 @@
 // Use boost::process v1 on macOS or when Boost >= 1.87
 // We use Boost.Process to run the Python interpreter in a separate process.
 #if defined(__APPLE__) || (BOOST_VERSION >= 108700)
-  #include <boost/process/v1.hpp>
-  namespace bp = boost::process::v1;
+#  include <boost/process/v1.hpp>
+namespace bp = boost::process::v1;
 #else
-  #include <boost/process.hpp>
-  namespace bp = boost::process;
+#  include <boost/process.hpp>
+namespace bp = boost::process;
 #endif
 
 namespace fs = boost::filesystem;

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -12,9 +12,16 @@
 #include <fstream>
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
 
-namespace bp = boost::process;
+// Use boost::process v1 on macOS or when Boost >= 1.87
+#if defined(__APPLE__) || (BOOST_VERSION >= 108700)
+  #include <boost/process/v1.hpp>
+  namespace bp = boost::process::v1;
+#else
+  #include <boost/process.hpp>
+  namespace bp = boost::process;
+#endif
+
 namespace fs = boost::filesystem;
 
 extern "C"

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -14,6 +14,7 @@
 #include <boost/filesystem.hpp>
 
 // Use boost::process v1 on macOS or when Boost >= 1.87
+// We use Boost.Process to run the Python interpreter in a separate process.
 #if defined(__APPLE__) || (BOOST_VERSION >= 108700)
   #include <boost/process/v1.hpp>
   namespace bp = boost::process::v1;


### PR DESCRIPTION
Boost >= 1.87 defaults to process v2, which lacks `search_path`. Conditionally use v1 on macOS and newer Boost versions while maintaining compatibility with older Linux systems.