### PR TITLE
Remove C Type Hashing from Python List Implementation

### DIFF
--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -179,18 +179,6 @@ static inline bool list_pop(List *l)
   return true;
 }
 
-/* ---------- type hashing ---------- */
-static inline size_t list_hash_string(const char *str)
-{
-  size_t hash = 5381;
-  int c;
-  while ((c = *str++))
-  {
-    hash = ((hash << 5) + hash) + c;
-  }
-  return hash;
-}
-
 static bool list_contains(
   const List *l,
   const void *item,

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -65,7 +65,7 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
     op, "$list_elem_type$", size_type(), type_name_expr);
 
   // TODO: Eventually we should build a reverse index of hash => type into the context
-  // this will allow better counter examples.
+  // this will allow better verification counter-examples.
   constant_exprt hash_value(size_type());
   hash_value.set_value(integer2binary(
     std::hash<std::string>{}(elem_type_name), config.ansi_c.address_width));

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -63,15 +63,16 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   // Create and declare temporary symbol for element type
   symbolt &elem_type_sym = converter_.create_tmp_symbol(
     op, "$list_elem_type$", size_type(), type_name_expr);
- 
+
   // TODO: Eventually we should build a reverse index of hash => type into the context
   // this will allow better counter examples.
   constant_exprt hash_value(size_type());
-  hash_value.set_value(integer2binary(std::hash<std::string>{}(elem_type_name), config.ansi_c.address_width));
+  hash_value.set_value(integer2binary(
+    std::hash<std::string>{}(elem_type_name), config.ansi_c.address_width));
   code_assignt hash_assignment(symbol_expr(elem_type_sym), hash_value);
   hash_assignment.location() = location;
   converter_.add_instruction(hash_assignment);
-  
+
   // Create and declare temporary symbol for list element
   symbolt &elem_symbol =
     converter_.create_tmp_symbol(op, "$list_elem$", elem.type(), elem);


### PR DESCRIPTION
This pull request removes the custom string hashing function for list types in `list.c` and replaces its usage in the Python frontend with a standard C++ hash implementation. This change simplifies the codebase by eliminating the need to call a C hashing function from C++ and directly computes the type hash using `std::hash` in the frontend.