### PR TITLE
[python] fix string literal handling in function call arguments

### DIFF
--- a/regression/python/github_3056/main.py
+++ b/regression/python/github_3056/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+        assert len(x) < 10
+
+foo("x")

--- a/regression/python/github_3056/test.desc
+++ b/regression/python/github_3056/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3056_2/main.py
+++ b/regression/python/github_3056_2/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+        assert len(x) < 10
+
+foo("\0")

--- a/regression/python/github_3056_2/test.desc
+++ b/regression/python/github_3056_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3056_2_fail/main.py
+++ b/regression/python/github_3056_2_fail/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+        assert len(x) > 10
+
+foo("\0")

--- a/regression/python/github_3056_2_fail/test.desc
+++ b/regression/python/github_3056_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3056_fail/main.py
+++ b/regression/python/github_3056_fail/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+        assert len(x) > 10
+
+foo("x")

--- a/regression/python/github_3056_fail/test.desc
+++ b/regression/python/github_3056_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2015,6 +2015,14 @@ exprt function_call_expr::handle_general_function_call()
   {
     exprt arg = converter_.get_expr(arg_node);
 
+    // Handle string literal constants
+    // Ensure they are proper null-terminated arrays
+    if (arg_node["_type"] == "Constant" && arg_node["value"].is_string())
+    {
+      std::string str_value = arg_node["value"].get<std::string>();
+      arg = converter_.get_string_builder().build_string_literal(str_value);
+    }
+
     if (
       function_id_.get_function() == "__ESBMC_get_object_size" &&
       (arg.type() == type_handler_.get_list_type() ||


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3056.

String literals passed as function arguments were incorrectly converted to ASCII values instead of null-terminated character arrays, causing `strlen()` and other C string functions to fail with invalid pointer errors. For example, foo("x") would pass `120` (ASCII for 'x') instead of ['x', '\0'].

This PR explicitly converts string constant arguments using `build_string_literal()` to ensure proper null-terminated arrays are passed to functions.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
