### PR TITLE
[python] extend type inference for loop variables in preprocessor-transformed for loops

### DIFF
--- a/regression/python/dict57/main.py
+++ b/regression/python/dict57/main.py
@@ -1,0 +1,6 @@
+d = {"a": 1, "b": 2}
+l = d.keys()
+keys = []
+for k in l:
+    keys.append(k)
+assert keys == ["a", "b"]

--- a/regression/python/dict57/test.desc
+++ b/regression/python/dict57/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict57_fail/main.py
+++ b/regression/python/dict57_fail/main.py
@@ -1,0 +1,6 @@
+d = {"a": 1, "b": 2}
+l = d.keys()
+keys = []
+for k in l:
+    keys.append(k)
+assert keys == ["b", "a"]

--- a/regression/python/dict57_fail/test.desc
+++ b/regression/python/dict57_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/python/dict58/main.py
+++ b/regression/python/dict58/main.py
@@ -1,0 +1,6 @@
+d = {"a": 1, "b": 2}
+l = d.values()
+keys = []
+for k in l:
+    keys.append(k)
+assert keys == [1, 2]

--- a/regression/python/dict58/test.desc
+++ b/regression/python/dict58/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict58_fail/main.py
+++ b/regression/python/dict58_fail/main.py
@@ -1,0 +1,6 @@
+d = {"a": 1, "b": 2}
+l = d.values()
+keys = []
+for k in l:
+    keys.append(k)
+assert keys == [2, 1]

--- a/regression/python/dict58_fail/test.desc
+++ b/regression/python/dict58_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$


### PR DESCRIPTION
The preprocessor transforms `for k in l:` into while loops before type annotation runs, causing loop variables to have a generic `Any` type instead of inheriting element types from their iterables. This PR adds `infer_loop_variable_types()` to propagate element types from annotated iterables (e.g., `list[str]`) to loop variables after while loop processing. This ensures loop variables such as `k` correctly inherit type `str` when iterating over `list[str]`. It fixes verification failures when `dict.keys()/values()` results are used in for loops without explicit type annotations.