### PR TITLE
[Build] Change the fmt usage to explicitly format

### DIFF
--- a/src/util/message/formats/bigint.h
+++ b/src/util/message/formats/bigint.h
@@ -40,6 +40,6 @@ struct fmt::formatter<BigInt>
     char tmp[128];
     char *number;
     number = p.as_string(tmp, 128, base);
-    return format_to(ctx.out(), "{}", number);
+    return fmt::format_to(ctx.out(), "{}", number);
   }
 };

--- a/src/util/message/formats/expr2t.h
+++ b/src/util/message/formats/expr2t.h
@@ -23,6 +23,6 @@ struct fmt::formatter<expr2t>
   template <typename FormatContext>
   auto format(const expr2t &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.pretty(0));
+    return fmt::format_to(ctx.out(), "{}", p.pretty(0));
   }
 };

--- a/src/util/message/formats/exprt.h
+++ b/src/util/message/formats/exprt.h
@@ -23,6 +23,6 @@ struct fmt::formatter<exprt>
   template <typename FormatContext>
   auto format(const exprt &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.pretty(0));
+    return fmt::format_to(ctx.out(), "{}", p.pretty(0));
   }
 };

--- a/src/util/message/formats/irep_idt.h
+++ b/src/util/message/formats/irep_idt.h
@@ -23,6 +23,6 @@ struct fmt::formatter<irep_idt>
   template <typename FormatContext>
   auto format(const irep_idt &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.as_string());
+    return fmt::format_to(ctx.out(), "{}", p.as_string());
   }
 };

--- a/src/util/message/formats/irept.h
+++ b/src/util/message/formats/irept.h
@@ -23,6 +23,6 @@ struct fmt::formatter<irept>
   template <typename FormatContext>
   auto format(const irept &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.pretty(0));
+    return fmt::format_to(ctx.out(), "{}", p.pretty(0));
   }
 };

--- a/src/util/message/formats/locationt.h
+++ b/src/util/message/formats/locationt.h
@@ -23,6 +23,6 @@ struct fmt::formatter<locationt>
   template <typename FormatContext>
   auto format(const locationt &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.as_string());
+    return fmt::format_to(ctx.out(), "{}", p.as_string());
   }
 };

--- a/src/util/message/formats/side_efect_expr_function_callt.h
+++ b/src/util/message/formats/side_efect_expr_function_callt.h
@@ -24,6 +24,6 @@ struct fmt::formatter<side_effect_expr_function_callt>
   auto
   format(const side_effect_expr_function_callt &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.pretty(0));
+    return fmt::format_to(ctx.out(), "{}", p.pretty(0));
   }
 };

--- a/src/util/message/formats/symbol.h
+++ b/src/util/message/formats/symbol.h
@@ -25,6 +25,6 @@ struct fmt::formatter<symbolt>
   {
     std::ostringstream oss;
     p.show(oss);
-    return format_to(ctx.out(), "{}", oss.str());
+    return fmt::format_to(ctx.out(), "{}", oss.str());
   }
 };

--- a/src/util/message/formats/type2t.h
+++ b/src/util/message/formats/type2t.h
@@ -23,6 +23,6 @@ struct fmt::formatter<type2t>
   template <typename FormatContext>
   auto format(const type2t &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.pretty(0));
+    return fmt::format_to(ctx.out(), "{}", p.pretty(0));
   }
 };

--- a/src/util/message/formats/typet.h
+++ b/src/util/message/formats/typet.h
@@ -23,6 +23,6 @@ struct fmt::formatter<typet>
   template <typename FormatContext>
   auto format(const typet &p, FormatContext &ctx) const
   {
-    return format_to(ctx.out(), "{}", p.pretty(0));
+    return fmt::format_to(ctx.out(), "{}", p.pretty(0));
   }
 };


### PR DESCRIPTION
### Description

This Pull Request addresses a potential namespace ambiguity/conflict by explicitly qualifying all calls to the formatting function `format_to` with the `fmt::` namespace prefix.

### Changes

The core change across all custom `fmt::formatter` specializations in the `src/util/message/formats` directory is:

* Changing `return format_to(ctx.out(), ...);`
* To the explicit call: `return fmt::format_to(ctx.out(), ...);`

### Rationale

In C++ projects, especially those integrating multiple libraries, an unqualified call to `format_to` can lead to ambiguity issues (due to Argument-Dependent Lookup or other name resolution complexities) if another library or the global namespace defines a function with the same name.
