### PR TITLE
[python] fix crash when iterating over union types such as list[str] | None

### DIFF
--- a/regression/python/github_3003_2/main.py
+++ b/regression/python/github_3003_2/main.py
@@ -1,0 +1,8 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, l: list[str] | None = None) -> None:
+        assert isinstance(l, list)
+        for s in l:
+            pass

--- a/regression/python/github_3003_2/test.desc
+++ b/regression/python/github_3003_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3003_3/main.py
+++ b/regression/python/github_3003_3/main.py
@@ -1,0 +1,8 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+    
+    def foo(self, l: list[str] | None = None) -> None:
+        assert isinstance(l, list)
+        for s in l:
+            assert isinstance(s, str)

--- a/regression/python/github_3003_3/test.desc
+++ b/regression/python/github_3003_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3003_3_fail/main.py
+++ b/regression/python/github_3003_3_fail/main.py
@@ -1,0 +1,11 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+    
+    def foo(self, l: list[str] | None = None) -> None:
+        assert isinstance(l, list)
+        for s in l:
+            assert isinstance(s, str)
+
+f = Foo()
+f.foo(None)

--- a/regression/python/github_3003_3_fail/test.desc
+++ b/regression/python/github_3003_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3003_4_fail/main.py
+++ b/regression/python/github_3003_4_fail/main.py
@@ -1,0 +1,11 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+    
+    def foo(self, l: list[str] | None = None) -> None:
+        assert isinstance(l, list)
+        for s in l:
+            assert isinstance(s, str)
+
+f = Foo()
+f.foo(None)

--- a/regression/python/github_3003_4_fail/test.desc
+++ b/regression/python/github_3003_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property --unwind 2 --no-bounds-check --no-pointer-check
+^Properties: 6 verified \✓ 5 passed, \✗ 1 failed$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4189,9 +4189,7 @@ typet python_converter::get_type_from_annotation(
     // List types are already pointers
     // Don't wrap list_type in another pointer; we just return it directly
     if (base_type == type_handler_.get_list_type())
-    {
       return base_type;
-    }
 
     // For other types (e.g., classes, lists), use pointer type
     return gen_pointer_type(base_type);

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3918,6 +3918,8 @@ python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
         std::string subscript_type = node["value"]["id"].get<std::string>();
         if (subscript_type == "Literal")
           return "__LITERAL__"; // Special marker for Literal types
+        // For list[str], dict[int], etc., return the base type (list, dict)
+        return subscript_type;
       }
       return ""; // Other subscript types
     }
@@ -4180,6 +4182,13 @@ typet python_converter::get_type_from_annotation(
     if (
       base_type == long_long_int_type() || base_type == long_long_uint_type() ||
       base_type == double_type() || base_type == bool_type())
+    {
+      return base_type;
+    }
+
+    // List types are already pointers
+    // Don't wrap list_type in another pointer; we just return it directly
+    if (base_type == type_handler_.get_list_type())
     {
       return base_type;
     }


### PR DESCRIPTION
ESBMC crashed with assertion failure when processing for-loops over parameters with union type annotations (e.g., `list[str] | None`). In particular, Union types with lists were being double-wrapped as `pointer(pointer(List))` instead of `pointer(List)`, thereby breaking subscript operations that expected array or vector types.

This PR:
- Handles Subscript nodes to extract base type from `list[T]` annotations.
- Prevents wrapping list types in an additional pointer for union types.
- Extracts element types from `BinOp` union annotations.

