### PR TITLE
[python] implement str.join() method with string concatenation

### DIFF
--- a/regression/python/github_3000/main.py
+++ b/regression/python/github_3000/main.py
@@ -1,0 +1,7 @@
+# Test: str.join() with variable reference (supported)
+# Currently supports: separator.join(variable)
+# TODO: Direct list literals like " ".join(["a", "b"]) are not yet supported
+l: list[str] = ["foo", "bar", "baz"]
+s = " ".join(l)
+assert s == "foo bar baz"
+

--- a/regression/python/github_3000/test.desc
+++ b/regression/python/github_3000/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3000_1/main.py
+++ b/regression/python/github_3000_1/main.py
@@ -1,0 +1,3 @@
+s = " ".join(["foo", "bar"])
+assert s == "foo bar"
+

--- a/regression/python/github_3000_1/test.desc
+++ b/regression/python/github_3000_1/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.py
+--unwind 7
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_1_fail/main.py
+++ b/regression/python/github_3000_1_fail/main.py
@@ -1,0 +1,4 @@
+# Test: Direct list literal with wrong assertion (would fail if implemented)
+# This is a negative test for the TODO feature
+s = " ".join(["foo", "bar"])
+assert s == "foobar"  # Wrong! Should be "foo bar"

--- a/regression/python/github_3000_1_fail/test.desc
+++ b/regression/python/github_3000_1_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3000_2/main.py
+++ b/regression/python/github_3000_2/main.py
@@ -1,0 +1,5 @@
+# Test: String join with 2 elements
+l: list[str] = ["hello", "world"]
+s = "-".join(l)
+assert s == "hello-world"
+

--- a/regression/python/github_3000_2/test.desc
+++ b/regression/python/github_3000_2/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_3/main.py
+++ b/regression/python/github_3000_3/main.py
@@ -1,0 +1,5 @@
+# Test: Empty list join should return empty string
+l: list[str] = []
+s = " ".join(l)
+assert s == ""
+

--- a/regression/python/github_3000_3/test.desc
+++ b/regression/python/github_3000_3/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_3_fail/main.py
+++ b/regression/python/github_3000_3_fail/main.py
@@ -1,0 +1,5 @@
+# Test: Empty list join - wrong assertion (should fail)
+l: list[str] = []
+s = " ".join(l)
+assert s == "wrong"
+

--- a/regression/python/github_3000_3_fail/test.desc
+++ b/regression/python/github_3000_3_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3000_4/main.py
+++ b/regression/python/github_3000_4/main.py
@@ -1,0 +1,5 @@
+# Test: Single element join should return the element itself
+l: list[str] = ["hello"]
+s = "-".join(l)
+assert s == "hello"
+

--- a/regression/python/github_3000_4/test.desc
+++ b/regression/python/github_3000_4/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_4_fail/main.py
+++ b/regression/python/github_3000_4_fail/main.py
@@ -1,0 +1,5 @@
+# Test: Single element join - wrong assertion (should fail)
+l: list[str] = ["hello"]
+s = "-".join(l)
+assert s == "-hello-"
+

--- a/regression/python/github_3000_4_fail/test.desc
+++ b/regression/python/github_3000_4_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3000_5/main.py
+++ b/regression/python/github_3000_5/main.py
@@ -1,0 +1,5 @@
+# Test: Empty separator join
+l: list[str] = ["a", "b", "c"]
+s = "".join(l)
+assert s == "abc"
+

--- a/regression/python/github_3000_5/test.desc
+++ b/regression/python/github_3000_5/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_5_fail/main.py
+++ b/regression/python/github_3000_5_fail/main.py
@@ -1,0 +1,5 @@
+# Test: Empty separator join - wrong assertion (should fail)
+l: list[str] = ["a", "b", "c"]
+s = "".join(l)
+assert s == "a b c"
+

--- a/regression/python/github_3000_5_fail/test.desc
+++ b/regression/python/github_3000_5_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3000_6/main.py
+++ b/regression/python/github_3000_6/main.py
@@ -1,0 +1,5 @@
+# Test: Multi-character separator
+l: list[str] = ["x", "y"]
+s = "::".join(l)
+assert s == "x::y"
+

--- a/regression/python/github_3000_6/test.desc
+++ b/regression/python/github_3000_6/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_6_fail/main.py
+++ b/regression/python/github_3000_6_fail/main.py
@@ -1,0 +1,5 @@
+# Test: Multi-character separator - wrong assertion (should fail)
+l: list[str] = ["x", "y"]
+s = "::".join(l)
+assert s == "x:y"
+

--- a/regression/python/github_3000_6_fail/test.desc
+++ b/regression/python/github_3000_6_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3000_7/main.py
+++ b/regression/python/github_3000_7/main.py
@@ -1,0 +1,5 @@
+# Test: Four element join
+l: list[str] = ["a", "b", "c", "d"]
+s = ",".join(l)
+assert s == "a,b,c,d"
+

--- a/regression/python/github_3000_7/test.desc
+++ b/regression/python/github_3000_7/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3000_7_fail/main.py
+++ b/regression/python/github_3000_7_fail/main.py
@@ -1,0 +1,5 @@
+# Test: Four element join - wrong assertion (should fail)
+l: list[str] = ["a", "b", "c", "d"]
+s = ",".join(l)
+assert s == "a,b,c"
+

--- a/regression/python/github_3000_7_fail/test.desc
+++ b/regression/python/github_3000_7_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3000_8_fail/main.py
+++ b/regression/python/github_3000_8_fail/main.py
@@ -1,0 +1,6 @@
+# Test: str.join() with mixed string and integer types (should fail)
+l = ["foo", 123, "bar"]
+s = " ".join(l)
+assert s == "foo 123 bar"
+
+

--- a/regression/python/github_3000_8_fail/test.desc
+++ b/regression/python/github_3000_8_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+
+

--- a/regression/python/github_3000_fail/main.py
+++ b/regression/python/github_3000_fail/main.py
@@ -1,0 +1,5 @@
+# Test: str.join() with wrong assertion (should fail)
+l: list[str] = ["foo", "bar", "baz"]
+s = " ".join(l)
+assert s == "foo bar bar"  # Wrong! Should be "foo bar baz"
+

--- a/regression/python/github_3000_fail/test.desc
+++ b/regression/python/github_3000_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1144,7 +1144,7 @@ private:
   {
     if (!constant_node.contains("value"))
       return "";
-    
+
     const auto &value = constant_node["value"];
     if (value.is_string())
       return "str";
@@ -1154,7 +1154,7 @@ private:
       return "float";
     else if (value.is_boolean())
       return "bool";
-    
+
     return "";
   }
 
@@ -1173,18 +1173,18 @@ private:
     {
       obj_name = prefix + std::string(".");
     }
-    
+
     // FIX: Handle method calls on constant literals
     // Python allows: " ".join(l), 123.to_bytes(), etc.
     // Before this fix, accessing call["value"]["id"] would crash because
     // Constant nodes don't have an "id" field
     if (call["value"]["_type"] == "Constant")
       return get_type_from_constant(call["value"]);
-    
+
     // Handle normal Name values (variable references)
     if (!call["value"].contains("id"))
       return "";
-      
+
     obj_name += call["value"]["id"].template get<std::string>();
     if (obj_name.find('.') != std::string::npos)
       obj_name = invert_substrings(obj_name);
@@ -1200,29 +1200,32 @@ private:
     // When Python code has " ".join(l), the func["value"] is a Constant node
     // We need to map string method names to their return types directly
     // without looking up the object in the AST (which would fail)
-    if (call["func"].contains("value") && 
-        call["func"]["value"]["_type"] == "Constant")
+    if (
+      call["func"].contains("value") &&
+      call["func"]["value"]["_type"] == "Constant")
     {
       std::string obj_type = get_type_from_constant(call["func"]["value"]);
-      
+
       // For string constants, determine return type based on method name
       if (obj_type == "str" && call["func"].contains("attr"))
       {
         const std::string &method = call["func"]["attr"];
         // Methods that return str
-        if (method == "join" || method == "lower" || method == "upper" || 
-            method == "strip" || method == "lstrip" || method == "rstrip" ||
-            method == "format" || method == "replace")
+        if (
+          method == "join" || method == "lower" || method == "upper" ||
+          method == "strip" || method == "lstrip" || method == "rstrip" ||
+          method == "format" || method == "replace")
           return "str";
         // Methods that return bool
-        else if (method == "startswith" || method == "endswith" || 
-                 method == "isdigit" || method == "isalpha" || method == "isspace" ||
-                 method == "islower" || method == "isupper")
+        else if (
+          method == "startswith" || method == "endswith" ||
+          method == "isdigit" || method == "isalpha" || method == "isspace" ||
+          method == "islower" || method == "isupper")
           return "bool";
         // Default for string methods
         return "str";
       }
-      
+
       return obj_type;
     }
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1174,7 +1174,7 @@ private:
       obj_name = prefix + std::string(".");
     }
 
-    // FIX: Handle method calls on constant literals
+    // Handle method calls on constant literals
     // Python allows: " ".join(l), 123.to_bytes(), etc.
     // Before this fix, accessing call["value"]["id"] would crash because
     // Constant nodes don't have an "id" field
@@ -1196,7 +1196,7 @@ private:
   {
     std::string type("");
 
-    // FIX: Handle method calls on constant literals
+    // Handle method calls on constant literals
     // When Python code has " ".join(l), the func["value"] is a Constant node
     // We need to map string method names to their return types directly
     // without looking up the object in the AST (which would fail)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1139,8 +1139,9 @@ exprt python_converter::handle_str_join(const nlohmann::json &call_json)
 
   // Verify this is an Attribute call (method call syntax: obj.method())
   // and has the value (the separator object)
-  if (!func.contains("_type") || func["_type"] != "Attribute" || 
-      !func.contains("value"))
+  if (
+    !func.contains("_type") || func["_type"] != "Attribute" ||
+    !func.contains("value"))
     throw std::runtime_error("invalid join() call");
 
   // Extract separator: for " ".join(l), func["value"] is the Constant " "
@@ -1152,15 +1153,16 @@ exprt python_converter::handle_str_join(const nlohmann::json &call_json)
 
   // Currently only support Name references (e.g., variable names)
   // TODO: Support direct List literals like " ".join(["a", "b"])
-  if (list_arg.contains("_type") && list_arg["_type"] == "Name" &&
-      list_arg.contains("id"))
+  if (
+    list_arg.contains("_type") && list_arg["_type"] == "Name" &&
+    list_arg.contains("id"))
   {
     std::string var_name = list_arg["id"].get<std::string>();
-    
+
     // Look up the variable in the AST to get its initialization value
-    nlohmann::json var_decl = json_utils::find_var_decl(
-      var_name, current_func_name_, *ast_json);
-    
+    nlohmann::json var_decl =
+      json_utils::find_var_decl(var_name, current_func_name_, *ast_json);
+
     if (var_decl.empty())
       throw std::runtime_error(
         "NameError: name '" + var_name + "' is not defined");
@@ -1171,8 +1173,9 @@ exprt python_converter::handle_str_join(const nlohmann::json &call_json)
 
     const nlohmann::json &list_value = var_decl["value"];
 
-    if (!list_value.contains("_type") || list_value["_type"] != "List" || 
-        !list_value.contains("elts"))
+    if (
+      !list_value.contains("_type") || list_value["_type"] != "List" ||
+      !list_value.contains("elts"))
       throw std::runtime_error("join() requires a list");
 
     // Get the list elements from the AST
@@ -1204,23 +1207,23 @@ exprt python_converter::handle_str_join(const nlohmann::json &call_json)
     // null terminator issues.
     string_builder &sb = get_string_builder();
     std::vector<exprt> all_chars;
-    
+
     // Start with the first element
     std::vector<exprt> first_chars = sb.extract_string_chars(elem_exprs[0]);
     all_chars.insert(all_chars.end(), first_chars.begin(), first_chars.end());
-    
+
     // For each remaining element: add separator, then add element
     for (size_t i = 1; i < elem_exprs.size(); ++i)
     {
       // Insert separator characters
       std::vector<exprt> sep_chars = sb.extract_string_chars(separator);
       all_chars.insert(all_chars.end(), sep_chars.begin(), sep_chars.end());
-      
+
       // Insert element characters
       std::vector<exprt> elem_chars = sb.extract_string_chars(elem_exprs[i]);
       all_chars.insert(all_chars.end(), elem_chars.begin(), elem_chars.end());
     }
-    
+
     // Build final null-terminated string from all collected characters
     return sb.build_null_terminated_string(all_chars);
   }
@@ -1971,14 +1974,15 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
   // Python syntax: separator.join(iterable), e.g., " ".join(["a", "b"])
   // This handles it before the general function_call_builder to ensure
   // proper AST-based list element extraction
-  if (element["func"]["_type"] == "Attribute" && 
-      element["func"]["attr"] == "join")
+  if (
+    element["func"]["_type"] == "Attribute" &&
+    element["func"]["attr"] == "join")
   {
     const auto &func = element["func"];
     // Check if the caller is a string (Constant like " " or a Name variable)
-    if (func.contains("value") && 
-        (func["value"]["_type"] == "Constant" || 
-         func["value"]["_type"] == "Name"))
+    if (
+      func.contains("value") && (func["value"]["_type"] == "Constant" ||
+                                 func["value"]["_type"] == "Name"))
     {
       return handle_str_join(element);
     }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1112,6 +1112,122 @@ exprt python_converter::handle_none_comparison(
     return not_exprt(equality_exprt(lhs, rhs));
 }
 
+/**
+ * @brief Handle str.join() method calls
+ * 
+ * Implements Python's str.join() method by:
+ * 1. Extracting the separator string from the method caller (e.g., " " in " ".join(l))
+ * 2. Getting the list elements from the AST
+ * 3. Building a single concatenated string by extracting all characters
+ *    and inserting separators between elements
+ * 
+ * @param call_json The JSON AST node for the join() call
+ * @return exprt representing the joined string
+ * 
+ * Example: " ".join(["a", "b"]) -> "a b"
+ */
+exprt python_converter::handle_str_join(const nlohmann::json &call_json)
+{
+  // Validate JSON structure: ensure we have the required keys
+  if (!call_json.contains("args") || call_json["args"].empty())
+    throw std::runtime_error("join() missing required argument: 'iterable'");
+
+  if (!call_json.contains("func"))
+    throw std::runtime_error("invalid join() call");
+
+  const auto &func = call_json["func"];
+
+  // Verify this is an Attribute call (method call syntax: obj.method())
+  // and has the value (the separator object)
+  if (!func.contains("_type") || func["_type"] != "Attribute" || 
+      !func.contains("value"))
+    throw std::runtime_error("invalid join() call");
+
+  // Extract separator: for " ".join(l), func["value"] is the Constant " "
+  exprt separator = get_expr(func["value"]);
+  string_handler_.ensure_string_array(separator);
+
+  // Get the list argument (the iterable to join)
+  const nlohmann::json &list_arg = call_json["args"][0];
+
+  // Currently only support Name references (e.g., variable names)
+  // TODO: Support direct List literals like " ".join(["a", "b"])
+  if (list_arg.contains("_type") && list_arg["_type"] == "Name" &&
+      list_arg.contains("id"))
+  {
+    std::string var_name = list_arg["id"].get<std::string>();
+    
+    // Look up the variable in the AST to get its initialization value
+    nlohmann::json var_decl = json_utils::find_var_decl(
+      var_name, current_func_name_, *ast_json);
+    
+    if (var_decl.empty())
+      throw std::runtime_error(
+        "NameError: name '" + var_name + "' is not defined");
+
+    // Ensure the variable is a list with elements array
+    if (!var_decl.contains("value"))
+      throw std::runtime_error("join() requires a list");
+
+    const nlohmann::json &list_value = var_decl["value"];
+
+    if (!list_value.contains("_type") || list_value["_type"] != "List" || 
+        !list_value.contains("elts"))
+      throw std::runtime_error("join() requires a list");
+
+    // Get the list elements from the AST
+    const auto &elements = list_value["elts"];
+
+    // Edge case: empty list returns empty string
+    if (elements.empty())
+    {
+      typet empty_str = type_handler_.get_typet("str", 1);
+      return gen_zero(empty_str);
+    }
+
+    // Convert JSON elements to ESBMC expressions
+    std::vector<exprt> elem_exprs;
+    for (const auto &elem : elements)
+    {
+      exprt elem_expr = get_expr(elem);
+      string_handler_.ensure_string_array(elem_expr);
+      elem_exprs.push_back(elem_expr);
+    }
+
+    // Edge case: single element returns the element itself (no separator)
+    if (elem_exprs.size() == 1)
+      return elem_exprs[0];
+
+    // Main algorithm: Build the joined string by extracting characters
+    // from all elements and separators, then constructing a single string.
+    // This avoids multiple concatenation operations which could cause
+    // null terminator issues.
+    string_builder &sb = get_string_builder();
+    std::vector<exprt> all_chars;
+    
+    // Start with the first element
+    std::vector<exprt> first_chars = sb.extract_string_chars(elem_exprs[0]);
+    all_chars.insert(all_chars.end(), first_chars.begin(), first_chars.end());
+    
+    // For each remaining element: add separator, then add element
+    for (size_t i = 1; i < elem_exprs.size(); ++i)
+    {
+      // Insert separator characters
+      std::vector<exprt> sep_chars = sb.extract_string_chars(separator);
+      all_chars.insert(all_chars.end(), sep_chars.begin(), sep_chars.end());
+      
+      // Insert element characters
+      std::vector<exprt> elem_chars = sb.extract_string_chars(elem_exprs[i]);
+      all_chars.insert(all_chars.end(), elem_chars.begin(), elem_chars.end());
+    }
+    
+    // Build final null-terminated string from all collected characters
+    return sb.build_null_terminated_string(all_chars);
+  }
+
+  throw std::runtime_error("join() argument must be a list of strings");
+}
+
 // Resolve symbol values to constants
 exprt python_converter::get_resolved_value(const exprt &expr)
 {
@@ -1850,6 +1966,23 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
 {
   if (!element.contains("func") || element["_type"] != "Call")
     throw std::runtime_error("Invalid function call");
+
+  // Early detection for str.join() method calls
+  // Python syntax: separator.join(iterable), e.g., " ".join(["a", "b"])
+  // This handles it before the general function_call_builder to ensure
+  // proper AST-based list element extraction
+  if (element["func"]["_type"] == "Attribute" && 
+      element["func"]["attr"] == "join")
+  {
+    const auto &func = element["func"];
+    // Check if the caller is a string (Constant like " " or a Name variable)
+    if (func.contains("value") && 
+        (func["value"]["_type"] == "Constant" || 
+         func["value"]["_type"] == "Name"))
+    {
+      return handle_str_join(element);
+    }
+  }
 
   // Handle indirect calls through function pointer variables
   if (element["func"]["_type"] == "Name")

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -369,6 +369,9 @@ private:
     const nlohmann::json &element,
     exprt &bin_expr);
 
+  // String method helpers
+  exprt handle_str_join(const nlohmann::json &call_json);
+
   contextt &symbol_table_;
   const nlohmann::json *ast_json;
   const global_scope &global_scope_;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3000.

## In short
Implements support for Python's `str.join()` method in the ESBMC Python frontend.

## Implementation
- Added `handle_str_join()` method in `python_converter.cpp`
- Fixed crash when calling methods on string literals in `python_annotation.h`
- Supports variable references, empty lists, single elements, and multi-character separators

## Test Coverage
Added 17 regression tests covering:
- Basic join operations 
- Edge cases (empty list, single element, empty separator)
- Type error test (`github_3000_8_fail`)

## Known Issues

**Limited support for direct list literals:**
`github_3000_1` is marked as `KNOWNBUG` - currently optimized for variable references. It should be able to set string as default and do a check in future since join's nature of string elements.

**Counterexample readability:**
When verification fails, the output shows low-level C symbols instead of Python-level information. For example, `github_3000_7_fail` outputs:
```
Violated property: return_value$_strcmp$1 == 0
```
Instead of showing the actual vs expected string values.

