### PR TITLE
[python] fix segfault when calling len() on optional string with None default

### DIFF
--- a/regression/python/github_3056_3/main.py
+++ b/regression/python/github_3056_3/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+      assert len(x) < 10
+
+foo()

--- a/regression/python/github_3056_3/test.desc
+++ b/regression/python/github_3056_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3056_4/main.py
+++ b/regression/python/github_3056_4/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+      assert len(x) > 10
+
+foo()

--- a/regression/python/github_3056_4/test.desc
+++ b/regression/python/github_3056_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2023,6 +2023,20 @@ exprt function_call_expr::handle_general_function_call()
       arg = converter_.get_string_builder().build_string_literal(str_value);
     }
 
+    // Check for zero-sized array pointer being passed to get_object_size or len
+    // This represents None/NULL in Python's optional types (e.g., str | None = None)
+    if ((function_id_.get_function() == "__ESBMC_get_object_size" ||
+         function_id_.get_function() == "len") &&
+        arg.type().is_pointer() &&
+        arg.type().subtype().is_array())
+    {
+      const array_typet &arr_type = to_array_type(arg.type().subtype());
+      // Check if array size is constant and equals zero
+      if (arr_type.size().is_constant() &&
+          to_constant_expr(arr_type.size()).is_zero())
+        return from_integer(0, long_long_int_type());
+    }
+
     if (
       function_id_.get_function() == "__ESBMC_get_object_size" &&
       (arg.type() == type_handler_.get_list_type() ||

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2025,15 +2025,16 @@ exprt function_call_expr::handle_general_function_call()
 
     // Check for zero-sized array pointer being passed to get_object_size or len
     // This represents None/NULL in Python's optional types (e.g., str | None = None)
-    if ((function_id_.get_function() == "__ESBMC_get_object_size" ||
-         function_id_.get_function() == "len") &&
-        arg.type().is_pointer() &&
-        arg.type().subtype().is_array())
+    if (
+      (function_id_.get_function() == "__ESBMC_get_object_size" ||
+       function_id_.get_function() == "len") &&
+      arg.type().is_pointer() && arg.type().subtype().is_array())
     {
       const array_typet &arr_type = to_array_type(arg.type().subtype());
       // Check if array size is constant and equals zero
-      if (arr_type.size().is_constant() &&
-          to_constant_expr(arr_type.size()).is_zero())
+      if (
+        arr_type.size().is_constant() &&
+        to_constant_expr(arr_type.size()).is_zero())
         return from_integer(0, long_long_int_type());
     }
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3056.

When a function with an optional string parameter (`str | None = None`) is called without arguments and `len()` is invoked on that parameter within a conditional check, ESBMC's symbolic execution segfaults when trying to execute `get_object_size()` on the zero-sized array pointer representing None.

This PR detects zero-sized array pointers being passed to `len()` or `__ESBMC_get_object_size()` and returns zero instead of attempting the function call.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.