### PR TITLE
[python] add --strict-types flag for primitive type-checking

### DIFF
--- a/regression/python/github_3020/main.py
+++ b/regression/python/github_3020/main.py
@@ -1,0 +1,4 @@
+def foo(s: str) -> None:
+    pass
+
+foo(42)

--- a/regression/python/github_3020/test.desc
+++ b/regression/python/github_3020/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/regression/python/github_3020_10/main.py
+++ b/regression/python/github_3020_10/main.py
@@ -1,0 +1,6 @@
+class C:
+    @classmethod
+    def make(cls, value: int) -> None:
+        pass
+
+C.make("wrong")

--- a/regression/python/github_3020_10/test.desc
+++ b/regression/python/github_3020_10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/regression/python/github_3020_2/main.py
+++ b/regression/python/github_3020_2/main.py
@@ -1,0 +1,5 @@
+def bar(x: int, y: str, z: float) -> None:
+    pass
+
+bar("wrong", 123, "also wrong")
+

--- a/regression/python/github_3020_2/test.desc
+++ b/regression/python/github_3020_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/regression/python/github_3020_3/main.py
+++ b/regression/python/github_3020_3/main.py
@@ -1,0 +1,5 @@
+def add(a: int, b: int) -> int:
+    return a + b
+
+result = add(5, 10)
+assert result == 15

--- a/regression/python/github_3020_3/test.desc
+++ b/regression/python/github_3020_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3020_4/main.py
+++ b/regression/python/github_3020_4/main.py
@@ -1,0 +1,4 @@
+def greet(name: str) -> None:
+    pass
+
+greet(42)

--- a/regression/python/github_3020_4/test.desc
+++ b/regression/python/github_3020_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3020_5/main.py
+++ b/regression/python/github_3020_5/main.py
@@ -1,0 +1,4 @@
+def process(value: int) -> None:
+    pass
+
+process(3.14)

--- a/regression/python/github_3020_5/test.desc
+++ b/regression/python/github_3020_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/regression/python/github_3020_6/main.py
+++ b/regression/python/github_3020_6/main.py
@@ -1,0 +1,6 @@
+class Calculator:
+    def multiply(self, x: int, y: int) -> int:
+        return x * y
+
+calc = Calculator()
+calc.multiply(5, "ten")

--- a/regression/python/github_3020_6/test.desc
+++ b/regression/python/github_3020_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/regression/python/github_3020_7/main.py
+++ b/regression/python/github_3020_7/main.py
@@ -1,0 +1,7 @@
+class Calculator:
+    def add(self, x: int, y: int) -> int:
+        return x + y
+
+calc = Calculator()
+result = calc.add(3, 7)
+assert result == 10

--- a/regression/python/github_3020_7/test.desc
+++ b/regression/python/github_3020_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3020_8/main.py
+++ b/regression/python/github_3020_8/main.py
@@ -1,0 +1,5 @@
+def process(value: int) -> int:
+    return value * 2
+
+result1 = process(5)  # Correct
+result2 = process("wrong")  # Should fail here

--- a/regression/python/github_3020_8/test.desc
+++ b/regression/python/github_3020_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/regression/python/github_3020_9/main.py
+++ b/regression/python/github_3020_9/main.py
@@ -1,0 +1,6 @@
+class MyClass:
+    @staticmethod
+    def static_func(x: int) -> int:
+        return x * 2
+
+MyClass.static_func("not an int")

--- a/regression/python/github_3020_9/test.desc
+++ b/regression/python/github_3020_9/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --strict-types
 ^VERIFICATION FAILED$

--- a/regression/python/github_3020_9/test.desc
+++ b/regression/python/github_3020_9/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--strict-types
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -75,6 +75,10 @@ const struct group_opt_templ all_cmd_options[] = {
      {"override-return-annotation",
       NULL,
       "Override return annotation with inferred type"},
+     {"strict-types",
+      NULL,
+      "Enforce strict type checking for function arguments during "
+      "verification"},
    }},
 #endif
 #ifdef ENABLE_SOLIDITY_FRONTEND

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -37,6 +37,14 @@ public:
   }
 
 private:
+  /*
+   * Validates that function call arguments match expected parameter types.
+   * Returns TypeError exception if type mismatch is detected, nil_exprt otherwise.
+   */
+  exprt check_argument_types(
+    const symbolt *func_symbol,
+    const nlohmann::json &args) const;
+
   // Helper methods for AttributeError detection
   std::vector<std::string>
   find_possible_class_types(const symbolt *obj_symbol) const;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3020.

This PR implements optional strict type checking for primitive Python function arguments during verification. When enabled via `--strict-types` flag, ESBMC now validates that argument types match function parameter annotations and raises `TypeError` exceptions with location information for mismatches.

In particular, this PR:
- Adds `--strict-types` command-line option to Python frontend
- Implement `check_argument_types()` to validate function call arguments
- Support instance methods, class methods, and free functions
- Generate `TypeError` with file location on type mismatches
- Add a comprehensive test suite covering various scenarios

Note: Class inheritance and custom type checking will be addressed in a follow-up PR.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for requesting this feature.