### PR TITLE
[python] resolve forward reference for method return types in classes

### DIFF
--- a/regression/python/github_3155/main.py
+++ b/regression/python/github_3155/main.py
@@ -1,0 +1,14 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, s: str) -> str:
+        if s == "foo":
+            return self.bar()
+        return "foo"
+
+    def bar(self) -> str:
+        return "bar"
+
+f = Foo()
+assert f.foo("foo") == "bar"

--- a/regression/python/github_3155/test.desc
+++ b/regression/python/github_3155/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3155_fail/main.py
+++ b/regression/python/github_3155_fail/main.py
@@ -1,0 +1,14 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, s: str) -> str:
+        if s == "foo":
+            return self.bar()
+        return "foo"
+
+    def bar(self) -> str:
+        return "bar"
+
+f = Foo()
+assert f.foo("foo") == "foo"

--- a/regression/python/github_3155_fail/test.desc
+++ b/regression/python/github_3155_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3155.

This PR looks up the return type from the AST when the called function's symbol is not yet in the symbol table, ensuring the correct type is used for temporary variables even with forward references.

When a method calls another method defined later in the class, the return type is unknown during conversion, causing a temporary variable to be created with void type instead of the correct return type; this led to a crash during symbolic execution.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
