### PR TITLE
[python] fix type resolution for Literal types in Union annotations

### DIFF
--- a/regression/python/github_3012/main.py
+++ b/regression/python/github_3012/main.py
@@ -1,0 +1,7 @@
+from typing import Literal
+
+def foo(s: Literal["bar"] | None) -> None:
+    assert s is not None
+    assert s == "bar"
+
+foo("bar")

--- a/regression/python/github_3012/test.desc
+++ b/regression/python/github_3012/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3012_2/main.py
+++ b/regression/python/github_3012_2/main.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+def foo(s: Literal["bar", "baz"] | None) -> None:
+    assert s is not None
+    if s == "bar":
+        pass
+    else:
+        assert s == "baz"
+
+foo("bar")

--- a/regression/python/github_3012_2/test.desc
+++ b/regression/python/github_3012_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3012_2_fail/main.py
+++ b/regression/python/github_3012_2_fail/main.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+def foo(s: Literal["bar", "baz"] | None) -> None:
+    assert s is not None
+    if s == "bar":
+        assert False
+    else:
+        assert s == "baz"
+
+foo("bar")

--- a/regression/python/github_3012_2_fail/test.desc
+++ b/regression/python/github_3012_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3012_3_fail/main.py
+++ b/regression/python/github_3012_3_fail/main.py
@@ -1,0 +1,13 @@
+import random
+from typing import Literal
+
+def foo(s: Literal["bar"] | None) -> None:
+    assert s is not None
+    assert s == "bar"
+
+x = random.randint(0, 1)
+
+if x:
+   foo("bar")
+else:
+   foo(None)

--- a/regression/python/github_3012_3_fail/test.desc
+++ b/regression/python/github_3012_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3012_fail/main.py
+++ b/regression/python/github_3012_fail/main.py
@@ -1,0 +1,7 @@
+from typing import Literal
+
+def foo(s: Literal["bar"] | None) -> None:
+    assert s is None
+    assert s != "bar"
+
+foo("bar")

--- a/regression/python/github_3012_fail/test.desc
+++ b/regression/python/github_3012_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties: 2 verified, \✗ 2 failed$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -23,6 +23,7 @@ ignored_dirs=(
   "github_2843_4_fail"
   "github_2993_fail"
   "github_2993_2_fail"
+  "github_3012_3_fai"
   "global"
   "integer_squareroot_fail"
   "int_from_bytes"


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3012.

This PR fixes verification of Optional Literal type parameters.

When handling unions such as `Literal["bar"] | None`, the type extractor was failing to recognize Subscript nodes (Literal types), causing it to return a generic pointer type instead of the correct specific type. This led to type mismatches during comparison operations and solver crashes.

This PR modifies `extract_non_none_type()` to detect Literal subscript nodes and return a special marker, and updated the `BinOp` handler in `get_type_from_annotation()` to recursively process Literal annotations when the marker is detected, ensuring proper type resolution.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.