### PR TITLE
[python] improve None and Optional handling

### DIFF
--- a/regression/python/none_compare1/main.py
+++ b/regression/python/none_compare1/main.py
@@ -1,0 +1,5 @@
+def foo(x: int) -> None:
+    assert (x == None) == False
+    assert (x != None) == True
+
+foo(10)

--- a/regression/python/none_compare1/test.desc
+++ b/regression/python/none_compare1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/none_compare2/main.py
+++ b/regression/python/none_compare2/main.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+def foo(x: Optional[int]) -> None:
+    # These should hold true for proper pointer comparisons
+    if x is None:
+        assert x == None
+        assert not (x != None)
+    else:
+        assert x != None
+        assert not (x == None)
+
+foo(None)
+foo(1)

--- a/regression/python/none_compare2/test.desc
+++ b/regression/python/none_compare2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/none_compare3/main.py
+++ b/regression/python/none_compare3/main.py
@@ -1,0 +1,7 @@
+def foo() -> None:
+    assert (None == None)
+    assert not (None != None)
+    assert (None is None)
+    assert not (None is not None)
+
+foo()

--- a/regression/python/none_compare3/test.desc
+++ b/regression/python/none_compare3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/none_compare4_fail/main.py
+++ b/regression/python/none_compare4_fail/main.py
@@ -1,0 +1,5 @@
+def foo() -> None:
+    # Deliberate contradiction
+    assert None != None
+
+foo()

--- a/regression/python/none_compare4_fail/test.desc
+++ b/regression/python/none_compare4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/optional3/main.py
+++ b/regression/python/optional3/main.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+def foo(x: int, y: Optional[str] = None, z: Optional[int] = None) -> int:
+    assert y is None or z is None
+    return 42
+
+
+foo(1)

--- a/regression/python/optional3/test.desc
+++ b/regression/python/optional3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional3_fail/main.py
+++ b/regression/python/optional3_fail/main.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+def foo(x: int, y: Optional[str] = None, z: Optional[int] = None) -> int:
+    assert y is not None or z is not None
+    return 42
+
+
+foo(1)

--- a/regression/python/optional3_fail/test.desc
+++ b/regression/python/optional3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/optional4/main.py
+++ b/regression/python/optional4/main.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+def foo(x: Optional[int]) -> int:
+    assert x is None or x is not None
+    if x is None:
+        return 0
+    else:
+        return x + 1
+
+foo(None)
+foo(42)
+

--- a/regression/python/optional4/test.desc
+++ b/regression/python/optional4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional4_fail/main.py
+++ b/regression/python/optional4_fail/main.py
@@ -1,0 +1,8 @@
+from typing import Optional
+
+def foo(x: Optional[int]) -> int:
+    # This should fail when x is None
+    assert x is not None
+    return x + 1
+
+foo(None)

--- a/regression/python/optional4_fail/test.desc
+++ b/regression/python/optional4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/optional_union/main.py
+++ b/regression/python/optional_union/main.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+def foo(x: Union[int, None]) -> None:
+    if x is None:
+        assert True
+    else:
+        assert isinstance(x, int)
+
+foo(None)
+foo(5)

--- a/regression/python/optional_union/test.desc
+++ b/regression/python/optional_union/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2871.

Optional[T] parameters were being constant-folded when compared with None, causing incorrect verification results.

This PR:
- Represents Optional[T] annotations as pointer types (T*)
- Generates runtime NULL checks for None comparisons with pointers

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.