### PR TITLE
[python] fix crash with Optional type annotations

### DIFF
--- a/regression/python/optional/main.py
+++ b/regression/python/optional/main.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+def foo(x: int, y: Optional[int] = None) -> int:
+    if y is None:
+        y = 0
+    return x + y
+
+assert foo(1) == 1

--- a/regression/python/optional/test.desc
+++ b/regression/python/optional/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional_fail/main.py
+++ b/regression/python/optional_fail/main.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+def foo(x: int, y: Optional[int] = None) -> int:
+    if y is None:
+        y = 0
+    return x + y
+
+assert foo(1) == 2

--- a/regression/python/optional_fail/test.desc
+++ b/regression/python/optional_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4034,6 +4034,21 @@ typet python_converter::get_type_from_annotation(
        annotation_node["value"]["id"] == "List"))
       return type_handler_.get_list_type();
 
+    // Handle Optional[T] - extract the inner type T
+    if (
+      annotation_node.contains("value") &&
+      annotation_node["value"]["id"] == "Optional")
+    {
+      if (
+        annotation_node.contains("slice") &&
+        annotation_node["slice"].contains("id"))
+      {
+        std::string inner_type =
+          annotation_node["slice"]["id"].get<std::string>();
+        return type_handler_.get_typet(inner_type);
+      }
+    }
+
     return type_handler_.get_list_type(element);
   }
   else if (


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2869.

This PR handles `Optional[T]` by extracting the inner type `T` instead of falling through to list type handling. It prevents type-mismatch assertion failures in `arith_2ops` when processing function parameters with Optional types in debugging mode.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.