### PR TITLE
[python] fix recursive module import handling

### DIFF
--- a/regression/python/github_2897/c.py
+++ b/regression/python/github_2897/c.py
@@ -1,0 +1,5 @@
+# c.py
+from l import Foo
+
+def create() -> Foo:
+    return Foo()

--- a/regression/python/github_2897/l.py
+++ b/regression/python/github_2897/l.py
@@ -1,0 +1,4 @@
+# l.py
+class Foo:
+    def __init__(self) -> None:
+        pass

--- a/regression/python/github_2897/main.py
+++ b/regression/python/github_2897/main.py
@@ -1,0 +1,4 @@
+import c
+from l import Foo
+
+f: Foo = c.create()

--- a/regression/python/github_2897/test.desc
+++ b/regression/python/github_2897/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2897_2/c.py
+++ b/regression/python/github_2897_2/c.py
@@ -1,0 +1,6 @@
+# c.py
+from l import Foo
+from l2 import Bar
+
+def create() -> Foo:
+    return Foo()

--- a/regression/python/github_2897_2/l.py
+++ b/regression/python/github_2897_2/l.py
@@ -1,0 +1,4 @@
+# l.py
+class Foo:
+    def __init__(self) -> None:
+        pass

--- a/regression/python/github_2897_2/l2.py
+++ b/regression/python/github_2897_2/l2.py
@@ -1,0 +1,4 @@
+# l2.py  
+x:int = 42
+class Bar:
+    pass

--- a/regression/python/github_2897_2/main.py
+++ b/regression/python/github_2897_2/main.py
@@ -1,0 +1,6 @@
+import c
+from l import Foo
+from l2 import x
+
+f: Foo = c.create()
+assert x == 42

--- a/regression/python/github_2897_2/test.desc
+++ b/regression/python/github_2897_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2897_2_fail/c.py
+++ b/regression/python/github_2897_2_fail/c.py
@@ -1,0 +1,6 @@
+# c.py
+from l import Foo
+from l2 import Bar
+
+def create() -> Foo:
+    return Foo()

--- a/regression/python/github_2897_2_fail/l.py
+++ b/regression/python/github_2897_2_fail/l.py
@@ -1,0 +1,4 @@
+# l.py
+class Foo:
+    def __init__(self) -> None:
+        pass

--- a/regression/python/github_2897_2_fail/l2.py
+++ b/regression/python/github_2897_2_fail/l2.py
@@ -1,0 +1,4 @@
+# l2.py  
+x:int = 42
+class Bar:
+    pass

--- a/regression/python/github_2897_2_fail/main.py
+++ b/regression/python/github_2897_2_fail/main.py
@@ -1,0 +1,6 @@
+import c
+from l import Foo
+from l2 import x
+
+f: Foo = c.create()
+assert x == 41

--- a/regression/python/github_2897_2_fail/test.desc
+++ b/regression/python/github_2897_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -19,6 +19,7 @@ class symbol_id;
 class function_call_expr;
 class type_handler;
 class string_builder;
+class module_locator;
 
 class python_converter
 {
@@ -354,6 +355,10 @@ private:
   exprt get_return_from_func(const char *func_symbol_id);
 
   void create_builtin_symbols();
+
+  void process_module_imports(
+    const nlohmann::json &module_ast,
+    module_locator &locator);
 
   symbolt *find_function_in_base_classes(
     const std::string &class_name,

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -358,7 +358,8 @@ private:
 
   void process_module_imports(
     const nlohmann::json &module_ast,
-    module_locator &locator);
+    module_locator &locator,
+    code_blockt &accumulated_code);
 
   symbolt *find_function_in_base_classes(
     const std::string &class_name,


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2897.

This PR adds a new method to process module imports depth-first, ensuring dependencies are loaded before they are used. It fixes crashes when importing classes from transitive dependencies (e.g., `ex.py` imports `c.py`, which imports `Foo` from `l.py`).

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.