### PR TITLE
[python] fix chr() with variable arguments incorrectly evaluated at compile-time

### DIFF
--- a/regression/python/github_3090_2/test.desc
+++ b/regression/python/github_3090_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--unwind 4
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3130_fail/main.py
+++ b/regression/python/github_3130_fail/main.py
@@ -1,0 +1,3 @@
+s = "xbm"
+for i in range(97, 100):
+    assert chr(i) not in s

--- a/regression/python/github_3130_fail/test.desc
+++ b/regression/python/github_3130_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3130.

This PR checks whether the symbol is an `lvalue` (mutable variable) before attempting compile-time constant folding. If the symbol is mutable, delegate to runtime conversion via `handle_chr_conversion()`, which calls the `__python_chr` model function with the symbolic variable value. This ensures that `chr()` with loop variables and other mutable variables is evaluated at runtime rather than at conversion time.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.