### PR TITLE
[CI] use cache to accelerate the build process

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -22,8 +22,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache CMake dependency src and build
-      uses: actions/cache@v3
+    - uses: actions/cache@v3
+      if: ${{ startsWith(inputs.operating-system, 'ubuntu-') }}
       with:
         path: |
           ${{github.workspace}}/build/_deps/*-src

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -22,6 +22,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Cache CMake dependency src and build
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{github.workspace}}/build/_deps/*-src
+          ${{github.workspace}}/build/_deps/*-build
+          ${{github.workspace}}/build/_deps/*-subbuild
+        key:  |
+          ${{ inputs.operating-system }}-${{ inputs.build-flags }}-${{ hashFiles('**/CMakeLists.txt') }}
+        restore-keys: |
+          ${{ inputs.operating-system }}-${{ inputs.build-flags }}-
+
     - name: Build ESBMC
       run: ./scripts/build.sh ${{ inputs.build-flags }}
     - uses: actions/upload-artifact@v4

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -261,7 +261,7 @@ fi
 OS=`uname`
 
 # Create build directory
-mkdir build && cd build || exit $?
+mkdir -p build && cd build || exit $?
 
 case $OS in
   'Linux')


### PR DESCRIPTION
This PR has set up a cache for External Dependencies to avoid rebuilding them from scratch every time.

https://github.com/actions/cache

We will use the SHA values of all the CMakeLists in the project as identifiers. When there are any modifications to them, we will update the cache.