### PR TITLE
[python] fix isdigit() to handle single characters correctly

### DIFF
--- a/regression/python/github_2986_2/main.py
+++ b/regression/python/github_2986_2/main.py
@@ -1,0 +1,3 @@
+s: str = "123"
+for c in s:
+    assert c.isdigit()

--- a/regression/python/github_2986_2/test.desc
+++ b/regression/python/github_2986_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2986_2_fail/main.py
+++ b/regression/python/github_2986_2_fail/main.py
@@ -1,0 +1,3 @@
+s: str = "123a"
+for c in s:
+    assert c.isdigit()

--- a/regression/python/github_2986_2_fail/test.desc
+++ b/regression/python/github_2986_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -155,6 +155,7 @@ const static std::vector<std::string> python_c_models = {
   "strchr",
   "list_contains",
   "__python_str_isdigit",
+  "__python_char_isdigit",
   "__python_str_isalpha",
   "__python_char_isalpha",
   "__python_str_isspace",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -59,6 +59,13 @@ __ESBMC_HIDE:;
   return 1;
 }
 
+// Python character isdigit - checks if a single character is a digit
+_Bool __python_char_isdigit(int c)
+{
+__ESBMC_HIDE:;
+  return (c >= '0' && c <= '9');
+}
+
 _Bool __python_str_isdigit(const char *s)
 {
 __ESBMC_HIDE:;

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -686,7 +686,26 @@ exprt string_handler::handle_string_isdigit(
   const exprt &string_obj,
   const locationt &location)
 {
-  // Ensure it's a proper null-terminated string
+  // Check if this is a single character
+  if (string_obj.type().is_unsignedbv() || string_obj.type().is_signedbv())
+  {
+    // Call Python's single-character version
+    symbolt *isdigit_symbol =
+      symbol_table_.find_symbol("c:@F@__python_char_isdigit");
+    if (!isdigit_symbol)
+      throw std::runtime_error(
+        "__python_char_isdigit function not found in symbol table");
+
+    side_effect_expr_function_callt isdigit_call;
+    isdigit_call.function() = symbol_expr(*isdigit_symbol);
+    isdigit_call.arguments().push_back(string_obj);
+    isdigit_call.location() = location;
+    isdigit_call.type() = bool_type();
+
+    return isdigit_call;
+  }
+
+  // For full strings, use the string version
   exprt string_copy = string_obj;
   exprt str_expr = ensure_null_terminated_string(string_copy);
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2986.

When iterating over strings character-by-character, `isdigit()` was incorrectly calling `__python_str_isdigit()` on single chars, causing array bounds violations during verification.

This PR adds `__python_char_isdigit()` function and updates `handle_string_isdigit()` to detect single-character types (`signedbv/unsignedbv`) and route them to the character-specific implementation, following the same pattern as `isalpha()`.