### PR TITLE
[testcomp] fix esbmc-wrapper

### DIFF
--- a/scripts/competitions/testcomp/esbmc-wrapper-cov.py
+++ b/scripts/competitions/testcomp/esbmc-wrapper-cov.py
@@ -203,6 +203,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, coverage)
       command_line += "--branch-function-coverage "
   elif prop == Property.reach:
     command_line += "--base-k-step 5 --enable-unreachability-intrinsic "
+    command_line += "--generate-testcase "
     if concurrency:
       command_line += "--no-pointer-check --no-bounds-check "
     else:


### PR DESCRIPTION
ESBMC got 0 score in Cover-Error categories due a small mistake in the wrapper. 

This is due to that we did not merge this PR: #2073 