### PR TITLE
[python] Detect conflicts between positional and keyword arguments

### DIFF
--- a/regression/python/github_3015/main.py
+++ b/regression/python/github_3015/main.py
@@ -1,0 +1,8 @@
+# Test: Correct function call with keyword arguments (should succeed)
+# Issue #3015: Correct usage of keyword arguments
+def foo(x: int, y: str) -> None:
+    assert x == 42
+    assert y == "foo"
+
+foo(x=42, y="foo")
+

--- a/regression/python/github_3015/test.desc
+++ b/regression/python/github_3015/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3015_1_fail/main.py
+++ b/regression/python/github_3015_1_fail/main.py
@@ -1,0 +1,7 @@
+# Test: Unknown keyword argument (should fail)
+# Issue #3015: Passing unexpected keyword argument
+def foo(x: int, y: str) -> None:
+    pass
+z: int = 42
+foo(z, x=1, y="foo")
+

--- a/regression/python/github_3015_1_fail/test.desc
+++ b/regression/python/github_3015_1_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^SyntaxError: Multiple values for argument 'x'$
+

--- a/regression/python/github_3015_2_fail/main.py
+++ b/regression/python/github_3015_2_fail/main.py
@@ -1,0 +1,7 @@
+# Test: Unknown keyword argument (should fail)
+# Issue #3015: Passing unexpected keyword argument
+def foo(y: int, x: str) -> None:
+    pass
+z: int = 42
+foo(z, y=1, x="foo")
+

--- a/regression/python/github_3015_2_fail/test.desc
+++ b/regression/python/github_3015_2_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^SyntaxError: Multiple values for argument 'y'$
+

--- a/regression/python/github_3015_3_fail/main.py
+++ b/regression/python/github_3015_3_fail/main.py
@@ -1,0 +1,7 @@
+# Test: Unknown keyword argument (should fail)
+# Issue #3015: Passing unexpected keyword argument
+def foo(y: int, x: str) -> None:
+    pass
+z: int = 42
+foo(z )
+

--- a/regression/python/github_3015_3_fail/test.desc
+++ b/regression/python/github_3015_3_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/regression/python/github_3015_4_fail/main.py
+++ b/regression/python/github_3015_4_fail/main.py
@@ -1,0 +1,7 @@
+# Test: Unknown keyword argument (should fail)
+# Issue #3015: Passing unexpected keyword argument
+def foo(x: int, y: str) -> None:
+    pass
+
+foo(z=42, x=1, y="foo")
+

--- a/regression/python/github_3015_4_fail/test.desc
+++ b/regression/python/github_3015_4_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.py
+
+^SyntaxError: Unknown keyword argument: z$
+

--- a/regression/python/github_3015_4_fail/test.desc
+++ b/regression/python/github_3015_4_fail/test.desc
@@ -1,5 +1,5 @@
-KNOWNBUG
+CORE
 main.py
 
-^SyntaxError: Unknown keyword argument: z$
+^ERROR: Unknown keyword argument: z in function foo$
 

--- a/regression/python/github_3015_fail/main.py
+++ b/regression/python/github_3015_fail/main.py
@@ -1,0 +1,7 @@
+# Test: Multiple values for keyword argument (should fail)
+# Issue #3015: foo gets multiple values for argument "x"
+def foo(x: int, y: str) -> None:
+    pass
+
+foo(42, x=1, y="foo")
+

--- a/regression/python/github_3015_fail/test.desc
+++ b/regression/python/github_3015_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^SyntaxError: Multiple values for argument 'x'$
+

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1085,7 +1085,7 @@ class Preprocessor(ast.NodeTransformer):
                 raise SyntaxError(
                     f"Multiple values for argument '{expectedArgs[i]}'",
                     (self.module_name, node.lineno, node.col_offset, ""))
-        
+
         # append defaults
         for i in range(len(node.args),len(expectedArgs)):
             if expectedArgs[i] in keywords:

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1078,6 +1078,14 @@ class Preprocessor(ast.NodeTransformer):
             self.generic_visit(node)
             return node
 
+        # Check for conflicts between positional and keyword arguments
+        for i in range(len(node.args)):
+            if i < len(expectedArgs) and expectedArgs[i] in keywords:
+                # Positional argument at position i conflicts with keyword argument
+                raise SyntaxError(
+                    f"Multiple values for argument '{expectedArgs[i]}'",
+                    (self.module_name, node.lineno, node.col_offset, ""))
+        
         # append defaults
         for i in range(len(node.args),len(expectedArgs)):
             if expectedArgs[i] in keywords:


### PR DESCRIPTION
Fixes #3015.

### What This PR Fixes
Added syntax checking to detect when a function receives multiple values for the same argument (e.g., `foo(42, x=1, y="foo")` where `x` is passed both positionally and as keyword).

### Known Issues

**1. Missing Class Definition Problem**
When the called element has no class definition, another error triggers **before** our syntax checking runs, preventing proper validation.

**Action needed:** This should be fixed in another separate issue.

**2. Inconsistent Error Handling**
- Too few arguments: Shows `Violated property: function call: not enough arguments` (verification failure)  --> BMC level
- Too many arguments: Shows `SyntaxError: Multiple values for argument 'x'` (this PR) --> syntax level

These should use the same error reporting mechanism for consistency.

### Test Results
✅ All regression tests pass for covered scenarios
- Valid keyword usage: Pass
- Multiple values for argument: Detected
- Unknown keyword argument: Detected
