### PR TITLE
[python] add nondet_str() for non-deterministic strings

### DIFF
--- a/regression/python/nondet_str/main.py
+++ b/regression/python/nondet_str/main.py
@@ -1,0 +1,43 @@
+# Tests for nondet_str(): nondeterministic strings with a maximum array size
+# defined by --nondet-str-length (default = 16). The last character is always
+# the null terminator. The visible string length is therefore <= max_len - 1.
+
+def test_length_is_non_negative():
+    s = nondet_str()
+    assert len(s) >= 0  # Always true
+
+
+test_length_is_non_negative()
+
+def test_length_respects_upper_bound():
+    s = nondet_str()
+    # If max_str_length is N, usable chars are in [0, N-1)
+    assert len(s) < 16  # default max_len = 16 → max visible length = 15
+
+
+test_length_respects_upper_bound()
+
+def test_function_argument_pass_through():
+    def check_string(x: str) -> bool:
+        return len(x) >= 0
+
+    s = nondet_str()
+    assert check_string(s)
+
+
+test_function_argument_pass_through()
+
+def test_non_empty_string_comparison():
+    s = nondet_str()
+    if len(s) > 0:
+        assert s != ""  # Non-empty string cannot equal empty string
+
+
+test_non_empty_string_comparison()
+
+def test_assume_empty_string():
+    s = nondet_str()
+    __ESBMC_assume(len(s) == 0)
+    assert s == ""  # Empty string should be represented as ""
+
+test_assume_empty_string()

--- a/regression/python/nondet_str/test.desc
+++ b/regression/python/nondet_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str2/main.py
+++ b/regression/python/nondet_str2/main.py
@@ -1,0 +1,6 @@
+def test_concat():
+    s = nondet_str()
+    result = s + "suffix"
+    assert len(result) >= 6  # At least the suffix length
+
+test_concat()

--- a/regression/python/nondet_str2/test.desc
+++ b/regression/python/nondet_str2/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str3/main.py
+++ b/regression/python/nondet_str3/main.py
@@ -1,0 +1,7 @@
+a = nondet_str()
+b = nondet_str()
+c = nondet_str()
+l = [a, b, c]
+assert l[0] == a
+assert l[1] == b
+assert l[2] == c

--- a/regression/python/nondet_str3/test.desc
+++ b/regression/python/nondet_str3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --nondet-str-length 3 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str4/main.py
+++ b/regression/python/nondet_str4/main.py
@@ -1,0 +1,7 @@
+a = nondet_str()
+b = nondet_str()
+c = nondet_str()
+d = {0: a, 1: b, 2: c}
+assert d[0] == a
+assert d[1] == b
+assert d[2] == c

--- a/regression/python/nondet_str4/test.desc
+++ b/regression/python/nondet_str4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --nondet-str-length 5 --ir
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -79,6 +79,9 @@ const struct group_opt_templ all_cmd_options[] = {
       NULL,
       "Enforce strict type checking for function arguments during "
       "verification"},
+     {"nondet-str-length",
+      boost::program_options::value<int>()->default_value(16)->value_name("nr"),
+      "set maximum length for non-deterministic strings (default is 16)"},
    }},
 #endif
 #ifdef ENABLE_SOLIDITY_FRONTEND


### PR DESCRIPTION
This PR adds support for non-deterministic string generation via `nondet_str()`. This enables verification of functions with string parameters as entry points.

The implementation creates a non-deterministic character array with a guaranteed null terminator at the last position, ensuring `strlen()` and other string operations remain within bounds.

This PR also adds `--nondet-str-length` option to configure maximum length (default: 16).