### PR TITLE
[python] skip AST processing for typing imports to prevent “Module not found” errors

### DIFF
--- a/regression/python/github_2929/main.py
+++ b/regression/python/github_2929/main.py
@@ -1,0 +1,4 @@
+from typing import List
+
+s: List[int] = [1, 2, 3]
+b = 1 in s

--- a/regression/python/github_2929/test.desc
+++ b/regression/python/github_2929/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -39,8 +39,8 @@ def import_module_by_name(module_name, output_dir):
         sys.exit(3)
 
     base_module = module_name.split(".")[0]
-    
-    # Skip typing module - it's for type annotations only
+
+    # Skip typing module - it's for type annotations only and doesn't need AST processing.
     if base_module == "typing":
         return None
 
@@ -155,8 +155,7 @@ def process_imports(node, output_dir):
     else:
         module = import_module_by_name(module_name, output_dir)
         if module is None:
-            # Module doesn't need processing (e.g., typing)
-            node.full_path = None
+            # Module doesn't need processing (e.g., typing) - don't set full_path
             return
         filename = module.__file__
 

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -39,6 +39,10 @@ def import_module_by_name(module_name, output_dir):
         sys.exit(3)
 
     base_module = module_name.split(".")[0]
+    
+    # Skip typing module - it's for type annotations only
+    if base_module == "typing":
+        return None
 
     if is_imported_model(base_module):
         parts = module_name.split(".")
@@ -150,6 +154,10 @@ def process_imports(node, output_dir):
         filename = os.path.join(models_dir, module_name + ".py")
     else:
         module = import_module_by_name(module_name, output_dir)
+        if module is None:
+            # Module doesn't need processing (e.g., typing)
+            node.full_path = None
+            return
         filename = module.__file__
 
     # Don't process the file here; we'll do it once after collecting all imports

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1773,7 +1773,7 @@ python_converter::find_imported_symbol(const std::string &symbol_id) const
   {
     if (
       (obj["_type"] == "ImportFrom" || obj["_type"] == "Import") &&
-      obj.contains("full_path"))
+      obj.contains("full_path") && !obj["full_path"].is_null())
     {
       std::regex pattern("py:(.*?)@");
       std::string imported_symbol = std::regex_replace(


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2929.

This PR fixes an issue where our Python frontend attempted to process modules from the typing package (e.g., `typing.List`), leading to errors such as: "Module 'typing. List' not found". Since the typing module is used only for type annotations and does not require AST processing, it is now skipped during import handling.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.