### PR TITLE
[python] Refactor hasattr() handling into symex

### DIFF
--- a/regression/python/has-attr-fail/main.py
+++ b/regression/python/has-attr-fail/main.py
@@ -1,0 +1,17 @@
+class Foo:
+    def __init__(self):
+        self.x = 10
+
+
+# Foo only has attribute "x".
+f = Foo()
+assert hasattr(f, "y")  # should be false, so this must fail
+
+# TODO: Fix this case
+# try:
+#     _ = f.y
+# except AttributeError:
+#     pass
+
+# Another missing attribute check
+assert hasattr(f, "z")

--- a/regression/python/has-attr-fail/test.desc
+++ b/regression/python/has-attr-fail/test.desc
@@ -1,0 +1,3 @@
+CORE
+main.py
+^VERIFICATION FAILED$

--- a/regression/python/has-attr/main.py
+++ b/regression/python/has-attr/main.py
@@ -1,7 +1,21 @@
 class Foo:
-    pass
+    def __init__(self):
+        self.x = 10
+
 
 f = Foo()
-f.x = 10
-assert hasattr(f, 'x') == True
-assert hasattr(f, 'y') == False
+
+# Existing attribute is detected.
+assert hasattr(f, "x")
+
+# Missing attribute returns False.
+assert not hasattr(f, "y") # This should pass
+
+# After adding dynamically, hasattr turns true.
+#f.y = 42
+#assert hasattr(f, "y")
+
+#assert not hasattr(1, "x")
+
+#has_z = hasattr(f, "z")
+#assert not has_z

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -132,8 +132,9 @@
   BOOST_PP_LIST_CONS(forall,                                                   \
   BOOST_PP_LIST_CONS(exists,                                                   \
   BOOST_PP_LIST_CONS(isinstance,                                               \
+  BOOST_PP_LIST_CONS(hasattr,                                                  \
   BOOST_PP_LIST_CONS(isnone,                                                   \
-  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -118,6 +118,7 @@ static const char *expr_names[] = {
   "forall",
   "exists",
   "isinstance",
+  "hasattr",
   "isnone"};
 // If this fires, you've added/removed an expr id, and need to update the list
 // above (which is ordered according to the enum list)

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1531,6 +1531,7 @@ irep_typedefs(capability_top, object_ops);
 irep_typedefs(forall, logic_2ops);
 irep_typedefs(exists, logic_2ops);
 irep_typedefs(isinstance, logic_2ops);
+irep_typedefs(hasattr, logic_2ops);
 irep_typedefs(isnone, logic_2ops);
 
 class exists2t : public exists_expr_methods
@@ -3147,6 +3148,18 @@ public:
   {
   }
   isinstance2t(const isinstance2t &ref) = default;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+class hasattr2t : public hasattr_expr_methods
+{
+public:
+  hasattr2t(const expr2tc &value, const expr2tc &attr)
+    : hasattr_expr_methods(get_bool_type(), hasattr_id, value, attr)
+  {
+  }
+  hasattr2t(const hasattr2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -253,6 +253,8 @@ std::string exists2t::field_names[esbmct::num_type_fields] =
   {"symbol", "predicate", "", "", ""};
 std::string isinstance2t::field_names[esbmct::num_type_fields] =
   {"value", "type", "", "", ""};
+std::string hasattr2t::field_names[esbmct::num_type_fields] =
+  {"value", "attr", "", "", ""};
 std::string isnone2t::field_names[esbmct::num_type_fields] =
   {"lhs", "rhs", "", "", ""};
 

--- a/src/irep2/templates/irep2_templates_expr_ops.cpp
+++ b/src/irep2/templates/irep2_templates_expr_ops.cpp
@@ -38,6 +38,7 @@ expr_typedefs1(overflow, overflow_ops);
 expr_typedefs1(valid_object, object_ops);
 expr_typedefs1(races_check, object_ops);
 expr_typedefs1(isinstance, logic_2ops);
+expr_typedefs1(hasattr, logic_2ops);
 expr_typedefs1(isnone, logic_2ops);
 expr_typedefs1(dynamic_size, object_ops);
 expr_typedefs1(deallocated_obj, object_ops);

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -2386,6 +2386,11 @@ std::string c_expr2stringt::convert(const exprt &src, unsigned &precedence)
     return convert_function(src, "ISINSTANCE", precedence = 15);
   }
 
+  else if (src.id() == "hasattr")
+  {
+    return convert_function(src, "HASATTR", precedence = 15);
+  }
+
   else if (src.id() == "isnone")
   {
     return convert_function(src, "ISNONE", precedence = 15);


### PR DESCRIPTION
This PR refactors the implementation of `hasattr()` to handle attribute verification into symex:

- The frontend now builds a new irep `hasattr` instead of evaluating the check immediately.
- At the symex level `simplify_python_builtins() ` evaluates hasattr by checking if an object (struct type) has a given attribute using `get_structure_member_names()`.
- For counterexamples, we now print HASATTR(...)

Master:
```
[Counterexample]


State 1 file /tmp/main.py line 8 column 0 thread 0
----------------------------------------------------
Violated property:
  file /tmp/main.py line 8 column 0
  assertion
  0


VERIFICATION FAILED
```

This PR:
```
[Counterexample]


State 1 file /tmp/main.py line 8 column 0 thread 0
----------------------------------------------------
Violated property:
  file /tmp/main.py line 8 column 0
  assertion
  HASATTR(f, "y")


VERIFICATION FAILED
```