### PR TITLE
Use __ESBMC_alloca instead of malloc in list.c

### DIFF
--- a/regression/python/bounds-checking_fail/test.desc
+++ b/regression/python/bounds-checking_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---no-pointer-check --force-malloc-success --ir
+--no-pointer-check  --ir
 ^\s*index\s*<\s*l->size\s*$

--- a/regression/python/builtin1/test.desc
+++ b/regression/python/builtin1/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 main.py
---no-pointer-check --force-malloc-success
+--no-pointer-check 
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes5/test.desc
+++ b/regression/python/bytes5/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 main.py
---no-pointer-check --force-malloc-success
+--no-pointer-check 
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate1/test.desc
+++ b/regression/python/enumerate1/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --ir
+ --unwind 9 --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate11/test.desc
+++ b/regression/python/enumerate11/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate11_fail/test.desc
+++ b/regression/python/enumerate11_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/enumerate15/test.desc
+++ b/regression/python/enumerate15/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate15_fail/test.desc
+++ b/regression/python/enumerate15_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/enumerate16/test.desc
+++ b/regression/python/enumerate16/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate16_fail/test.desc
+++ b/regression/python/enumerate16_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/enumerate1_fail/test.desc
+++ b/regression/python/enumerate1_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --ir
+ --unwind 9 --ir
 ^VERIFICATION FAILED$

--- a/regression/python/enumerate2/test.desc
+++ b/regression/python/enumerate2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate2_fail/test.desc
+++ b/regression/python/enumerate2_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/enumerate6/test.desc
+++ b/regression/python/enumerate6/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate7_fail/test.desc
+++ b/regression/python/enumerate7_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/enumerate9/test.desc
+++ b/regression/python/enumerate9/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop11/test.desc
+++ b/regression/python/for-loop11/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop12/test.desc
+++ b/regression/python/for-loop12/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop12_fail/test.desc
+++ b/regression/python/for-loop12_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop13/test.desc
+++ b/regression/python/for-loop13/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --ir
+ --unwind 9 --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop2/test.desc
+++ b/regression/python/for-loop2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop2_fail/test.desc
+++ b/regression/python/for-loop2_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop5/test.desc
+++ b/regression/python/for-loop5/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop7_fail/test.desc
+++ b/regression/python/for-loop7_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop9/test.desc
+++ b/regression/python/for-loop9/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param2/test.desc
+++ b/regression/python/infer-func-param2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param2_fail/test.desc
+++ b/regression/python/infer-func-param2_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --ir
+ --unwind 9 --ir
 ^VERIFICATION FAILED$

--- a/regression/python/is5/test.desc
+++ b/regression/python/is5/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check --ir
+ --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/len-list/test.desc
+++ b/regression/python/len-list/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 main.py
---force-malloc-success --incremental-bmc
+ --incremental-bmc
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-append/test.desc
+++ b/regression/python/list-append/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check
+ --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-concat-fail/test.desc
+++ b/regression/python/list-concat-fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
---incremental-bmc --force-malloc-success
+--incremental-bmc 
 
 ^VERIFICATION FAILED$

--- a/regression/python/list-concat/test.desc
+++ b/regression/python/list-concat/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
---incremental-bmc --force-malloc-success
+--incremental-bmc 
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-insert/test.desc
+++ b/regression/python/list-insert/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---unwind 25 --force-malloc-success
+--unwind 25 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-insert_fail/test.desc
+++ b/regression/python/list-insert_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---unwind 25 --force-malloc-success
+--unwind 25 
 ^VERIFICATION FAILED$

--- a/regression/python/list-mult-dim-fail/test.desc
+++ b/regression/python/list-mult-dim-fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --ir
+ --unwind 9 --ir
 ^VERIFICATION FAILED$

--- a/regression/python/list-mult-dim/test.desc
+++ b/regression/python/list-mult-dim/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-repetition/test.desc
+++ b/regression/python/list-repetition/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --no-pointer-check --no-bounds-check --ir
+ --unwind 9 --no-pointer-check --no-bounds-check --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-with-char_fail/test.desc
+++ b/regression/python/list-with-char_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---multi-property --force-malloc-success --unwind 3
+--multi-property  --unwind 3
 ^Properties\: 44 verified ✓ 42 passed, ✗ 2 failed$

--- a/regression/python/list/test.desc
+++ b/regression/python/list/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---unwind 9 --force-malloc-success
+--unwind 9 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list10/test.desc
+++ b/regression/python/list10/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list12/test.desc
+++ b/regression/python/list12/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list14/test.desc
+++ b/regression/python/list14/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 10
+ --unwind 10
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list17/test.desc
+++ b/regression/python/list17/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check
+ --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list20/test.desc
+++ b/regression/python/list20/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list6/test.desc
+++ b/regression/python/list6/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 10
+ --unwind 10
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list7-fail/test.desc
+++ b/regression/python/list7-fail/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
---incremental-bmc --force-malloc-success
+--incremental-bmc 
 
 ^VERIFICATION FAILED$

--- a/regression/python/list7/test.desc
+++ b/regression/python/list7/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/question_1_002/test.desc
+++ b/regression/python/question_1_002/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/question_1_002_fail/test.desc
+++ b/regression/python/question_1_002_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/return4/test.desc
+++ b/regression/python/return4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return4_fail/test.desc
+++ b/regression/python/return4_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/search1/test.desc
+++ b/regression/python/search1/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/search1_fail/test.desc
+++ b/regression/python/search1_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9
+ --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/search2/test.desc
+++ b/regression/python/search2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --no-pointer-check --no-bounds-check --unwind 9 --ir
+ --no-pointer-check --no-bounds-check --unwind 9 --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/search2_fail/test.desc
+++ b/regression/python/search2_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --ir
+ --unwind 9 --ir
 ^VERIFICATION FAILED$

--- a/regression/python/search4/test.desc
+++ b/regression/python/search4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check --ir
+ --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check --ir
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/search4_fail/test.desc
+++ b/regression/python/search4_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9  --no-pointer-check --no-unwinding-assertions --ir
+ --unwind 9  --no-pointer-check --no-unwinding-assertions --ir
 ^VERIFICATION FAILED$

--- a/regression/python/slicing-bounds-fail/test.desc
+++ b/regression/python/slicing-bounds-fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
---force-malloc-success --incremental-bmc
+ --incremental-bmc
 
 ^ERROR: List out of bounds at\b

--- a/regression/python/slicing-fail/test.desc
+++ b/regression/python/slicing-fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --no-pointer-check --no-bounds-check --unwind 9
+ --no-pointer-check --no-bounds-check --unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/slicing/test.desc
+++ b/regression/python/slicing/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---force-malloc-success --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check
+ --unwind 9 --no-pointer-check --no-bounds-check --no-div-by-zero-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -175,7 +175,7 @@ static inline bool list_pop(List *l)
 {
   if (l->size == 0)
     return false;
-  l->size--;  
+  l->size--;
   return true;
 }
 

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -19,7 +19,7 @@ typedef struct
 /* ---------- create ---------- */
 static inline List *list_create(Object *backing)
 {
-  List *l = malloc(sizeof(List));
+  List *l = __ESBMC_alloca(sizeof(List));
 
   __ESBMC_assume(l != NULL);
 
@@ -111,10 +111,7 @@ static inline bool list_push(List *l, const void *value, size_t type_id)
 static inline bool
 list_push(List *l, const void *value, size_t type_id, size_t type_size)
 {
-  void *copied_value = malloc(type_size);
-
-  // Force malloc to succeed for verification
-  __ESBMC_assume(copied_value != NULL);
+  void *copied_value = __ESBMC_alloca(type_size);
 
   memcpy(copied_value, value, type_size);
 
@@ -145,8 +142,7 @@ static inline bool list_insert(
     return list_push(l, value, type_id, type_size);
 
   // Make a copy of the value
-  void *copied_value = malloc(type_size);
-  __ESBMC_assume(copied_value != NULL);
+  void *copied_value = __ESBMC_alloca(type_size);
   memcpy(copied_value, value, type_size);
 
   // Shift all elements from index onwards one position to the right
@@ -234,8 +230,7 @@ static inline void list_extend(List *l, const List *other)
   {
     const Object *elem = &other->items[i];
 
-    void *copied_value = malloc(elem->size);
-    __ESBMC_assume(copied_value != NULL);
+    void *copied_value = __ESBMC_alloca(elem->size);
     memcpy(copied_value, elem->value, elem->size);
 
     l->items[l->size].value = copied_value;

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -175,8 +175,7 @@ static inline bool list_pop(List *l)
 {
   if (l->size == 0)
     return false;
-  l->size--;
-  free((void *)l->items[l->size].value); // Free the copied data
+  l->size--;  
   return true;
 }
 


### PR DESCRIPTION
Stack allocations:

- Always works
- Will not trigger memleaks (useful if we eventually mix C/Python code)