### PR TITLE
[python] Fix crash in handle_string_endswith when string_obj is pointer type

### DIFF
--- a/regression/python/github_3068/main.py
+++ b/regression/python/github_3068/main.py
@@ -1,0 +1,4 @@
+def foo(x: str) -> None:
+    assert x.endswith("foo")
+
+foo("foo")

--- a/regression/python/github_3068/test.desc
+++ b/regression/python/github_3068/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3068_fail/main.py
+++ b/regression/python/github_3068_fail/main.py
@@ -1,0 +1,4 @@
+def foo(x: str) -> None:
+    assert not x.endswith("foo")
+
+foo("foo")

--- a/regression/python/github_3068_fail/test.desc
+++ b/regression/python/github_3068_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/string-endswith/test.desc
+++ b/regression/python/string-endswith/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3068.

The function was assuming string expressions would always be arrays after `ensure_null_terminated_string()`, but they can also be pointers. This caused a crash when calling `to_array_type()` on pointer types.

This PR:
- Handles both pointer and array types for string expressions.
- Uses `strlen()` for runtime length calculation instead of compile-time array sizes.
- Avoids `to_array_type()` calls on non-array types

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.