### PR TITLE
[python] fix union type variable declarations with deferred assignment

### DIFF
--- a/regression/python/github_3313/main.py
+++ b/regression/python/github_3313/main.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+dt: str | datetime
+dt = datetime(2, 3, 4)
+rv = (2, 3, 4)
+assert foo(dt) == rv

--- a/regression/python/github_3313/test.desc
+++ b/regression/python/github_3313/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3313_2/main.py
+++ b/regression/python/github_3313_2/main.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+dt: str | datetime
+dt = "foo"
+rv = (0, 0, 0)
+assert foo(dt) == rv

--- a/regression/python/github_3313_2/test.desc
+++ b/regression/python/github_3313_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3313_2_fail/main.py
+++ b/regression/python/github_3313_2_fail/main.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+dt: str | datetime
+dt = "foo"
+rv = (0, 0, 1)
+assert foo(dt) == rv

--- a/regression/python/github_3313_2_fail/test.desc
+++ b/regression/python/github_3313_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3313_3/main.py
+++ b/regression/python/github_3313_3/main.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+b = nondet_bool()
+
+if b:
+    dt1:datetime = datetime(2, 3, 4)
+    rv = (2, 3, 4)
+    assert foo(dt1) == rv
+else:
+    dt2:str = "foo"
+    rv = (0, 0, 0)
+    assert foo(dt2) == rv
+
+assert b or isinstance(dt2, str)
+assert not b or isinstance(dt1, datetime)

--- a/regression/python/github_3313_3/test.desc
+++ b/regression/python/github_3313_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3313_3_fail/main.py
+++ b/regression/python/github_3313_3_fail/main.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+b = nondet_bool()
+
+if b:
+    dt1:datetime = datetime(2, 3, 4)
+    rv = (2, 3, 4)
+    assert foo(dt1) == rv
+else:
+    dt2:str = "foo"
+    rv = (0, 0, 0)
+    assert foo(dt2) == rv
+
+assert b or isinstance(dt2, datetime) # should fail
+assert not b or isinstance(dt1, datetime)

--- a/regression/python/github_3313_3_fail/test.desc
+++ b/regression/python/github_3313_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_3313_fail/main.py
+++ b/regression/python/github_3313_fail/main.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+def foo(datetime_str: str | datetime) -> tuple[int, int, int]:
+    if isinstance(datetime_str, datetime):
+        return (
+            datetime_str.year,
+            datetime_str.month,
+            datetime_str.day,
+        )
+    else:
+        return (0, 0, 0)
+
+dt: str | datetime
+dt = datetime(2, 3, 4)
+rv = (2, 4, 4)
+assert foo(dt) == rv

--- a/regression/python/github_3313_fail/test.desc
+++ b/regression/python/github_3313_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -43,6 +43,7 @@ ignored_dirs=(
   "github_3090_4_fail"
   "github_3090_5"
   "github_3090_5_fail"
+  "github_3313_3"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3865,6 +3865,25 @@ void python_converter::get_var_assign(
     sid.set_object(name);
     annotated_name = name;
 
+    // Check if this is a forward declaration with union type and no value
+    // e.g., dt: str | datetime (without assignment)
+    // These should be skipped; wait for the actual assignment
+    bool is_union_type = false;
+    if (
+      ast_node.contains("annotation") && !ast_node["annotation"].is_null() &&
+      ast_node["annotation"].contains("_type") &&
+      ast_node["annotation"]["_type"] == "BinOp")
+    {
+      is_union_type = true;
+    }
+
+    if (is_union_type && ast_node["value"].is_null())
+    {
+      // Skip this forward declaration; wait for the actual assignment
+      // that will give us the type information
+      return;
+    }
+
     // Infer type from function return if annotation is "Any"
     lhs_type = infer_type_from_any_annotation(ast_node, lhs_type);
 


### PR DESCRIPTION
This PR skips bare union type annotations without assignments. This defers symbol creation until the assignment provides a concrete type, matching Python's runtime semantics, in which type-only annotations don't create variables. 

Before this PR, when a variable is declared with a union type annotation (e.g., `dt: str | datetime`) followed by a concrete assignment (e.g., `dt: datetime = datetime(2, 3, 4)`), the first declaration was creating a symbol with a generic pointer type, causing the subsequent assignment to fail with "Access to object out of bounds".

