### PR TITLE
[SV-COMP] support thread local for data races check

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -516,6 +516,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   symbol.is_extern = vd.hasExternalStorage();
   symbol.file_local = (vd.getStorageClass() == clang::SC_Static) ||
                       (!vd.isExternallyVisible() && !vd.hasGlobalStorage());
+  symbol.is_thread_local = vd.getTLSKind() != clang::VarDecl::TLS_None;
 
   if (
     symbol.static_lifetime &&

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -79,7 +79,8 @@ void rw_sett::read_write_rec(
     const symbolt *symbol = ns.lookup(symbol_expr.get_identifier());
     if (symbol)
     {
-      if (!symbol->static_lifetime && !dereferenced)
+      if (
+        (!symbol->static_lifetime && !dereferenced) || symbol->is_thread_local)
       {
         return; // ignore for now
       }

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -531,6 +531,7 @@ const irep_idt irept::a_is_parameter = dstring("is_parameter");
 const irep_idt irept::a_is_expression = dstring("#is_expression");
 const irep_idt irept::a_is_extern = dstring("is_extern");
 const irep_idt irept::a_is_macro = dstring("is_macro");
+const irep_idt irept::a_is_thread_local = dstring("is_thread_local");
 const irep_idt irept::a_is_type = dstring("is_type");
 const irep_idt irept::a_cmt_lvalue = dstring("#lvalue");
 const irep_idt irept::a_lvalue = dstring("lvalue");

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -582,6 +582,11 @@ public:
     return get_bool(a_is_macro);
   }
 
+  inline bool is_thread_local() const
+  {
+    return get_bool(a_is_thread_local);
+  }
+
   inline bool is_type() const
   {
     return get_bool(a_is_type);
@@ -915,6 +920,11 @@ public:
   inline void is_macro(bool val)
   {
     set(a_is_macro, val);
+  }
+
+  inline void is_thread_local(bool val)
+  {
+    set(a_is_thread_local, val);
   }
 
   inline void is_type(bool val)
@@ -1274,7 +1284,7 @@ public:
   static const irep_idt a_hex_or_oct, a_hide, a_implicit, a_incomplete;
   static const irep_idt a_initialization, a_inlined, a_invalid_object;
   static const irep_idt a_is_parameter, a_is_expression;
-  static const irep_idt a_is_extern, a_is_macro;
+  static const irep_idt a_is_extern, a_is_macro, a_is_thread_local;
   static const irep_idt a_is_type, a_cmt_lvalue;
   static const irep_idt a_lvalue, a_reference, a_static_lifetime, a_theorem;
   static const irep_idt a_cmt_unsigned, a_user_provided, a_cmt_volatile;

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -48,6 +48,8 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
       out << " extern";
     if (s.is_macro)
       out << " macro";
+    if (s.is_thread_local)
+      out << " is_thread_local";
 
     out << "\n";
     out << "Location....: " << s.location << "\n";

--- a/src/util/symbol.cpp
+++ b/src/util/symbol.cpp
@@ -12,7 +12,7 @@ void symbolt::clear()
   value.make_nil();
   location.make_nil();
   lvalue = static_lifetime = file_local = is_extern = is_type = is_parameter =
-    is_macro = false;
+    is_macro = is_thread_local = false;
   id = module = name = mode = "";
 }
 
@@ -37,6 +37,7 @@ void symbolt::swap(symbolt &b)
   SYM_SWAP2(static_lifetime);
   SYM_SWAP2(file_local);
   SYM_SWAP2(is_extern);
+  SYM_SWAP2(is_thread_local);
 }
 
 void symbolt::dump() const
@@ -72,6 +73,8 @@ void symbolt::show(std::ostream &out) const
     out << " extern";
   if (is_macro)
     out << " macro";
+  if (is_thread_local)
+    out << " is_thread_local";
 
   out << "\n";
   out << "Location....: " << location << "\n";
@@ -110,6 +113,8 @@ void symbolt::to_irep(irept &dest) const
     dest.file_local(true);
   if (is_extern)
     dest.is_extern(true);
+  if (is_thread_local)
+    dest.is_thread_local(true);
 }
 
 void symbolt::from_irep(const irept &src)
@@ -130,6 +135,7 @@ void symbolt::from_irep(const irept &src)
   static_lifetime = src.static_lifetime();
   file_local = src.file_local();
   is_extern = src.is_extern();
+  is_thread_local = src.is_thread_local();
 }
 
 irep_idt symbolt::get_function_name() const

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -23,7 +23,7 @@ public:
   bool is_type, is_macro, is_parameter;
 
   // ANSI-C
-  bool lvalue, static_lifetime, file_local, is_extern;
+  bool lvalue, static_lifetime, file_local, is_extern, is_thread_local;
 
   symbolt();
 


### PR DESCRIPTION
A thread-local variable is stored per thread, so each thread accesses its own private value instead of sharing it with other threads.

Although this PR does not actually support thread local, it does not suffer from a data race in a data race check.