### PR TITLE
[python] fix union types and attribute assignments

### DIFF
--- a/regression/python/github_2895/main.py
+++ b/regression/python/github_2895/main.py
@@ -1,0 +1,5 @@
+class Foo:
+    def __init__(self, x: str | None = None) -> None:
+        self.x = x
+
+f: Foo = Foo("foo")

--- a/regression/python/github_2895/test.desc
+++ b/regression/python/github_2895/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2895_2/l.py
+++ b/regression/python/github_2895_2/l.py
@@ -1,0 +1,4 @@
+# l.py
+class Foo:
+    def __init__(self, x: str | None = None) -> None:
+        self.x = x

--- a/regression/python/github_2895_2/main.py
+++ b/regression/python/github_2895_2/main.py
@@ -1,0 +1,3 @@
+from l import Foo
+
+f: Foo = Foo("foo")

--- a/regression/python/github_2895_2/test.desc
+++ b/regression/python/github_2895_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2895.

This PR:
- Supports PEP 604 union types (`T | None`) in annotations by handling `BinOp` nodes and treating them as `Optional[T]`.
- Handles Attribute targets in Assign statements to support imported classes with attribute assignments such as `self.x = value`.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.