### PR TITLE
[python] fix crash on open-ended string slice with pointer parameters

### DIFF
--- a/regression/python/github_3295/main.py
+++ b/regression/python/github_3295/main.py
@@ -1,0 +1,6 @@
+def f(s: str) -> None:
+    ss: str = s[1:]
+    assert ss == "oo"
+
+s: str = "foo"
+f(s)

--- a/regression/python/github_3295/test.desc
+++ b/regression/python/github_3295/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3295_fail/main.py
+++ b/regression/python/github_3295_fail/main.py
@@ -1,0 +1,6 @@
+def f(s: str) -> None:
+    ss: str = s[2:]
+    assert ss == "oo"
+
+s: str = "foo"
+f(s)

--- a/regression/python/github_3295_fail/test.desc
+++ b/regression/python/github_3295_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3295.

This PR calls `strlen()` to determine the upper bound before creating the slice array, avoiding the double declaration.

When slicing string parameters with open-ended syntax (e.g., `s[1:]`), ESBMC generated a zero-length array declaration followed by a redeclaration with the correct size, causing a "migrate expr failed" crash. The issue occurred because pointer types (string parameters) don't have compile-time length information. 

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.