### PR TITLE
[python] support string parameter slicing

### DIFF
--- a/regression/python/github_3043/main.py
+++ b/regression/python/github_3043/main.py
@@ -1,0 +1,3 @@
+def foo(s: str) -> None:
+    l = 2
+    ss: str = s[1:l]

--- a/regression/python/github_3043/test.desc
+++ b/regression/python/github_3043/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3043_2/main.py
+++ b/regression/python/github_3043_2/main.py
@@ -1,0 +1,6 @@
+def foo(s: str) -> None:
+    l = 2
+    ss: str = s[1:l]
+    assert ss == "a"
+
+foo("bar")

--- a/regression/python/github_3043_2/test.desc
+++ b/regression/python/github_3043_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3043_2_fail/main.py
+++ b/regression/python/github_3043_2_fail/main.py
@@ -1,0 +1,6 @@
+def foo(s: str) -> None:
+    l = 2
+    ss: str = s[1:l]
+    assert ss == "b"
+
+foo("bar")

--- a/regression/python/github_3043_2_fail/test.desc
+++ b/regression/python/github_3043_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3082/main.py
+++ b/regression/python/github_3082/main.py
@@ -1,0 +1,3 @@
+s = "foobar"
+ss = s[1:3]
+assert ss == "oo"

--- a/regression/python/github_3082/test.desc
+++ b/regression/python/github_3082/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3082_2/main.py
+++ b/regression/python/github_3082_2/main.py
@@ -1,0 +1,5 @@
+def foo(s: str) -> None:
+    ss = s[1:3]
+    assert ss == "oo"
+
+foo("foobar")

--- a/regression/python/github_3082_2/test.desc
+++ b/regression/python/github_3082_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3082_2_fail/main.py
+++ b/regression/python/github_3082_2_fail/main.py
@@ -1,0 +1,5 @@
+def foo(s: str) -> None:
+    ss = s[1:3]
+    assert ss == "foo"
+
+foo("foobar")

--- a/regression/python/github_3082_2_fail/test.desc
+++ b/regression/python/github_3082_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/github_3082_fail/main.py
+++ b/regression/python/github_3082_fail/main.py
@@ -1,0 +1,3 @@
+s = "foobar"
+ss = s[1:3]
+assert ss == "foo"

--- a/regression/python/github_3082_fail/test.desc
+++ b/regression/python/github_3082_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3043.
Fixes https://github.com/esbmc/esbmc/issues/3082.

String parameters are pointer-to-char, not arrays! 

This PR updates `handle_range_slice` to detect and handle pointer-to-char alongside char arrays, enabling correct array-based slicing for both local strings and string parameters.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.