### PR TITLE
[python] Prioritize local modules over system modules

### DIFF
--- a/regression/python/github_3116/main.py
+++ b/regression/python/github_3116/main.py
@@ -1,0 +1,16 @@
+import toml  # type: ignore[import]
+
+
+def main() -> None:
+    toml_string = """
+[servers]
+[servers.alpha]
+ip = "10.0.0.1"
+role = "frontend"
+"""
+
+    parsed_toml = toml.loads(toml_string)
+    assert parsed_toml == "foo"
+
+
+main()

--- a/regression/python/github_3116/test.desc
+++ b/regression/python/github_3116/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3116/toml.py
+++ b/regression/python/github_3116/toml.py
@@ -1,0 +1,2 @@
+def loads(_: str) -> str:
+    return "foo"

--- a/regression/python/github_3116_1/main.py
+++ b/regression/python/github_3116_1/main.py
@@ -1,0 +1,16 @@
+import toml as local_toml 
+
+
+def main() -> None:
+    data = """
+[servers]
+[servers.alpha]
+ip = "10.0.0.1"
+role = "frontend"
+"""
+
+    assert local_toml.loads(data) == "foo"
+
+
+main()
+

--- a/regression/python/github_3116_1/test.desc
+++ b/regression/python/github_3116_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3116_1/toml.py
+++ b/regression/python/github_3116_1/toml.py
@@ -1,0 +1,3 @@
+def loads(_: str) -> str:
+    return "foo"
+

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -449,8 +449,10 @@ def main():
         print("\033[93m\nType checking warning:\033[0m")
         print(result.stdout)
 
-    # Add the script directory to the import search path
-    sys.path.append(os.path.dirname(filename))
+    # Add the script directory to the front of the import search path
+    script_dir = os.path.dirname(os.path.abspath(filename))
+    if script_dir and script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)


### PR DESCRIPTION
## Description  
Implements local module priority for Python frontend to match standard Python interpreter behavior.  
  
## Fixes  
Closes #3116  
  
## Testing  
- Verified local `toml.py` is loaded before system `toml` package  
- Still would fallback to system modules when local module doesn't exist  
- All existing Python regression tests pass
- Would not affect math, os, numpy import