### PR TITLE
[Python verification] fix crash when using isinstance in expression

### DIFF
--- a/regression/python/github_3339/main.py
+++ b/regression/python/github_3339/main.py
@@ -1,0 +1,3 @@
+s = "foo"
+b = isinstance(s, str)
+assert b

--- a/regression/python/github_3339/test.desc
+++ b/regression/python/github_3339/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3339_fail/main.py
+++ b/regression/python/github_3339_fail/main.py
@@ -1,0 +1,3 @@
+s = "foo"
+b = isinstance(s, str)
+assert not b

--- a/regression/python/github_3339_fail/test.desc
+++ b/regression/python/github_3339_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -282,6 +282,7 @@ void goto_symext::symex_assign(
   replace_dynamic_allocation(rhs);
 
   replace_races_check(lhs);
+  simplify_python_builtins(rhs);
 
   // If rhs is a printf expression, handle it specially
   if (is_code_printf2t(rhs))


### PR DESCRIPTION
fixes #3339 