### PR TITLE
[python] add type annotations to loop variables in regex operational model

### DIFF
--- a/regression/python/github_2964/ll.py
+++ b/regression/python/github_2964/ll.py
@@ -1,0 +1,5 @@
+import re
+
+class Foo:
+    def __init__(self) -> None:
+        pass

--- a/regression/python/github_2964/main.py
+++ b/regression/python/github_2964/main.py
@@ -1,0 +1,1 @@
+import ll

--- a/regression/python/github_2964/test.desc
+++ b/regression/python/github_2964/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -20,7 +20,7 @@ def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> i
     if string_len == 0:
         return 1 if quantifier == '*' else 0
 
-    i = 0
+    i: int = 0
     while i < string_len:
         c: str = string[i]
         if c < start_char or c > end_char:
@@ -109,7 +109,7 @@ def match(pattern: str, string: str) -> bool:
         if pattern[pattern_len - 2] == '.' and pattern[pattern_len - 1] == '*':
             prefix_len: int = pattern_len - 2
             has_meta_in_prefix: bool = False
-            i = 0
+            i: int = 0
             while i < prefix_len:
                 c: str = pattern[i]
                 if c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '(' or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\':
@@ -120,7 +120,7 @@ def match(pattern: str, string: str) -> bool:
             if not has_meta_in_prefix:
                 if len(string) < prefix_len:
                     return False
-                j = 0
+                j: int = 0
                 while j < prefix_len:
                     if pattern[j] != string[j]:
                         return False
@@ -129,7 +129,7 @@ def match(pattern: str, string: str) -> bool:
 
     # Check for metacharacters
     has_meta: bool = False
-    k = 0
+    k: int = 0
     while k < pattern_len - 1:
         ch: str = pattern[k]
         if ch == '.' or ch == '*' or ch == '+' or ch == '?' or ch == '[' or ch == ']' or ch == '(' or ch == ')' or ch == '|' or ch == '^' or ch == '$' or ch == '\\':
@@ -142,7 +142,7 @@ def match(pattern: str, string: str) -> bool:
         effective_pattern_len: int = pattern_len - 1
         if len(string) - 1 < effective_pattern_len:
             return False
-        m = 0
+        m: int = 0
         while m < effective_pattern_len:
             if pattern[m] != string[m]:
                 return False
@@ -169,7 +169,7 @@ def search(pattern: str, string: str) -> bool:
 
     # Check if pattern contains regex metacharacters
     has_meta: bool = False
-    i = 0
+    i: int = 0
     while i < pattern_len:
         c: str = pattern[i]
         if c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '(' or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\':
@@ -183,10 +183,10 @@ def search(pattern: str, string: str) -> bool:
             return False
 
         # Try matching at each position in string
-        pos = 0
+        pos: int = 0
         while pos <= len(string) - pattern_len:
             match_found: bool = True
-            j = 0
+            j: int = 0
             while j < pattern_len:
                 if string[pos + j] != pattern[j]:
                     match_found = False
@@ -243,7 +243,7 @@ def fullmatch(pattern: str, string: str) -> bool:
         if len(pattern) != len(string):
             return False
 
-        j = 0
+        j: int = 0
         while j < pattern_len:
             if pattern[j] != string[j]:
                 return False


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2964.

Variables in simple assignments (i = 0) without type annotations cause "Type undefined" errors during conversion. 

This PR added `: int` annotations to all loop counter variables (i, j, k, m, pos) in the regex model to ensure proper type inference during the Assign statement processing.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

