### PR TITLE
[python] handle union type annotations in extract_type_info()

### DIFF
--- a/regression/python/github_3153/main.py
+++ b/regression/python/github_3153/main.py
@@ -1,0 +1,6 @@
+import re
+
+s: str = "foo"
+match: re.Match[str] | None = re.match(r"foo", s)
+if match is not None:
+    pass

--- a/regression/python/github_3153/test.desc
+++ b/regression/python/github_3153/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2957,6 +2957,13 @@ python_converter::extract_type_info(const nlohmann::json &var_node)
       var_type_str = ann["attr"];
     else if (ann.contains("id"))
       var_type_str = var_node["annotation"]["id"];
+    else if (ann.contains("_type") && ann["_type"] == "BinOp")
+    {
+      // Handle union types (e.g., re.Match[str] | None)
+      // Use get_type_from_annotation which has proper union handling
+      var_typet = get_type_from_annotation(ann, var_node);
+      return {var_type_str, var_typet};
+    }
 
     if (var_type_str.empty())
       return {var_type_str, var_typet};


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3153.

This PR delegates `BinOp` (union type) handling to `get_type_from_annotation()`, which properly extracts the `non-None` type and returns an appropriate pointer type for Optional values.

When a variable has a union type annotation such as `re.Match[str] | None`, `extract_type_info()` was returning an empty type for `BinOp` nodes, causing a crash during symbolic execution.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.