### PR TITLE
[python] fix nested loop variable collision in preprocessor

### DIFF
--- a/regression/python/github_2892/main.py
+++ b/regression/python/github_2892/main.py
@@ -1,0 +1,16 @@
+MAX_LEN = 20
+caracteres_especiais_invalidos = '!@#$%^&*()_+=-[]{}|;:,.<>?/~`'
+
+def validate_title(title: str):
+    for char in title:
+        char_encontrado = False
+        for caractere_especial in caracteres_especiais_invalidos:
+            if char == caractere_especial:
+                char_encontrado = True
+        assert not char_encontrado, "O título não deve conter caracteres especiais."
+
+def main() -> None:
+    title = "Livro"
+    validate_title(title)
+
+main()

--- a/regression/python/github_2892/test.desc
+++ b/regression/python/github_2892/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2892_fail/main.py
+++ b/regression/python/github_2892_fail/main.py
@@ -1,0 +1,16 @@
+MAX_LEN = 20
+caracteres_especiais_invalidos = '!@#$%^&*()_+=-[]{}|;:,.<>?/~`'
+
+def validate_title(title: str):
+    for char in title:
+        char_encontrado = False
+        for caractere_especial in caracteres_especiais_invalidos:
+            if char == caractere_especial:
+                char_encontrado = True
+        assert not char_encontrado, "O título não deve conter caracteres especiais."
+
+def main() -> None:
+    title = "Livro$"
+    validate_title(title)
+
+main()

--- a/regression/python/github_2892_fail/test.desc
+++ b/regression/python/github_2892_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -689,7 +689,7 @@ class Preprocessor(ast.NodeTransformer):
         index_var = f'ESBMC_index_{loop_id}'
         length_var = f'ESBMC_length_{loop_id}'
         iter_var_base = 'ESBMC_iter'
-        
+
         # Handle the target variable name
         if hasattr(node.target, 'id'):
             target_var_name = node.target.id

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -685,7 +685,7 @@ class Preprocessor(ast.NodeTransformer):
         # Generate unique variable names for this loop level
         loop_id = self.iterable_loop_counter
         self.iterable_loop_counter += 1
-        
+
         index_var = f'ESBMC_index_{loop_id}'
         length_var = f'ESBMC_length_{loop_id}'
         iter_var_base = 'ESBMC_iter'
@@ -724,7 +724,7 @@ class Preprocessor(ast.NodeTransformer):
         while_cond = self._create_while_condition(node, index_var, length_var)
 
         # Create loop body with unique variable names
-        transformed_body = self._create_loop_body(node, target_var_name, iter_var_name, 
+        transformed_body = self._create_loop_body(node, target_var_name, iter_var_name,
                                                 annotation_id, index_var)
 
         # Create the while statement
@@ -797,7 +797,7 @@ class Preprocessor(ast.NodeTransformer):
     def _create_loop_body(self, node, target_var_name, iter_var_name, annotation_id, index_var='ESBMC_index'):
         """Create the complete loop body with custom index variable name."""
         # Item assignment
-        item_assign = self._create_item_assignment(node, target_var_name, iter_var_name, 
+        item_assign = self._create_item_assignment(node, target_var_name, iter_var_name,
                                                 annotation_id, index_var)
 
         # Index increment


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2892.

Nested for-loops were reusing `ESBMC_index`/`ESBMC_length` variables, causing ESBMC's slicer to incorrectly simplify away assertions. 

This PR adds a loop counter to generate unique variable names for each nesting level (`ESBMC_index_0`, `ESBMC_index_1`, etc.).