### PR TITLE
[python] handle unsupported functions with assert(false) to prevent crashes

### DIFF
--- a/regression/python/github_2993/main.py
+++ b/regression/python/github_2993/main.py
@@ -1,0 +1,8 @@
+def not_called(s: str) -> None:
+    b: bytes = s.encode("utf-8")
+    assert len(b) > 0
+
+def foo(i: int) -> bool:
+    return i > 5
+
+assert not foo(0)

--- a/regression/python/github_2993/test.desc
+++ b/regression/python/github_2993/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2993_2/main.py
+++ b/regression/python/github_2993_2/main.py
@@ -1,0 +1,4 @@
+def not_called(s: str) -> None:
+    b: bytes = s.encode("utf-8")  # Unsupported but not called
+    
+assert True  # Should verify successfully

--- a/regression/python/github_2993_2/test.desc
+++ b/regression/python/github_2993_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2993_2_fail/main.py
+++ b/regression/python/github_2993_2_fail/main.py
@@ -1,0 +1,4 @@
+def called(s: str) -> None:
+    b: bytes = s.encode("utf-8")  # Unsupported and IS called
+    
+called("test")

--- a/regression/python/github_2993_2_fail/test.desc
+++ b/regression/python/github_2993_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2993_fail/main.py
+++ b/regression/python/github_2993_fail/main.py
@@ -1,0 +1,9 @@
+def not_called(s: str) -> None:
+    b: bytes = s.encode("utf-8")
+    assert len(b) > 0
+
+def foo(i: int) -> bool:
+    not_called("test")
+    return i > 5
+
+assert not foo(0)

--- a/regression/python/github_2993_fail/test.desc
+++ b/regression/python/github_2993_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2993_real_world/main.py
+++ b/regression/python/github_2993_real_world/main.py
@@ -1,0 +1,7 @@
+from mylib import basic_feature
+
+def main():
+    result = basic_feature(5)
+    assert result  # Should verify!
+
+main()

--- a/regression/python/github_2993_real_world/mylib.py
+++ b/regression/python/github_2993_real_world/mylib.py
@@ -1,0 +1,8 @@
+# mylib.py - Library with some unsupported features
+def advanced_feature(data: str) -> bytes:
+    """Uses encoding - not yet supported"""
+    return data.encode('utf-8')
+
+def basic_feature(x: int) -> bool:
+    """Simple operation - fully supported"""
+    return x > 0

--- a/regression/python/github_2993_real_world/test.desc
+++ b/regression/python/github_2993_real_world/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-from-function-fail/test.desc
+++ b/regression/python/import-from-function-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-^WARNING: Undefined function: foo$
+^VERIFICATION FAILED$

--- a/regression/python/import-from-multiple-fail/test.desc
+++ b/regression/python/import-from-multiple-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 
-^WARNING: Undefined function: sub$
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -21,6 +21,8 @@ ignored_dirs=(
   "function-option-fail"
   "github_2843_fail"
   "github_2843_4_fail"
+  "github_2993_fail"
+  "github_2993_2_fail"
   "global"
   "integer_squareroot_fail"
   "int_from_bytes"

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -208,6 +208,12 @@ private:
   exprt handle_list_extend() const;
 
   /*
+   * Replace undefined function calls with assert(false):
+   * if reached, verification fails; if unreached, verification succeeds.
+   */
+  codet gen_unsupported_function_assert(const std::string &func_name) const;
+
+  /*
    * Check if the current function call is to a regular expression module function
    * Returns true if the function is match, search, or fullmatch from the re module
    */


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2993.

This PR replaces undefined function calls with `assert(false)`, rather than returning empty expressions that cause crashes. This maintains soundness while allowing verification of programs that contain unsupported functions that are unreachable.

In particular, this PR:
- Adds `gen_unsupported_function_assert()` to `function_call_expr`.
- Modifies `handle_general_function_call()` to use the new assertion method.
- Update warning messages to indicate replacement strategy.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for requesting this feature.