### PR TITLE
[python] propagate type annotations for dict subscript access

### DIFF
--- a/regression/python/dict_subscript_typed/main.py
+++ b/regression/python/dict_subscript_typed/main.py
@@ -1,0 +1,12 @@
+d: dict[int, float] = {1: 3.14}
+
+x = d[1]
+
+# ESBMC should know that x is a float
+assert isinstance(x, float)
+
+# And NOT an int
+assert not isinstance(x, int)
+
+# Float arithmetic must work
+assert abs(x + 1.0 - 4.14) < 1e-6

--- a/regression/python/dict_subscript_typed/test.desc
+++ b/regression/python/dict_subscript_typed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_subscript_typed_assign/main.py
+++ b/regression/python/dict_subscript_typed_assign/main.py
@@ -1,0 +1,16 @@
+# Typed dictionary: int -> float
+d: dict[int, float] = {1: 1.0}
+
+# Correct assignment: value is a float
+d[2] = 3.5
+
+# ESBMC should know this is valid
+assert isinstance(d[2], float)
+assert d[2] == 3.5
+
+# Ensure the previous entry is preserved
+assert d[1] == 1.0
+
+# Ensure the dict did not accidentally change type
+assert not isinstance(d[2], int)
+

--- a/regression/python/dict_subscript_typed_assign/test.desc
+++ b/regression/python/dict_subscript_typed_assign/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_subscript_typed_assign_fail/main.py
+++ b/regression/python/dict_subscript_typed_assign_fail/main.py
@@ -1,0 +1,10 @@
+# Typed dictionary: int -> float
+d: dict[int, float] = {1: 1.0}
+
+# Wrong assignment: assigning a string where a float is expected
+d[2] = "wrong-type"
+
+x = d[2]
+
+# ESBMC should detect mismatch and fail
+assert isinstance(x, float)   # This must fail

--- a/regression/python/dict_subscript_typed_assign_fail/test.desc
+++ b/regression/python/dict_subscript_typed_assign_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/python/dict_subscript_typed_wrong_type_fail/main.py
+++ b/regression/python/dict_subscript_typed_wrong_type_fail/main.py
@@ -1,0 +1,7 @@
+d: dict[int, str] = {1: "not-a-float"}  # Wrong type, ESBMC must detect mismatch
+
+x = d[1]
+
+# This assertion must fail because x is *not* a float
+assert isinstance(x, float)
+

--- a/regression/python/dict_subscript_typed_wrong_type_fail/test.desc
+++ b/regression/python/dict_subscript_typed_wrong_type_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3278/main.py
+++ b/regression/python/github_3278/main.py
@@ -1,0 +1,27 @@
+d1: dict[int, int] = {1: 2, 3: 4}
+assert d1[1] == 2
+assert d1[3] == 4
+
+d2: dict[str, int] = {"hello": 42, "world": 100}
+assert d2["hello"] == 42
+assert d2["world"] == 100
+
+d3: dict[int, str] = {1: "one", 2: "two"}
+assert d3[1] == "one"
+assert d3[2] == "two"
+
+d4: dict[str, str] = {"key": "value"}
+assert d4["key"] == "value"
+
+d5: dict[int, bool] = {0: False, 1: True}
+assert d5[0] == False
+assert d5[1] == True
+
+d6: dict[int, float] = {1: 3.14, 2: 2.71}
+assert d6[1] == 3.14
+assert d6[2] == 2.71
+
+d: dict[int, float] = {1: 3.14}
+x = d[1]
+assert isinstance(x, float)
+

--- a/regression/python/github_3278/test.desc
+++ b/regression/python/github_3278/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 7
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2751,21 +2751,6 @@ exprt python_converter::get_lambda_expr(const nlohmann::json &element)
 typet python_converter::get_dict_value_type_from_annotation(
   const nlohmann::json &annotation_node)
 {
-  // Check if it's a dict annotation: dict[K, V] or Dict[K, V]
-  if (
-    !annotation_node.contains("_type") ||
-    annotation_node["_type"] != "Subscript")
-    return empty_typet();
-
-  if (
-    !annotation_node.contains("value") ||
-    !annotation_node["value"].contains("id"))
-    return empty_typet();
-
-  std::string type_name = annotation_node["value"]["id"].get<std::string>();
-  if (type_name != "dict" && type_name != "Dict")
-    return empty_typet();
-
   // Get the slice which contains the key and value types
   if (!annotation_node.contains("slice"))
     return empty_typet();

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -484,6 +484,20 @@ private:
   // =========================================================================
 
   /**
+   * Extract the value type from a dict type annotation.
+   * For dict[K, V], returns V.
+   * For dict[K, dict[K2, V2]], returns dict[K2, V2].
+   */
+  typet
+  get_dict_value_type_from_annotation(const nlohmann::json &annotation_node);
+
+  /**
+   * Resolve the expected return type for a dict subscript operation
+   * by examining the dict variable's type annotation.
+   */
+  typet resolve_expected_type_for_dict_subscript(const exprt &dict_expr);
+
+  /**
    * @brief Handles dictionary subscript assignment (dict[key] = value).
    *
    * Detects and processes assignments where the target is a dictionary subscript


### PR DESCRIPTION
This PR adds type-annotation propagation to correctly infer return types for dictionary subscript operations (e.g., d[1] where d: dict[int, int]). The dict handler currently receives empty type information for subscript operations, causing it to default to a fallback type (`long_long_int`) instead of using the actual annotated value type. This change extracts value types from Python type annotations and passes them to the dict handler.

In particular, this PR:
- Adds `get_dict_value_type_from_annotation()` to extract dict[K,V] value types
- Adds `resolve_expected_type_for_dict_subscript()` to look up variable annotations
- Modifies `SUBSCRIPT` case in `get_expr()` to resolve and pass expected types

This enables the dict handler to return values with the correct type as specified in the dict annotation, improving type safety and allowing proper verification of dict operations.

Note: This implementation also lays the groundwork for future support for nested dictionaries by recursively extracting value types from dict annotations.