### PR TITLE
[python] fix Optional parameter handling in keyword-only function arguments

### DIFF
--- a/regression/python/github_3168/main.py
+++ b/regression/python/github_3168/main.py
@@ -1,0 +1,9 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, *, s: str, b: bool | None = None, t: str | None = None) -> None:
+        pass
+    
+f = Foo()
+f.foo(s="foo")

--- a/regression/python/github_3168/test.desc
+++ b/regression/python/github_3168/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3168.

This PR skips default argument filling in `function_call_expr` when keywords are present in the call, allowing `handle_keywords()` to handle Optional wrapping. Before this PR, when calling functions with keyword-only Optional parameters (e.g., `def foo(*, s: str, b: bool | None = None)`), `function_call_expr` was prematurely filling default arguments with pointer NULL values before `handle_keywords()` could process them. This caused type mismatches: optional parameters (structs with an is_none field) received plain pointers instead of properly wrapped Optional structs.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

