### PR TITLE
[python] recognize pointer-to-char-array as string type in is_string_type()

### DIFF
--- a/regression/python/github_3154/main.py
+++ b/regression/python/github_3154/main.py
@@ -1,0 +1,13 @@
+import re
+from datetime import datetime
+
+def foo(s: str | datetime) -> bool:
+    if isinstance(s, datetime):
+        return True
+
+    assert isinstance(s, str)
+    match = re.match(r"foo", s)
+    return match is not None
+
+s: str = "foo"
+foo(s)

--- a/regression/python/github_3154/test.desc
+++ b/regression/python/github_3154/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3154_fail/main.py
+++ b/regression/python/github_3154_fail/main.py
@@ -1,0 +1,13 @@
+import re
+from datetime import datetime
+
+def foo(s: str | datetime) -> bool:
+    if isinstance(s, datetime):
+        return True
+
+    assert isinstance(s, int)
+    match = re.match(r"foo", s)
+    return match is not None
+
+s: str = "foo"
+foo(s)

--- a/regression/python/github_3154_fail/test.desc
+++ b/regression/python/github_3154_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -233,8 +233,21 @@ public:
   static bool is_string_type(const typet &type)
   {
     // String types are represented as arrays or pointers to char
-    return type.is_array() ||
-           (type.is_pointer() && type.subtype() == char_type());
+    if (type.is_array() && type.subtype() == char_type())
+      return true;
+
+    if (type.is_pointer())
+    {
+      const typet &subtype = type.subtype();
+      // Direct pointer to char: char*
+      if (subtype == char_type())
+        return true;
+      // Pointer to char array: char(*)[N] (string literals)
+      if (subtype.is_array() && subtype.subtype() == char_type())
+        return true;
+    }
+
+    return false;
   }
 
 private:


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3154.

This PR extends `is_string_type()` to recognize all three forms:
- `char[N]` (direct array)
- `char*` (pointer to char)
- `char(*)[N]` (pointer to char array)

Note that string literals can be represented as either char arrays or pointers to char arrays. The `is_string_type()` function was only checking for direct pointers to char (`char*`) but not pointers to char arrays (`char(*)[N]`), causing regex functions to reject string literal patterns incorrectly.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.