### PR TITLE
[python] extend symbol lookup to use enclosing function scope

### DIFF
--- a/regression/python/github_3041/main.py
+++ b/regression/python/github_3041/main.py
@@ -1,0 +1,5 @@
+def foo() -> None:
+    x = "5"
+    assert (int(x) <= 5) and True
+
+foo()

--- a/regression/python/github_3041/test.desc
+++ b/regression/python/github_3041/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3041_fail/main.py
+++ b/regression/python/github_3041_fail/main.py
@@ -1,0 +1,5 @@
+def foo() -> None:
+    x = "10"
+    assert (int(x) <= 5) and True
+
+foo()

--- a/regression/python/github_3041_fail/test.desc
+++ b/regression/python/github_3041_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -761,8 +761,19 @@ const symbolt *
 function_call_expr::lookup_python_symbol(const std::string &var_name) const
 {
   std::string filename = function_id_.get_filename();
-  std::string var_symbol = "py:" + filename + "@" + var_name;
+  std::string enclosing_function = converter_.current_function_name();
+
+  // Construct the full symbol identifier with function scope
+  std::string var_symbol =
+    "py:" + filename + "@F@" + enclosing_function + "@" + var_name;
   const symbolt *sym = converter_.find_symbol(var_symbol);
+
+  // If not found in function scope, try module-level scope
+  if (!sym)
+  {
+    var_symbol = "py:" + filename + "@" + var_name;
+    sym = converter_.find_symbol(var_symbol);
+  }
 
   if (!sym)
   {


### PR DESCRIPTION
This PR uses `converter_.current_function_name()` to get the proper enclosing function context, with fallback to module-level scope for globals.