### PR TITLE
[python] Add a lib path for pyenv

### DIFF
--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -102,6 +102,12 @@ def is_standard_library_file(filename):
         '/opt/homebrew/Cellar/python',  # Homebrew Python on macOS (Apple Silicon)
         '/usr/local/Cellar/python',     # Homebrew Python on macOS (Intel)
     ]
+    # Check pyenv paths
+    pyenv_root = os.environ.get('PYENV_ROOT', os.path.expanduser('~/.pyenv'))
+    if pyenv_root and filename.startswith(pyenv_root):
+        # Check if it's in the versions directory (standard library location)
+        if '/versions/' in filename and '/lib/python' in filename:
+            return True
     return any(filename.startswith(path) for path in stdlib_paths)
 
 


### PR DESCRIPTION
## Problem

ESBMC fails with `TypeError: match() missing 2 required positional arguments` when using Python installed via pyenv (e.g., Python 3.12.9).

**Root cause**: `is_standard_library_file()` does not recognize pyenv paths (`~/.pyenv/versions/*/lib/python*/`), causing standard library to be processed as user code and triggering parameter validation errors.

Might Fixes #3255 but need to support for other version control. This only works for pyenv

## Solution

Added pyenv path detection to `is_standard_library_file()`:
- Checks `PYENV_ROOT` environment variable (defaults to `~/.pyenv`)
- Recognizes `$PYENV_ROOT/versions/*/lib/python*/` as standard library paths
- Maintains backward compatibility

## Changes

- `src/python-frontend/parser.py`: Added pyenv path detection

## Testing

- ✅ Python 3.12.9 via pyenv (previously failing, now works)
- ✅ System Python 3.12.3 (still works)
- ✅ User code not incorrectly identified as stdlib

## Future Work

- Add support for other Python version managers