### PR TITLE
[CI] optimize cache hits && switch to the appropriate runner

### DIFF
--- a/.github/workflows/benchexec-diff.yml
+++ b/.github/workflows/benchexec-diff.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   create-diff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/build-onpush.yml
+++ b/.github/workflows/build-onpush.yml
@@ -7,7 +7,7 @@ jobs:
 
   # Check testing tool suite
   testing-tool:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v4
     - name: Runs testing tool unit test

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v5
       if: ${{ startsWith(inputs.operating-system, 'ubuntu-') }}
       with:
         path: |

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -22,15 +22,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/cache@v5
+    # For restore ccache
+    - uses: hendrikmuhs/ccache-action@v1.2
       if: ${{ startsWith(inputs.operating-system, 'ubuntu-') }}
       with:
-        path: |
-          ${{github.workspace}}/build/_deps/*-src
-          ${{github.workspace}}/build/_deps/*-build
-          ${{github.workspace}}/build/_deps/*-subbuild
-        key:  |
-          ${{ inputs.operating-system }}-${{ hashFiles('**/CMakeLists.txt') }}
+        save: ${{ github.event_name == 'push' }}
+        key: ${{ inputs.operating-system }}-${{ hashFiles('**/*.cpp','**/*.h') }}
         restore-keys: |
           ${{ inputs.operating-system }}-
 

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -30,9 +30,9 @@ jobs:
           ${{github.workspace}}/build/_deps/*-build
           ${{github.workspace}}/build/_deps/*-subbuild
         key:  |
-          ${{ inputs.operating-system }}-${{ inputs.build-flags }}-${{ hashFiles('**/CMakeLists.txt') }}
+          ${{ inputs.operating-system }}-${{ hashFiles('**/CMakeLists.txt') }}
         restore-keys: |
-          ${{ inputs.operating-system }}-${{ inputs.build-flags }}-
+          ${{ inputs.operating-system }}-
 
     - name: Build ESBMC
       run: ./scripts/build.sh ${{ inputs.build-flags }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
  
   # Build developer doc
   build-developer-doc:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Git repository
       uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ jobs:
 
   # Check testing tool suite
   testing-tool:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v4
     - name: Runs testing tool unit test
@@ -14,7 +14,7 @@ jobs:
  
   # Build developer doc
   build-developer-doc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Set up Git repository
       uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     # Check project with clang-format
   code-style:
     name: Check C/C++ code-style
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.
@@ -101,7 +101,7 @@ jobs:
   # Check project with YAPF
   python-style:
       name: Check Python code style (YAPF)
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-slim
       permissions:
         contents: write
       steps:
@@ -146,7 +146,7 @@ jobs:
 
   cmake-lint:
     name: Check CMake modules
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     continue-on-error: true # TODO: Eventually this will be removed
     steps:
     - uses: actions/checkout@v4

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,10 +41,12 @@ ubuntu_setup () {
         python-is-python3 csmith python3 \
         git ccache unzip wget curl libcsmith-dev gperf \
         cmake bison flex g++-multilib linux-libc-dev \
-        libboost-all-dev ninja-build python3-setuptools \
-        libtinfo-dev pkg-config python3-pip python3-toml \
+        libboost-date-time-dev libboost-program-options-dev \
+        libboost-iostreams-dev libboost-system-dev \
+        libboost-filesystem-dev ninja-build python3-setuptools \
+        libtinfo-dev python3-pip python3-toml \
         openjdk-11-jdk tar xz-utils \
-    "    
+    "
     if [ -z "$STATIC" ]; then STATIC=ON; fi
     if [ $STATIC = OFF ]; then
         PKGS="$PKGS \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ ubuntu_setup () {
     # Tested on ubuntu 22.04
     PKGS="\
         python-is-python3 csmith python3 \
-        git ccache unzip wget curl libcsmith-dev gperf \
+        git unzip wget curl libcsmith-dev gperf \
         cmake bison flex g++-multilib linux-libc-dev \
         libboost-date-time-dev libboost-program-options-dev \
         libboost-iostreams-dev libboost-system-dev \


### PR DESCRIPTION
1. This PR has switched some GitHub host runners to the slim version. 
2. Remove the unnecessary packages to save disk space.

For some simple tasks with low load, we can use some runners with lower costs: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners

Use ccache to significantly accelerate the build process, following these rules:
1. Check if there are any code modifications (in *.cpp and *.h files) in the branch. If so, update the cache.
2. Only update the cache in the onpush workflow.