### PR TITLE
[python] extend type resolution to parameters in class methods

### DIFF
--- a/regression/python/github_3003/main.py
+++ b/regression/python/github_3003/main.py
@@ -1,0 +1,8 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, l: list[str]) -> None:
+        assert isinstance(l, list)
+        for s in l:
+            pass

--- a/regression/python/github_3003/test.desc
+++ b/regression/python/github_3003/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -217,10 +217,27 @@ const JsonType find_var_decl(
 
   if (!function.empty())
   {
+    // Search in top-level functions
     for (const auto &elem : ast["body"])
     {
       if (elem["_type"] == "FunctionDef" && elem["name"] == function)
         ref = get_var_node(var_name, elem);
+
+      // Search in class methods
+      if (elem["_type"] == "ClassDef" && elem.contains("body"))
+      {
+        for (const auto &class_member : elem["body"])
+        {
+          if (
+            class_member["_type"] == "FunctionDef" &&
+            class_member["name"] == function)
+          {
+            ref = get_var_node(var_name, class_member);
+            if (!ref.empty())
+              return ref;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR extends type resolution to parameters in class methods, enabling correct type inference for iterator variables in for-loops.

This is the first step to fix https://github.com/esbmc/esbmc/issues/3003. The second step is to extend our union support to handle union types such as `list[str] | None = None` (PEP 604 syntax).
