### PR TITLE
[python] fix struct-to-pointer conversion for union-typed function parameters

### DIFF
--- a/regression/python/github_3145/main.py
+++ b/regression/python/github_3145/main.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+def foo(d: datetime | str) -> None:
+    pass
+
+t = datetime(1, 1, 1, 0, 0, 0)
+foo(t)
+assert t.year == 1
+assert t.month == 1
+assert t.day == 1

--- a/regression/python/github_3145/test.desc
+++ b/regression/python/github_3145/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3145.

When a function parameter has a union type (e.g., `datetime | str`), the parameter is typed as a pointer. However, when passing a struct argument, the converter was not properly converting the struct value to a pointer by taking its address.

This PR adds logic after the function call, building to:
1. Check if the parameter expects a pointer and the argument is a struct.
2. Resolve symbol type references using the namespace to get the concrete type.
3. Automatically insert address-of operation for struct arguments.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.