### PR TITLE
[python] fix list membership operator to use element comparison instead of substring search

### DIFF
--- a/regression/python/list21/main.py
+++ b/regression/python/list21/main.py
@@ -1,0 +1,2 @@
+l = ["Foo", "Bar", "Baz"]
+assert "Bar" in l

--- a/regression/python/list21/test.desc
+++ b/regression/python/list21/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list21_fail/main.py
+++ b/regression/python/list21_fail/main.py
@@ -1,0 +1,2 @@
+l = ["Foo", "Bar", "Baz"]
+assert "Test" in l

--- a/regression/python/list21_fail/test.desc
+++ b/regression/python/list21_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/list22/main.py
+++ b/regression/python/list22/main.py
@@ -1,0 +1,2 @@
+l = ["Foo", "Bar", 2]
+assert 2 in l

--- a/regression/python/list22/test.desc
+++ b/regression/python/list22/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list22_fail/main.py
+++ b/regression/python/list22_fail/main.py
@@ -1,0 +1,2 @@
+l = ["Foo", "Bar", 2]
+assert "2" in l

--- a/regression/python/list22_fail/test.desc
+++ b/regression/python/list22_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -121,7 +121,8 @@ const static std::vector<std::string> python_c_models = {
   "matmul",       "pow",
   "log",          "pow_by_squaring",
   "log2",         "ldexp",
-  "log1p_taylor", "strstr"};
+  "log1p_taylor", "strstr",
+  "list_contains"};
 
 } // namespace
 

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -195,3 +195,30 @@ static inline size_t list_hash_string(const char *str)
   }
   return hash;
 }
+
+static bool list_contains(
+  const List *l,
+  const void *item,
+  size_t item_type_id,
+  size_t item_size)
+{
+  if (!l || !item)
+    return false;
+
+  size_t i = 0;
+  while (i < l->size)
+  {
+    const Object *elem = &l->items[i];
+
+    // Check if types and sizes match
+    if (elem->type_id == item_type_id && elem->size == item_size)
+    {
+      // Compare the actual data
+      if (elem->value == item || memcmp(elem->value, item, item_size) == 0)
+        return true;
+    }
+
+    ++i;
+  }
+  return false;
+}

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2068,10 +2068,21 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   attach_symbol_location(lhs, symbol_table());
   attach_symbol_location(rhs, symbol_table());
 
-  // Handle 'in' operator for string membership testing
-  if (op == "In" && (lhs.type().is_array() || rhs.type().is_array()))
+  // Handle 'in' operator
+  if (op == "In")
   {
-    return handle_string_membership(lhs, rhs, element);
+    typet list_type = type_handler_.get_list_type();
+
+    // Handle list membership: "item" in [list]
+    if (rhs.type() == list_type)
+    {
+      python_list list(*this, element);
+      return list.contains(lhs, rhs);
+    }
+
+    // Handle string membership testing: "substr" in "string"
+    if (lhs.type().is_array() || rhs.type().is_array())
+      return handle_string_membership(lhs, rhs, element);
   }
 
   // Function calls in expressions like "fib(n-1) + fib(n-2)" need to be converted to side effects

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -35,6 +35,8 @@ public:
 
   exprt compare(const exprt &l1, const exprt &l2, const std::string &op);
 
+  exprt contains(const exprt &item, const exprt &list);
+
   exprt list_repetition(
     const nlohmann::json &left_node,
     const nlohmann::json &right_node,


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2876.

We previously treated list membership as a substring search using `strstr()`. This PR now properly checks list elements using the new `list_contains()` function.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.