### PR TITLE
[python] Fix string membership to use strstr for string pointers

### DIFF
--- a/regression/python/github_3137/main.py
+++ b/regression/python/github_3137/main.py
@@ -1,0 +1,4 @@
+def foo(s: str) -> None:
+    assert s in ("foo", "bar")
+
+foo("foo")

--- a/regression/python/github_3137/test.desc
+++ b/regression/python/github_3137/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3137_fail/main.py
+++ b/regression/python/github_3137_fail/main.py
@@ -1,0 +1,4 @@
+def foo(s: str) -> None:
+    assert s in ("foo", "bar")
+
+foo("zoo")

--- a/regression/python/github_3137_fail/test.desc
+++ b/regression/python/github_3137_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -907,42 +907,49 @@ exprt string_handler::handle_string_membership(
   exprt &rhs,
   const nlohmann::json &element)
 {
-  bool lhs_is_char_value = false;
-
   // Get the width of char type from config
   std::size_t char_width = config.ansi_c.char_width;
 
-  // Check if lhs is a pointer to a single character
-  if (lhs.type().is_pointer())
+  // Determine if lhs represents a single character or a string
+  bool lhs_is_single_char = false;
+
+  // Check if lhs is a direct char value
+  if (
+    (lhs.type().is_signedbv() || lhs.type().is_unsignedbv()) &&
+    bv_width(lhs.type()) == char_width)
+  {
+    lhs_is_single_char = true;
+  }
+
+  // Check if lhs is a void* (pointer with empty/nil subtype)
+  if (!lhs_is_single_char && lhs.type().is_pointer())
   {
     const typet &subtype = lhs.type().subtype();
-    if (
-      (subtype.is_signedbv() || subtype.is_unsignedbv()) &&
-      bv_width(subtype) == char_width)
+    if (subtype.is_nil() || subtype.id() == "empty")
     {
-      lhs_is_char_value = true;
+      lhs_is_single_char = true;
     }
   }
 
-  // Check if lhs is a symbol holding a character value
-  if (!lhs_is_char_value && lhs.is_symbol())
+  // Check if lhs is a symbol holding a character value (not pointer)
+  if (!lhs_is_single_char && lhs.is_symbol())
   {
     const symbolt *sym =
       symbol_table_.find_symbol(lhs.get_string("identifier"));
     if (sym)
     {
-      const typet &value_type = sym->value.type();
+      const typet &sym_type = sym->type;
       if (
-        (value_type.is_signedbv() || value_type.is_unsignedbv()) &&
-        bv_width(value_type) == char_width)
+        (sym_type.is_signedbv() || sym_type.is_unsignedbv()) &&
+        bv_width(sym_type) == char_width)
       {
-        lhs_is_char_value = true;
+        lhs_is_single_char = true;
       }
     }
   }
 
   // Use strchr for single character membership testing
-  if (lhs_is_char_value)
+  if (lhs_is_single_char)
   {
     symbolt *strchr_symbol = symbol_table_.find_symbol("c:@F@strchr");
     if (!strchr_symbol)
@@ -968,8 +975,20 @@ exprt string_handler::handle_string_membership(
     exprt rhs_str = ensure_null_terminated_string(rhs);
     exprt rhs_addr = get_array_base_address(rhs_str);
 
-    // lhs contains the character value (as void*), cast directly to int
-    typecast_exprt char_as_int(lhs, int_type());
+    // Convert lhs to int for strchr
+    // If lhs is void*, first cast to char type, then to int
+    exprt char_as_int = lhs;
+    if (lhs.type().is_pointer())
+    {
+      const typet &subtype = lhs.type().subtype();
+      if (subtype.is_nil() || subtype.id() == "empty")
+      {
+        // lhs is void*, cast to char first
+        char_as_int = typecast_exprt(lhs, char_type());
+      }
+    }
+    // Now cast to int
+    char_as_int = typecast_exprt(char_as_int, int_type());
 
     // Call strchr(string, character)
     side_effect_expr_function_callt strchr_call;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3137.

This PR uses `strchr` for direct character values, ensuring that string pointers use' strstr'. Before this PR, the code incorrectly used `strchr` for string pointer parameters in membership tests (e.g., `s in ("foo", "bar")` where `s` is a function parameter), casting the pointer value to `int` instead of using `strstr` for substring matching.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

