### PR TITLE
[python] Crash when __init__ calls a method defined later

### DIFF
--- a/regression/python/github_2962/main.py
+++ b/regression/python/github_2962/main.py
@@ -1,0 +1,8 @@
+class Foo:
+    def __init__(self) -> None:
+        self._init_members()
+
+    def _init_members(self) -> None:
+        pass
+
+f = Foo()

--- a/regression/python/github_2962/test.desc
+++ b/regression/python/github_2962/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2962_fail/main.py
+++ b/regression/python/github_2962_fail/main.py
@@ -1,0 +1,10 @@
+# Test for Issue #2962: Method is properly executed and can fail
+# Verifies that _init_members() called from __init__ actually runs
+class Foo:
+    def __init__(self) -> None:
+        self._init_members()
+
+    def _init_members(self) -> None:
+        assert False  # Should fail here, proving method was executed
+
+f = Foo()

--- a/regression/python/github_2962_fail/test.desc
+++ b/regression/python/github_2962_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1640,14 +1640,48 @@ exprt function_call_expr::handle_general_function_call()
       }
       else if (function_type_ == FunctionType::InstanceMethod)
       {
-        assert(obj_symbol);
-        assert(func_symbol);
+        if (obj_symbol && func_symbol)
+        {
+          converter_.update_instance_from_self(
+            get_classname_from_symbol_id(func_symbol->id.as_string()),
+            function_id_.get_function(),
+            obj_symbol_id.to_string());
+        }
+        
+        // Handle forward reference: method not yet in symbol table
+        if (!func_symbol)
+        {
+          locationt location = converter_.get_location_from_decl(call_);
+          code_function_callt call;
+          call.location() = location;
+          call.function() = symbol_exprt(func_symbol_id, code_typet());
+          call.type() = empty_typet();
 
-        // Update obj attributes from self
-        converter_.update_instance_from_self(
-          get_classname_from_symbol_id(func_symbol->id.as_string()),
-          function_id_.get_function(),
-          obj_symbol_id.to_string());
+          if (obj_symbol)
+            call.arguments().push_back(gen_address_of(symbol_expr(*obj_symbol)));
+
+          for (const auto &arg_node : call_["args"])
+          {
+            exprt arg = converter_.get_expr(arg_node);
+            if (arg.type().is_array())
+            {
+              if (
+                arg_node["_type"] == "Constant" &&
+                arg_node["value"].is_string())
+              {
+                arg = string_constantt(
+                  arg_node["value"].get<std::string>(),
+                  arg.type(),
+                  string_constantt::k_default);
+              }
+              call.arguments().push_back(address_of_exprt(arg));
+            }
+            else
+              call.arguments().push_back(arg);
+          }
+
+          return std::move(call);
+        }
       }
     }
     else

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1647,7 +1647,7 @@ exprt function_call_expr::handle_general_function_call()
             function_id_.get_function(),
             obj_symbol_id.to_string());
         }
-        
+
         // Handle forward reference: method not yet in symbol table
         if (!func_symbol)
         {
@@ -1658,7 +1658,8 @@ exprt function_call_expr::handle_general_function_call()
           call.type() = empty_typet();
 
           if (obj_symbol)
-            call.arguments().push_back(gen_address_of(symbol_expr(*obj_symbol)));
+            call.arguments().push_back(
+              gen_address_of(symbol_expr(*obj_symbol)));
 
           for (const auto &arg_node : call_["args"])
           {


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2962.

### Problem
ESBMC crashes with segmentation fault when a Python class's `__init__` method calls an instance method defined later in the class:
```python
class Foo:
    def __init__(self):
        self._init_members()  # ← Crash: _init_members not yet in symbol table
    
    def _init_members(self):
        pass
```

### Root Cause
The Python frontend processes class methods **sequentially in definition order**. When processing the `__init__` method body, subsequent methods like `_init_members` have not yet been added to the symbol table. This causes `func_symbol` to be `nullptr`, triggering either an `assert` failure or null pointer dereference.

**Why C++ doesn't have this problem:** The C++ frontend uses Clang, which performs complete semantic analysis before ESBMC conversion. Clang scans all method declarations in a class first (building the complete symbol table), then processes method bodies. This two-phase approach naturally handles forward references.

### Solution
When an instance method symbol is not found, create a **forward reference**:
- Use the symbol ID to create `symbol_exprt` (doesn't require the symbol to exist yet)
- Defer symbol resolution to the linking phase
- Return immediately to avoid null pointer dereference

This approach mimics how compilers (including Clang) handle forward references.

### Future Improvements
A more fundamental solution would be **two-phase class processing**:
Register all method signatures (build complete symbol table). Then, process method bodies (all symbols now available)

This matches the standard compiler design but requires a refactoring development on the python frontend I guess.
