### PR TITLE
[python] fix single-character string handling in list append and access

### DIFF
--- a/regression/python/github_3127_2/main.py
+++ b/regression/python/github_3127_2/main.py
@@ -1,0 +1,18 @@
+def my_split(s: str, sep: str) -> list[str]:
+    result = []
+    word = ""
+    for char in s:
+        if char == sep:
+            result.append(word)
+            word = ""
+        else:
+            word += char
+    result.append(word)
+    return result
+
+s: str = "a,b"
+l = my_split(s, ",")
+assert len(l) == 2
+assert l[0] == "a"
+assert l[1] == "b"
+assert l == ["a", "b"]

--- a/regression/python/github_3127_2/test.desc
+++ b/regression/python/github_3127_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3
+--unwind 4
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3127_2_fail/main.py
+++ b/regression/python/github_3127_2_fail/main.py
@@ -1,0 +1,17 @@
+def my_split(s: str, sep: str) -> list[str]:
+    result = []
+    word = ""
+    for char in s:
+        if char == sep:
+            result.append(word)
+            word = ""
+        else:
+            word += char
+    result.append(word)
+    return result
+
+s: str = "a,b"
+l = my_split(s, ",")
+assert len(l) == 2
+assert l[0] == "b"
+assert l[1] == "a"

--- a/regression/python/github_3127_2_fail/test.desc
+++ b/regression/python/github_3127_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1645,6 +1645,22 @@ exprt function_call_expr::handle_list_append() const
 
   // Get the value to append
   exprt value_to_append = converter_.get_expr(args[0]);
+
+  if (
+    value_to_append.type().is_array() &&
+    value_to_append.type().subtype() == char_type())
+  {
+    const array_typet &array_type = to_array_type(value_to_append.type());
+    // Only convert single-element char arrays (string literals)
+    if (array_type.size().is_constant())
+    {
+      const constant_exprt &size_const = to_constant_expr(array_type.size());
+      BigInt size_value = binary2integer(size_const.value().c_str(), false);
+      if (size_value == 1)
+        value_to_append.type() = gen_pointer_type(char_type());
+    }
+  }
+
   if (value_to_append.is_constant())
   {
     // Create tmp variable to hold value

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -344,6 +344,8 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     ast_type == "str" || ast_type == "chr" || ast_type == "hex" ||
     ast_type == "oct")
   {
+    if (type_size == 0)
+      return gen_pointer_type(char_type());
     if (type_size == 1)
     {
       typet type = char_type();      // 8-bit char

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -344,8 +344,6 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     ast_type == "str" || ast_type == "chr" || ast_type == "hex" ||
     ast_type == "oct")
   {
-    if (type_size == 0)
-      return gen_pointer_type(char_type());
     if (type_size == 1)
     {
       typet type = char_type();      // 8-bit char


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3127.

This PR fixes issues with single-character strings when appending to and accessing from lists. In particular, this PR makes the following changes:

1. **List append**: Convert single-element char arrays (size 1) to `char*` pointers during list append operations. This ensures proper storage semantics for single-character strings while preserving correct behavior for larger char arrays (e.g., from `nondet_str()`).

2. **List access**: When retrieving list elements, distinguish between string pointers (`char*`) and other types:
   - For `char*` strings: cast `void*` directly to `char*` (no dereference needed, as the pointer value is already stored)
   - For all other types: cast `void*` to pointer-to-type, then dereference.

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.

