### PR TITLE
[python] fix len() for single character in string iteration

### DIFF
--- a/regression/python/github_3141/main.py
+++ b/regression/python/github_3141/main.py
@@ -1,0 +1,3 @@
+s = "abcdefg"
+for c in s:
+    assert len(c) == 1

--- a/regression/python/github_3141/test.desc
+++ b/regression/python/github_3141/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3141_1/main.py
+++ b/regression/python/github_3141_1/main.py
@@ -1,0 +1,4 @@
+letters = ["w", "x", "y", "z"]
+for idx in range(len(letters)):
+    ch = letters[idx]
+    assert len(ch) == 1

--- a/regression/python/github_3141_1/test.desc
+++ b/regression/python/github_3141_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3141_1_fail/main.py
+++ b/regression/python/github_3141_1_fail/main.py
@@ -1,0 +1,3 @@
+letters = ["p", "q"]
+for ch in letters:
+    assert len(ch) == 2

--- a/regression/python/github_3141_1_fail/test.desc
+++ b/regression/python/github_3141_1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3141_fail/main.py
+++ b/regression/python/github_3141_fail/main.py
@@ -1,0 +1,3 @@
+s = "abcdefg"
+for c in s:
+    assert len(c) == 0

--- a/regression/python/github_3141_fail/test.desc
+++ b/regression/python/github_3141_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -371,6 +371,14 @@ exprt function_call_builder::build() const
 {
   symbol_id function_id = build_function_id();
 
+  if (is_len_call(function_id) && !call_["args"].empty())
+  {
+    exprt arg_expr = converter_.get_expr(call_["args"][0]);
+
+    if (arg_expr.type().is_signedbv() || arg_expr.type().is_unsignedbv())
+      return from_integer(1, long_long_int_type());
+  }
+
   // Special handling for single character len() calls
   if (function_id.get_function() == "__ESBMC_len_single_char")
     return from_integer(1, long_long_int_type());


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3141.

## Changes
Fixed `len()` handling for single characters during string iteration.

## Solution
- Added type check in `function_call_builder.cpp` to return `1` for single character `len()` calls
- Added test cases: `github_3141` (pass) and `github_3141_fail` (fail) and another list variant.

## Test
```python
s = "abcdefg"
for c in s:
    assert len(c) == 1  # Now correctly returns 1
```
