### PR TITLE
 [python] Fix: Handle empty width string in get_type_width on macOS

### DIFF
--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -756,7 +756,7 @@ int type_handler::get_array_dimensions(const nlohmann::json &arr) const
 
 size_t type_handler::get_type_width(const typet &type) const
 {
-  // First try to parse width directly  
+  // First try to parse width directly
   std::string width_str = type.width().c_str();
   if (!width_str.empty())
   {
@@ -769,12 +769,11 @@ size_t type_handler::get_type_width(const typet &type) const
       // Fall through to type name inference
     }
   }
-  
+
   // If width is empty or parsing failed, try to infer from type name
   std::string type_str = type.width().as_string();
   if (!type_str.empty())
   {
-
     // Handle common Python/ESBMC type mappings
     if (type_str == "int32")
       return 32;
@@ -810,7 +809,7 @@ size_t type_handler::get_type_width(const typet &type) const
       }
     }
   }
-  
+
   // Default to 32 for unknown types
   return 32;
 }

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -756,15 +756,24 @@ int type_handler::get_array_dimensions(const nlohmann::json &arr) const
 
 size_t type_handler::get_type_width(const typet &type) const
 {
-  // First try to parse width directly
-  try
+  // First try to parse width directly  
+  std::string width_str = type.width().c_str();
+  if (!width_str.empty())
   {
-    return std::stoi(type.width().c_str());
+    try
+    {
+      return std::stoi(width_str);
+    }
+    catch (const std::exception &)
+    {
+      // Fall through to type name inference
+    }
   }
-  catch (const std::exception &)
+  
+  // If width is empty or parsing failed, try to infer from type name
+  std::string type_str = type.width().as_string();
+  if (!type_str.empty())
   {
-    // If direct parsing fails, try to infer from type name
-    std::string type_str = type.width().as_string();
 
     // Handle common Python/ESBMC type mappings
     if (type_str == "int32")
@@ -800,8 +809,8 @@ size_t type_handler::get_type_width(const typet &type) const
         // Fall through to default
       }
     }
-
-    // Default to 32 for unknown types
-    return 32;
   }
+  
+  // Default to 32 for unknown types
+  return 32;
 }


### PR DESCRIPTION
Fixes #2937.

### Problem
ESBMC-Python was crashing on macOS due to differences in how macOS and Linux handle symbol processing. When `type.width().c_str()` returns an empty string, calling `std::stoi()` directly causes an exception.

### Solution
Added a check to verify the width string is not empty before attempting to parse it. If empty or parsing fails, the function now falls back to inferring the type width from the type name.

### Testing
- Tested on Ubuntu 22.04 to ensure no regression in existing ESBMC-Python functionality
- Resolves the macOS crash while maintaining backward compatibility

### Changes
- Added empty string validation before `std::stoi()` call
- Improved error handling flow in `get_type_width()`

### TODO
Currently, ESBMC-Python fails multiple regression tests on macOS, mostly due to minor differences in how macOS and Linux handle certain operations. These issues are expected to be addressed incrementally in the near future.

This PR should have fixed 15 related regression failing cases on the Mac.
#### master:
- **passed**: 723 
- **failed**:  49 
- **skipped**: 133 (THOROUGH)
#### this:
- **passed**: 738 
- **failed**: 34 
- **skipped**: 133
