### PR TITLE
[python]  fix the function call to wrap None values in the Optional struct

### DIFF
--- a/regression/python/github_3087/ll.py
+++ b/regression/python/github_3087/ll.py
@@ -1,0 +1,20 @@
+class Foo:
+    def __init__(self, t: str) -> None:
+        self.t = t
+    
+
+class Bar:
+    def __init__(self, t: str) -> None:
+        self.t = t
+    
+def create(
+    s: str,
+    t: str,
+    b: bool | None = None,
+) -> Foo | Bar:
+    if s == 'foo':
+        return Foo(t)
+    elif s == 'bar':
+        return Bar(t)
+    else:
+        raise NotImplementedError("Unknown class")

--- a/regression/python/github_3087/main.py
+++ b/regression/python/github_3087/main.py
@@ -1,0 +1,4 @@
+import ll
+from ll import Foo
+
+f: Foo = ll.create('foo', t='t')

--- a/regression/python/github_3087/test.desc
+++ b/regression/python/github_3087/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3087.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.