### PR TITLE
[python] fix crash when using dictionaries in boolean contexts

### DIFF
--- a/regression/python/dict40/test.desc
+++ b/regression/python/dict40/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict43/main.py
+++ b/regression/python/dict43/main.py
@@ -1,0 +1,7 @@
+def test_empty_dict():
+    d = {}
+
+    assert not d
+    assert len(d) == 0
+
+test_empty_dict()

--- a/regression/python/dict43/test.desc
+++ b/regression/python/dict43/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict44_fail/main.py
+++ b/regression/python/dict44_fail/main.py
@@ -1,0 +1,6 @@
+def test_empty_dict():
+    d = {}
+
+    assert d
+
+test_empty_dict()

--- a/regression/python/dict44_fail/test.desc
+++ b/regression/python/dict44_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$


### PR DESCRIPTION
This PR converts dictionary truthiness checks to emptiness tests by calling `__ESBMC_list_size(dict.keys)` instead of using the struct directly as a boolean.

In particular, this PR handles two cases:
- Unary 'not' operator: 'not d' → len(d.keys) == 0
- Direct assertions: 'assert d' → len(d.keys) != 0

This properly implements Python's truthiness semantics, where empty dicts are falsy and non-empty dicts are truthy.