### PR TITLE
[python] fix Optional[T] comparison with None for primitive types

### DIFF
--- a/regression/python/github_3078/main.py
+++ b/regression/python/github_3078/main.py
@@ -1,0 +1,5 @@
+def foo(x: int | None = None) -> None:
+    if x is not None:
+        assert False
+
+foo()

--- a/regression/python/github_3078/test.desc
+++ b/regression/python/github_3078/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3078_fail/main.py
+++ b/regression/python/github_3078_fail/main.py
@@ -1,0 +1,5 @@
+def foo(x: int | None = None) -> None:
+    if x is not None:
+        assert False
+
+foo(2)

--- a/regression/python/github_3078_fail/test.desc
+++ b/regression/python/github_3078_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/optional5/main.py
+++ b/regression/python/optional5/main.py
@@ -1,0 +1,5 @@
+def foo(x: int | None = None) -> None:
+    if x is not None and x is not None:
+        assert False
+
+foo()

--- a/regression/python/optional5/test.desc
+++ b/regression/python/optional5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional5_fail/main.py
+++ b/regression/python/optional5_fail/main.py
@@ -1,0 +1,5 @@
+def foo(x: int | None = None) -> None:
+    if x is not None and x is not None:
+        assert False
+
+foo(2)

--- a/regression/python/optional5_fail/test.desc
+++ b/regression/python/optional5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/optional6/main.py
+++ b/regression/python/optional6/main.py
@@ -1,0 +1,6 @@
+def foo(x: int | None = None) -> None:
+    if x is not None:
+        assert len(x) == 0
+
+foo()
+

--- a/regression/python/optional6/test.desc
+++ b/regression/python/optional6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional6_fail/main.py
+++ b/regression/python/optional6_fail/main.py
@@ -1,0 +1,5 @@
+def foo(x: str | None = None) -> None:
+    if x is not None:
+        assert len(x) == 0
+
+foo("foo")

--- a/regression/python/optional6_fail/test.desc
+++ b/regression/python/optional6_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2040,7 +2040,7 @@ exprt function_call_expr::handle_general_function_call()
         const struct_typet &struct_type = to_struct_type(param_type);
         std::string tag = struct_type.tag().as_string();
 
-        if (tag.find("tag-Optional_") == 0)
+        if (tag.starts_with("tag-Optional_"))
         {
           // Wrap the argument in Optional struct
           arg = converter_.wrap_in_optional(arg, param_type);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -370,6 +370,12 @@ private:
   // String method helpers
   exprt handle_str_join(const nlohmann::json &call_json);
 
+  // Wrap values in Optional
+  exprt wrap_in_optional(const exprt &value, const typet &optional_type);
+
+  // Handle Optional value access
+  exprt unwrap_optional_if_needed(const exprt &expr);
+
   contextt &symbol_table_;
   const nlohmann::json *ast_json;
   const global_scope &global_scope_;

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -850,3 +850,25 @@ typet type_handler::get_tuple_type(const nlohmann::json &tuple_node) const
 
   return tuple_type;
 }
+
+typet type_handler::build_optional_type(const typet &base_type)
+{
+  // Create a struct with two fields:
+  // 1. is_none: bool - indicates if value is None
+  // 2. value: T - the actual value when not None
+
+  struct_typet optional_type;
+  optional_type.tag("tag-Optional_" + base_type.to_string());
+
+  // Add is_none field
+  struct_typet::componentt is_none_field("is_none", "is_none", bool_type());
+  is_none_field.set_access("public");
+  optional_type.components().push_back(is_none_field);
+
+  // Add value field
+  struct_typet::componentt value_field("value", "value", base_type);
+  value_field.set_access("public");
+  optional_type.components().push_back(value_field);
+
+  return optional_type;
+}

--- a/src/python-frontend/type_handler.h
+++ b/src/python-frontend/type_handler.h
@@ -99,6 +99,8 @@ public:
    */
   size_t get_type_width(const typet &type) const;
 
+  typet build_optional_type(const typet &base_type);
+
 private:
   /// Encapsulate the const_cast in one place with clear documentation
   exprt get_expr_helper(const nlohmann::json &json) const;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3078.

When comparing `Optional[int]` parameters with None using 'is'/'is not', the comparison was incorrectly constant-folded.

In this PR, Python's `Optional[T] (T | None)` types are now modeled as structs with two fields: `is_none` (bool) and `value` (T). This allows correct handling of both None checks and value operations.

In particular, this PR:
- Adds `build_optional_type()` to create Optional wrapper structs
- Wrap primitive Optional parameters in struct on function calls
- Unwrap `Optional.value` for arithmetic/comparison operations
- Preserve `Optional.is_none` field for 'is None' checks
- Fix type mismatch when comparing Optional structs

Future work: Create an irep is_none2t and perform the check in the symex level.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.