### PR TITLE
[python] fix keyword-only parameter resolution in list iteration

### DIFF
--- a/regression/python/github_3243/main.py
+++ b/regression/python/github_3243/main.py
@@ -1,0 +1,7 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+
+    def foo(self, *, l: list[str]):
+        for i in l:
+            pass

--- a/regression/python/github_3243/test.desc
+++ b/regression/python/github_3243/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3243_2/main.py
+++ b/regression/python/github_3243_2/main.py
@@ -1,0 +1,20 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+    
+    def foo(self, *, l: list[str]):
+        assert len(l) > 0
+        
+        count = 0
+        for i in l:
+            assert isinstance(i, str)
+            assert i is not None
+            count += 1
+        
+        # Assert we iterated through all elements
+        assert count == len(l)
+
+f = Foo()
+test_list = ["hello", "world", "test"]
+f.foo(l=test_list)
+f.foo(l=["single"])

--- a/regression/python/github_3243_2/test.desc
+++ b/regression/python/github_3243_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3243_2_fail/main.py
+++ b/regression/python/github_3243_2_fail/main.py
@@ -1,0 +1,20 @@
+class Foo:
+    def __init__(self) -> None:
+        pass
+    
+    def foo(self, *, l: list[str]):
+        assert len(l) > 0
+        
+        count = 0
+        for i in l:
+            assert isinstance(i, str)
+            assert i is None
+            count += 1
+        
+        # Assert we iterated through all elements
+        assert count == len(l)
+
+f = Foo()
+test_list = ["hello", "world", "test"]
+f.foo(l=test_list)
+f.foo(l=["single"])

--- a/regression/python/github_3243_2_fail/test.desc
+++ b/regression/python/github_3243_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -298,6 +298,16 @@ find_var_in_function(const std::string &var_name, const JsonType &func_node)
     }
   }
 
+  // Search in keyword-only arguments (after *)
+  if (func_node.contains("args") && func_node["args"].contains("kwonlyargs"))
+  {
+    for (const auto &arg : func_node["args"]["kwonlyargs"])
+    {
+      if (arg.contains("arg") && arg["arg"] == var_name)
+        return arg;
+    }
+  }
+
   // Then search in function body
   return get_var_node(var_name, func_node);
 }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3243.

This PR adds support for keyword-only parameters (parameters after *) in `find_var_in_function` by searching the kwonlyargs field in addition to the regular args field. This fixes crashes when iterating over lists passed as keyword-only parameters.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.