### PR TITLE
[python] support union types with None

### DIFF
--- a/regression/python/github_2934/main.py
+++ b/regression/python/github_2934/main.py
@@ -1,0 +1,5 @@
+def foo(x: int | None = None) -> None:
+    if x is not None:
+        assert x != 42
+
+foo(5)

--- a/regression/python/github_2934/test.desc
+++ b/regression/python/github_2934/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2934_fail/main.py
+++ b/regression/python/github_2934_fail/main.py
@@ -1,0 +1,5 @@
+def foo(x: int | None = None) -> None:
+    if x is not None:
+        assert x == 42
+
+foo(5)

--- a/regression/python/github_2934_fail/test.desc
+++ b/regression/python/github_2934_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3485,6 +3485,43 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
   return std::move(code);
 }
 
+// Extract non-None type from union
+std::string
+python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
+{
+  std::function<std::string(const nlohmann::json &)> extract_type =
+    [&](const nlohmann::json &node) -> std::string {
+    if (
+      node.contains("_type") && node["_type"] == "Constant" &&
+      node.contains("value") && node["value"].is_null())
+      return ""; // This is None
+
+    if (node.contains("id"))
+      return node["id"].get<std::string>();
+
+    // Recursively handle nested BinOp (e.g., bool | str in bool | str | None)
+    if (node.contains("_type") && node["_type"] == "BinOp")
+    {
+      std::string left_type = extract_type(node["left"]);
+      if (!left_type.empty())
+        return left_type;
+      return extract_type(node["right"]);
+    }
+
+    return "";
+  };
+
+  const auto &left = annotation_node["left"];
+  const auto &right = annotation_node["right"];
+
+  // Extract the first non-None type
+  std::string inner_type = extract_type(left);
+  if (inner_type.empty())
+    inner_type = extract_type(right);
+
+  return inner_type;
+}
+
 typet python_converter::get_type_from_annotation(
   const nlohmann::json &annotation_node,
   const nlohmann::json &element)
@@ -3509,18 +3546,7 @@ typet python_converter::get_type_from_annotation(
         std::string inner_type =
           annotation_node["slice"]["id"].get<std::string>();
         typet base_type = type_handler_.get_typet(inner_type);
-
-        // For primitive types (int, float, bool), don't use pointer
-        // Use the base type directly and treat NULL as a special value (0)
-        if (
-          base_type == long_long_int_type() ||
-          base_type == long_long_uint_type() || base_type == double_type() ||
-          base_type == bool_type())
-        {
-          return base_type;
-        }
-
-        // For complex types (classes, lists), use pointer type
+        // Always use pointer type for Optional to properly represent None
         return gen_pointer_type(base_type);
       }
     }
@@ -3530,36 +3556,7 @@ typet python_converter::get_type_from_annotation(
   else if (annotation_node["_type"] == "BinOp")
   {
     // Handle union types such as str | None (PEP 604 syntax)
-    const auto &left = annotation_node["left"];
-    const auto &right = annotation_node["right"];
-
-    // Extract a non-None type from potentially nested unions
-    std::function<std::string(const nlohmann::json &)> extract_type =
-      [&](const nlohmann::json &node) -> std::string {
-      if (
-        node.contains("_type") && node["_type"] == "Constant" &&
-        node.contains("value") && node["value"].is_null())
-        return ""; // This is None
-
-      if (node.contains("id"))
-        return node["id"].get<std::string>();
-
-      // Recursively handle nested BinOp (e.g., bool | str in bool | str | None)
-      if (node.contains("_type") && node["_type"] == "BinOp")
-      {
-        std::string left_type = extract_type(node["left"]);
-        if (!left_type.empty())
-          return left_type;
-        return extract_type(node["right"]);
-      }
-
-      return "";
-    };
-
-    // Extract the first non-None type
-    std::string inner_type = extract_type(left);
-    if (inner_type.empty())
-      inner_type = extract_type(right);
+    std::string inner_type = extract_non_none_type(annotation_node);
 
     if (inner_type.empty())
     {
@@ -3569,17 +3566,7 @@ typet python_converter::get_type_from_annotation(
 
     // Treat T | ... | None as Optional[T]
     typet base_type = type_handler_.get_typet(inner_type);
-
-    // For primitive types (int, float, bool), don't use pointer
-    // Use the base type directly and treat NULL as a special value (0)
-    if (
-      base_type == long_long_int_type() || base_type == long_long_uint_type() ||
-      base_type == double_type() || base_type == bool_type())
-    {
-      return base_type;
-    }
-
-    // For other types (e.g., classes, lists), use pointer type
+    // Always use pointer type for union with None to properly represent None
     return gen_pointer_type(base_type);
   }
   else if (

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3509,7 +3509,19 @@ typet python_converter::get_type_from_annotation(
         std::string inner_type =
           annotation_node["slice"]["id"].get<std::string>();
         typet base_type = type_handler_.get_typet(inner_type);
-        return gen_pointer_type(base_type); // Return pointer type
+
+        // For primitive types (int, float, bool), don't use pointer
+        // Use the base type directly and treat NULL as a special value (0)
+        if (
+          base_type == long_long_int_type() ||
+          base_type == long_long_uint_type() || base_type == double_type() ||
+          base_type == bool_type())
+        {
+          return base_type;
+        }
+
+        // For complex types (classes, lists), use pointer type
+        return gen_pointer_type(base_type);
       }
     }
 
@@ -3555,8 +3567,19 @@ typet python_converter::get_type_from_annotation(
       return pointer_type();
     }
 
-    // Treat T | ... | None as Optional[T] - return pointer type
+    // Treat T | ... | None as Optional[T]
     typet base_type = type_handler_.get_typet(inner_type);
+
+    // For primitive types (int, float, bool), don't use pointer
+    // Use the base type directly and treat NULL as a special value (0)
+    if (
+      base_type == long_long_int_type() || base_type == long_long_uint_type() ||
+      base_type == double_type() || base_type == bool_type())
+    {
+      return base_type;
+    }
+
+    // For other types (e.g., classes, lists), use pointer type
     return gen_pointer_type(base_type);
   }
   else if (

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -341,6 +341,8 @@ private:
     const nlohmann::json &element,
     bool invert);
 
+  std::string extract_non_none_type(const nlohmann::json &annotation_node);
+
   // helper methods for get_var_assign
   std::pair<std::string, typet>
   extract_type_info(const nlohmann::json &ast_node);

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -2,6 +2,7 @@
 
 #include <util/c_types.h>
 #include <util/expr.h>
+#include <util/expr_util.h>
 #include <util/type.h>
 
 #include <nlohmann/json.hpp>
@@ -232,6 +233,22 @@ public:
     // String types are represented as arrays or pointers to char
     return type.is_array() ||
            (type.is_pointer() && type.subtype() == char_type());
+  }
+
+  // Handle optional type logic
+  static typet handle_optional_type(const typet &base_type)
+  {
+    // For primitive types (int, float, bool), don't use pointer
+    // Use the base type directly and treat NULL as a special value (0)
+    if (
+      base_type == long_long_int_type() || base_type == long_long_uint_type() ||
+      base_type == double_type() || base_type == bool_type())
+    {
+      return base_type;
+    }
+
+    // For other types (e.g., classes, lists), use pointer type
+    return gen_pointer_type(base_type);
   }
 
 private:


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2934.

This PR extends the type representation for primitive unions (`int | None`).

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
