### PR TITLE
[Python verification] include line numbers in stacktrace

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -179,7 +179,8 @@ void goto_convertt::do_atomic_begin(
   {
     code_function_callt call;
     call.function() = symbol_expr(*context.find_symbol("c:@F@__ESBMC_yield"));
-    do_function_call(call.lhs(), call.function(), call.arguments(), dest);
+    do_function_call(
+      call.lhs(), call.function(), call.arguments(), function.location(), dest);
   }
 
   goto_programt::targett t = dest.add_instruction(ATOMIC_BEGIN);

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -735,7 +735,8 @@ void goto_convertt::convert_assign(
     Forall_operands (it, rhs)
       remove_sideeffects(*it, dest);
 
-    do_function_call(lhs, rhs.op0(), rhs.op1().operands(), dest);
+    do_function_call(
+      lhs, rhs.op0(), rhs.op1().operands(), rhs.location(), dest);
   }
   else if (
     rhs.id() == "sideeffect" &&

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -118,6 +118,7 @@ protected:
     const exprt &lhs,
     const exprt &function,
     const exprt::operandst &arguments,
+    const locationt &location,
     goto_programt &dest);
 
   virtual void do_function_call_if(

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -16,6 +16,7 @@ void goto_convertt::convert_function_call(
     function_call.lhs(),
     function_call.function(),
     function_call.arguments(),
+    function_call.location(),
     dest);
 }
 
@@ -23,12 +24,14 @@ void goto_convertt::do_function_call(
   const exprt &lhs,
   const exprt &function,
   const exprt::operandst &arguments,
+  const locationt &location,
   goto_programt &dest)
 {
   // make it all side effect free
   exprt new_lhs = lhs, new_function = function;
 
   exprt::operandst new_arguments = arguments;
+  new_function.location() = location;
 
   if (!new_lhs.is_nil())
   {
@@ -106,7 +109,7 @@ void goto_convertt::do_function_call_if(
   goto_programt tmp_y;
   goto_programt::targett y;
 
-  do_function_call(lhs, function.op2(), arguments, tmp_y);
+  do_function_call(lhs, function.op2(), arguments, locationt(), tmp_y);
 
   if (tmp_y.instructions.empty())
     y = tmp_y.add_instruction(SKIP);
@@ -129,7 +132,7 @@ void goto_convertt::do_function_call_if(
   // w: f();
   goto_programt tmp_w;
 
-  do_function_call(lhs, function.op1(), arguments, tmp_w);
+  do_function_call(lhs, function.op1(), arguments, locationt(), tmp_w);
 
   if (tmp_w.instructions.empty())
     tmp_w.add_instruction(SKIP);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3251.

```python
def bar(x: int) -> None:
    assert x != 2

def foo(x: int) -> None:
    bar(x + 1)

foo(0)
foo(1) # <---- This one fails
foo(2)
```

This PR:
`--show-stacktrace`
```c
----------------------------------------------------
Violated property:
  file main5.py line 2 column 4 function bar
Stack trace:
  py:main5.py@F@bar at file main5.py line 5 column 4 function foo
  py:main5.py@F@foo at file main5.py line 8 column 0
  python_user_main
  assertion
  x != 2
```