### PR TITLE
[python] Add Python str.lstrip() support for removing leading whitespace

### DIFF
--- a/regression/python/github_2909/main.py
+++ b/regression/python/github_2909/main.py
@@ -1,0 +1,11 @@
+MAX_LEN = 20
+
+def validate_title(title: str)-> None:
+    if title.lstrip() == title:
+        raise AssertionError("O título não deve começar com espaço.")
+
+def main() -> None:
+    title = " Livro"
+    validate_title(title)
+
+main()

--- a/regression/python/github_2909/test.desc
+++ b/regression/python/github_2909/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2909_2/main.py
+++ b/regression/python/github_2909_2/main.py
@@ -1,0 +1,3 @@
+text:str = " esbmc-python"
+assert text.lstrip() == "esbmc-python"
+

--- a/regression/python/github_2909_2/test.desc
+++ b/regression/python/github_2909_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 13
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2909_2_fail/main.py
+++ b/regression/python/github_2909_2_fail/main.py
@@ -1,0 +1,3 @@
+text:str = "esbmc python"
+assert text.lstrip() == "esbmcpython"
+

--- a/regression/python/github_2909_2_fail/test.desc
+++ b/regression/python/github_2909_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 13
+^VERIFICATION FAILED$

--- a/regression/python/github_2909_fail/main.py
+++ b/regression/python/github_2909_fail/main.py
@@ -1,0 +1,11 @@
+MAX_LEN = 20
+
+def validate_title(title: str)-> None:
+    if title.lstrip() != title:
+        raise AssertionError("O título não deve começar com espaço.")
+
+def main() -> None:
+    title = " Livro"
+    validate_title(title)
+
+main()

--- a/regression/python/github_2909_fail/test.desc
+++ b/regression/python/github_2909_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -157,6 +157,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_char_isalpha",
   "__python_str_isspace",
   "isspace",
+  "__python_str_lstrip",
 };
 
 } // namespace

--- a/src/c2goto/library/ctype.c
+++ b/src/c2goto/library/ctype.c
@@ -203,3 +203,21 @@ int toupper(int c)
 __ESBMC_HIDE:;
   return (c >= 'a' && c <= 'z') ? c - ('a' - 'A') : c;
 }
+
+// Python string lstrip: removes leading whitespace characters
+// Returns a pointer to the first non-whitespace character
+const char *__python_str_lstrip(const char *s)
+{
+__ESBMC_HIDE:;
+  if (!s)
+    return s;
+
+  // Skip leading whitespace
+  while (*s && (*s == ' ' || *s == '\t' || *s == '\n' || *s == '\v' ||
+                *s == '\f' || *s == '\r'))
+  {
+    s++;
+  }
+
+  return s;
+}

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -351,6 +351,18 @@ exprt function_call_builder::build() const
         return converter_.handle_string_isspace(obj_expr, loc);
       }
     }
+
+    if (method_name == "lstrip")
+    {
+      exprt obj_expr = converter_.get_expr(call_["func"]["value"]);
+
+      // lstrip() takes optional chars argument, but we only support no arguments
+      if (!call_["args"].empty())
+        throw std::runtime_error("lstrip() with arguments not yet supported");
+
+      locationt loc = converter_.get_location_from_decl(call_);
+      return converter_.handle_string_lstrip(obj_expr, loc);
+    }
   }
 
   // Add len function to symbol table

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -295,6 +295,8 @@ private:
     const typet &symbol_type,
     const exprt &symbol_value);
 
+  exprt handle_string_lstrip(const exprt &str_expr, const locationt &location);
+
   exprt get_logical_operator_expr(const nlohmann::json &element);
 
   exprt get_conditional_stm(const nlohmann::json &ast_node);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2909.

This PR implements `lstrip()` method for Python strings to remove leading whitespace characters (space, tab, newline, vertical tab, form feed, carriage return). In particular, this PR:

- Adds `__python_str_lstrip()` C model that returns a pointer to the first non-whitespace character.
- Adds `handle_string_lstrip()` to process `lstrip()` method calls.
- Adds `__python_str_lstrip` to `python_c_models` whitelist.
- Support `lstrip()` with no arguments (custom chars not yet supported).

Thanks to [Spsuelen](https://github.com/Spsuelen) for reporting this issue.