### PR TITLE
[python] register instance attributes for class-typed parameters

### DIFF
--- a/regression/python/nested-ctor-calls_2/main.py
+++ b/regression/python/nested-ctor-calls_2/main.py
@@ -1,0 +1,10 @@
+class Foo:
+    def __init__(self) -> None:
+        self.x: int = 42
+
+class Bar:
+    def __init__(self, f: Foo) -> None:
+        self.y: int = f.x
+
+b = Bar(Foo())
+assert b.y == 42

--- a/regression/python/nested-ctor-calls_2/test.desc
+++ b/regression/python/nested-ctor-calls_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-ctor-calls_2_fail/main.py
+++ b/regression/python/nested-ctor-calls_2_fail/main.py
@@ -1,0 +1,10 @@
+class Foo:
+    def __init__(self) -> None:
+        self.x: int = 41
+
+class Bar:
+    def __init__(self, f: Foo) -> None:
+        self.y: int = f.x
+
+b = Bar(Foo())
+assert b.y == 42

--- a/regression/python/nested-ctor-calls_2_fail/test.desc
+++ b/regression/python/nested-ctor-calls_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
This PR fixes attribute resolution for constructor parameters with class types.

When a class instance is passed as a parameter (e.g., `f: Foo` in `Bar.__init__(self, f: Foo)`), the parameter symbol now correctly inherits the class's instance attributes, allowing attribute access such as `f.x` to resolve properly.

Previously, only direct object instantiations tracked instance attributes, leading to "Attribute not found" errors when accessing instance attributes via parameters.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

