### PR TITLE
[symex] fix printf format specifier type validation

### DIFF
--- a/regression/esbmc-unix/github_1628/main.c
+++ b/regression/esbmc-unix/github_1628/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+struct Foo {};
+
+int main(int argc, char **argv)
+{
+  struct Foo f;
+  printf("%s\n", f);
+}

--- a/regression/esbmc-unix/github_1628/test.desc
+++ b/regression/esbmc-unix/github_1628/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_10/main.c
+++ b/regression/esbmc-unix/github_1628_10/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+  float f = 3.14;
+  printf("%s\n", f);
+}

--- a/regression/esbmc-unix/github_1628_10/test.desc
+++ b/regression/esbmc-unix/github_1628_10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_11/main.c
+++ b/regression/esbmc-unix/github_1628_11/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+  int x = 123;
+  printf("%10.5s\n", x);
+}

--- a/regression/esbmc-unix/github_1628_11/test.desc
+++ b/regression/esbmc-unix/github_1628_11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_12/main.c
+++ b/regression/esbmc-unix/github_1628_12/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void)
+{
+  printf("%s %d\n", "hello");
+}

--- a/regression/esbmc-unix/github_1628_12/test.desc
+++ b/regression/esbmc-unix/github_1628_12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf has more format specifiers than arguments$

--- a/regression/esbmc-unix/github_1628_13/main.c
+++ b/regression/esbmc-unix/github_1628_13/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void)
+{
+  printf("%s\n", "hello", 123, 3.14);
+}
+

--- a/regression/esbmc-unix/github_1628_13/test.desc
+++ b/regression/esbmc-unix/github_1628_13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_1628_14/main.c
+++ b/regression/esbmc-unix/github_1628_14/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main(void)
+{
+  int x = 1;
+  printf("%p\n", x); // invalid: pointer expected
+}
+

--- a/regression/esbmc-unix/github_1628_14/test.desc
+++ b/regression/esbmc-unix/github_1628_14/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%p requires pointer argument$

--- a/regression/esbmc-unix/github_1628_2/main.c
+++ b/regression/esbmc-unix/github_1628_2/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+  char c = 'x';
+  printf("%s\n", c);
+}

--- a/regression/esbmc-unix/github_1628_2/test.desc
+++ b/regression/esbmc-unix/github_1628_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_3/main.c
+++ b/regression/esbmc-unix/github_1628_3/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+  int x = 42;
+  printf("%s\n", x);
+}

--- a/regression/esbmc-unix/github_1628_3/test.desc
+++ b/regression/esbmc-unix/github_1628_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_4/main.c
+++ b/regression/esbmc-unix/github_1628_4/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+  const char *s = "hello";
+  printf("%s\n", s);
+}

--- a/regression/esbmc-unix/github_1628_4/test.desc
+++ b/regression/esbmc-unix/github_1628_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_1628_5/main.c
+++ b/regression/esbmc-unix/github_1628_5/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+  char arr[] = "test";
+  printf("%s\n", arr);
+}

--- a/regression/esbmc-unix/github_1628_5/test.desc
+++ b/regression/esbmc-unix/github_1628_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_1628_6/main.c
+++ b/regression/esbmc-unix/github_1628_6/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+struct Bar {};
+int main(void)
+{
+  int x = 10;
+  struct Bar b;
+  printf("%d %s\n", x, b);
+}

--- a/regression/esbmc-unix/github_1628_6/test.desc
+++ b/regression/esbmc-unix/github_1628_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_7/main.c
+++ b/regression/esbmc-unix/github_1628_7/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+struct Foo {};
+int main(void)
+{
+  struct Foo f;
+  char buf[100];
+  snprintf(buf, 100, "%s\n", f);
+}

--- a/regression/esbmc-unix/github_1628_7/test.desc
+++ b/regression/esbmc-unix/github_1628_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/regression/esbmc-unix/github_1628_8/main.c
+++ b/regression/esbmc-unix/github_1628_8/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+int main(void)
+{
+  const char *s = "hello";
+  int x = 42;
+  printf("%s %d %c\n", s, x, 'a');
+}

--- a/regression/esbmc-unix/github_1628_8/test.desc
+++ b/regression/esbmc-unix/github_1628_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-unix/github_1628_9/main.c
+++ b/regression/esbmc-unix/github_1628_9/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+union Data {
+  int i;
+  float f;
+};
+int main(void)
+{
+  union Data d;
+  d.i = 42;
+  printf("%s\n", d);
+}

--- a/regression/esbmc-unix/github_1628_9/test.desc
+++ b/regression/esbmc-unix/github_1628_9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--printf-check
+^  printf format specifier \%s requires pointer argument$

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -826,6 +826,73 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
   else
     abort();
 
+  // Check format specifiers against original operands before renaming/conversion
+  if (options.get_bool_option("printf-check"))
+  {
+    const code_printf2t &original_rhs = to_code_printf2t(rhs);
+    std::string format_str = fmt.as_string();
+    size_t arg_idx = 0;
+
+    for (size_t i = 0; i < format_str.length(); i++)
+    {
+      if (format_str[i] == '%')
+      {
+        if (i + 1 < format_str.length() && format_str[i + 1] == '%')
+        {
+          i++; // Skip %%
+          continue;
+        }
+
+        // Skip flags, width, precision
+        i++;
+        while (i < format_str.length() &&
+               (format_str[i] == '-' || format_str[i] == '+' ||
+                format_str[i] == ' ' || format_str[i] == '#' ||
+                format_str[i] == '0'))
+          i++;
+        while (i < format_str.length() && isdigit(format_str[i]))
+          i++;
+        if (i < format_str.length() && format_str[i] == '.')
+        {
+          i++;
+          while (i < format_str.length() && isdigit(format_str[i]))
+            i++;
+        }
+
+        // Skip length modifiers
+        while (i < format_str.length() &&
+               (format_str[i] == 'h' || format_str[i] == 'l' ||
+                format_str[i] == 'L' || format_str[i] == 'z' ||
+                format_str[i] == 'j' || format_str[i] == 't'))
+          i++;
+
+        // Check conversion specifier against original operands
+        size_t actual_arg_idx = idx + arg_idx;
+        if (
+          i < format_str.length() &&
+          actual_arg_idx < original_rhs.operands.size())
+        {
+          char spec = format_str[i];
+          const expr2tc &arg = original_rhs.operands[actual_arg_idx];
+
+          if (arg && spec == 's')
+          {
+            // %s requires a pointer type
+            if (!is_pointer_type(arg->type))
+            {
+              claim(
+                gen_false_expr(),
+                "printf format specifier %s requires pointer argument");
+            }
+          }
+
+          if (spec != 'n' && spec != '*')
+            arg_idx++;
+        }
+      }
+    }
+  }
+
   // Only perform dereference checks if printf-check is enabled
   if (options.get_bool_option("printf-check"))
   {

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -867,27 +867,37 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
           i++;
 
         // Check conversion specifier against original operands
-        size_t actual_arg_idx = idx + arg_idx;
-        if (
-          i < format_str.length() &&
-          actual_arg_idx < original_rhs.operands.size())
+        if (i < format_str.length())
         {
           char spec = format_str[i];
-          const expr2tc &arg = original_rhs.operands[actual_arg_idx];
+          size_t actual_arg_idx = idx + arg_idx;
 
-          if (arg && spec == 's')
+          // Check if we have enough arguments (skip %n and %*)
+          if (spec != 'n' && spec != '*')
           {
-            // %s requires a pointer type
-            if (!is_pointer_type(arg->type))
+            if (actual_arg_idx >= original_rhs.operands.size())
             {
               claim(
                 gen_false_expr(),
-                "printf format specifier %s requires pointer argument");
+                "printf has more format specifiers than arguments");
             }
-          }
+            else
+            {
+              const expr2tc &arg = original_rhs.operands[actual_arg_idx];
 
-          if (spec != 'n' && spec != '*')
+              if (arg && spec == 's')
+              {
+                // %s requires a pointer type
+                if (!is_pointer_type(arg->type))
+                {
+                  claim(
+                    gen_false_expr(),
+                    "printf format specifier %s requires pointer argument");
+                }
+              }
+            }
             arg_idx++;
+          }
         }
       }
     }

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -885,14 +885,20 @@ void goto_symext::symex_printf(const expr2tc &lhs, expr2tc &rhs)
             {
               const expr2tc &arg = original_rhs.operands[actual_arg_idx];
 
-              if (arg && spec == 's')
+              if (arg)
               {
-                // %s requires a pointer type
-                if (!is_pointer_type(arg->type))
+                if (spec == 's' || spec == 'p')
                 {
-                  claim(
-                    gen_false_expr(),
-                    "printf format specifier %s requires pointer argument");
+                  // %s and %p require pointer types
+                  if (!is_pointer_type(arg->type))
+                  {
+                    claim(
+                      gen_false_expr(),
+                      spec == 's'
+                        ? "printf format specifier %s requires pointer argument"
+                        : "printf format specifier %p requires pointer "
+                          "argument");
+                  }
                 }
               }
             }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/1628.

This PR validates `printf` format specifiers against argument types before symbolic execution performs type conversions. Previously, struct arguments passed to %s and %p specifiers were silently converted to pointers, causing undefined behavior to go undetected. This PR parses the format string and checks original operands against expected types. Currently, validates %s and %p require pointer arguments, which catch common errors such as passing structs or chars to string format specifiers.

