### PR TITLE
[python] add type inference for set literals

### DIFF
--- a/regression/python/github_3054/main.py
+++ b/regression/python/github_3054/main.py
@@ -1,0 +1,3 @@
+LL = { "foo", "bar" }
+
+assert "foo" in LL

--- a/regression/python/github_3054/test.desc
+++ b/regression/python/github_3054/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1387,6 +1387,8 @@ private:
       inferred_type = get_type_from_constant(stmt["value"]);
     else if (value_type == "List")
       inferred_type = "list";
+    else if (value_type == "Set")
+      inferred_type = "set";
     else if (value_type == "Compare")
       inferred_type = "bool";
     else if (value_type == "UnaryOp") // Handle negative numbers


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3054.

Infer "set" type for set literal assignments such as x = {"foo", "bar"} to avoid "Type undefined" errors when no explicit annotation is provided.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for requesting this feature.