### PR TITLE
[Python-frontend] Fix the exception catch for MacOS

### DIFF
--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -667,10 +667,16 @@ exprt function_call_expr::handle_str_symbol_to_float(const symbolt *sym) const
     double dval = std::stod(*value_opt);
     return from_double(dval, type_handler_.get_typet("float", 0));
   }
-  catch (const std::exception &e)
+  catch (const std::invalid_argument &)
   {
     log_error(
-      "Failed float conversion from string \"{}\": {}", *value_opt, e.what());
+      "Failed float conversion from string \"{}\": invalid argument", *value_opt);
+    return from_double(0.0, type_handler_.get_typet("float", 0));
+  }
+  catch (const std::out_of_range &)
+  {
+    log_error(
+      "Failed float conversion from string \"{}\": out of range", *value_opt);
     return from_double(0.0, type_handler_.get_typet("float", 0));
   }
 }
@@ -945,10 +951,16 @@ exprt function_call_expr::build_constant_from_arg() const
         double dval = std::stod(arg["value"].get<std::string>());
         return from_double(dval, type_handler_.get_typet("float", 0));
       }
-      catch (const std::exception &e)
+      catch (const std::invalid_argument &)
       {
-        std::string m = "could not convert string to float : " +
+        std::string m = "could not convert string to float : '" +
                         arg["value"].get<std::string>() + "'";
+        return gen_exception_raise("ValueError", m);
+      }
+      catch (const std::out_of_range &)
+      {
+        std::string m = "could not convert string to float : '" +
+                        arg["value"].get<std::string>() + "' (out of range)";
         return gen_exception_raise("ValueError", m);
       }
     }

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -670,7 +670,8 @@ exprt function_call_expr::handle_str_symbol_to_float(const symbolt *sym) const
   catch (const std::invalid_argument &)
   {
     log_error(
-      "Failed float conversion from string \"{}\": invalid argument", *value_opt);
+      "Failed float conversion from string \"{}\": invalid argument",
+      *value_opt);
     return from_double(0.0, type_handler_.get_typet("float", 0));
   }
   catch (const std::out_of_range &)

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -162,7 +162,7 @@ def process_imports(node, output_dir):
         if not hasattr(module, '__file__') or module.__file__ is None:
             # Skip built-in C extension modules (e.g., _sre, _socket, etc.)
             return
-        
+
         filename = module.__file__
 
     # Don't process the file here; we'll do it once after collecting all imports

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -157,7 +157,7 @@ def process_imports(node, output_dir):
         if module is None:
             # Module doesn't need processing (e.g., typing) - don't set full_path
             return
-        
+
         # Check if module has __file__ attribute (built-in C extensions don't)
         if not hasattr(module, '__file__') or module.__file__ is None:
             # Skip built-in C extension modules (e.g., _sre, _socket, etc.)

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -157,6 +157,12 @@ def process_imports(node, output_dir):
         if module is None:
             # Module doesn't need processing (e.g., typing) - don't set full_path
             return
+        
+        # Check if module has __file__ attribute (built-in C extensions don't)
+        if not hasattr(module, '__file__') or module.__file__ is None:
+            # Skip built-in C extension modules (e.g., _sre, _socket, etc.)
+            return
+        
         filename = module.__file__
 
     # Don't process the file here; we'll do it once after collecting all imports

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1026,7 +1026,7 @@ class Preprocessor(ast.NodeTransformer):
             # Replace 'big' argument with True and anything else with False
             # Only process if there are enough arguments, MacOS has different AST nodes for 'big'
             if len(node.args) > 1:
-                # Check for both ast.Str and ast.Constant 
+                # Check for both ast.Str and ast.Constant
                 if (isinstance(node.args[1], ast.Str) and node.args[1].s == 'big') or \
                    (isinstance(node.args[1], ast.Constant) and node.args[1].value == 'big'):
                     node.args[1] = ast.Constant(value=True)

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1024,10 +1024,14 @@ class Preprocessor(ast.NodeTransformer):
         # Transformation for int.from_bytes calls
         if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name) and node.func.value.id == "int" and node.func.attr == "from_bytes":
             # Replace 'big' argument with True and anything else with False
-            if len(node.args) > 1 and isinstance(node.args[1], ast.Str) and node.args[1].s == 'big':
-                node.args[1] = ast.NameConstant(value=True)
-            else:
-                node.args[1] = ast.NameConstant(value=False)
+            # Only process if there are enough arguments, MacOS has different AST nodes for 'big'
+            if len(node.args) > 1:
+                # Check for both ast.Str and ast.Constant 
+                if (isinstance(node.args[1], ast.Str) and node.args[1].s == 'big') or \
+                   (isinstance(node.args[1], ast.Constant) and node.args[1].value == 'big'):
+                    node.args[1] = ast.Constant(value=True)
+                else:
+                    node.args[1] = ast.Constant(value=False)
 
         # if not a function or preprocessor doesn't have function definition return
         if not isinstance(node.func,ast.Name) or node.func.id not in self.functionParams:

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -756,15 +756,24 @@ int type_handler::get_array_dimensions(const nlohmann::json &arr) const
 
 size_t type_handler::get_type_width(const typet &type) const
 {
-  // First try to parse width directly
-  try
+  // First try to parse width directly  
+  std::string width_str = type.width().c_str();
+  if (!width_str.empty())
   {
-    return std::stoi(type.width().c_str());
+    try
+    {
+      return std::stoi(width_str);
+    }
+    catch (const std::exception &)
+    {
+      // Fall through to type name inference
+    }
   }
-  catch (const std::exception &)
+  
+  // If width is empty or parsing failed, try to infer from type name
+  std::string type_str = type.width().as_string();
+  if (!type_str.empty())
   {
-    // If direct parsing fails, try to infer from type name
-    std::string type_str = type.width().as_string();
 
     // Handle common Python/ESBMC type mappings
     if (type_str == "int32")
@@ -800,8 +809,8 @@ size_t type_handler::get_type_width(const typet &type) const
         // Fall through to default
       }
     }
-
-    // Default to 32 for unknown types
-    return 32;
   }
+  
+  // Default to 32 for unknown types
+  return 32;
 }


### PR DESCRIPTION
### As mention in #2941 
### Reason: 
Some behaviour of MacOS is different from Linux.

### Current:
Runtime_Exception_FileExistsError (1):
  - regression/python/exception7
```
zsh: abort      ./build/src/esbmc/esbmc ./regression/python/exception7/main.py
```

#### master:
- **passed**: 738 
- **failed**:  34
- **skipped**: 133 (THOROUGH)

#### this:
- **passed**: 771
- **failed**: 1 
- **skipped**: 133