### PR TITLE
[python] add support for assertion messages

### DIFF
--- a/regression/python/assert-message_fail/main.py
+++ b/regression/python/assert-message_fail/main.py
@@ -1,0 +1,3 @@
+x = 1
+y = 2
+assert x == y, 'x is equal to y'

--- a/regression/python/assert-message_fail/test.desc
+++ b/regression/python/assert-message_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^  x is equal to y$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2872.

This PR extracts and displays user-provided assertion messages from Python assert statements. Messages are now included in ESBMC's violation output via the location comment field.

Example: `assert x == y, 'x is equal to y'`

With this PR, we now show: `assertion x is equal to y` in the output.

Thanks for [zhassan-aws](https://github.com/zhassan-aws) to request this nice feature.