### PR TITLE
[python] Fix type hash and size calculation for void* strings in list contains

### DIFF
--- a/regression/python/github_3119/main.py
+++ b/regression/python/github_3119/main.py
@@ -1,0 +1,7 @@
+LL: list[str] = ["foo", "foobar"]
+
+def foo(s: str) -> None:
+    assert s in LL
+
+
+foo("foobar")

--- a/regression/python/github_3119/test.desc
+++ b/regression/python/github_3119/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3119_2/main.py
+++ b/regression/python/github_3119_2/main.py
@@ -1,0 +1,6 @@
+LL: set[str] = {"foo", "foobar"}
+
+def foo(s: str) -> None:
+    assert s in LL
+
+foo("foobar")

--- a/regression/python/github_3119_2/test.desc
+++ b/regression/python/github_3119_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3119_2_fail/main.py
+++ b/regression/python/github_3119_2_fail/main.py
@@ -1,0 +1,6 @@
+LL: set[str] = {"foo", "foobar"}
+
+def foo(s: str) -> None:
+    assert s in LL
+
+foo("bar")

--- a/regression/python/github_3119_2_fail/test.desc
+++ b/regression/python/github_3119_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3119_fail/main.py
+++ b/regression/python/github_3119_fail/main.py
@@ -1,0 +1,7 @@
+LL: list[str] = ["foo", "foobar"]
+
+def foo(s: str) -> None:
+    assert s in LL
+
+
+foo("bar")

--- a/regression/python/github_3119_fail/test.desc
+++ b/regression/python/github_3119_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3119.

This PR detects `void*` strings from list iteration and uses the stored type information from `list_type_map` to:
- Generate the correct type hash for string arrays.
- Call `strlen` at runtime to get the actual string length.

Note that, when checking if a string is in a list, there are two cases to handle:

1. String parameters (char*): These already work correctly since `get_list_element_info()` calls strlen at runtime to get the actual size.
2. Loop iteration over lists (void*): When iterating over a list of strings with `for s in list`, the extracted element has type `void*` 
   instead of `char*`. This caused incorrect type hashing (`void*` hash instead of string array hash) and wrong size (1 instead of `strlen` result).

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

