### PR TITLE
[python] Fix type adjustment in binary expressions

### DIFF
--- a/regression/python/range_int_cast/main.py
+++ b/regression/python/range_int_cast/main.py
@@ -1,0 +1,3 @@
+n: int = 9
+for i in range(2, int(n ** 0.5) + 1):
+    print(i)

--- a/regression/python/range_int_cast/test.desc
+++ b/regression/python/range_int_cast/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 5
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1797,6 +1797,23 @@ exprt python_converter::build_binary_expression(
   exprt &lhs,
   exprt &rhs)
 {
+  // Adjust types for non-relational operations
+  if (!type_utils::is_relational_op(op))
+  {
+    // Check for critical type incompatibilities
+    const typet &lhs_type = lhs.type();
+    const typet &rhs_type = rhs.type();
+
+    // Check for bitvector width mismatch
+    if (
+      (lhs_type.is_signedbv() || lhs_type.is_unsignedbv()) &&
+      (rhs_type.is_signedbv() || rhs_type.is_unsignedbv()) &&
+      lhs_type.width() != rhs_type.width())
+    {
+      adjust_statement_types(lhs, rhs);
+    }
+  }
+
   // Determine result type
   typet type;
   if (type_utils::is_relational_op(op))


### PR DESCRIPTION
Fixes type compatibility issue in binary operations that was causing arith_2ops assertion failures in expressions like `int(n ** 0.5) + 1`.

Partial fix for #3213