### PR TITLE
[python] extend support for union type annotations (PEP 604)

### DIFF
--- a/regression/python/github_2910/main.py
+++ b/regression/python/github_2910/main.py
@@ -1,0 +1,4 @@
+def foo(x: bool | str | None = None) -> None:
+    pass
+
+foo(True)

--- a/regression/python/github_2910/test.desc
+++ b/regression/python/github_2910/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2910_2/main.py
+++ b/regression/python/github_2910_2/main.py
@@ -1,0 +1,4 @@
+def foo(x: bool | str = True) -> None:
+    pass
+
+foo(True)

--- a/regression/python/github_2910_2/test.desc
+++ b/regression/python/github_2910_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2910_3/main.py
+++ b/regression/python/github_2910_3/main.py
@@ -1,0 +1,6 @@
+def foo(x: bool | str | None = None) -> None:
+    pass
+
+foo(True)
+foo("hello")
+foo(None)

--- a/regression/python/github_2910_3/test.desc
+++ b/regression/python/github_2910_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2910.

This PR handles nested `BinOp` nodes in union types such as `bool | str | None` by recursively extracting the first non-None type. Previously, only simple two-element unions were supported, causing "Unsupported union type pattern in annotation" errors for multi-type unions.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.