### PR TITLE
[python] add deterministic handlers for common regex patterns

### DIFF
--- a/regression/python/github_3013/main.py
+++ b/regression/python/github_3013/main.py
@@ -1,0 +1,9 @@
+import re
+
+# Any string with two lower case letters
+PATTERN = r"^[a-z][a-z]$"
+
+def is_valid(s: str) -> bool:
+    return bool(re.match(PATTERN, s))
+
+assert is_valid("aa")

--- a/regression/python/github_3013/test.desc
+++ b/regression/python/github_3013/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3013_2/main.py
+++ b/regression/python/github_3013_2/main.py
@@ -1,0 +1,8 @@
+import re
+
+PATTERN = r".a"
+
+def is_valid(s: str) -> bool:
+    return bool(re.match(PATTERN, s))
+
+assert is_valid("aa")

--- a/regression/python/github_3013_2/test.desc
+++ b/regression/python/github_3013_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3014_fail/main.py
+++ b/regression/python/github_3014_fail/main.py
@@ -1,0 +1,8 @@
+import re
+
+PATTERN = r"ab"
+
+def is_valid(s: str) -> bool:
+    return bool(re.match(PATTERN, s))
+
+assert is_valid("aa")

--- a/regression/python/github_3014_fail/test.desc
+++ b/regression/python/github_3014_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -6,6 +6,7 @@
 # 2) We will need to integrate existing string solvers such as Z3-str, CVC5, or Z3's sequence theory.
 # 3) String constraint solving can be expensive; we may need further strategies for handling large string programs.
 
+
 def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> int:
     """Match [x-y]+ or [x-y]* patterns"""
     if pattern_len != 6:
@@ -85,9 +86,8 @@ def try_match_two_char_class_range(pattern: str, pattern_len: int, string: str) 
     if pattern_len != 12:
         return -1
 
-    if not (pattern[0] == '^' and pattern[1] == '[' and pattern[3] == '-' and
-            pattern[5] == ']' and pattern[6] == '[' and pattern[8] == '-' and
-            pattern[10] == ']' and pattern[11] == '$'):
+    if not (pattern[0] == '^' and pattern[1] == '[' and pattern[3] == '-' and pattern[5] == ']' and
+            pattern[6] == '[' and pattern[8] == '-' and pattern[10] == ']' and pattern[11] == '$'):
         return -1
 
     start_char1: str = pattern[2]
@@ -120,10 +120,10 @@ def try_match_dot_literal(pattern: str, pattern_len: int, string: str) -> int:
 
     # Second character should be a literal (not a metacharacter)
     literal_char: str = pattern[1]
-    if (literal_char == '.' or literal_char == '*' or literal_char == '+' or
-        literal_char == '?' or literal_char == '[' or literal_char == ']' or
-        literal_char == '(' or literal_char == ')' or literal_char == '|' or
-        literal_char == '^' or literal_char == '$' or literal_char == '\\'):
+    if (literal_char == '.' or literal_char == '*' or literal_char == '+' or literal_char == '?'
+            or literal_char == '[' or literal_char == ']' or literal_char == '('
+            or literal_char == ')' or literal_char == '|' or literal_char == '^'
+            or literal_char == '$' or literal_char == '\\'):
         return -1
 
     string_len: int = len(string)

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -1,11 +1,11 @@
 # Regular Expression Operational Model
-# TODO: Currently, the regex model uses manual pattern recognizers with 
-# nondeterministic fallbacks. A proper string solver would handle 
+# TODO: Currently, the regex model uses manual pattern recognizers with
+# nondeterministic fallbacks. A proper string solver would handle
 # regex operations formally and completely. We'll have to consider the following:
 # 1) We will need to represent strings as first-class types in our intermediate representation.
 # 2) We will need to integrate existing string solvers such as Z3-str, CVC5, or Z3's sequence theory.
 # 3) String constraint solving can be expensive; we may need further strategies for handling large string programs.
-    
+
 def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> int:
     """Match [x-y]+ or [x-y]* patterns"""
     if pattern_len != 6:

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -1,6 +1,11 @@
 # Regular Expression Operational Model
-
-
+# TODO: Currently, the regex model uses manual pattern recognizers with 
+# nondeterministic fallbacks. A proper string solver would handle 
+# regex operations formally and completely. We'll have to consider the following:
+# 1) We will need to represent strings as first-class types in our intermediate representation.
+# 2) We will need to integrate existing string solvers such as Z3-str, CVC5, or Z3's sequence theory.
+# 3) String constraint solving can be expensive; we may need further strategies for handling large string programs.
+    
 def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> int:
     """Match [x-y]+ or [x-y]* patterns"""
     if pattern_len != 6:


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3013.
Fixes https://github.com/esbmc/esbmc/issues/3014.

This PR adds three new pattern recognizers to handle cases that were incorrectly falling through to nondeterministic behavior:
- `try_match_two_char_class_range()`: Handle ^[x-y][x-y]$ patterns (e.g., ^[a-z][a-z]$)
- `try_match_dot_literal()`: Handle .x patterns (e.g., .a)

This PR also fixed a literal pattern-matching bug: `pattern_len - 1` caused only `n-1` characters to be compared instead of all n characters, making "ab" incorrectly match "aa".

**Future work**: Currently, the regex model uses manual pattern recognizers with nondeterministic fallbacks. A proper string solver would handle regex operations formally and completely.
