### PR TITLE
[python] infer return types from non-recursive return statements 

### DIFF
--- a/regression/python/github_3197/main.py
+++ b/regression/python/github_3197/main.py
@@ -1,0 +1,6 @@
+def f(x):
+    if x == 0:
+        return 0
+    return f(x - 1)
+
+assert f(3) == 0

--- a/regression/python/github_3197/test.desc
+++ b/regression/python/github_3197/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-no-return/main.py
+++ b/regression/python/infer-func-no-return/main.py
@@ -10,23 +10,6 @@ def get_float():
 def get_boolean():
     return True
 
-# ===============================================
-# Functions with wrong return annotations
-# to test type inference
-# ===============================================
-
-def int_float() -> int: # Should infer to float
-  return 0.5
-
-
-def float_bool() -> float: # Should infer to bool
-  return False
-
-
-def bool_int() -> bool: # Should infer to int
-  return 3
-
-
 # ==============================
 # Test Cases with Assertions
 # ==============================
@@ -41,12 +24,3 @@ assert b == 0.5
 c = get_boolean()
 assert c == True
 
-# With incorrect annotations
-d = int_float()
-assert d == 0.5
-
-e = float_bool()
-assert e == False
-
-f = bool_int()
-assert f == 3

--- a/regression/python/infer-func-no-return2/main.py
+++ b/regression/python/infer-func-no-return2/main.py
@@ -1,0 +1,30 @@
+# ===============================================
+# Functions with wrong return annotations
+# to test type inference
+# ===============================================
+
+def int_float() -> int:
+  return 0.5
+
+
+def float_bool() -> float:
+  return False
+
+
+def bool_int() -> bool:
+  return 3
+
+
+# ==============================
+# Test Cases with Assertions
+# ==============================
+
+# With incorrect annotations
+d = int_float()
+assert d == 0.5
+
+e = float_bool()
+assert e == False
+
+f = bool_int()
+assert f == 3

--- a/regression/python/infer-func-no-return2/test.desc
+++ b/regression/python/infer-func-no-return2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--override-return-annotation
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-no-return_fail/main.py
+++ b/regression/python/infer-func-no-return_fail/main.py
@@ -1,0 +1,30 @@
+# ===============================================
+# Functions with wrong return annotations
+# to test type inference
+# ===============================================
+
+def int_float() -> int:
+  return 0.5
+
+
+def float_bool() -> float:
+  return False
+
+
+def bool_int() -> bool:
+  return 3
+
+
+# ==============================
+# Test Cases with Assertions
+# ==============================
+
+# With incorrect annotations
+d = int_float()
+assert d == 0.5
+
+e = float_bool()
+assert e == False
+
+f = bool_int()
+assert f == 3

--- a/regression/python/infer-func-no-return_fail/test.desc
+++ b/regression/python/infer-func-no-return_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -44,6 +44,7 @@ ignored_dirs=(
   "github_3090_5"
   "github_3090_5_fail"
   "global"
+  "infer-func-no-return_fail"
   "integer_squareroot_fail"
   "int_from_bytes"
   "input"

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -162,42 +162,10 @@ private:
           continue; // Skip this recursive call
         }
 
-        // Try to infer type from the return value
-        if (return_val["_type"] == "Constant")
-        {
-          const auto &value = return_val["value"];
-          if (value.is_number_integer())
-            return "int";
-          if (value.is_number_float())
-            return "float";
-          if (value.is_boolean())
-            return "bool";
-          if (value.is_string())
-            return "str";
-          if (value.is_null())
-            return "NoneType";
-        }
-        else if (return_val["_type"] == "Name")
-        {
-          // Try to find the variable's type
-          Json var_node =
-            json_utils::find_var_decl(return_val["id"], func_name, ast_);
-          if (
-            !var_node.empty() && var_node.contains("annotation") &&
-            !var_node["annotation"].is_null() &&
-            var_node["annotation"].contains("id"))
-          {
-            return var_node["annotation"]["id"];
-          }
-        }
-        else if (return_val["_type"] == "BinOp")
-        {
-          // For binary operations, try to infer from operands
-          Json dummy_stmt = {{"value", return_val}};
-          std::string type = get_type_from_binary_expr(dummy_stmt, ast_);
-          if (!type.empty())
-            return type;
-        }
+        // Reuse get_argument_type to infer the return value type
+        std::string inferred_type = get_argument_type(return_val);
+        if (!inferred_type.empty())
+          return inferred_type;
       }
 
       // Recursively check nested blocks (if/while/for/try)


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3197.

This PR fixes an infinite recursion crash when analyzing unannotated recursive functions by inferring return types from constant return values rather than from recursive calls.

The type annotator now:
- Tracks functions currently being analyzed to detect recursion.
- Infers return types from non-recursive return statements (e.g., "return 0").
- Skips recursive function calls during type inference.
- Prevents void/empty type assignments that crash GOTO processing.

Thanks to [brcfarias](https://github.com/brcfarias) for reporting this issue.