### PR TITLE
[python] fix handling of Sequence[T] | None union types in type annotations

### DIFF
--- a/regression/python/github_3045/main.py
+++ b/regression/python/github_3045/main.py
@@ -1,0 +1,4 @@
+from typing import Sequence
+
+def foo(s: Sequence[str] | None = None) -> None:
+    pass

--- a/regression/python/github_3045/test.desc
+++ b/regression/python/github_3045/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3893,8 +3893,7 @@ python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
     if (node.contains("id"))
       return node["id"].get<std::string>();
 
-    // Handle Subscript nodes (such as Literal["bar"])
-    // Don't try to extract a string type name - return a marker
+    // Handle Subscript nodes (such as Literal["bar"] or Sequence[str])
     if (node.contains("_type") && node["_type"] == "Subscript")
     {
       if (node.contains("value") && node["value"].contains("id"))
@@ -3902,7 +3901,10 @@ python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
         std::string subscript_type = node["value"]["id"].get<std::string>();
         if (subscript_type == "Literal")
           return "__LITERAL__"; // Special marker for Literal types
-        // For list[str], dict[int], etc., return the base type (list, dict)
+        // For Sequence[str], List[int], etc., return "list" as the concrete type
+        if (subscript_type == "Sequence" || subscript_type == "List")
+          return "list";
+        // For other generic types, return the base type
         return subscript_type;
       }
       return ""; // Other subscript types


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3045.

The converter was failing to extract types from unions that include generic types, such as `Sequence[str] | None`, resulting in a `"NameError: name 'Sequence' is not defined"`. 

This PR updates `extract_non_none_type` to properly handle `Subscript` nodes by mapping `Sequence` and `List` to the internal "list" type.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.