### PR TITLE
[python] fix type inference for Union/Optional type annotations

### DIFF
--- a/regression/python/github_3307/main.py
+++ b/regression/python/github_3307/main.py
@@ -1,0 +1,5 @@
+def foo(s: list[str] | None = None) -> None:
+    if s is not None:
+        assert len(s) > 0, "s must not be empty"
+
+foo(["a", "b", "c"])

--- a/regression/python/github_3307/test.desc
+++ b/regression/python/github_3307/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3307_2/main.py
+++ b/regression/python/github_3307_2/main.py
@@ -1,0 +1,5 @@
+def foo(s: list[int] | None = None) -> None:
+    if s is not None:
+        assert len(s) > 0, "s must not be empty"
+
+foo([1, 2, 3])

--- a/regression/python/github_3307_2/test.desc
+++ b/regression/python/github_3307_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3307_2_fail/main.py
+++ b/regression/python/github_3307_2_fail/main.py
@@ -1,0 +1,5 @@
+def foo(s: list[int] | None = None) -> None:
+    if s is not None:
+        assert len(s) == 2, "s has three elements"
+
+foo([1, 2, 3])

--- a/regression/python/github_3307_2_fail/test.desc
+++ b/regression/python/github_3307_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3307_fail/main.py
+++ b/regression/python/github_3307_fail/main.py
@@ -1,0 +1,5 @@
+def foo(s: list[str] | None = None) -> None:
+    if s is not None:
+        assert len(s) == 4, "s has three elements"
+
+foo(["a", "b", "c"])

--- a/regression/python/github_3307_fail/test.desc
+++ b/regression/python/github_3307_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -117,14 +117,65 @@ std::string type_handler::get_var_type(const std::string &var_name) const
     return std::string();
 
   const auto &annotation = ref["annotation"];
+
+  // Handle simple type annotations: int, str, list, etc.
   if (annotation.is_object() && annotation.contains("id"))
     return annotation["id"].get<std::string>();
 
+  // Handle subscripted types: List[str], Optional[int], etc.
   if (
     annotation.is_object() && annotation.contains("_type") &&
     annotation["_type"] == "Subscript" && annotation.contains("value") &&
     annotation["value"].is_object() && annotation["value"].contains("id"))
     return annotation["value"]["id"];
+
+  // Handle Union types (e.g., list[str] | None, str | int)
+  // Union is represented as BinOp with BitOr operator
+  if (
+    annotation.is_object() && annotation.contains("_type") &&
+    annotation["_type"] == "BinOp" && annotation.contains("op") &&
+    annotation["op"]["_type"] == "BitOr")
+  {
+    // For Union types, extract the non-None type
+    // Check left side first
+    if (annotation.contains("left"))
+    {
+      const auto &left = annotation["left"];
+
+      // Skip None type on the left
+      if (!(left.contains("_type") && left["_type"] == "Constant" &&
+            left.contains("value") && left["value"].is_null()))
+      {
+        // Recursively extract type from left side
+        if (left.contains("id"))
+          return left["id"].get<std::string>();
+
+        // Handle subscripted types on left: list[str] | None
+        if (
+          left["_type"] == "Subscript" && left.contains("value") &&
+          left["value"].contains("id"))
+          return left["value"]["id"].get<std::string>();
+      }
+    }
+
+    // If left was None, check right side
+    if (annotation.contains("right"))
+    {
+      const auto &right = annotation["right"];
+
+      if (!(right.contains("_type") && right["_type"] == "Constant" &&
+            right.contains("value") && right["value"].is_null()))
+      {
+        if (right.contains("id"))
+          return right["id"].get<std::string>();
+
+        if (
+          right["_type"] == "Subscript" && right.contains("value") &&
+          right["value"].contains("id"))
+          return right["value"]["id"].get<std::string>();
+      }
+    }
+  }
 
   return std::string();
 }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3307.

This PR adds support for parsing Union types represented as `BinOp` with `BitOr` operator in the AST. Extract the non-None type from the union by checking both left and right operands, handling both simple types (`str | None`) and subscripted types (`list[str] | None`). 

Before this PR, the type handler's `get_var_type()` returned an empty string for Union type annotations (e.g., `list[str] | None`), causing downstream code to misinterpret the variable type. This led to `len()` incorrectly using `strlen` instead of `__ESBMC_get_object_size` for list types.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.