### PR TITLE
[python] fix string literal type annotation for str returns

### DIFF
--- a/regression/python/return10_2/test.desc
+++ b/regression/python/return10_2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4537,7 +4537,10 @@ void python_converter::get_function_definition(
   {
     std::string type_string =
       type_utils::remove_quotes(return_node["value"].get<std::string>());
-    type.return_type() = type_handler_.get_typet(type_string);
+    if (type_string == "str")
+      type.return_type() = gen_pointer_type(char_type());
+    else
+      type.return_type() = type_handler_.get_typet(type_string);
   }
   else
     throw std::runtime_error("Return type undefined");


### PR DESCRIPTION

### Problem
- `-> "str"` (with quotes) returns **array type** ❌
- `-> str` (no quotes) returns **pointer type** ✅
- Type mismatch causes verification to fail

```python
def str_annotation() -> "str":  # ← String literal annotation
    return "hello"

result = str_annotation()
assert result == "hello"
```


### Fix
add a handling:

```cpp
if (type_string == "str")
  type.return_type() = gen_pointer_type(char_type());
else
  type.return_type() = type_handler_.get_typet(type_string);
```

### Result
Both annotation styles now return pointer type consistently.

**Test**: `return10_2` changes from `KNOWNBUG` → `CORE` ✅
