### PR TITLE
[python] fix ord() to handle runtime variables in loops

### DIFF
--- a/regression/python/github_3150/main.py
+++ b/regression/python/github_3150/main.py
@@ -1,0 +1,4 @@
+s = "foo"
+for c in s:
+    i: int = ord(c)
+    assert i == 102 or i == 111

--- a/regression/python/github_3150/test.desc
+++ b/regression/python/github_3150/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3150_2/main.py
+++ b/regression/python/github_3150_2/main.py
@@ -1,0 +1,6 @@
+s = "foo"
+for c in s:
+    i: int = ord(c)
+    assert len(c) == 1
+    assert isinstance(i, int)
+    assert i == ord(c)        # trivially true

--- a/regression/python/github_3150_2/test.desc
+++ b/regression/python/github_3150_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3150_2_fail/main.py
+++ b/regression/python/github_3150_2_fail/main.py
@@ -1,0 +1,6 @@
+s = "foo"
+for c in s:
+    i: int = ord(c)
+    assert len(c) == 1
+    assert isinstance(i, str)
+    assert i == ord(c)        # trivially true

--- a/regression/python/github_3150_2_fail/test.desc
+++ b/regression/python/github_3150_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3150_fail/main.py
+++ b/regression/python/github_3150_fail/main.py
@@ -1,0 +1,4 @@
+s = "foo"
+for c in s:
+    i: int = ord(c)
+    assert i == 2

--- a/regression/python/github_3150_fail/test.desc
+++ b/regression/python/github_3150_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3150.

This PR added a runtime conversion path using typecast for char-to-int conversion when the symbol is mutable or has no constant value, enabling `ord()` to work with both constant strings and runtime variables. 

The `ord()` function was failing when called on loop iteration variables (e.g., `for c in s: ord(c)`) because it only supported compile-time constant strings.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.