### PR TITLE
[SV-COMP] new option to simplify verification for data races check

### DIFF
--- a/regression/esbmc-unix/00_race28/test.desc
+++ b/regression/esbmc-unix/00_race28/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---context-bound 1 --no-slice --data-races
+--context-bound 1 --no-slice --data-races-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/00_rwlock/test.desc
+++ b/regression/esbmc-unix/00_rwlock/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---no-por --data-races
+--no-por --data-races-check
 ^VERIFICATION FAILED$

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -290,7 +290,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
       command_line += "--no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind "
   elif prop == Property.datarace:
     # TODO: can we do better in case 'concurrency == False'?
-    command_line += "--no-pointer-check --no-bounds-check --data-races-check --no-assertions "
+    command_line += "--no-pointer-check --no-bounds-check --data-races-check-only --no-assertions "
   else:
     print("Unknown property")
     exit(1)

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2004,7 +2004,9 @@ bool esbmc_parseoptionst::process_goto_program(
 
     goto_functions.update();
 
-    if (cmdline.isset("data-races-check") || cmdline.isset("data-races-check-only"))
+    if (
+      cmdline.isset("data-races-check") ||
+      cmdline.isset("data-races-check-only"))
     {
       log_status("Adding Data Race Checks");
       options.set_option("data-races-check", true);

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2004,9 +2004,10 @@ bool esbmc_parseoptionst::process_goto_program(
 
     goto_functions.update();
 
-    if (cmdline.isset("data-races-check"))
+    if (cmdline.isset("data-races-check") || cmdline.isset("data-races-check-only"))
     {
       log_status("Adding Data Race Checks");
+      options.set_option("data-races-check", true);
       add_race_assertions(context, goto_functions);
     }
 

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -394,6 +394,10 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "enable global and local deadlock check with mutex"},
     {"data-races-check", NULL, "enable data races check"},
+    {"data-races-check-only",
+     NULL,
+     "enable data races check and only focus on race checks to reduce "
+     "thread interleaving"},
     {"lock-order-check", NULL, "enable for lock acquisition ordering check"},
     {"atomicity-check", NULL, "enable atomicity check at visible assignments"},
     {"stack-limit",

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -144,6 +144,18 @@ void add_race_assertions(
       instruction.make_skip();
       i_it++;
 
+      {
+        goto_programt::targett t = goto_program.insert(i_it);
+        t->type = FUNCTION_CALL;
+        code_function_callt call;
+        call.function() =
+          symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
+
+        migrate_expr(call, t->code);
+        t->location = original_instruction.location;
+        i_it = ++t;
+      }
+
       // Avoid adding too much thread interleaving by using atomic block
       // yield();
       // atomic {Assert tmp_A == 0; tmp_A = 1; A = n;}
@@ -201,7 +213,7 @@ void add_race_assertions(
         i_it = ++t;
       }
 
-      if (config.options.get_bool_option("data-race-check-only"))
+      if (config.options.get_bool_option("data-races-check-only"))
       {
         goto_programt::targett t = goto_program.insert(i_it);
         t->type = FUNCTION_CALL;

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -144,18 +144,6 @@ void add_race_assertions(
       instruction.make_skip();
       i_it++;
 
-      {
-        goto_programt::targett t = goto_program.insert(i_it);
-        t->type = FUNCTION_CALL;
-        code_function_callt call;
-        call.function() =
-          symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
-
-        migrate_expr(call, t->code);
-        t->location = original_instruction.location;
-        i_it = ++t;
-      }
-
       // Avoid adding too much thread interleaving by using atomic block
       // yield();
       // atomic {Assert tmp_A == 0; tmp_A = 1; A = n;}
@@ -210,6 +198,19 @@ void add_race_assertions(
         goto_programt::targett t = goto_program.insert(i_it);
 
         *t = ATOMIC_END;
+        i_it = ++t;
+      }
+
+      if (config.options.get_bool_option("data-race-check-only"))
+      {
+        goto_programt::targett t = goto_program.insert(i_it);
+        t->type = FUNCTION_CALL;
+        code_function_callt call;
+        call.function() =
+          symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
+
+        migrate_expr(call, t->code);
+        t->location = original_instruction.location;
         i_it = ++t;
       }
 

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -825,6 +825,9 @@ void execution_statet::get_expr_globals(
   const expr2tc &expr,
   std::set<expr2tc> &globals_list)
 {
+  if (options.get_bool_option("data-races-check-only"))
+    return;
+
   if (is_nil_expr(expr))
     return;
 


### PR DESCRIPTION
The current data race check is based on multi-threaded verification. 

This means that there will be more thread interleaving, whereas in SV-COMP (no-races category) will focus on race checking so we can discard these irrelevant context switches.