### PR TITLE
[python] fix crash with omitted optional parameters in keyword argument calls

### DIFF
--- a/regression/python/optional2/l.py
+++ b/regression/python/optional2/l.py
@@ -1,0 +1,14 @@
+# l.py
+
+from typing import Optional
+
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(
+        self,
+        x: int,
+        o: Optional[int] = None
+    ) -> None:
+        pass

--- a/regression/python/optional2/main.py
+++ b/regression/python/optional2/main.py
@@ -1,0 +1,9 @@
+# ex.py
+
+from l import Foo
+
+def s() -> None:
+    f: Foo = Foo()
+    f.foo(x=120)
+
+s()

--- a/regression/python/optional2/test.desc
+++ b/regression/python/optional2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2519,6 +2519,17 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
 
       args[it->second] = arg_expr;
     }
+
+    // Fill empty arguments with None for optional parameters
+    for (size_t i = 0; i < args.size(); ++i)
+    {
+      if (args[i].is_nil() || args[i].id().empty())
+      {
+        constant_exprt none_expr(none_type());
+        none_expr.set_value("NULL");
+        args[i] = none_expr;
+      }
+    }
   };
 
   handle_keywords(call_expr);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2870.

This PR fills empty argument slots with `None` values after processing keyword arguments to ensure all parameters have valid expressions for migration. It prevents `migrate expr failed` crash when optional parameters are not provided in function calls using keyword arguments.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.