### PR TITLE
[python] fix list index access for nondet lists with type annotations

### DIFF
--- a/regression/python/nondet_list11/main.py
+++ b/regression/python/nondet_list11/main.py
@@ -1,0 +1,17 @@
+def test_nondet_list_in_conditional():
+    """Test nondet list behavior in conditionals."""
+    x:list[int] = nondet_list(9)
+
+    result = 0
+
+    if len(x) == 0:
+        result = 0
+    elif len(x) == 1:
+        result = x[0]
+    elif len(x) == 2:
+        result = x[0] + x[1]
+
+    # Result is always defined
+    assert result == result
+
+test_nondet_list_in_conditional()

--- a/regression/python/nondet_list11/test.desc
+++ b/regression/python/nondet_list11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 11 --ir --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list12/main.py
+++ b/regression/python/nondet_list12/main.py
@@ -1,0 +1,7 @@
+def test_nondet_list_append():
+    """Test appending to a nondet list."""
+    x = nondet_list(4)
+    x.append(42)
+    assert x[len(x) - 1] == 42
+
+test_nondet_list_append()

--- a/regression/python/nondet_list12/test.desc
+++ b/regression/python/nondet_list12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/slicing-bounds-fail/test.desc
+++ b/regression/python/slicing-bounds-fail/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.py
- --incremental-bmc
-
-^ERROR: List out of bounds at\b
+--unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/slicing-bounds-fail/test.desc
+++ b/regression/python/slicing-bounds-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 9
-^VERIFICATION FAILED$
+^  out-of-bounds read in list$


### PR DESCRIPTION
This PR adds a fallback that extracts the element type from type annotations before throwing an error, allowing nondet lists with annotations to work correctly in conditionals. Before this PR, when accessing elements from nondet lists (e.g., x:list[int] = nondet_list(9)), the `list_type_map` is empty, causing out-of-bounds exceptions.