### PR TITLE
[python] materialize function calls in conditional expressions

### DIFF
--- a/regression/python/nondet_list19/main.py
+++ b/regression/python/nondet_list19/main.py
@@ -1,0 +1,8 @@
+import math
+
+l = []
+x = nondet_float()
+if not math.isnan(x):
+    l.append(x)
+
+assert len(l) >= 0

--- a/regression/python/nondet_list19/test.desc
+++ b/regression/python/nondet_list19/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list20/main.py
+++ b/regression/python/nondet_list20/main.py
@@ -1,0 +1,9 @@
+import math
+
+l:list[float] = nondet_list(2, nondet_float())
+__ESBMC_assume(len(l)>0)
+x = l[0]
+if not math.isnan(x):
+    l.append(x)
+
+assert len(l) > 0

--- a/regression/python/nondet_list20/test.desc
+++ b/regression/python/nondet_list20/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list21/main.py
+++ b/regression/python/nondet_list21/main.py
@@ -1,0 +1,10 @@
+import math
+
+l:list[float] = nondet_list(2, nondet_float())
+__ESBMC_assume(len(l)>0)
+x = l[0]
+if not math.isnan(x):
+    l.append(x)
+
+assert len(l) > 0
+assert l[0] == 2.2

--- a/regression/python/nondet_list21/test.desc
+++ b/regression/python/nondet_list21/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-align-check
+^VERIFICATION FAILED$


### PR DESCRIPTION
This PR detects function calls within `UnaryOp` and direct Call nodes in conditional tests, materializes them into temporary variables before the conditional statement, and reconstructs the expression using the temp variable. Before this PR, function calls embedded in conditional expressions (e.g., `if not math.isnan(x):`) were being inlined directly into IF statements, causing segfaults during solver encoding. 

Fixes verification of patterns such as:
- `if not math.isnan(x):`
- `if math.isnan(x):`