### PR TITLE
[SV-COMP] ignore unsupport witness assumptions

### DIFF
--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -62,7 +62,7 @@ void build_goto_trace(
     if (SSA_step.hidden && is_compact_trace)
       continue;
 
-    if (!smt_conv.l_get(SSA_step.guard_ast).is_true() && !SSA_step.is_assume())
+    if (!smt_conv.l_get(SSA_step.guard_ast).is_true())
       continue;
 
     goto_trace_stept goto_trace_step;

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -926,7 +926,8 @@ std::string get_formated_assignment(
   std::string assignment = "";
   if (
     !is_nil_expr(step.value) && is_constant_expr(step.value) &&
-    is_valid_witness_step(ns, step))
+    !is_constant_array2t(step.value) && !is_constant_struct2t(step.value) &&
+    !is_constant_union2t(step.value) && is_valid_witness_step(ns, step))
   {
     assignment += from_expr(ns, "", step.lhs, presentationt::WITNESS);
     assignment += " == ";


### PR DESCRIPTION
fixes #3120
fixes #3121
fixes #3122 

`Error: Invalid configuration (Cannot parse witness: The witness automaton provided is invalid! Reason: Cannot parse <string_A == { 0, 0, 0, 0, 0 };>) (AutomatonGraphmlParser.getAssumptions, SEVERE)`

We ignore array, struct, union initialization, because these aren't C-expressions.