### PR TITLE
[python] Extract string handling into dedicated string_handler class

### DIFF
--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(pythonfrontend STATIC
             numpy_call_expr.cpp
             function_call_builder.cpp
             string_builder.cpp
+            string_handler.cpp
             parse_float.cpp
             convert_float_literal.cpp)
 

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -293,7 +293,8 @@ exprt function_call_builder::build() const
       exprt prefix_arg = converter_.get_expr(call_["args"][0]);
       locationt loc = converter_.get_location_from_decl(call_);
 
-      return converter_.handle_string_startswith(obj_expr, prefix_arg, loc);
+      return converter_.get_string_handler().handle_string_startswith(
+        obj_expr, prefix_arg, loc);
     }
 
     if (method_name == "endswith")
@@ -306,7 +307,8 @@ exprt function_call_builder::build() const
       exprt suffix_arg = converter_.get_expr(call_["args"][0]);
       locationt loc = converter_.get_location_from_decl(call_);
 
-      return converter_.handle_string_endswith(obj_expr, suffix_arg, loc);
+      return converter_.get_string_handler().handle_string_endswith(
+        obj_expr, suffix_arg, loc);
     }
 
     if (method_name == "isdigit")
@@ -318,7 +320,8 @@ exprt function_call_builder::build() const
 
       locationt loc = converter_.get_location_from_decl(call_);
 
-      return converter_.handle_string_isdigit(obj_expr, loc);
+      return converter_.get_string_handler().handle_string_isdigit(
+        obj_expr, loc);
     }
 
     if (method_name == "isalpha")
@@ -328,7 +331,8 @@ exprt function_call_builder::build() const
         throw std::runtime_error("isalpha() takes no arguments");
 
       locationt loc = converter_.get_location_from_decl(call_);
-      return converter_.handle_string_isalpha(obj_expr, loc);
+      return converter_.get_string_handler().handle_string_isalpha(
+        obj_expr, loc);
     }
 
     if (method_name == "isspace")
@@ -343,12 +347,14 @@ exprt function_call_builder::build() const
       if (obj_expr.type().is_unsignedbv() || obj_expr.type().is_signedbv())
       {
         // Single character - use C's isspace function
-        return converter_.handle_char_isspace(obj_expr, loc);
+        return converter_.get_string_handler().handle_char_isspace(
+          obj_expr, loc);
       }
       else
       {
         // String variable - use the string version
-        return converter_.handle_string_isspace(obj_expr, loc);
+        return converter_.get_string_handler().handle_string_isspace(
+          obj_expr, loc);
       }
     }
 
@@ -361,7 +367,8 @@ exprt function_call_builder::build() const
         throw std::runtime_error("lstrip() with arguments not yet supported");
 
       locationt loc = converter_.get_location_from_decl(call_);
-      return converter_.handle_string_lstrip(obj_expr, loc);
+      return converter_.get_string_handler().handle_string_lstrip(
+        obj_expr, loc);
     }
   }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -798,408 +798,6 @@ void python_converter::handle_float_division(
   bin_expr.id(get_op("div", float_type));
 }
 
-BigInt python_converter::get_string_size(const exprt &expr)
-{
-  if (!expr.type().is_array())
-  {
-    // For non-array types in f-strings, convert them first to get actual size
-    if (expr.is_constant() && type_utils::is_integer_type(expr.type()))
-    {
-      // Convert the actual integer to string to get real size
-      BigInt value =
-        binary2integer(expr.value().as_string(), expr.type().is_signedbv());
-      std::string str_repr = std::to_string(value.to_int64());
-      return BigInt(str_repr.size() + 1); // +1 for null terminator
-    }
-
-    if (expr.is_symbol())
-    {
-      const symbolt *symbol = symbol_table_.find_symbol(expr.identifier());
-      if (symbol && symbol->type.is_array())
-      {
-        const auto &arr_type = to_array_type(symbol->type);
-        return binary2integer(arr_type.size().value().as_string(), false);
-      }
-      // For non-array symbols, we need a reasonable default since we can't compute actual size
-      return BigInt(20); // Conservative default
-    }
-
-    // For other types, use conservative defaults
-    if (expr.type().is_bool())
-      return BigInt(6); // "False" + null terminator
-
-    // Default fallback
-    return BigInt(20);
-  }
-
-  const auto &arr_type = to_array_type(expr.type());
-  return binary2integer(arr_type.size().value().as_string(), false);
-}
-
-std::string
-python_converter::process_format_spec(const nlohmann::json &format_spec)
-{
-  if (format_spec.is_null() || !format_spec.contains("_type"))
-    return "";
-
-  // Handle direct Constant format spec
-  if (format_spec["_type"] == "Constant" && format_spec.contains("value"))
-    return format_spec["value"].get<std::string>();
-
-  // Handle JoinedStr format spec (which contains Constant values)
-  if (format_spec["_type"] == "JoinedStr" && format_spec.contains("values"))
-  {
-    std::string result;
-    for (const auto &value : format_spec["values"])
-      if (value["_type"] == "Constant" && value.contains("value"))
-        result += value["value"].get<std::string>();
-    return result;
-  }
-
-  // Log warning for unsupported format specifications
-  std::string spec_type = format_spec.contains("_type")
-                            ? format_spec["_type"].get<std::string>()
-                            : "unknown";
-  log_warning("Unsupported f-string format specification type: {}", spec_type);
-
-  return "";
-}
-
-exprt python_converter::apply_format_specification(
-  const exprt &expr,
-  const std::string &format)
-{
-  // Basic format specification handling
-  if (format.empty())
-    return convert_to_string(expr);
-
-  // Handle integer formatting
-  if (format == "d" || format == "i")
-    return convert_to_string(expr);
-
-  // Handle float formatting with precision
-  else if (format.find(".") != std::string::npos && format.back() == 'f')
-  {
-    // Extract precision from format string (e.g., ".2f" -> 2)
-    size_t dot_pos = format.find(".");
-    size_t f_pos = format.find("f");
-    if (
-      dot_pos != std::string::npos && f_pos != std::string::npos &&
-      f_pos > dot_pos)
-    {
-      std::string precision_str =
-        format.substr(dot_pos + 1, f_pos - dot_pos - 1);
-      int precision = 6; // default
-      try
-      {
-        precision = std::stoi(precision_str);
-      }
-      catch (...)
-      {
-        precision = 6;
-      }
-
-      // Handle floatbv expressions (both constant and symbols)
-      if (expr.type().is_floatbv())
-      {
-        const typet &t = expr.type();
-        const std::size_t float_width = bv_width(t);
-
-        // Support common floating point widths
-        if (t.is_floatbv() && (float_width == 32 || float_width == 64))
-        {
-          const std::string *float_bits = nullptr;
-
-          // Handle constant expressions
-          if (expr.is_constant())
-            float_bits = &expr.value().as_string();
-          // Handle symbol expressions
-          else if (expr.is_symbol())
-          {
-            const symbol_exprt &sym_expr = to_symbol_expr(expr);
-            const symbolt *symbol =
-              symbol_table_.find_symbol(sym_expr.get_identifier());
-
-            if (symbol && symbol->value.is_constant())
-              float_bits = &symbol->value.value().as_string();
-          }
-
-          if (float_bits && float_bits->length() == float_width)
-          {
-            double val = 0.0;
-
-            // Handle different floating point widths
-            if (float_width == 32)
-            {
-              // IEEE 754 single precision
-              uint32_t bits = 0;
-              for (std::size_t i = 0; i < float_width; ++i)
-                if ((*float_bits)[i] == '1')
-                  bits |= (1U << (float_width - 1 - i));
-
-              float float_val;
-              std::memcpy(&float_val, &bits, sizeof(float));
-              val = static_cast<double>(float_val);
-            }
-            else if (float_width == 64)
-            {
-              // IEEE 754 double precision
-              uint64_t bits = 0;
-              for (std::size_t i = 0; i < float_width; ++i)
-                if ((*float_bits)[i] == '1')
-                  bits |= (1ULL << (float_width - 1 - i));
-
-              std::memcpy(&val, &bits, sizeof(double));
-            }
-
-            // Use proper rounding to avoid IEEE 754 precision issues
-            double multiplier = std::pow(10.0, precision);
-            double rounded = std::round(val * multiplier) / multiplier;
-
-            std::ostringstream oss;
-            oss << std::fixed << std::setprecision(precision) << rounded;
-            std::string formatted_str = oss.str();
-
-            typet string_type =
-              type_handler_.build_array(char_type(), formatted_str.size() + 1);
-            std::vector<unsigned char> chars(
-              formatted_str.begin(), formatted_str.end());
-            chars.push_back('\0');
-
-            return make_char_array_expr(chars, string_type);
-          }
-        }
-      }
-    }
-  }
-
-  // Default: just convert to string
-  return convert_to_string(expr);
-}
-
-exprt python_converter::convert_to_string(const exprt &expr)
-{
-  const typet &t = expr.type();
-
-  // Already a string/char array - return as is
-  if (t.is_array() && t.subtype() == char_type())
-    return expr;
-
-  // Handle symbol references
-  if (expr.is_symbol())
-  {
-    const symbolt *symbol = symbol_table_.find_symbol(expr.identifier());
-    if (symbol)
-    {
-      // If symbol has string type, return it
-      if (symbol->type.is_array() && symbol->type.subtype() == char_type())
-        return expr;
-
-      // If symbol has a constant value, convert that
-      if (symbol->value.is_constant())
-        return convert_to_string(symbol->value);
-    }
-  }
-
-  // Handle constants
-  if (expr.is_constant())
-  {
-    if (type_utils::is_integer_type(t))
-    {
-      BigInt value = binary2integer(expr.value().as_string(), t.is_signedbv());
-      std::string str_value = std::to_string(value.to_int64());
-
-      typet string_type =
-        type_handler_.build_array(char_type(), str_value.size() + 1);
-      std::vector<unsigned char> chars(str_value.begin(), str_value.end());
-      chars.push_back('\0'); // null terminator
-
-      return make_char_array_expr(chars, string_type);
-    }
-    else if (t.is_floatbv())
-    {
-      std::string str_value = "0.0";
-      if (expr.is_constant() && !expr.value().empty())
-      {
-        const std::string &float_bits = expr.value().as_string();
-        if (t.is_floatbv() && bv_width(t) == 64 && float_bits.length() == 64)
-        {
-          uint64_t bits = 0;
-          for (size_t i = 0; i < 64; ++i)
-          {
-            if (float_bits[i] == '1')
-              bits |= (1ULL << (63 - i));
-          }
-          double val;
-          std::memcpy(&val, &bits, sizeof(double));
-
-          // Use proper rounding for default precision (6 decimal places)
-          double multiplier = std::pow(10.0, 6);
-          double rounded = std::round(val * multiplier) / multiplier;
-
-          std::ostringstream oss;
-          oss << std::fixed << std::setprecision(6) << rounded;
-          str_value = oss.str();
-        }
-      }
-
-      typet string_type =
-        type_handler_.build_array(char_type(), str_value.size() + 1);
-      std::vector<unsigned char> chars(str_value.begin(), str_value.end());
-      chars.push_back('\0');
-
-      return make_char_array_expr(chars, string_type);
-    }
-    else if (t.is_bool())
-    {
-      // Convert boolean to string
-      bool value = expr.is_true();
-      std::string str_value = value ? "True" : "False";
-
-      typet string_type =
-        type_handler_.build_array(char_type(), str_value.size() + 1);
-      std::vector<unsigned char> chars(str_value.begin(), str_value.end());
-      chars.push_back('\0');
-
-      return make_char_array_expr(chars, string_type);
-    }
-  }
-
-  // For non-constant expressions, we'd need runtime conversion
-  // For now, create a placeholder string
-  std::string placeholder = "<expr>";
-  typet string_type =
-    type_handler_.build_array(char_type(), placeholder.size() + 1);
-  std::vector<unsigned char> chars(placeholder.begin(), placeholder.end());
-  chars.push_back('\0');
-
-  return make_char_array_expr(chars, string_type);
-}
-
-exprt python_converter::get_fstring_expr(const nlohmann::json &element)
-{
-  if (!element.contains("values") || element["values"].empty())
-  {
-    // Empty f-string
-    typet empty_string_type = type_handler_.build_array(char_type(), 1);
-    exprt empty_str = gen_zero(empty_string_type);
-    empty_str.operands().at(0) = from_integer(0, char_type());
-    return empty_str;
-  }
-
-  const auto &values = element["values"];
-  std::vector<exprt> parts;
-  BigInt total_estimated_size = BigInt(1); // Start with 1 for null terminator
-
-  for (const auto &value : values)
-  {
-    exprt part_expr;
-
-    try
-    {
-      if (value["_type"] == "Constant")
-      {
-        // String literal part
-        part_expr = get_literal(value);
-      }
-      else if (value["_type"] == "FormattedValue")
-      {
-        // Expression to be formatted
-        exprt expr = get_expr(value["value"]);
-
-        // Handle format specification if present
-        if (value.contains("format_spec") && !value["format_spec"].is_null())
-        {
-          std::string format = process_format_spec(value["format_spec"]);
-          part_expr = apply_format_specification(expr, format);
-        }
-        else
-          part_expr = convert_to_string(expr);
-      }
-      else
-      {
-        // Other expression types
-        exprt expr = get_expr(value);
-        part_expr = convert_to_string(expr);
-      }
-
-      parts.push_back(part_expr);
-      total_estimated_size += get_string_size(part_expr) -
-                              1; // -1 to avoid double counting terminators
-    }
-    catch (const std::exception &e)
-    {
-      log_warning("Error processing f-string part: {}", e.what());
-      // Create error placeholder
-      std::string error_str = "<error>";
-      typet error_type =
-        type_handler_.build_array(char_type(), error_str.size() + 1);
-      std::vector<unsigned char> chars(error_str.begin(), error_str.end());
-      chars.push_back('\0');
-      parts.push_back(make_char_array_expr(chars, error_type));
-      total_estimated_size += BigInt(error_str.size());
-    }
-  }
-
-  // If only one part, return it directly
-  if (parts.size() == 1)
-    return parts[0];
-
-  // Concatenate all parts
-  exprt result = parts[0];
-  for (size_t i = 1; i < parts.size(); ++i)
-  {
-    nlohmann::json empty_left, empty_right;
-    result =
-      handle_string_concatenation(result, parts[i], empty_left, empty_right);
-  }
-
-  return result;
-}
-
-exprt python_converter::handle_string_concatenation(
-  const exprt &lhs,
-  const exprt &rhs,
-  const nlohmann::json &left,
-  const nlohmann::json &right)
-{
-  return string_builder_->concatenate_strings(lhs, rhs, left, right);
-}
-
-bool python_converter::is_zero_length_array(const exprt &expr)
-{
-  if (expr.id() == "sideeffect")
-    return false;
-
-  if (!expr.type().is_array())
-    return false;
-
-  const auto &arr_type = to_array_type(expr.type());
-  if (!arr_type.size().is_constant())
-    return false;
-
-  BigInt size = binary2integer(arr_type.size().value().as_string(), false);
-  return size == 0;
-}
-
-std::string python_converter::extract_string_from_array_operands(
-  const exprt &array_expr) const
-{
-  std::string result;
-  for (const auto &op : array_expr.operands())
-  {
-    if (op.is_constant())
-    {
-      BigInt val =
-        binary2integer(op.value().as_string(), op.type().is_signedbv());
-      if (val == 0)
-        break;
-      result += static_cast<char>(val.to_uint64());
-    }
-  }
-  return result;
-}
-
 std::pair<exprt, exprt> python_converter::resolve_comparison_operands_internal(
   const exprt &lhs,
   const exprt &rhs)
@@ -1316,7 +914,7 @@ exprt python_converter::handle_indexed_comparison_internal(
   BigInt idx =
     binary2integer(index.value().as_string(), index.type().is_signedbv());
 
-  std::string rhs_str = extract_string_from_array_operands(rhs);
+  std::string rhs_str = string_handler_.extract_string_from_array_operands(rhs);
 
   const exprt &array = lhs.operands()[0];
   exprt resolved_array = get_resolved_value(array);
@@ -1343,7 +941,8 @@ exprt python_converter::handle_indexed_comparison_internal(
     idx < (BigInt)resolved_array.operands().size())
   {
     const exprt &string_element = resolved_array.operands()[idx.to_uint64()];
-    std::string lhs_str = extract_string_from_array_operands(string_element);
+    std::string lhs_str =
+      string_handler_.extract_string_from_array_operands(string_element);
     bool strings_equal = (lhs_str == rhs_str);
     return gen_boolean((op == "Eq") ? strings_equal : !strings_equal);
   }
@@ -1373,9 +972,9 @@ exprt python_converter::handle_type_mismatches(
 
     // Both are strings: compare based on content
     // check if empty
-    bool lhs_empty = is_zero_length_array(lhs) ||
+    bool lhs_empty = string_handler_.is_zero_length_array(lhs) ||
                      (lhs.is_constant() && lhs.operands().size() <= 1);
-    bool rhs_empty = is_zero_length_array(rhs) ||
+    bool rhs_empty = string_handler_.is_zero_length_array(rhs) ||
                      (rhs.is_constant() && rhs.operands().size() <= 1);
 
     if (lhs_empty != rhs_empty)
@@ -1407,7 +1006,9 @@ exprt python_converter::handle_string_comparison(
     throw std::runtime_error("Cannot compare non-function side effects");
 
   // Handle zero-length arrays early
-  if (is_zero_length_array(resolved_lhs) && is_zero_length_array(resolved_rhs))
+  if (
+    string_handler_.is_zero_length_array(resolved_lhs) &&
+    string_handler_.is_zero_length_array(resolved_rhs))
     return gen_boolean(op == "Eq");
 
   // Try constant comparisons
@@ -1430,9 +1031,9 @@ exprt python_converter::handle_string_comparison(
 
   // At this point, both operands should be strings (arrays of char)
   if (resolved_lhs.type().is_array())
-    resolved_lhs = get_array_base_address(resolved_lhs);
+    resolved_lhs = string_handler_.get_array_base_address(resolved_lhs);
   if (resolved_rhs.type().is_array())
-    resolved_rhs = get_array_base_address(resolved_rhs);
+    resolved_rhs = string_handler_.get_array_base_address(resolved_rhs);
 
   symbolt *strncmp_symbol = symbol_table_.find_symbol("c:@F@strcmp");
   if (!strncmp_symbol)
@@ -1727,43 +1328,6 @@ bool python_converter::is_identity_function(
   return false;
 }
 
-void python_converter::ensure_string_array(exprt &expr)
-{
-  if (expr.type().is_pointer())
-    return;
-
-  if (!expr.type().is_array())
-  {
-    typet t = type_handler_.build_array(expr.type(), 1);
-    exprt arr = gen_zero(t);
-    arr.operands().at(0) = expr;
-    expr = arr;
-  }
-}
-
-exprt python_converter::handle_string_operations(
-  const std::string &op,
-  exprt &lhs,
-  exprt &rhs,
-  const nlohmann::json &left,
-  const nlohmann::json &right,
-  const nlohmann::json &element)
-{
-  ensure_string_array(lhs);
-  ensure_string_array(rhs);
-
-  assert(lhs.type().is_array() || lhs.type().is_pointer());
-  assert(rhs.type().is_array() || rhs.type().is_pointer());
-
-  if (op == "Eq" || op == "NotEq")
-    return handle_string_comparison(op, lhs, rhs, element);
-
-  if (op == "Add")
-    return handle_string_concatenation(lhs, rhs, left, right);
-
-  return nil_exprt();
-}
-
 /// Construct the expression for Python 'is' operator
 exprt python_converter::get_binary_operator_expr_for_is(
   const exprt &lhs,
@@ -1776,7 +1340,8 @@ exprt python_converter::get_binary_operator_expr_for_is(
   {
     // Compare base addresses of the arrays
     is_expr.copy_to_operands(
-      get_array_base_address(lhs), get_array_base_address(rhs));
+      string_handler_.get_array_base_address(lhs),
+      string_handler_.get_array_base_address(rhs));
   }
   else
   {
@@ -1785,13 +1350,6 @@ exprt python_converter::get_binary_operator_expr_for_is(
   }
 
   return is_expr;
-}
-
-/// Get address of the first element of an array
-exprt python_converter::get_array_base_address(const exprt &arr)
-{
-  exprt index = index_exprt(arr, from_integer(0, index_type()));
-  return address_of_exprt(index);
 }
 
 /// Construct the negation of an 'is' expression, used for 'is not'
@@ -1822,42 +1380,6 @@ void python_converter::convert_function_calls_to_side_effects(
     to_side_effect_call(lhs);
   if (rhs.is_function_call())
     to_side_effect_call(rhs);
-}
-
-/// Handle string concatenation with type promotion
-exprt python_converter::handle_string_concatenation_with_promotion(
-  exprt &lhs,
-  exprt &rhs,
-  const nlohmann::json &left,
-  const nlohmann::json &right)
-{
-  // After the string concatenation section, before the type determination:
-  if (lhs.type().is_array() && !rhs.type().is_array())
-  {
-    // LHS is array, RHS is single char - promote RHS to string array
-    if (type_utils::is_integer_type(rhs.type()))
-    {
-      typet string_type = type_handler_.build_array(char_type(), 2);
-      exprt str_array = gen_zero(string_type);
-      str_array.operands().at(0) = rhs;
-      str_array.operands().at(1) = gen_zero(char_type()); // null terminator
-      rhs = str_array;
-    }
-  }
-  else if (!lhs.type().is_array() && rhs.type().is_array())
-  {
-    // RHS is array, LHS is single char - promote LHS to string array
-    if (type_utils::is_integer_type(lhs.type()))
-    {
-      typet string_type = type_handler_.build_array(char_type(), 2);
-      exprt str_array = gen_zero(string_type);
-      str_array.operands().at(0) = lhs;
-      str_array.operands().at(1) = gen_zero(char_type()); // null terminator
-      lhs = str_array;
-    }
-  }
-
-  return handle_string_concatenation(lhs, rhs, left, right);
 }
 
 /// Handle chained comparisons
@@ -1897,395 +1419,6 @@ exprt python_converter::handle_chained_comparisons_logic(
   return cond;
 }
 
-exprt python_converter::ensure_null_terminated_string(exprt &e)
-{
-  return string_builder_->ensure_null_terminated_string(e);
-}
-
-exprt python_converter::handle_string_startswith(
-  const exprt &string_obj,
-  const exprt &prefix_arg,
-  const locationt &location)
-{
-  // Ensure both are proper null-terminated strings
-  exprt string_copy = string_obj;
-  exprt prefix_copy = prefix_arg;
-  exprt str_expr = ensure_null_terminated_string(string_copy);
-  exprt prefix_expr = ensure_null_terminated_string(prefix_copy);
-
-  // Get string addresses
-  exprt str_addr = get_array_base_address(str_expr);
-  exprt prefix_addr = get_array_base_address(prefix_expr);
-
-  // Calculate prefix length: len(prefix_expr) - 1 (exclude null terminator)
-  const array_typet &prefix_type = to_array_type(prefix_expr.type());
-  exprt prefix_len = prefix_type.size();
-
-  // Subtract 1 for null terminator
-  exprt one = from_integer(1, prefix_len.type());
-  exprt actual_len("-", prefix_len.type());
-  actual_len.copy_to_operands(prefix_len, one);
-
-  // Find strncmp symbol
-  symbolt *strncmp_symbol = symbol_table_.find_symbol("c:@F@strncmp");
-  if (!strncmp_symbol)
-    throw std::runtime_error("strncmp function not found for startswith()");
-
-  // Call strncmp(str, prefix, len(prefix))
-  side_effect_expr_function_callt strncmp_call;
-  strncmp_call.function() = symbol_expr(*strncmp_symbol);
-  strncmp_call.arguments() = {str_addr, prefix_addr, actual_len};
-  strncmp_call.location() = location;
-  strncmp_call.type() = int_type();
-
-  // Check if result == 0 (strings match)
-  exprt zero = gen_zero(int_type());
-  exprt equal("=", bool_type());
-  equal.copy_to_operands(strncmp_call, zero);
-
-  return equal;
-}
-
-exprt python_converter::handle_string_endswith(
-  const exprt &string_obj,
-  const exprt &suffix_arg,
-  const locationt &location)
-{
-  // Ensure both are proper null-terminated strings
-  exprt string_copy = string_obj;
-  exprt suffix_copy = suffix_arg;
-  exprt str_expr = ensure_null_terminated_string(string_copy);
-  exprt suffix_expr = ensure_null_terminated_string(suffix_copy);
-
-  // Get string addresses
-  exprt str_addr = get_array_base_address(str_expr);
-  exprt suffix_addr = get_array_base_address(suffix_expr);
-
-  // Calculate lengths (exclude null terminators)
-  const array_typet &str_type = to_array_type(str_expr.type());
-  const array_typet &suffix_type = to_array_type(suffix_expr.type());
-
-  exprt str_len = str_type.size();
-  exprt suffix_len = suffix_type.size();
-
-  exprt one = from_integer(1, str_len.type());
-
-  // actual_str_len = str_len - 1
-  exprt actual_str_len("-", str_len.type());
-  actual_str_len.copy_to_operands(str_len, one);
-
-  // actual_suffix_len = suffix_len - 1
-  exprt actual_suffix_len("-", suffix_len.type());
-  actual_suffix_len.copy_to_operands(suffix_len, one);
-
-  // Check if suffix is longer than string: if (suffix_len > str_len) return false
-  exprt len_check(">", bool_type());
-  len_check.copy_to_operands(actual_suffix_len, actual_str_len);
-
-  // Calculate offset: str_len - suffix_len
-  exprt offset("-", str_len.type());
-  offset.copy_to_operands(actual_str_len, actual_suffix_len);
-
-  // Get pointer to the position: str + offset
-  exprt offset_ptr("+", gen_pointer_type(char_type()));
-  offset_ptr.copy_to_operands(str_addr, offset);
-
-  // Find strncmp symbol
-  symbolt *strncmp_symbol = symbol_table_.find_symbol("c:@F@strncmp");
-  if (!strncmp_symbol)
-    throw std::runtime_error("strncmp function not found for endswith()");
-
-  // Call strncmp(str + offset, suffix, len(suffix))
-  side_effect_expr_function_callt strncmp_call;
-  strncmp_call.function() = symbol_expr(*strncmp_symbol);
-  strncmp_call.arguments() = {offset_ptr, suffix_addr, actual_suffix_len};
-  strncmp_call.location() = location;
-  strncmp_call.type() = int_type();
-
-  // Check if result == 0 (strings match)
-  exprt zero = gen_zero(int_type());
-  exprt strings_equal("=", bool_type());
-  strings_equal.copy_to_operands(strncmp_call, zero);
-
-  // Return: (suffix_len <= str_len) && (strncmp(...) == 0)
-  exprt len_ok("not", bool_type());
-  len_ok.copy_to_operands(len_check);
-
-  exprt result("and", bool_type());
-  result.copy_to_operands(len_ok, strings_equal);
-
-  return result;
-}
-
-exprt python_converter::handle_string_isdigit(
-  const exprt &string_obj,
-  const locationt &location)
-{
-  // Ensure it's a proper null-terminated string
-  exprt string_copy = string_obj;
-  exprt str_expr = ensure_null_terminated_string(string_copy);
-
-  // Get base address of the string
-  exprt str_addr = get_array_base_address(str_expr);
-
-  // Find the helper function symbol
-  symbolt *isdigit_str_symbol =
-    symbol_table_.find_symbol("c:@F@__python_str_isdigit");
-  if (!isdigit_str_symbol)
-    throw std::runtime_error("str_isdigit function not found in symbol table");
-
-  // Call str_isdigit(str) - returns bool (0 or 1)
-  side_effect_expr_function_callt isdigit_call;
-  isdigit_call.function() = symbol_expr(*isdigit_str_symbol);
-  isdigit_call.arguments().push_back(str_addr);
-  isdigit_call.location() = location;
-  isdigit_call.type() = bool_type();
-
-  return isdigit_call;
-}
-
-exprt python_converter::handle_string_isalpha(
-  const exprt &string_obj,
-  const locationt &location)
-{
-  // Check if this is a single character
-  if (string_obj.type().is_unsignedbv() || string_obj.type().is_signedbv())
-  {
-    // Call Python's single-character version (not C's isalpha)
-    symbolt *isalpha_symbol =
-      symbol_table_.find_symbol("c:@F@__python_char_isalpha");
-    if (!isalpha_symbol)
-      throw std::runtime_error(
-        "__python_char_isalpha function not found in symbol table");
-
-    side_effect_expr_function_callt isalpha_call;
-    isalpha_call.function() = symbol_expr(*isalpha_symbol);
-    isalpha_call.arguments().push_back(string_obj);
-    isalpha_call.location() = location;
-    isalpha_call.type() = bool_type();
-
-    return isalpha_call;
-  }
-
-  // For full strings, use the string version
-  exprt string_copy = string_obj;
-  exprt str_expr = ensure_null_terminated_string(string_copy);
-  exprt str_addr = get_array_base_address(str_expr);
-
-  symbolt *isalpha_str_symbol =
-    symbol_table_.find_symbol("c:@F@__python_str_isalpha");
-  if (!isalpha_str_symbol)
-    throw std::runtime_error("str_isalpha function not found in symbol table");
-
-  side_effect_expr_function_callt isalpha_call;
-  isalpha_call.function() = symbol_expr(*isalpha_str_symbol);
-  isalpha_call.arguments().push_back(str_addr);
-  isalpha_call.location() = location;
-  isalpha_call.type() = bool_type();
-
-  return isalpha_call;
-}
-
-exprt python_converter::handle_string_isspace(
-  const exprt &str_expr,
-  const locationt &location)
-{
-  symbol_id func_id;
-  func_id.set_prefix("c:");
-  func_id.set_function("__python_str_isspace");
-
-  std::string func_symbol_id = func_id.to_string();
-
-  if (symbol_table().find_symbol(func_symbol_id.c_str()) == nullptr)
-  {
-    code_typet code_type;
-    code_type.return_type() = bool_type();
-
-    code_typet::argumentt arg;
-    arg.type() = pointer_typet(char_type());
-    code_type.arguments().push_back(arg);
-
-    symbolt symbol = create_symbol(
-      "", "__python_str_isspace", func_symbol_id, location, code_type);
-
-    add_symbol(symbol);
-  }
-
-  // Get the string pointer
-  exprt str_ptr = str_expr;
-
-  if (str_expr.is_constant() && str_expr.type().is_array())
-  {
-    str_ptr = exprt("index", pointer_typet(char_type()));
-    str_ptr.copy_to_operands(str_expr);
-    str_ptr.copy_to_operands(from_integer(0, int_type()));
-  }
-  else if (str_expr.type().is_array())
-  {
-    str_ptr = exprt("address_of", pointer_typet(char_type()));
-    exprt index_expr("index", char_type());
-    index_expr.copy_to_operands(str_expr);
-    index_expr.copy_to_operands(from_integer(0, int_type()));
-    str_ptr.copy_to_operands(index_expr);
-  }
-  else if (!str_expr.type().is_pointer())
-  {
-    str_ptr = exprt("address_of", pointer_typet(char_type()));
-    str_ptr.copy_to_operands(str_expr);
-  }
-
-  // Create function call
-  side_effect_expr_function_callt call;
-  call.function() = symbol_exprt(func_symbol_id, code_typet());
-  call.arguments().push_back(str_ptr);
-  call.type() = bool_type();
-  call.location() = location;
-
-  return call;
-}
-
-exprt python_converter::handle_char_isspace(
-  const exprt &char_expr,
-  const locationt &location)
-{
-  // For single characters, use the standard C isspace() function
-  symbol_id func_id;
-  func_id.set_prefix("c:");
-  func_id.set_function("isspace");
-
-  std::string func_symbol_id = func_id.to_string();
-
-  if (symbol_table().find_symbol(func_symbol_id.c_str()) == nullptr)
-  {
-    code_typet code_type;
-    code_type.return_type() = int_type();
-
-    code_typet::argumentt arg;
-    arg.type() = int_type();
-    code_type.arguments().push_back(arg);
-
-    symbolt symbol =
-      create_symbol("", "isspace", func_symbol_id, location, code_type);
-
-    add_symbol(symbol);
-  }
-
-  // Convert char to int for isspace
-  exprt char_as_int = char_expr;
-  if (char_expr.type() != int_type())
-  {
-    char_as_int = typecast_exprt(char_expr, int_type());
-  }
-
-  // Create function call to C's isspace
-  side_effect_expr_function_callt call;
-  call.function() = symbol_exprt(func_symbol_id, code_typet());
-  call.arguments().push_back(char_as_int);
-  call.type() = int_type();
-  call.location() = location;
-
-  // Convert result to boolean (isspace returns non-zero for whitespace)
-  exprt result("notequal", bool_type());
-  result.copy_to_operands(call);
-  result.copy_to_operands(from_integer(0, int_type()));
-
-  return result;
-}
-
-exprt python_converter::handle_string_lstrip(
-  const exprt &str_expr,
-  const locationt &location)
-{
-  symbol_id func_id;
-  func_id.set_prefix("c:");
-  func_id.set_function("__python_str_lstrip");
-
-  std::string func_symbol_id = func_id.to_string();
-
-  if (symbol_table().find_symbol(func_symbol_id.c_str()) == nullptr)
-  {
-    code_typet code_type;
-    code_type.return_type() = pointer_typet(char_type());
-
-    code_typet::argumentt arg;
-    arg.type() = pointer_typet(char_type());
-    code_type.arguments().push_back(arg);
-
-    symbolt symbol = create_symbol(
-      "", "__python_str_lstrip", func_symbol_id, location, code_type);
-
-    add_symbol(symbol);
-  }
-
-  // Get the string pointer
-  exprt str_ptr = str_expr;
-
-  if (str_expr.is_constant() && str_expr.type().is_array())
-  {
-    str_ptr = exprt("index", pointer_typet(char_type()));
-    str_ptr.copy_to_operands(str_expr);
-    str_ptr.copy_to_operands(from_integer(0, int_type()));
-  }
-  else if (str_expr.type().is_array())
-  {
-    str_ptr = exprt("address_of", pointer_typet(char_type()));
-    exprt index_expr("index", char_type());
-    index_expr.copy_to_operands(str_expr);
-    index_expr.copy_to_operands(from_integer(0, int_type()));
-    str_ptr.copy_to_operands(index_expr);
-  }
-  else if (!str_expr.type().is_pointer())
-  {
-    str_ptr = exprt("address_of", pointer_typet(char_type()));
-    str_ptr.copy_to_operands(str_expr);
-  }
-
-  // Create function call
-  side_effect_expr_function_callt call;
-  call.function() = symbol_exprt(func_symbol_id, code_typet());
-  call.arguments().push_back(str_ptr);
-  call.type() = pointer_typet(char_type());
-  call.location() = location;
-
-  return call;
-}
-
-exprt python_converter::handle_string_membership(
-  exprt &lhs,
-  exprt &rhs,
-  const nlohmann::json &element)
-{
-  // Convert both operands to proper null-terminated strings
-  exprt lhs_str = ensure_null_terminated_string(lhs);
-  exprt rhs_str = ensure_null_terminated_string(rhs);
-
-  // Get base addresses for C string functions
-  exprt lhs_addr = get_array_base_address(lhs_str);
-  exprt rhs_addr = get_array_base_address(rhs_str);
-
-  // Find strstr symbol - returns pointer to first occurrence or NULL
-  symbolt *strstr_symbol = symbol_table_.find_symbol("c:@F@strstr");
-  if (!strstr_symbol)
-    throw std::runtime_error("strstr function not found for 'in' operator");
-
-  // Call strstr(haystack, needle) - in Python "needle in haystack"
-  side_effect_expr_function_callt strstr_call;
-  strstr_call.function() = symbol_expr(*strstr_symbol);
-  strstr_call.arguments() = {
-    rhs_addr, lhs_addr}; // haystack is rhs, needle is lhs
-  strstr_call.location() = get_location_from_decl(element);
-  strstr_call.type() = gen_pointer_type(char_type());
-
-  // Check if result != NULL (substring found)
-  constant_exprt null_ptr(gen_pointer_type(char_type()));
-  null_ptr.set_value("NULL");
-
-  exprt not_equal("notequal", bool_type());
-  not_equal.copy_to_operands(strstr_call, null_ptr);
-
-  return not_equal;
-}
-
 exprt python_converter::handle_membership_operator(
   exprt &lhs,
   exprt &rhs,
@@ -2305,7 +1438,8 @@ exprt python_converter::handle_membership_operator(
   // Handle string membership testing: "substr" in "string" or "substr" not in "string"
   if (lhs.type().is_array() || rhs.type().is_array())
   {
-    exprt membership_expr = handle_string_membership(lhs, rhs, element);
+    exprt membership_expr =
+      string_handler_.handle_string_membership(lhs, rhs, element);
     return invert ? not_exprt(membership_expr) : membership_expr;
   }
 
@@ -2367,7 +1501,8 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   {
     // Check for zero-length arrays
     if (
-      is_zero_length_array(lhs) && is_zero_length_array(rhs) &&
+      string_handler_.is_zero_length_array(lhs) &&
+      string_handler_.is_zero_length_array(rhs) &&
       (op == "Eq" || op == "NotEq"))
     {
       return gen_boolean(op == "Eq");
@@ -2375,7 +1510,8 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
     // Handle string concatenation with type promotion
     if (op == "Add")
-      return handle_string_concatenation_with_promotion(lhs, rhs, left, right);
+      return string_handler_.handle_string_concatenation_with_promotion(
+        lhs, rhs, left, right);
   }
 
   // Handle list operations
@@ -2474,8 +1610,8 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
   if (lhs_type == "str" && rhs_type == "str")
   {
-    const exprt &result =
-      handle_string_operations(op, lhs, rhs, left, right, element);
+    const exprt &result = string_handler_.handle_string_operations(
+      op, lhs, rhs, left, right, element);
     if (!result.is_nil())
       return result;
   }
@@ -2809,7 +1945,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // Convert array to pointer to match parameter type
       const typet &param_type = params[it->second].type();
       if (arg_expr.type().is_array() && param_type.is_pointer())
-        arg_expr = get_array_base_address(arg_expr);
+        arg_expr = string_handler_.get_array_base_address(arg_expr);
 
       args[it->second] = arg_expr;
     }
@@ -3411,7 +2547,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     break;
   }
   case ExpressionType::FSTRING:
-    expr = get_fstring_expr(element);
+    expr = string_handler_.get_fstring_expr(element);
     break;
   default:
   {
@@ -3666,7 +2802,7 @@ void python_converter::handle_assignment_type_adjustments(
       typet pointer_type = gen_pointer_type(element_type);
       lhs_symbol->type = pointer_type;
       lhs.type() = pointer_type;
-      rhs = get_array_base_address(rhs);
+      rhs = string_handler_.get_array_base_address(rhs);
     }
     // String and list type size adjustments
     else if (
@@ -4204,7 +3340,7 @@ void python_converter::get_compound_assign(
     nlohmann::json left = ast_node["target"];
     nlohmann::json right = ast_node["value"];
     exprt concatenated =
-      handle_string_concatenation(lhs, rhs_expr, left, right);
+      string_handler_.handle_string_concatenation(lhs, rhs_expr, left, right);
 
     // Update the variable's type to match the concatenated result
     if (!var_name.empty() && concatenated.type().is_array())
@@ -5279,7 +4415,7 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
 
       exprt arg = get_expr(element["exc"]["args"][0]);
       arg = string_constantt(
-        process_format_spec(element["exc"]["args"][0]),
+        string_handler_.process_format_spec(element["exc"]["args"][0]),
         arg.type(),
         string_constantt::k_default);
 
@@ -5351,13 +4487,14 @@ python_converter::python_converter(
     ast_json(ast),
     global_scope_(gs),
     type_handler_(*this),
-    string_builder_(new string_builder(*this)),
+    string_builder_(new string_builder(*this, &string_handler_)),
     sym_generator_("python_converter::"),
     ns(_context),
     current_func_name_(""),
     current_class_name_(""),
     current_block(nullptr),
-    current_lhs(nullptr)
+    current_lhs(nullptr),
+    string_handler_(*this, symbol_table_, type_handler_, string_builder_)
 {
 }
 
@@ -5368,6 +4505,11 @@ python_converter::~python_converter()
 
 string_builder &python_converter::get_string_builder()
 {
+  if (!string_builder_)
+  {
+    string_builder_ = new string_builder(*this, &string_handler_);
+    string_handler_.set_string_builder(string_builder_);
+  }
   return *string_builder_;
 }
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -3,6 +3,7 @@
 #include <python-frontend/global_scope.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
+#include <python-frontend/string_handler.h>
 #include <util/context.h>
 #include <util/namespace.h>
 #include <util/std_code.h>
@@ -33,7 +34,9 @@ public:
 
   void convert();
 
-  string_builder &get_string_builder();
+  string_builder& get_string_builder();  
+  
+  string_handler& get_string_handler() { return string_handler_; }
 
   const nlohmann::json &ast() const
   {
@@ -49,10 +52,6 @@ public:
   {
     return type_handler_;
   }
-
-  bool is_zero_length_array(const exprt &expr);
-
-  void ensure_string_array(exprt &expr);
 
   const std::string &python_file() const
   {
@@ -111,6 +110,15 @@ public:
     const std::vector<unsigned char> &string_literal,
     const typet &t);
 
+  exprt get_literal(const nlohmann::json &element);
+
+  exprt get_expr(const nlohmann::json &element);
+
+  locationt get_location_from_decl(const nlohmann::json &element);
+  
+  exprt handle_string_comparison(const std::string &op, exprt &lhs, exprt &rhs,
+                                  const nlohmann::json &element);
+
 private:
   friend class function_call_expr;
   friend class numpy_call_expr;
@@ -146,10 +154,6 @@ private:
   void
   get_class_definition(const nlohmann::json &class_node, codet &target_block);
 
-  locationt get_location_from_decl(const nlohmann::json &ast_node);
-
-  exprt get_expr(const nlohmann::json &element);
-
   exprt get_unary_operator_expr(const nlohmann::json &element);
 
   exprt get_binary_operator_expr(const nlohmann::json &element);
@@ -158,15 +162,11 @@ private:
 
   exprt build_power_expression(const exprt &base, const BigInt &exp);
 
-  BigInt get_string_size(const exprt &expr);
-
   bool is_bytes_literal(const nlohmann::json &element);
 
   exprt get_binary_operator_expr_for_is(const exprt &lhs, const exprt &rhs);
 
   exprt get_negated_is_expr(const exprt &lhs, const exprt &rhs);
-
-  exprt get_array_base_address(const exprt &arr);
 
   exprt get_resolved_value(const exprt &expr);
 
@@ -178,20 +178,9 @@ private:
 
   symbolt create_assert_temp_variable(const locationt &location);
 
-  std::string extract_string_from_array_operands(const exprt &array_expr) const;
-
   exprt get_lambda_expr(const nlohmann::json &element);
 
-  exprt convert_to_string(const exprt &expr);
-
-  exprt get_fstring_expr(const nlohmann::json &element);
-
-  std::string process_format_spec(const nlohmann::json &format_spec);
-
   codet convert_expression_to_code(exprt &expr);
-
-  exprt
-  apply_format_specification(const exprt &expr, const std::string &format);
 
   std::string remove_quotes_from_type_string(const std::string &type_string);
 
@@ -237,57 +226,10 @@ private:
     const exprt &func_value,
     const std::string &func_identifier);
 
-  exprt handle_string_concatenation(
-    const exprt &lhs,
-    const exprt &rhs,
-    const nlohmann::json &left,
-    const nlohmann::json &right);
-
-  exprt handle_string_comparison(
-    const std::string &op,
-    exprt &lhs,
-    exprt &rhs,
-    const nlohmann::json &element);
-
   exprt handle_none_comparison(
     const std::string &op,
     const exprt &lhs,
     const exprt &rhs);
-
-  exprt handle_string_operations(
-    const std::string &op,
-    exprt &lhs,
-    exprt &rhs,
-    const nlohmann::json &left,
-    const nlohmann::json &right,
-    const nlohmann::json &element);
-
-  exprt handle_string_membership(
-    exprt &lhs,
-    exprt &rhs,
-    const nlohmann::json &element);
-
-  exprt ensure_null_terminated_string(exprt &e);
-
-  exprt handle_string_startswith(
-    const exprt &string_obj,
-    const exprt &prefix_arg,
-    const locationt &location);
-
-  exprt handle_string_endswith(
-    const exprt &string_obj,
-    const exprt &suffix_arg,
-    const locationt &location);
-
-  exprt
-  handle_string_isdigit(const exprt &string_obj, const locationt &location);
-
-  exprt
-  handle_string_isalpha(const exprt &string_obj, const locationt &location);
-
-  exprt handle_string_isspace(const exprt &str_expr, const locationt &location);
-
-  exprt handle_char_isspace(const exprt &char_expr, const locationt &location);
 
   symbolt &create_tmp_symbol(
     const nlohmann::json &element,
@@ -295,15 +237,11 @@ private:
     const typet &symbol_type,
     const exprt &symbol_value);
 
-  exprt handle_string_lstrip(const exprt &str_expr, const locationt &location);
-
   exprt get_logical_operator_expr(const nlohmann::json &element);
 
   exprt get_conditional_stm(const nlohmann::json &ast_node);
 
   exprt get_function_call(const nlohmann::json &ast_block);
-
-  exprt get_literal(const nlohmann::json &element);
 
   exprt get_block(const nlohmann::json &ast_block);
 
@@ -417,12 +355,6 @@ private:
   // Helper methods for binary operator expression handling
   void convert_function_calls_to_side_effects(exprt &lhs, exprt &rhs);
 
-  exprt handle_string_concatenation_with_promotion(
-    exprt &lhs,
-    exprt &rhs,
-    const nlohmann::json &left,
-    const nlohmann::json &right);
-
   exprt handle_chained_comparisons_logic(
     const nlohmann::json &element,
     exprt &bin_expr);
@@ -443,6 +375,7 @@ private:
   std::string current_class_name_;
   code_blockt *current_block;
   exprt *current_lhs;
+  string_handler string_handler_;
 
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -34,9 +34,12 @@ public:
 
   void convert();
 
-  string_builder& get_string_builder();  
-  
-  string_handler& get_string_handler() { return string_handler_; }
+  string_builder &get_string_builder();
+
+  string_handler &get_string_handler()
+  {
+    return string_handler_;
+  }
 
   const nlohmann::json &ast() const
   {
@@ -115,9 +118,12 @@ public:
   exprt get_expr(const nlohmann::json &element);
 
   locationt get_location_from_decl(const nlohmann::json &element);
-  
-  exprt handle_string_comparison(const std::string &op, exprt &lhs, exprt &rhs,
-                                  const nlohmann::json &element);
+
+  exprt handle_string_comparison(
+    const std::string &op,
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &element);
 
 private:
   friend class function_call_expr;

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -48,7 +48,7 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   code_function_callt list_type_hash_func_call;
   list_type_hash_func_call.function() = symbol_expr(*hash_func_symbol);
   list_type_hash_func_call.arguments().push_back(
-    converter_.get_array_base_address(type_name_expr));
+    converter_.get_string_handler().get_array_base_address(type_name_expr));
   list_type_hash_func_call.lhs() = symbol_expr(elem_type_sym);
   list_type_hash_func_call.type() = size_type();
   list_type_hash_func_call.location() = location;
@@ -373,7 +373,8 @@ symbolt &python_list::create_list()
   list_create_func_call.function() = symbol_expr(*create_func_sym);
   list_create_func_call.lhs() = symbol_expr(list_symbol);
   list_create_func_call.arguments().push_back(
-    converter_.get_array_base_address(symbol_expr(inf_array_symbol)));
+    converter_.get_string_handler().get_array_base_address(
+      symbol_expr(inf_array_symbol)));
   list_create_func_call.type() = list_type;
   list_create_func_call.location() = location;
   converter_.add_instruction(list_create_func_call);

--- a/src/python-frontend/string_builder.cpp
+++ b/src/python-frontend/string_builder.cpp
@@ -5,8 +5,8 @@
 #include <util/std_code.h>
 #include <util/expr_util.h>
 
-string_builder::string_builder(python_converter &converter)
-  : converter_(converter)
+string_builder::string_builder(python_converter &conv, string_handler *handler)
+  : converter_(conv), str_handler_(handler)
 {
 }
 
@@ -195,7 +195,7 @@ exprt string_builder::ensure_null_terminated_string(exprt &e)
   }
 
   // For other types, fallback to converter's ensure_string_array
-  converter_.ensure_string_array(e);
+  str_handler_->ensure_string_array(e);
   return e;
 }
 
@@ -207,10 +207,10 @@ exprt string_builder::concatenate_strings(
 {
   // Handle edge cases with empty strings
   bool lhs_is_empty =
-    converter_.is_zero_length_array(lhs) ||
+    str_handler_->is_zero_length_array(lhs) ||
     (lhs.is_constant() && lhs.type().is_array() && lhs.operands().size() <= 1);
   bool rhs_is_empty =
-    converter_.is_zero_length_array(rhs) ||
+    str_handler_->is_zero_length_array(rhs) ||
     (rhs.is_constant() && rhs.type().is_array() && rhs.operands().size() <= 1);
 
   if (lhs_is_empty && rhs_is_empty)

--- a/src/python-frontend/string_builder.h
+++ b/src/python-frontend/string_builder.h
@@ -11,13 +11,14 @@
 class python_converter;
 class type_handler;
 class contextt;
+class string_handler;
 
 /// Helper class for building and manipulating string expressions in Python frontend
 /// Handles null-termination, character extraction, and string concatenation
 class string_builder
 {
 public:
-  explicit string_builder(python_converter &converter);
+  explicit string_builder(python_converter &converter, string_handler *handler);
 
   /// Create a null terminator character constant
   exprt make_null_terminator();
@@ -56,6 +57,7 @@ public:
 
 private:
   python_converter &converter_;
+  string_handler *str_handler_;
   contextt &get_symbol_table() const;
   type_handler &get_type_handler();
 };

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -1,0 +1,904 @@
+#include <python-frontend/string_handler.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/string_builder.h>
+#include <python-frontend/type_utils.h>
+#include <python-frontend/symbol_id.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/expr_util.h>
+#include <util/python_types.h>
+#include <util/std_expr.h>
+#include <util/std_code.h>
+#include <util/string_constant.h>
+#include <util/symbol.h>
+#include <util/type.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+string_handler::string_handler(
+  python_converter &converter,
+  contextt &symbol_table,
+  type_handler &type_handler,
+  string_builder *str_builder)
+  : converter_(converter),
+    symbol_table_(symbol_table),
+    type_handler_(type_handler),
+    string_builder_(str_builder)
+{
+}
+
+BigInt string_handler::get_string_size(const exprt &expr)
+{
+  if (!expr.type().is_array())
+  {
+    // For non-array types in f-strings, convert them first to get actual size
+    if (expr.is_constant() && type_utils::is_integer_type(expr.type()))
+    {
+      // Convert the actual integer to string to get real size
+      BigInt value =
+        binary2integer(expr.value().as_string(), expr.type().is_signedbv());
+      std::string str_repr = std::to_string(value.to_int64());
+      return BigInt(str_repr.size() + 1); // +1 for null terminator
+    }
+
+    if (expr.is_symbol())
+    {
+      const symbolt *symbol = symbol_table_.find_symbol(expr.identifier());
+      if (symbol && symbol->type.is_array())
+      {
+        const auto &arr_type = to_array_type(symbol->type);
+        return binary2integer(arr_type.size().value().as_string(), false);
+      }
+      // For non-array symbols, we need a reasonable default since we can't compute actual size
+      return BigInt(20); // Conservative default
+    }
+
+    // For other types, use conservative defaults
+    if (expr.type().is_bool())
+      return BigInt(6); // "False" + null terminator
+
+    // Default fallback
+    return BigInt(20);
+  }
+
+  const auto &arr_type = to_array_type(expr.type());
+  return binary2integer(arr_type.size().value().as_string(), false);
+}
+
+std::string
+string_handler::process_format_spec(const nlohmann::json &format_spec)
+{
+  if (format_spec.is_null() || !format_spec.contains("_type"))
+    return "";
+
+  // Handle direct Constant format spec
+  if (format_spec["_type"] == "Constant" && format_spec.contains("value"))
+    return format_spec["value"].get<std::string>();
+
+  // Handle JoinedStr format spec (which contains Constant values)
+  if (format_spec["_type"] == "JoinedStr" && format_spec.contains("values"))
+  {
+    std::string result;
+    for (const auto &value : format_spec["values"])
+      if (value["_type"] == "Constant" && value.contains("value"))
+        result += value["value"].get<std::string>();
+    return result;
+  }
+
+  // Log warning for unsupported format specifications
+  std::string spec_type = format_spec.contains("_type")
+                            ? format_spec["_type"].get<std::string>()
+                            : "unknown";
+  log_warning("Unsupported f-string format specification type: {}", spec_type);
+
+  return "";
+}
+
+std::string string_handler::float_to_string(
+  const std::string &float_bits,
+  std::size_t width,
+  int precision)
+{
+  double val = 0.0;
+
+  if (width == 32 && float_bits.length() == 32)
+  {
+    // IEEE 754 single precision
+    uint32_t bits = 0;
+    for (std::size_t i = 0; i < width; ++i)
+      if (float_bits[i] == '1')
+        bits |= (1U << (width - 1 - i));
+
+    float float_val;
+    std::memcpy(&float_val, &bits, sizeof(float));
+    val = static_cast<double>(float_val);
+  }
+  else if (width == 64 && float_bits.length() == 64)
+  {
+    // IEEE 754 double precision
+    uint64_t bits = 0;
+    for (std::size_t i = 0; i < width; ++i)
+      if (float_bits[i] == '1')
+        bits |= (1ULL << (width - 1 - i));
+
+    std::memcpy(&val, &bits, sizeof(double));
+  }
+  else
+  {
+    throw std::runtime_error("Invalid float bit width");
+  }
+
+  // Use proper rounding to avoid IEEE 754 precision issues
+  double multiplier = std::pow(10.0, precision);
+  double rounded = std::round(val * multiplier) / multiplier;
+
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(precision) << rounded;
+  return oss.str();
+}
+
+exprt string_handler::apply_format_specification(
+  const exprt &expr,
+  const std::string &format)
+{
+  // Basic format specification handling
+  if (format.empty())
+    return convert_to_string(expr);
+
+  // Handle integer formatting
+  if (format == "d" || format == "i")
+    return convert_to_string(expr);
+
+  // Handle float formatting with precision
+  else if (format.find(".") != std::string::npos && format.back() == 'f')
+  {
+    // Extract precision from format string (e.g., ".2f" -> 2)
+    size_t dot_pos = format.find(".");
+    size_t f_pos = format.find("f");
+    if (
+      dot_pos != std::string::npos && f_pos != std::string::npos &&
+      f_pos > dot_pos)
+    {
+      std::string precision_str =
+        format.substr(dot_pos + 1, f_pos - dot_pos - 1);
+      int precision = 6; // default
+      try
+      {
+        precision = std::stoi(precision_str);
+      }
+      catch (...)
+      {
+        precision = 6;
+      }
+
+      // Handle floatbv expressions (both constant and symbols)
+      if (expr.type().is_floatbv())
+      {
+        const typet &t = expr.type();
+        const std::size_t float_width = bv_width(t);
+
+        // Support common floating point widths
+        if (t.is_floatbv() && (float_width == 32 || float_width == 64))
+        {
+          const std::string *float_bits = nullptr;
+
+          // Handle constant expressions
+          if (expr.is_constant())
+            float_bits = &expr.value().as_string();
+          // Handle symbol expressions
+          else if (expr.is_symbol())
+          {
+            const symbol_exprt &sym_expr = to_symbol_expr(expr);
+            const symbolt *symbol =
+              symbol_table_.find_symbol(sym_expr.get_identifier());
+
+            if (symbol && symbol->value.is_constant())
+              float_bits = &symbol->value.value().as_string();
+          }
+
+          if (float_bits && float_bits->length() == float_width)
+          {
+            std::string formatted_str =
+              float_to_string(*float_bits, float_width, precision);
+
+            typet string_type =
+              type_handler_.build_array(char_type(), formatted_str.size() + 1);
+            std::vector<unsigned char> chars(
+              formatted_str.begin(), formatted_str.end());
+            chars.push_back('\0');
+
+            return make_char_array_expr(chars, string_type);
+          }
+        }
+      }
+    }
+  }
+
+  // Default: just convert to string
+  return convert_to_string(expr);
+}
+
+exprt string_handler::make_char_array_expr(
+  const std::vector<unsigned char> &chars,
+  const typet &type)
+{
+  exprt arr = gen_zero(type);
+  for (size_t i = 0; i < chars.size() && i < arr.operands().size(); ++i)
+  {
+    arr.operands()[i] = from_integer(chars[i], char_type());
+  }
+  return arr;
+}
+
+exprt string_handler::convert_to_string(const exprt &expr)
+{
+  const typet &t = expr.type();
+
+  // Already a string/char array - return as is
+  if (t.is_array() && t.subtype() == char_type())
+    return expr;
+
+  // Handle symbol references
+  if (expr.is_symbol())
+  {
+    const symbolt *symbol = symbol_table_.find_symbol(expr.identifier());
+    if (symbol)
+    {
+      // If symbol has string type, return it
+      if (symbol->type.is_array() && symbol->type.subtype() == char_type())
+        return expr;
+
+      // If symbol has a constant value, convert that
+      if (symbol->value.is_constant())
+        return convert_to_string(symbol->value);
+    }
+  }
+
+  // Handle constants
+  if (expr.is_constant())
+  {
+    if (type_utils::is_integer_type(t))
+    {
+      BigInt value = binary2integer(expr.value().as_string(), t.is_signedbv());
+      std::string str_value = std::to_string(value.to_int64());
+
+      typet string_type =
+        type_handler_.build_array(char_type(), str_value.size() + 1);
+      std::vector<unsigned char> chars(str_value.begin(), str_value.end());
+      chars.push_back('\0'); // null terminator
+
+      return make_char_array_expr(chars, string_type);
+    }
+    else if (t.is_floatbv())
+    {
+      std::string str_value = "0.0";
+      if (expr.is_constant() && !expr.value().empty())
+      {
+        const std::string &float_bits = expr.value().as_string();
+        if (t.is_floatbv() && bv_width(t) == 64 && float_bits.length() == 64)
+        {
+          str_value = float_to_string(float_bits, 64, 6);
+        }
+      }
+
+      typet string_type =
+        type_handler_.build_array(char_type(), str_value.size() + 1);
+      std::vector<unsigned char> chars(str_value.begin(), str_value.end());
+      chars.push_back('\0');
+
+      return make_char_array_expr(chars, string_type);
+    }
+    else if (t.is_bool())
+    {
+      // Convert boolean to string
+      bool value = expr.is_true();
+      std::string str_value = value ? "True" : "False";
+
+      typet string_type =
+        type_handler_.build_array(char_type(), str_value.size() + 1);
+      std::vector<unsigned char> chars(str_value.begin(), str_value.end());
+      chars.push_back('\0');
+
+      return make_char_array_expr(chars, string_type);
+    }
+  }
+
+  // For non-constant expressions, we'd need runtime conversion
+  // For now, create a placeholder string
+  std::string placeholder = "<expr>";
+  typet string_type =
+    type_handler_.build_array(char_type(), placeholder.size() + 1);
+  std::vector<unsigned char> chars(placeholder.begin(), placeholder.end());
+  chars.push_back('\0');
+
+  return make_char_array_expr(chars, string_type);
+}
+
+exprt string_handler::get_fstring_expr(const nlohmann::json &element)
+{
+  if (!element.contains("values") || element["values"].empty())
+  {
+    // Empty f-string
+    typet empty_string_type = type_handler_.build_array(char_type(), 1);
+    exprt empty_str = gen_zero(empty_string_type);
+    empty_str.operands().at(0) = from_integer(0, char_type());
+    return empty_str;
+  }
+
+  const auto &values = element["values"];
+  std::vector<exprt> parts;
+  BigInt total_estimated_size = BigInt(1); // Start with 1 for null terminator
+
+  for (const auto &value : values)
+  {
+    exprt part_expr;
+
+    try
+    {
+      if (value["_type"] == "Constant")
+      {
+        // String literal part - delegate to converter
+        part_expr = converter_.get_literal(value);
+      }
+      else if (value["_type"] == "FormattedValue")
+      {
+        // Expression to be formatted
+        exprt expr = converter_.get_expr(value["value"]);
+
+        // Handle format specification if present
+        if (value.contains("format_spec") && !value["format_spec"].is_null())
+        {
+          std::string format = process_format_spec(value["format_spec"]);
+          part_expr = apply_format_specification(expr, format);
+        }
+        else
+          part_expr = convert_to_string(expr);
+      }
+      else
+      {
+        // Other expression types
+        exprt expr = converter_.get_expr(value);
+        part_expr = convert_to_string(expr);
+      }
+
+      parts.push_back(part_expr);
+      total_estimated_size += get_string_size(part_expr) -
+                              1; // -1 to avoid double counting terminators
+    }
+    catch (const std::exception &e)
+    {
+      log_warning("Error processing f-string part: {}", e.what());
+      // Create error placeholder
+      std::string error_str = "<e>";
+      typet error_type =
+        type_handler_.build_array(char_type(), error_str.size() + 1);
+      std::vector<unsigned char> chars(error_str.begin(), error_str.end());
+      chars.push_back('\0');
+      parts.push_back(make_char_array_expr(chars, error_type));
+      total_estimated_size += BigInt(error_str.size());
+    }
+  }
+
+  // If only one part, return it directly
+  if (parts.size() == 1)
+    return parts[0];
+
+  // Concatenate all parts
+  exprt result = parts[0];
+  for (size_t i = 1; i < parts.size(); ++i)
+  {
+    nlohmann::json empty_left, empty_right;
+    result =
+      handle_string_concatenation(result, parts[i], empty_left, empty_right);
+  }
+
+  return result;
+}
+
+exprt string_handler::handle_string_concatenation(
+  const exprt &lhs,
+  const exprt &rhs,
+  const nlohmann::json &left,
+  const nlohmann::json &right)
+{
+  return string_builder_->concatenate_strings(lhs, rhs, left, right);
+}
+
+bool string_handler::is_zero_length_array(const exprt &expr)
+{
+  if (expr.id() == "sideeffect")
+    return false;
+
+  if (!expr.type().is_array())
+    return false;
+
+  const auto &arr_type = to_array_type(expr.type());
+  if (!arr_type.size().is_constant())
+    return false;
+
+  BigInt size = binary2integer(arr_type.size().value().as_string(), false);
+  return size == 0;
+}
+
+std::string string_handler::extract_string_from_array_operands(
+  const exprt &array_expr) const
+{
+  std::string result;
+  for (const auto &op : array_expr.operands())
+  {
+    if (op.is_constant())
+    {
+      BigInt val =
+        binary2integer(op.value().as_string(), op.type().is_signedbv());
+      if (val == 0)
+        break;
+      result += static_cast<char>(val.to_uint64());
+    }
+  }
+  return result;
+}
+
+void string_handler::ensure_string_array(exprt &expr)
+{
+  if (expr.type().is_pointer())
+    return;
+
+  if (!expr.type().is_array())
+  {
+    typet t = type_handler_.build_array(expr.type(), 1);
+    exprt arr = gen_zero(t);
+    arr.operands().at(0) = expr;
+    expr = arr;
+  }
+}
+
+exprt string_handler::handle_string_operations(
+  const std::string &op,
+  exprt &lhs,
+  exprt &rhs,
+  const nlohmann::json &left,
+  const nlohmann::json &right,
+  const nlohmann::json &element)
+{
+  ensure_string_array(lhs);
+  ensure_string_array(rhs);
+
+  assert(lhs.type().is_array() || lhs.type().is_pointer());
+  assert(rhs.type().is_array() || rhs.type().is_pointer());
+
+  if (op == "Eq" || op == "NotEq")
+    return handle_string_comparison(op, lhs, rhs, element);
+
+  if (op == "Add")
+    return handle_string_concatenation(lhs, rhs, left, right);
+
+  return nil_exprt();
+}
+
+exprt string_handler::get_array_base_address(const exprt &arr)
+{
+  exprt index = index_exprt(arr, from_integer(0, index_type()));
+  return address_of_exprt(index);
+}
+
+exprt string_handler::handle_string_concatenation_with_promotion(
+  exprt &lhs,
+  exprt &rhs,
+  const nlohmann::json &left,
+  const nlohmann::json &right)
+{
+  if (lhs.type().is_array() && !rhs.type().is_array())
+  {
+    // LHS is array, RHS is single char - promote RHS to string array
+    if (type_utils::is_integer_type(rhs.type()))
+    {
+      typet string_type = type_handler_.build_array(char_type(), 2);
+      exprt str_array = gen_zero(string_type);
+      str_array.operands().at(0) = rhs;
+      str_array.operands().at(1) = gen_zero(char_type()); // null terminator
+      rhs = str_array;
+    }
+  }
+  else if (!lhs.type().is_array() && rhs.type().is_array())
+  {
+    // RHS is array, LHS is single char - promote LHS to string array
+    if (type_utils::is_integer_type(lhs.type()))
+    {
+      typet string_type = type_handler_.build_array(char_type(), 2);
+      exprt str_array = gen_zero(string_type);
+      str_array.operands().at(0) = lhs;
+      str_array.operands().at(1) = gen_zero(char_type()); // null terminator
+      lhs = str_array;
+    }
+  }
+
+  return handle_string_concatenation(lhs, rhs, left, right);
+}
+
+exprt string_handler::ensure_null_terminated_string(exprt &e)
+{
+  return string_builder_->ensure_null_terminated_string(e);
+}
+
+exprt string_handler::handle_string_comparison(
+  const std::string &op,
+  exprt &lhs,
+  exprt &rhs,
+  const nlohmann::json &element)
+{
+  return converter_.handle_string_comparison(op, lhs, rhs, element);
+}
+
+std::string string_handler::ensure_string_function_symbol(
+  const std::string &function_name,
+  const typet &return_type,
+  const std::vector<typet> &arg_types,
+  const locationt &location)
+{
+  symbol_id func_id;
+  func_id.set_prefix("c:");
+  func_id.set_function(function_name);
+
+  std::string func_symbol_id = func_id.to_string();
+
+  if (symbol_table_.find_symbol(func_symbol_id.c_str()) == nullptr)
+  {
+    code_typet code_type;
+    code_type.return_type() = return_type;
+
+    for (const auto &arg_type : arg_types)
+    {
+      code_typet::argumentt arg;
+      arg.type() = arg_type;
+      code_type.arguments().push_back(arg);
+    }
+
+    symbolt symbol = converter_.create_symbol(
+      "", function_name, func_symbol_id, location, code_type);
+
+    converter_.add_symbol(symbol);
+  }
+
+  return func_symbol_id;
+}
+
+exprt string_handler::handle_string_startswith(
+  const exprt &string_obj,
+  const exprt &prefix_arg,
+  const locationt &location)
+{
+  // Ensure both are proper null-terminated strings
+  exprt string_copy = string_obj;
+  exprt prefix_copy = prefix_arg;
+  exprt str_expr = ensure_null_terminated_string(string_copy);
+  exprt prefix_expr = ensure_null_terminated_string(prefix_copy);
+
+  // Get string addresses
+  exprt str_addr = get_array_base_address(str_expr);
+  exprt prefix_addr = get_array_base_address(prefix_expr);
+
+  // Calculate prefix length: len(prefix_expr) - 1 (exclude null terminator)
+  const array_typet &prefix_type = to_array_type(prefix_expr.type());
+  exprt prefix_len = prefix_type.size();
+
+  // Subtract 1 for null terminator
+  exprt one = from_integer(1, prefix_len.type());
+  exprt actual_len("-", prefix_len.type());
+  actual_len.copy_to_operands(prefix_len, one);
+
+  // Find strncmp symbol
+  symbolt *strncmp_symbol = symbol_table_.find_symbol("c:@F@strncmp");
+  if (!strncmp_symbol)
+    throw std::runtime_error("strncmp function not found for startswith()");
+
+  // Call strncmp(str, prefix, len(prefix))
+  side_effect_expr_function_callt strncmp_call;
+  strncmp_call.function() = symbol_expr(*strncmp_symbol);
+  strncmp_call.arguments() = {str_addr, prefix_addr, actual_len};
+  strncmp_call.location() = location;
+  strncmp_call.type() = int_type();
+
+  // Check if result == 0 (strings match)
+  exprt zero = gen_zero(int_type());
+  exprt equal("=", bool_type());
+  equal.copy_to_operands(strncmp_call, zero);
+
+  return equal;
+}
+
+exprt string_handler::handle_string_endswith(
+  const exprt &string_obj,
+  const exprt &suffix_arg,
+  const locationt &location)
+{
+  // Ensure both are proper null-terminated strings
+  exprt string_copy = string_obj;
+  exprt suffix_copy = suffix_arg;
+  exprt str_expr = ensure_null_terminated_string(string_copy);
+  exprt suffix_expr = ensure_null_terminated_string(suffix_copy);
+
+  // Get string addresses
+  exprt str_addr = get_array_base_address(str_expr);
+  exprt suffix_addr = get_array_base_address(suffix_expr);
+
+  // Calculate lengths (exclude null terminators)
+  const array_typet &str_type = to_array_type(str_expr.type());
+  const array_typet &suffix_type = to_array_type(suffix_expr.type());
+
+  exprt str_len = str_type.size();
+  exprt suffix_len = suffix_type.size();
+
+  exprt one = from_integer(1, str_len.type());
+
+  // actual_str_len = str_len - 1
+  exprt actual_str_len("-", str_len.type());
+  actual_str_len.copy_to_operands(str_len, one);
+
+  // actual_suffix_len = suffix_len - 1
+  exprt actual_suffix_len("-", suffix_len.type());
+  actual_suffix_len.copy_to_operands(suffix_len, one);
+
+  // Check if suffix is longer than string: if (suffix_len > str_len) return false
+  exprt len_check(">", bool_type());
+  len_check.copy_to_operands(actual_suffix_len, actual_str_len);
+
+  // Calculate offset: str_len - suffix_len
+  exprt offset("-", str_len.type());
+  offset.copy_to_operands(actual_str_len, actual_suffix_len);
+
+  // Get pointer to the position: str + offset
+  exprt offset_ptr("+", gen_pointer_type(char_type()));
+  offset_ptr.copy_to_operands(str_addr, offset);
+
+  // Find strncmp symbol
+  symbolt *strncmp_symbol = symbol_table_.find_symbol("c:@F@strncmp");
+  if (!strncmp_symbol)
+    throw std::runtime_error("strncmp function not found for endswith()");
+
+  // Call strncmp(str + offset, suffix, len(suffix))
+  side_effect_expr_function_callt strncmp_call;
+  strncmp_call.function() = symbol_expr(*strncmp_symbol);
+  strncmp_call.arguments() = {offset_ptr, suffix_addr, actual_suffix_len};
+  strncmp_call.location() = location;
+  strncmp_call.type() = int_type();
+
+  // Check if result == 0 (strings match)
+  exprt zero = gen_zero(int_type());
+  exprt strings_equal("=", bool_type());
+  strings_equal.copy_to_operands(strncmp_call, zero);
+
+  // Return: (suffix_len <= str_len) && (strncmp(...) == 0)
+  exprt len_ok("not", bool_type());
+  len_ok.copy_to_operands(len_check);
+
+  exprt result("and", bool_type());
+  result.copy_to_operands(len_ok, strings_equal);
+
+  return result;
+}
+
+exprt string_handler::handle_string_isdigit(
+  const exprt &string_obj,
+  const locationt &location)
+{
+  // Ensure it's a proper null-terminated string
+  exprt string_copy = string_obj;
+  exprt str_expr = ensure_null_terminated_string(string_copy);
+
+  // Get base address of the string
+  exprt str_addr = get_array_base_address(str_expr);
+
+  // Find the helper function symbol
+  symbolt *isdigit_str_symbol =
+    symbol_table_.find_symbol("c:@F@__python_str_isdigit");
+  if (!isdigit_str_symbol)
+    throw std::runtime_error("str_isdigit function not found in symbol table");
+
+  // Call str_isdigit(str) - returns bool (0 or 1)
+  side_effect_expr_function_callt isdigit_call;
+  isdigit_call.function() = symbol_expr(*isdigit_str_symbol);
+  isdigit_call.arguments().push_back(str_addr);
+  isdigit_call.location() = location;
+  isdigit_call.type() = bool_type();
+
+  return isdigit_call;
+}
+
+exprt string_handler::handle_string_isalpha(
+  const exprt &string_obj,
+  const locationt &location)
+{
+  // Check if this is a single character
+  if (string_obj.type().is_unsignedbv() || string_obj.type().is_signedbv())
+  {
+    // Call Python's single-character version (not C's isalpha)
+    symbolt *isalpha_symbol =
+      symbol_table_.find_symbol("c:@F@__python_char_isalpha");
+    if (!isalpha_symbol)
+      throw std::runtime_error(
+        "__python_char_isalpha function not found in symbol table");
+
+    side_effect_expr_function_callt isalpha_call;
+    isalpha_call.function() = symbol_expr(*isalpha_symbol);
+    isalpha_call.arguments().push_back(string_obj);
+    isalpha_call.location() = location;
+    isalpha_call.type() = bool_type();
+
+    return isalpha_call;
+  }
+
+  // For full strings, use the string version
+  exprt string_copy = string_obj;
+  exprt str_expr = ensure_null_terminated_string(string_copy);
+  exprt str_addr = get_array_base_address(str_expr);
+
+  symbolt *isalpha_str_symbol =
+    symbol_table_.find_symbol("c:@F@__python_str_isalpha");
+  if (!isalpha_str_symbol)
+    throw std::runtime_error("str_isalpha function not found in symbol table");
+
+  side_effect_expr_function_callt isalpha_call;
+  isalpha_call.function() = symbol_expr(*isalpha_str_symbol);
+  isalpha_call.arguments().push_back(str_addr);
+  isalpha_call.location() = location;
+  isalpha_call.type() = bool_type();
+
+  return isalpha_call;
+}
+
+exprt string_handler::handle_string_isspace(
+  const exprt &str_expr,
+  const locationt &location)
+{
+  std::string func_symbol_id = ensure_string_function_symbol(
+    "__python_str_isspace",
+    bool_type(),
+    {pointer_typet(char_type())},
+    location);
+
+  // Get the string pointer
+  exprt str_ptr = str_expr;
+
+  if (str_expr.is_constant() && str_expr.type().is_array())
+  {
+    str_ptr = exprt("index", pointer_typet(char_type()));
+    str_ptr.copy_to_operands(str_expr);
+    str_ptr.copy_to_operands(from_integer(0, int_type()));
+  }
+  else if (str_expr.type().is_array())
+  {
+    str_ptr = exprt("address_of", pointer_typet(char_type()));
+    exprt index_expr("index", char_type());
+    index_expr.copy_to_operands(str_expr);
+    index_expr.copy_to_operands(from_integer(0, int_type()));
+    str_ptr.copy_to_operands(index_expr);
+  }
+  else if (!str_expr.type().is_pointer())
+  {
+    str_ptr = exprt("address_of", pointer_typet(char_type()));
+    str_ptr.copy_to_operands(str_expr);
+  }
+
+  // Create function call
+  side_effect_expr_function_callt call;
+  call.function() = symbol_exprt(func_symbol_id, code_typet());
+  call.arguments().push_back(str_ptr);
+  call.type() = bool_type();
+  call.location() = location;
+
+  return call;
+}
+
+exprt string_handler::handle_char_isspace(
+  const exprt &char_expr,
+  const locationt &location)
+{
+  // For single characters, use the standard C isspace() function
+  std::string func_symbol_id = ensure_string_function_symbol(
+    "isspace", int_type(), {int_type()}, location);
+
+  // Convert char to int for isspace
+  exprt char_as_int = char_expr;
+  if (char_expr.type() != int_type())
+  {
+    char_as_int = typecast_exprt(char_expr, int_type());
+  }
+
+  // Create function call to C's isspace
+  side_effect_expr_function_callt call;
+  call.function() = symbol_exprt(func_symbol_id, code_typet());
+  call.arguments().push_back(char_as_int);
+  call.type() = int_type();
+  call.location() = location;
+
+  // Convert result to boolean (isspace returns non-zero for whitespace)
+  exprt result("notequal", bool_type());
+  result.copy_to_operands(call);
+  result.copy_to_operands(from_integer(0, int_type()));
+
+  return result;
+}
+
+exprt string_handler::handle_string_lstrip(
+  const exprt &str_expr,
+  const locationt &location)
+{
+  std::string func_symbol_id = ensure_string_function_symbol(
+    "__python_str_lstrip",
+    pointer_typet(char_type()),
+    {pointer_typet(char_type())},
+    location);
+
+  // Get the string pointer
+  exprt str_ptr = str_expr;
+
+  if (str_expr.is_constant() && str_expr.type().is_array())
+  {
+    str_ptr = exprt("index", pointer_typet(char_type()));
+    str_ptr.copy_to_operands(str_expr);
+    str_ptr.copy_to_operands(from_integer(0, int_type()));
+  }
+  else if (str_expr.type().is_array())
+  {
+    str_ptr = exprt("address_of", pointer_typet(char_type()));
+    exprt index_expr("index", char_type());
+    index_expr.copy_to_operands(str_expr);
+    index_expr.copy_to_operands(from_integer(0, int_type()));
+    str_ptr.copy_to_operands(index_expr);
+  }
+  else if (!str_expr.type().is_pointer())
+  {
+    str_ptr = exprt("address_of", pointer_typet(char_type()));
+    str_ptr.copy_to_operands(str_expr);
+  }
+
+  // Create function call
+  side_effect_expr_function_callt call;
+  call.function() = symbol_exprt(func_symbol_id, code_typet());
+  call.arguments().push_back(str_ptr);
+  call.type() = pointer_typet(char_type());
+  call.location() = location;
+
+  return call;
+}
+
+exprt string_handler::handle_string_membership(
+  exprt &lhs,
+  exprt &rhs,
+  const nlohmann::json &element)
+{
+  // Convert both operands to proper null-terminated strings
+  exprt lhs_str = ensure_null_terminated_string(lhs);
+  exprt rhs_str = ensure_null_terminated_string(rhs);
+
+  // Get base addresses for C string functions
+  exprt lhs_addr = get_array_base_address(lhs_str);
+  exprt rhs_addr = get_array_base_address(rhs_str);
+
+  // Find strstr symbol - returns pointer to first occurrence or NULL
+  symbolt *strstr_symbol = symbol_table_.find_symbol("c:@F@strstr");
+  if (!strstr_symbol)
+    throw std::runtime_error("strstr function not found for 'in' operator");
+
+  // Call strstr(haystack, needle) - in Python "needle in haystack"
+  side_effect_expr_function_callt strstr_call;
+  strstr_call.function() = symbol_expr(*strstr_symbol);
+  strstr_call.arguments() = {
+    rhs_addr, lhs_addr}; // haystack is rhs, needle is lhs
+  strstr_call.location() = converter_.get_location_from_decl(element);
+  strstr_call.type() = gen_pointer_type(char_type());
+
+  // Check if result != NULL (substring found)
+  constant_exprt null_ptr(gen_pointer_type(char_type()));
+  null_ptr.set_value("NULL");
+
+  exprt not_equal("notequal", bool_type());
+  not_equal.copy_to_operands(strstr_call, null_ptr);
+
+  return not_equal;
+}

--- a/src/python-frontend/string_handler.h
+++ b/src/python-frontend/string_handler.h
@@ -44,10 +44,13 @@ public:
     type_handler &type_handler,
     string_builder *str_builder);
 
-  void set_string_builder(string_builder *sb) { string_builder_ = sb; }
+  void set_string_builder(string_builder *sb)
+  {
+    string_builder_ = sb;
+  }
 
   // String size and conversion operations
-  
+
   /**
    * @brief Calculate the size of a string expression
    * @param expr Expression to measure
@@ -97,7 +100,8 @@ public:
    * @param format Format string
    * @return Formatted expression
    */
-  exprt apply_format_specification(const exprt &expr, const std::string &format);
+  exprt
+  apply_format_specification(const exprt &expr, const std::string &format);
 
   /**
    * @brief Convert f-string JSON to expression
@@ -202,9 +206,8 @@ public:
    * @param location Source location
    * @return Boolean expression result
    */
-  exprt handle_string_isdigit(
-    const exprt &string_obj,
-    const locationt &location);
+  exprt
+  handle_string_isdigit(const exprt &string_obj, const locationt &location);
 
   /**
    * @brief Handle str.isalpha() method
@@ -212,9 +215,8 @@ public:
    * @param location Source location
    * @return Boolean expression result
    */
-  exprt handle_string_isalpha(
-    const exprt &string_obj,
-    const locationt &location);
+  exprt
+  handle_string_isalpha(const exprt &string_obj, const locationt &location);
 
   /**
    * @brief Handle str.isspace() method for strings
@@ -222,9 +224,7 @@ public:
    * @param location Source location
    * @return Boolean expression result
    */
-  exprt handle_string_isspace(
-    const exprt &str_expr,
-    const locationt &location);
+  exprt handle_string_isspace(const exprt &str_expr, const locationt &location);
 
   /**
    * @brief Handle char.isspace() method for single characters
@@ -232,9 +232,7 @@ public:
    * @param location Source location
    * @return Boolean expression result
    */
-  exprt handle_char_isspace(
-    const exprt &char_expr,
-    const locationt &location);
+  exprt handle_char_isspace(const exprt &char_expr, const locationt &location);
 
   /**
    * @brief Handle str.lstrip() method
@@ -242,9 +240,7 @@ public:
    * @param location Source location
    * @return Pointer to stripped string
    */
-  exprt handle_string_lstrip(
-    const exprt &str_expr,
-    const locationt &location);
+  exprt handle_string_lstrip(const exprt &str_expr, const locationt &location);
 
   /**
    * @brief Handle 'in' operator for strings

--- a/src/python-frontend/string_handler.h
+++ b/src/python-frontend/string_handler.h
@@ -1,0 +1,322 @@
+#ifndef PYTHON_FRONTEND_STRING_HANDLER_H
+#define PYTHON_FRONTEND_STRING_HANDLER_H
+
+#include <util/expr.h>
+#include <util/std_types.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/context.h>
+#include <util/message.h>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+// Forward declarations
+class python_converter;
+class type_handler;
+class string_builder;
+
+/**
+ * @brief Handles all string-related operations for Python-to-C conversion
+ * 
+ * This class extracts string manipulation functionality from python_converter
+ * to improve modularity and maintainability. It handles:
+ * - String size calculations
+ * - String-to-expression conversions
+ * - String formatting and f-string processing
+ * - String comparison operations
+ * - String method operations (startswith, endswith, isdigit, isalpha, etc.)
+ * - String concatenation and membership testing
+ */
+class string_handler
+{
+public:
+  /**
+   * @brief Constructs a string_handler
+   * @param converter Reference to the parent python_converter
+   * @param symbol_table Reference to the symbol table (contextt)
+   * @param type_handler Reference to the type handler
+   * @param str_builder Pointer to the string builder
+   */
+  string_handler(
+    python_converter &converter,
+    contextt &symbol_table,
+    type_handler &type_handler,
+    string_builder *str_builder);
+
+  void set_string_builder(string_builder *sb) { string_builder_ = sb; }
+
+  // String size and conversion operations
+  
+  /**
+   * @brief Calculate the size of a string expression
+   * @param expr Expression to measure
+   * @return Size of string including null terminator
+   */
+  BigInt get_string_size(const exprt &expr);
+
+  /**
+   * @brief Convert an expression to a string representation
+   * @param expr Expression to convert
+   * @return String array expression
+   */
+  exprt convert_to_string(const exprt &expr);
+
+  /**
+   * @brief Extract string content from array operands
+   * @param array_expr Array expression containing characters
+   * @return Extracted string
+   */
+  std::string extract_string_from_array_operands(const exprt &array_expr) const;
+
+  /**
+   * @brief Ensure an expression is a null-terminated string array
+   * @param expr Expression to convert
+   */
+  void ensure_string_array(exprt &expr);
+
+  /**
+   * @brief Ensure string is null-terminated
+   * @param e String expression
+   * @return Null-terminated string expression
+   */
+  exprt ensure_null_terminated_string(exprt &e);
+
+  // Format string operations
+
+  /**
+   * @brief Process format specification for f-strings
+   * @param format_spec JSON format specification
+   * @return Format string
+   */
+  std::string process_format_spec(const nlohmann::json &format_spec);
+
+  /**
+   * @brief Apply format specification to an expression
+   * @param expr Expression to format
+   * @param format Format string
+   * @return Formatted expression
+   */
+  exprt apply_format_specification(const exprt &expr, const std::string &format);
+
+  /**
+   * @brief Convert f-string JSON to expression
+   * @param element JSON element representing f-string
+   * @return Concatenated f-string expression
+   */
+  exprt get_fstring_expr(const nlohmann::json &element);
+
+  // String concatenation operations
+
+  /**
+   * @brief Handle string concatenation
+   * @param lhs Left operand
+   * @param rhs Right operand
+   * @param left JSON node for left operand
+   * @param right JSON node for right operand
+   * @return Concatenated string expression
+   */
+  exprt handle_string_concatenation(
+    const exprt &lhs,
+    const exprt &rhs,
+    const nlohmann::json &left,
+    const nlohmann::json &right);
+
+  /**
+   * @brief Handle string concatenation with type promotion
+   * @param lhs Left operand
+   * @param rhs Right operand
+   * @param left JSON node for left operand
+   * @param right JSON node for right operand
+   * @return Concatenated string expression
+   */
+  exprt handle_string_concatenation_with_promotion(
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &left,
+    const nlohmann::json &right);
+
+  // String comparison operations
+
+  /**
+   * @brief Handle string comparison operations
+   * @param op Comparison operator (Eq, NotEq, etc.)
+   * @param lhs Left operand
+   * @param rhs Right operand
+   * @param element JSON element with location info
+   * @return Comparison expression or nil_exprt to continue with standard comparison
+   */
+  exprt handle_string_comparison(
+    const std::string &op,
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &element);
+
+  /**
+   * @brief Handle general string operations
+   * @param op Operation type
+   * @param lhs Left operand
+   * @param rhs Right operand
+   * @param left JSON node for left operand
+   * @param right JSON node for right operand
+   * @param element JSON element with location info
+   * @return Operation result expression
+   */
+  exprt handle_string_operations(
+    const std::string &op,
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &left,
+    const nlohmann::json &right,
+    const nlohmann::json &element);
+
+  // String method operations
+
+  /**
+   * @brief Handle str.startswith() method
+   * @param string_obj String object
+   * @param prefix_arg Prefix to check
+   * @param location Source location
+   * @return Boolean expression result
+   */
+  exprt handle_string_startswith(
+    const exprt &string_obj,
+    const exprt &prefix_arg,
+    const locationt &location);
+
+  /**
+   * @brief Handle str.endswith() method
+   * @param string_obj String object
+   * @param suffix_arg Suffix to check
+   * @param location Source location
+   * @return Boolean expression result
+   */
+  exprt handle_string_endswith(
+    const exprt &string_obj,
+    const exprt &suffix_arg,
+    const locationt &location);
+
+  /**
+   * @brief Handle str.isdigit() method
+   * @param string_obj String object
+   * @param location Source location
+   * @return Boolean expression result
+   */
+  exprt handle_string_isdigit(
+    const exprt &string_obj,
+    const locationt &location);
+
+  /**
+   * @brief Handle str.isalpha() method
+   * @param string_obj String object (can be string or single char)
+   * @param location Source location
+   * @return Boolean expression result
+   */
+  exprt handle_string_isalpha(
+    const exprt &string_obj,
+    const locationt &location);
+
+  /**
+   * @brief Handle str.isspace() method for strings
+   * @param str_expr String expression
+   * @param location Source location
+   * @return Boolean expression result
+   */
+  exprt handle_string_isspace(
+    const exprt &str_expr,
+    const locationt &location);
+
+  /**
+   * @brief Handle char.isspace() method for single characters
+   * @param char_expr Character expression
+   * @param location Source location
+   * @return Boolean expression result
+   */
+  exprt handle_char_isspace(
+    const exprt &char_expr,
+    const locationt &location);
+
+  /**
+   * @brief Handle str.lstrip() method
+   * @param str_expr String expression
+   * @param location Source location
+   * @return Pointer to stripped string
+   */
+  exprt handle_string_lstrip(
+    const exprt &str_expr,
+    const locationt &location);
+
+  /**
+   * @brief Handle 'in' operator for strings
+   * @param lhs Substring to find
+   * @param rhs String to search in
+   * @param element JSON element with location info
+   * @return Boolean expression result
+   */
+  exprt handle_string_membership(
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &element);
+
+  // Utility methods
+
+  /**
+   * @brief Check if an expression is a zero-length array
+   * @param expr Expression to check
+   * @return True if zero-length array
+   */
+  bool is_zero_length_array(const exprt &expr);
+
+  /**
+   * @brief Get base address of array (first element)
+   * @param arr Array expression
+   * @return Address expression
+   */
+  exprt get_array_base_address(const exprt &arr);
+
+private:
+  python_converter &converter_;
+  contextt &symbol_table_;
+  type_handler &type_handler_;
+  string_builder *string_builder_;
+
+  // Helper methods for internal use
+
+  /**
+   * @brief Create a character array expression
+   * @param chars Character data
+   * @param type Array type
+   * @return Character array expression
+   */
+  exprt make_char_array_expr(
+    const std::vector<unsigned char> &chars,
+    const typet &type);
+
+  /**
+   * @brief Find or create a function symbol for string operations
+   * @param function_name Name of the function
+   * @param return_type Return type of function
+   * @param arg_types Argument types
+   * @param location Source location
+   * @return Function identifier
+   */
+  std::string ensure_string_function_symbol(
+    const std::string &function_name,
+    const typet &return_type,
+    const std::vector<typet> &arg_types,
+    const locationt &location);
+
+  /**
+   * @brief Convert float bits to string representation
+   * @param float_bits Binary representation of float
+   * @param width Bit width (32 or 64)
+   * @param precision Number of decimal places
+   * @return String representation
+   */
+  std::string float_to_string(
+    const std::string &float_bits,
+    std::size_t width,
+    int precision);
+};
+
+#endif // PYTHON_FRONTEND_STRING_HANDLER_H


### PR DESCRIPTION
This PR moves 26 string manipulation methods (~1,200 lines) from `python_converter` into a new `string_handler` class to improve code organization and maintainability.

Key changes:
- Created `string_handler` class with all string operations (size, conversion, f-strings, concatenation, comparison, and string methods).
- Updated `python_converter` to delegate string operations via `string_handler_`.
- Modified `string_builder` to use `string_handler*` for array utilities.
- Added accessor method `get_string_handler()` for cross-class access.
- Updated `function_call_builder` and `python_list` to use new accessor.

This refactoring reduces `python_converter` complexity while preserving all functionality—no behavioral changes.