### PR TITLE
[python] exclude null terminator in negative string indexing

### DIFF
--- a/regression/python/github_2885/main.py
+++ b/regression/python/github_2885/main.py
@@ -1,0 +1,2 @@
+text:str = "test"
+assert text[-1] == "t"

--- a/regression/python/github_2885/test.desc
+++ b/regression/python/github_2885/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2885_2/main.py
+++ b/regression/python/github_2885_2/main.py
@@ -1,0 +1,2 @@
+text: str = "abcd"
+assert text[3] == "d"  # valid: last element by positive index

--- a/regression/python/github_2885_2/test.desc
+++ b/regression/python/github_2885_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2885_2_fail/main.py
+++ b/regression/python/github_2885_2_fail/main.py
@@ -1,0 +1,2 @@
+text: str = ""
+assert text[-1] == "a"  # invalid: empty string has no last element

--- a/regression/python/github_2885_2_fail/test.desc
+++ b/regression/python/github_2885_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2885_3/main.py
+++ b/regression/python/github_2885_3/main.py
@@ -1,0 +1,4 @@
+text: str = "python"
+assert text[-1] == "n"
+assert text[-2] == "o"
+assert text[-6] == "p"  # first element by negative index

--- a/regression/python/github_2885_3/test.desc
+++ b/regression/python/github_2885_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2885_3_fail/main.py
+++ b/regression/python/github_2885_3_fail/main.py
@@ -1,0 +1,2 @@
+text: str = "abcd"
+assert text[4] == "?"  # invalid: index 4 out of bounds (len = 4)

--- a/regression/python/github_2885_3_fail/test.desc
+++ b/regression/python/github_2885_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2885_4_fail/main.py
+++ b/regression/python/github_2885_4_fail/main.py
@@ -1,0 +1,2 @@
+text: str = "hi"
+assert text[-3] == "h"  # invalid: index -3 < -len("hi")

--- a/regression/python/github_2885_4_fail/test.desc
+++ b/regression/python/github_2885_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2885_fail/main.py
+++ b/regression/python/github_2885_fail/main.py
@@ -1,0 +1,2 @@
+text:str = "test"
+assert text[-1] == "s"

--- a/regression/python/github_2885_fail/test.desc
+++ b/regression/python/github_2885_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -518,6 +518,10 @@ exprt python_list::handle_index_access(
       const array_typet &t = static_cast<const array_typet &>(array.type());
       BigInt s = binary2integer(t.size().value().c_str(), true);
 
+      // For char arrays (strings), exclude null terminator from logical length
+      if (t.subtype() == char_type())
+        s -= 1;
+
       v += s;
       pos_expr = from_integer(v, pos_expr.type());
     }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2885.

When accessing strings with negative indices, such as `text[-1]`, the calculation incorrectly included the null terminator in the array size. With this PR, we now subtract 1 for char arrays to match Python semantics.

````
Before: text[-1] on "test" accessed index 4 (null terminator)
After:  text[-1] on "test" accesses index 3 (character 't')
````