### PR TITLE
[python] extract tuple operations to dedicated tuple_handler

### DIFF
--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(pythonfrontend STATIC
             string_builder.cpp
             string_handler.cpp
             parse_float.cpp
+            tuple_handler.cpp
             convert_float_literal.cpp)
 
 target_include_directories(pythonfrontend

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -22,6 +22,7 @@ class function_call_expr;
 class type_handler;
 class string_builder;
 class module_locator;
+class tuple_handler;
 
 class python_converter
 {
@@ -45,6 +46,11 @@ public:
   string_handler &get_string_handler()
   {
     return string_handler_;
+  }
+
+  tuple_handler &get_tuple_handler()
+  {
+    return *tuple_handler_;
   }
 
   const nlohmann::json &ast() const
@@ -137,6 +143,7 @@ private:
   friend class function_call_builder;
   friend class type_handler;
   friend class python_list;
+  friend class tuple_handler;
   bool processing_list_elements = false;
 
   template <typename Func>
@@ -283,6 +290,7 @@ private:
     const nlohmann::json &function_node,
     const code_typet &type,
     exprt &function_body);
+
   exprt compare_constants_internal(
     const std::string &op,
     const exprt &lhs,
@@ -347,12 +355,6 @@ private:
   std::pair<std::string, typet>
   extract_type_info(const nlohmann::json &ast_node);
 
-  void handle_tuple_unpacking(
-    const nlohmann::json &ast_node,
-    const nlohmann::json &target,
-    exprt &rhs,
-    codet &target_block);
-
   void handle_array_unpacking(
     const nlohmann::json &ast_node,
     const nlohmann::json &target,
@@ -362,11 +364,6 @@ private:
   void handle_list_literal_unpacking(
     const nlohmann::json &ast_node,
     const nlohmann::json &target,
-    codet &target_block);
-
-  exprt prepare_rhs_for_unpacking(
-    const nlohmann::json &ast_node,
-    exprt &rhs,
     codet &target_block);
 
   exprt create_lhs_expression(
@@ -395,6 +392,7 @@ private:
   void process_forward_reference(
     const nlohmann::json &annotation,
     codet &target_block);
+
   // Wrap values in Optional
   exprt wrap_in_optional(const exprt &value, const typet &optional_type);
 
@@ -419,6 +417,7 @@ private:
   exprt *current_lhs;
   string_handler string_handler_;
   python_math math_handler_;
+  tuple_handler *tuple_handler_;
 
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -1,0 +1,298 @@
+#include <python-frontend/tuple_handler.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/type_handler.h>
+#include <python-frontend/symbol_id.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+
+tuple_handler::tuple_handler(
+  python_converter &converter,
+  type_handler &type_handler)
+  : converter_(converter), type_handler_(type_handler)
+{
+}
+
+std::string
+tuple_handler::build_tuple_tag(const std::vector<typet> &element_types) const
+{
+  std::string tag_name = "tag-tuple";
+  for (const auto &type : element_types)
+  {
+    tag_name += "_" + type.to_string();
+  }
+  return tag_name;
+}
+
+struct_typet tuple_handler::create_tuple_struct_type(
+  const std::vector<typet> &element_types) const
+{
+  struct_typet tuple_type;
+
+  // Add components for each element
+  for (size_t i = 0; i < element_types.size(); i++)
+  {
+    std::string comp_name = "element_" + std::to_string(i);
+    struct_typet::componentt comp(comp_name, comp_name, element_types[i]);
+    tuple_type.components().push_back(comp);
+  }
+
+  // Set the tag to ensure type identity
+  tuple_type.tag(build_tuple_tag(element_types));
+
+  return tuple_type;
+}
+
+exprt tuple_handler::get_tuple_expr(const nlohmann::json &element)
+{
+  assert(element.contains("_type") && element["_type"] == "Tuple");
+  assert(element.contains("elts"));
+
+  const nlohmann::json &elts = element["elts"];
+
+  // Process each element and collect expressions
+  std::vector<exprt> element_exprs;
+  std::vector<typet> element_types;
+  element_exprs.reserve(elts.size());
+  element_types.reserve(elts.size());
+
+  // First pass: get all expressions to determine types
+  for (size_t i = 0; i < elts.size(); i++)
+  {
+    exprt elem_expr = converter_.get_expr(elts[i]);
+    element_exprs.push_back(elem_expr);
+    element_types.push_back(elem_expr.type());
+  }
+
+  // Create struct type for the tuple
+  struct_typet tuple_type = create_tuple_struct_type(element_types);
+
+  // Create struct expression with tuple type
+  struct_exprt tuple_expr(tuple_type);
+  tuple_expr.operands() = element_exprs;
+
+  // Set location information
+  if (element.contains("lineno"))
+  {
+    locationt loc = converter_.get_location_from_decl(element);
+    tuple_expr.location() = loc;
+  }
+
+  return tuple_expr;
+}
+
+bool tuple_handler::is_tuple_type(const typet &type) const
+{
+  if (!type.is_struct())
+    return false;
+
+  const struct_typet &struct_type = to_struct_type(type);
+  return struct_type.tag().as_string().find("tag-tuple") == 0;
+}
+
+exprt tuple_handler::handle_tuple_subscript(
+  const exprt &array,
+  const nlohmann::json &slice,
+  const nlohmann::json &element)
+{
+  assert(array.type().is_struct());
+  const struct_typet &tuple_type = to_struct_type(array.type());
+
+  // Verify it's a tuple
+  if (!is_tuple_type(tuple_type))
+  {
+    throw std::runtime_error(
+      "Subscript on non-tuple struct type: " + tuple_type.tag().as_string());
+  }
+
+  // Convert subscript to member access
+  exprt index_expr = converter_.get_expr(slice);
+
+  // Index must be a constant for struct member access
+  if (!index_expr.is_constant())
+  {
+    throw std::runtime_error(
+      "Tuple subscript with non-constant index is not supported");
+  }
+
+  const constant_exprt &const_index = to_constant_expr(index_expr);
+  BigInt index_val = binary2integer(const_index.value().c_str(), false);
+
+  // Convert BigInt to size_t for array indexing
+  size_t idx = index_val.to_int64();
+
+  // Check bounds
+  if (index_val < 0 || idx >= tuple_type.components().size())
+  {
+    throw std::runtime_error(
+      "Tuple index " + integer2string(index_val) + " out of range (size: " +
+      std::to_string(tuple_type.components().size()) + ")");
+  }
+
+  // Create member access expression: t[0] -> t.element_0
+  std::string member_name = "element_" + integer2string(index_val);
+  const struct_typet::componentt &comp = tuple_type.components()[idx];
+
+  exprt result = member_exprt(array, member_name, comp.type());
+
+  if (element.contains("lineno"))
+  {
+    locationt loc = converter_.get_location_from_decl(element);
+    result.location() = loc;
+  }
+
+  return result;
+}
+
+exprt tuple_handler::prepare_rhs_for_unpacking(
+  const nlohmann::json &ast_node,
+  exprt &rhs,
+  codet &target_block)
+{
+  // If RHS is a function call, we need to create a temporary variable first
+  // because we can't do member access on a side effect expression
+  if (rhs.is_function_call() || rhs.id() == "sideeffect")
+  {
+    locationt loc = converter_.get_location_from_decl(ast_node);
+    std::string temp_name =
+      "ESBMC_unpack_temp_" +
+      std::to_string(reinterpret_cast<uintptr_t>(&ast_node));
+
+    symbol_id temp_sid = converter_.create_symbol_id();
+    temp_sid.set_object(temp_name);
+
+    symbolt temp_symbol = converter_.create_symbol(
+      loc.get_file().as_string(),
+      temp_name,
+      temp_sid.to_string(),
+      loc,
+      rhs.type());
+    temp_symbol.lvalue = true;
+    temp_symbol.file_local = true;
+    temp_symbol.is_extern = false;
+    temp_symbol.static_lifetime = false;
+
+    symbolt *added_temp =
+      converter_.symbol_table().move_symbol_to_context(temp_symbol);
+    exprt temp_var = symbol_expr(*added_temp);
+
+    if (rhs.is_function_call())
+    {
+      code_function_callt &call = static_cast<code_function_callt &>(rhs);
+      call.lhs() = temp_var;
+      target_block.copy_to_operands(rhs);
+    }
+    else
+    {
+      code_assignt temp_assign(temp_var, rhs);
+      temp_assign.location() = loc;
+      target_block.copy_to_operands(temp_assign);
+    }
+
+    return temp_var;
+  }
+
+  return rhs;
+}
+
+void tuple_handler::handle_tuple_unpacking(
+  const nlohmann::json &ast_node,
+  const nlohmann::json &target,
+  exprt &rhs,
+  codet &target_block)
+{
+  const struct_typet &tuple_type = to_struct_type(rhs.type());
+
+  // Verify it's a tuple
+  if (!is_tuple_type(tuple_type))
+  {
+    throw std::runtime_error(
+      "Cannot unpack non-tuple type: " + tuple_type.tag().as_string());
+  }
+
+  const auto &targets = target["elts"];
+
+  if (targets.size() != tuple_type.components().size())
+  {
+    throw std::runtime_error(
+      "Cannot unpack tuple: expected " + std::to_string(targets.size()) +
+      " values, got " + std::to_string(tuple_type.components().size()));
+  }
+
+  // Create assignments: x = temp.element_0, y = temp.element_1, ...
+  for (size_t i = 0; i < targets.size(); i++)
+  {
+    if (targets[i]["_type"] != "Name")
+    {
+      throw std::runtime_error(
+        "Tuple unpacking only supports simple names, not " +
+        targets[i]["_type"].get<std::string>());
+    }
+
+    std::string var_name = targets[i]["id"].get<std::string>();
+    symbol_id var_sid = converter_.create_symbol_id();
+    var_sid.set_object(var_name);
+
+    symbolt *var_symbol = converter_.find_symbol(var_sid.to_string());
+
+    if (!var_symbol)
+    {
+      locationt loc = converter_.get_location_from_decl(targets[i]);
+      const typet &elem_type = tuple_type.components()[i].type();
+
+      symbolt new_symbol = converter_.create_symbol(
+        loc.get_file().as_string(),
+        var_name,
+        var_sid.to_string(),
+        loc,
+        elem_type);
+      new_symbol.lvalue = true;
+      new_symbol.file_local = true;
+      new_symbol.is_extern = false;
+      var_symbol = converter_.symbol_table().move_symbol_to_context(new_symbol);
+    }
+
+    // Create member access: temp.element_i
+    std::string member_name = "element_" + std::to_string(i);
+    member_exprt member_access(
+      rhs, member_name, tuple_type.components()[i].type());
+
+    // Create assignment
+    code_assignt assign(symbol_expr(*var_symbol), member_access);
+    assign.location() = converter_.get_location_from_decl(ast_node);
+    target_block.copy_to_operands(assign);
+  }
+}
+
+typet tuple_handler::get_tuple_type_from_annotation(
+  const nlohmann::json &annotation_node)
+{
+  assert(
+    annotation_node["_type"] == "Subscript" &&
+    annotation_node["value"]["id"] == "tuple");
+
+  struct_typet tuple_type;
+  const auto &slice = annotation_node["slice"];
+
+  // Build tag name matching the pattern used in get_tuple_expr
+  std::vector<typet> element_types;
+
+  if (slice.contains("elts"))
+  {
+    // Multiple element types: tuple[int, str, float]
+    const auto &elts = slice["elts"];
+    for (size_t i = 0; i < elts.size(); i++)
+    {
+      typet elem_type;
+      if (elts[i].contains("id"))
+        elem_type = type_handler_.get_typet(elts[i]["id"].get<std::string>());
+      else
+        elem_type = type_handler_.get_typet(elts[i]);
+
+      element_types.push_back(elem_type);
+    }
+  }
+
+  return create_tuple_struct_type(element_types);
+}

--- a/src/python-frontend/tuple_handler.h
+++ b/src/python-frontend/tuple_handler.h
@@ -1,0 +1,107 @@
+#ifndef ESBMC_PYTHON_TUPLE_HANDLER_H
+#define ESBMC_PYTHON_TUPLE_HANDLER_H
+
+#include <python-frontend/python_converter.h>
+#include <util/type.h>
+#include <util/expr.h>
+#include <nlohmann/json.hpp>
+#include <string>
+
+class python_converter;
+class type_handler;
+
+/**
+ * @brief Handler for Python tuple operations
+ * 
+ * This class manages tuple creation, subscripting, unpacking, and type handling
+ * for Python tuples in the ESBMC converter.
+ */
+class tuple_handler
+{
+public:
+  /**
+   * @brief Construct a new tuple handler
+   * @param converter Reference to the parent python_converter
+   * @param type_handler Reference to the type_handler for type operations
+   */
+  tuple_handler(python_converter &converter, type_handler &type_handler);
+
+  /**
+   * @brief Create a tuple expression from AST elements
+   * @param element JSON AST node representing a Tuple
+   * @return exprt The tuple represented as a struct expression
+   */
+  exprt get_tuple_expr(const nlohmann::json &element);
+
+  /**
+   * @brief Handle tuple subscripting (e.g., t[0])
+   * @param array The tuple expression to subscript
+   * @param slice The index expression
+   * @param element The original AST element for location info
+   * @return exprt Member access expression for the tuple element
+   */
+  exprt handle_tuple_subscript(
+    const exprt &array,
+    const nlohmann::json &slice,
+    const nlohmann::json &element);
+
+  /**
+   * @brief Check if a type represents a tuple
+   * @param type The type to check
+   * @return bool True if the type is a tuple struct type
+   */
+  bool is_tuple_type(const typet &type) const;
+
+  /**
+   * @brief Handle tuple unpacking assignments
+   * @param ast_node The assignment AST node
+   * @param target The target tuple pattern (e.g., (x, y, z))
+   * @param rhs The right-hand side expression
+   * @param target_block The code block to append assignments to
+   */
+  void handle_tuple_unpacking(
+    const nlohmann::json &ast_node,
+    const nlohmann::json &target,
+    exprt &rhs,
+    codet &target_block);
+
+  /**
+   * @brief Get tuple type from annotation (e.g., tuple[int, str])
+   * @param annotation_node The annotation AST node
+   * @return typet The tuple struct type
+   */
+  typet get_tuple_type_from_annotation(const nlohmann::json &annotation_node);
+
+  /**
+   * @brief Prepare RHS for unpacking (handle function calls)
+   * @param ast_node The assignment AST node
+   * @param rhs The right-hand side expression
+   * @param target_block The code block to append temporary declarations to
+   * @return exprt The prepared expression (original or temporary variable)
+   */
+  exprt prepare_rhs_for_unpacking(
+    const nlohmann::json &ast_node,
+    exprt &rhs,
+    codet &target_block);
+
+private:
+  /**
+   * @brief Build a unique tag name for a tuple based on element types
+   * @param element_types Vector of types for tuple elements
+   * @return std::string The tag name (e.g., "tag-tuple_int_str")
+   */
+  std::string build_tuple_tag(const std::vector<typet> &element_types) const;
+
+  /**
+   * @brief Create a tuple struct type from element types
+   * @param element_types Vector of types for tuple elements
+   * @return struct_typet The tuple struct type with components
+   */
+  struct_typet
+  create_tuple_struct_type(const std::vector<typet> &element_types) const;
+
+  python_converter &converter_;
+  type_handler &type_handler_;
+};
+
+#endif // ESBMC_PYTHON_TUPLE_HANDLER_H


### PR DESCRIPTION
This PR refactors tuple-related functionality from `python_converter` into a new `tuple_handler` class following the existing handler pattern (`string_handler`, `math_handler`, `type_handler`).

In particular, this PR:
- Adds `tuple_handler.h/cpp` with tuple creation, subscripting, and unpacking.
- Move `get_tuple_expr`, `handle_tuple_subscript`, `handle_tuple_unpacking`, and `prepare_rhs_for_unpacking` from `python_converter` to `tuple_handler`.
- Update `python_converter` to delegate tuple operations to `tuple_handler`.