### PR TITLE
[python] handle pointer types in isinstance() for Python containers

### DIFF
--- a/regression/python/isinstance1/main.py
+++ b/regression/python/isinstance1/main.py
@@ -1,0 +1,2 @@
+l = [1, 2, 3]
+assert isinstance(l, list)

--- a/regression/python/isinstance1/test.desc
+++ b/regression/python/isinstance1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance10/main.py
+++ b/regression/python/isinstance10/main.py
@@ -1,0 +1,2 @@
+i = 42
+assert not isinstance(i, str)

--- a/regression/python/isinstance10/test.desc
+++ b/regression/python/isinstance10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance11/main.py
+++ b/regression/python/isinstance11/main.py
@@ -1,0 +1,2 @@
+x = 42
+assert isinstance(x, (int, str))

--- a/regression/python/isinstance11/test.desc
+++ b/regression/python/isinstance11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance12/main.py
+++ b/regression/python/isinstance12/main.py
@@ -1,0 +1,2 @@
+x = "hello"
+assert isinstance(x, (int, str, float))

--- a/regression/python/isinstance12/test.desc
+++ b/regression/python/isinstance12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance13/main.py
+++ b/regression/python/isinstance13/main.py
@@ -1,0 +1,2 @@
+x = 3.14
+assert not isinstance(x, (int, str))

--- a/regression/python/isinstance13/test.desc
+++ b/regression/python/isinstance13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance14/main.py
+++ b/regression/python/isinstance14/main.py
@@ -1,0 +1,2 @@
+l = []
+assert isinstance(l, list)

--- a/regression/python/isinstance14/test.desc
+++ b/regression/python/isinstance14/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance15/main.py
+++ b/regression/python/isinstance15/main.py
@@ -1,0 +1,2 @@
+d = {}
+assert isinstance(d, dict)

--- a/regression/python/isinstance15/test.desc
+++ b/regression/python/isinstance15/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance16/main.py
+++ b/regression/python/isinstance16/main.py
@@ -1,0 +1,2 @@
+nested = [[1, 2], [3, 4]]
+assert isinstance(nested, list)

--- a/regression/python/isinstance16/test.desc
+++ b/regression/python/isinstance16/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance17/main.py
+++ b/regression/python/isinstance17/main.py
@@ -1,0 +1,4 @@
+x = [1, 2, 3]
+if isinstance(x, list):
+    y = len(x)
+    assert y == 3

--- a/regression/python/isinstance17/test.desc
+++ b/regression/python/isinstance17/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance18/main.py
+++ b/regression/python/isinstance18/main.py
@@ -1,0 +1,8 @@
+def check_type(val):
+    if isinstance(val, int):
+        return val * 2
+    else:
+        return 0
+
+result = check_type(5)
+assert result == 10

--- a/regression/python/isinstance18/test.desc
+++ b/regression/python/isinstance18/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance19/main.py
+++ b/regression/python/isinstance19/main.py
@@ -1,0 +1,7 @@
+a = [1, 2, 3]
+b = {"key": "value"}
+c = "text"
+
+assert isinstance(a, list)
+assert isinstance(b, dict)
+assert isinstance(c, str)

--- a/regression/python/isinstance19/test.desc
+++ b/regression/python/isinstance19/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance2/main.py
+++ b/regression/python/isinstance2/main.py
@@ -1,0 +1,2 @@
+d = {"key": "value", "num": 42}
+assert isinstance(d, dict)

--- a/regression/python/isinstance2/test.desc
+++ b/regression/python/isinstance2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance20_fail/main.py
+++ b/regression/python/isinstance20_fail/main.py
@@ -1,0 +1,2 @@
+l = [1, 2, 3]
+assert isinstance(l, dict)

--- a/regression/python/isinstance20_fail/test.desc
+++ b/regression/python/isinstance20_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/isinstance3/main.py
+++ b/regression/python/isinstance3/main.py
@@ -1,0 +1,2 @@
+s = "hello world"
+assert isinstance(s, str)

--- a/regression/python/isinstance3/test.desc
+++ b/regression/python/isinstance3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance4/main.py
+++ b/regression/python/isinstance4/main.py
@@ -1,0 +1,2 @@
+i = 42
+assert isinstance(i, int)

--- a/regression/python/isinstance4/test.desc
+++ b/regression/python/isinstance4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance5/main.py
+++ b/regression/python/isinstance5/main.py
@@ -1,0 +1,2 @@
+f = 3.14
+assert isinstance(f, float)

--- a/regression/python/isinstance5/test.desc
+++ b/regression/python/isinstance5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance6/main.py
+++ b/regression/python/isinstance6/main.py
@@ -1,0 +1,2 @@
+b = True
+assert isinstance(b, bool)

--- a/regression/python/isinstance6/test.desc
+++ b/regression/python/isinstance6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance7/main.py
+++ b/regression/python/isinstance7/main.py
@@ -1,0 +1,2 @@
+t = (1, 2, 3)
+assert isinstance(t, tuple)

--- a/regression/python/isinstance7/test.desc
+++ b/regression/python/isinstance7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance8/main.py
+++ b/regression/python/isinstance8/main.py
@@ -1,0 +1,2 @@
+s = {1, 2, 3}
+assert isinstance(s, set)

--- a/regression/python/isinstance8/test.desc
+++ b/regression/python/isinstance8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Python containers (lists, dictionaries, etc.) are reference types. This PR extracts the pointee symbol type instead of using the pointer directly to avoid `std::bad_cast` during type checking.