### PR TITLE
[python] add minimal set support

### DIFF
--- a/regression/python/github_2965/main.py
+++ b/regression/python/github_2965/main.py
@@ -1,0 +1,2 @@
+s: set[str] = { 'foo', 'bar' }
+assert 'foo' in s

--- a/regression/python/github_2965/test.desc
+++ b/regression/python/github_2965/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_fail/main.py
+++ b/regression/python/github_2965_fail/main.py
@@ -1,0 +1,2 @@
+s: set[str] = { 'foo', 'bar' }
+assert 'test' in s

--- a/regression/python/github_2965_fail/test.desc
+++ b/regression/python/github_2965_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2965_set_unique/main.py
+++ b/regression/python/github_2965_set_unique/main.py
@@ -1,0 +1,8 @@
+s: set[int] = { 1, 2, 1 }
+assert 1 in s
+
+a = 0
+for x in s:
+  a = a + x
+
+assert a == 3

--- a/regression/python/github_2965_set_unique/test.desc
+++ b/regression/python/github_2965_set_unique/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_set_unique/test.desc
+++ b/regression/python/github_2965_set_unique/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_set_unique_fail/main.py
+++ b/regression/python/github_2965_set_unique_fail/main.py
@@ -1,0 +1,8 @@
+s: set[int] = { 1, 2, 1 }
+assert 1 in s
+
+a = 0
+for x in s:
+  a = a + x
+
+assert a == 4

--- a/regression/python/github_2965_set_unique_fail/test.desc
+++ b/regression/python/github_2965_set_unique_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2965_set_unique_fail/test.desc
+++ b/regression/python/github_2965_set_unique_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -182,6 +182,7 @@ static ExpressionType get_expression_type(const nlohmann::json &element)
     {"IfExp", ExpressionType::IF_EXPR},
     {"Subscript", ExpressionType::SUBSCRIPT},
     {"List", ExpressionType::LIST},
+    {"Set", ExpressionType::LIST},
     {"Lambda", ExpressionType::FUNC_CALL},
     {"JoinedStr", ExpressionType::FSTRING},
     {"Tuple", ExpressionType::TUPLE}};
@@ -1437,7 +1438,8 @@ exprt python_converter::handle_membership_operator(
 {
   typet list_type = type_handler_.get_list_type();
 
-  // Handle list membership: "item" in [list] or "item" not in [list]
+  // Handle set/list membership:
+  // "item" in [list/set] or "item" not in [list/set]
   if (rhs.type() == list_type)
   {
     python_list list(*this, element);
@@ -2368,15 +2370,31 @@ exprt python_converter::get_expr(const nlohmann::json &element)
   }
   case ExpressionType::LIST:
   {
-    if (build_static_lists)
+    // Handle both List and Set
+    if (element["_type"] == "Set")
     {
-      typet size = type_handler_.get_typet(element["elts"]);
-      return get_static_array(element, size);
+      // For now, treat set literals such as lists
+      // Store elements in order they appear (order doesn't matter for sets)
+      if (build_static_lists)
+      {
+        typet size = type_handler_.get_typet(element["elts"]);
+        return get_static_array(element, size);
+      }
+
+      python_list list(*this, element);
+      expr = list.get();
     }
+    else
+    {
+      if (build_static_lists)
+      {
+        typet size = type_handler_.get_typet(element["elts"]);
+        return get_static_array(element, size);
+      }
 
-    python_list list(*this, element);
-    expr = list.get();
-
+      python_list list(*this, element);
+      expr = list.get();
+    }
     break;
   }
   case ExpressionType::VARIABLE_REF:

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2370,31 +2370,15 @@ exprt python_converter::get_expr(const nlohmann::json &element)
   }
   case ExpressionType::LIST:
   {
-    // Handle both List and Set
-    if (element["_type"] == "Set")
+    // For now, treat set literals such as lists
+    // Store elements in order they appear (order doesn't matter for sets)
+    if (build_static_lists)
     {
-      // For now, treat set literals such as lists
-      // Store elements in order they appear (order doesn't matter for sets)
-      if (build_static_lists)
-      {
-        typet size = type_handler_.get_typet(element["elts"]);
-        return get_static_array(element, size);
-      }
-
-      python_list list(*this, element);
-      expr = list.get();
+      typet size = type_handler_.get_typet(element["elts"]);
+      return get_static_array(element, size);
     }
-    else
-    {
-      if (build_static_lists)
-      {
-        typet size = type_handler_.get_typet(element["elts"]);
-        return get_static_array(element, size);
-      }
-
-      python_list list(*this, element);
-      expr = list.get();
-    }
+    python_list list(*this, element);
+    expr = list.get(element["_type"] == "Set");
     break;
   }
   case ExpressionType::VARIABLE_REF:

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -401,19 +401,26 @@ symbolt &python_list::create_list()
   return list_symbol;
 }
 
-exprt python_list::get()
+exprt python_list::get(bool is_set)
 {
   symbolt &list_symbol = create_list();
+  list_symbol.is_set = true;
+
   const std::string &list_id = list_symbol.id.as_string();
 
+  // TODO: if same element is added indirectly this will fail
+  //       e.g. (2, 1+1)
+  std::set<exprt> elements;
   for (auto &e : list_value_["elts"])
   {
     exprt elem = converter_.get_expr(e);
+    if (is_set && elements.count(elem))
+      continue;
+
+    elements.insert(elem);
     exprt list_push_func_call =
       build_push_list_call(list_symbol, list_value_, elem);
-
     converter_.add_instruction(list_push_func_call);
-
     list_type_map[list_id].push_back(
       std::make_pair(elem.identifier().as_string(), elem.type()));
   }

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -29,7 +29,7 @@ public:
   {
   }
 
-  exprt get();
+  exprt get(bool is_set = false);
 
   exprt index(const exprt &array, const nlohmann::json &slice_node);
 

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -279,6 +279,10 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "tuple")
     return empty_typet();
 
+  // Reuse list infrastructure for simplicity for now
+  if (ast_type == "set")
+    return get_list_type();
+
   // Custom user-defined types / classes
   if (
     json_utils::is_class(ast_type, converter_.ast()) ||

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -66,8 +66,9 @@ public:
       name == "chr" || name == "hex" || name == "oct" || name == "ord" ||
       name == "abs" || name == "tuple" || name == "list" || name == "dict" ||
       name == "set" || name == "frozenset" || name == "bytes" ||
-      name == "bytearray" || name == "range" || name == "complex" ||
-      name == "type" || name == "object" || name == "None");
+      name == "set" || name == "bytearray" || name == "range" ||
+      name == "complex" || name == "type" || name == "object" ||
+      name == "None");
   }
 
   static bool is_consensus_type(const std::string &name)

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -25,6 +25,9 @@ public:
   // ANSI-C
   bool lvalue, static_lifetime, file_local, is_extern;
 
+  // For python use
+  bool is_set;
+
   symbolt();
 
   void clear();


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2965.

This PR implements basic set literal and membership testing support by treating sets as lists internally. This allows verification of simple set membership assertions such as `assert 'foo' in s`.

Limitations (according to https://docs.python.org/3/library/sets.html):
- No set operations (add, remove, union, intersection, difference, etc.)
- O(n) membership testing instead of O(1)
- Insertion order preserved (in contrast to Python sets)

Sets reuse the existing list infrastructure for simplicity for now.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for requesting this feature.