### PR TITLE
Always use c parser to process bundles c libaries (solves #3088)

### DIFF
--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -282,7 +282,11 @@ void add_cprover_library(contextt &context, const languaget *language)
   if (clib->size == 0)
   {
     if (language)
-      return add_bundled_library_sources(context, *language);
+    {
+      // C library sources must be parsed with C frontend, not the current language
+      std::unique_ptr<languaget> c_lang(new_language(language_idt::C));
+      return add_bundled_library_sources(context, *c_lang);
+    }
     log_error("Zero-lengthed internal C library");
     abort();
   }


### PR DESCRIPTION
Fixes #3088 by always using the C parser when processing bundled C libraries.