### PR TITLE
[python] add visit_AnnAssign to track type annotations in preprocessor

### DIFF
--- a/regression/python/github_2986/main.py
+++ b/regression/python/github_2986/main.py
@@ -1,0 +1,3 @@
+s: str = "foo"
+for c in s:
+    assert c != 'a'

--- a/regression/python/github_2986/test.desc
+++ b/regression/python/github_2986/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2986_fail/main.py
+++ b/regression/python/github_2986_fail/main.py
@@ -1,0 +1,3 @@
+s: str = "foo"
+for c in s:
+    assert c == 'a'

--- a/regression/python/github_2986_fail/test.desc
+++ b/regression/python/github_2986_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1018,6 +1018,19 @@ class Preprocessor(ast.NodeTransformer):
                     assignments.append(individual_assign)
             return assignments
 
+    def visit_AnnAssign(self, node):
+        """Track type annotations from annotated assignments like x: int = 5"""
+        # First visit child nodes
+        self.generic_visit(node)
+
+        # Track the type if target is a simple Name and has annotation
+        if isinstance(node.target, ast.Name) and node.annotation is not None:
+            var_name = node.target.id
+            var_type = self._extract_type_from_annotation(node.annotation)
+            self.known_variable_types[var_name] = var_type
+
+        return node
+
 
     # This method is responsible for visiting and transforming Call nodes in the AST.
     def visit_Call(self, node):


### PR DESCRIPTION
Partially fixes https://github.com/esbmc/esbmc/issues/2986.

The preprocessor was not tracking type annotations from annotated assignments (e.g., s: str = "foo"), causing it to misidentify string variables as lists during for-loop transformations. This led to incorrect code generation and crashes in ESBMC.

This PR adds the `visit_AnnAssign` method to tracks variable types from annotated assignments, ensuring correct type inference for string iteration and other type-dependent transformations.

It fixes a crash when iterating over annotated string variables.