### PR TITLE
[python] add type-based API for nondet_dict with comprehensive test suite

### DIFF
--- a/regression/python/nondet_dict10/main.py
+++ b/regression/python/nondet_dict10/main.py
@@ -1,0 +1,11 @@
+def test_nondet_dict_key_exists() -> None:
+    """Test key membership in nondet dictionary."""
+    x = nondet_dict(2, key_type=nondet_int(), value_type=nondet_int())
+    __ESBMC_assume(len(x) > 0)
+    
+    # Test that at least one key could exist
+    k: int = nondet_int()
+    # If the dict is non-empty, membership test should work
+    exists: bool = k in x
+    assert exists == True or exists == False  # Trivially true
+test_nondet_dict_key_exists()

--- a/regression/python/nondet_dict10/test.desc
+++ b/regression/python/nondet_dict10/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict10_fail/main.py
+++ b/regression/python/nondet_dict10_fail/main.py
@@ -1,0 +1,9 @@
+def test_nondet_dict_key_exists() -> None:
+    """Test key membership in nondet dictionary."""
+    x = nondet_dict(2, key_type=nondet_int(), value_type=nondet_int())
+    __ESBMC_assume(len(x) > 0)
+    
+    k: int = nondet_int()
+    exists: bool = k in x
+    assert exists == True
+test_nondet_dict_key_exists()

--- a/regression/python/nondet_dict10_fail/test.desc
+++ b/regression/python/nondet_dict10_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/nondet_dict11/main.py
+++ b/regression/python/nondet_dict11/main.py
@@ -1,0 +1,7 @@
+def test_nondet_dict_empty_possible() -> None:
+    """Test that empty dictionary is possible."""
+    x = nondet_dict(5)
+    # This should be satisfiable - empty dict is valid
+    if len(x) == 0:
+        assert len(x) == 0
+test_nondet_dict_empty_possible()

--- a/regression/python/nondet_dict11/test.desc
+++ b/regression/python/nondet_dict11/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict11_fail/main.py
+++ b/regression/python/nondet_dict11_fail/main.py
@@ -1,0 +1,6 @@
+def test_nondet_dict_empty_possible() -> None:
+    """Test that empty dictionary is possible."""
+    x = nondet_dict(5)
+    if len(x) == 0:
+        assert len(x) == 1
+test_nondet_dict_empty_possible()

--- a/regression/python/nondet_dict11_fail/test.desc
+++ b/regression/python/nondet_dict11_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/nondet_dict12/main.py
+++ b/regression/python/nondet_dict12/main.py
@@ -1,0 +1,6 @@
+def test_nondet_dict_int_to_int() -> None:
+    """Test nondet dictionary with int keys and int values."""
+    x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+    assert len(x) >= 0
+    assert len(x) <= 3
+test_nondet_dict_int_to_int()

--- a/regression/python/nondet_dict12/test.desc
+++ b/regression/python/nondet_dict12/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict12_fail/main.py
+++ b/regression/python/nondet_dict12_fail/main.py
@@ -1,0 +1,5 @@
+def test_nondet_dict_int_to_int() -> None:
+    """Test nondet dictionary with int keys and int values."""
+    x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+    assert len(x) == 0
+test_nondet_dict_int_to_int()

--- a/regression/python/nondet_dict12_fail/test.desc
+++ b/regression/python/nondet_dict12_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/nondet_dict13/main.py
+++ b/regression/python/nondet_dict13/main.py
@@ -1,0 +1,9 @@
+def test_nondet_dict_access_value() -> None:
+       x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+       __ESBMC_assume(len(x) > 0)
+       k: int = nondet_int()
+       if k in x:
+           v = x[k]
+           assert v == v
+
+test_nondet_dict_access_value()

--- a/regression/python/nondet_dict13/test.desc
+++ b/regression/python/nondet_dict13/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict13_fail/main.py
+++ b/regression/python/nondet_dict13_fail/main.py
@@ -1,0 +1,9 @@
+def test_nondet_dict_access_value() -> None:
+       x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+       __ESBMC_assume(len(x) > 0)
+       k: int = nondet_int()
+       if k in x:
+           v = x[k]
+           assert v != v
+
+test_nondet_dict_access_value()

--- a/regression/python/nondet_dict13_fail/test.desc
+++ b/regression/python/nondet_dict13_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/nondet_dict14/main.py
+++ b/regression/python/nondet_dict14/main.py
@@ -1,0 +1,9 @@
+def test_nondet_dict_str_keys() -> None:
+       x = nondet_dict(2, key_type=nondet_str(), value_type=nondet_int())
+       __ESBMC_assume(len(x) > 0)
+       k: str = nondet_str()
+       if k in x:
+           v = x[k]
+           assert v == v
+
+test_nondet_dict_str_keys()

--- a/regression/python/nondet_dict14/test.desc
+++ b/regression/python/nondet_dict14/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict5/main.py
+++ b/regression/python/nondet_dict5/main.py
@@ -1,0 +1,7 @@
+def test_nondet_dict_basic() -> None:
+    """Test basic nondet dictionary creation and access."""
+    x = nondet_dict(2)
+    assert len(x) >= 0
+    assert len(x) <= 2
+
+test_nondet_dict_basic()

--- a/regression/python/nondet_dict5/test.desc
+++ b/regression/python/nondet_dict5/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict6/main.py
+++ b/regression/python/nondet_dict6/main.py
@@ -1,0 +1,6 @@
+def test_nondet_dict_default_size() -> None:
+    """Test nondet dictionary with default size."""
+    x = nondet_dict()
+    assert len(x) >= 0
+    assert len(x) <= 8  # Default max size
+test_nondet_dict_default_size()

--- a/regression/python/nondet_dict6/test.desc
+++ b/regression/python/nondet_dict6/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict7/main.py
+++ b/regression/python/nondet_dict7/main.py
@@ -1,0 +1,9 @@
+def test_nondet_dict_bool_to_int() -> None:
+    """Test nondet dictionary with bool keys and int values."""
+    x = nondet_dict(2, key_type=nondet_bool(), value_type=nondet_int())
+    assert len(x) >= 0
+    assert len(x) <= 2
+    # Bool keys can only have at most 2 distinct values (True, False)
+    __ESBMC_assume(len(x) == 2)
+    assert len(x) == 2
+test_nondet_dict_bool_to_int()

--- a/regression/python/nondet_dict7/test.desc
+++ b/regression/python/nondet_dict7/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict8/main.py
+++ b/regression/python/nondet_dict8/main.py
@@ -1,0 +1,12 @@
+def test_nondet_dict_iteration() -> None:
+    """Test iterating over nondet dictionary keys."""
+    x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+    __ESBMC_assume(len(x) == 2)
+    
+    count: int = 0
+    for key in x:
+        count = count + 1
+        assert key in x
+    
+    assert count == 2
+test_nondet_dict_iteration()

--- a/regression/python/nondet_dict8/test.desc
+++ b/regression/python/nondet_dict8/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_dict9/main.py
+++ b/regression/python/nondet_dict9/main.py
@@ -1,0 +1,12 @@
+def test_nondet_dict_float_values() -> None:
+    """Test nondet dictionary with float values."""
+    x = nondet_dict(2, key_type=nondet_int(), value_type=nondet_float())
+    __ESBMC_assume(len(x) > 0)
+    
+    # Test value access with nondet key
+    k: int = nondet_int()
+    if k in x:
+        v = x[k]
+        # Float value comparisons
+        assert v == v  # Reflexivity
+test_nondet_dict_float_values()

--- a/regression/python/nondet_dict9/test.desc
+++ b/regression/python/nondet_dict9/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -9,10 +9,10 @@ USAGE:
     x = nondet_list(max_size=10, elem_type=nondet_bool())     # bool list, size [0, 10]
     
     # Dictionaries:
-    x = nondet_dict()                                    # str->int dict, size [0, 8]
-    x = nondet_dict(5)                                   # str->int dict, size [0, 5]
-    x = nondet_dict(key_type=nondet_str(), value_type=nondet_float())
-    x = nondet_dict(max_size=10, key_type=nondet_int(), value_type=nondet_bool())
+    d = nondet_dict()                                    # int->int dict, size [0, 8]
+    d = nondet_dict(5)                                   # int->int dict, size [0, 5]
+    d = nondet_dict(key_type=nondet_str(), value_type=nondet_float())
+    d = nondet_dict(max_size=10, key_type=nondet_int(), value_type=nondet_bool())
 """
 
 from typing import Any
@@ -44,8 +44,8 @@ def nondet_list(max_size: int = _DEFAULT_NONDET_SIZE, elem_type: Any = None) -> 
     Args:
         max_size: Maximum size of the list (default: 8).
                   The actual size will be in range [0, max_size].
-        elem_type: Type constructor for list elements (default: nondet_int()).
-              Supported: nondet_int(), nondet_float(), nondet_bool()
+        elem_type: Value returned by type constructor for list elements (default: nondet_int()).
+                   Supported: nondet_int(), nondet_float(), nondet_bool(), nondet_str()
     
     Returns:
         list: A list with arbitrary size and contents of specified type.
@@ -74,23 +74,32 @@ def nondet_dict(max_size: int = _DEFAULT_NONDET_SIZE,
     Args:
         max_size: Maximum size of the dictionary (default: 8).
                   The actual size will be in range [0, max_size].
-        key_type: Type constructor for dictionary keys (default: nondet_int()).
+        key_type: Value returned by type constructor for dictionary keys (default: nondet_int()).
                   Supported: nondet_int(), nondet_str(), nondet_bool()
-        value_type: Type constructor for dictionary values (default: nondet_int()).
+        value_type: Value returned by type constructor for dictionary values (default: nondet_int()).
                     Supported: nondet_int(), nondet_float(), nondet_bool(), nondet_str()
 
     Returns:
         dict: A dictionary with arbitrary size and contents of specified types.
+
+    Examples:
+        d = nondet_dict()                    # int->int dict, size [0, 8]
+        d = nondet_dict(5)                   # int->int dict, size [0, 5]
+        d = nondet_dict(key_type=nondet_str(), value_type=nondet_float())
+        d = nondet_dict(max_size=10, key_type=nondet_int(), value_type=nondet_bool())
     """
+    # Default to nondet_int if no types specified
+    if key_type is None:
+        key_type = nondet_int()
+    if value_type is None:
+        value_type = nondet_int()
+
     result: dict = {}
     size: int = _nondet_size(max_size)
 
     i: int = 0
     while i < size:
-        # Generate fresh nondet values inside the loop
-        k: int = nondet_int() if key_type is None else key_type
-        v: int = nondet_int() if value_type is None else value_type
-        result[k] = v
+        result[key_type] = value_type
         i = i + 1
 
     return result


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3177.

This PR:
- Updates `nondet_dict` to match `nondet_list` pattern.
- Adds default handling for `key_type` and `value_type` parameters before the loop.
- Simplifies the loop body to use the same nondet value.
- Adds comprehensive test cases covering:
  * Basic creation and size bounds
  * Multiple type combinations (int, float, bool)
  * Dictionary operations (access, membership, iteration)
  * Edge cases (empty, full size, exact size constraints)

All tests avoid unsupported methods (`keys/values/items`) for ESBMC.