### PR TITLE
[python] fix crash when parsing list elements without value key

### DIFF
--- a/regression/python/github_3238/main.py
+++ b/regression/python/github_3238/main.py
@@ -1,0 +1,13 @@
+def pascal(n:int):
+    rows = [[1]]
+    for r in range(1, n):
+        row = []
+        for c in range(0, r + 1):
+            upleft = rows[r - 1][c - 1] if c > 0 else 0
+            upright = rows[r - 1][c] if c < r else 0
+            row.append(upleft + upright)
+        rows.append(row)
+
+    return rows
+
+assert pascal(1) == [[1]]

--- a/regression/python/github_3238/test.desc
+++ b/regression/python/github_3238/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--no-standard-checks --unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3238/test.desc
+++ b/regression/python/github_3238/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
---no-standard-checks --unwind 8
+--no-standard-checks --unwind 2
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/pascal/test.desc
+++ b/regression/quixbugs/pascal/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--unwind 9 --no-standard-checks
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1246,11 +1246,13 @@ private:
     if (!list.contains("elts"))
       return "";
 
-    if (!list["elts"].empty())
+    if (!list["elts"].empty() && list["elts"][0].contains("value"))
       list_subtype = get_type_from_json(list["elts"][0]["value"]);
 
     for (const auto &elem : list["elts"])
-      if (get_type_from_json(elem["value"]) != list_subtype)
+      if (
+        elem.contains("value") &&
+        get_type_from_json(elem["value"]) != list_subtype)
         throw std::runtime_error("Multiple typed lists are not supported\n");
 
     return list_subtype;


### PR DESCRIPTION
This PR adds `contains("value")` checks in `get_list_subtype` before accessing the `"value"` field. Simple literals, such as integers, don't have a "value" key in their AST representation, causing assertion failures in the JSON library when accessed via `operator[]`.