### PR TITLE
[python] fix type inference for imported class constructors

### DIFF
--- a/regression/python/github_3114/ll.py
+++ b/regression/python/github_3114/ll.py
@@ -1,0 +1,3 @@
+class Foo:
+    def __init__(self, s: str) -> None:
+        self.s = s

--- a/regression/python/github_3114/main.py
+++ b/regression/python/github_3114/main.py
@@ -1,0 +1,5 @@
+from typing import Any
+import ll
+from ll import Foo
+
+f = Foo(s="foo")

--- a/regression/python/github_3114/test.desc
+++ b/regression/python/github_3114/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3114.

This PR fixes the issue where importing 'Any' from typing caused type inference to fail for imported class instantiation.

When inferring types for calls to imported classes (e.g., `Foo()` from an imported module), the type inference was failing because `__init__` methods return `None`, not the class type, now, when `get_function()` returns an `empty` or `NoneType` return_type_, we treat it as a class constructor and return the class name as the type.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
