### PR TITLE
[python] implement list.clear() method support

### DIFF
--- a/regression/python/list-clear/main.py
+++ b/regression/python/list-clear/main.py
@@ -1,0 +1,48 @@
+# Test 1: Basic clear operation
+l = [1, 2, 3]
+assert len(l) == 3
+l.clear()
+assert len(l) == 0
+
+# Test 2: Clear empty list (should not error)
+l = []
+l.clear()
+assert len(l) == 0
+
+# Test 3: Clear and re-populate
+l = [1, 2, 3]
+l.clear()
+assert len(l) == 0
+l.append(4)
+assert len(l) == 1
+assert l[0] == 4
+
+# Test 4: Clear list with mixed types
+l = [1, "hello", 3.14, True]
+assert len(l) == 4
+l.clear()
+assert len(l) == 0
+
+# Test 5: Multiple clears (idempotent)
+l = [1, 2, 3]
+l.clear()
+assert len(l) == 0
+l.clear()
+assert len(l) == 0
+
+# Test 6: Clear doesn't affect other lists
+l1 = [1, 2, 3]
+l2 = [4, 5, 6]
+l1.clear()
+assert len(l1) == 0
+assert len(l2) == 3
+assert l2[0] == 4
+
+# Test 7: Clear after extend
+l1 = [1, 2]
+l2 = [3, 4]
+l1.extend(l2)
+assert len(l1) == 4
+l1.clear()
+assert len(l1) == 0
+assert len(l2) == 2  # l2 unchanged

--- a/regression/python/list-clear/test.desc
+++ b/regression/python/list-clear/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -97,6 +97,7 @@ const static std::vector<std::string> python_c_models = {
   "list_in_bounds",
   "list_at",
   "list_cat",
+  "list_clear",
   "list_get_as",
   "list_push",
   "list_insert",

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -228,3 +228,11 @@ static inline void list_extend(List *l, const List *other)
     ++i;
   }
 }
+
+/* ---------- clear list ---------- */
+static inline void list_clear(List *l)
+{
+  if (!l)
+    return;
+  l->size = 0;
+}

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -223,6 +223,7 @@ private:
   exprt handle_list_append() const;
   exprt handle_list_insert() const;
   exprt handle_list_extend() const;
+  exprt handle_list_clear() const;
 
   /*
    * Replace undefined function calls with assert(false):


### PR DESCRIPTION
This PR adds support for Python's `list.clear()` method, which removes all elements from a list by resetting its size to zero.

In particular, this PR:
- Adds `list_clear()` function to C list operational model
- Implements `handle_list_clear()` in Python frontend
- Adds `list_clear` to C library whitelist for Python models
- Updates `is_list_method_call()` to recognize 'clear' method

The implementation efficiently clears lists by setting the size to 0 without deallocating the underlying storage array.