### PR TITLE
[python] fix crash when function call used as if-statement condition

### DIFF
--- a/regression/python/github_3129/main.py
+++ b/regression/python/github_3129/main.py
@@ -1,0 +1,16 @@
+def baz() -> bool:
+    return True
+
+def bar() -> int:
+    if baz():
+        return 42
+    else:
+        return 0
+
+
+def foo(i: int) -> None:
+    pass
+
+i = bar()
+assert i == 42
+foo(i)

--- a/regression/python/github_3129/test.desc
+++ b/regression/python/github_3129/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3129_fail/main.py
+++ b/regression/python/github_3129_fail/main.py
@@ -1,0 +1,16 @@
+def baz() -> bool:
+    return True
+
+def bar() -> int:
+    if baz():
+        return 42
+    else:
+        return 0
+
+
+def foo(i: int) -> None:
+    pass
+
+i = bar()
+assert i == 0
+foo(i)

--- a/regression/python/github_3129_fail/test.desc
+++ b/regression/python/github_3129_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3129.

When a function call such as `baz()` is used directly as an if-statement condition, ESBMC crashes with assertion failure in `clang_cpp_adjust_code.cpp` because the condition expression isn't properly transformed into statements.

This PR transforms function call conditions by:
- Creating a temporary variable to store the call result.
- Wrapping the call in a decl-block with declaration + assignment.
- Using the temporary variable as the actual condition.

This matches the existing pattern used for assertions with function calls.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.