### PR TITLE
[python] add support for dict.keys() and dict.values() methods

### DIFF
--- a/regression/python/dict46/main.py
+++ b/regression/python/dict46/main.py
@@ -1,0 +1,6 @@
+def test_dict_keys():
+    d = {"a": 1, "b": 2}
+
+    assert set(d.keys()) == {"a", "b"}
+
+test_dict_keys()

--- a/regression/python/dict46/test.desc
+++ b/regression/python/dict46/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict46_fail/main.py
+++ b/regression/python/dict46_fail/main.py
@@ -1,0 +1,6 @@
+def test_dict_keys():
+    d = {"a": 1, "b": 2}
+
+    assert set(d.keys()) == {"a", "c"}
+
+test_dict_keys()

--- a/regression/python/dict46_fail/test.desc
+++ b/regression/python/dict46_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 3
+^VERIFICATION FAILED$

--- a/regression/python/dict47/main.py
+++ b/regression/python/dict47/main.py
@@ -1,0 +1,6 @@
+def test_dict_values():
+    d = {"a": 1, "b": 2}
+
+    assert set(d.values()) == {1, 2}
+
+test_dict_values()

--- a/regression/python/dict47/test.desc
+++ b/regression/python/dict47/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict47_fail/main.py
+++ b/regression/python/dict47_fail/main.py
@@ -1,0 +1,6 @@
+def test_dict_values():
+    d = {"a": 1, "b": 2}
+
+    assert set(d.values()) == {0, 1}
+
+test_dict_values()

--- a/regression/python/dict47_fail/test.desc
+++ b/regression/python/dict47_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$


### PR DESCRIPTION
This PR implements `dict.keys()` and `dict.values()` by returning the corresponding member of the dict struct instead of treating them as undefined function calls. It converts member expressions in list comparisons into temporary variables to fix assertions involving dict methods.