### PR TITLE
[python] add nondet_list() operational model for verification

### DIFF
--- a/regression/python/nondet_list/main.py
+++ b/regression/python/nondet_list/main.py
@@ -1,0 +1,7 @@
+def test_basic_nondet_list():
+    """Basic nondet list with default int elements."""
+    x = nondet_list(8)
+    # x is a list with nondet length [0, 8] and nondet int elements
+    assert len(x) >= 0
+
+test_basic_nondet_list()

--- a/regression/python/nondet_list/test.desc
+++ b/regression/python/nondet_list/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list10/main.py
+++ b/regression/python/nondet_list10/main.py
@@ -1,0 +1,15 @@
+def test_nondet_list_in_conditional():
+    """Test nondet list behavior in conditionals."""
+    x:list[int] = nondet_list(9)
+
+    result = 0
+
+    if len(x) == 0:
+        result = 0
+    elif len(x) == 1:
+        result = x[0]
+    
+    # Result is always defined
+    assert result == result
+
+test_nondet_list_in_conditional()

--- a/regression/python/nondet_list10/test.desc
+++ b/regression/python/nondet_list10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 11 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list2/main.py
+++ b/regression/python/nondet_list2/main.py
@@ -1,0 +1,9 @@
+def test_nondet_list_int():
+    """Nondet list with explicit int type."""
+    x:list[int] = nondet_list(8)
+    if len(x) > 0:
+        elem = x[0]
+        # Each element is a nondet integer - can be any value
+        assert elem == elem  # Trivially true, tests element access
+
+test_nondet_list_int()

--- a/regression/python/nondet_list2/test.desc
+++ b/regression/python/nondet_list2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list3/main.py
+++ b/regression/python/nondet_list3/main.py
@@ -1,0 +1,8 @@
+def test_nondet_list_append():
+    """Test appending to a nondet list."""
+    x = nondet_list(4)
+    original_len = len(x)
+    x.append(42)
+    assert len(x) == original_len + 1
+
+test_nondet_list_append()

--- a/regression/python/nondet_list3/test.desc
+++ b/regression/python/nondet_list3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list4/main.py
+++ b/regression/python/nondet_list4/main.py
@@ -1,0 +1,32 @@
+def test_list_size_nonnegative():
+    """Verify list size is always non-negative."""
+    x = nondet_list(5)
+    assert len(x) >= 0
+
+test_list_size_nonnegative()
+
+def test_list_size_bounded():
+    """Verify list size is bounded by max length."""
+    x = nondet_list(6)
+    # Default --nondet-list-length=8
+    assert len(x) <= 8
+
+test_list_size_bounded()
+
+def test_list_can_be_empty():
+    """Verify empty list is a valid outcome."""
+    x = nondet_list(0)
+    if len(x) == 0:
+        # Empty list is valid
+        assert True
+
+test_list_can_be_empty()
+
+def test_list_can_have_elements():
+    """Verify non-empty list is a valid outcome."""
+    x = nondet_list(2)
+    # Assume we have at least one element for this test
+    __ESBMC_assume(len(x) > 0)
+    assert x[0] is not None
+
+test_list_can_have_elements()

--- a/regression/python/nondet_list4/test.desc
+++ b/regression/python/nondet_list4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list5/main.py
+++ b/regression/python/nondet_list5/main.py
@@ -1,0 +1,19 @@
+def test_sum_of_positive_elements():
+    """Verify sum of positive elements is positive."""
+    x = nondet_list(4)
+    
+    # Assume all elements are positive and list is non-empty
+    if len(x) > 0:
+        all_positive = True
+        for elem in x:
+            if elem <= 0:
+                all_positive = False
+                break
+        
+        if all_positive:
+            total = 0
+            for elem in x:
+                total += elem
+            assert total > 0
+
+test_sum_of_positive_elements()

--- a/regression/python/nondet_list5/test.desc
+++ b/regression/python/nondet_list5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list6/main.py
+++ b/regression/python/nondet_list6/main.py
@@ -1,0 +1,20 @@
+def test_find_element_in_list():
+    """Verify element search works correctly."""
+    x = nondet_list(6)
+    target = nondet_int()
+    
+    found = False
+    for elem in x:
+        if elem == target:
+            found = True
+            break
+    
+    # If we found it, verify it's actually in the list
+    if found:
+        actually_found = False
+        for elem in x:
+            if elem == target:
+                actually_found = True
+        assert actually_found
+
+test_find_element_in_list()

--- a/regression/python/nondet_list6/test.desc
+++ b/regression/python/nondet_list6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list7/main.py
+++ b/regression/python/nondet_list7/main.py
@@ -1,0 +1,15 @@
+def test_max_element_property():
+    """Verify max element is >= all elements."""
+    x:list[int] = nondet_list(4)
+    
+    if len(x) > 0:
+        max_val = x[0]
+        for i in range(1, len(x)):
+            if x[i] > max_val:
+                max_val = x[i]
+        
+        # Verify max_val is indeed the maximum
+        for elem in x:
+            assert max_val >= elem
+
+test_max_element_property()

--- a/regression/python/nondet_list7/test.desc
+++ b/regression/python/nondet_list7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list8/main.py
+++ b/regression/python/nondet_list8/main.py
@@ -1,0 +1,15 @@
+def sum_list(items: list[int]) -> int:
+    """Sum all elements in a list."""
+    total = 0
+    for item in items:
+        total += item
+    return total
+
+def test_sum_with_nondet_list():
+    """Test sum_list with nondet input."""
+    x:list[int] = nondet_list(7)
+    result = sum_list(x)
+    # Result is well-defined
+    assert result == result
+
+test_sum_with_nondet_list()

--- a/regression/python/nondet_list8/test.desc
+++ b/regression/python/nondet_list8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list9/main.py
+++ b/regression/python/nondet_list9/main.py
@@ -1,0 +1,9 @@
+def test_nondet_list_modification():
+    """Test modifying elements of a nondet list."""
+    x = nondet_list(10)
+    __ESBMC_assume(len(x) > 0)
+    
+    x[0] = 100
+    assert x[0] == 100
+
+test_nondet_list_modification()

--- a/regression/python/nondet_list9/test.desc
+++ b/regression/python/nondet_list9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 11 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -28,11 +28,11 @@ def nondet_list(max_size: int = _DEFAULT_NONDET_LIST_SIZE) -> list:
     size: int = nondet_int()
     __ESBMC_assume(size >= 0)
     __ESBMC_assume(size <= max_size)
-    
+
     i: int = 0
     while i < size:
         elem: int = nondet_int()
         result.append(elem)
         i = i + 1
-    
+
     return result

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -1,0 +1,38 @@
+"""
+Operational model for non-deterministic list functions in ESBMC Python frontend.
+
+USAGE:
+    # Default: list of integers with size in [0, 8]
+    x = nondet_list()
+    
+    # With explicit size:
+    x = nondet_list(5)              # list of ints, size in [0, 5]
+"""
+
+# Default maximum size for nondet lists
+_DEFAULT_NONDET_LIST_SIZE: int = 8
+
+
+def nondet_list(max_size: int = _DEFAULT_NONDET_LIST_SIZE) -> list:
+    """
+    Return a non-deterministic list of integers.
+    
+    Args:
+        max_size: Maximum size of the list (default: 8).
+                  The actual size will be in range [0, max_size].
+    
+    Returns:
+        list: A list with arbitrary size and integer contents.
+    """
+    result: list = []
+    size: int = nondet_int()
+    __ESBMC_assume(size >= 0)
+    __ESBMC_assume(size <= max_size)
+    
+    i: int = 0
+    while i < size:
+        elem: int = nondet_int()
+        result.append(elem)
+        i = i + 1
+    
+    return result

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6080,7 +6080,13 @@ void python_converter::convert()
     const std::string &ast_output_dir =
       (*ast_json)["ast_output_dir"].get<std::string>();
     std::list<std::string> model_files = {
-      "range", "int", "consensus", "random", "exceptions", "datetime"};
+      "range",
+      "int",
+      "consensus",
+      "random",
+      "exceptions",
+      "datetime",
+      "nondet"};
     std::list<std::string> model_folders = {"os", "numpy"};
 
     for (const auto &folder : model_folders)


### PR DESCRIPTION
This PR adds support for non-deterministic lists in the Python frontend. The `nondet_list(max_size)` function creates a list with:
- Non-deterministic size bounded by max_size (default: 8)
- Non-deterministic integer elements

Usage:
  x = nondet_list()      # size in [0, 8]
  x = nondet_list(5)     # size in [0, 5]
