### PR TITLE
[python] fix character and string comparison handling

### DIFF
--- a/regression/python-coverage/branch_coverage_complex/test.desc
+++ b/regression/python-coverage/branch_coverage_complex/test.desc
@@ -1,7 +1,7 @@
 THOROUGH
 main.py
 --branch-coverage
-^Branches : 20
-^Reached : 20
+^Branches : 16
+^Reached : 16
 ^Branch Coverage: 100%
 ^VERIFICATION FAILED$

--- a/regression/python/github_3297/main.py
+++ b/regression/python/github_3297/main.py
@@ -1,0 +1,10 @@
+def my_find(s: str, c: str, start_index: int = 0) -> int:
+    """Find the index of the first occurrence of a character in a string."""
+    for i in range(start_index, len(s)):
+        if s[i] == c:
+            return i
+    return -1
+
+s: str = "foo:bar"
+i = my_find(s, ':')
+assert i == 3

--- a/regression/python/github_3297/test.desc
+++ b/regression/python/github_3297/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3297_fail/main.py
+++ b/regression/python/github_3297_fail/main.py
@@ -1,0 +1,10 @@
+def my_find(s: str, c: str, start_index: int = 0) -> int:
+    """Find the index of the first occurrence of a character in a string."""
+    for i in range(start_index, len(s)):
+        if s[i] == c:
+            return i
+    return -1
+
+s: str = "foo:bar"
+i = my_find(s, ':')
+assert i == -1

--- a/regression/python/github_3297_fail/test.desc
+++ b/regression/python/github_3297_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1765,12 +1765,17 @@ exprt python_converter::handle_relational_type_mismatches(
   exprt &rhs,
   const nlohmann::json &element)
 {
-  // Single character comparisons
-  if (type_utils::is_ordered_comparison(op))
+  // Single character comparisons (including equality/inequality)
+  if (type_utils::is_ordered_comparison(op) || op == "Eq" || op == "NotEq")
   {
-    exprt char_comp_result = handle_single_char_comparison(op, lhs, rhs);
-    if (!char_comp_result.is_nil())
-      return char_comp_result;
+    // Special handling. Reject cases where both operands are character arrays (like chr(65) == "A")
+    // Todo: we should change the all expression to a correct format in future.
+    if (!(lhs.type().is_array() && rhs.type().is_array()))
+    {
+      exprt char_comp_result = handle_single_char_comparison(op, lhs, rhs);
+      if (!char_comp_result.is_nil())
+        return char_comp_result;
+    }
   }
 
   // Float vs string comparisons

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1770,7 +1770,9 @@ exprt python_converter::handle_relational_type_mismatches(
   {
     // Special handling. Reject cases where both operands are character arrays (like chr(65) == "A")
     // Todo: we should change the all expression to a correct format in future.
-    if (!(lhs.type().is_array() && rhs.type().is_array()))
+    bool both_arrays = lhs.type().is_array() && rhs.type().is_array();
+    
+    if (!both_arrays)
     {
       exprt char_comp_result = handle_single_char_comparison(op, lhs, rhs);
       if (!char_comp_result.is_nil())

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1771,7 +1771,7 @@ exprt python_converter::handle_relational_type_mismatches(
     // Special handling. Reject cases where both operands are character arrays (like chr(65) == "A")
     // Todo: we should change the all expression to a correct format in future.
     bool both_arrays = lhs.type().is_array() && rhs.type().is_array();
-    
+
     if (!both_arrays)
     {
       exprt char_comp_result = handle_single_char_comparison(op, lhs, rhs);

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -481,7 +481,7 @@ exprt string_handler::handle_string_operations(
   assert(lhs.type().is_array() || lhs.type().is_pointer());
   assert(rhs.type().is_array() || rhs.type().is_pointer());
 
-  if (op == "Eq" || op == "NotEq")
+  if (op == "Eq" || op == "NotEq" || type_utils::is_ordered_comparison(op))
     return handle_string_comparison(op, lhs, rhs, element);
   else if (op == "Add")
     return handle_string_concatenation(lhs, rhs, left, right);


### PR DESCRIPTION
Fixes #3297

## Description

This PR fixes character and string comparison handling in the Python frontend, addressing issues with single character comparisons, string ordered comparisons, and `chr()` function return value comparisons.

## Problem

1. **Character comparison in functions**: Comparisons like `s[i] == c` (where `s[i]` is a single character from a string and `c` is a character literal) were not being handled correctly, causing incorrect verification results.

2. **String ordered comparisons**: String comparisons with ordered operators (`<`, `>`, `<=`, `>=`) like `"A" < "B"` were not being routed to the string comparison handler, leading to verification failures.

3. **chr() function comparisons**: Comparisons involving `chr()` return values (e.g., `chr(65) == "A"`) were incorrectly being processed as single character comparisons instead of string comparisons.

4. This seems to be a technical debt. We should try to unify the operation and expression of single char string. It might need to be covered in the string_handler refactor.

## Solution

1. **Extended `handle_relational_type_mismatches`**: Added support for `Eq` and `NotEq` operators to handle single character comparisons. Added a check to reject cases where both operands are character arrays (like `chr(65) == "A"`), routing them to string comparison instead.

2. **Extended `handle_string_operations`**: Added support for ordered comparison operators (`Lt`, `Gt`, `LtE`, `GtE`) to properly route string comparisons to `handle_string_comparison`, which uses `strcmp` for lexicographical comparison.

## Changes

- `src/python-frontend/python_converter.cpp`: 
  - Modified `handle_relational_type_mismatches` to handle `Eq`/`NotEq` for single character comparisons
  - Added `both_arrays` check to reject both-array cases and route them to string comparison
  
- `src/python-frontend/string_handler.cpp`:
  - Extended `handle_string_operations` to support ordered comparisons (`Lt`, `Gt`, `LtE`, `GtE`)

## Testing

All affected tests now pass:
- ✅ `regression/python/github_3297/main.py`: Character comparison in functions with str parameters
- ✅ `regression/python/casting10/main.py`: String ordered comparisons (`"A" < "B"`)
- ✅ `regression/python/casting14/main.py`: `chr()` and string indexing comparisons

## Related Issues

Fixes character comparison issues related to #3297 and casting test cases.
