### PR TITLE
[python] fix string containment check in lists by using stored element type info

### DIFF
--- a/regression/python/github_2979/main.py
+++ b/regression/python/github_2979/main.py
@@ -1,0 +1,6 @@
+def foo(l: list[str]) -> None:
+    ll = ["foo", "bar", "baz"]
+    for s in l:
+        assert s in ll
+
+foo(["foo", "bar"])

--- a/regression/python/github_2979/test.desc
+++ b/regression/python/github_2979/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2979_fail/main.py
+++ b/regression/python/github_2979_fail/main.py
@@ -1,0 +1,6 @@
+def foo(l: list[str]) -> None:
+    ll = ["foo", "bar", "baz"]
+    for s in l:
+        assert s in ll
+
+foo(["foo1", "bar1"])

--- a/regression/python/github_2979_fail/test.desc
+++ b/regression/python/github_2979_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1101,44 +1101,55 @@ exprt python_list::contains(const exprt &item, const exprt &list)
 
   contains_call.arguments().push_back(item_arg);
 
-  // Use the type and size from the list elements, not from the search item
-  // Get the type information from what was stored in the list
-  const std::string &list_name = list.identifier().as_string();
-  auto type_map_it = list_type_map.find(list_name);
-
+  // For void/char pointers from iteration, use stored type info from list
   exprt type_hash = symbol_expr(*item_info.elem_type_sym);
   exprt elem_size = item_info.elem_size;
 
-  if (type_map_it != list_type_map.end() && !type_map_it->second.empty())
+  // Check if item is a pointer (void* or char* - from loop iteration over strings)
+  if (item_info.elem_symbol->type.is_pointer())
   {
-    // Use the type information from the list's stored elements
-    const typet &stored_type = type_map_it->second[0].second;
+    const std::string &list_name = list.identifier().as_string();
+    auto type_map_it = list_type_map.find(list_name);
 
-    // Recalculate hash for stored type
-    const type_handler type_handler_ = converter_.get_type_handler();
-    const std::string stored_type_name =
-      type_handler_.type_to_string(stored_type);
-    constant_exprt stored_hash(size_type());
-    stored_hash.set_value(integer2binary(
-      std::hash<std::string>{}(stored_type_name), config.ansi_c.address_width));
-    type_hash = stored_hash;
-
-    // Recalculate size for stored type
-    if (stored_type.is_array())
+    if (type_map_it != list_type_map.end() && !type_map_it->second.empty())
     {
-      const array_typet &array_type =
-        static_cast<const array_typet &>(stored_type);
-      const size_t array_length =
-        std::stoull(array_type.size().value().as_string(), nullptr, 2);
-      const size_t subtype_size_bits =
-        std::stoull(stored_type.subtype().width().as_string(), nullptr, 10);
-      size_t size_bytes = (array_length * subtype_size_bits) / 8;
-      elem_size = from_integer(BigInt(size_bytes), size_type());
+      // Look for a string array type (char array) in the list
+      for (const auto &stored_entry : type_map_it->second)
+      {
+        const typet &stored_type = stored_entry.second;
+
+        // Check if stored type is a char array (string)
+        if (stored_type.is_array() && stored_type.subtype() == char_type())
+        {
+          // Use the stored string array type instead of pointer type
+          const type_handler type_handler_ = converter_.get_type_handler();
+          const std::string stored_type_name =
+            type_handler_.type_to_string(stored_type);
+
+          constant_exprt stored_hash(size_type());
+          stored_hash.set_value(integer2binary(
+            std::hash<std::string>{}(stored_type_name),
+            config.ansi_c.address_width));
+          type_hash = stored_hash;
+
+          // Recalculate size for stored array type
+          const array_typet &array_type =
+            static_cast<const array_typet &>(stored_type);
+          const size_t array_length =
+            std::stoull(array_type.size().value().as_string(), nullptr, 2);
+          const size_t subtype_size_bits =
+            std::stoull(stored_type.subtype().width().as_string(), nullptr, 10);
+          size_t size_bytes = (array_length * subtype_size_bits) / 8;
+          elem_size = from_integer(BigInt(size_bytes), size_type());
+
+          break; // Found string array type, use it
+        }
+      }
     }
   }
 
-  contains_call.arguments().push_back(type_hash); // item type hash from list
-  contains_call.arguments().push_back(elem_size); // item size from list
+  contains_call.arguments().push_back(type_hash);
+  contains_call.arguments().push_back(elem_size);
 
   contains_call.type() = bool_type();
   contains_call.location() = converter_.get_location_from_decl(list_value_);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2979.

When checking whether a string is in a list (e.g., "foo" in ["foo"]), the contains function used type information from the loop variable rather than the list's stored elements. Loop variables for strings are treated as pointers, causing size mismatches.

This PR retrieves type and size information from `list_type_map` to match what was stored during `list_push`, ensuring correct string comparison in `list_contains`.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.