### PR TITLE
[python] support empty set creation (set())

### DIFF
--- a/regression/python/github_3040/main.py
+++ b/regression/python/github_3040/main.py
@@ -1,0 +1,1 @@
+s: set[int] = set()

--- a/regression/python/github_3040/test.desc
+++ b/regression/python/github_3040/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3040_2/main.py
+++ b/regression/python/github_3040_2/main.py
@@ -1,0 +1,5 @@
+def foo():
+    empty_set: set[str] = set()
+    return empty_set
+
+foo()

--- a/regression/python/github_3040_2/test.desc
+++ b/regression/python/github_3040_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1729,6 +1729,16 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
   }
 
+  // Handle empty set() creation
+  if (
+    element["func"]["_type"] == "Name" && element["func"]["id"] == "set" &&
+    (!element.contains("args") || element["args"].empty()))
+  {
+    // Create an empty set (modeled as list)
+    python_list list(*this, element);
+    return list.get_empty_set();
+  }
+
   const std::string function = config.options.get_option("function");
   // To verify a specific function, it is necessary to load the definitions of functions it calls.
   if (!function.empty() && !is_loading_models)

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1215,3 +1215,14 @@ exprt python_list::build_extend_list_call(
 
   return extend_func_call;
 }
+
+exprt python_list::get_empty_set()
+{
+  // Create an empty list structure for the set
+  symbolt &list_symbol = create_list();
+  list_symbol.is_set = true;
+
+  // No elements to add for empty set
+  // Type information will be determined when elements are added
+  return symbol_expr(list_symbol);
+}

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -82,6 +82,12 @@ public:
     }
   }
 
+  /**
+   * @brief Create an empty set
+   * @return Expression representing the empty set
+   */
+  exprt get_empty_set();
+
 private:
   exprt create_vla(
     const nlohmann::json &element,

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -521,7 +521,9 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
     list_value.is_null() ||
     (list_value.contains("elts") && list_value["elts"].empty()))
   {
-    return build_array(empty_typet(), 0);
+    // For empty containers, return the list type pointer
+    // The actual element type will be determined when elements are added
+    return get_list_type();
   }
 
   if (list_value["_type"] == "arg" && list_value.contains("annotation"))


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3040.

This PR prevents a crash when creating empty sets by intercepting empty set() calls and deferring type inference until elements are added.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
