### PR TITLE
[SV-COMP] refactor the data race check

### DIFF
--- a/regression/esbmc-unix/github_2661/main.c
+++ b/regression/esbmc-unix/github_2661/main.c
@@ -1,0 +1,60 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int balance = 1000; // Shared bank account balance
+
+void *withdraw(void *arg)
+{
+  int amount = *(int *)arg;
+
+  // Check if we have enough money
+  if (balance >= amount)
+  {
+    printf(
+      "Thread %ld: Checking balance... $%d available\n",
+      pthread_self(),
+      balance);
+
+    // Simulate some processing time (ATM communication, etc.)
+    usleep(100000); // 100ms delay
+
+    // Withdraw the money
+    balance -= amount;
+    printf(
+      "Thread %ld: Withdrew $%d, new balance: $%d\n",
+      pthread_self(),
+      amount,
+      balance);
+  }
+  else
+  {
+    printf(
+      "Thread %ld: Insufficient funds for $%d withdrawal\n",
+      pthread_self(),
+      amount);
+  }
+
+  return NULL;
+}
+
+int main()
+{
+  pthread_t thread1, thread2;
+  int amount1 = 800;
+  int amount2 = 600;
+
+  printf("Initial balance: $%d\n", balance);
+
+  // Two people trying to withdraw money simultaneously
+  pthread_create(&thread1, NULL, withdraw, &amount1);
+  pthread_create(&thread2, NULL, withdraw, &amount2);
+
+  pthread_join(thread1, NULL);
+  pthread_join(thread2, NULL);
+
+  printf("Final balance: $%d\n", balance);
+
+  return 0;
+}

--- a/regression/esbmc-unix/github_2661/test.desc
+++ b/regression/esbmc-unix/github_2661/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--data-races-check-only --context-bound 2
+^\s*R/W data race on c:@balance$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2246,7 +2246,8 @@ void goto_symext::replace_races_check(expr2tc &expr)
     expr2tc flag;
     migrate_expr(symbol_expr(*ns.lookup("c:@F@__ESBMC_races_flag")), flag);
 
-    expr2tc max_offset = constant_int2tc(get_uint64_type(), 1000);
+    expr2tc max_offset =
+      constant_int2tc(get_uint_type(config.ansi_c.address_width), 1000);
     // The reason for not using address directly is that address
     // is modeled as an nondet value, which depends on the address space constraints.
     // VCC becomes complex and inefficient in this case.
@@ -2258,8 +2259,10 @@ void goto_symext::replace_races_check(expr2tc &expr)
     // XL: Should we let the user choose this value?
     expr2tc mul = mul2tc(
       size_type2(), pointer_object2tc(pointer_type2(), obj.value), max_offset);
-    expr2tc add =
-      add2tc(size_type2(), mul, pointer_offset2tc(get_int64_type(), obj.value));
+    expr2tc add = add2tc(
+      size_type2(),
+      mul,
+      pointer_offset2tc(get_int_type(config.ansi_c.address_width), obj.value));
 
     expr2tc index_expr = index2tc(get_bool_type(), flag, add);
 


### PR DESCRIPTION
`races_check[][] = array_of(array_of(0));`
It is not feasible to create an unbounded 2D array. 

Therefore, in this new method, we try to flatten the 2D array to keep track of the variable.