### PR TITLE
[python] add support for 'not in' operator

### DIFF
--- a/regression/python/github_2881/main.py
+++ b/regression/python/github_2881/main.py
@@ -1,0 +1,11 @@
+caracteres_especiais_invalidos = '!@#$%^&*()_+=-[]{}|;:,.<>?/~`'
+
+def validate_category(category: str):
+    for char in category:
+        assert char not in caracteres_especiais_invalidos, "A categoria não deve conter caracteres especiais."
+
+def main() -> None:
+    category = "academia"
+    validate_category(category)
+
+main()

--- a/regression/python/github_2881/test.desc
+++ b/regression/python/github_2881/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2881_2/main.py
+++ b/regression/python/github_2881_2/main.py
@@ -1,0 +1,7 @@
+def test_not_in_behavior() -> None:
+    assert 'a' not in 'xyz'
+    assert 'x' not in ['y', 'z']
+    assert not ('a' not in 'abc')
+
+test_not_in_behavior()
+

--- a/regression/python/github_2881_2/test.desc
+++ b/regression/python/github_2881_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2881_3_fail/main.py
+++ b/regression/python/github_2881_3_fail/main.py
@@ -1,0 +1,6 @@
+def unsupported_not_in():
+    x = 5
+    y = 10
+    assert x not in y  # should be invalid
+
+unsupported_not_in()

--- a/regression/python/github_2881_3_fail/test.desc
+++ b/regression/python/github_2881_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: Unsupported expression for \'not in\' operation$

--- a/regression/python/github_2881_fail/main.py
+++ b/regression/python/github_2881_fail/main.py
@@ -1,0 +1,11 @@
+caracteres_especiais_invalidos = '!@#$%^&*()_+=-[]{}|;:,.<>?/~`'
+
+def validate_category(category: str):
+    for char in category:
+        assert char not in caracteres_especiais_invalidos, "A categoria não deve conter caracteres especiais."
+
+def main() -> None:
+    category = "academ!a"
+    validate_category(category)
+
+main()

--- a/regression/python/github_2881_fail/test.desc
+++ b/regression/python/github_2881_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/notin2_fail/main.py
+++ b/regression/python/notin2_fail/main.py
@@ -1,0 +1,15 @@
+def test_string_boundaries() -> None:
+    s = "start-middle-end"
+    
+    # Not in (substring absent)
+    assert 'xyz' not in s
+
+    # Not in (exact match absent)
+    assert not ('start' in s)
+    assert not ('end' in s)
+
+    # Not in (check for 'in' at boundaries)
+    assert not ('start' not in s)
+    assert not ('end' not in s)
+
+test_string_boundaries()

--- a/regression/python/notin2_fail/test.desc
+++ b/regression/python/notin2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/notin_fail/main.py
+++ b/regression/python/notin_fail/main.py
@@ -1,0 +1,7 @@
+def test_empty_containers() -> None:	
+    # Empty string	
+    assert 'a' not in ''	
+    assert '' not in 'abc'	
+    assert '' not in ''
+
+test_empty_containers()

--- a/regression/python/notin_fail/test.desc
+++ b/regression/python/notin_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -373,6 +373,12 @@ private:
     std::list<std::string> &file_list,
     const std::string &dir_path);
 
+  exprt handle_membership_operator(
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &element,
+    bool invert);
+
   // helper methods for get_var_assign
   std::pair<std::string, typet>
   extract_type_info(const nlohmann::json &ast_node);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2881.

This PR implements `NotIn` operator handling by negating the result of the existing 'in' operator logic for both list and string membership tests.

This PR also extracts common logic between 'in' and 'not in' operators into a single helper method `handle_membership_operator()`. 

Thanks to [Spsuelen](https://github.com/Spsuelen) for reporting this issue.
