### PR TITLE
[python] add support for list.pop() method

### DIFF
--- a/regression/python/list7-fail/test.desc
+++ b/regression/python/list7-fail/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc 
-
+--unwind 9
 ^VERIFICATION FAILED$

--- a/regression/python/list_pop/main.py
+++ b/regression/python/list_pop/main.py
@@ -1,0 +1,6 @@
+l = [1, 2, 3]
+x = l.pop()
+assert x == 3
+assert len(l) == 2
+assert l[0] == 1
+assert l[1] == 2

--- a/regression/python/list_pop/test.desc
+++ b/regression/python/list_pop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop2/main.py
+++ b/regression/python/list_pop2/main.py
@@ -1,0 +1,7 @@
+l = [10, 20, 30, 40]
+x = l.pop(1)  # Remove element at index 1
+assert x == 20
+assert len(l) == 3
+assert l[0] == 10
+assert l[1] == 30
+assert l[2] == 40

--- a/regression/python/list_pop2/test.desc
+++ b/regression/python/list_pop2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop2_fail/main.py
+++ b/regression/python/list_pop2_fail/main.py
@@ -1,0 +1,2 @@
+l = [1, 2, 3]
+x = l.pop(5)  # Index out of range

--- a/regression/python/list_pop2_fail/test.desc
+++ b/regression/python/list_pop2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/list_pop3/main.py
+++ b/regression/python/list_pop3/main.py
@@ -1,0 +1,7 @@
+l = [5, 10, 15, 20]
+x = l.pop(-2)  # Remove second-to-last element
+assert x == 15
+assert len(l) == 3
+assert l[0] == 5
+assert l[1] == 10
+assert l[2] == 20

--- a/regression/python/list_pop3/test.desc
+++ b/regression/python/list_pop3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop4/main.py
+++ b/regression/python/list_pop4/main.py
@@ -1,0 +1,6 @@
+l = [1, 2, 3]
+x = l.pop(0)
+assert x == 1
+assert len(l) == 2
+assert l[0] == 2
+assert l[1] == 3

--- a/regression/python/list_pop4/test.desc
+++ b/regression/python/list_pop4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop5/main.py
+++ b/regression/python/list_pop5/main.py
@@ -1,0 +1,8 @@
+l = [1, 2, 3]
+a = l.pop()
+assert a == 3
+b = l.pop()
+assert b == 2
+c = l.pop()
+assert c == 1
+assert len(l) == 0

--- a/regression/python/list_pop5/test.desc
+++ b/regression/python/list_pop5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop6/main.py
+++ b/regression/python/list_pop6/main.py
@@ -1,0 +1,7 @@
+l = [1, 2.5, 3]
+x = l.pop()
+assert x == 3
+y = l.pop()
+assert y >= 2.5
+z = l.pop()
+assert z == 1

--- a/regression/python/list_pop6/test.desc
+++ b/regression/python/list_pop6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop7/main.py
+++ b/regression/python/list_pop7/main.py
@@ -1,0 +1,9 @@
+l = [1, 2, 3, 4, 5]
+l.pop()
+l.pop(0)
+l.append(99)
+assert len(l) == 4
+assert l[0] == 2
+assert l[1] == 3
+assert l[2] == 4
+assert l[3] == 99

--- a/regression/python/list_pop7/test.desc
+++ b/regression/python/list_pop7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop8/main.py
+++ b/regression/python/list_pop8/main.py
@@ -1,0 +1,7 @@
+l = [10, 20, 30, 40, 50]
+a = l.pop(-1)  # 50
+assert a == 50
+b = l.pop(-1)  # 40
+assert b == 40
+assert len(l) == 3
+assert l[2] == 30

--- a/regression/python/list_pop8/test.desc
+++ b/regression/python/list_pop8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop9/main.py
+++ b/regression/python/list_pop9/main.py
@@ -1,0 +1,3 @@
+l = ['a', 'b', 'c']
+x = l.pop(0)
+assert x == 'a'

--- a/regression/python/list_pop9/test.desc
+++ b/regression/python/list_pop9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_pop_fail/main.py
+++ b/regression/python/list_pop_fail/main.py
@@ -1,0 +1,2 @@
+l = []
+x = l.pop()  # Should trigger IndexError assertion

--- a/regression/python/list_pop_fail/test.desc
+++ b/regression/python/list_pop_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/regression/quixbugs/shunting_yard/test.desc
+++ b/regression/quixbugs/shunting_yard/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+-unwind 8 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -168,7 +168,8 @@ const static std::vector<std::string> python_c_models = {
   "__python_str_concat",
   "__ESBMC_list_find_index",
   "__ESBMC_list_remove_at",
-  "__ESBMC_list_set_at"};
+  "__ESBMC_list_set_at",
+  "__ESBMC_list_pop"};
 } // namespace
 
 static void generate_symbol_deps(

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -225,6 +225,7 @@ private:
   exprt handle_list_insert() const;
   exprt handle_list_extend() const;
   exprt handle_list_clear() const;
+  exprt handle_list_pop() const;
 
   /*
    * Check if the current function call is to a regular expression module function

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1348,3 +1348,19 @@ exprt python_list::get_empty_set()
   // Type information will be determined when elements are added
   return symbol_expr(list_symbol);
 }
+
+typet python_list::get_list_element_type(
+  const std::string &list_id,
+  size_t index)
+{
+  auto type_map_it = list_type_map.find(list_id);
+
+  if (type_map_it == list_type_map.end() || type_map_it->second.empty())
+    return typet();
+
+  // If index is out of bounds, return the first element's type
+  if (index >= type_map_it->second.size())
+    index = 0;
+
+  return type_map_it->second[index].second;
+}

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -88,6 +88,14 @@ public:
    */
   exprt get_empty_set();
 
+  /**
+   * Get the element type for a list at a given index.
+   * If index is not specified or out of bounds, returns the first element's type.
+   * Returns empty typet() if type information is not available.
+   */
+  static typet
+  get_list_element_type(const std::string &list_id, size_t index = 0);
+
 private:
   friend class python_dict_handler;
 


### PR DESCRIPTION
This PR implements the `list.pop()` method:
- Adds `__ESBMC_list_pop()` to the C operational model with bounds checking.
- Supports both `pop()` (remove last) and `pop(index)` variants.
- Handles negative indices correctly.
- Raises `IndexError` for empty lists and out-of-bounds access.