### PR TITLE
[python] replace static dict counter with location-based naming for determinism

### DIFF
--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -401,6 +401,20 @@ private:
     const exprt &obj_value,
     const typet &expected_type,
     const locationt &location);
+
+  /**
+   * @brief Generate a unique dictionary name based on source location
+   * 
+   * Creates deterministic names using file, line, and column information.
+   * Falls back to JSON node hash if location is unavailable.
+   * 
+   * @param element The JSON AST node for the dictionary
+   * @param location The source location
+   * @return A unique dictionary identifier
+   */
+  std::string generate_unique_dict_name(
+    const nlohmann::json &element,
+    const locationt &location) const;
 };
 
 #endif // PYTHON_DICT_HANDLER_H


### PR DESCRIPTION
This PR replaces a global mutable static counter with deterministic name generation based on source location (file, line, column) and content hash.

Benefits:
- Deterministic: same code produces the same names.
- Thread-safe: no shared mutable state.
- Better debugging: names traceable to source.
- No counter overflow or reset issues.