### PR TITLE
[python] add isnone expression for symex-level None comparison handling

### DIFF
--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -132,7 +132,8 @@
   BOOST_PP_LIST_CONS(forall,                                                   \
   BOOST_PP_LIST_CONS(exists,                                                   \
   BOOST_PP_LIST_CONS(isinstance,                                               \
-  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_CONS(isnone,                                                   \
+  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -117,7 +117,8 @@ static const char *expr_names[] = {
   "capability_top",
   "forall",
   "exists",
-  "isinstance"};
+  "isinstance",
+  "isnone"};
 // If this fires, you've added/removed an expr id, and need to update the list
 // above (which is ordered according to the enum list)
 static_assert(

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1531,6 +1531,7 @@ irep_typedefs(capability_top, object_ops);
 irep_typedefs(forall, logic_2ops);
 irep_typedefs(exists, logic_2ops);
 irep_typedefs(isinstance, logic_2ops);
+irep_typedefs(isnone, logic_2ops);
 
 class exists2t : public exists_expr_methods
 {
@@ -3146,6 +3147,19 @@ public:
   {
   }
   isinstance2t(const isinstance2t &ref) = default;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class isnone2t : public isnone_expr_methods
+{
+public:
+  isnone2t(const expr2tc &lhs, const expr2tc &rhs)
+    : isnone_expr_methods(get_bool_type(), isnone_id, lhs, rhs)
+  {
+  }
+
+  isnone2t(const isnone2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -253,6 +253,8 @@ std::string exists2t::field_names[esbmct::num_type_fields] =
   {"symbol", "predicate", "", "", ""};
 std::string isinstance2t::field_names[esbmct::num_type_fields] =
   {"value", "type", "", "", ""};
+std::string isnone2t::field_names[esbmct::num_type_fields] =
+  {"lhs", "rhs", "", "", ""};
 
 // For CRCing to actually be accurate, expr/type ids mustn't overflow out of
 // a byte. If this happens then a) there are too many exprs, and b) the expr

--- a/src/irep2/templates/irep2_templates_expr_ops.cpp
+++ b/src/irep2/templates/irep2_templates_expr_ops.cpp
@@ -38,6 +38,7 @@ expr_typedefs1(overflow, overflow_ops);
 expr_typedefs1(valid_object, object_ops);
 expr_typedefs1(races_check, object_ops);
 expr_typedefs1(isinstance, logic_2ops);
+expr_typedefs1(isnone, logic_2ops);
 expr_typedefs1(dynamic_size, object_ops);
 expr_typedefs1(deallocated_obj, object_ops);
 expr_typedefs1(invalid_pointer, invalid_pointer_ops);

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -2386,6 +2386,11 @@ std::string c_expr2stringt::convert(const exprt &src, unsigned &precedence)
     return convert_function(src, "ISINSTANCE", precedence = 15);
   }
 
+  else if (src.id() == "isnone")
+  {
+    return convert_function(src, "ISNONE", precedence = 15);
+  }
+
   else if (src.id() == "capability_base")
   {
     return convert_function(src, "CAPABILITY_BASE", precedence = 15);

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1531,6 +1531,12 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     convert_operand_pair(expr, op0, op1);
     new_expr_ref = isinstance2tc(op0, op1);
   }
+  else if (expr.id() == "isnone")
+  {
+    expr2tc op0, op1;
+    convert_operand_pair(expr, op0, op1);
+    new_expr_ref = isnone2tc(op0, op1);
+  }
   else if (expr.id() == "capability_base")
   {
     expr2tc op0;
@@ -2889,6 +2895,14 @@ exprt migrate_expr_back(const expr2tc &ref)
     exprt back("isinstance", bool_typet());
     back.copy_to_operands(migrate_expr_back(ins.side_1));
     back.copy_to_operands(migrate_expr_back(ins.side_2));
+    return back;
+  }
+  case expr2t::isnone_id:
+  {
+    const isnone2t &isn = to_isnone2t(ref);
+    exprt back("isnone", bool_typet());
+    back.copy_to_operands(migrate_expr_back(isn.side_1));
+    back.copy_to_operands(migrate_expr_back(isn.side_2));
     return back;
   }
   case expr2t::deallocated_obj_id:


### PR DESCRIPTION
This PR implements simplification of None comparisons at the symbolic execution level. The isnone expression is created during Python AST conversion and simplified during symex, with full type information and value-set analysis.

In particular, this PR:
- Adds `isnone` expression type to `irep2` system
- Generates `isnone` expressions in `python_converter` for `None` comparisons
- Implements `simplify_python_builtins` to handle:
  * `Optional[T]` vs None (check `is_none` field)
  * None vs pointer (NULL comparison)
  * None vs non-None (constant folding)
  * None vs None (always true)
- Uses not wrapper for inequality checks (x is not None)
- Updates migration support for isnone expressions

This approach defers None comparison logic to Symex, where we have access to renamed values, value sets, and complete type information, enabling more precise analysis than at the conversion level.