### PR TITLE
[python] fix type inference for tuple unpacking from function calls

### DIFF
--- a/regression/python/github_3044/main.py
+++ b/regression/python/github_3044/main.py
@@ -1,0 +1,9 @@
+def foo() -> tuple[int, int]:
+    return (1, 2)
+
+x: int
+y: int
+x, y = foo()
+
+assert x == 1
+assert y == 2

--- a/regression/python/github_3044/test.desc
+++ b/regression/python/github_3044/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3044_fail/main.py
+++ b/regression/python/github_3044_fail/main.py
@@ -1,0 +1,9 @@
+def foo() -> tuple[int, int]:
+    return (1, 2)
+
+x: int
+y: int
+x, y = foo()
+
+assert x == 2
+assert y == 1

--- a/regression/python/github_3044_fail/test.desc
+++ b/regression/python/github_3044_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties: 2 verified, \✗ 2 failed$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1389,6 +1389,8 @@ private:
       inferred_type = "list";
     else if (value_type == "Set")
       inferred_type = "set";
+    else if (value_type == "Tuple")
+      inferred_type = "tuple";
     else if (value_type == "Compare")
       inferred_type = "bool";
     else if (value_type == "UnaryOp") // Handle negative numbers


### PR DESCRIPTION
This PR handles assignments such as `x, y = foo()` where `foo()` returns `tuple[int, int]`.