### PR TITLE
 [python-frontend] Support class imports from modules

### DIFF
--- a/regression/python/github_3338/ex.py
+++ b/regression/python/github_3338/ex.py
@@ -1,5 +1,4 @@
-d: dict[str, list[int]] = {'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
-l: list[int] = d['a']
-assert len(l) == 10
-for i in d['a']:
-    assert i <= 10
+import ll
+
+s = "foo"
+c = ll.Foo(s)

--- a/regression/python/github_3338/ex.py
+++ b/regression/python/github_3338/ex.py
@@ -1,0 +1,5 @@
+d: dict[str, list[int]] = {'a': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+l: list[int] = d['a']
+assert len(l) == 10
+for i in d['a']:
+    assert i <= 10

--- a/regression/python/github_3338/ll.py
+++ b/regression/python/github_3338/ll.py
@@ -1,0 +1,6 @@
+def f(b: bool) -> None:
+    pass
+
+class Foo:
+    def __init__(self, s: str) -> None:
+        self.s = s

--- a/regression/python/github_3338/test.desc
+++ b/regression/python/github_3338/test.desc
@@ -1,4 +1,4 @@
 CORE
 ex.py
---unwind 11
+
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3338/test.desc
+++ b/regression/python/github_3338/test.desc
@@ -1,0 +1,4 @@
+CORE
+ex.py
+--unwind 11
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-class-constructor/main.py
+++ b/regression/python/import-class-constructor/main.py
@@ -1,0 +1,8 @@
+import mod1
+
+# Test 1: Verify basic class import and constructor call
+# Tests class_definition support in module.h and ClassDef parsing in module_manager.cpp
+c = mod1.MyClass("test")
+# Verify constructor call succeeds (type inference works correctly)
+assert True
+

--- a/regression/python/import-class-constructor/mod1.py
+++ b/regression/python/import-class-constructor/mod1.py
@@ -1,0 +1,4 @@
+class MyClass:
+    def __init__(self, value: str) -> None:
+        self.value = value
+

--- a/regression/python/import-class-constructor/test.desc
+++ b/regression/python/import-class-constructor/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/import-class-inheritance/main.py
+++ b/regression/python/import-class-inheritance/main.py
@@ -1,0 +1,8 @@
+import mod2
+
+# Test 2: Verify class with base classes
+# Tests base class parsing in module_manager.cpp
+c = mod2.Derived("test")
+# Verify constructor call succeeds (type inference works correctly)
+assert True
+

--- a/regression/python/import-class-inheritance/mod2.py
+++ b/regression/python/import-class-inheritance/mod2.py
@@ -1,0 +1,7 @@
+class Base:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+class Derived(Base):
+    pass
+

--- a/regression/python/import-class-inheritance/test.desc
+++ b/regression/python/import-class-inheritance/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/import-class-methods/main.py
+++ b/regression/python/import-class-methods/main.py
@@ -1,0 +1,8 @@
+import mod3
+
+# Test 3: Verify class with methods
+# Tests method parsing in module_manager.cpp
+c = mod3.MyClass()
+result = c.get_value()
+assert result == 42
+

--- a/regression/python/import-class-methods/mod3.py
+++ b/regression/python/import-class-methods/mod3.py
@@ -1,0 +1,7 @@
+class MyClass:
+    def __init__(self) -> None:
+        self.value = 42
+    
+    def get_value(self) -> int:
+        return self.value
+

--- a/regression/python/import-class-methods/test.desc
+++ b/regression/python/import-class-methods/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/import-class-null-returns/main.py
+++ b/regression/python/import-class-null-returns/main.py
@@ -1,0 +1,8 @@
+import mod5
+
+# Test 5: Verify JSON parsing error fix for null returns
+# Tests safe handling of null returns in module_manager.cpp
+c = mod5.MyClass()
+# Verify constructor call succeeds even with null return type handling
+assert True
+

--- a/regression/python/import-class-null-returns/mod5.py
+++ b/regression/python/import-class-null-returns/mod5.py
@@ -1,0 +1,7 @@
+def helper_func() -> None:
+    pass
+
+class MyClass:
+    def __init__(self) -> None:
+        pass
+

--- a/regression/python/import-class-null-returns/test.desc
+++ b/regression/python/import-class-null-returns/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/import-class-submodule/main.py
+++ b/regression/python/import-class-submodule/main.py
@@ -1,0 +1,7 @@
+import pkg.mod4
+
+# Test 4: Verify submodule class merging
+# Tests class merging in module_manager.cpp load_directory()
+c = pkg.mod4.MyClass("test")
+# Verify constructor call succeeds (type inference works correctly)
+assert True

--- a/regression/python/import-class-submodule/pkg/mod4.py
+++ b/regression/python/import-class-submodule/pkg/mod4.py
@@ -1,0 +1,4 @@
+class MyClass:
+    def __init__(self, value: str) -> None:
+        self.value = value
+

--- a/regression/python/import-class-submodule/test.desc
+++ b/regression/python/import-class-submodule/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+

--- a/src/python-frontend/module.h
+++ b/src/python-frontend/module.h
@@ -98,9 +98,12 @@ public:
     classes_.insert(other_classes.begin(), other_classes.end());
   }
 
+  /// @brief Retrieve a class definition by name
+  /// @param class_name The name of the class to find
+  /// @return The class definition, or empty class_definition if not found
+  /// @complexity O(1) average case via hash lookup
   class_definition get_class(const std::string &class_name) const
   {
-    // Use find() for O(1) lookup
     class_definition key;
     key.name_ = class_name;
     auto it = classes_.find(key);
@@ -111,9 +114,12 @@ public:
     return {};
   }
 
+  /// @brief Retrieve a function definition by name
+  /// @param func_name The name of the function to find
+  /// @return The function definition, or empty function if not found
+  /// @complexity O(1) average case via hash lookup
   function get_function(const std::string &func_name) const
   {
-    // Use find() for O(1) lookup
     function key;
     key.name_ = func_name;
     auto it = functions_.find(key);

--- a/src/python-frontend/module.h
+++ b/src/python-frontend/module.h
@@ -1,9 +1,12 @@
 #pragma once
 
-#include <algorithm>
+#include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 #include <nlohmann/json.hpp>
+
+class module;
 
 struct function
 {
@@ -30,6 +33,28 @@ using FunctionsList = std::unordered_set<function, function_hash>;
 using SubmodulesList = std::unordered_set<std::shared_ptr<module>>;
 
 using OverloadList = std::vector<nlohmann::json>;
+
+struct class_definition
+{
+  std::string name_;
+  std::vector<std::string> bases_;
+  std::vector<std::string> methods_;
+
+  bool operator==(const class_definition &other) const
+  {
+    return name_ == other.name_;
+  }
+};
+
+struct class_definition_hash
+{
+  std::size_t operator()(const class_definition &c) const
+  {
+    return std::hash<std::string>()(c.name_);
+  }
+};
+
+using ClassesList = std::unordered_set<class_definition, class_definition_hash>;
 
 class module
 {
@@ -63,12 +88,35 @@ public:
     overloads_.push_back(ast);
   }
 
+  void add_class(const class_definition &cls)
+  {
+    classes_.insert(cls);
+  }
+
+  void add_classes(const ClassesList &other_classes)
+  {
+    classes_.insert(other_classes.begin(), other_classes.end());
+  }
+
+  class_definition get_class(const std::string &class_name) const
+  {
+    // Use find() for O(1) lookup
+    class_definition key;
+    key.name_ = class_name;
+    auto it = classes_.find(key);
+
+    if (it != classes_.end())
+      return *it;
+
+    return {};
+  }
+
   function get_function(const std::string &func_name) const
   {
-    auto it = std::find_if(
-      functions_.begin(), functions_.end(), [&](const function &func) {
-        return func.name_ == func_name;
-      });
+    // Use find() for O(1) lookup
+    function key;
+    key.name_ = func_name;
+    auto it = functions_.find(key);
 
     if (it != functions_.end())
       return *it;
@@ -91,9 +139,15 @@ public:
     return overloads_;
   }
 
+  const ClassesList &classes() const
+  {
+    return classes_;
+  }
+
 private:
   std::string name_;
   FunctionsList functions_;
   SubmodulesList submodules_;
   OverloadList overloads_;
+  ClassesList classes_;
 };

--- a/src/python-frontend/module_manager.cpp
+++ b/src/python-frontend/module_manager.cpp
@@ -18,10 +18,10 @@ std::string get_string_safe(const nlohmann::json &node, const std::string &key)
 {
   if (!node.contains(key))
     return "";
-  
+
   if (node[key].is_string())
     return node[key].get<std::string>();
-  
+
   return "";
 }
 } // namespace
@@ -36,7 +36,8 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
   std::ifstream json_file(json_path);
   if (!json_file.is_open())
   {
-    log_warning("[module_manager] create_module: failed to open {}", json_path.string());
+    log_warning(
+      "[module_manager] create_module: failed to open {}", json_path.string());
     return nullptr;
   }
 
@@ -60,10 +61,11 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
 
     for (const auto &node : ast["body"])
     {
-      std::string node_type = node.contains("_type") && node["_type"].is_string()
-                                ? node["_type"].get<std::string>()
-                                : "unknown";
-      
+      std::string node_type =
+        node.contains("_type") && node["_type"].is_string()
+          ? node["_type"].get<std::string>()
+          : "unknown";
+
       if (node_type == "unknown")
       {
         log_warning(
@@ -71,7 +73,7 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
           json_path.string());
         continue;
       }
-      
+
       if (node_type == "FunctionDef")
       {
         function f;
@@ -128,7 +130,7 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
       else if (node_type == "ClassDef")
       {
         class_definition c;
-        
+
         // Safely get class name
         c.name_ = get_string_safe(node, "name");
         if (c.name_.empty())

--- a/src/python-frontend/module_manager.cpp
+++ b/src/python-frontend/module_manager.cpp
@@ -10,6 +10,22 @@
 
 namespace fs = std::filesystem;
 
+namespace
+{
+// Helper function to safely extract string value from JSON node
+// Returns empty string if the field is missing, null, or not a string
+std::string get_string_safe(const nlohmann::json &node, const std::string &key)
+{
+  if (!node.contains(key))
+    return "";
+  
+  if (node[key].is_string())
+    return node[key].get<std::string>();
+  
+  return "";
+}
+} // namespace
+
 module_manager::module_manager(const std::string &module_search_path)
   : module_search_path_(module_search_path)
 {
@@ -19,9 +35,13 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
 {
   std::ifstream json_file(json_path);
   if (!json_file.is_open())
+  {
+    log_warning("[module_manager] create_module: failed to open {}", json_path.string());
     return nullptr;
+  }
 
-  auto md = std::make_shared<module>(json_path.stem().string());
+  std::string module_name = json_path.stem().string();
+  auto md = std::make_shared<module>(module_name);
 
   try
   {
@@ -29,12 +49,21 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
     json_file >> ast;
     json_file.close();
 
-    for (const auto &node : ast["body"])
+    for (size_t i = 0; i < ast["body"].size(); ++i)
     {
-      if (node["_type"] == "FunctionDef")
+      const auto &node = ast["body"][i];
+      std::string node_type = node.contains("_type") && node["_type"].is_string()
+                                ? node["_type"].get<std::string>()
+                                : "unknown";
+      
+      if (node_type == "FunctionDef")
       {
         function f;
-        f.name_ = node["name"];
+        f.name_ = get_string_safe(node, "name");
+        if (f.name_.empty())
+        {
+          continue;
+        }
 
         if (node["returns"].is_null())
           continue;
@@ -43,38 +72,104 @@ std::shared_ptr<module> create_module(const fs::path &json_path)
         if (node["returns"]["_type"] == "BinOp")
           f.return_type_ = "Union";
         else if (node["returns"]["_type"] == "Subscript")
-          f.return_type_ = node["returns"]["value"]["id"];
+        {
+          if (
+            node["returns"].contains("value") &&
+            node["returns"]["value"].contains("id") &&
+            node["returns"]["value"]["id"].is_string())
+            f.return_type_ = node["returns"]["value"]["id"].get<std::string>();
+        }
         else if (node["returns"]["_type"] == "Tuple")
           f.return_type_ = "Tuple";
         else if (
           node["returns"]["_type"] == "Constant" ||
           node["returns"]["_type"] == "Str")
+        {
           // Handle string annotations like -> "int" (legacy forward references)
-          f.return_type_ = node["returns"]["value"];
+          if (node["returns"].contains("value"))
+          {
+            if (node["returns"]["value"].is_string())
+              f.return_type_ = node["returns"]["value"].get<std::string>();
+            else if (node["returns"]["value"].is_null())
+              f.return_type_ = "None";
+          }
+        }
         else if (
           node["returns"].contains("value") &&
           node["returns"]["value"].is_null())
           f.return_type_ = "None";
+        else if (
+          node["returns"].contains("id") && node["returns"]["id"].is_string())
+          f.return_type_ = node["returns"]["id"].get<std::string>();
         else
-          f.return_type_ = node["returns"]["id"];
+          f.return_type_ = "None";
 
         if (json_utils::has_overload_decorator(node))
           md->add_overload(node);
 
         md->add_function(f);
       }
+      else if (node_type == "ClassDef")
+      {
+        class_definition c;
+        
+        // Safely get class name
+        c.name_ = get_string_safe(node, "name");
+        if (c.name_.empty())
+        {
+          continue;
+        }
+
+        // Process base classes
+        if (node.contains("bases") && node["bases"].is_array())
+        {
+          for (const auto &base : node["bases"])
+          {
+            std::string base_name = get_string_safe(base, "id");
+            if (!base_name.empty())
+              c.bases_.push_back(base_name);
+          }
+        }
+
+        // Process methods
+        if (node.contains("body") && node["body"].is_array())
+        {
+          for (const auto &item : node["body"])
+          {
+            if (item["_type"] == "FunctionDef")
+            {
+              std::string method_name = get_string_safe(item, "name");
+              if (!method_name.empty())
+                c.methods_.push_back(method_name);
+            }
+          }
+        }
+
+        md->add_class(c);
+      }
     }
 
     return md;
   }
+  catch (const nlohmann::json::type_error &e)
+  {
+    log_error(
+      "JSON type error in create_module for {}: {} (id: {})",
+      json_path.string(),
+      e.what(),
+      e.id);
+    return nullptr;
+  }
   catch (const nlohmann::json::parse_error &e)
   {
     // Catches JSON parsing errors (e.g., invalid JSON content)
-    log_error("Error parsing the JSON: {}", e.what());
+    log_error("Error parsing the JSON {}: {}", json_path.string(), e.what());
     return nullptr;
   }
   catch (const std::exception &e)
   {
+    log_error(
+      "Exception in create_module for {}: {}", json_path.string(), e.what());
     return nullptr;
   }
 }
@@ -92,12 +187,15 @@ void module_manager::load_directory(
       if (submodule)
       {
         if (main_module_ == submodule->name())
+        {
           continue;
+        }
 
         auto current_module = get_module(submodule->name());
         if (current_module)
         {
           current_module->add_functions(submodule->functions());
+          current_module->add_classes(submodule->classes());
           continue;
         }
 
@@ -237,5 +335,6 @@ ModulePtr get_module_recursive(
 const ModulePtr module_manager::get_module(const std::string &module_name) const
 {
   std::vector<std::string> parts = split(module_name, '.');
-  return get_module_recursive(parts, modules_);
+  auto result = get_module_recursive(parts, modules_);
+  return result;
 }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1685,7 +1685,7 @@ private:
     {
       // Try to get module using the object name directly
       auto module = module_manager_->get_module(obj);
-      
+
       // If not found, try using get_object_alias to resolve import aliases
       if (!module && !obj.empty())
       {
@@ -1695,7 +1695,7 @@ private:
           module = module_manager_->get_module(resolved_obj);
         }
       }
-      
+
       if (module)
       {
         // First try as function
@@ -1712,7 +1712,7 @@ private:
           // Return the class name as the type for constructor calls
           return cls.name_;
         }
-        
+
         // If module exists but attribute not found, don't continue to search
         // in AST (which would fail for imported modules)
         return "";


### PR DESCRIPTION
Fixes #3338 

## Summary
Add support for importing and using Python classes from modules in ESBMC's Python frontend.

## Changes
- Added `class_definition` structure to store class metadata (name, base classes, methods)
- Extended `module` class with `add_class()`, `get_class()`, and `add_classes()` methods
- Updated `create_module()` to parse `ClassDef` nodes from Python AST
- Modified type inference in `python_annotation.h` to handle class constructor calls
- Added `get_string_safe()` helper for robust JSON parsing

## How it works
When importing a module:
1. Parser extracts class definitions from AST JSON (name, bases, methods)
2. Classes are stored in an `unordered_set` for O(1) lookup
3. During type inference, `get_class()` is called for constructor expressions
4. Constructor calls return the class name as the inferred type

## Testing
Added 5 regression tests covering:
- Basic class import and constructor calls
- Class inheritance
- Class methods
- Submodule classes
- Null return type handling


