### PR TITLE
[python] fix len() calls on set types to use correct length function

### DIFF
--- a/regression/python/github_2965_2/main.py
+++ b/regression/python/github_2965_2/main.py
@@ -1,0 +1,2 @@
+s: set[str] = { 'foo', 'bar' }
+assert len(s) == 2

--- a/regression/python/github_2965_2/test.desc
+++ b/regression/python/github_2965_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_2_fail/main.py
+++ b/regression/python/github_2965_2_fail/main.py
@@ -1,0 +1,2 @@
+s: set[str] = { 'foo', 'bar', 'test' }
+assert len(s) == 2

--- a/regression/python/github_2965_2_fail/test.desc
+++ b/regression/python/github_2965_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2965_3/main.py
+++ b/regression/python/github_2965_3/main.py
@@ -1,0 +1,2 @@
+s: set[str] = { 'foo', 'bar', 'foo', 'bar' }
+assert len(s) == 2

--- a/regression/python/github_2965_3/test.desc
+++ b/regression/python/github_2965_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_set_unique/test.desc
+++ b/regression/python/github_2965_set_unique/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc
+--unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -270,7 +270,7 @@ symbol_id function_call_builder::build_function_id() const
       }
       if (
         var_type == "bytes" || var_type == "list" || var_type == "List" ||
-        var_type.empty())
+        var_type == "set" || var_type == "dict" || var_type.empty())
         func_name = kGetObjectSize;
       else if (var_type == "str")
       {


### PR DESCRIPTION
The preprocessor used `len()` for all iterable types, which is converted to `strlen()` in C. This is incorrect for pointer-based collections (e.g., `set`) in ESBMC's operational model, causing verification failures and incorrect loop bounds.

This PR uses `__ESBMC_get_object_size()` for pointer-based collections (`set`) and len() for array-based types (`str`). This ensures the correct C function is called based on the iterable's underlying representation.
