### PR TITLE
[python] support float modulo via fmod() conversion

### DIFF
--- a/regression/python/float_modulo_basic/main.py
+++ b/regression/python/float_modulo_basic/main.py
@@ -1,0 +1,45 @@
+def test_basic_float_modulo():
+    x: float = 5.5
+    y: float = 2.0
+    z: float = x % y
+    assert z == 1.5
+
+def test_equal_operands():
+    x: float = 2.2
+    y: float = 2.2
+    z: float = x % y
+    assert z == 0.0
+
+def test_negative_dividend():
+    # Python: -5.5 % 2.0 = 0.5 (result has sign of divisor y=2.0)
+    x: float = -5.5
+    y: float = 2.0
+    z: float = x % y
+    assert z == 0.5
+
+def test_negative_divisor():
+    # Python: 5.5 % -2.0 = -0.5 (result has sign of divisor y=-2.0)
+    x: float = 5.5
+    y: float = -2.0
+    z: float = x % y
+    assert z == -0.5
+
+def test_both_negative():
+    # Python: -5.5 % -2.0 = -1.5 (result has sign of divisor y=-2.0)
+    x: float = -5.5
+    y: float = -2.0
+    z: float = x % y
+    assert z == -1.5
+
+def test_positive_operands():
+    x: float = 7.0
+    y: float = 3.0
+    z: float = x % y
+    assert z == 1.0
+
+test_basic_float_modulo()
+test_equal_operands()
+test_negative_dividend()
+test_negative_divisor()
+test_both_negative()
+test_positive_operands()

--- a/regression/python/float_modulo_basic/test.desc
+++ b/regression/python/float_modulo_basic/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_compound_assign/main.py
+++ b/regression/python/float_modulo_compound_assign/main.py
@@ -1,0 +1,25 @@
+def test_compound_modulo_assign():
+    x: float = 10.5
+    x %= 3.0
+    assert x == 1.5
+
+def test_compound_modulo_negative():
+    x: float = -10.5
+    x %= 3.0
+    assert x == 1.5  # Result has sign of divisor (3.0)
+
+def test_compound_modulo_negative_divisor():
+    x: float = 10.5
+    x %= -3.0
+    assert x == -1.5  # Result has sign of divisor (-3.0)
+
+def test_multiple_compound_assigns():
+    x: float = 20.0
+    x %= 7.0
+    x %= 3.0
+    assert x == 0.0
+
+test_compound_modulo_assign()
+test_compound_modulo_negative()
+test_compound_modulo_negative_divisor()
+test_multiple_compound_assigns()

--- a/regression/python/float_modulo_compound_assign/test.desc
+++ b/regression/python/float_modulo_compound_assign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_edge_cases/main.py
+++ b/regression/python/float_modulo_edge_cases/main.py
@@ -1,0 +1,37 @@
+def test_zero_dividend():
+    x: float = 0.0
+    y: float = 5.0
+    z: float = x % y
+    assert z == 0.0
+
+def test_small_numbers():
+    x: float = 0.1
+    y: float = 0.3
+    z: float = x % y
+    assert z == 0.1
+
+def test_large_dividend():
+    x: float = 1000.5
+    y: float = 3.0
+    z: float = x % y
+    assert z == 1.5
+
+def test_fractional_divisor():
+    x: float = 5.0
+    y: float = 1.5
+    z: float = x % y
+    assert z == 0.5
+
+def test_negative_zero_result():
+    # When result should be exactly zero with negative divisor
+    x: float = 6.0
+    y: float = -3.0
+    z: float = x % y
+    assert z == 0.0
+
+test_zero_dividend()
+test_small_numbers()
+test_large_dividend()
+test_fractional_divisor()
+test_negative_zero_result()
+

--- a/regression/python/float_modulo_edge_cases/test.desc
+++ b/regression/python/float_modulo_edge_cases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_expression/main.py
+++ b/regression/python/float_modulo_expression/main.py
@@ -1,0 +1,29 @@
+def test_modulo_in_expression():
+    x: float = 10.5
+    y: float = 3.0
+    result: float = (x % y) + 1.0
+    assert result == 2.5
+
+def test_chained_modulo():
+    x: float = 17.0
+    y: float = 5.0
+    z: float = 2.0
+    result: float = (x % y) % z
+    assert result == 0.0
+
+def test_modulo_with_arithmetic():
+    a: float = 7.5
+    b: float = 2.0
+    c: float = (a % b) * 2.0
+    assert c == 3.0
+
+def test_negative_in_expression():
+    x: float = -10.0
+    y: float = 3.0
+    result: float = (x % y) + 5.0
+    assert result == 7.0  # 2.0 + 5.0 = 7.0
+
+test_modulo_in_expression()
+test_chained_modulo()
+test_modulo_with_arithmetic()
+test_negative_in_expression()

--- a/regression/python/float_modulo_expression/test.desc
+++ b/regression/python/float_modulo_expression/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_mixed_types/main.py
+++ b/regression/python/float_modulo_mixed_types/main.py
@@ -1,0 +1,28 @@
+def test_int_mod_float():
+    x: int = 5
+    y: float = 2.0
+    z: float = x % y
+    assert z == 1.0
+
+def test_float_mod_int():
+    x: float = 5.5
+    y: int = 2
+    z: float = x % y
+    assert z == 1.5
+
+def test_negative_int_mod_float():
+    x: int = -7
+    y: float = 3.0
+    z: float = x % y
+    assert z == 2.0  # Python: -7 % 3 = 2, not -1
+
+def test_float_mod_negative_int():
+    x: float = 7.5
+    y: int = -3
+    z: float = x % y
+    assert z == -1.5  # Python: 7.5 % -3 = -1.5
+
+test_int_mod_float()
+test_float_mod_int()
+test_negative_int_mod_float()
+test_float_mod_negative_int()

--- a/regression/python/float_modulo_mixed_types/test.desc
+++ b/regression/python/float_modulo_mixed_types/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_python_semantics/main.py
+++ b/regression/python/float_modulo_python_semantics/main.py
@@ -1,0 +1,38 @@
+def test_result_sign_matches_positive_divisor():
+    # Negative dividend, positive divisor -> positive result
+    x: float = -10.0
+    y: float = 3.0
+    z: float = x % y
+    assert z == 2.0  # -10 = 3*(-4) + 2
+
+def test_result_sign_matches_negative_divisor():
+    # Positive dividend, negative divisor -> negative result
+    x: float = 10.0
+    y: float = -3.0
+    z: float = x % y
+    assert z == -2.0  # 10 = -3*(-4) + (-2)
+
+def test_classic_python_example():
+    # The classic example showing Python vs C difference
+    x: float = -7.0
+    y: float = 3.0
+    z: float = x % y
+    assert z == 2.0  # Python: -7 % 3 = 2, C fmod: -1
+
+def test_another_sign_example():
+    x: float = 17.0
+    y: float = -5.0
+    z: float = x % y
+    assert z == -3.0  # Python: 17 % -5 = -3, C fmod: 2
+
+def test_fractional_negative():
+    x: float = -8.5
+    y: float = 3.0
+    z: float = x % y
+    assert z == 0.5  # -8.5 = 3*(-3) + 0.5
+
+test_result_sign_matches_positive_divisor()
+test_result_sign_matches_negative_divisor()
+test_classic_python_example()
+test_another_sign_example()
+test_fractional_negative()

--- a/regression/python/float_modulo_python_semantics/test.desc
+++ b/regression/python/float_modulo_python_semantics/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_zero_divisor_fail/main.py
+++ b/regression/python/float_modulo_zero_divisor_fail/main.py
@@ -1,0 +1,8 @@
+def test_float_modulo_zero_divisor():
+    x: float = 5.0
+    y: float = 0.0
+    z: float = x % y  # Should raise ZeroDivisionError in Python
+    assert False, "Modulo by zero should not succeed"
+
+test_float_modulo_zero_divisor()
+

--- a/regression/python/float_modulo_zero_divisor_fail/test.desc
+++ b/regression/python/float_modulo_zero_divisor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--overflow-check
+^VERIFICATION FAILED$

--- a/regression/python/mod-fail7/test.desc
+++ b/regression/python/mod-fail7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--overflow-check
 ^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -164,7 +164,8 @@ const static std::vector<std::string> python_c_models = {
   "__python_char_islower",
   "__python_str_islower",
   "__python_char_lower",
-  "__python_str_lower"};
+  "__python_str_lower",
+  "fmod"};
 
 } // namespace
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -166,6 +166,9 @@ private:
 
   exprt handle_power_operator(exprt base, exprt exp);
 
+  exprt
+  handle_modulo_operator(exprt lhs, exprt rhs, const nlohmann::json &element);
+
   exprt build_power_expression(const exprt &base, const BigInt &exp);
 
   bool is_bytes_literal(const nlohmann::json &element);

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -125,7 +125,7 @@ public:
            func_name == "det" || func_name == "matmul" || func_name == "pow" ||
            func_name == "log" || func_name == "pow_by_squaring" ||
            func_name == "log2" || func_name == "log1p_taylor" ||
-           func_name == "ldexp";
+           func_name == "ldexp" || func_name == "fmod";
   }
 
   static bool is_ordered_comparison(const std::string &op)


### PR DESCRIPTION
Convert Python's float % float operations to fmod() calls. Handles mixed types and edge cases.