### PR TITLE
[python] fix nested dereference and type inference for string module

### DIFF
--- a/regression/python/string-concat12/test.desc
+++ b/regression/python/string-concat12/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc
+--unwind 28
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-concat13/main.py
+++ b/regression/python/string-concat13/main.py
@@ -1,0 +1,9 @@
+import string
+
+def f():
+    s = ""
+    alphabet:str = string.digits + string.ascii_uppercase
+    s = alphabet[0] + s
+    assert s == "0"
+f()
+

--- a/regression/python/string-concat13/test.desc
+++ b/regression/python/string-concat13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 28
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-concat13_fail/main.py
+++ b/regression/python/string-concat13_fail/main.py
@@ -1,0 +1,9 @@
+import string
+
+def f():
+    s = ""
+    alphabet:str = string.digits + string.ascii_uppercase
+    s = alphabet[0] + s
+    assert s == ""
+f()
+

--- a/regression/python/string-concat13_fail/test.desc
+++ b/regression/python/string-concat13_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 28
+^VERIFICATION FAILED$

--- a/regression/quixbugs/to_base/test.desc
+++ b/regression/quixbugs/to_base/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
--unwind 28 --smt-during-symex --smt-symex-guard --bitwuzla --no-standard-checks
+--unwind 28 --smt-during-symex --smt-symex-guard --bitwuzla --no-standard-checks
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/to_base/test.desc
+++ b/regression/quixbugs/to_base/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---unwind 40
-
+-unwind 28 --smt-during-symex --smt-symex-guard --bitwuzla --no-standard-checks
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/to_base_fail/main.py
+++ b/regression/quixbugs/to_base_fail/main.py
@@ -1,0 +1,33 @@
+
+import string
+def to_base(num, b):
+    result = ''
+    alphabet = string.digits + string.ascii_uppercase
+    while num > 0:
+        i = num % b
+        num = num // b
+        result = alphabet[i] + result
+    return result
+
+"""
+import string
+def to_base(num, b):
+    result = ''
+    alphabet = string.digits + string.ascii_uppercase
+    while num > 0:
+        i = num % b
+        num = num // b
+        result = result + alphabet[i]
+    return result[::-1]
+"""
+
+assert to_base(8227, 18) == "1771"
+assert to_base(73, 8) == "111"
+assert to_base(16, 19) == "G"
+assert to_base(31, 16) == "1F"
+assert to_base(41, 2) == "10100" # this should fail
+assert to_base(44, 5) == "134"
+assert to_base(27, 23) == "14"
+assert to_base(56, 23) == "2A"
+assert to_base(8237, 24) == "E75"
+assert to_base(8237, 34) == "749"

--- a/regression/quixbugs/to_base_fail/test.desc
+++ b/regression/quixbugs/to_base_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 28 --smt-during-symex --smt-symex-guard --bitwuzla --no-standard-checks
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -86,6 +86,17 @@ static const std::map<std::string, std::string> builtin_functions = {
   {"exec", "NoneType"},
   {"compile", "code"},
 
+  // String module constants
+  {"string.digits", "str"},
+  {"string.ascii_lowercase", "str"},
+  {"string.ascii_uppercase", "str"},
+  {"string.ascii_letters", "str"},
+  {"string.punctuation", "str"},
+  {"string.whitespace", "str"},
+  {"string.printable", "str"},
+  {"string.hexdigits", "str"},
+  {"string.octdigits", "str"},
+
   // Import functions
   {"__import__", "module"}};
 
@@ -931,6 +942,19 @@ private:
         type = get_type_from_constant(lhs);
       else if (lhs["_type"] == "Call" && lhs["func"]["_type"] == "Attribute")
         type = get_type_from_method(lhs);
+      else if (lhs["_type"] == "Attribute")
+      {
+        // Construct full attribute name (e.g., "string.digits")
+        if (lhs["value"]["_type"] == "Name" && lhs["value"].contains("id"))
+        {
+          std::string full_name =
+            lhs["value"]["id"].template get<std::string>() + "." +
+            lhs["attr"].template get<std::string>();
+          auto it = builtin_functions.find(full_name);
+          if (it != builtin_functions.end())
+            type = it->second;
+        }
+      }
     }
 
     // If still unknown, try RHS or fallback to Any for arithmetic ops

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -521,9 +521,20 @@ exprt string_handler::handle_string_concatenation_with_promotion(
     // RHS is array, LHS is single char - promote LHS to string array
     if (type_utils::is_integer_type(lhs.type()))
     {
+      // Extract index/dereference to avoid nested dereferences
+      exprt lhs_value = lhs;
+      if (lhs.is_index())
+      {
+        symbolt &temp = converter_.create_tmp_symbol(
+          nlohmann::json(), "$char_temp$", lhs.type(), gen_zero(lhs.type()));
+        code_assignt assign(symbol_expr(temp), lhs);
+        converter_.add_instruction(assign);
+        lhs_value = symbol_expr(temp);
+      }
+
       typet string_type = type_handler_.build_array(char_type(), 2);
       exprt str_array = gen_zero(string_type);
-      str_array.operands().at(0) = lhs;
+      str_array.operands().at(0) = lhs_value;
       str_array.operands().at(1) = gen_zero(char_type()); // null terminator
       lhs = str_array;
     }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3316.

This PR extracts index operations to temporary variables before creating aggregate expressions, ensuring proper GOTO code generation. Before this PR, when concatenating a single character with a string (e.g., `alphabet[0] + s`), the string promotion logic directly embedded index expressions into aggregate initializers, producing invalid GOTO code.

Additionally, this PR extends `builtin_functions` map to include string module constants (`digits`, `ascii_uppercase`, etc.) to fix type inference failure when variables are assigned from binary expressions such as: `alphabet = string.digits + string.ascii_uppercase`.

