### PR TITLE
[python] fix multi-type union handling to use proper pointer types

### DIFF
--- a/regression/python/github_3106/main.py
+++ b/regression/python/github_3106/main.py
@@ -1,0 +1,5 @@
+def foo(a: bytes | str | None = None) -> None:
+    pass
+
+a = "a"
+foo(a=a)

--- a/regression/python/github_3106/test.desc
+++ b/regression/python/github_3106/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3106.

This PR uses `any_type()` (void*) for multi-type unions, which correctly represents "pointer to any type".

Multi-type unions (e.g., `bytes | str | None`) were incorrectly resolved to `unsignedbv` instead of pointer types, causing type mismatches when passing string variables as arguments. In particular, the issue was that `pointer_type()` returns an integer representation of `pointer width (unsignedbv)`, not an actual pointer type. 

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.