### PR TITLE
[python] fix method calls on for-loop variables via symbol table

### DIFF
--- a/regression/python/for-loop17/main.py
+++ b/regression/python/for-loop17/main.py
@@ -1,0 +1,9 @@
+def validate_category(category: str) -> None:
+    for char in category:
+        assert char.isalpha()
+
+def main() -> None:
+    category = "Livros"
+    validate_category(category)
+
+main()

--- a/regression/python/for-loop17/test.desc
+++ b/regression/python/for-loop17/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop17_fail/main.py
+++ b/regression/python/for-loop17_fail/main.py
@@ -1,0 +1,9 @@
+def validate_category(category: str) -> None:
+    for char in category:
+        assert not char.isalpha()
+
+def main() -> None:
+    category = "Livros"
+    validate_category(category)
+
+main()

--- a/regression/python/for-loop17_fail/test.desc
+++ b/regression/python/for-loop17_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2879.

The converter failed to find loop variables (e.g., `char` in `for char in category: char.isalpha()`) because AST search doesn't traverse loop bodies. 

This PR uses symbol table lookup instead of `find_var_decl()` to resolve variable types for method calls. It fixes: "Class char not found" error for preprocessed for-loops.

Thanks to [Spsuelen](https://github.com/Spsuelen) for reporting this issue.