### PR TITLE
[python verificaiton] refactor the python isinstance implementation

### DIFF
--- a/regression/python/github_2966/main.py
+++ b/regression/python/github_2966/main.py
@@ -1,0 +1,3 @@
+i = 42
+x: Any = "foo" if i > 10 else i + 10
+assert isinstance(x, str)

--- a/regression/python/github_2966/main.py
+++ b/regression/python/github_2966/main.py
@@ -1,8 +1,0 @@
-# Test case for GitHub issue #2966
-# isinstance should work correctly with ternary operators
-from typing import Any
-
-i = 42
-x: Any = "foo" if i > 10 else i + 10
-assert isinstance(x, str)
-

--- a/regression/python/github_2966/main.py
+++ b/regression/python/github_2966/main.py
@@ -1,3 +1,4 @@
+from typing import Any
 i = 42
 x: Any = "foo" if i > 10 else i + 10
 assert isinstance(x, str)

--- a/regression/python/github_2966/test.desc
+++ b/regression/python/github_2966/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2966/test.desc
+++ b/regression/python/github_2966/test.desc
@@ -1,5 +1,0 @@
-CORE
-main.py
-
-^VERIFICATION SUCCESSFUL$
-

--- a/regression/python/github_2966_fail/main.py
+++ b/regression/python/github_2966_fail/main.py
@@ -1,3 +1,4 @@
+from typing import Any
 i = 5
 x: Any = "foo" if i > 10 else i + 10
 assert isinstance(x, str)

--- a/regression/python/github_2966_fail/main.py
+++ b/regression/python/github_2966_fail/main.py
@@ -1,8 +1,0 @@
-# Test case for GitHub issue #2966 (failure case)
-# isinstance should correctly fail when condition is false
-from typing import Any
-
-i = 5  # i <= 10, so x will be int, not str
-x: Any = "foo" if i > 10 else i + 10
-assert isinstance(x, str)
-

--- a/regression/python/github_2966_fail/main.py
+++ b/regression/python/github_2966_fail/main.py
@@ -1,0 +1,3 @@
+i = 5
+x: Any = "foo" if i > 10 else i + 10
+assert isinstance(x, str)

--- a/regression/python/github_2966_fail/test.desc
+++ b/regression/python/github_2966_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2966_fail/test.desc
+++ b/regression/python/github_2966_fail/test.desc
@@ -1,5 +1,0 @@
-CORE
-main.py
-
-^VERIFICATION FAILED$
-

--- a/regression/python/github_2975/main.py
+++ b/regression/python/github_2975/main.py
@@ -1,0 +1,14 @@
+def foo(s: str | int) -> int:
+    if isinstance(s, int):
+        return s
+
+    if isinstance(s, str):
+        if 'X' not in s:
+            return 42
+        else:
+            return 17
+
+    return -1
+
+assert foo(4) == 4
+assert foo('') == 42

--- a/regression/python/github_2975/test.desc
+++ b/regression/python/github_2975/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2975_fail/main.py
+++ b/regression/python/github_2975_fail/main.py
@@ -1,0 +1,14 @@
+def foo(s: str | int) -> int:
+    if isinstance(s, int):
+        return s
+
+    if isinstance(s, str):
+        if 'X' not in s:
+            return 42
+        else:
+            return 17
+
+    return -1
+
+assert foo(4) == 4
+assert foo('') != 42

--- a/regression/python/github_2975_fail/test.desc
+++ b/regression/python/github_2975_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2989/main.py
+++ b/regression/python/github_2989/main.py
@@ -1,0 +1,5 @@
+def foo(s: str | None = None) -> None:
+    if s is not None:
+        assert isinstance(s, str)
+
+foo("foo")

--- a/regression/python/github_2989/test.desc
+++ b/regression/python/github_2989/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2989_1/main.py
+++ b/regression/python/github_2989_1/main.py
@@ -1,0 +1,4 @@
+def foo(s: str) -> None:
+    assert isinstance(s, str), "s must be a string"
+
+foo("foo")

--- a/regression/python/github_2989_1/test.desc
+++ b/regression/python/github_2989_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2989_1_fail/main.py
+++ b/regression/python/github_2989_1_fail/main.py
@@ -1,0 +1,4 @@
+def foo(s: str) -> None:
+    assert isinstance(s, int), "s must be a string"
+
+foo("foo")

--- a/regression/python/github_2989_1_fail/test.desc
+++ b/regression/python/github_2989_1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_2989_fail/main.py
+++ b/regression/python/github_2989_fail/main.py
@@ -1,0 +1,5 @@
+def foo(s: str | None = None) -> None:
+    if s is not None:
+        assert isinstance(s, None)
+
+foo("foo")

--- a/regression/python/github_2989_fail/test.desc
+++ b/regression/python/github_2989_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2631,11 +2631,11 @@ void goto_symext::replace_races_check(expr2tc &expr)
   }
 }
 
-void goto_symext::replace_python_impl(expr2tc &expr)
+void goto_symext::simplify_python_builtins(expr2tc &expr)
 {
   expr->Foreach_operand([this](expr2tc &e) {
     if (!is_nil_expr(e))
-      replace_python_impl(e);
+      simplify_python_builtins(e);
   });
 
   if (is_isinstance2t(expr))

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2676,7 +2676,7 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
           expr = gen_true_expr();
         else
           expr = gen_false_expr();
-        
+
         return;
       }
 

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -763,13 +763,11 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     new_rhs.operands.erase(new_rhs.operands.begin());
 
   std::list<expr2tc> args;
-  new_rhs.foreach_operand(
-    [this, &args](const expr2tc &e)
-    {
-      expr2tc tmp = e;
-      do_simplify(tmp);
-      args.push_back(tmp);
-    });
+  new_rhs.foreach_operand([this, &args](const expr2tc &e) {
+    expr2tc tmp = e;
+    do_simplify(tmp);
+    args.push_back(tmp);
+  });
 
   if (!is_nil_expr(lhs))
   {
@@ -2306,8 +2304,7 @@ void goto_symext::intrinsic_builtin_object_size(
   //   - 0 if the object cannot be determined (for type=2 or 3).
   // The type parameter encodes whether we want the full size (0/2)
   // or remaining size after pointer offset (1/3).
-  auto create_fallback_size = [&](bool use_zero)
-  {
+  auto create_fallback_size = [&](bool use_zero) {
     return use_zero ? constant_int2tc(size_type2(), BigInt(0))
                     : constant_int2tc(
                         size_type2(),
@@ -2597,12 +2594,10 @@ void goto_symext::replace_races_check(expr2tc &expr)
 
   // replace RACE_CHECK(&x) with __ESBMC_races_flag[&x]
   // recursion is needed for this case: !RACE_CHECK(&x)
-  expr->Foreach_operand(
-    [this](expr2tc &e)
-    {
-      if (!is_nil_expr(e))
-        replace_races_check(e);
-    });
+  expr->Foreach_operand([this](expr2tc &e) {
+    if (!is_nil_expr(e))
+      replace_races_check(e);
+  });
 
   if (is_races_check2t(expr))
   {
@@ -2638,12 +2633,10 @@ void goto_symext::replace_races_check(expr2tc &expr)
 
 void goto_symext::simplify_python_builtins(expr2tc &expr)
 {
-  expr->Foreach_operand(
-    [this](expr2tc &e)
-    {
-      if (!is_nil_expr(e))
-        simplify_python_builtins(e);
-    });
+  expr->Foreach_operand([this](expr2tc &e) {
+    if (!is_nil_expr(e))
+      simplify_python_builtins(e);
+  });
 
   if (is_isinstance2t(expr))
   {

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2654,8 +2654,6 @@ void goto_symext::replace_python_impl(expr2tc &expr)
         const object_descriptor2t &o = to_object_descriptor2t(obj);
         value = o.object;
       }
-      else
-        value = obj;
     }
 
     cur_state->rename(value);
@@ -2685,7 +2683,7 @@ void goto_symext::replace_python_impl(expr2tc &expr)
 
     type2t::type_ids id;
     if (is_index2t(value))
-      // Special case, str is modeled as a pointer, we need to get its subtype
+      // Special case, str is modeled as a array, we need to get its subtype
       id = to_index2t(value).source_value->type.get()->type_id;
     else
       id = value->type.get()->type_id;

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -763,11 +763,13 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
     new_rhs.operands.erase(new_rhs.operands.begin());
 
   std::list<expr2tc> args;
-  new_rhs.foreach_operand([this, &args](const expr2tc &e) {
-    expr2tc tmp = e;
-    do_simplify(tmp);
-    args.push_back(tmp);
-  });
+  new_rhs.foreach_operand(
+    [this, &args](const expr2tc &e)
+    {
+      expr2tc tmp = e;
+      do_simplify(tmp);
+      args.push_back(tmp);
+    });
 
   if (!is_nil_expr(lhs))
   {
@@ -2304,7 +2306,8 @@ void goto_symext::intrinsic_builtin_object_size(
   //   - 0 if the object cannot be determined (for type=2 or 3).
   // The type parameter encodes whether we want the full size (0/2)
   // or remaining size after pointer offset (1/3).
-  auto create_fallback_size = [&](bool use_zero) {
+  auto create_fallback_size = [&](bool use_zero)
+  {
     return use_zero ? constant_int2tc(size_type2(), BigInt(0))
                     : constant_int2tc(
                         size_type2(),
@@ -2594,10 +2597,12 @@ void goto_symext::replace_races_check(expr2tc &expr)
 
   // replace RACE_CHECK(&x) with __ESBMC_races_flag[&x]
   // recursion is needed for this case: !RACE_CHECK(&x)
-  expr->Foreach_operand([this](expr2tc &e) {
-    if (!is_nil_expr(e))
-      replace_races_check(e);
-  });
+  expr->Foreach_operand(
+    [this](expr2tc &e)
+    {
+      if (!is_nil_expr(e))
+        replace_races_check(e);
+    });
 
   if (is_races_check2t(expr))
   {
@@ -2633,10 +2638,12 @@ void goto_symext::replace_races_check(expr2tc &expr)
 
 void goto_symext::simplify_python_builtins(expr2tc &expr)
 {
-  expr->Foreach_operand([this](expr2tc &e) {
-    if (!is_nil_expr(e))
-      simplify_python_builtins(e);
-  });
+  expr->Foreach_operand(
+    [this](expr2tc &e)
+    {
+      if (!is_nil_expr(e))
+        simplify_python_builtins(e);
+    });
 
   if (is_isinstance2t(expr))
   {
@@ -2681,7 +2688,9 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
       }
 
       // Check sub class
-      if (is_subclass_of(expect_type->type, value->type, ns))
+      if (
+        base_type_eq(expect_type->type, value->type, ns) ||
+        is_subclass_of(expect_type->type, value->type, ns))
         expr = gen_true_expr();
       else
         expr = gen_false_expr();

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2676,6 +2676,8 @@ void goto_symext::replace_python_impl(expr2tc &expr)
           expr = gen_true_expr();
         else
           expr = gen_false_expr();
+        
+        return;
       }
 
       // Check sub class

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -515,7 +515,7 @@ protected:
   /* Handles dereferencing between threads and is used only in data race checks. **/
   void replace_races_check(expr2tc &expr);
 
-  void replace_python_impl(expr2tc &expr);
+  void simplify_python_builtins(expr2tc &expr);
 
   /** Walk back up stack frame looking for exception handler. */
   bool symex_throw();

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -515,6 +515,8 @@ protected:
   /* Handles dereferencing between threads and is used only in data race checks. **/
   void replace_races_check(expr2tc &expr);
 
+  void replace_python_impl(expr2tc &expr);
+
   /** Walk back up stack frame looking for exception handler. */
   bool symex_throw();
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -227,6 +227,7 @@ void goto_symext::symex_step(reachability_treet &art)
 
     dereference(tmp, dereferencet::READ);
     replace_dynamic_allocation(tmp);
+    replace_python_impl(tmp);
 
     symex_goto(tmp);
   }
@@ -499,6 +500,7 @@ void goto_symext::symex_assert()
   replace_dynamic_allocation(tmp);
 
   replace_races_check(tmp);
+  replace_python_impl(tmp);
 
   claim(tmp, msg);
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -227,7 +227,7 @@ void goto_symext::symex_step(reachability_treet &art)
 
     dereference(tmp, dereferencet::READ);
     replace_dynamic_allocation(tmp);
-    replace_python_impl(tmp);
+    simplify_python_builtins(tmp);
 
     symex_goto(tmp);
   }
@@ -500,7 +500,7 @@ void goto_symext::symex_assert()
   replace_dynamic_allocation(tmp);
 
   replace_races_check(tmp);
-  replace_python_impl(tmp);
+  simplify_python_builtins(tmp);
 
   claim(tmp, msg);
 }

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -131,7 +131,8 @@
   BOOST_PP_LIST_CONS(capability_top,                                           \
   BOOST_PP_LIST_CONS(forall,                                                   \
   BOOST_PP_LIST_CONS(exists,                                                   \
-  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_CONS(isinstance,                                               \
+  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -117,7 +117,7 @@ static const char *expr_names[] = {
   "capability_top",
   "forall",
   "exists",
-};
+  "isinstance"};
 // If this fires, you've added/removed an expr id, and need to update the list
 // above (which is ordered according to the enum list)
 static_assert(

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1530,6 +1530,7 @@ irep_typedefs(capability_base, object_ops);
 irep_typedefs(capability_top, object_ops);
 irep_typedefs(forall, logic_2ops);
 irep_typedefs(exists, logic_2ops);
+irep_typedefs(isinstance, logic_2ops);
 
 class exists2t : public exists_expr_methods
 {
@@ -3133,6 +3134,18 @@ public:
   {
   }
   races_check2t(const races_check2t &ref) = default;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class isinstance2t : public isinstance_expr_methods
+{
+public:
+  isinstance2t(const expr2tc &value, const expr2tc &type)
+    : isinstance_expr_methods(get_bool_type(), isinstance_id, value, type)
+  {
+  }
+  isinstance2t(const isinstance2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -251,6 +251,8 @@ std::string forall2t::field_names[esbmct::num_type_fields] =
   {"symbol", "predicate", "", "", ""};
 std::string exists2t::field_names[esbmct::num_type_fields] =
   {"symbol", "predicate", "", "", ""};
+std::string isinstance2t::field_names[esbmct::num_type_fields] =
+  {"value", "type", "", "", ""};
 
 // For CRCing to actually be accurate, expr/type ids mustn't overflow out of
 // a byte. If this happens then a) there are too many exprs, and b) the expr

--- a/src/irep2/templates/irep2_templates_expr_ops.cpp
+++ b/src/irep2/templates/irep2_templates_expr_ops.cpp
@@ -37,6 +37,7 @@ expr_typedefs1(address_of, pointer_ops);
 expr_typedefs1(overflow, overflow_ops);
 expr_typedefs1(valid_object, object_ops);
 expr_typedefs1(races_check, object_ops);
+expr_typedefs1(isinstance, logic_2ops);
 expr_typedefs1(dynamic_size, object_ops);
 expr_typedefs1(deallocated_obj, object_ops);
 expr_typedefs1(invalid_pointer, invalid_pointer_ops);

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -283,11 +283,19 @@ exprt function_call_expr::handle_isinstance() const
 
   auto build_isinstance = [&](const std::string &type_name) {
     typet expected_type = type_handler_.get_typet(type_name, 0);
-    exprt zero = gen_zero(expected_type);
+    exprt t;
+    if (expected_type.is_symbol())
+    {
+      // struct type
+      const symbolt *symbol = converter_.ns.lookup(expected_type);
+      t = symbol_expr(*symbol);
+    }
+    else
+      t = gen_zero(expected_type);
 
     exprt isinstance("isinstance", typet("bool"));
     isinstance.copy_to_operands(obj_expr);
-    isinstance.move_to_operands(zero);
+    isinstance.move_to_operands(t);
     return isinstance;
   };
 

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -230,45 +230,6 @@ exprt function_call_expr::build_nondet_call() const
   return rhs;
 }
 
-bool function_call_expr::is_same_type(
-  const exprt &obj_expr,
-  const nlohmann::json &type_node) const
-{
-  if (type_node["_type"] != "Name")
-    throw std::runtime_error("Unsupported type in isinstance()");
-
-  std::string type_name = type_node["id"];
-
-  // Special handling for tuple type checking
-  if (type_name == "tuple")
-  {
-    // Check if object is a tuple by examining struct tag
-    if (obj_expr.type().id() == "struct")
-    {
-      const struct_typet &struct_type = to_struct_type(obj_expr.type());
-
-      // Check if this is a tuple by examining the tag
-      if (struct_type.tag().as_string().find("tag-tuple") == 0)
-        return true;
-    }
-    return false;
-  }
-
-  // Get the internal type representation from the type name
-  typet expected_type = type_handler_.get_typet(type_name, 0);
-
-  /* NOTE: Comparing the types directly may be insufficient.
-           Inheritance or type aliases may require deeper analysis. */
-
-  if (base_type_eq(obj_expr.type(), expected_type, converter_.ns))
-    return true;
-
-  if (is_subclass_of(obj_expr.type(), expected_type, converter_.ns))
-    return true;
-
-  return false;
-}
-
 exprt function_call_expr::handle_isinstance() const
 {
   const auto &args = call_["args"];

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -293,11 +293,20 @@ exprt function_call_expr::handle_isinstance() const
 
   if (type_arg["_type"] == "Name")
   {
+    // isinstance(v, int)
     std::string type_name = args[1]["id"];
+    return build_isinstance(type_name);
+  }
+  else if (type_arg["_type"] == "Constant")
+  {
+    // isintance(v, None)
+    std::string type_name = "NoneType";
     return build_isinstance(type_name);
   }
   else if (type_arg["_type"] == "Tuple")
   {
+    // isinstance(v, (int, str))
+    // converted into instance(v, int) || isinstance(v, str)
     const auto &elts = type_arg["elts"];
 
     std::string first_type = elts[0]["id"];

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -277,92 +277,12 @@ exprt function_call_expr::handle_isinstance() const
   if (args.size() != 2)
     throw std::runtime_error("isinstance() expects 2 arguments");
 
-  const auto &obj_arg = args[0];
+  // Convert the first argument (the object being checked) into an expression
+  exprt obj_expr = converter_.get_expr(args[0]);
   const auto &type_arg = args[1];
 
-  // Special handling: check if the object is a variable assigned from IfExp
-  if (
-    obj_arg.contains("_type") && obj_arg["_type"] == "Name" &&
-    obj_arg.contains("id") && type_arg["_type"] == "Name")
-  {
-    std::string var_name = obj_arg["id"].get<std::string>();
-    nlohmann::json var_decl = json_utils::find_var_decl(
-      var_name, converter_.current_function_name(), converter_.ast());
-
-    // Check if variable is assigned from a ternary operator (IfExp)
-    if (
-      !var_decl.empty() && var_decl.contains("value") &&
-      var_decl["value"].contains("_type") &&
-      var_decl["value"]["_type"] == "IfExp")
-    {
-      const auto &ifexp = var_decl["value"];
-
-      // Convert the condition and branches directly from AST
-      exprt cond = converter_.get_expr(ifexp["test"]);
-      exprt then_expr = converter_.get_expr(ifexp["body"]);
-      exprt else_expr = converter_.get_expr(ifexp["orelse"]);
-
-      // Check if each branch matches the type
-      bool then_matches = is_same_type(then_expr, type_arg);
-      bool else_matches = is_same_type(else_expr, type_arg);
-
-      if (then_matches && else_matches)
-      {
-        // Both branches match - always return true
-        return gen_boolean(true);
-      }
-      else if (!then_matches && !else_matches)
-      {
-        // Neither branch matches - always return false
-        return gen_boolean(false);
-      }
-      else
-      {
-        // One branch matches, one doesn't - generate runtime check
-        // isinstance(x, type) where x = (cond ? then : else)
-        //   => cond ? isinstance(then, type) : isinstance(else, type)
-        //   => cond ? then_matches : else_matches
-        if_exprt result(
-          cond, gen_boolean(then_matches), gen_boolean(else_matches));
-        result.type() = type_handler_.get_typet("bool", 0);
-        return result;
-      }
-    }
-  }
-
-  // Convert the first argument (the object being checked) into an expression
-  exprt obj_expr = converter_.get_expr(obj_arg);
-
   if (type_arg["_type"] == "Name")
-  {
-    // Check if the expression itself is an if expression
-    if (obj_expr.id() == "if")
-    {
-      const if_exprt &if_expr = to_if_expr(obj_expr);
-
-      // Check if each branch matches the type
-      bool then_matches = is_same_type(if_expr.true_case(), type_arg);
-      bool else_matches = is_same_type(if_expr.false_case(), type_arg);
-
-      if (then_matches && else_matches)
-      {
-        return gen_boolean(true);
-      }
-      else if (!then_matches && !else_matches)
-      {
-        return gen_boolean(false);
-      }
-      else
-      {
-        if_exprt result(
-          if_expr.cond(), gen_boolean(then_matches), gen_boolean(else_matches));
-        result.type() = type_handler_.get_typet("bool", 0);
-        return result;
-      }
-    }
-
     return gen_boolean(is_same_type(obj_expr, type_arg));
-  }
   else if (type_arg["_type"] == "Tuple")
   {
     const auto &elts = type_arg["elts"];

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -111,9 +111,6 @@ private:
    */
   const symbolt *lookup_python_symbol(const std::string &var_name) const;
 
-  bool
-  is_same_type(const exprt &obj_expr, const nlohmann::json &type_node) const;
-
   exprt handle_isinstance() const;
 
   exprt handle_hasattr() const;

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -408,12 +408,12 @@ static std::string reformat_class_name(const std::string &from)
   std::string classname;
   if (pos == std::string::npos)
   {
-    classname = "tag." + from;
+    classname = "tag-" + from;
   }
   else
   {
     pos++;
-    classname = from.substr(0, pos) + "tag." + from.substr(pos);
+    classname = from.substr(0, pos) + "tag-" + from.substr(pos);
   }
 
   return classname;

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -2381,6 +2381,11 @@ std::string c_expr2stringt::convert(const exprt &src, unsigned &precedence)
     return convert_function(src, "RACE_CHECK", precedence = 15);
   }
 
+  else if (src.id() == "isinstance")
+  {
+    return convert_function(src, "ISINSTANCE", precedence = 15);
+  }
+
   else if (src.id() == "capability_base")
   {
     return convert_function(src, "CAPABILITY_BASE", precedence = 15);

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1525,6 +1525,12 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     migrate_expr(expr.op0(), op0);
     new_expr_ref = races_check2tc(op0);
   }
+  else if (expr.id() == "isinstance")
+  {
+    expr2tc op0, op1;
+    convert_operand_pair(expr, op0, op1);
+    new_expr_ref = isinstance2tc(op0, op1);
+  }
   else if (expr.id() == "capability_base")
   {
     expr2tc op0;
@@ -2876,6 +2882,14 @@ exprt migrate_expr_back(const expr2tc &ref)
     exprt theexpr("races_check", thetype);
     theexpr.copy_to_operands(op0);
     return theexpr;
+  }
+  case expr2t::isinstance_id:
+  {
+    const isinstance2t &ins = to_isinstance2t(ref);
+    exprt back("isinstance", bool_typet());
+    back.copy_to_operands(migrate_expr_back(ins.side_1));
+    back.copy_to_operands(migrate_expr_back(ins.side_2));
+    return back;
   }
   case expr2t::deallocated_obj_id:
   {


### PR DESCRIPTION
fixes #2989 
fixes #2975

This PR refactored the implementation of isinstance:

1. A new irep is introduced to pass the arguments of isinstance to the symex stage for comparison `ISINSTANCE()`.
2. Support new isinstace type: None
3. At the symex level, we compare base type, subclass, tuple type

In short, we collect the set of values of a variable (i.e. the values it has been assigned to), which we use to infer its real type.

```python
def foo(s: int | str) -> None:
   assert isisntance(s, str)
foo("sss")
```
s = "sss" -> "sss" is str type

