### PR TITLE
[python] Fix Array Type Dereference Error in Python List Iteration and Class Member Assignment

### DIFF
--- a/regression/python/github_2999/main.py
+++ b/regression/python/github_2999/main.py
@@ -1,0 +1,3 @@
+l: list[str] = ["foo", "bar", "baz"]
+for s in l:
+    pass

--- a/regression/python/github_2999/test.desc
+++ b/regression/python/github_2999/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2999_2/main.py
+++ b/regression/python/github_2999_2/main.py
@@ -1,0 +1,5 @@
+l: list[str] = ["foo", "bar", "baz"]
+x = 0
+for s in l:
+    x += 1
+assert x == 3

--- a/regression/python/github_2999_2/test.desc
+++ b/regression/python/github_2999_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2999_2_fail/main.py
+++ b/regression/python/github_2999_2_fail/main.py
@@ -1,0 +1,5 @@
+l: list[str] = ["foo", "bar", "baz"]
+x = 0
+for s in l:
+    x += 1
+assert x == 2

--- a/regression/python/github_2999_2_fail/test.desc
+++ b/regression/python/github_2999_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/python/github_2999_3/main.py
+++ b/regression/python/github_2999_3/main.py
@@ -1,0 +1,10 @@
+class Foo:
+    def __init__(self) -> None:
+        self.x = "foo"
+    def foo(self) -> int:
+        return 42
+
+f: Foo = Foo()
+result = f.foo()
+assert result == 42
+

--- a/regression/python/github_2999_3/test.desc
+++ b/regression/python/github_2999_3/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_2999_3_fail/main.py
+++ b/regression/python/github_2999_3_fail/main.py
@@ -1,0 +1,10 @@
+class Foo:
+    def __init__(self) -> None:
+        self.x = "foo"
+    def foo(self) -> int:
+        return 42
+
+f: Foo = Foo()
+result = f.foo()
+assert result == 99
+

--- a/regression/python/github_2999_3_fail/test.desc
+++ b/regression/python/github_2999_3_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_2999_fail/main.py
+++ b/regression/python/github_2999_fail/main.py
@@ -1,0 +1,4 @@
+l: list[str] = ["foo", "bar", "baz"]
+for s in l:
+    pass
+assert False

--- a/regression/python/github_2999_fail/test.desc
+++ b/regression/python/github_2999_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2071,7 +2071,17 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   else
   {
     // Strings are null-terminated
-    return string_builder_->build_string_literal(str_val);
+    exprt result = string_builder_->build_string_literal(str_val);
+    
+    // When assigning a string literal to a class member that has pointer type,
+    // we need to convert the string array to its base address (array-to-pointer decay).
+    // This ensures type compatibility: char* = &"string_literal"[0]
+    if (current_lhs && current_lhs->id() == "member" && 
+        current_lhs->type().is_pointer() && result.type().is_array())
+    {
+      return string_handler_.get_array_base_address(result);
+    }
+    return result;
   }
 
   return make_char_array_expr(string_literal, t);
@@ -2533,12 +2543,15 @@ exprt python_converter::get_expr(const nlohmann::json &element)
 
       if (is_converting_lhs)
       {
-        // Add member in the class if not exists
+        // Add member to the class if it doesn't exist yet (dynamic member addition)
         if (!class_type.has_component(attr_name))
         {
           struct_typet::componentt comp = build_component(
             class_type.tag().as_string(), attr_name, current_element_type);
           class_type.components().push_back(comp);
+          
+          // Update the class symbol's type in the symbol table
+          class_symbol->type = class_type;
         }
 
         // Register instance attribute for both regular and normalized keys
@@ -3002,14 +3015,28 @@ void python_converter::handle_assignment_type_adjustments(
         lhs.type() = rhs.type();
       }
     }
-    // Array to pointer decay
+    // Array to pointer decay handling
+    // In Python, regular variables undergo array-to-pointer decay (e.g., str variables),
+    // but struct/class members should preserve their array type to enable proper initialization.
     else if (lhs.type().id().empty() && rhs.type().is_array())
     {
-      const typet &element_type = to_array_type(rhs.type()).subtype();
-      typet pointer_type = gen_pointer_type(element_type);
-      lhs_symbol->type = pointer_type;
-      lhs.type() = pointer_type;
-      rhs = string_handler_.get_array_base_address(rhs);
+      if (lhs.id() == "member")
+      {
+        // Struct/class members: preserve array type for proper value semantics
+        // Example: self.name = "Alice" should store the full string array
+        lhs_symbol->type = rhs.type();
+        lhs.type() = rhs.type();
+      }
+      else
+      {
+        // Regular variables: apply array-to-pointer decay
+        // Example: s = "hello" creates a pointer to the string literal
+        const typet &element_type = to_array_type(rhs.type()).subtype();
+        typet pointer_type = gen_pointer_type(element_type);
+        lhs_symbol->type = pointer_type;
+        lhs.type() = pointer_type;
+        rhs = string_handler_.get_array_base_address(rhs);
+      }
     }
     // String and list type size adjustments
     else if (
@@ -4242,11 +4269,20 @@ void python_converter::get_attributes_from_self(
       stmt["target"]["value"]["id"] == "self")
     {
       std::string attr_name = stmt["target"]["attr"];
-      const std::string &annotated_type =
-        stmt["annotation"]["id"].get<std::string>();
+      std::string annotated_type = stmt["annotation"]["id"].get<std::string>();
+      
       typet type;
       if (annotated_type == "str")
+      {
+        // String members are represented as char* (pointer type) rather than char[] (array type).
+        // Rationale:
+        // 1. Python strings are immutable references, matching pointer semantics
+        // 2. Pointers allow flexible assignment (e.g., self.msg = param_str)
+        // 3. Avoids C array assignment restrictions in struct members
+        // Note: String literals assigned to these members will be converted to pointers
+        // via array-to-pointer decay in get_literal()
         type = gen_pointer_type(char_type());
+      }
       else if (annotated_type == "Optional")
       {
         typet base_type = get_type_from_annotation(stmt["annotation"], stmt);

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2072,12 +2072,13 @@ exprt python_converter::get_literal(const nlohmann::json &element)
   {
     // Strings are null-terminated
     exprt result = string_builder_->build_string_literal(str_val);
-    
+
     // When assigning a string literal to a class member that has pointer type,
     // we need to convert the string array to its base address (array-to-pointer decay).
     // This ensures type compatibility: char* = &"string_literal"[0]
-    if (current_lhs && current_lhs->id() == "member" && 
-        current_lhs->type().is_pointer() && result.type().is_array())
+    if (
+      current_lhs && current_lhs->id() == "member" &&
+      current_lhs->type().is_pointer() && result.type().is_array())
     {
       return string_handler_.get_array_base_address(result);
     }
@@ -2549,7 +2550,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           struct_typet::componentt comp = build_component(
             class_type.tag().as_string(), attr_name, current_element_type);
           class_type.components().push_back(comp);
-          
+
           // Update the class symbol's type in the symbol table
           class_symbol->type = class_type;
         }
@@ -4270,7 +4271,7 @@ void python_converter::get_attributes_from_self(
     {
       std::string attr_name = stmt["target"]["attr"];
       std::string annotated_type = stmt["annotation"]["id"].get<std::string>();
-      
+
       typet type;
       if (annotated_type == "str")
       {

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -885,10 +885,15 @@ exprt python_list::handle_index_access(
     // Cast from void* to target type pointer
     typecast_exprt tc(obj_value, pointer_typet(elem_type));
 
-    // For array types (like strings), return the pointer instead of dereferencing
-    // C doesn't allow dereferencing array types
+    // For array types (like strings), apply array-to-pointer decay
+    // Convert pointer-to-array (e.g., char[4]*) to pointer-to-element (e.g., char*)
+    // by casting to the element pointer type
     if (elem_type.is_array())
-      return tc;
+    {
+      const typet &element_type = to_array_type(elem_type).subtype();
+      typecast_exprt array_to_ptr(tc, pointer_typet(element_type));
+      return array_to_ptr;
+    }
 
     // For non-array types, dereference to get the actual value
     dereference_exprt deref(elem_type);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -882,10 +882,15 @@ exprt python_list::handle_index_access(
       base.swap(deref);
     }
 
-    // Cast from void* to target type pointer and dereference
+    // Cast from void* to target type pointer
     typecast_exprt tc(obj_value, pointer_typet(elem_type));
 
-    // Dereference to get the actual value
+    // For array types (like strings), return the pointer instead of dereferencing
+    // C doesn't allow dereferencing array types
+    if (elem_type.is_array())
+      return tc;
+
+    // For non-array types, dereference to get the actual value
     dereference_exprt deref(elem_type);
     deref.op0() = tc;
     return deref;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2999.

## Problem
String iteration like `for s in ["foo", "bar"]` was trying to dereference `char[4]*` directly, causing crashes. Similar issue when assigning strings to class members.

## Changes
Fixed array-to-pointer decay in two places:
- `python_list.cpp`: Convert `char[N]*` → `char*` when accessing list elements
- `python_converter.cpp`: Keep array types for class members, apply pointer decay for local variables

This matches Python's string semantics where strings are immutable references.

## Tests
Added `github_2999`, `github_2999_2`, `github_2999_3` with corresponding failure cases.