### PR TITLE
[python] Infer builtin call types in logical expressions

### DIFF
--- a/regression/python/boolop-len-or/main.py
+++ b/regression/python/boolop-len-or/main.py
@@ -1,0 +1,7 @@
+def pick_len(s, t):
+    return len(s) or len(t)
+
+
+assert pick_len("", "abc") == 3
+assert pick_len("hi", "") == 2
+assert pick_len("", "") == 0

--- a/regression/python/boolop-len-or/test.desc
+++ b/regression/python/boolop-len-or/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -546,6 +546,8 @@ exprt function_call_builder::build() const
       throw std::runtime_error("__ESBMC_assume requires one boolean argument");
 
     exprt condition = converter_.get_expr(call_["args"][0]);
+    if (!condition.type().is_bool())
+      condition = typecast_exprt(condition, bool_type());
 
     // Create code_assume statement
     codet assume_code("assume");

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -474,7 +474,24 @@ private:
     else if (arg["_type"] == "Tuple")
       return "tuple";
     else if (arg["_type"] == "BoolOp")
+    {
+      if (arg.contains("values") && arg["values"].is_array())
+      {
+        for (const auto &val : arg["values"])
+        {
+          if (
+            val.contains("_type") && val["_type"] == "Call" &&
+            val.contains("func") && val["func"].contains("_type") &&
+            val["func"]["_type"] == "Name" && val["func"].contains("id"))
+          {
+            auto it = builtin_functions.find(val["func"]["id"]);
+            if (it != builtin_functions.end())
+              return it->second;
+          }
+        }
+      }
       return "bool";
+    }
     else if (arg["_type"] == "Call")
     {
       // Handle function calls like abs(a - b), len(list), etc.


### PR DESCRIPTION
Improve type inference for builtin calls (e.g., len) in logical expressions, ensuring statements like `len(a) or len(b)` are handled as int in the Python frontend.

Fix needed by #3236 