### PR TITLE
[python] fix #2966: Problem of isinstance handles ternary operators 

### DIFF
--- a/regression/python/github_2966/main.py
+++ b/regression/python/github_2966/main.py
@@ -1,0 +1,8 @@
+# Test case for GitHub issue #2966
+# isinstance should work correctly with ternary operators
+from typing import Any
+
+i = 42
+x: Any = "foo" if i > 10 else i + 10
+assert isinstance(x, str)
+

--- a/regression/python/github_2966/test.desc
+++ b/regression/python/github_2966/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_2966_fail/main.py
+++ b/regression/python/github_2966_fail/main.py
@@ -1,0 +1,8 @@
+# Test case for GitHub issue #2966 (failure case)
+# isinstance should correctly fail when condition is false
+from typing import Any
+
+i = 5  # i <= 10, so x will be int, not str
+x: Any = "foo" if i > 10 else i + 10
+assert isinstance(x, str)
+

--- a/regression/python/github_2966_fail/test.desc
+++ b/regression/python/github_2966_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -306,9 +306,7 @@ exprt function_call_expr::handle_isinstance() const
         //   => cond ? isinstance(then, type) : isinstance(else, type)
         //   => cond ? then_matches : else_matches
         if_exprt result(
-          cond,
-          gen_boolean(then_matches),
-          gen_boolean(else_matches));
+          cond, gen_boolean(then_matches), gen_boolean(else_matches));
         result.type() = type_handler_.get_typet("bool", 0);
         return result;
       }
@@ -340,9 +338,7 @@ exprt function_call_expr::handle_isinstance() const
       else
       {
         if_exprt result(
-          if_expr.cond(),
-          gen_boolean(then_matches),
-          gen_boolean(else_matches));
+          if_expr.cond(), gen_boolean(then_matches), gen_boolean(else_matches));
         result.type() = type_handler_.get_typet("bool", 0);
         return result;
       }

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -260,12 +260,96 @@ exprt function_call_expr::handle_isinstance() const
   if (args.size() != 2)
     throw std::runtime_error("isinstance() expects 2 arguments");
 
-  // Convert the first argument (the object being checked) into an expression
-  exprt obj_expr = converter_.get_expr(args[0]);
+  const auto &obj_arg = args[0];
   const auto &type_arg = args[1];
 
+  // Special handling: check if the object is a variable assigned from IfExp
+  if (
+    obj_arg.contains("_type") && obj_arg["_type"] == "Name" &&
+    obj_arg.contains("id") && type_arg["_type"] == "Name")
+  {
+    std::string var_name = obj_arg["id"].get<std::string>();
+    nlohmann::json var_decl = json_utils::find_var_decl(
+      var_name, converter_.current_function_name(), converter_.ast());
+
+    // Check if variable is assigned from a ternary operator (IfExp)
+    if (
+      !var_decl.empty() && var_decl.contains("value") &&
+      var_decl["value"].contains("_type") &&
+      var_decl["value"]["_type"] == "IfExp")
+    {
+      const auto &ifexp = var_decl["value"];
+
+      // Convert the condition and branches directly from AST
+      exprt cond = converter_.get_expr(ifexp["test"]);
+      exprt then_expr = converter_.get_expr(ifexp["body"]);
+      exprt else_expr = converter_.get_expr(ifexp["orelse"]);
+
+      // Check if each branch matches the type
+      bool then_matches = is_same_type(then_expr, type_arg);
+      bool else_matches = is_same_type(else_expr, type_arg);
+
+      if (then_matches && else_matches)
+      {
+        // Both branches match - always return true
+        return gen_boolean(true);
+      }
+      else if (!then_matches && !else_matches)
+      {
+        // Neither branch matches - always return false
+        return gen_boolean(false);
+      }
+      else
+      {
+        // One branch matches, one doesn't - generate runtime check
+        // isinstance(x, type) where x = (cond ? then : else)
+        //   => cond ? isinstance(then, type) : isinstance(else, type)
+        //   => cond ? then_matches : else_matches
+        if_exprt result(
+          cond,
+          gen_boolean(then_matches),
+          gen_boolean(else_matches));
+        result.type() = type_handler_.get_typet("bool", 0);
+        return result;
+      }
+    }
+  }
+
+  // Convert the first argument (the object being checked) into an expression
+  exprt obj_expr = converter_.get_expr(obj_arg);
+
   if (type_arg["_type"] == "Name")
+  {
+    // Check if the expression itself is an if expression
+    if (obj_expr.id() == "if")
+    {
+      const if_exprt &if_expr = to_if_expr(obj_expr);
+
+      // Check if each branch matches the type
+      bool then_matches = is_same_type(if_expr.true_case(), type_arg);
+      bool else_matches = is_same_type(if_expr.false_case(), type_arg);
+
+      if (then_matches && else_matches)
+      {
+        return gen_boolean(true);
+      }
+      else if (!then_matches && !else_matches)
+      {
+        return gen_boolean(false);
+      }
+      else
+      {
+        if_exprt result(
+          if_expr.cond(),
+          gen_boolean(then_matches),
+          gen_boolean(else_matches));
+        result.type() = type_handler_.get_typet("bool", 0);
+        return result;
+      }
+    }
+
     return gen_boolean(is_same_type(obj_expr, type_arg));
+  }
   else if (type_arg["_type"] == "Tuple")
   {
     const auto &elts = type_arg["elts"];


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2966.

## Description

Fixes `isinstance()` incorrectly failing when checking variables assigned from ternary operators with mixed types.

**Example:**
```python
from typing import Any
i = 42
x: Any = "foo" if i > 10 else i + 10
assert isinstance(x, str)  # Was: ASSERT 0, Now: runtime check
```

## Solution

Modified `handle_isinstance()` to detect IfExp assignments and generate runtime type checks instead of static `ASSERT 0`:
- Both branches match → `ASSERT 1` 
- Neither matches → `ASSERT 0`
- Mixed → `ASSERT (cond ? true : false)` 

## Testing

Added regression tests:
- `regression/python/github_2966/` (pass case)
- `regression/python/github_2966_fail/` (fail case)




