### PR TITLE
[python] fix character comparison in functions with str parameters

### DIFF
--- a/regression/python/github_3288/main.py
+++ b/regression/python/github_3288/main.py
@@ -1,0 +1,11 @@
+def is_digit(c: str) -> bool:
+    return c >= '0' and c <= '9'
+
+def foo(x: str) -> None:
+    assert len(x) > 2
+    assert is_digit(x[0])
+    assert is_digit(x[1])
+    assert is_digit(x[2])
+
+x: str = "123"
+foo(x)

--- a/regression/python/github_3288/test.desc
+++ b/regression/python/github_3288/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3288_fail/main.py
+++ b/regression/python/github_3288_fail/main.py
@@ -1,0 +1,11 @@
+def is_digit(c: str) -> bool:
+    return c >= '0' and c <= '9'
+
+def foo(x: str) -> None:
+    assert len(x) > 2
+    assert is_digit(x[0])
+    assert is_digit(x[1])
+    assert is_digit(x[2])
+
+x: str = "abc"
+foo(x)

--- a/regression/python/github_3288_fail/test.desc
+++ b/regression/python/github_3288_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties: 3 verified, \✗ 3 failed$


### PR DESCRIPTION
This PR fixed two issues in our Python-to-GOTO conversion for character comparisons:

1. **Comparison handling**: When `str` parameters (pointer type) were compared with character literals, the pointer value was treated as a memory address instead of being dereferenced. Added logic in `handle_single_char_comparison()` to dereference pointer parameters before comparison.

2. **Function call argument passing**: When passing a character value (e.g., `x[0]`) to a function expecting a `str` parameter, the character was passed directly instead of as a pointer to a null-terminated string. Added conversion logic to create a temporary array holding the character and null terminator, then pass its address.