### PR TITLE
[python] fix list.pop() and empty list detection

### DIFF
--- a/regression/python/list27_fail/main.py
+++ b/regression/python/list27_fail/main.py
@@ -1,0 +1,7 @@
+def f() -> float:
+    xs = [3.0, 5.1]
+    b = xs.pop()
+    a = xs.pop()
+    return a + b
+
+assert f() == 8.0

--- a/regression/python/list27_fail/test.desc
+++ b/regression/python/list27_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 9 --no-standard-checks
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/regression/python/list28/main.py
+++ b/regression/python/list28/main.py
@@ -1,0 +1,5 @@
+xs = [1.0, 2.0, 3.0]
+s = 0.0
+while xs:
+    s = s + xs.pop()
+assert s == 6.0

--- a/regression/python/list28/test.desc
+++ b/regression/python/list28/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list28_fail/main.py
+++ b/regression/python/list28_fail/main.py
@@ -1,0 +1,5 @@
+xs = [1.0, 2.0, 3.0]
+s = 0.1
+while xs:
+    s = s + xs.pop()
+assert s == 6.0

--- a/regression/python/list28_fail/test.desc
+++ b/regression/python/list28_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/regression/python/list29/main.py
+++ b/regression/python/list29/main.py
@@ -1,0 +1,23 @@
+xs: list[float] = [1.0, 2.0, 3.0]
+result: float = 0.0
+
+# Test with non-empty list
+if xs:
+    result = 1.0
+else:
+    result = 2.0
+
+assert result == 1.0  # List was non-empty
+
+# Pop all elements
+xs.pop()
+xs.pop()
+xs.pop()
+
+# Test with empty list
+if xs:
+    result = 3.0
+else:
+    result = 4.0
+
+assert result == 4.0  # List was empty

--- a/regression/python/list29/test.desc
+++ b/regression/python/list29/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list29_fail/main.py
+++ b/regression/python/list29_fail/main.py
@@ -1,0 +1,11 @@
+xs: list[float] = [1.0, 2.0, 3.0]
+result: float = 0.0
+xl = [] # empty list
+
+# Test with empty list
+if xl:
+    result = 1.0
+else:
+    result = 2.0
+
+assert result == 1.0  # List was empty

--- a/regression/python/list29_fail/test.desc
+++ b/regression/python/list29_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1614,22 +1614,13 @@ exprt function_call_expr::handle_list_pop() const
   const typet pyobject_ptr_type =
     pointer_typet(converter_.get_type_handler().get_list_element_type());
 
-  symbolt &pop_result_sym = converter_.create_tmp_symbol(
-    call_, "$pop_result$", pyobject_ptr_type, exprt());
-
-  code_declt pop_result_decl(symbol_expr(pop_result_sym));
-  pop_result_decl.location() = converter_.get_location_from_decl(call_);
-  converter_.add_instruction(pop_result_decl);
-
-  // Build function call
-  code_function_callt pop_call;
+  // Build side-effect function call expression
+  side_effect_expr_function_callt pop_call;
   pop_call.function() = symbol_expr(*pop_func);
-  pop_call.lhs() = symbol_expr(pop_result_sym);
   pop_call.arguments().push_back(symbol_expr(*list_symbol));
   pop_call.arguments().push_back(index_expr);
   pop_call.type() = pyobject_ptr_type;
   pop_call.location() = converter_.get_location_from_decl(call_);
-  converter_.add_instruction(pop_call);
 
   // Determine the element type from the list's type map
   const std::string &list_id = list_symbol->id.as_string();
@@ -1661,8 +1652,7 @@ exprt function_call_expr::handle_list_pop() const
   }
 
   // Extract value from PyObject: pop_result->value
-  member_exprt obj_value(
-    symbol_expr(pop_result_sym), "value", pointer_typet(empty_typet()));
+  member_exprt obj_value(pop_call, "value", pointer_typet(empty_typet()));
 
   // Dereference the PyObject*
   {


### PR DESCRIPTION
This PR:
- Uses `side_effect_expr_function_callt` in `handle_list_pop()` to prevent duplicate pop operations.
- Transforms list truthiness checks (`while xs:`, `if xs:`) to explicit `len()` comparisons in the preprocessor.