### PR TITLE
[python] fix None comparison in lists and type-mismatched comparisons

### DIFF
--- a/regression/python/none4/main.py
+++ b/regression/python/none4/main.py
@@ -1,0 +1,2 @@
+l = [None]
+assert l[0] is None

--- a/regression/python/none4/test.desc
+++ b/regression/python/none4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/none4_fail/main.py
+++ b/regression/python/none4_fail/main.py
@@ -1,0 +1,2 @@
+l = [None]
+assert l[0] is not None

--- a/regression/python/none4_fail/test.desc
+++ b/regression/python/none4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -84,6 +84,11 @@ size_t __ESBMC_list_size(const PyListObject *l)
 
 static inline void *__ESBMC_copy_value(const void *value, size_t size)
 {
+  // None type (NULL pointer with size 0)
+  // Don't allocate: return NULL to preserve None semantics
+  if (value == NULL && size == 0)
+    return NULL;
+
   void *copied = __ESBMC_alloca(size);
 
   if (size == 8)

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2977,12 +2977,6 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
                is_empty_type(ptr_type.subtype);
       }
 
-      if (is_constant_int2t(e))
-      {
-        const constant_int2t &const_val = to_constant_int2t(e);
-        return const_val.value.is_zero();
-      }
-
       return false;
     };
 

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2969,9 +2969,21 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
       rhs = to_typecast2t(rhs).from;
 
     auto is_none_type = [](const expr2tc &e) -> bool {
-      // None is represented as pointer to bool
-      return is_pointer_type(e) &&
-             is_bool_type(to_pointer_type(e->type).subtype);
+      // Check for pointer to bool or pointer to empty (void*)
+      if (is_pointer_type(e))
+      {
+        const pointer_type2t &ptr_type = to_pointer_type(e->type);
+        return is_bool_type(ptr_type.subtype) ||
+               is_empty_type(ptr_type.subtype);
+      }
+
+      if (is_constant_int2t(e))
+      {
+        const constant_int2t &const_val = to_constant_int2t(e);
+        return const_val.value.is_zero();
+      }
+
+      return false;
     };
 
     const bool lhs_is_none = is_none_type(lhs);


### PR DESCRIPTION
This PR:
- Stores `None` pointers directly (such as strings) instead of by address.
- Sets `size=0` for None to skip `memcpy` and preserve NULL.
- Updates `__ESBMC_copy_value` to return NULL for `size=0 + NULL` input.
- Handles type-mismatched comparisons (`None vs int/str/etc`).
- Accepts constant 0 as `None` in `ISNONE` simplification.
- Treats `None` such as strings in list indexing (no extra dereference).

Previously, None values in lists were stored by address (&None), causing verification failures when checking list[i] == None due to dereferencing a NULL pointer. Additionally, comparisons such as "None != 0" were incorrectly treated as None identity checks instead of type mismatch comparisons.

