### PR TITLE
[python] fix attribute access on imported class parameters

### DIFF
--- a/regression/python/github_3042/main.py
+++ b/regression/python/github_3042/main.py
@@ -1,0 +1,5 @@
+from typing import Any
+from datetime import datetime
+
+def foo(d: datetime) -> int:
+    return d.microsecond

--- a/regression/python/github_3042/test.desc
+++ b/regression/python/github_3042/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2499,10 +2499,21 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       std::string obj_type_name;
       const typet &symbol_type =
         (symbol->type.is_pointer()) ? symbol->type.subtype() : symbol->type;
-      for (const auto &it : symbol_type.get_named_sub())
+
+      if (symbol_type.id() == "struct")
       {
-        if (it.first == "identifier")
-          obj_type_name = it.second.id_string();
+        // Struct types store class name in "tag" field
+        const struct_typet &struct_type = to_struct_type(symbol_type);
+        obj_type_name = "tag-" + struct_type.tag().as_string();
+      }
+      else
+      {
+        // Search named_sub for identifier
+        for (const auto &it : symbol_type.get_named_sub())
+        {
+          if (it.first == "identifier")
+            obj_type_name = it.second.id_string();
+        }
       }
 
       // Get class definition from symbols table

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -321,14 +321,6 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   // Check if it's a defined class in the AST
   bool is_defined = json_utils::is_class(ast_type, converter_.ast());
 
-  // Check if it's a built-in type (handles tuple, list, dict, etc.)
-  if (!is_defined)
-    is_defined = type_utils::is_builtin_type(ast_type);
-
-  // Check if it's imported
-  if (!is_defined)
-    is_defined = converter_.is_imported_module(ast_type);
-
   // Look up the type in the symbol table
   if (!is_defined)
   {
@@ -336,6 +328,14 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     if (s)
       return s->type;
   }
+
+  // Check if it's a built-in type (handles tuple, list, dict, etc.)
+  if (!is_defined)
+    is_defined = type_utils::is_builtin_type(ast_type);
+
+  // Check if it's imported
+  if (!is_defined)
+    is_defined = converter_.is_imported_module(ast_type);
 
   // If still not found, it's a NameError
   if (!is_defined)


### PR DESCRIPTION
Fixes #3042

This PR adds explicit handling in `python_converter::get_expr()` for struct type representations when extracting class names for attribute access. Before this PR, accessing attributes on function parameters with imported class types (e.g., `d.microsecond` where `d: datetime`) threw `"Class \"\" not found"` errors. The `obj_type_name` extraction only searched for "identifier" in `named_sub`, but struct types store the class name in the "tag" field.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
