### PR TITLE
[python] use strchr for single-char membership tests

### DIFF
--- a/regression/python/github_2932/main.py
+++ b/regression/python/github_2932/main.py
@@ -1,0 +1,6 @@
+def foo(s: str) -> None:
+    l: list[str] = ['a', 'b', 'c']
+    for ss in l:
+        assert ss not in s
+
+foo("foo")

--- a/regression/python/github_2932/test.desc
+++ b/regression/python/github_2932/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2932_2/main.py
+++ b/regression/python/github_2932_2/main.py
@@ -1,0 +1,4 @@
+s: str = "foo"
+l: list[str] = ['a', 'b', 'c']
+for ss in l:
+    assert ss not in s

--- a/regression/python/github_2932_2/test.desc
+++ b/regression/python/github_2932_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2932_2_fail/main.py
+++ b/regression/python/github_2932_2_fail/main.py
@@ -1,0 +1,4 @@
+s: str = "foo"
+l: list[str] = ['a', 'b', 'c']
+for ss in l:
+    assert ss in s

--- a/regression/python/github_2932_2_fail/test.desc
+++ b/regression/python/github_2932_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/github_2932_fail/main.py
+++ b/regression/python/github_2932_fail/main.py
@@ -1,0 +1,6 @@
+def foo(s: str) -> None:
+    l: list[str] = ['a', 'b', 'c']
+    for ss in l:
+        assert ss in s
+
+foo("foo")

--- a/regression/python/github_2932_fail/test.desc
+++ b/regression/python/github_2932_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -152,6 +152,7 @@ const static std::vector<std::string> python_c_models = {
   "ldexp",
   "log1p_taylor",
   "strstr",
+  "strchr",
   "list_contains",
   "__python_str_isdigit",
   "__python_str_isalpha",

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1435,8 +1435,14 @@ exprt python_converter::handle_membership_operator(
     return invert ? not_exprt(contains_expr) : contains_expr;
   }
 
+  // Get string type identifiers
+  std::string lhs_type = type_handler_.type_to_string(lhs.type());
+  std::string rhs_type = type_handler_.type_to_string(rhs.type());
+
   // Handle string membership testing: "substr" in "string" or "substr" not in "string"
-  if (lhs.type().is_array() || rhs.type().is_array())
+  if (
+    lhs.type().is_array() || rhs.type().is_array() || lhs_type == "str" ||
+    rhs_type == "str")
   {
     exprt membership_expr =
       string_handler_.handle_string_membership(lhs, rhs, element);

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -872,7 +872,88 @@ exprt string_handler::handle_string_membership(
   exprt &rhs,
   const nlohmann::json &element)
 {
-  // Convert both operands to proper null-terminated strings
+  bool lhs_is_char_value = false;
+
+  // Get the width of char type from config
+  std::size_t char_width = config.ansi_c.char_width;
+
+  // Check if lhs is a pointer to a single character
+  if (lhs.type().is_pointer())
+  {
+    const typet &subtype = lhs.type().subtype();
+    if (
+      (subtype.is_signedbv() || subtype.is_unsignedbv()) &&
+      bv_width(subtype) == char_width)
+    {
+      lhs_is_char_value = true;
+    }
+  }
+
+  // Check if lhs is a symbol holding a character value
+  if (!lhs_is_char_value && lhs.is_symbol())
+  {
+    const symbolt *sym =
+      symbol_table_.find_symbol(lhs.get_string("identifier"));
+    if (sym)
+    {
+      const typet &value_type = sym->value.type();
+      if (
+        (value_type.is_signedbv() || value_type.is_unsignedbv()) &&
+        bv_width(value_type) == char_width)
+      {
+        lhs_is_char_value = true;
+      }
+    }
+  }
+
+  // Use strchr for single character membership testing
+  if (lhs_is_char_value)
+  {
+    symbolt *strchr_symbol = symbol_table_.find_symbol("c:@F@strchr");
+    if (!strchr_symbol)
+    {
+      // Create strchr symbol if it doesn't exist
+      symbolt new_symbol;
+      new_symbol.name = "strchr";
+      new_symbol.id = "c:@F@strchr";
+      new_symbol.mode = "C";
+      new_symbol.is_extern = true;
+
+      code_typet strchr_type;
+      typet char_ptr = gen_pointer_type(char_type());
+      strchr_type.return_type() = char_ptr;
+      strchr_type.arguments().push_back(code_typet::argumentt(char_ptr));
+      strchr_type.arguments().push_back(code_typet::argumentt(int_type()));
+      new_symbol.type = strchr_type;
+
+      symbol_table_.add(new_symbol);
+      strchr_symbol = symbol_table_.find_symbol("c:@F@strchr");
+    }
+
+    exprt rhs_str = ensure_null_terminated_string(rhs);
+    exprt rhs_addr = get_array_base_address(rhs_str);
+
+    // lhs contains the character value (as void*), cast directly to int
+    typecast_exprt char_as_int(lhs, int_type());
+
+    // Call strchr(string, character)
+    side_effect_expr_function_callt strchr_call;
+    strchr_call.function() = symbol_expr(*strchr_symbol);
+    strchr_call.arguments() = {rhs_addr, char_as_int};
+    strchr_call.location() = converter_.get_location_from_decl(element);
+    strchr_call.type() = gen_pointer_type(char_type());
+
+    // Check if result != NULL (character found)
+    constant_exprt null_ptr(gen_pointer_type(char_type()));
+    null_ptr.set_value("NULL");
+
+    exprt not_equal("notequal", bool_type());
+    not_equal.copy_to_operands(strchr_call, null_ptr);
+
+    return not_equal;
+  }
+
+  // Use strstr for substring membership testing
   exprt lhs_str = ensure_null_terminated_string(lhs);
   exprt rhs_str = ensure_null_terminated_string(rhs);
 
@@ -888,15 +969,14 @@ exprt string_handler::handle_string_membership(
   // Call strstr(haystack, needle) - in Python "needle in haystack"
   side_effect_expr_function_callt strstr_call;
   strstr_call.function() = symbol_expr(*strstr_symbol);
-  strstr_call.arguments() = {
-    rhs_addr, lhs_addr}; // haystack is rhs, needle is lhs
+  strstr_call.arguments() = {rhs_addr, lhs_addr};
   strstr_call.location() = converter_.get_location_from_decl(element);
   strstr_call.type() = gen_pointer_type(char_type());
 
-  // Check if result != NULL (substring found)
   constant_exprt null_ptr(gen_pointer_type(char_type()));
   null_ptr.set_value("NULL");
 
+  // Check if result != NULL (substring found)
   exprt not_equal("notequal", bool_type());
   not_equal.copy_to_operands(strstr_call, null_ptr);
 

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -969,14 +969,15 @@ exprt string_handler::handle_string_membership(
   // Call strstr(haystack, needle) - in Python "needle in haystack"
   side_effect_expr_function_callt strstr_call;
   strstr_call.function() = symbol_expr(*strstr_symbol);
-  strstr_call.arguments() = {rhs_addr, lhs_addr};
+  strstr_call.arguments() = {
+    rhs_addr, lhs_addr}; // haystack is rhs, needle is lhs
   strstr_call.location() = converter_.get_location_from_decl(element);
   strstr_call.type() = gen_pointer_type(char_type());
 
+  // Check if result != NULL (substring found)
   constant_exprt null_ptr(gen_pointer_type(char_type()));
   null_ptr.set_value("NULL");
 
-  // Check if result != NULL (substring found)
   exprt not_equal("notequal", bool_type());
   not_equal.copy_to_operands(strstr_call, null_ptr);
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2932.

When testing membership of single characters from `list[str]` (e.g., 'a' not in "foo"), the converter was incorrectly using `strstr`, which expects two string pointers. Single characters from lists are stored as `void*` cast from `char` values.

This PR:
- Detects single-char values in `handle_string_membership` by checking if symbol holds char values.
- Uses `strchr(string, char)` instead of `strstr(string, string)` for single-character membership tests.
- Adds `strchr` to `python_c_models` whitelist.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
