### PR TITLE
[symex] track and report trivially verified assertions

### DIFF
--- a/regression/esbmc-unix/simplifier/test.desc
+++ b/regression/esbmc-unix/simplifier/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
 --multi-property
-^Properties: 10 verified \✓ 1 passed, \✗ 9 failed$
+^VERIFICATION FAILED$

--- a/regression/python/any-example_fail/test.desc
+++ b/regression/python/any-example_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 2 verified, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/cover5/test.desc
+++ b/regression/python/cover5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property --unwind 10
-^Properties: 43 verified \✓ 38 passed, \✗ 5 failed$
+^VERIFICATION FAILED$

--- a/regression/python/enough-args_fail/test.desc
+++ b/regression/python/enough-args_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 4 verified, \✗ 4 failed$
+^VERIFICATION FAILED$

--- a/regression/python/exception_fail/test.desc
+++ b/regression/python/exception_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 4 verified \✓ 1 passed, \✓ 1 skipped, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/fstring2_fail/test.desc
+++ b/regression/python/fstring2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 7 verified, \✗ 7 failed$
+^VERIFICATION FAILED$

--- a/regression/python/getrandbits_fail/test.desc
+++ b/regression/python/getrandbits_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/github_2944_fail/test.desc
+++ b/regression/python/github_2944_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/github_2992_islower_fail/test.desc
+++ b/regression/python/github_2992_islower_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties: 9 verified, \✗ 9 failed$
+^VERIFICATION FAILED$

--- a/regression/python/github_3012_fail/test.desc
+++ b/regression/python/github_3012_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties: 2 verified, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/github_3288_fail/test.desc
+++ b/regression/python/github_3288_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/github_3341_fail/main.py
+++ b/regression/python/github_3341_fail/main.py
@@ -1,0 +1,7 @@
+x = 1
+y = x
+assert x == y
+y += 1
+assert x < y
+y -= 1
+assert x != y

--- a/regression/python/github_3341_fail/test.desc
+++ b/regression/python/github_3341_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties: 1 verified \✓ 2 trivial, \✗ 1 failed$
+^VERIFICATION FAILED$

--- a/regression/python/github_3341_fail/test.desc
+++ b/regression/python/github_3341_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^Properties: 1 verified \✓ 2 trivial, \✗ 1 failed$

--- a/regression/python/lambda10_fail/test.desc
+++ b/regression/python/lambda10_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 5 verified, \✗ 5 failed$
+^VERIFICATION FAILED$

--- a/regression/python/lambda2_fail/test.desc
+++ b/regression/python/lambda2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/lambda4_fail/test.desc
+++ b/regression/python/lambda4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 2 verified, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/object_passing_comprehensive_fail/test.desc
+++ b/regression/python/object_passing_comprehensive_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
 --multi-property
-^Properties: 64 verified, \✗ 64 failed$
+^VERIFICATION FAILED$

--- a/regression/python/randrange_fail/test.desc
+++ b/regression/python/randrange_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/single-char1_fail/test.desc
+++ b/regression/python/single-char1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 2 verified, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/strict-type-checking_fail/test.desc
+++ b/regression/python/strict-type-checking_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property --strict-types
-^Properties: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/string-indexing2_fail/test.desc
+++ b/regression/python/string-indexing2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 11 verified \✓ 8 passed, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/regression/python/string-indexing4_fail/test.desc
+++ b/regression/python/string-indexing4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 4 verified \✓ 2 passed, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/ternary_string_fail/test.desc
+++ b/regression/python/ternary_string_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 2 verified, \✗ 2 failed$
+^VERIFICATION FAILED$

--- a/regression/python/type_annotation4_fail/test.desc
+++ b/regression/python/type_annotation4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 6 verified, \✗ 6 failed$
+^VERIFICATION FAILED$

--- a/regression/python/uniform_fail/test.desc
+++ b/regression/python/uniform_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^Properties\: 3 verified, \✗ 3 failed$
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1339,8 +1339,10 @@ smt_convt::resultt bmct::multi_property_check(
 
   // Add summary tracking
   SimpleSummary summary;
-  summary.total_properties = remaining_claims;
-  summary.trivial_properties = symex->get_cur_state().trivial_claims;
+  summary.simplified_properties = symex->get_cur_state().simplified_claims;
+  summary.total_properties = remaining_claims + summary.simplified_properties;
+  summary.passed_properties =
+    summary.passed_properties + summary.simplified_properties;
 
   // For coverage info
   auto &reached_claims = symex->goto_functions.reached_claims;
@@ -1696,10 +1698,6 @@ void bmct::report_simple_summary(const SimpleSummary &summary) const
   if (summary.passed_properties > 0)
     properties_oss << " " << GREEN << "✓ " << summary.passed_properties
                    << " passed" << RESET;
-
-  if (summary.trivial_properties > 0)
-    properties_oss << " " << GREEN << "✓ " << summary.trivial_properties
-                   << " trivial" << RESET;
 
   if (summary.skipped_properties > 0)
     properties_oss << ", " << GREEN << "✓ " << summary.skipped_properties

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1176,7 +1176,8 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
       return smt_convt::P_SMTLIB;
 
     log_status(
-      "Generated {} VCC(s), {} remaining after simplification ({} assignments)",
+      "Generated {} VCC(s), {} remaining after simplification ({} "
+      "assignments)",
       solver_result.total_claims,
       remaining_asserts,
       BigInt(eq->SSA_steps.size()) - ignored);
@@ -1339,6 +1340,7 @@ smt_convt::resultt bmct::multi_property_check(
   // Add summary tracking
   SimpleSummary summary;
   summary.total_properties = remaining_claims;
+  summary.trivial_properties = symex->get_cur_state().trivial_claims;
 
   // For coverage info
   auto &reached_claims = symex->goto_functions.reached_claims;
@@ -1694,6 +1696,10 @@ void bmct::report_simple_summary(const SimpleSummary &summary) const
   if (summary.passed_properties > 0)
     properties_oss << " " << GREEN << "✓ " << summary.passed_properties
                    << " passed" << RESET;
+
+  if (summary.trivial_properties > 0)
+    properties_oss << " " << GREEN << "✓ " << summary.trivial_properties
+                   << " trivial" << RESET;
 
   if (summary.skipped_properties > 0)
     properties_oss << ", " << GREEN << "✓ " << summary.skipped_properties

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -123,7 +123,7 @@ private:
     std::atomic<size_t> total_properties = 0;
     std::atomic<size_t> passed_properties = 0;
     std::atomic<size_t> skipped_properties = 0;
-    std::atomic<size_t> trivial_properties{0};
+    std::atomic<size_t> simplified_properties = 0;
     std::atomic<size_t> failed_properties = 0;
     std::atomic<double> total_time_s = 0.0;
     std::string solver_name;

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -123,6 +123,7 @@ private:
     std::atomic<size_t> total_properties = 0;
     std::atomic<size_t> passed_properties = 0;
     std::atomic<size_t> skipped_properties = 0;
+    std::atomic<size_t> trivial_properties{0};
     std::atomic<size_t> failed_properties = 0;
     std::atomic<double> total_time_s = 0.0;
     std::string solver_name;

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1324,18 +1324,21 @@ void schedule_execution_statet::claim(
   const expr2tc &expr,
   const std::string &msg)
 {
-  unsigned int tmp_total, tmp_remaining;
+  unsigned int tmp_total, tmp_remaining, tmp_trivial;
 
   tmp_total = total_claims;
   tmp_remaining = remaining_claims;
+  tmp_trivial = trivial_claims;
 
   execution_statet::claim(expr, msg);
 
   tmp_total = total_claims - tmp_total;
   tmp_remaining = remaining_claims - tmp_remaining;
+  tmp_trivial = trivial_claims - tmp_trivial;
 
   *ptotal_claims += tmp_total;
   *premaining_claims += tmp_remaining;
+  *ptrivial_claims += tmp_trivial;
 }
 
 execution_statet::state_hashing_level2t::state_hashing_level2t(

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -1324,21 +1324,20 @@ void schedule_execution_statet::claim(
   const expr2tc &expr,
   const std::string &msg)
 {
-  unsigned int tmp_total, tmp_remaining, tmp_trivial;
+  unsigned int tmp_total, tmp_remaining, tmp_simplified;
 
   tmp_total = total_claims;
   tmp_remaining = remaining_claims;
-  tmp_trivial = trivial_claims;
-
+  tmp_simplified = simplified_claims;
   execution_statet::claim(expr, msg);
 
   tmp_total = total_claims - tmp_total;
   tmp_remaining = remaining_claims - tmp_remaining;
-  tmp_trivial = trivial_claims - tmp_trivial;
+  tmp_simplified = simplified_claims - tmp_simplified;
 
   *ptotal_claims += tmp_total;
   *premaining_claims += tmp_remaining;
-  *ptrivial_claims += tmp_trivial;
+  *psimplified_claims += tmp_simplified;
 }
 
 execution_statet::state_hashing_level2t::state_hashing_level2t(

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -663,7 +663,7 @@ public:
     optionst &options,
     unsigned int *ptotal_claims,
     unsigned int *premaining_claims,
-    unsigned int *ptrivial_claims)
+    unsigned int *psimplified_claims)
     : execution_statet(
         goto_functions,
         ns,
@@ -675,10 +675,10 @@ public:
   {
     this->ptotal_claims = ptotal_claims;
     this->premaining_claims = premaining_claims;
-    this->ptrivial_claims = ptrivial_claims;
+    this->psimplified_claims = psimplified_claims;
     *ptotal_claims = 0;
     *premaining_claims = 0;
-    *ptrivial_claims = 0;
+    *psimplified_claims = 0;
   };
 
   schedule_execution_statet(const schedule_execution_statet &ref) = default;
@@ -688,7 +688,7 @@ public:
 
   unsigned int *ptotal_claims;
   unsigned int *premaining_claims;
-  unsigned int *ptrivial_claims;
+  unsigned int *psimplified_claims;
 };
 
 #endif /* EXECUTION_STATE_H_ */

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -662,7 +662,8 @@ public:
     contextt &context,
     optionst &options,
     unsigned int *ptotal_claims,
-    unsigned int *premaining_claims)
+    unsigned int *premaining_claims,
+    unsigned int *ptrivial_claims)
     : execution_statet(
         goto_functions,
         ns,
@@ -674,8 +675,10 @@ public:
   {
     this->ptotal_claims = ptotal_claims;
     this->premaining_claims = premaining_claims;
+    this->ptrivial_claims = ptrivial_claims;
     *ptotal_claims = 0;
     *premaining_claims = 0;
+    *ptrivial_claims = 0;
   };
 
   schedule_execution_statet(const schedule_execution_statet &ref) = default;
@@ -685,6 +688,7 @@ public:
 
   unsigned int *ptotal_claims;
   unsigned int *premaining_claims;
+  unsigned int *ptrivial_claims;
 };
 
 #endif /* EXECUTION_STATE_H_ */

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -89,12 +89,17 @@ public:
     symex_resultt(
       std::shared_ptr<symex_targett> t,
       unsigned int claims,
-      unsigned int remain)
-      : target(std::move(t)), total_claims(claims), remaining_claims(remain){};
+      unsigned int remain,
+      unsigned int trivial)
+      : target(std::move(t)),
+        total_claims(claims),
+        remaining_claims(remain),
+        trivial_claims(trivial){};
 
     std::shared_ptr<symex_targett> target;
     unsigned int total_claims;
     unsigned int remaining_claims;
+    unsigned int trivial_claims;
   };
 
   // Macros
@@ -1097,6 +1102,8 @@ protected:
   unsigned total_claims;
   /** Number of assertions remaining to be discharged. */
   unsigned remaining_claims;
+  /** Number of assertions that were trivially verified. */
+  unsigned trivial_claims;
   /** Reachability tree we're working with. */
   reachability_treet *art1;
   /** Unwind bounds, loop number -> max unwinds. */

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -90,16 +90,15 @@ public:
       std::shared_ptr<symex_targett> t,
       unsigned int claims,
       unsigned int remain,
-      unsigned int trivial)
+      unsigned int simplified)
       : target(std::move(t)),
         total_claims(claims),
         remaining_claims(remain),
-        trivial_claims(trivial){};
-
+        simplified_claims(simplified){};
     std::shared_ptr<symex_targett> target;
     unsigned int total_claims;
     unsigned int remaining_claims;
-    unsigned int trivial_claims;
+    unsigned int simplified_claims;
   };
 
   // Macros
@@ -1103,7 +1102,7 @@ protected:
   /** Number of assertions remaining to be discharged. */
   unsigned remaining_claims;
   /** Number of assertions that were trivially verified. */
-  unsigned trivial_claims;
+  unsigned simplified_claims;
   /** Reachability tree we're working with. */
   reachability_treet *art1;
   /** Unwind bounds, loop number -> max unwinds. */

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -67,7 +67,8 @@ void reachability_treet::setup_for_new_explore()
       permanent_context,
       options,
       &schedule_total_claims,
-      &schedule_remaining_claims));
+      &schedule_remaining_claims,
+      &schedule_trivial_claims));
   }
   else
   {
@@ -617,7 +618,10 @@ goto_symext::symex_resultt reachability_treet::generate_schedule_formula()
   }
 
   return goto_symext::symex_resultt(
-    schedule_target, schedule_total_claims, schedule_remaining_claims);
+    schedule_target,
+    schedule_total_claims,
+    schedule_remaining_claims,
+    schedule_trivial_claims);
 }
 
 bool reachability_treet::restore_from_dfs_state(void *)

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -68,7 +68,7 @@ void reachability_treet::setup_for_new_explore()
       options,
       &schedule_total_claims,
       &schedule_remaining_claims,
-      &schedule_trivial_claims));
+      &schedule_simplified_claims));
   }
   else
   {
@@ -621,7 +621,7 @@ goto_symext::symex_resultt reachability_treet::generate_schedule_formula()
     schedule_target,
     schedule_total_claims,
     schedule_remaining_claims,
-    schedule_trivial_claims);
+    schedule_simplified_claims);
 }
 
 bool reachability_treet::restore_from_dfs_state(void *)

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -346,6 +346,8 @@ protected:
   unsigned int schedule_total_claims;
   /** Number of remaining claims in current --schedule exploration */
   unsigned int schedule_remaining_claims;
+  /** Number of trivial claims in current --schedule exploration */
+  unsigned int schedule_trivial_claims;
   /** Next thread ID to switch to, decided by analyse_* routines */
   unsigned int next_thread_id;
   /** Whether partial-order-reduction is enabled */

--- a/src/goto-symex/reachability_tree.h
+++ b/src/goto-symex/reachability_tree.h
@@ -347,7 +347,7 @@ protected:
   /** Number of remaining claims in current --schedule exploration */
   unsigned int schedule_remaining_claims;
   /** Number of trivial claims in current --schedule exploration */
-  unsigned int schedule_trivial_claims;
+  unsigned int schedule_simplified_claims;
   /** Next thread ID to switch to, decided by analyse_* routines */
   unsigned int next_thread_id;
   /** Whether partial-order-reduction is enabled */

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -22,7 +22,7 @@ goto_symext::goto_symext(
     first_loop(0),
     total_claims(0),
     remaining_claims(0),
-    trivial_claims(0),
+    simplified_claims(0),
     max_unwind(options.get_option("unwind").c_str()),
     constant_propagation(!options.get_bool_option("no-propagation")),
     ns(_ns),
@@ -148,7 +148,7 @@ goto_symext &goto_symext::operator=(const goto_symext &sym)
   constant_propagation = sym.constant_propagation;
   total_claims = sym.total_claims;
   remaining_claims = sym.remaining_claims;
-  trivial_claims = sym.trivial_claims;
+  simplified_claims = sym.simplified_claims;
   guard_identifier_s = sym.guard_identifier_s;
   depth_limit = sym.depth_limit;
   break_insn = sym.break_insn;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -22,6 +22,7 @@ goto_symext::goto_symext(
     first_loop(0),
     total_claims(0),
     remaining_claims(0),
+    trivial_claims(0),
     max_unwind(options.get_option("unwind").c_str()),
     constant_propagation(!options.get_bool_option("no-propagation")),
     ns(_ns),
@@ -147,6 +148,7 @@ goto_symext &goto_symext::operator=(const goto_symext &sym)
   constant_propagation = sym.constant_propagation;
   total_claims = sym.total_claims;
   remaining_claims = sym.remaining_claims;
+  trivial_claims = sym.trivial_claims;
   guard_identifier_s = sym.guard_identifier_s;
   depth_limit = sym.depth_limit;
   break_insn = sym.break_insn;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -74,6 +74,13 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
 
   if (is_true(new_expr))
   {
+    // Log that this assertion was trivially verified
+    log_success(
+      "✓ TRIVIAL: '{}' at {}", msg, cur_state->source.pc->location.as_string());
+
+    // Track trivially verified claims
+    ++trivial_claims;
+
     // Strengthen the claim by assuming it when trivially true
     assume(claim_expr);
     return;
@@ -167,7 +174,8 @@ void goto_symext::assume(const expr2tc &the_assumption)
 
 goto_symext::symex_resultt goto_symext::get_symex_result()
 {
-  return goto_symext::symex_resultt(target, total_claims, remaining_claims);
+  return goto_symext::symex_resultt(
+    target, total_claims, remaining_claims, trivial_claims);
 }
 
 void goto_symext::symex_step(reachability_treet &art)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -78,12 +78,12 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
     {
       // Log that this assertion was trivially verified
       log_success(
-        "✓ TRIVIAL: '{}' at {}",
+        "✓ PASSED: '{}' at {}",
         msg,
         cur_state->source.pc->location.as_string());
 
       // Track trivially verified claims
-      ++trivial_claims;
+      ++simplified_claims;
     }
 
     // Strengthen the claim by assuming it when trivially true
@@ -180,7 +180,7 @@ void goto_symext::assume(const expr2tc &the_assumption)
 goto_symext::symex_resultt goto_symext::get_symex_result()
 {
   return goto_symext::symex_resultt(
-    target, total_claims, remaining_claims, trivial_claims);
+    target, total_claims, remaining_claims, simplified_claims);
 }
 
 void goto_symext::symex_step(reachability_treet &art)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -74,12 +74,17 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
 
   if (is_true(new_expr))
   {
-    // Log that this assertion was trivially verified
-    log_success(
-      "✓ TRIVIAL: '{}' at {}", msg, cur_state->source.pc->location.as_string());
+    if (options.get_bool_option("multi-property"))
+    {
+      // Log that this assertion was trivially verified
+      log_success(
+        "✓ TRIVIAL: '{}' at {}",
+        msg,
+        cur_state->source.pc->location.as_string());
 
-    // Track trivially verified claims
-    ++trivial_claims;
+      // Track trivially verified claims
+      ++trivial_claims;
+    }
 
     // Strengthen the claim by assuming it when trivially true
     assume(claim_expr);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3341.

This PR adds tracking for assertions that are simplified to true during symbolic execution. These "simplified" assertions are now:
- Logged immediately when detected during symex.
- Counted separately in verification statistics.
- Displayed in the final properties summary.

This provides better visibility into which properties were proven via simplification rather than by SMT solver reasoning.

Changes:
- Add `simplified_claims` counter to `goto_symext` and `execution_statet`.
- Update `symex_resultt` to include simplified claim count.
- Extend SimpleSummary with `simplified_properties` tracking.
- Update `schedule_execution_statet` for simplified claims in `--schedule mode`.
- Add "✓ PASSED" log messages when assertions simplify to true.
- Include simplified count in symex completion and final summary output.

This is the new output:

<img width="1145" height="911" alt="image" src="https://github.com/user-attachments/assets/c85be20a-bd47-4079-8250-1d689822c3e3" />


Thanks to [zhassan-aws](https://github.com/zhassan-aws) for requesting this feature.