### PR TITLE
[python] resolve dict value types from function return annotations

### DIFF
--- a/regression/python/dict19/main.py
+++ b/regression/python/dict19/main.py
@@ -1,0 +1,10 @@
+def foo() -> dict[str, list[str]]:
+    return {
+        "foo": ["bar", "baz"],
+        "qux": ["quux", "quuz"]
+    }
+
+f = foo()
+l = f["foo"]
+for s in l:
+    assert s == "bar" or s == "baz"

--- a/regression/python/dict19/test.desc
+++ b/regression/python/dict19/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict19_fail/main.py
+++ b/regression/python/dict19_fail/main.py
@@ -1,0 +1,10 @@
+def foo() -> dict[str, list[str]]:
+    return {
+        "foo": ["bar", "baz"],
+        "qux": ["quux", "quuz"]
+    }
+
+f = foo()
+l = f["foo"]
+for s in l:
+    assert s == "baz"

--- a/regression/python/dict19_fail/test.desc
+++ b/regression/python/dict19_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3326.

This PR fixes verification of dict subscript access when the assignment target lacks explicit type annotations. 

In particular, this PR:
- Traces back to the source function's return type annotation when the variable has only a simple "dict" annotation.
- Extracts the value type from `dict[K, V]` annotations.
- Populates `list_type_map` when extracting lists from dicts to ensure correct iteration semantics.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.
