### PR TITLE
[python] annotate imported modules to resolve cross-module type inference

### DIFF
--- a/regression/python/github_2935/ll.py
+++ b/regression/python/github_2935/ll.py
@@ -1,0 +1,3 @@
+def foo(s: str) -> None:
+    l = ["foo", "bar", "baz"]
+    assert s in l

--- a/regression/python/github_2935/main.py
+++ b/regression/python/github_2935/main.py
@@ -1,0 +1,3 @@
+import ll
+
+ll.foo("foo")

--- a/regression/python/github_2935/test.desc
+++ b/regression/python/github_2935/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/version/test.desc
+++ b/regression/python/version/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
 
-^ERROR: Type undefined for "__version__"$
+^ERROR: Object \"importlib\.metadata\" not found.$

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -20,7 +20,7 @@ def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> i
     if string_len == 0:
         return 1 if quantifier == '*' else 0
 
-    i: int = 0
+    i = 0
     while i < string_len:
         c: str = string[i]
         if c < start_char or c > end_char:
@@ -109,27 +109,27 @@ def match(pattern: str, string: str) -> bool:
         if pattern[pattern_len - 2] == '.' and pattern[pattern_len - 1] == '*':
             prefix_len: int = pattern_len - 2
             has_meta_in_prefix: bool = False
-            i: int = 0
+            i = 0
             while i < prefix_len:
                 c: str = pattern[i]
                 if c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '(' or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\':
                     has_meta_in_prefix = True
                     break
-                i: int = i + 1
+                i = i + 1
 
             if not has_meta_in_prefix:
                 if len(string) < prefix_len:
                     return False
-                j: int = 0
+                j = 0
                 while j < prefix_len:
                     if pattern[j] != string[j]:
                         return False
-                    j: int = j + 1
+                    j = j + 1
                 return True
 
     # Check for metacharacters
     has_meta: bool = False
-    k: int = 0
+    k = 0
     while k < pattern_len - 1:
         ch: str = pattern[k]
         if ch == '.' or ch == '*' or ch == '+' or ch == '?' or ch == '[' or ch == ']' or ch == '(' or ch == ')' or ch == '|' or ch == '^' or ch == '$' or ch == '\\':
@@ -142,11 +142,11 @@ def match(pattern: str, string: str) -> bool:
         effective_pattern_len: int = pattern_len - 1
         if len(string) - 1 < effective_pattern_len:
             return False
-        m: int = 0
+        m = 0
         while m < effective_pattern_len:
             if pattern[m] != string[m]:
                 return False
-            m: int = m + 1
+            m = m + 1
         return True
 
     # Nondeterministic fallback
@@ -169,7 +169,7 @@ def search(pattern: str, string: str) -> bool:
 
     # Check if pattern contains regex metacharacters
     has_meta: bool = False
-    i: int = 0
+    i = 0
     while i < pattern_len:
         c: str = pattern[i]
         if c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '(' or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\':
@@ -183,18 +183,18 @@ def search(pattern: str, string: str) -> bool:
             return False
 
         # Try matching at each position in string
-        pos: int = 0
+        pos = 0
         while pos <= len(string) - pattern_len:
             match_found: bool = True
-            j: int = 0
+            j = 0
             while j < pattern_len:
                 if string[pos + j] != pattern[j]:
                     match_found = False
                     break
-                j: int = j + 1
+                j = j + 1
             if match_found:
                 return True
-            pos: int = pos + 1
+            pos = pos + 1
         return False
 
     # For patterns with metacharacters, use nondeterministic behavior
@@ -243,11 +243,11 @@ def fullmatch(pattern: str, string: str) -> bool:
         if len(pattern) != len(string):
             return False
 
-        j: int = 0
+        j = 0
         while j < pattern_len:
             if pattern[j] != string[j]:
                 return False
-            j: int = j + 1
+            j = j + 1
         return True
 
     # For patterns with metacharacters, use nondeterministic behavior

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -115,7 +115,7 @@ def match(pattern: str, string: str) -> bool:
                 if c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '(' or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\':
                     has_meta_in_prefix = True
                     break
-                i = i + 1
+                i: int = i + 1
 
             if not has_meta_in_prefix:
                 if len(string) < prefix_len:
@@ -124,7 +124,7 @@ def match(pattern: str, string: str) -> bool:
                 while j < prefix_len:
                     if pattern[j] != string[j]:
                         return False
-                    j = j + 1
+                    j: int = j + 1
                 return True
 
     # Check for metacharacters
@@ -146,7 +146,7 @@ def match(pattern: str, string: str) -> bool:
         while m < effective_pattern_len:
             if pattern[m] != string[m]:
                 return False
-            m = m + 1
+            m: int = m + 1
         return True
 
     # Nondeterministic fallback
@@ -191,10 +191,10 @@ def search(pattern: str, string: str) -> bool:
                 if string[pos + j] != pattern[j]:
                     match_found = False
                     break
-                j = j + 1
+                j: int = j + 1
             if match_found:
                 return True
-            pos = pos + 1
+            pos: int = pos + 1
         return False
 
     # For patterns with metacharacters, use nondeterministic behavior
@@ -247,7 +247,7 @@ def fullmatch(pattern: str, string: str) -> bool:
         while j < pattern_len:
             if pattern[j] != string[j]:
                 return False
-            j = j + 1
+            j: int = j + 1
         return True
 
     # For patterns with metacharacters, use nondeterministic behavior

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3,6 +3,7 @@
 #include <python-frontend/type_utils.h>
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/function_call_builder.h>
+#include <python-frontend/python_annotation.h>
 #include <python-frontend/python_list.h>
 #include <python-frontend/module_locator.h>
 #include <python-frontend/string_builder.h>
@@ -4945,6 +4946,11 @@ void python_converter::convert()
 
         // Create built-in symbols for imported module
         create_builtin_symbols();
+
+        // Annotate types in imported module before conversion
+        python_annotation<nlohmann::json> imported_annotator(
+          imported_module_json, const_cast<global_scope &>(global_scope_));
+        imported_annotator.add_type_annotation();
 
         exprt imported_code = with_ast(&imported_module_json, [&]() {
           return get_block(imported_module_json["body"]);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2935.

This PR annotates imported Python modules before conversion to ensure variable assignments are type-annotated. Previously, imported modules were converted directly without annotation, causing "Type undefined" errors when their functions contained unannotated assignments.

Fixes issue where calling ll.foo() from ex.py failed with:
  ERROR: Type undefined for "l"

The annotation phase now runs on imported modules, converting statements such as `l = ["foo", "bar"]` to `l: list = ["foo", "bar"]` before the converter processes them.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.