### PR TITLE
[python] fix list membership check for string parameters

### DIFF
--- a/regression/python/github_2898/main.py
+++ b/regression/python/github_2898/main.py
@@ -1,0 +1,5 @@
+def check(s: str) -> None:
+    l: list[str] = ['foo', 'bar', 'baz']
+    assert s in l
+
+check('foo')

--- a/regression/python/github_2898/test.desc
+++ b/regression/python/github_2898/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2898_fail/main.py
+++ b/regression/python/github_2898_fail/main.py
@@ -1,0 +1,5 @@
+def check(s: str) -> None:
+    l: list[str] = ['foo', 'bar', 'baz']
+    assert not s in l
+
+check('foo')

--- a/regression/python/github_2898_fail/test.desc
+++ b/regression/python/github_2898_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2898.

String parameters (`char*`) were incorrectly using pointer size (1 byte) instead of the actual string length when checking membership in lists, causing verification failures. 

This PR fixes it by calling `strlen()` for pointer types to match the size of stored string elements.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.