### PR TITLE
[python] fix dictionary subscript value extraction in arithmetic expressions

### DIFF
--- a/regression/python/github_3244/main.py
+++ b/regression/python/github_3244/main.py
@@ -1,0 +1,6 @@
+d: dict[str, int] = {"a": 1, "b": 2, "c": 3}
+
+assert 'a' in d, "a is in d"
+assert 'b' in d, "b is in d"
+assert 'c' in d, "c is in d"
+assert d['a'] + d['b'] + d['c'] == 6, "sum of a, b, c is 6"

--- a/regression/python/github_3244/test.desc
+++ b/regression/python/github_3244/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3244_2/main.py
+++ b/regression/python/github_3244_2/main.py
@@ -1,0 +1,9 @@
+d: dict[str, int] = {"a": 1, "b": 2, "c": 3}
+
+assert 'a' in d, "a is in d"
+assert 'b' in d, "b is in d"
+assert 'c' in d, "c is in d"
+x:int = d['a']
+y:int = d['b']
+z:int = d['c']
+assert x + y + z == 6, "sum of a, b, c is 6"

--- a/regression/python/github_3244_2/test.desc
+++ b/regression/python/github_3244_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3244_fail/main.py
+++ b/regression/python/github_3244_fail/main.py
@@ -1,0 +1,6 @@
+d: dict[str, int] = {"a": 1, "b": 2, "c": 3}
+
+assert 'a' in d, "a is in d"
+assert 'b' in d, "b is in d"
+assert 'c' in d, "c is in d"
+assert d['a'] + d['b'] + d['c'] == 5, "sum of a, b, c is 6"

--- a/regression/python/github_3244_fail/test.desc
+++ b/regression/python/github_3244_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1383,6 +1383,9 @@ void python_converter::resolve_dict_subscript_types(
     {
       lhs = dict_handler_->handle_dict_subscript(
         dict_expr, left["slice"], rhs.type());
+      // Dereference the pointer to get the actual value
+      if (lhs.type().is_pointer())
+        lhs = dereference_exprt(lhs, lhs.type().subtype());
     }
   }
 
@@ -1396,6 +1399,9 @@ void python_converter::resolve_dict_subscript_types(
     {
       rhs = dict_handler_->handle_dict_subscript(
         dict_expr, right["slice"], lhs.type());
+      // Dereference the pointer to get the actual value
+      if (rhs.type().is_pointer())
+        rhs = dereference_exprt(rhs, rhs.type().subtype());
     }
   }
 
@@ -1413,6 +1419,9 @@ void python_converter::resolve_dict_subscript_types(
     {
       lhs = dict_handler_->handle_dict_subscript(
         lhs_dict, left["slice"], default_type);
+      // Dereference the pointer to get the actual value
+      if (lhs.type().is_pointer())
+        lhs = dereference_exprt(lhs, lhs.type().subtype());
     }
 
     exprt rhs_dict = get_expr(right["value"]);
@@ -1422,6 +1431,11 @@ void python_converter::resolve_dict_subscript_types(
     {
       rhs = dict_handler_->handle_dict_subscript(
         rhs_dict, right["slice"], default_type);
+      // Dereference the pointer to get the actual value
+      if (rhs.type().is_pointer())
+      {
+        rhs = dereference_exprt(rhs, rhs.type().subtype());
+      }
     }
   }
 }

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -256,22 +256,27 @@ exprt python_dict_handler::handle_dict_subscript(
   if (expected_type.is_floatbv())
   {
     typecast_exprt value_as_float_ptr(obj_value, pointer_typet(expected_type));
-    return dereference_exprt(value_as_float_ptr, expected_type);
+    dereference_exprt result(value_as_float_ptr, expected_type);
+    result.type() = expected_type;
+    return result;
   }
 
   // Handle integer types: cast void* to int*, then dereference
   if (expected_type.is_signedbv() || expected_type.is_unsignedbv())
   {
-    typet int_type = expected_type.is_nil() ? long_int_type() : expected_type;
-    typecast_exprt value_as_int_ptr(obj_value, pointer_typet(int_type));
-    return dereference_exprt(value_as_int_ptr, int_type);
+    typecast_exprt value_as_int_ptr(obj_value, pointer_typet(expected_type));
+    dereference_exprt result(value_as_int_ptr, expected_type);
+    result.type() = expected_type;
+    return result;
   }
 
   // Handle boolean types: cast void* to bool*, then dereference
   if (expected_type.is_bool())
   {
     typecast_exprt value_as_bool_ptr(obj_value, pointer_typet(bool_type()));
-    return dereference_exprt(value_as_bool_ptr, bool_type());
+    dereference_exprt result(value_as_bool_ptr, bool_type());
+    result.type() = bool_type();
+    return result;
   }
 
   // Default: cast void* to char* for string values


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3244.

This PR fixes `resolve_dict_subscript_types` to dereference the pointer to get the actual value. It also explicitly sets the type after construction using `result.type() = expected_type` for float, integer, and boolean branches. Before this PR, the `dereference_exprt` two-argument constructor did not properly set the result type, causing dictionary subscript expressions in arithmetic contexts to have nil type instead of the expected type.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

