### PR TITLE
[symex] include assertion expression in verification messages

### DIFF
--- a/regression/python/assert5_fail/main.py
+++ b/regression/python/assert5_fail/main.py
@@ -1,0 +1,7 @@
+x = 1
+y = x
+assert x == y
+y += 1
+assert x < y
+y -= 1
+assert x != y

--- a/regression/python/assert5_fail/test.desc
+++ b/regression/python/assert5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--multi-property
+^\✓ PASSED: \'assertion x == y\' at file main\.py line 3 column 0$

--- a/regression/python/assert5_fail/test.desc
+++ b/regression/python/assert5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --multi-property
-^\✓ PASSED: \'assertion x == y\' at file main\.py line 3 column 0$
+^  assertion x != y$

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -5,6 +5,8 @@
 #include <goto-symex/reachability_tree.h>
 #include <goto-symex/symex_target_equation.h>
 
+#include <langapi/language_util.h>
+
 #include <pointer-analysis/value_set_analysis.h>
 
 #include <util/c_types.h>
@@ -500,11 +502,14 @@ void goto_symext::symex_assert()
   if (cur_state->source.pc->location.user_provided() && no_assertions)
     return;
 
+  const goto_programt::instructiont &instruction = *cur_state->source.pc;
+
   std::string msg = cur_state->source.pc->location.comment().as_string();
   if (msg == "")
-    msg = "assertion";
-
-  const goto_programt::instructiont &instruction = *cur_state->source.pc;
+  {
+    exprt guard = migrate_expr_back(instruction.guard);
+    msg = "assertion " + from_expr(ns, "", guard);
+  }
 
   expr2tc tmp = instruction.guard;
   replace_nondet(tmp);


### PR DESCRIPTION
This PR shows the assertion condition (e.g., "x == y") in pass/fail messages when no explicit comment exists, thereby matching --show-claims formatting.