### PR TITLE
[python] add support for generator expressions

### DIFF
--- a/regression/python/github_3036/main.py
+++ b/regression/python/github_3036/main.py
@@ -1,0 +1,8 @@
+def validate_no_letters(price: str) -> None:
+    assert all(not ('a' <= c.lower() <= 'z') for c in price), "Erro: O valor contém letras."
+
+def main() -> None:
+    price = "123"
+    validate_no_letters(price)
+
+main()

--- a/regression/python/github_3036/test.desc
+++ b/regression/python/github_3036/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3036_2/main.py
+++ b/regression/python/github_3036_2/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    xs = [1, 2, 3]
+    ys = [x * 2 for x in xs]
+    assert ys == [2, 4, 6]
+
+main()

--- a/regression/python/github_3036_2/test.desc
+++ b/regression/python/github_3036_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3036_2_fail/main.py
+++ b/regression/python/github_3036_2_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    xs = [1, 2, 3]
+    ys = [x * 2 for x in xs]
+    assert ys == [2, 4, 5]
+
+main()

--- a/regression/python/github_3036_2_fail/test.desc
+++ b/regression/python/github_3036_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/github_3036_3/main.py
+++ b/regression/python/github_3036_3/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    xs = [1, 2, 3, 4]
+    ys = [x for x in xs if x % 2 == 0]
+    assert ys == [2, 4]
+
+main()

--- a/regression/python/github_3036_3/test.desc
+++ b/regression/python/github_3036_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3036_3_fail/main.py
+++ b/regression/python/github_3036_3_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    xs = [1, 2, 3, 4]
+    ys = [x for x in xs if x % 2 == 0]
+    assert ys == [1, 4]
+
+main()

--- a/regression/python/github_3036_3_fail/test.desc
+++ b/regression/python/github_3036_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/github_3036_4/main.py
+++ b/regression/python/github_3036_4/main.py
@@ -1,0 +1,11 @@
+def main() -> None:
+    xs = [1, 2, 3, 4, 5, 6, 10]
+    # Logic: Keep if (Even AND > 4) OR (exactly 1)
+    # 1 -> Odd (Fail) OR 1==1 (True) -> Keep
+    # 2 -> Even (True) AND > 4 (Fail) -> Fail
+    # 6 -> Even (True) AND > 6 (True) -> Keep
+    ys = [x for x in xs if (x % 2 == 0 and x > 4) or x == 1]
+    
+    assert ys == [1, 6, 10]
+
+main()

--- a/regression/python/github_3036_4/test.desc
+++ b/regression/python/github_3036_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3036_4_fail/main.py
+++ b/regression/python/github_3036_4_fail/main.py
@@ -1,0 +1,11 @@
+def main() -> None:
+    xs = [1, 2, 3, 4, 5, 6, 10]
+    # Logic: Keep if (Even AND > 4) OR (exactly 1)
+    # 1 -> Odd (Fail) OR 1==1 (True) -> Keep
+    # 2 -> Even (True) AND > 4 (Fail) -> Fail
+    # 6 -> Even (True) AND > 6 (True) -> Keep
+    ys = [x for x in xs if (x % 2 == 0 and x > 4) or x == 1]
+    
+    assert ys == [1, 6, 11]
+
+main()

--- a/regression/python/github_3036_4_fail/test.desc
+++ b/regression/python/github_3036_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/github_3036_5/main.py
+++ b/regression/python/github_3036_5/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    xs = [1, 2, 3]
+    # Adding int to float should produce a list of floats
+    ys = [x + 0.5 for x in xs]
+    assert ys == [1.5, 2.5, 3.5]
+    assert isinstance(ys[0], float) 
+
+main()

--- a/regression/python/github_3036_5/test.desc
+++ b/regression/python/github_3036_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3036_5_fail/main.py
+++ b/regression/python/github_3036_5_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    xs = [1, 2, 3]
+    ys = [x + 0.5 for x in xs]
+    assert ys == [1.5, 2.5, 3.4]
+
+main()

--- a/regression/python/github_3036_5_fail/test.desc
+++ b/regression/python/github_3036_5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/github_3036_6/main.py
+++ b/regression/python/github_3036_6/main.py
@@ -1,0 +1,10 @@
+def validate_hex_color(color_code: str) -> None:
+    valid_chars = "0123456789abcdefABCDEF"
+    # Generator checks if every character c exists in the valid_chars string
+    assert all(c in valid_chars for c in color_code), "Error: Invalid hex character found."
+
+def main() -> None:
+    color = "1A2b3C"
+    validate_hex_color(color)
+
+main()

--- a/regression/python/github_3036_6/test.desc
+++ b/regression/python/github_3036_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 25
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3036_6_fail/main.py
+++ b/regression/python/github_3036_6_fail/main.py
@@ -1,0 +1,10 @@
+def validate_hex_color(color_code: str) -> None:
+    valid_chars = "0123456789abcdefABCDEF"
+    # Generator checks if every character c exists in the valid_chars string
+    assert all(c in valid_chars for c in color_code), "Error: Invalid hex character found."
+
+def main() -> None:
+    color_fail = "1A2b3G" # 'G' is invalid
+    validate_hex_color(color_fail)
+
+main()

--- a/regression/python/github_3036_6_fail/test.desc
+++ b/regression/python/github_3036_6_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--no-pointer-check --no-bounds-check --no-align-check --unwind 25
+^VERIFICATION FAILED$

--- a/regression/python/github_3036_fail/main.py
+++ b/regression/python/github_3036_fail/main.py
@@ -1,0 +1,8 @@
+def validate_no_letters(price: str) -> None:
+    assert all(not ('a' <= c.lower() <= 'z') for c in price), "Erro: O valor contém letras."
+
+def main() -> None:
+    price = "123a"
+    validate_no_letters(price)
+
+main()

--- a/regression/python/github_3036_fail/test.desc
+++ b/regression/python/github_3036_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc
+--unwind 5
 ^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -196,6 +196,7 @@ static ExpressionType get_expression_type(const nlohmann::json &element)
     {"Subscript", ExpressionType::SUBSCRIPT},
     {"List", ExpressionType::LIST},
     {"Set", ExpressionType::LIST},
+    {"GeneratorExp", ExpressionType::LIST},
     {"Lambda", ExpressionType::FUNC_CALL},
     {"JoinedStr", ExpressionType::FSTRING},
     {"Tuple", ExpressionType::TUPLE},
@@ -2605,6 +2606,14 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     {
       python_set set_handler(*this, element);
       expr = set_handler.get();
+      break;
+    }
+
+    // Handle generator expressions
+    if (element["_type"] == "GeneratorExp")
+    {
+      python_list list(*this, element);
+      expr = list.handle_comprehension(element);
       break;
     }
 

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -96,6 +96,13 @@ public:
   static typet
   get_list_element_type(const std::string &list_id, size_t index = 0);
 
+  /**
+   * @brief Convert generator expressions and list comprehensions to lists
+   * @param element The GeneratorExp or ListComp AST node
+   * @return Expression representing the materialized list
+   */
+  exprt handle_comprehension(const nlohmann::json &element);
+
 private:
   friend class python_dict_handler;
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3036.

This PR implements conversion of generator expressions (`genexpr`) to imperative loops that build lists. In particular, this PR:
- Adds `GeneratorExp` to the expression type map.
- Implements `handle_comprehension()` in `python_list` class to convert comprehensions to while loops with proper element evaluation.
- Supports iteration over strings, arrays, and dynamic lists.
- Handles filter conditions (if clauses) in comprehensions.
- Ensures element expressions evaluate inside the loop body by managing converter context switches correctly.

Future work: Python comprehensions can have multiple generators.

Thanks to [Spsuelen](https://github.com/Spsuelen) for reporting this issue.