### PR TITLE
[Python verification] support str find method

### DIFF
--- a/regression/python/str-find/main.py
+++ b/regression/python/str-find/main.py
@@ -1,0 +1,9 @@
+s: str = "foo:bar:baz"
+i = s.find(':')
+assert i == 3
+
+i1 = s.find('')
+assert i1 == 0
+
+i2 = s.find('d')
+assert i2 == -1

--- a/regression/python/str-find/test.desc
+++ b/regression/python/str-find/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/str-find_fail/main.py
+++ b/regression/python/str-find_fail/main.py
@@ -1,0 +1,9 @@
+s: str = "foo:bar:baz"
+i = s.find(':')
+assert i != 3
+
+i1 = s.find('')
+assert i1 == 0
+
+i2 = s.find('d')
+assert i2 == -1

--- a/regression/python/str-find_fail/test.desc
+++ b/regression/python/str-find_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -170,6 +170,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_str_islower",
   "__python_char_lower",
   "__python_str_lower",
+  "__python_str_find",
   "__ESBMC_create_inf_obj",
   "__python_int",
   "__python_chr",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -184,6 +184,27 @@ __ESBMC_HIDE:;
   return buffer;
 }
 
+int __python_str_find(const char *s1, const char *s2)
+{
+__ESBMC_HIDE:;
+  // str.find('') = 0
+  if (s2[0] == '\0')
+    return 0;
+
+  int len_s = strlen(s1);
+  int len_sub = strlen(s2);
+
+  int i = 0;
+  while (i <= len_s - len_sub)
+  {
+    if (strncmp(s1 + i, s2, len_sub) == 0)
+      return i;
+    i++;
+  }
+
+  return -1;
+}
+
 // Python int() builtin - converts string to integer
 int __python_int(const char *s, int base)
 {

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -578,6 +578,20 @@ exprt function_call_builder::build() const
       return converter_.get_string_handler().handle_string_lower(obj_expr, loc);
     }
 
+    if (method_name == "find")
+    {
+      exprt obj_expr = converter_.get_expr(call_["func"]["value"]);
+
+      if (call_["args"].size() != 1)
+        throw std::runtime_error("find() requires exactly one argument");
+
+      exprt find_arg = converter_.get_expr(call_["args"][0]);
+
+      locationt loc = converter_.get_location_from_decl(call_);
+      return converter_.get_string_handler().handle_string_find(
+        obj_expr, find_arg, loc);
+    }
+
     if (method_name == "isalpha")
     {
       exprt obj_expr = converter_.get_expr(call_["func"]["value"]);

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -1215,6 +1215,34 @@ exprt string_handler::handle_string_lower(
   return lower_call;
 }
 
+exprt string_handler::handle_string_find(
+  const exprt &string_obj,
+  const exprt &find_arg,
+  const locationt &location)
+{
+  exprt string_copy = string_obj;
+  exprt str_expr = ensure_null_terminated_string(string_copy);
+  exprt str_addr = get_array_base_address(str_expr);
+
+  exprt arg_copy = find_arg;
+  exprt arg_expr = ensure_null_terminated_string(arg_copy);
+  exprt arg_addr = get_array_base_address(arg_expr);
+
+  symbolt *find_str_symbol =
+    symbol_table_.find_symbol("c:@F@__python_str_find");
+  if (!find_str_symbol)
+    throw std::runtime_error("str_find function not found in symbol table");
+
+  side_effect_expr_function_callt find_call;
+  find_call.function() = symbol_expr(*find_str_symbol);
+  find_call.arguments().push_back(str_addr);
+  find_call.arguments().push_back(arg_addr);
+  find_call.location() = location;
+  find_call.type() = int_type();
+
+  return find_call;
+}
+
 exprt string_handler::handle_string_to_int(
   const exprt &string_obj,
   const exprt &base_arg,

--- a/src/python-frontend/string_handler.h
+++ b/src/python-frontend/string_handler.h
@@ -281,6 +281,19 @@ public:
    */
   exprt handle_string_lower(const exprt &string_obj, const locationt &location);
 
+  /**
+   * @brief Handle str.find() method
+   * @param string_obj String object
+   * @param find_arg String to check
+   * @param location Source location
+   * @return returns the index of the first occurrence of the substring.
+   * If not found, it returns -1.
+   */
+  exprt handle_string_find(
+    const exprt &string_obj,
+    const exprt &find_arg,
+    const locationt &location);
+
   // Utility methods
 
   /**


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3296.

Some issues with the simplified module have led us to have to use `--incremental-bmc`.

Cannot be simplified:
```
s: str = "foo:bar:baz"
i = s.find(':')
```

Can be:
```
s: str = "foo:bar:baz"
a: str = ':'
i = s.find(a)
```

Additionally, in Python's c2goto, it seems that such code cannot be used. Has anyone encountered this issue?
```
for (int i = 0; i < 1; ++i)
{
}
```