### PR TITLE
[python] implement tuple unpacking

### DIFF
--- a/regression/python/github_3044_2/main.py
+++ b/regression/python/github_3044_2/main.py
@@ -1,0 +1,7 @@
+def foo() -> tuple[int, int]:
+    return (1, 2)
+
+t: tuple[int, int] = foo()
+(x, y) = t
+assert x == 1
+assert y == 2

--- a/regression/python/github_3044_2/test.desc
+++ b/regression/python/github_3044_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3044_2_fail/main.py
+++ b/regression/python/github_3044_2_fail/main.py
@@ -1,0 +1,7 @@
+def foo() -> tuple[int, int]:
+    return (1, 2)
+
+t: tuple[int, int] = foo()
+(x, y) = t
+assert x == 2
+assert y == 1

--- a/regression/python/github_3044_2_fail/test.desc
+++ b/regression/python/github_3044_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties: 2 verified, \✗ 2 failed$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -980,8 +980,6 @@ class Preprocessor(ast.NodeTransformer):
                     assignments.append(individual_assign)
         else:
             # Don't transform tuple unpacking from variables - let converter handle it
-            # The C++ converter has proper logic to handle struct member access for tuples
-            # Transforming to subscripts here breaks tuple (struct) unpacking
             return source_node
 
         return assignments

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -979,29 +979,10 @@ class Preprocessor(ast.NodeTransformer):
                     self._update_variable_types_simple(target_elem, value_elem)
                     assignments.append(individual_assign)
         else:
-            # For all other cases (including lists and complex expressions),
-            # use temporary variable to avoid AST node sharing issues
-            temp_var_name = f"ESBMC_unpack_temp_{id(source_node)}"
-            temp_var = ast.Name(id=temp_var_name, ctx=ast.Store())
-            self._copy_location_info(source_node, temp_var)
-            temp_assign = self._create_individual_assignment(temp_var, value, source_node)
-            assignments.append(temp_assign)
-
-            # Now create individual assignments from temp variable
-            for i, target_elem in enumerate(target.elts):
-                if isinstance(target_elem, ast.Name):
-                    subscript = ast.Subscript(
-                        value=ast.Name(id=temp_var_name, ctx=ast.Load()),
-                        slice=ast.Constant(value=i),
-                        ctx=ast.Load()
-                    )
-                    self._copy_location_info(source_node, subscript)
-                    self._copy_location_info(source_node, subscript.value)
-                    self._copy_location_info(source_node, subscript.slice)
-
-                    individual_assign = self._create_individual_assignment(target_elem, subscript, source_node)
-                    self.known_variable_types[target_elem.id] = 'Any'
-                    assignments.append(individual_assign)
+            # Don't transform tuple unpacking from variables - let converter handle it
+            # The C++ converter has proper logic to handle struct member access for tuples
+            # Transforming to subscripts here breaks tuple (struct) unpacking
+            return source_node
 
         return assignments
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1615,7 +1615,7 @@ private:
       if (stmt_type != "Assign" || !element["type_comment"].is_null())
         continue;
 
-      // Skip tuple/list unpacking assignments - they don't need type annotation
+      // Skip tuple/list unpacking assignments
       // The C++ converter will handle them directly with proper type inference
       if (
         element.contains("targets") && !element["targets"].empty() &&

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1615,6 +1615,17 @@ private:
       if (stmt_type != "Assign" || !element["type_comment"].is_null())
         continue;
 
+      // Skip tuple/list unpacking assignments - they don't need type annotation
+      // The C++ converter will handle them directly with proper type inference
+      if (
+        element.contains("targets") && !element["targets"].empty() &&
+        element["targets"][0].contains("_type") &&
+        (element["targets"][0]["_type"] == "Tuple" ||
+         element["targets"][0]["_type"] == "List"))
+      {
+        continue;
+      }
+
       std::string inferred_type("");
 
       // Check if LHS was previously annotated

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -347,6 +347,28 @@ private:
   std::pair<std::string, typet>
   extract_type_info(const nlohmann::json &ast_node);
 
+  void handle_tuple_unpacking(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &target,
+    exprt &rhs,
+    codet &target_block);
+
+  void handle_array_unpacking(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &target,
+    exprt &rhs,
+    codet &target_block);
+
+  void handle_list_literal_unpacking(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &target,
+    codet &target_block);
+
+  exprt prepare_rhs_for_unpacking(
+    const nlohmann::json &ast_node,
+    exprt &rhs,
+    codet &target_block);
+
   exprt create_lhs_expression(
     const nlohmann::json &target,
     symbolt *lhs_symbol,


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3044.

This PR supports tuple unpacking assignments such as `(x, y) = t` and `(x, y) = foo()`:

1. When RHS is a function call, create a temporary variable to hold the result before unpacking (required because member access cannot be performed directly on side effect expressions).
2. Generate proper struct member access (`temp.element_0`, `temp.element_1`) for tuple unpacking instead of invalid array indexing.
3. Handle array/list unpacking with subscript operations.

This PR fixes `symbolic_type_excp` crash and assertion failure in `member2t` constructor during GOTO program generation (see https://github.com/esbmc/esbmc/issues/3044).

Future work: Refactor our `python_converter` to move the tuple operators into a dedicated handler (e.g., `tuple_hanlder`).

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.