### PR TITLE
[python] add support for keyword-only argument validation

### DIFF
--- a/regression/python/github_3010_5_fail/main.py
+++ b/regression/python/github_3010_5_fail/main.py
@@ -1,0 +1,9 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, *, a: str, b: str) -> None:
+        pass
+
+f = Foo()
+f.foo(a="a")

--- a/regression/python/github_3010_5_fail/test.desc
+++ b/regression/python/github_3010_5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^TypeError: foo\(\) missing 1 required keyword-only argument: \'b\'$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3010.

This PR tracks and validates keyword-only parameters (args after * in function signatures). It raises `TypeError` when required keyword-only arguments are missing from function calls. In particular, it fixes validation for methods such as `def foo(self, *, a: str, b: str)` to match Python's behavior when called without all required keyword arguments.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.