### PR TITLE
[python] add support for list.extend() method

### DIFF
--- a/regression/python/list23/main.py
+++ b/regression/python/list23/main.py
@@ -1,0 +1,14 @@
+# Initial lists
+a = [1, 2, 3]
+b = [4, 5, 6]
+
+# Extend list a with elements from list b
+a.extend(b)
+
+# Expected output: [1, 2, 3, 4, 5, 6]
+assert a[0] == 1
+assert a[1] == 2
+assert a[2] == 3
+assert a[3] == 4
+assert a[4] == 5
+assert a[5] == 6

--- a/regression/python/list23/test.desc
+++ b/regression/python/list23/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list23_fail/main.py
+++ b/regression/python/list23_fail/main.py
@@ -1,0 +1,14 @@
+# Initial lists
+a = [1, 2, 3]
+b = [4, 5, 6]
+
+# Extend list a with elements from list b
+a.extend(b)
+
+# Expected output: [1, 2, 3, 4, 5, 6]
+assert a[0] == 6
+assert a[1] == 5
+assert a[2] == 4
+assert a[3] == 3
+assert a[4] == 2
+assert a[5] == 1

--- a/regression/python/list23_fail/test.desc
+++ b/regression/python/list23_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -100,6 +100,7 @@ const static std::vector<std::string> python_c_models = {
   "list_get_as",
   "list_push",
   "list_insert",
+  "list_extend",
   "list_push_object",
   "list_replace",
   "list_pop",

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -222,3 +222,27 @@ static bool list_contains(
   }
   return false;
 }
+
+/* ---------- extend list ---------- */
+static inline void list_extend(List *l, const List *other)
+{
+  if (!l || !other)
+    return;
+
+  size_t i = 0;
+  while (i < other->size)
+  {
+    const Object *elem = &other->items[i];
+
+    void *copied_value = malloc(elem->size);
+    __ESBMC_assume(copied_value != NULL);
+    memcpy(copied_value, elem->value, elem->size);
+
+    l->items[l->size].value = copied_value;
+    l->items[l->size].type_id = elem->type_id;
+    l->items[l->size].size = elem->size;
+    l->size++;
+
+    ++i;
+  }
+}

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1134,6 +1134,9 @@ exprt function_call_expr::handle_list_method() const
     return handle_list_append();
   if (method_name == "insert")
     return handle_list_insert();
+  if (method_name == "extend")
+    return handle_list_extend();
+
   // Add other methods as needed
 
   throw std::runtime_error("Unsupported list method: " + method_name);
@@ -1178,6 +1181,30 @@ exprt function_call_expr::handle_list_append() const
     value_to_append.type());
 
   return list.build_push_list_call(*list_symbol, call_, value_to_append);
+}
+
+exprt function_call_expr::handle_list_extend() const
+{
+  const auto &args = call_["args"];
+
+  if (args.size() != 1)
+    throw std::runtime_error("extend() takes exactly one argument");
+
+  std::string list_name = get_object_name();
+
+  symbol_id list_symbol_id = converter_.create_symbol_id();
+  list_symbol_id.set_object(list_name);
+  const symbolt *list_symbol =
+    converter_.find_symbol(list_symbol_id.to_string());
+
+  if (!list_symbol)
+    throw std::runtime_error("List variable not found: " + list_name);
+
+  exprt other_list = converter_.get_expr(args[0]);
+
+  python_list list(converter_, nlohmann::json());
+
+  return list.build_extend_list_call(*list_symbol, call_, other_list);
 }
 
 bool function_call_expr::is_print_call() const

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -202,6 +202,7 @@ private:
   exprt handle_list_method() const;
   exprt handle_list_append() const;
   exprt handle_list_insert() const;
+  exprt handle_list_extend() const;
 
   /*
    * Check if the current function call is to a regular expression module function

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -54,6 +54,11 @@ public:
     const nlohmann::json &op,
     const exprt &elem);
 
+  exprt build_extend_list_call(
+    const symbolt &list,
+    const nlohmann::json &op,
+    const exprt &other_list);
+
   // Build: result = lhs + rhs   (concatenation)
   exprt build_concat_list_call(
     const exprt &lhs,


### PR DESCRIPTION
This PR implements the `extend()` method for Python lists, allowing lists to be extended with elements from another list in-place.

- Added `list_extend()` function to list.c C model that copies elements from source list to destination list
- Added `list_extend` to `python_c_models` whitelist
- Implemented `handle_list_extend()` in `function_call_expr` to handle extend method calls
- Implemented `build_extend_list_call()` in `python_list` to generate the function call and update `list_type_map` with new element types
- Updated `is_list_method_call()` to recognize "extend" as a list method