### PR TITLE
[python] handle nested constructor calls as function arguments

### DIFF
--- a/regression/python/nested-ctor-calls/main.py
+++ b/regression/python/nested-ctor-calls/main.py
@@ -1,0 +1,9 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+class Bar:
+    def __init__(self, f: Foo) -> None:
+        pass
+
+b = Bar(Foo())

--- a/regression/python/nested-ctor-calls/test.desc
+++ b/regression/python/nested-ctor-calls/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1948,7 +1948,17 @@ exprt function_call_expr::handle_general_function_call()
         if (func_symbol != nullptr)
         {
           const code_typet &func_type = to_code_type(func_symbol->type);
-          func_call.type() = func_type.return_type();
+          typet return_type = func_type.return_type();
+
+          // Special handling for constructors
+          if (return_type.id() == "constructor")
+          {
+            // For constructors, use the class type instead of "constructor"
+            return_type =
+              type_handler_.get_typet(func_symbol->name.as_string());
+          }
+
+          func_call.type() = return_type;
         }
       }
 


### PR DESCRIPTION
This PR fixes a crash that occurs when constructors are passed as arguments to other functions (e.g., `Bar(Foo())`). In particular, this PR fixes the return type when converting nested constructor calls to side-effect expressions, using the actual class type rather than the abstract "constructor" type. This ensures nested constructor calls generate correct GOTO code and don't cause symbolic execution crashes.