### PR TITLE
[python] fix attribute access on union type parameters

### DIFF
--- a/regression/python/github_3305/main.py
+++ b/regression/python/github_3305/main.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+assert foo(datetime(2, 3, 4)) == (2, 3, 4)

--- a/regression/python/github_3305/test.desc
+++ b/regression/python/github_3305/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3305_2/main.py
+++ b/regression/python/github_3305_2/main.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, int):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+assert foo("foo") == (0, 0, 0)

--- a/regression/python/github_3305_2/test.desc
+++ b/regression/python/github_3305_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3305_fail/main.py
+++ b/regression/python/github_3305_fail/main.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+assert foo(datetime(2, 3, 4)) == (1, 3, 4)

--- a/regression/python/github_3305_fail/test.desc
+++ b/regression/python/github_3305_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3305.

When a function parameter has a union type (e.g., `str | datetime`), it's represented internally as `pointer->array` (char*). Accessing attributes on such parameters (e.g., `datetime_str.year`) previously failed because the code couldn't resolve the class type from the union representation.

This PR adds special handling for union types by:
- Detecting when the symbol type is `array[char]` (union representation).
- Searching all class types in the symbol table to find one that has the requested attribute.
- Casting the pointer from `char*` to the concrete class type.
- Dereferencing and performing member access on the struct type.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.