### PR TITLE
[python] materialize nondet_str() in temporary before address-of

### DIFF
--- a/regression/python/nondet_list17/test.desc
+++ b/regression/python/nondet_list17/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 16
+--unwind 17
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list18/test.desc
+++ b/regression/python/nondet_list18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 3 --nondet-str-length 3
+--unwind 4 --nondet-str-length 3
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str10/main.py
+++ b/regression/python/nondet_str10/main.py
@@ -1,0 +1,5 @@
+s = nondet_str()
+original = s
+s = "modified"
+# This assertion should FAIL because s was reassigned
+assert s == original

--- a/regression/python/nondet_str10/test.desc
+++ b/regression/python/nondet_str10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/nondet_str5/main.py
+++ b/regression/python/nondet_str5/main.py
@@ -1,0 +1,6 @@
+foo = nondet_str()
+
+if foo == "":
+    foo = "foo"
+
+assert foo == "foo" or foo == "" or foo != "foo"

--- a/regression/python/nondet_str5/test.desc
+++ b/regression/python/nondet_str5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str6/main.py
+++ b/regression/python/nondet_str6/main.py
@@ -1,0 +1,6 @@
+foo = nondet_str()
+
+if foo == "":
+    foo = "foo"
+
+assert foo == "foo" or foo == ""

--- a/regression/python/nondet_str6/test.desc
+++ b/regression/python/nondet_str6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/nondet_str7/main.py
+++ b/regression/python/nondet_str7/main.py
@@ -1,0 +1,46 @@
+# Test 1: Basic nondet_str() with reassignment on empty
+a = nondet_str()
+if a == "":
+    a = "default"
+
+# Test 2: Multiple independent nondet_str() allocations
+b = nondet_str()
+c = nondet_str()
+
+# Test 3: String reassignment
+d = nondet_str()
+d = "fixed"
+assert d == "fixed"
+
+# Test 4: Comparison with non-empty constant
+e = nondet_str()
+if e == "test":
+    e = "matched"
+else:
+    e = "other"
+
+# Test 5: List storage and retrieval (regression test)
+str1 = nondet_str()
+str2 = nondet_str()
+str3 = nondet_str()
+l = [str1, str2, str3]
+assert l[0] == str1
+assert l[1] == str2
+assert l[2] == str3
+
+# Test 6: Multiple reassignments
+f = nondet_str()
+f = "first"
+f = "second"
+assert f == "second"
+
+# Test 7: Empty string edge case
+g = nondet_str()
+if g == "":
+    g = "was_empty"
+    assert g == "was_empty"
+
+# Test 8: Inequality check
+h = nondet_str()
+i = nondet_str()
+result = (h == i)

--- a/regression/python/nondet_str7/test.desc
+++ b/regression/python/nondet_str7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 20
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str8/main.py
+++ b/regression/python/nondet_str8/main.py
@@ -1,0 +1,4 @@
+x = nondet_str()
+# This assertion should FAIL because x is nondeterministic
+# It could be any string (including empty), not necessarily "hello"
+assert x == "hello"

--- a/regression/python/nondet_str8/test.desc
+++ b/regression/python/nondet_str8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/nondet_str9/main.py
+++ b/regression/python/nondet_str9/main.py
@@ -1,0 +1,5 @@
+a = nondet_str()
+b = nondet_str()
+# This assertion should FAIL because a and b are independent nondeterministic values
+# They could be different strings
+assert a == b

--- a/regression/python/nondet_str9/test.desc
+++ b/regression/python/nondet_str9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3284.

This PR creates a temporary array, assigns `nondet` value, ensures null termination, and `returns &arr[0]` as `char*` (not `char(*)[16]`), thereby matching Python string semantics. 

Before this PR, `nondet_str()` returned a `with` expression (value), which crashed when its address was taken. 

Thanks to [zhassan-aws](https://github.com/zhassan-aws) for reporting this issue.