### PR TITLE
Python string slice fix

### DIFF
--- a/regression/python/string-slice2-bug1/main.py
+++ b/regression/python/string-slice2-bug1/main.py
@@ -1,0 +1,7 @@
+s: str = "foo"
+l = len(s)
+ss: str = s[1:l]
+
+assert ss == "oop"
+l2 = len(ss)
+assert l2 == 2

--- a/regression/python/string-slice2-bug1/test.desc
+++ b/regression/python/string-slice2-bug1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/string-slice2-bug2/main.py
+++ b/regression/python/string-slice2-bug2/main.py
@@ -1,0 +1,7 @@
+s: str = "foo"
+l = len(s)
+ss: str = s[1:l]
+
+assert ss == "oo"
+l2 = len(ss)
+assert l2 == 3

--- a/regression/python/string-slice2-bug2/test.desc
+++ b/regression/python/string-slice2-bug2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/string-slice2/main.py
+++ b/regression/python/string-slice2/main.py
@@ -1,0 +1,7 @@
+s: str = "foo"
+l = len(s)
+ss: str = s[1:l]
+
+assert ss == "oo"
+l2 = len(ss)
+assert l2 == 2

--- a/regression/python/string-slice2/test.desc
+++ b/regression/python/string-slice2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3437,11 +3437,29 @@ void python_converter::get_var_assign(
       const std::string &rhs_identifier = rhs.identifier().as_string();
       python_list::copy_type_info(rhs_identifier, lhs_identifier);
     }
+    else if (
+      rhs.type() != lhs.type() && lhs.type().is_array() &&
+      !rhs.type().is_code())
+    {
+#ifndef NDEBUG
+      const array_typet &thetype = lhs.type();
+      thetype.size().is_constant();
+      // I am curious what else could arrive here. So add a debug
+      // assertion just to prevent us from doing something bad and to
+      // know that we are about to do something weird.
+      assert(thetype.size().is_nil());
+#endif
+      // For VLA is not enough to just update the type, we need to make an explicit
+      // declaration. This lets ESBMC do all the internal initializations
+      lhs_symbol->type = rhs.type();
 
-    lhs_symbol->type = rhs.type();
-    typet &thetype = lhs.type();
-    thetype = rhs.type();
-     
+      code_declt decl(symbol_expr(*lhs_symbol), rhs);
+      decl.location() = location_begin;
+      target_block.copy_to_operands(decl);
+      current_lhs = nullptr;
+      return;
+    }
+
     code_assignt code_assign(lhs, rhs);
     code_assign.location() = location_begin;
     target_block.copy_to_operands(code_assign);

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3438,6 +3438,10 @@ void python_converter::get_var_assign(
       python_list::copy_type_info(rhs_identifier, lhs_identifier);
     }
 
+    lhs_symbol->type = rhs.type();
+    typet &thetype = lhs.type();
+    thetype = rhs.type();
+     
     code_assignt code_assign(lhs, rhs);
     code_assign.location() = location_begin;
     target_block.copy_to_operands(code_assign);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2976.

This pull request introduces new regression tests for Python string slicing edge cases and updates the C++ Python frontend to better handle variable-length arrays (VLAs) during type assignment. The changes are primarily focused on improving the correctness and coverage of string slicing behavior and ensuring robust handling of array types in the frontend.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
