### PR TITLE
[python] fix method parameter resolution for classes with same method names

### DIFF
--- a/regression/python/github_3081/main.py
+++ b/regression/python/github_3081/main.py
@@ -1,0 +1,16 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def f(self, x: int) -> None:
+        pass
+
+class Bar:
+    def __init__(self) -> None:
+        pass
+
+    def f(self, y: int) -> None:
+        pass
+
+c: Foo = Foo()
+c.f(x=1)

--- a/regression/python/github_3081/test.desc
+++ b/regression/python/github_3081/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3081.

This PR uses qualified names (`ClassName.method_name`) to prevent collisions when multiple classes define methods with the same name but different parameter lists. It handles method calls by looking up the variable's type annotation and using the qualified name, falling back to unqualified lookup for non-method functions.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.