### PR TITLE
[python] move dict type resolution to python_dict_handler

### DIFF
--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -58,6 +58,9 @@ public:
   }
   exprt get_expr(const nlohmann::json &element);
   std::string get_op(const std::string &op, const typet &type) const;
+  typet get_type_from_annotation(
+    const nlohmann::json &annotation_node,
+    const nlohmann::json &element);
 
   string_builder &get_string_builder();
 
@@ -165,24 +168,6 @@ public:
     exprt &rhs,
     const nlohmann::json &element);
 
-  /**
-   * @brief Resolves dictionary subscript types for binary operations.
-   *
-   * When comparing dictionary values with primitive types (int, bool, float),
-   * the dict subscript initially returns a char* pointer. This method detects
-   * such cases and re-fetches the dictionary value with the correct expected type.
-   *
-   * @param left The left operand JSON AST node.
-   * @param right The right operand JSON AST node.
-   * @param lhs The left operand expression (may be modified).
-   * @param rhs The right operand expression (may be modified).
-   */
-  void resolve_dict_subscript_types(
-    const nlohmann::json &left,
-    const nlohmann::json &right,
-    exprt &lhs,
-    exprt &rhs);
-
   python_typechecking &get_typechecker();
   const python_typechecking &get_typechecker() const;
 
@@ -250,10 +235,6 @@ private:
   std::string remove_quotes_from_type_string(const std::string &type_string);
 
   bool function_has_missing_return_paths(const nlohmann::json &function_node);
-
-  typet get_type_from_annotation(
-    const nlohmann::json &annotation_node,
-    const nlohmann::json &element);
 
   symbolt create_return_temp_variable(
     const typet &return_type,
@@ -364,9 +345,6 @@ private:
     const std::string &op,
     const exprt &lhs,
     const exprt &rhs);
-
-  exprt
-  handle_single_char_comparison(const std::string &op, exprt &lhs, exprt &rhs);
 
   void get_attributes_from_self(
     const nlohmann::json &method_body,
@@ -492,20 +470,6 @@ private:
   // =========================================================================
   // Dictionary assignment helper methods
   // =========================================================================
-
-  /**
-   * Extract the value type from a dict type annotation.
-   * For dict[K, V], returns V.
-   * For dict[K, dict[K2, V2]], returns dict[K2, V2].
-   */
-  typet
-  get_dict_value_type_from_annotation(const nlohmann::json &annotation_node);
-
-  /**
-   * Resolve the expected return type for a dict subscript operation
-   * by examining the dict variable's type annotation.
-   */
-  typet resolve_expected_type_for_dict_subscript(const exprt &dict_expr);
 
   /**
    * @brief Handles dictionary subscript assignment (dict[key] = value).
@@ -862,20 +826,10 @@ private:
   // String method helpers
   // =========================================================================
 
-  exprt handle_str_join(const nlohmann::json &call_json);
-
   exprt handle_string_type_mismatch(
     const exprt &lhs,
     const exprt &rhs,
     const std::string &op);
-
-  // Create character comparison expression from preprocessed operands
-  exprt create_char_comparison_expr(
-    const std::string &op,
-    const exprt &lhs_char_value,
-    const exprt &rhs_char_value,
-    const exprt &lhs_source,
-    const exprt &rhs_source) const;
 
   void process_forward_reference(
     const nlohmann::json &annotation,

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -102,6 +102,7 @@ class symbolt;
  * - Dictionary mutation (assignment, deletion)
  * - Membership testing (`in` / `not in`)
  * - Nested dictionary support with proper reference semantics
+ * - Type resolution for dictionary subscripts
  */
 class python_dict_handler
 {
@@ -283,6 +284,50 @@ public:
    * @return The struct_typet representing Python dictionaries.
    */
   struct_typet get_dict_struct_type();
+
+  /**
+   * @brief Resolve dictionary subscript types for comparisons
+   *
+   * When comparing dict[key] with primitives, this method ensures both
+   * operands have compatible types by dereferencing dict subscripts.
+   *
+   * Handles three cases:
+   * 1. LHS is dict subscript, RHS is primitive
+   * 2. RHS is dict subscript, LHS is primitive  
+   * 3. Both are dict subscripts
+   *
+   * @param left Left JSON AST node
+   * @param right Right JSON AST node
+   * @param lhs Left operand expression (modified in place)
+   * @param rhs Right operand expression (modified in place)
+   */
+  void resolve_dict_subscript_types(
+    const nlohmann::json &left,
+    const nlohmann::json &right,
+    exprt &lhs,
+    exprt &rhs);
+
+  /**
+   * @brief Extract value type from dict type annotation
+   *
+   * For annotations like `dict[K, V]`, extracts the value type V.
+   *
+   * @param annotation_node The annotation AST node (Subscript with slice)
+   * @return The value type, or empty_typet if cannot be determined
+   */
+  typet
+  get_dict_value_type_from_annotation(const nlohmann::json &annotation_node);
+
+  /**
+   * @brief Resolve expected type for dict subscript using variable annotation
+   *
+   * Looks up the dict variable's annotation to determine what type
+   * the subscript operation should return.
+   *
+   * @param dict_expr The dictionary expression (must be a symbol)
+   * @return The expected value type from annotation, or empty_typet
+   */
+  typet resolve_expected_type_for_dict_subscript(const exprt &dict_expr);
 
 private:
   /// Reference to the main Python converter


### PR DESCRIPTION
This PR moves dictionary type resolution methods from `python_converter` to `python_dict_handler` to improve modularity. In particular, this PR:
- Moves `resolve_dict_subscript_types()` (~75 lines)
- Moves `get_dict_value_type_from_annotation()` (~20 lines)
- Moves `resolve_expected_type_for_dict_subscript()` (~25 lines)

This PR also adds public accessor `get_type_from_annotation()` to `python_converter` for handler delegation. Lastly, it adds `json_utils.h` include to `python_dict_handler`. It updates `python_converter` to delegate dict type resolution operations.

Total reduction: ~120 lines from `python_converter.cpp`.