### PR TITLE
[python] support module-qualified type annotations in class attributes

### DIFF
--- a/regression/python/github_2931/l/__init__.py
+++ b/regression/python/github_2931/l/__init__.py
@@ -1,0 +1,12 @@
+from typing import Any
+import l.md as md
+
+class Foo:
+    def __init__(self) -> None:
+        self._md: md.Bar = md.Bar('bar')
+
+def create(s: str) -> Any:
+    if s == "foo":
+        return Foo()
+    else:
+        assert False, "Invalid string"

--- a/regression/python/github_2931/l/md.py
+++ b/regression/python/github_2931/l/md.py
@@ -1,0 +1,6 @@
+class Bar:
+    def __init__(self, s: str) -> None:
+        self.s = s
+
+    def bar(self) -> str:
+        return self.s

--- a/regression/python/github_2931/main.py
+++ b/regression/python/github_2931/main.py
@@ -1,0 +1,4 @@
+import l
+from l import Foo
+
+f: Foo = l.create('foo')

--- a/regression/python/github_2931/test.desc
+++ b/regression/python/github_2931/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2931.

This PR extracts the class name from `ast.Attribute` nodes by reading the "attr" field, enabling proper type resolution for both simple annotations (`self.x: Foo`) and module-qualified annotations (`self.x: module.Foo`). Before this PR, class attributes with module-qualified type annotations (e.g., `self._md: md.Bar`) were skipped with an "unsupported annotation type" warning. This occurred because the code only handled simple name annotations (`ast.Name with "id" field`) but not attribute access annotations (`ast.Attribute`).

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

