### PR TITLE
[SVCOMP] update script for SVCOMP26 && fix correctness witness

### DIFF
--- a/.github/workflows/benchexec.yml
+++ b/.github/workflows/benchexec.yml
@@ -29,13 +29,13 @@ on:
         type: choice
         description: Run-set to use (be sure to set mode to "RunSet")
         options:
-        - SV-COMP25_unreach-call
-        - SV-COMP25_no-data-race
-        - SV-COMP25_valid-memcleanup
-        - SV-COMP25_valid-memsafety
-        - SV-COMP25_termination
-        - SV-COMP25_no-overflow
-        - SV-COMP25_ConcurrencySafety
+        - SV-COMP26_unreach-call
+        - SV-COMP26_no-data-race
+        - SV-COMP26_valid-memcleanup
+        - SV-COMP26_valid-memsafety
+        - SV-COMP26_termination
+        - SV-COMP26_no-overflow
+        - SV-COMP26_ConcurrencySafety
         - Custom
       task:
         type: choice
@@ -122,7 +122,7 @@ jobs:
         if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'Custom' }}
         run: cp ./esbmc-src/scripts/competitions/svcomp/custom-reach.set $HOME/sv-benchmarks/c/ && mv ./esbmc-src/scripts/competitions/svcomp/custom.xml ./esbmc-src/scripts/competitions/svcomp/esbmc.xml
       - name: Set up the Concurrency runset
-        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
+        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP26_ConcurrencySafety' }}
         run: mv ./esbmc-src/scripts/competitions/svcomp/ConcurrencySafety.xml ./esbmc-src/scripts/competitions/svcomp/esbmc.xml
       - name: Run Benchexec (Full)
         if: ${{ inputs.mode == 'Full' }}
@@ -131,13 +131,13 @@ jobs:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
       - name: Run Benchexec (ConcurrencyRunSet)
-        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP25_ConcurrencySafety' }}
+        if: ${{ inputs.mode == 'RunSet' && inputs.runset == 'SV-COMP26_ConcurrencySafety' }}
         run: ./esbmc-src/scripts/benchexec.sh -f
         env:
           TIMEOUT: ${{ inputs.timeout }}
           ESBMC_OPTS: ${{ inputs.options }}
       - name: Run Benchexec (RunSet)
-        if: ${{ inputs.mode == 'RunSet'  && inputs.runset != 'SV-COMP25_ConcurrencySafety'}}
+        if: ${{ inputs.mode == 'RunSet'  && inputs.runset != 'SV-COMP26_ConcurrencySafety'}}
         run: ./esbmc-src/scripts/benchexec.sh -r ${{ inputs.runset }}
         env:
           TIMEOUT: ${{ inputs.timeout }}

--- a/scripts/competitions/svcomp/ConcurrencySafety.xml
+++ b/scripts/competitions/svcomp/ConcurrencySafety.xml
@@ -8,28 +8,28 @@
   
   <option name="-s">kinduction</option>
 
-  <rundefinition name="SV-COMP25_unreach-call">
+  <rundefinition name="SV-COMP26_unreach-call">
     <tasks name="ConcurrencySafety-Main">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_no-data-race">
+  <rundefinition name="SV-COMP26_no-data-race">
     <tasks name="NoDataRace-Main">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_valid-memsafety">
+  <rundefinition name="SV-COMP26_valid-memsafety">
     <tasks name="ConcurrencySafety-MemSafety">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_no-overflow">
+  <rundefinition name="SV-COMP26_no-overflow">
     <tasks name="ConcurrencySafety-NoOverflows">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>

--- a/scripts/competitions/svcomp/cpachecker.xml
+++ b/scripts/competitions/svcomp/cpachecker.xml
@@ -18,206 +18,273 @@
 
 
 <rundefinition name="SV-COMP26_unreach-call">
-
   <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
   <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
-	
-  <tasks name="ReachSafety-Arrays">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-BitVectors">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-ControlFlow">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-ECA">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Floats">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Heap">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Loops">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-ProductLines">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Recursive">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Sequentialized">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-XCSP">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-XCSP.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Combinations">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Combinations.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Hardware">
-    <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Hardware.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
 
-  <tasks name="ConcurrencySafety-Main">
-    <includesfile>$HOME/sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
+    <tasks name="ReachSafety-Arrays">
+      <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-BitVectors">
+      <includesfile>$HOME/sv-benchmarks/c/BitVectors.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-ControlFlow">
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-ECA">
+      <includesfile>$HOME/sv-benchmarks/c/ECA.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Floats">
+      <includesfile>$HOME/sv-benchmarks/c/Floats.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Heap">
+      <includesfile>$HOME/sv-benchmarks/c/Heap.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/LinkedLists.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Loops">
+      <includesfile>$HOME/sv-benchmarks/c/Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Loops.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-ProductLines">
+      <includesfile>$HOME/sv-benchmarks/c/ProductLines.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Recursive">
+      <includesfile>$HOME/sv-benchmarks/c/Recursive.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Recursive.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Sequentialized">
+      <includesfile>$HOME/sv-benchmarks/c/Sequentialized.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-XCSP">
+      <includesfile>$HOME/sv-benchmarks/c/XCSP.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Combinations">
+      <includesfile>$HOME/sv-benchmarks/c/Combinations.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Hardware">
+      <includesfile>$HOME/sv-benchmarks/c/Hardware.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Hardness">
+      <includesfile>$HOME/sv-benchmarks/c/Hardness.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="ReachSafety-Fuzzle">
+      <includesfile>$HOME/sv-benchmarks/c/Fuzzle.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
 
-  <tasks name="SoftwareSystems-AWS-C-Common-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-AWS-C-Common-ReachSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-BusyBox-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-ReachSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
-    <excludesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</excludesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-DeviceDriversLinux64Large-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large-ReachSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-uthash-ReachSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash-ReachSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
-  </tasks>
+    <tasks name="ConcurrencySafety-Main">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+
+    <tasks name="SoftwareSystems-AWS-C-Common-ReachSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-AWS-C-Common.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64.set</includesfile>
+      <excludesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large.set</excludesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-DeviceDriversLinux64Large-ReachSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64Large.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-Other-ReachSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-OpenBSD.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-uthash-ReachSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-Intel-TDX-Module-ReachSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-Intel-TDX-Module.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    </tasks>
 </rundefinition>
 
 <rundefinition name="SV-COMP26_no-data-race">
   <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
   <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
-  <tasks name="NoDataRace-Main">
-    <includesfile>$HOME/sv-benchmarks/c/NoDataRace-Main.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
-  </tasks>
+    <tasks name="NoDataRace-Main">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
+    </tasks>
 </rundefinition>
 
 <rundefinition name="SV-COMP26_valid-memcleanup">
   <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
   <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
-  <tasks name="MemSafety-MemCleanup">
-    <includesfile>$HOME/sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
-  </tasks>
+    <tasks name="MemSafety-MemCleanup">
+      <includesfile>$HOME/sv-benchmarks/c/Heap.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Juliet.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/LinkedLists.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Recursive.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-uthash-MemCleanup">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
+    </tasks>
 </rundefinition>
 
 <rundefinition name="SV-COMP26_valid-memsafety">
   <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
   <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
-  <tasks name="MemSafety-Arrays">
-    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-Heap">
-    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Heap.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-LinkedLists">
-    <includesfile>$HOME/sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-Other">
-    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Other.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-Juliet">
-    <includesfile>$HOME/sv-benchmarks/c/MemSafety-Juliet.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
 
-  <tasks name="SoftwareSystems-BusyBox-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-DeviceDriversLinux64-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-MemSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-OpenBSD-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-OpenBSD-MemSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-uthash-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash-MemSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
+    <tasks name="MemSafety-Arrays">
+      <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Heap-Termination.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Recursive.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="MemSafety-Heap">
+      <includesfile>$HOME/sv-benchmarks/c/Heap.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="MemSafety-LinkedLists">
+      <includesfile>$HOME/sv-benchmarks/c/LinkedLists.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="MemSafety-Other">
+      <includesfile>$HOME/sv-benchmarks/c/Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow-Termination.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Recursive.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="MemSafety-Juliet">
+      <includesfile>$HOME/sv-benchmarks/c/Juliet.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
 
-  <tasks name="ConcurrencySafety-MemSafety">
-    <includesfile>$HOME/sv-benchmarks/c/ConcurrencySafety-MemSafety.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
-  </tasks>
+    <tasks name="SoftwareSystems-coreutils-MemSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-DeviceDriversLinux64-MemSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-Other-MemSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-OpenBSD.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-uthash-MemSafety">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
+
+    <tasks name="ConcurrencySafety-MemSafety">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    </tasks>
 </rundefinition>
 
 <rundefinition name="SV-COMP26_no-overflow">
   <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
   <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
-  <tasks name="NoOverflows-Main">
-    <includesfile>$HOME/sv-benchmarks/c/NoOverflows-Main.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
-  </tasks>
-  <tasks name="NoOverflows-Juliet">
-    <includesfile>$HOME/sv-benchmarks/c/NoOverflows-Juliet.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
-  </tasks>
+    <tasks name="NoOverflows-Main">
+      <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/BitVectors.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/BitVectors-Termination.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow-Termination.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ECA.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Floats.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Heap.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Heap-Termination.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/LinkedLists.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Recursive.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Sequentialized.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/VerifyThis-Recursive.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/XCSP.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-AWS-C-Common.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
+    <tasks name="NoOverflows-Juliet">
+      <includesfile>$HOME/sv-benchmarks/c/Juliet.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
 
-  <tasks name="SoftwareSystems-BusyBox-NoOverflows">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
-  </tasks>
-  <tasks name="SoftwareSystems-uthash-NoOverflows">
-    <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash-NoOverflows.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
-  </tasks>
+    <tasks name="SoftwareSystems-BusyBox-NoOverflows">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-BusyBox.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-coreutils-NoOverflows">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-coreutils.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-uthash-NoOverflows">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
 
-  <tasks name="ConcurrencySafety-NoOverflows">
-    <includesfile>$HOME/sv-benchmarks/c/ConcurrencySafety-NoOverflows.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
-  </tasks>
+    <tasks name="ConcurrencySafety-NoOverflows">
+      <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    </tasks>
 </rundefinition>
 
 <rundefinition name="SV-COMP26_termination">
   <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
   <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
-  <tasks name="Termination-BitVectors">
-    <includesfile>$HOME/sv-benchmarks/c/Termination-BitVectors.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
-  </tasks>
-  <tasks name="Termination-MainControlFlow">
-    <includesfile>$HOME/sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
-  </tasks>
-  <tasks name="Termination-MainHeap">
-    <includesfile>$HOME/sv-benchmarks/c/Termination-MainHeap.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
-  </tasks>
-  <tasks name="Termination-Other">
-    <includesfile>$HOME/sv-benchmarks/c/Termination-Other.set</includesfile>
-    <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
-  </tasks>
+    <tasks name="Termination-BitVectors">
+      <includesfile>$HOME/sv-benchmarks/c/BitVectors-Termination.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    </tasks>
+    <tasks name="Termination-MainControlFlow">
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow-Termination.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    </tasks>
+    <tasks name="Termination-MainHeap">
+      <includesfile>$HOME/sv-benchmarks/c/Heap-Termination.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    </tasks>
+    <tasks name="Termination-Other">
+      <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/BitVectors.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ControlFlow.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ECA.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Floats.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Heap.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Loops.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/ProductLines.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Recursive.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/Sequentialized.set</includesfile>
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-uthash.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    </tasks>
+    <tasks name="SoftwareSystems-DeviceDriversLinux64-Termination">
+      <includesfile>$HOME/sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64.set</includesfile>
+      <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>
+    </tasks>
 </rundefinition>
 
 </benchmark>

--- a/scripts/competitions/svcomp/cpachecker.xml
+++ b/scripts/competitions/svcomp/cpachecker.xml
@@ -17,10 +17,10 @@
   <option name="-setprop">cpa.smg.deallocationFunctions=free,kfree,kfree_const</option>
 
 
-<rundefinition name="SV-COMP23_unreach-call">
+<rundefinition name="SV-COMP26_unreach-call">
 
-  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
-  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
+  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 	
   <tasks name="ReachSafety-Arrays">
     <includesfile>$HOME/sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
@@ -103,9 +103,9 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="SV-COMP23_no-data-race">
-  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
-  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+<rundefinition name="SV-COMP26_no-data-race">
+  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
+  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
   <tasks name="NoDataRace-Main">
     <includesfile>$HOME/sv-benchmarks/c/NoDataRace-Main.set</includesfile>
@@ -113,9 +113,9 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="SV-COMP23_valid-memcleanup">
-  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
-  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+<rundefinition name="SV-COMP26_valid-memcleanup">
+  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
+  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
   <tasks name="MemSafety-MemCleanup">
     <includesfile>$HOME/sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
@@ -123,9 +123,9 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="SV-COMP23_valid-memsafety">
-  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
-  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+<rundefinition name="SV-COMP26_valid-memsafety">
+  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
+  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
   <tasks name="MemSafety-Arrays">
     <includesfile>$HOME/sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>$HOME/sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
@@ -170,9 +170,9 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="SV-COMP23_no-overflow">
-  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
-  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+<rundefinition name="SV-COMP26_no-overflow">
+  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
+  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
   <tasks name="NoOverflows-Main">
     <includesfile>$HOME/sv-benchmarks/c/NoOverflows-Main.set</includesfile>
@@ -198,9 +198,9 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="SV-COMP23_termination">
-  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</requiredfiles>
-  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.graphml</option>
+<rundefinition name="SV-COMP26_termination">
+  <requiredfiles>$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</requiredfiles>
+  <option name="-witness">$HOME/witness-files/${rundefinition_name}/${taskdef_name}/witness.{graphml,yml}</option>
 
   <tasks name="Termination-BitVectors">
     <includesfile>$HOME/sv-benchmarks/c/Termination-BitVectors.set</includesfile>

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -262,7 +262,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
 
   # Add witness arg
   witness_name = os.path.basename(benchmark) if esbmc_ci else "witness"
-  command_line += "--witness-output " + witness_name + ".graphml
+  command_line += "--witness-output " + witness_name + ".graphml"
 
   # Special case for termination, it runs regardless of the strategy
   if prop == Property.termination:

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -262,7 +262,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
 
   # Add witness arg
   witness_name = os.path.basename(benchmark) if esbmc_ci else "witness"
-  command_line += "--witness-output " + witness_name + ".graphml"
+  command_line += "--witness-output-yaml " + witness_name + ".yml "
 
   # Special case for termination, it runs regardless of the strategy
   if prop == Property.termination:

--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -262,7 +262,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
 
   # Add witness arg
   witness_name = os.path.basename(benchmark) if esbmc_ci else "witness"
-  command_line += "--witness-output-yaml " + witness_name + ".yml "
+  command_line += "--witness-output " + witness_name + ".graphml
 
   # Special case for termination, it runs regardless of the strategy
   if prop == Property.termination:

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -7,6 +7,7 @@
   <resultfiles>**/*.graphml</resultfiles>
   
   <option name="-s">kinduction</option>
+  <option name="--ci"/>
 
   <rundefinition name="SV-COMP26_unreach-call">
     <tasks name="ReachSafety-Arrays">

--- a/scripts/competitions/svcomp/esbmc.xml
+++ b/scripts/competitions/svcomp/esbmc.xml
@@ -8,7 +8,7 @@
   
   <option name="-s">kinduction</option>
 
-  <rundefinition name="SV-COMP25_unreach-call">
+  <rundefinition name="SV-COMP26_unreach-call">
     <tasks name="ReachSafety-Arrays">
       <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
@@ -107,14 +107,14 @@
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_no-data-race">
+  <rundefinition name="SV-COMP26_no-data-race">
     <tasks name="NoDataRace-Main">
       <includesfile>$HOME/sv-benchmarks/c/Concurrency.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/no-data-race.prp</propertyfile>
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_valid-memcleanup">
+  <rundefinition name="SV-COMP26_valid-memcleanup">
     <tasks name="MemSafety-MemCleanup">
       <includesfile>$HOME/sv-benchmarks/c/Heap.set</includesfile>
       <includesfile>$HOME/sv-benchmarks/c/Juliet.set</includesfile>
@@ -129,7 +129,7 @@
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_valid-memsafety">
+  <rundefinition name="SV-COMP26_valid-memsafety">
     <tasks name="MemSafety-Arrays">
       <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
       <includesfile>$HOME/sv-benchmarks/c/Heap-Termination.set</includesfile>
@@ -181,7 +181,7 @@
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_no-overflow">
+  <rundefinition name="SV-COMP26_no-overflow">
     <tasks name="NoOverflows-Main">
       <includesfile>$HOME/sv-benchmarks/c/Arrays.set</includesfile>
       <includesfile>$HOME/sv-benchmarks/c/BitVectors.set</includesfile>
@@ -227,7 +227,7 @@
     </tasks>
   </rundefinition>
 
-  <rundefinition name="SV-COMP25_termination">
+  <rundefinition name="SV-COMP26_termination">
     <tasks name="Termination-BitVectors">
       <includesfile>$HOME/sv-benchmarks/c/BitVectors-Termination.set</includesfile>
       <propertyfile>$HOME/sv-benchmarks/c/properties/termination.prp</propertyfile>

--- a/scripts/witness.sh
+++ b/scripts/witness.sh
@@ -6,14 +6,15 @@ BENCHEXEC_COMMON_FLAGS="-o $HOME/witness-output/ -N 9 ./cpachecker.xml --read-on
 # Prepare Environment to run benchexec
 setup_folder () {
     echo "Setting up machine folder..."
+    ls $HOME/esbmc-output/
     mv $HOME/esbmc-output/*.files $HOME/witness-files
     cp esbmc-src/scripts/competitions/svcomp/cpachecker.xml $HOME/cpachecker.xml
     rm -rf $HOME/validation-action $HOME/witness-output $HOME/witness-output.zip
     mkdir $HOME/validation-action
     cd $HOME/validation-action
-    
+
     curl -L https://zenodo.org/records/16682497/files/CPAchecker-4.1-unix.zip?download=1 -o cpa.zip
-    unzip cpa.tar.gz
+    unzip cpa.zip
     mv CPAchecker* cpachecker && cd cpachecker
     cp $HOME/cpachecker.xml .
     echo "Configuration done. See files below"

--- a/scripts/witness.sh
+++ b/scripts/witness.sh
@@ -15,7 +15,7 @@ setup_folder () {
 
     curl -L https://zenodo.org/records/16682497/files/CPAchecker-4.1-unix.zip?download=1 -o cpa.zip
     unzip cpa.zip
-    mv CPAchecker* cpachecker && cd cpachecker
+    mv CPAchecker* cpachecker && cd cpachecker/bin
     cp $HOME/cpachecker.xml .
     echo "Configuration done. See files below"
     ls -l

--- a/scripts/witness.sh
+++ b/scripts/witness.sh
@@ -11,13 +11,10 @@ setup_folder () {
     rm -rf $HOME/validation-action $HOME/witness-output $HOME/witness-output.zip
     mkdir $HOME/validation-action
     cd $HOME/validation-action
-    # Don't ask
-    export http_proxy=socks://localhost:1080
-    export https_proxy=socks://localhost:1080
     
-    curl https://zenodo.org/records/10066216/files/CPAchecker-2.2.1-svn-44999-unix.zip?download=1 -o cpa.zip
-    unzip cpa.zip
-    mv CPAchecker* cpachecker && cd cpachecker    
+    curl -L https://zenodo.org/records/16682497/files/CPAchecker-4.1-unix.zip?download=1 -o cpa.zip
+    unzip cpa.tar.gz
+    mv CPAchecker* cpachecker && cd cpachecker
     cp $HOME/cpachecker.xml .
     echo "Configuration done. See files below"
     ls -l

--- a/scripts/witness.sh
+++ b/scripts/witness.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 BENCHEXEC_BIN=/usr/bin/benchexec
-BENCHEXEC_COMMON_FLAGS="-o $HOME/witness-output/ -N 9 ./cpachecker.xml --read-only-dir / --overlay-dir /home  --container"
+BENCHEXEC_COMMON_FLAGS="-o $HOME/witness-output/ -N 9 ./cpachecker.xml --read-only-dir / --overlay-dir /home/benchexec  --container"
 
 # Prepare Environment to run benchexec
 setup_folder () {
@@ -13,9 +13,9 @@ setup_folder () {
     mkdir $HOME/validation-action
     cd $HOME/validation-action
 
-    curl -L https://zenodo.org/records/16682497/files/CPAchecker-4.1-unix.zip?download=1 -o cpa.zip
-    unzip cpa.zip
-    mv CPAchecker* cpachecker && cd cpachecker/bin
+    curl -#L https://zenodo.org/records/16682497/files/CPAchecker-4.1-unix.zip?download=1 -o cpa.zip
+    unzip -q cpa.zip
+    mv CPAchecker* cpachecker && cd cpachecker
     cp $HOME/cpachecker.xml .
     echo "Configuration done. See files below"
     ls -l

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -100,10 +100,10 @@ void yamlt::generate_yaml(optionst &options)
   else
     create_correctness_yaml_emitter(this->verified_file, options, yaml_emitter);
 
+  yaml_emitter << YAML::Key << "content" << YAML::Value << YAML::BeginSeq;
+
   if (!this->segments.empty())
   {
-    yaml_emitter << YAML::Key << "content" << YAML::Value << YAML::BeginSeq;
-
     for (auto &waypoint : this->segments)
     {
       yaml_emitter << YAML::BeginMap;
@@ -114,9 +114,9 @@ void yamlt::generate_yaml(optionst &options)
       yaml_emitter << YAML::EndSeq;
       yaml_emitter << YAML::EndMap;
     }
-
-    yaml_emitter << YAML::EndSeq;
   }
+
+  yaml_emitter << YAML::EndSeq;
 
   yaml_emitter << YAML::EndMap;
   yaml_emitter << YAML::EndSeq;
@@ -1139,7 +1139,8 @@ void generate_testcase(
   // We should only show the symbol one time
   std::unordered_set<std::string> nondet;
 
-  auto generate_input = [&test_case, &smt_conv, &nondet](const expr2tc &expr) {
+  auto generate_input = [&test_case, &smt_conv, &nondet](const expr2tc &expr)
+  {
     if (!expr || !is_symbol2t(expr))
       return;
     const symbol2t &sym = to_symbol2t(expr);

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1139,8 +1139,7 @@ void generate_testcase(
   // We should only show the symbol one time
   std::unordered_set<std::string> nondet;
 
-  auto generate_input = [&test_case, &smt_conv, &nondet](const expr2tc &expr)
-  {
+  auto generate_input = [&test_case, &smt_conv, &nondet](const expr2tc &expr) {
     if (!expr || !is_symbol2t(expr))
       return;
     const symbol2t &sym = to_symbol2t(expr);


### PR DESCRIPTION
To further fix witness, we still need self host runner to update JAVA to 16 or above, to support CPAchecker.

Do we need the pass --CI flag? So far I can't find witness files in `esbmc-output`, but I remember there used to be (two years ago?). Am I missing something?