### PR TITLE
[python] fix list element storage for pointer types (strings)

### DIFF
--- a/regression/python/github_3127/main.py
+++ b/regression/python/github_3127/main.py
@@ -1,0 +1,14 @@
+def my_split(s: str, sep: str) -> list[str]:
+    result = []
+    word = ""
+    for char in s:
+        word = word + char
+        assert word == "a" or "ab"
+    assert word == "ab"
+    result.append(word)
+    result == ["ab"]
+    return result
+
+s: str = "ab"
+l = my_split(s, ",")
+assert l == ["ab"]

--- a/regression/python/github_3127/test.desc
+++ b/regression/python/github_3127/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3127_fail/main.py
+++ b/regression/python/github_3127_fail/main.py
@@ -1,0 +1,14 @@
+def my_split(s: str, sep: str) -> list[str]:
+    result = []
+    word = ""
+    for char in s:
+        word = word + char
+        assert word == "a" or "ab"
+    assert word == "ab"
+    result.append(word)
+    result == ["ab"]
+    return result
+
+s: str = "ab"
+l = my_split(s, ",")
+assert l == ["ba"]

--- a/regression/python/github_3127_fail/test.desc
+++ b/regression/python/github_3127_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$


### PR DESCRIPTION
This PR checks whether the element type is a pointer in `build_push_list_call()`. If so, pass the symbol directly; otherwise, take its address as before.

Note that when pushing pointer-type elements (e.g., strings) onto lists, the code was incorrectly passing the address of the pointer variable (`&ptr`) rather than the pointer value itself (`ptr`). This caused strings to be stored as `char**` instead of `char*`, leading to incorrect list comparisons.

The `__ESBMC_list_push` function expects a `void*` pointing to the data. For strings (`char*`), we should pass the pointer directly since it already points to the string data. For non-pointer types (such as `int`, `float`), we still need to pass their address.