### PR TITLE
[python] Convert bool-returning functions to side-effect exprs in logical ops

### DIFF
--- a/regression/python/github_3288_2/main.py
+++ b/regression/python/github_3288_2/main.py
@@ -1,0 +1,9 @@
+def is_digit(c: str) -> bool:
+    return c >= '0' and c <= '9'
+
+def foo(x: str) -> None:
+    assert len(x) > 2
+    assert is_digit(x[0]) and is_digit(x[1]) and is_digit(x[2])
+
+x: str = "123"
+foo(x)

--- a/regression/python/github_3288_2/test.desc
+++ b/regression/python/github_3288_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3288_2_fail/main.py
+++ b/regression/python/github_3288_2_fail/main.py
@@ -1,0 +1,9 @@
+def is_digit(c: str) -> bool:
+    return c >= '0' and c <= '9'
+
+def foo(x: str) -> None:
+    assert len(x) > 2
+    assert is_digit(x[0]) and is_digit(x[1]) and is_digit(x[2])
+
+x: str = "abc"
+foo(x)

--- a/regression/python/github_3288_2_fail/test.desc
+++ b/regression/python/github_3288_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3288.

When boolean-returning functions are used as operands in logical operations (and/or), they must be represented as side-effect expressions rather than code statements to convert to GOTO IR properly.

This PR:
1. Sets `is_converting_rhs` flag when processing logical operator operands.
2. Convert boolean-returning `code_function_callt` to `side_effect_expr_function_callt` when the flag is active.

This ensures that function calls in expression contexts are properly represented while preserving the normal behavior of standalone calls.