### PR TITLE
[python] fix ternary expression array-to-pointer conversion for pointer assignments

### DIFF
--- a/regression/python/github_3038/main.py
+++ b/regression/python/github_3038/main.py
@@ -1,0 +1,6 @@
+class Foo:
+    def __init__(self, b: bool) -> None:
+        self.s: str = "foo" if b else "bar"
+
+f = Foo(True)
+assert f.s == "foo"

--- a/regression/python/github_3038/test.desc
+++ b/regression/python/github_3038/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3038_2/main.py
+++ b/regression/python/github_3038_2/main.py
@@ -1,0 +1,7 @@
+class Foo:
+    def __init__(self, b: bool) -> None:
+        self.b = b
+        self.s: str = "foo" if self.b else "bar"
+
+f = Foo(True)
+assert f.s == "foo"

--- a/regression/python/github_3038_2/test.desc
+++ b/regression/python/github_3038_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3038_2_fail/main.py
+++ b/regression/python/github_3038_2_fail/main.py
@@ -1,0 +1,7 @@
+class Foo:
+    def __init__(self, b: bool) -> None:
+        self.b = b
+        self.s: str = "foo" if self.b else "bar"
+f = Foo(True)
+assert f.s == "foo"
+assert f.s == "bar"

--- a/regression/python/github_3038_2_fail/test.desc
+++ b/regression/python/github_3038_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3038_fail/main.py
+++ b/regression/python/github_3038_fail/main.py
@@ -1,0 +1,6 @@
+class Foo:
+    def __init__(self, b: bool) -> None:
+        self.s: str = "foo" if b else "bar"
+f = Foo(True)
+assert f.s == "foo"
+assert f.s == "bar"

--- a/regression/python/github_3038_fail/test.desc
+++ b/regression/python/github_3038_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3981,6 +3981,17 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
     typet result_type =
       resolve_ternary_type(then.type(), else_expr.type(), current_element_type);
 
+    // Handle array-to-pointer conversion for ternary expressions
+    // When assigning to a pointer (e.g., str field), convert array branches to pointers
+    if (
+      then.type().is_array() && else_expr.type().is_array() && current_lhs &&
+      current_lhs->type().is_pointer())
+    {
+      then = string_handler_.get_array_base_address(then);
+      else_expr = string_handler_.get_array_base_address(else_expr);
+      result_type = then.type(); // Use pointer type as result
+    }
+
     // Create fully symbolic if expression
     exprt if_expr("if", result_type);
     if_expr.copy_to_operands(cond, then, else_expr);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3038.

This PR converts each branch to a pointer before building the `if`-expression when a ternary expression with array operands (e.g., string literals) is assigned to a pointer member. This prevents `compute_pointer_offset` errors when the backend tries to take the address of an if expression with an array type.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.