### PR TITLE
[python] optimize list operations by reducing redundancy

### DIFF
--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -82,6 +82,18 @@ size_t __ESBMC_list_size(const PyListObject *l)
   return l ? l->size : 0;
 }
 
+static inline void *__ESBMC_copy_value(const void *value, size_t size)
+{
+  void *copied = __ESBMC_alloca(size);
+
+  if (size == 8)
+    *(uint64_t *)copied = *(const uint64_t *)value;
+  else
+    memcpy(copied, value, size);
+
+  return copied;
+}
+
 bool __ESBMC_list_push(
   PyListObject *l,
   const void *value,
@@ -89,12 +101,13 @@ bool __ESBMC_list_push(
   size_t type_size)
 {
   // TODO: __ESBMC_obj_cpy
-  void *copied_value = __ESBMC_alloca(type_size);
-  memcpy(copied_value, value, type_size);
+  void *copied_value = __ESBMC_copy_value(value, type_size);
 
-  l->items[l->size].value = copied_value;
-  l->items[l->size].type_id = type_id;
-  l->items[l->size].size = type_size;
+  // Use a pointer to avoid repeated indexing
+  PyObject *item = &l->items[l->size];
+  item->value = copied_value;
+  item->type_id = type_id;
+  item->size = type_size;
   l->size++;
 
   // TODO: Nondeterministic failure?

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2650,6 +2650,10 @@ expr2tc smt_convt::get(const expr2tc &expr)
           array,
           to_constant_int2t(idx).value.to_uint64(),
           get_flattened_array_subtype(res->type));
+
+      // If we got a nil result, return original expression
+      if (is_nil_expr(res))
+        return expr;
     }
 
     // TODO: Give up, then what?


### PR DESCRIPTION
This PR:
- Caches `l->items[l->size]` in `__ESBMC_list_push` to eliminate repeated indexing.
- Uses direct assignment for 8-byte values in `__ESBMC_copy_value` to avoid `memcpy` overhead.

These changes improve ESBMC's overall performance.

As an example:

````Python
l = [1, 2]
assert l[0] == 1
````

ESBMC now produces (take also a look at --show-vcc):

````
Caching time: 0.001s (removed 17 assertions)
Slicing time: 0.001s (removed 86 assignments)
Generated 80 VCC(s), 20 remaining after simplification (46 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.116s
Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.000s
BMC program time: 0.188s

VERIFICATION SUCCESSFUL
````

<img width="1900" height="958" alt="image" src="https://github.com/user-attachments/assets/9bb355ef-163c-472e-881a-1f86aa0b8ba0" />


Before this PR:
````
Symex completed in: 0.491s (315 assignments)
Caching time: 0.003s (removed 27 assertions)
Slicing time: 0.010s (removed 148 assignments)
Generated 194 VCC(s), 48 remaining after simplification (140 assignments)
No solver specified; defaulting to Boolector
Encoding remaining VCC(s) using bit-vector/floating-point arithmetic
Encoding to solver time: 0.376s
Solving with solver Boolector 3.2.2
Runtime decision procedure: 0.029s
BMC program time: 0.911s

VERIFICATION SUCCESSFUL
````

<img width="1871" height="963" alt="image" src="https://github.com/user-attachments/assets/7c657a49-4d38-44c7-bc4c-1488aacd70d0" />
