### PR TITLE
[python] handle list retrieval from dictionary

### DIFF
--- a/regression/python/dict14_fail/main.py
+++ b/regression/python/dict14_fail/main.py
@@ -1,0 +1,12 @@
+d: dict[str, list[int]] = {'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+l: list[int] = d['a']
+assert l[0] == 1
+assert l[1] == 2
+assert l[2] == 3
+assert l[3] == 4
+assert l[4] == 5
+assert l[5] == 6
+assert l[6] == 6 # should fail
+assert l[7] == 8
+assert l[8] == 9
+assert l[9] == 10

--- a/regression/python/dict14_fail/test.desc
+++ b/regression/python/dict14_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dict9/main.py
+++ b/regression/python/dict9/main.py
@@ -1,0 +1,12 @@
+d: dict[str, list[int]] = {'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+l: list[int] = d['a']
+assert l[0] == 1
+assert l[1] == 2
+assert l[2] == 3
+assert l[3] == 4
+assert l[4] == 5
+assert l[5] == 6
+assert l[6] == 7
+assert l[7] == 8
+assert l[8] == 9
+assert l[9] == 10

--- a/regression/python/dict9/test.desc
+++ b/regression/python/dict9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3621,10 +3621,14 @@ exprt python_converter::get_rhs_with_dict_resolution(
     return get_expr(ast_node["value"]);
 
   // Check if we need special dict subscript handling for typed variables
+  // Including list type
+  typet list_type = type_handler_.get_list_type();
   if (
     !target_type.is_signedbv() && !target_type.is_unsignedbv() &&
-    !target_type.is_bool())
+    !target_type.is_bool() && target_type != list_type)
+  {
     return get_expr(ast_node["value"]);
+  }
 
   exprt dict_expr = get_expr(ast_node["value"]["value"]);
   if (

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -252,6 +252,19 @@ exprt python_dict_handler::handle_dict_subscript(
     "value",
     pointer_typet(empty_typet()));
 
+  // Handle list types
+  if (expected_type == list_type)
+  {
+    // obj_value is void* pointing to a (PyListObj*)
+    // We need to:
+    // 1. Cast void* to (PyListObj**)  - pointer to pointer to list
+    // 2. Dereference to get PyListObj*
+    typecast_exprt value_as_list_ptr_ptr(obj_value, pointer_typet(list_type));
+    dereference_exprt list_ptr(value_as_list_ptr_ptr, list_type);
+    list_ptr.type() = list_type;
+    return list_ptr;
+  }
+
   // Handle float types: cast void* to double*, then dereference
   if (expected_type.is_floatbv())
   {

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -121,8 +121,16 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   // Calculate element size in bytes
   exprt elem_size;
 
+  // For list pointers (PyListObj*), use pointer size
+  typet list_type = converter_.get_type_handler().get_list_type();
+  if (elem_symbol.type == list_type)
+  {
+    // This is a pointer to PyListObj: use pointer size
+    const size_t pointer_size_bytes = config.ansi_c.pointer_width() / 8;
+    elem_size = from_integer(BigInt(pointer_size_bytes), size_type());
+  }
   // For string pointers (char*), calculate length at runtime using strlen
-  if (
+  else if (
     elem_symbol.type.is_pointer() && elem_symbol.type.subtype() == char_type())
   {
     // Call strlen to get actual string length


### PR DESCRIPTION
This PR implements dictionary subscript operations that return lists by properly handling pointer indirection and element sizes.

In particular, this PR makes the following changes:
- **handle_dict_subscript**: dereference pointer-to-pointer when retrieving list values from dictionary to get the actual list pointer
- **get_list_element_info**: use correct pointer size (8 bytes) instead of default size (1 byte) when storing list pointers in dictionary values
- **get_rhs_with_dict_resolution**: include list type in typed variable check to ensure proper type resolution for dictionary subscripts