### PR TITLE
[python] implement len(dict) support and extend nondet collections

### DIFF
--- a/regression/python/nondet_dict3/main.py
+++ b/regression/python/nondet_dict3/main.py
@@ -1,0 +1,6 @@
+def test_nondet_dict_basic():
+    """Test basic nondet dictionary creation and access."""
+    x = nondet_dict(2)
+    assert len(x) >= 0
+
+test_nondet_dict_basic()

--- a/regression/python/nondet_dict3/test.desc
+++ b/regression/python/nondet_dict3/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict4/main.py
+++ b/regression/python/nondet_dict4/main.py
@@ -1,0 +1,7 @@
+def test_nondet_dict_basic():
+    """Test basic nondet dictionary creation and access."""
+    x = nondet_dict(2)
+    __ESBMC_assume(len(x) > 0)
+    assert len(x) > 0
+
+test_nondet_dict_basic()

--- a/regression/python/nondet_dict4/test.desc
+++ b/regression/python/nondet_dict4/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -5,8 +5,8 @@ USAGE:
     # Lists:
     x = nondet_list()                                    # int list, size [0, 8]
     x = nondet_list(5)                                   # int list, size [0, 5]
-    x = nondet_list(type=nondet_float())                 # float list, size [0, 8]
-    x = nondet_list(max_size=10, type=nondet_bool())     # bool list, size [0, 10]
+    x = nondet_list(elem_type=nondet_float())                 # float list, size [0, 8]
+    x = nondet_list(max_size=10, elem_type=nondet_bool())     # bool list, size [0, 10]
     
     # Dictionaries:
     x = nondet_dict()                                    # str->int dict, size [0, 8]
@@ -37,29 +37,29 @@ def _nondet_size(max_size: int) -> int:
     return size
 
 
-def nondet_list(max_size: int = _DEFAULT_NONDET_SIZE, type: Any = None) -> list:
+def nondet_list(max_size: int = _DEFAULT_NONDET_SIZE, elem_type: Any = None) -> list:
     """
     Return a non-deterministic list with specified element type.
     
     Args:
         max_size: Maximum size of the list (default: 8).
                   The actual size will be in range [0, max_size].
-        type: Type constructor for list elements (default: nondet_int()).
+        elem_type: Type constructor for list elements (default: nondet_int()).
               Supported: nondet_int(), nondet_float(), nondet_bool()
     
     Returns:
         list: A list with arbitrary size and contents of specified type.
     """
     # Default to nondet_int if no type specified
-    if type is None:
-        type = nondet_int()
+    if elem_type is None:
+        elem_type = nondet_int()
 
     result: list = []
     size: int = _nondet_size(max_size)
 
     i: int = 0
     while i < size:
-        result.append(type)
+        result.append(elem_type)
         i = i + 1
 
     return result

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -1,57 +1,96 @@
 """
-Operational model for non-deterministic list functions in ESBMC Python frontend.
+Operational model for non-deterministic collection functions in ESBMC Python frontend.
 
 USAGE:
-    # Default: list of integers with size in [0, 8]
-    x = nondet_list()
+    # Lists:
+    x = nondet_list()                                    # int list, size [0, 8]
+    x = nondet_list(5)                                   # int list, size [0, 5]
+    x = nondet_list(type=nondet_float())                 # float list, size [0, 8]
+    x = nondet_list(max_size=10, type=nondet_bool())     # bool list, size [0, 10]
     
-    # With explicit size:
-    x = nondet_list(5)              # list of ints, size in [0, 5]
-
-    # With type specification:
-    x = nondet_list(type=nondet_float())  # list of floats
-    x = nondet_list(type=nondet_bool())   # list of bools
-    x = nondet_list(max_size=10, type=nondet_int())  # list of ints, size in [0, 10]
+    # Dictionaries:
+    x = nondet_dict()                                    # str->int dict, size [0, 8]
+    x = nondet_dict(5)                                   # str->int dict, size [0, 5]
+    x = nondet_dict(key_type=nondet_str(), value_type=nondet_float())
+    x = nondet_dict(max_size=10, key_type=nondet_int(), value_type=nondet_bool())
 """
 
 from typing import Any
 
-# Default maximum size for nondet lists
-_DEFAULT_NONDET_LIST_SIZE: int = 8
+# Shared default maximum size for nondet collections
+_DEFAULT_NONDET_SIZE: int = 8
 
 
-def nondet_list(max_size: int = _DEFAULT_NONDET_LIST_SIZE, nondet_type: Any = None) -> list:
+def _nondet_size(max_size: int) -> int:
+    """
+    Generate a non-deterministic size in range [0, max_size].
+
+    Args:
+        max_size: Maximum size (inclusive).
+
+    Returns:
+        int: A non-deterministic integer in [0, max_size].
+    """
+    size: int = nondet_int()
+    __ESBMC_assume(size >= 0)
+    __ESBMC_assume(size <= max_size)
+    return size
+
+
+def nondet_list(max_size: int = _DEFAULT_NONDET_SIZE, type: Any = None) -> list:
     """
     Return a non-deterministic list with specified element type.
     
     Args:
         max_size: Maximum size of the list (default: 8).
                   The actual size will be in range [0, max_size].
-        nondet_type: Type constructor for list elements (default: nondet_int()).
+        type: Type constructor for list elements (default: nondet_int()).
               Supported: nondet_int(), nondet_float(), nondet_bool()
     
     Returns:
         list: A list with arbitrary size and contents of specified type.
-
-    Examples:
-        >>> x = nondet_list()                          # int list, size [0, 8]
-        >>> y = nondet_list(5)                         # int list, size [0, 5]
-        >>> z = nondet_list(type=nondet_float())         # float list, size [0, 8]
-        >>> w = nondet_list(max_size=10, type=nondet_bool())  # bool list, size [0, 10]
     """
     # Default to nondet_int if no type specified
-    if nondet_type is None:
-        nondet_type = nondet_int()
+    if type is None:
+        type = nondet_int()
 
     result: list = []
-    size: int = nondet_int()
-    __ESBMC_assume(size >= 0)
-    __ESBMC_assume(size <= max_size)
+    size: int = _nondet_size(max_size)
 
     i: int = 0
     while i < size:
-        elem: Any = nondet_type
-        result.append(elem)
+        result.append(type)
+        i = i + 1
+
+    return result
+
+
+def nondet_dict(max_size: int = _DEFAULT_NONDET_SIZE,
+                key_type: Any = None,
+                value_type: Any = None) -> dict:
+    """
+    Return a non-deterministic dictionary with specified key and value types.
+
+    Args:
+        max_size: Maximum size of the dictionary (default: 8).
+                  The actual size will be in range [0, max_size].
+        key_type: Type constructor for dictionary keys (default: nondet_int()).
+                  Supported: nondet_int(), nondet_str(), nondet_bool()
+        value_type: Type constructor for dictionary values (default: nondet_int()).
+                    Supported: nondet_int(), nondet_float(), nondet_bool(), nondet_str()
+
+    Returns:
+        dict: A dictionary with arbitrary size and contents of specified types.
+    """
+    result: dict = {}
+    size: int = _nondet_size(max_size)
+
+    i: int = 0
+    while i < size:
+        # Generate fresh nondet values inside the loop
+        k: int = nondet_int() if key_type is None else key_type
+        v: int = nondet_int() if value_type is None else value_type
+        result[k] = v
         i = i + 1
 
     return result


### PR DESCRIPTION
This PR:

- adds special handling for `len(dict)` to call `__ESBMC_list_size(dict.keys)` instead of incorrectly using `get_object_size` on dict struct.
- generates fresh nondet values inside the loop rather than reusing a single value.
- unifies default size constants and `extract _nondet_size()` helper.
- consolidates documentation and usage examples.