### PR TITLE
[python] fix missing argument validation for method calls

### DIFF
--- a/regression/python/github_3010_4_fail/main.py
+++ b/regression/python/github_3010_4_fail/main.py
@@ -1,0 +1,9 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, x: int, y: int) -> int:
+        return x + y
+
+f = Foo()
+f.foo(x=3)

--- a/regression/python/github_3010_4_fail/test.desc
+++ b/regression/python/github_3010_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^TypeError: foo\(\) missing 1 required positional argument: \'y\'$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3010.

The preprocessor was not validating arguments for method calls (e.g., obj.method()), only for regular function calls. This caused ESBMC to incorrectly verify code that should fail with TypeError.

This PR adds handling for `ast.Attribute` nodes in visit_Call to detect method calls and validate their arguments, skipping the implicit 'self' parameter.