### PR TITLE
[python] fix single-character string initialization and comparison

### DIFF
--- a/regression/python/github_3089/main.py
+++ b/regression/python/github_3089/main.py
@@ -1,0 +1,2 @@
+s: str = "x"
+assert s == "x"

--- a/regression/python/github_3089/test.desc
+++ b/regression/python/github_3089/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3089_fail/main.py
+++ b/regression/python/github_3089_fail/main.py
@@ -1,0 +1,2 @@
+s: str = "x"
+assert s == "x1"

--- a/regression/python/github_3089_fail/test.desc
+++ b/regression/python/github_3089_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -900,8 +900,12 @@ exprt python_converter::handle_str_join(const nlohmann::json &call_json)
     // Edge case: empty list returns empty string
     if (elements.empty())
     {
-      typet empty_str = type_handler_.get_typet("str", 1);
-      return gen_zero(empty_str);
+      // Create a proper null-terminated empty string
+      typet empty_string_type = type_handler_.build_array(char_type(), 1);
+      exprt empty_str = gen_zero(empty_string_type);
+      // Explicitly set the first (and only) element to null terminator
+      empty_str.operands().at(0) = from_integer(0, char_type());
+      return empty_str;
     }
 
     // Convert JSON elements to ESBMC expressions

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -450,7 +450,9 @@ void string_handler::ensure_string_array(exprt &expr)
 
   if (!expr.type().is_array())
   {
-    typet t = type_handler_.build_array(expr.type(), 1);
+    // Explicitly build the array and 
+    // ensure null-termination (size 2: char + \0)
+    typet t = type_handler_.build_array(expr.type(), 2);
     exprt arr = gen_zero(t);
     arr.operands().at(0) = expr;
     expr = arr;

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -450,7 +450,7 @@ void string_handler::ensure_string_array(exprt &expr)
 
   if (!expr.type().is_array())
   {
-    // Explicitly build the array and 
+    // Explicitly build the array and
     // ensure null-termination (size 2: char + \0)
     typet t = type_handler_.build_array(expr.type(), 2);
     exprt arr = gen_zero(t);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3089.

This PR fixes a regression where string comparisons involving single-character string literals failed verification, while comparisons with longer strings passed. As a result of this fix, this PR also fixes the empty list join returning an uninitialized string.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.