### PR TITLE
[python] move math operations to python_math class

### DIFF
--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(pythonfrontend STATIC
             python_language.cpp
             python_converter.cpp
             python_list.cpp
+            python_math.cpp
             pythonastgen.c
             module_manager.cpp
             module_locator.cpp

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <python-frontend/global_scope.h>
+#include <python-frontend/python_math.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/type_utils.h>
 #include <python-frontend/string_handler.h>
@@ -164,13 +165,6 @@ private:
 
   exprt get_binary_operator_expr(const nlohmann::json &element);
 
-  exprt handle_power_operator(exprt base, exprt exp);
-
-  exprt
-  handle_modulo_operator(exprt lhs, exprt rhs, const nlohmann::json &element);
-
-  exprt build_power_expression(const exprt &base, const BigInt &exp);
-
   bool is_bytes_literal(const nlohmann::json &element);
 
   exprt get_binary_operator_expr_for_is(const exprt &lhs, const exprt &rhs);
@@ -182,8 +176,6 @@ private:
   exprt get_function_constant_return(const exprt &func_value);
 
   exprt resolve_function_call(const exprt &func_expr, const exprt &args_expr);
-
-  exprt handle_power_operator_sym(exprt base, exprt exp);
 
   symbolt create_assert_temp_variable(const locationt &location);
 
@@ -261,8 +253,6 @@ private:
   symbol_id create_symbol_id() const;
 
   symbol_id create_symbol_id(const std::string &filename) const;
-
-  exprt compute_math_expr(const exprt &expr) const;
 
   void promote_int_to_float(exprt &op, const typet &target_type) const;
 
@@ -392,6 +382,7 @@ private:
   code_blockt *current_block;
   exprt *current_lhs;
   string_handler string_handler_;
+  python_math math_handler_;
 
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -280,7 +280,7 @@ exprt python_math::handle_floor_division(
   const exprt &bin_expr)
 {
   typet div_type = bin_expr.type();
-  
+
   // remainder = num % den;
   exprt remainder("mod", div_type);
   remainder.copy_to_operands(lhs, rhs);
@@ -288,7 +288,7 @@ exprt python_math::handle_floor_division(
   // Get num signal
   exprt is_num_neg("<", bool_type());
   is_num_neg.copy_to_operands(lhs, gen_zero(div_type));
-  
+
   // Get den signal
   exprt is_den_neg("<", bool_type());
   is_den_neg.copy_to_operands(rhs, gen_zero(div_type));
@@ -303,7 +303,7 @@ exprt python_math::handle_floor_division(
 
   exprt cond("and", bool_type());
   cond.copy_to_operands(pos_remainder, diff_signals);
-  
+
   exprt if_expr("if", div_type);
   if_expr.copy_to_operands(cond, gen_one(div_type), gen_zero(div_type));
 
@@ -314,10 +314,8 @@ exprt python_math::handle_floor_division(
   return floor_div;
 }
 
-void python_math::handle_float_division(
-  exprt &lhs,
-  exprt &rhs,
-  exprt &bin_expr) const
+void python_math::handle_float_division(exprt &lhs, exprt &rhs, exprt &bin_expr)
+  const
 {
   const typet float_type = double_type();
 
@@ -360,7 +358,8 @@ void python_math::handle_float_division(
   bin_expr.id("ieee_div");
 }
 
-void python_math::promote_int_to_float(exprt &op, const typet &target_type) const
+void python_math::promote_int_to_float(exprt &op, const typet &target_type)
+  const
 {
   typet &op_type = op.type();
 
@@ -386,7 +385,8 @@ void python_math::promote_int_to_float(exprt &op, const typet &target_type) cons
     catch (const std::exception &e)
     {
       log_error(
-        "math_handler_.promote_int_to_float: Failed to promote constant to float: {}",
+        "math_handler_.promote_int_to_float: Failed to promote constant to "
+        "float: {}",
         e.what());
       return;
     }
@@ -399,4 +399,3 @@ void python_math::promote_int_to_float(exprt &op, const typet &target_type) cons
   if (op.is_symbol())
     converter.update_symbol(op);
 }
-

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -1,0 +1,402 @@
+#include <python-frontend/python_math.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/type_utils.h>
+#include <python-frontend/convert_float_literal.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+#include <util/message.h>
+
+#include <cmath>
+
+python_math::python_math(
+  python_converter &conv,
+  contextt &ctx,
+  type_handler &th)
+  : converter(conv), symbol_table(ctx), type_handler_(th)
+{
+}
+
+exprt python_math::resolve_symbol(const exprt &operand) const
+{
+  if (operand.is_symbol())
+  {
+    symbolt *s = symbol_table.find_symbol(operand.identifier());
+    assert(s && "Symbol not found in symbol table");
+    return s->value;
+  }
+  return operand;
+}
+
+exprt python_math::compute_expr(const exprt &expr) const
+{
+  // Resolve operands to their constant values
+  const exprt lhs = resolve_symbol(expr.operands().at(0));
+  const exprt rhs = resolve_symbol(expr.operands().at(1));
+
+  // Convert to BigInt for computation
+  const BigInt op1 =
+    binary2integer(lhs.value().as_string(), lhs.type().is_signedbv());
+  const BigInt op2 =
+    binary2integer(rhs.value().as_string(), rhs.type().is_signedbv());
+
+  // Perform the math operation
+  BigInt result;
+  if (expr.id() == "+")
+    result = op1 + op2;
+  else if (expr.id() == "-")
+    result = op1 - op2;
+  else if (expr.id() == "*")
+    result = op1 * op2;
+  else if (expr.id() == "/")
+    result = op1 / op2;
+  else
+    throw std::runtime_error("Unsupported math operation: " + expr.id_string());
+
+  // Return the result as a constant expression
+  return constant_exprt(result, lhs.type());
+}
+
+exprt python_math::handle_power_symbolic(exprt base, exprt exp)
+{
+  // Find the pow function symbol
+  symbolt *pow_symbol = symbol_table.find_symbol("c:@F@pow");
+  if (!pow_symbol)
+    throw std::runtime_error("pow function not found in symbol table");
+
+  // Convert arguments to double type if needed
+  exprt double_base = base;
+  exprt double_exp = exp;
+
+  if (!base.type().is_floatbv())
+  {
+    double_base = exprt("typecast", double_type());
+    double_base.copy_to_operands(base);
+  }
+
+  if (!exp.type().is_floatbv())
+  {
+    double_exp = exprt("typecast", double_type());
+    double_exp.copy_to_operands(exp);
+  }
+
+  // Create the function call
+  side_effect_expr_function_callt pow_call;
+  pow_call.function() = symbol_expr(*pow_symbol);
+  pow_call.arguments() = {double_base, double_exp};
+  pow_call.type() = double_type();
+
+  // Always return double result: Python power with float operands returns float
+  return pow_call;
+}
+
+exprt python_math::build_power_expression(const exprt &base, const BigInt &exp)
+{
+  if (exp == 0)
+    return from_integer(1, base.type());
+  if (exp == 1)
+    return base;
+
+  // For small exponents, use simple multiplication chain
+  if (exp <= 10)
+  {
+    exprt result = base;
+    for (BigInt i = 1; i < exp; ++i)
+    {
+      exprt mul_expr("*", base.type());
+      mul_expr.copy_to_operands(result, base);
+      result = mul_expr;
+    }
+    return result;
+  }
+
+  // For larger exponents, use exponentiation by squaring
+  // This reduces the number of operations from O(n) to O(log n)
+  if (exp % 2 == 0)
+  {
+    // Even exponent: (base^2)^(exp/2)
+    exprt square("*", base.type());
+    square.copy_to_operands(base, base);
+    return build_power_expression(square, exp / 2);
+  }
+  else
+  {
+    // Odd exponent: base * base^(exp-1)
+    exprt mul_expr("*", base.type());
+    exprt sub_power = build_power_expression(base, exp - 1);
+    mul_expr.copy_to_operands(base, sub_power);
+    return mul_expr;
+  }
+}
+
+exprt python_math::handle_power(exprt lhs, exprt rhs)
+{
+  // Handle pow symbolically if one of the operands is floatbv
+  if (lhs.type().is_floatbv() || rhs.type().is_floatbv())
+    return handle_power_symbolic(lhs, rhs);
+
+  // Helper lambda to check if expression is a math expression
+  auto is_math_expr = [](const exprt &expr) {
+    const std::string &id = expr.id().as_string();
+    return id == "+" || id == "-" || id == "*" || id == "/";
+  };
+
+  // Try to resolve constant values of both lhs and rhs
+  exprt resolved_lhs = lhs;
+  if (lhs.is_symbol())
+  {
+    const symbolt *s = symbol_table.find_symbol(lhs.identifier());
+    if (s && !s->value.value().empty())
+      resolved_lhs = s->value;
+  }
+  else if (is_math_expr(lhs))
+    resolved_lhs = compute_expr(lhs);
+
+  exprt resolved_rhs = rhs;
+  if (rhs.is_symbol())
+  {
+    const symbolt *s = symbol_table.find_symbol(rhs.identifier());
+    if (s && !s->value.value().empty())
+      resolved_rhs = s->value;
+  }
+  else if (is_math_expr(rhs))
+    resolved_rhs = compute_expr(rhs);
+
+  // If rhs is still not constant, we need to handle this case
+  if (!resolved_rhs.is_constant())
+  {
+    log_warning(
+      "ESBMC-Python does not support power expressions with non-constant "
+      "exponents");
+    return from_integer(1, lhs.type());
+  }
+
+  // Check if the exponent is a floating-point number
+  if (resolved_rhs.type().is_floatbv())
+  {
+    log_warning("ESBMC-Python does not support floating-point exponents yet");
+    return from_integer(1, lhs.type());
+  }
+
+  // Convert rhs to integer exponent
+  BigInt exponent;
+  try
+  {
+    exponent = binary2integer(
+      resolved_rhs.value().as_string(), resolved_rhs.type().is_signedbv());
+  }
+  catch (...)
+  {
+    log_warning("Failed to convert exponent to integer");
+    return from_integer(1, lhs.type());
+  }
+
+  // Handle negative exponents more gracefully
+  if (exponent < 0)
+  {
+    log_warning(
+      "ESBMC-Python does not support power expressions with negative "
+      "exponents, treating as symbolic");
+    return from_integer(1, lhs.type());
+  }
+
+  // Handle special cases first
+  if (exponent == 0)
+    return from_integer(1, lhs.type());
+  if (exponent == 1)
+    return lhs;
+
+  // Check resolved base for special cases
+  if (resolved_lhs.is_constant())
+  {
+    BigInt base = binary2integer(
+      resolved_lhs.value().as_string(), resolved_lhs.type().is_signedbv());
+
+    // Special cases for constant base
+    if (base == 0 && exponent > 0)
+      return from_integer(0, lhs.type());
+    if (base == 1)
+      return from_integer(1, lhs.type());
+    if (base == -1)
+      return from_integer((exponent % 2 == 0) ? 1 : -1, lhs.type());
+  }
+
+  // Build symbolic multiplication tree using exponentiation by squaring for efficiency
+  return build_power_expression(lhs, exponent);
+}
+
+exprt python_math::handle_modulo(
+  exprt lhs,
+  exprt rhs,
+  const nlohmann::json &element)
+{
+  // Find required function symbols
+  symbolt *floor_symbol = symbol_table.find_symbol("c:@F@floor");
+  if (!floor_symbol)
+    throw std::runtime_error("floor function not found in symbol table");
+
+  // Promote both operands to double if needed
+  exprt double_lhs = lhs;
+  exprt double_rhs = rhs;
+
+  if (!lhs.type().is_floatbv())
+  {
+    double_lhs = exprt("typecast", double_type());
+    double_lhs.copy_to_operands(lhs);
+  }
+
+  if (!rhs.type().is_floatbv())
+  {
+    double_rhs = exprt("typecast", double_type());
+    double_rhs.copy_to_operands(rhs);
+  }
+
+  // Create division: x / y
+  exprt div_expr("ieee_div", double_type());
+  div_expr.copy_to_operands(double_lhs, double_rhs);
+
+  // Create floor(x / y)
+  side_effect_expr_function_callt floor_call;
+  floor_call.function() = symbol_expr(*floor_symbol);
+  floor_call.arguments() = {div_expr};
+  floor_call.type() = double_type();
+  floor_call.location() = converter.get_location_from_decl(element);
+
+  // Create floor(x/y) * y
+  exprt mult_expr("ieee_mul", double_type());
+  mult_expr.copy_to_operands(floor_call, double_rhs);
+
+  // Create x - floor(x/y) * y
+  exprt result_expr("ieee_sub", double_type());
+  result_expr.copy_to_operands(double_lhs, mult_expr);
+  result_expr.location() = converter.get_location_from_decl(element);
+
+  return result_expr;
+}
+
+exprt python_math::handle_floor_division(
+  const exprt &lhs,
+  const exprt &rhs,
+  const exprt &bin_expr)
+{
+  typet div_type = bin_expr.type();
+  
+  // remainder = num % den;
+  exprt remainder("mod", div_type);
+  remainder.copy_to_operands(lhs, rhs);
+
+  // Get num signal
+  exprt is_num_neg("<", bool_type());
+  is_num_neg.copy_to_operands(lhs, gen_zero(div_type));
+  
+  // Get den signal
+  exprt is_den_neg("<", bool_type());
+  is_den_neg.copy_to_operands(rhs, gen_zero(div_type));
+
+  // remainder != 0
+  exprt pos_remainder("notequal", bool_type());
+  pos_remainder.copy_to_operands(remainder, gen_zero(div_type));
+
+  // diff_signals = is_num_neg ^ is_den_neg;
+  exprt diff_signals("bitxor", bool_type());
+  diff_signals.copy_to_operands(is_num_neg, is_den_neg);
+
+  exprt cond("and", bool_type());
+  cond.copy_to_operands(pos_remainder, diff_signals);
+  
+  exprt if_expr("if", div_type);
+  if_expr.copy_to_operands(cond, gen_one(div_type), gen_zero(div_type));
+
+  // floor_div = (lhs / rhs) - (1 if (lhs % rhs != 0) and (lhs < 0) ^ (rhs < 0) else 0)
+  exprt floor_div("-", div_type);
+  floor_div.copy_to_operands(bin_expr, if_expr); // bin_expr contains lhs/rhs
+
+  return floor_div;
+}
+
+void python_math::handle_float_division(
+  exprt &lhs,
+  exprt &rhs,
+  exprt &bin_expr) const
+{
+  const typet float_type = double_type();
+
+  auto promote_to_float = [&](exprt &e) {
+    const typet &t = e.type();
+    const bool is_integer = type_utils::is_integer_type(t);
+
+    if (!is_integer)
+      return;
+
+    // Handle constant integers: convert them to float literals
+    if (e.is_constant())
+    {
+      try
+      {
+        const bool is_signed = t.is_signedbv();
+        const BigInt val = binary2integer(e.value().as_string(), is_signed);
+        const double float_val = static_cast<double>(val.to_int64());
+        convert_float_literal(std::to_string(float_val), e);
+      }
+      catch (const std::exception &ex)
+      {
+        log_error(
+          "handle_float_division: failed to promote constant to float: {}",
+          ex.what());
+      }
+    }
+    else
+    {
+      // For non-constant operands (like function parameters), create explicit typecast expression
+      e = typecast_exprt(e, float_type);
+    }
+  };
+
+  promote_to_float(lhs);
+  promote_to_float(rhs);
+
+  // Set the result type and operator ID to reflect float division
+  bin_expr.type() = float_type;
+  bin_expr.id("ieee_div");
+}
+
+void python_math::promote_int_to_float(exprt &op, const typet &target_type) const
+{
+  typet &op_type = op.type();
+
+  // Only promote if operand is an integer type
+  if (!(type_utils::is_integer_type(op_type)))
+    return;
+
+  // Handle constant integers
+  if (op.is_constant())
+  {
+    try
+    {
+      const BigInt int_val =
+        binary2integer(op.value().as_string(), op_type.is_signedbv());
+
+      // Generate a string like "3.0" for float parsing
+      const std::string float_literal =
+        std::to_string(int_val.to_int64()) + ".0";
+
+      // Convert string literal to float expression
+      convert_float_literal(float_literal, op);
+    }
+    catch (const std::exception &e)
+    {
+      log_error(
+        "math_handler_.promote_int_to_float: Failed to promote constant to float: {}",
+        e.what());
+      return;
+    }
+  }
+
+  // Update the operand type
+  op.type() = target_type;
+
+  // Update symbol type info if necessary
+  if (op.is_symbol())
+    converter.update_symbol(op);
+}
+

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -38,10 +38,7 @@ public:
    * @param ctx Reference to the symbol table context
    * @param th Reference to the type handler
    */
-  python_math(
-    python_converter &conv,
-    contextt &ctx,
-    type_handler &th);
+  python_math(python_converter &conv, contextt &ctx, type_handler &th);
 
   /**
    * @brief Compute a mathematical expression with constant operands

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -1,0 +1,159 @@
+#ifndef CPROVER_PYTHON_FRONTEND_PYTHON_MATH_H
+#define CPROVER_PYTHON_FRONTEND_PYTHON_MATH_H
+
+#include <util/arith_tools.h>
+#include <util/expr.h>
+#include <util/std_code.h>
+#include <nlohmann/json.hpp>
+
+class python_converter;
+class type_handler;
+class contextt;
+
+/**
+ * @brief Handles mathematical operations for Python-to-C conversion
+ * 
+ * This class encapsulates all math-related operations in the ESBMC Python frontend,
+ * including arithmetic evaluation, power operations, division variants (true division,
+ * floor division, modulo), and type promotions required by Python's semantics.
+ */
+class python_math
+{
+private:
+  python_converter &converter;
+  contextt &symbol_table;
+  type_handler &type_handler_;
+
+  /**
+   * @brief Resolve a symbol to its constant value if possible
+   * @param operand The operand to resolve (may be symbol or constant)
+   * @return The resolved constant expression
+   */
+  exprt resolve_symbol(const exprt &operand) const;
+
+public:
+  /**
+   * @brief Constructor
+   * @param conv Reference to the parent python_converter
+   * @param ctx Reference to the symbol table context
+   * @param th Reference to the type handler
+   */
+  python_math(
+    python_converter &conv,
+    contextt &ctx,
+    type_handler &th);
+
+  /**
+   * @brief Compute a mathematical expression with constant operands
+   * 
+   * Evaluates binary arithmetic operations (+, -, *, /) when both operands
+   * are constants or can be resolved to constants via symbol lookup.
+   * 
+   * @param expr The binary expression to evaluate
+   * @return A constant expression with the computed result
+   * @throws std::runtime_error if operation is unsupported
+   */
+  exprt compute_expr(const exprt &expr) const;
+
+  /**
+   * @brief Handle Python's power operator (**)
+   * 
+   * Implements Python's exponentiation with special handling for:
+   * - Floating-point operands (delegates to symbolic pow)
+   * - Constant integer exponents (compile-time evaluation)
+   * - Negative exponents (converts to symbolic)
+   * - Special cases (0**n, 1**n, (-1)**n)
+   * 
+   * @param lhs Base expression
+   * @param rhs Exponent expression
+   * @return Expression representing base**exponent
+   */
+  exprt handle_power(exprt lhs, exprt rhs);
+
+  /**
+   * @brief Handle power operation symbolically using C's pow() function
+   * 
+   * Creates a function call to C's pow(base, exp) for cases where
+   * compile-time evaluation isn't possible or operands are floating-point.
+   * 
+   * @param base Base expression (promoted to double if needed)
+   * @param exp Exponent expression (promoted to double if needed)
+   * @return Function call expression to pow()
+   * @throws std::runtime_error if pow symbol not found
+   */
+  exprt handle_power_symbolic(exprt base, exprt exp);
+
+  /**
+   * @brief Build power expression using exponentiation by squaring
+   * 
+   * Efficiently constructs a multiplication tree for base**exp using
+   * the binary exponentiation algorithm, reducing operations from O(n) to O(log n).
+   * 
+   * @param base The base expression
+   * @param exp The exponent (must be non-negative integer)
+   * @return Expression tree representing the power operation
+   */
+  exprt build_power_expression(const exprt &base, const BigInt &exp);
+
+  /**
+   * @brief Handle Python's modulo operator (%)
+   * 
+   * Implements Python's modulo semantics where the result has the sign of the divisor:
+   * x % y = x - floor(x/y) * y
+   * 
+   * This differs from C's fmod where result has the sign of the dividend.
+   * 
+   * @param lhs Dividend expression
+   * @param rhs Divisor expression
+   * @param element JSON AST node for location information
+   * @return Expression implementing Python modulo semantics
+   * @throws std::runtime_error if floor function not found
+   */
+  exprt handle_modulo(exprt lhs, exprt rhs, const nlohmann::json &element);
+
+  /**
+   * @brief Handle Python's floor division operator (//)
+   * 
+   * Implements floor division: (lhs // rhs) = floor(lhs / rhs)
+   * Special handling ensures correct behavior with negative operands:
+   * result = (lhs / rhs) - (1 if (lhs % rhs != 0) and signs_differ else 0)
+   * 
+   * @param lhs Dividend expression
+   * @param rhs Divisor expression
+   * @param bin_expr The division expression to modify
+   * @return Expression implementing floor division
+   */
+  exprt handle_floor_division(
+    const exprt &lhs,
+    const exprt &rhs,
+    const exprt &bin_expr);
+
+  /**
+   * @brief Handle Python's true division operator (/)
+   * 
+   * Python 3's / operator always performs floating-point division,
+   * even with integer operands. This function promotes operands to float
+   * and sets up IEEE floating-point division.
+   * 
+   * @param lhs Left operand (modified to float if needed)
+   * @param rhs Right operand (modified to float if needed)
+   * @param bin_expr Binary expression (modified to ieee_div)
+   */
+  void handle_float_division(exprt &lhs, exprt &rhs, exprt &bin_expr) const;
+
+  /**
+   * @brief Promote integer expression to floating-point type
+   * 
+   * Converts integer operands to floatbv type, typically for Python's
+   * true division where / must always yield float results.
+   * 
+   * Handles both constant integers (converts literal value) and
+   * non-constant integers (updates type metadata).
+   * 
+   * @param op The operand to promote (modified in place)
+   * @param target_type The target floating-point type
+   */
+  void promote_int_to_float(exprt &op, const typet &target_type) const;
+};
+
+#endif


### PR DESCRIPTION
This PR refactored the ESBMC-Python converter:
- Extract eight math operations into a new `python_math` class
- Reduce `python_converter` complexity by ~350 lines
- Follow existing handler pattern architecture
