### PR TITLE
[C++ verification] pointer-to-member

### DIFF
--- a/regression/esbmc-cpp/cpp/ptr_to_member_1/main.cpp
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_1/main.cpp
@@ -1,0 +1,13 @@
+struct S {
+    int x;
+    int y;
+};
+
+
+int main() {
+    S s{42};
+
+    int S::* pm = &S::x;
+
+    __ESBMC_assert(s.*pm == 42, "");
+}

--- a/regression/esbmc-cpp/cpp/ptr_to_member_1/test.desc
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ptr_to_member_1_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_1_fail/main.cpp
@@ -1,0 +1,13 @@
+struct S {
+    int x;
+    int y;
+};
+
+
+int main() {
+    S s{42};
+
+    int S::* pm = &S::x;
+
+    __ESBMC_assert(s.*pm != 42, "");
+}

--- a/regression/esbmc-cpp/cpp/ptr_to_member_1_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/ptr_to_member_2/main.cpp
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_2/main.cpp
@@ -1,0 +1,16 @@
+struct S
+{
+    int x;
+    int y;
+};
+
+int main()
+{
+    S s{42};
+
+    int S::*pm = &S::x;
+
+    S *r = &s;
+
+    __ESBMC_assert(r->*pm == 42, "");
+}

--- a/regression/esbmc-cpp/cpp/ptr_to_member_2/test.desc
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/ptr_to_member_2_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_2_fail/main.cpp
@@ -1,0 +1,16 @@
+struct S
+{
+    int x;
+    int y;
+};
+
+int main()
+{
+    S s{42};
+
+    int S::*pm = &S::x;
+
+    S *r = &s;
+
+    __ESBMC_assert(r->*pm != 42, "");
+}

--- a/regression/esbmc-cpp/cpp/ptr_to_member_2_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/ptr_to_member_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -157,6 +157,19 @@ void clang_c_adjust::adjust_expr(exprt &expr)
     }
     assert(new_comp.size() == ops.size());
   }
+  else if (expr.id() == "ptr_mem")
+  {
+    adjust_operands(expr);
+
+    exprt &base = expr.op0();
+    if (base.type().is_pointer())
+    {
+      exprt deref("dereference");
+      deref.type() = base.type().subtype();
+      deref.move_to_operands(base);
+      base.swap(deref);
+    }
+  }
   else
   {
     // Just check operands of everything else

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3312,7 +3312,7 @@ bool clang_c_convertert::get_binary_operator_expr(
 
   case clang::BO_PtrMemI:
   case clang::BO_PtrMemD:
-    new_expr = exprt("ptrmem", t);
+    new_expr = exprt("ptr_mem", t);
     break;
 
   default:

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3310,6 +3310,11 @@ bool clang_c_convertert::get_binary_operator_expr(
     new_expr = exprt("comma", t);
     break;
 
+  case clang::BO_PtrMemI:
+  case clang::BO_PtrMemD:
+    new_expr = exprt("ptrmem", t);
+    break;
+
   default:
   {
     const clang::CompoundAssignOperator &compop =

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1840,18 +1840,6 @@ bool clang_cpp_convertert::get_decl_ref(
 
     break;
   }
-  case clang::Decl::Field:
-  {
-    // pointer-to-member
-    const clang::FieldDecl &fd = static_cast<const clang::FieldDecl &>(decl);
-
-    get_decl_name(fd, name, id);
-    if (get_type(fd.getType(), type))
-      return true;
-
-    new_expr = member_ref_exprt(name, type);
-    break;
-  }
 
   default:
   {

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1840,6 +1840,18 @@ bool clang_cpp_convertert::get_decl_ref(
 
     break;
   }
+  case clang::Decl::Field:
+  {
+    // pointer-to-member
+    const clang::FieldDecl &fd = static_cast<const clang::FieldDecl &>(decl);
+
+    get_decl_name(fd, name, id);
+    if (get_type(fd.getType(), type))
+      return true;
+
+    new_expr = member_ref_exprt(name, type);
+    break;
+  }
 
   default:
   {

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -280,6 +280,12 @@ bool clang_cpp_convertert::get_type(
       return true;
 #endif
 
+    if (mpt.isMemberFunctionPointer())
+    {
+      log_error("ESBMC currently does not support Member-Function-Pointer");
+      return true;
+    }
+
     new_type = gen_pointer_type(sub_type);
     new_type.set("to-member", class_type);
     break;

--- a/src/goto-symex/dynamic_allocation.cpp
+++ b/src/goto-symex/dynamic_allocation.cpp
@@ -143,7 +143,7 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
     expr2tc member = ptr.member_pointer;
 
     cur_state->rename(member);
-    
+
     if (is_member_ref2t(member))
     {
       const member_ref2t &ref = to_member_ref2t(member);

--- a/src/goto-symex/dynamic_allocation.cpp
+++ b/src/goto-symex/dynamic_allocation.cpp
@@ -135,4 +135,27 @@ void goto_symext::default_replace_dynamic_allocation(expr2tc &expr)
 
     convert_capability_member(expr, size.value, irep_idt("top"), ns);
   }
+  else if (is_ptr_mem2t(expr))
+  {
+    const ptr_mem2t &ptr = to_ptr_mem2t(expr);
+
+    expr2tc source = ptr.source_value;
+    expr2tc member = ptr.member_pointer;
+
+    cur_state->rename(member);
+    
+    if (is_member_ref2t(member))
+    {
+      const member_ref2t &ref = to_member_ref2t(member);
+
+      // give the pm = &S::x and s.*pm
+      // convert the s.*pm into s.x
+      expr = member2tc(to_pointer_type(ref.type).subtype, source, ref.member);
+    }
+    else
+    {
+      log_error("pointer-to-member: constant propagation failed");
+      abort();
+    }
+  }
 }

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -85,6 +85,9 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
   if (is_vector_type(expr))
     return true;
 
+  if (is_member_ref2t(expr))
+    return true;
+
   // It's fine to constant propagate something that's absent.
   if (is_nil_expr(expr))
     return true;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -452,10 +452,10 @@ void goto_symext::symex_assign_symbol(
     cur_state->rename(to_index2t(new_lhs).index);
 
   if (is_member_ref2t(rhs))
-  // In pointer-to-member, the following assignment will occur:
-  // int S::* pm = &S::x;
-  // This assignment is static and we do not need to generate an SSA for it,
-  // we can simply skip it - constant propagation can handle it.
+    // In pointer-to-member, the following assignment will occur:
+    // int S::* pm = &S::x;
+    // This assignment is static and we do not need to generate an SSA for it,
+    // we can simply skip it - constant propagation can handle it.
     return;
 
   guardt tmp_guard(cur_state->guard);

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -451,6 +451,13 @@ void goto_symext::symex_assign_symbol(
   if (is_index2t(new_lhs))
     cur_state->rename(to_index2t(new_lhs).index);
 
+  if (is_member_ref2t(rhs))
+  // In pointer-to-member, the following assignment will occur:
+  // int S::* pm = &S::x;
+  // This assignment is static and we do not need to generate an SSA for it,
+  // we can simply skip it - constant propagation can handle it.
+    return;
+
   guardt tmp_guard(cur_state->guard);
   tmp_guard.append(guard);
 

--- a/src/goto-symex/symex_valid_object.cpp
+++ b/src/goto-symex/symex_valid_object.cpp
@@ -78,6 +78,10 @@ void goto_symext::replace_dynamic_allocation(expr2tc &expr)
   {
     default_replace_dynamic_allocation(expr);
   }
+  else if (is_ptr_mem2t(expr))
+  {
+    default_replace_dynamic_allocation(expr);
+  }
 }
 
 bool goto_symext::is_valid_object(const symbolt &symbol)

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -86,6 +86,7 @@
   BOOST_PP_LIST_CONS(with,                                                     \
   BOOST_PP_LIST_CONS(member,                                                   \
   BOOST_PP_LIST_CONS(member_ref,                                               \
+  BOOST_PP_LIST_CONS(ptr_mem,                                                  \
   BOOST_PP_LIST_CONS(index,                                                    \
   BOOST_PP_LIST_CONS(isnan,                                                    \
   BOOST_PP_LIST_CONS(overflow,                                                 \
@@ -135,7 +136,7 @@
   BOOST_PP_LIST_CONS(isinstance,                                               \
   BOOST_PP_LIST_CONS(hasattr,                                                  \
   BOOST_PP_LIST_CONS(isnone,                                                   \
-  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -85,6 +85,7 @@
   BOOST_PP_LIST_CONS(byte_update,                                              \
   BOOST_PP_LIST_CONS(with,                                                     \
   BOOST_PP_LIST_CONS(member,                                                   \
+  BOOST_PP_LIST_CONS(member_ref,                                               \
   BOOST_PP_LIST_CONS(index,                                                    \
   BOOST_PP_LIST_CONS(isnan,                                                    \
   BOOST_PP_LIST_CONS(overflow,                                                 \
@@ -134,7 +135,7 @@
   BOOST_PP_LIST_CONS(isinstance,                                               \
   BOOST_PP_LIST_CONS(hasattr,                                                  \
   BOOST_PP_LIST_CONS(isnone,                                                   \
-  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -72,6 +72,7 @@ static const char *expr_names[] = {
   "with",
   "member",
   "member_ref",
+  "ptr_mem",
   "index",
   "isnan",
   "overflow",

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -71,6 +71,7 @@ static const char *expr_names[] = {
   "byte_update",
   "with",
   "member",
+  "member_ref",
   "index",
   "isnan",
   "overflow",

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -834,6 +834,27 @@ public:
   typedef esbmct::expr2t_traits<source_value_field, member_field> traits;
 };
 
+class member_ref_data : public datatype_ops
+{
+public:
+  member_ref_data(
+    const type2tc &t,
+    datatype_ops::expr_ids id,
+    const irep_idt &m)
+    : datatype_ops(t, id), member(m)
+  {
+  }
+  member_ref_data(const member_ref_data &ref) = default;
+
+  irep_idt member;
+
+  // Type mangling:
+  typedef esbmct::
+    field_traits<irep_idt, member_ref_data, &member_ref_data::member>
+      member_field;
+  typedef esbmct::expr2t_traits<member_field> traits;
+};
+
 class index_data : public datatype_ops
 {
 public:
@@ -1482,6 +1503,7 @@ irep_typedefs(byte_extract, byte_extract_data);
 irep_typedefs(byte_update, byte_update_data);
 irep_typedefs(with, with_data);
 irep_typedefs(member, member_data);
+irep_typedefs(member_ref, member_ref_data);
 irep_typedefs(index, index_data);
 irep_typedefs(isnan, bool_1op);
 irep_typedefs(overflow, overflow_ops);
@@ -2920,6 +2942,23 @@ public:
   member2t(const member2t &ref) = default;
 
   expr2tc do_simplify() const override;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+/** Member reference
+ *  @extends member_ref_data */
+class member_ref2t : public member_ref_expr_methods
+{
+public:
+  /** Primary constructor.
+   *  @param type Type of extracted member.
+   *  @param memb Name of member to extract.  */
+  member_ref2t(const type2tc &type, const irep_idt &memb)
+    : member_ref_expr_methods(type, member_ref_id, memb)
+  {
+  }
+  member_ref2t(const member_ref2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -2997,10 +2997,10 @@ class ptr_mem2t : public ptr_mem_expr_methods
 {
 public:
   /** Primary constructor.
-   *  @param type Type of extracted member.
-   *  @param memb Name of member to extract.  */
-  ptr_mem2t(const type2tc &type, const expr2tc &source, const expr2tc &p)
-    : ptr_mem_expr_methods(type, ptr_mem_id, source, p)
+   *  @param source Data structure to extract from.
+   *  @param pointer Pointer to member.  */
+  ptr_mem2t(const type2tc &type, const expr2tc &source, const expr2tc &pointer)
+    : ptr_mem_expr_methods(type, ptr_mem_id, source, pointer)
   {
   }
   ptr_mem2t(const ptr_mem2t &ref) = default;

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -855,6 +855,30 @@ public:
   typedef esbmct::expr2t_traits<member_field> traits;
 };
 
+class ptr_mem_data : public datatype_ops
+{
+public:
+  ptr_mem_data(
+    const type2tc &t,
+    datatype_ops::expr_ids id,
+    const expr2tc &s,
+    const expr2tc &p)
+    : datatype_ops(t, id), source_value(s), member_pointer(p)
+  {
+  }
+  ptr_mem_data(const ptr_mem_data &ref) = default;
+
+  expr2tc source_value;
+  expr2tc member_pointer;
+
+  // Type mangling:
+  typedef esbmct::field_traits<expr2tc, ptr_mem_data, &ptr_mem_data::source_value>
+    source_value_field;
+  typedef esbmct::field_traits<expr2tc, ptr_mem_data, &ptr_mem_data::member_pointer>
+    member_pointer_field;
+  typedef esbmct::expr2t_traits<source_value_field, member_pointer_field> traits;
+};
+
 class index_data : public datatype_ops
 {
 public:
@@ -1504,6 +1528,7 @@ irep_typedefs(byte_update, byte_update_data);
 irep_typedefs(with, with_data);
 irep_typedefs(member, member_data);
 irep_typedefs(member_ref, member_ref_data);
+irep_typedefs(ptr_mem, ptr_mem_data);
 irep_typedefs(index, index_data);
 irep_typedefs(isnan, bool_1op);
 irep_typedefs(overflow, overflow_ops);
@@ -2959,6 +2984,23 @@ public:
   {
   }
   member_ref2t(const member_ref2t &ref) = default;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+/** Member pointer
+ *  @extends ptr_mem_data */
+class ptr_mem2t : public ptr_mem_expr_methods
+{
+public:
+  /** Primary constructor.
+   *  @param type Type of extracted member.
+   *  @param memb Name of member to extract.  */
+  ptr_mem2t(const type2tc &type, const expr2tc &source, const expr2tc &p)
+    : ptr_mem_expr_methods(type, ptr_mem_id, source, p)
+  {
+  }
+  ptr_mem2t(const ptr_mem2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -872,11 +872,14 @@ public:
   expr2tc member_pointer;
 
   // Type mangling:
-  typedef esbmct::field_traits<expr2tc, ptr_mem_data, &ptr_mem_data::source_value>
-    source_value_field;
-  typedef esbmct::field_traits<expr2tc, ptr_mem_data, &ptr_mem_data::member_pointer>
-    member_pointer_field;
-  typedef esbmct::expr2t_traits<source_value_field, member_pointer_field> traits;
+  typedef esbmct::
+    field_traits<expr2tc, ptr_mem_data, &ptr_mem_data::source_value>
+      source_value_field;
+  typedef esbmct::
+    field_traits<expr2tc, ptr_mem_data, &ptr_mem_data::member_pointer>
+      member_pointer_field;
+  typedef esbmct::expr2t_traits<source_value_field, member_pointer_field>
+    traits;
 };
 
 class index_data : public datatype_ops

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -152,6 +152,8 @@ std::string with2t::field_names[esbmct::num_type_fields] =
   {"source_value", "update_field", "update_value", "", ""};
 std::string member2t::field_names[esbmct::num_type_fields] =
   {"source_value", "member_name", "", "", ""};
+std::string member_ref2t::field_names[esbmct::num_type_fields] =
+  {"member_name", "", "", "", ""};
 std::string index2t::field_names[esbmct::num_type_fields] =
   {"source_value", "index", "", "", ""};
 std::string isnan2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -154,6 +154,8 @@ std::string member2t::field_names[esbmct::num_type_fields] =
   {"source_value", "member_name", "", "", ""};
 std::string member_ref2t::field_names[esbmct::num_type_fields] =
   {"member_name", "", "", "", ""};
+std::string ptr_mem2t::field_names[esbmct::num_type_fields] =
+  {"source_value", "member_pointer", "", "", ""};
 std::string index2t::field_names[esbmct::num_type_fields] =
   {"source_value", "index", "", "", ""};
 std::string isnan2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates_expr_data.cpp
+++ b/src/irep2/templates/irep2_templates_expr_data.cpp
@@ -26,6 +26,7 @@ expr_typedefs3(byte_extract, byte_extract_data);
 expr_typedefs4(byte_update, byte_update_data);
 expr_typedefs3(with, with_data);
 expr_typedefs2(member, member_data);
+expr_typedefs2(member_ref, member_ref_data);
 expr_typedefs2(index, index_data);
 expr_typedefs2(overflow_cast, overflow_cast_data);
 expr_typedefs3(dynamic_object, dynamic_object_data);

--- a/src/irep2/templates/irep2_templates_expr_data.cpp
+++ b/src/irep2/templates/irep2_templates_expr_data.cpp
@@ -27,6 +27,7 @@ expr_typedefs4(byte_update, byte_update_data);
 expr_typedefs3(with, with_data);
 expr_typedefs2(member, member_data);
 expr_typedefs2(member_ref, member_ref_data);
+expr_typedefs2(ptr_mem, ptr_mem_data);
 expr_typedefs2(index, index_data);
 expr_typedefs2(overflow_cast, overflow_cast_data);
 expr_typedefs3(dynamic_object, dynamic_object_data);

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -2331,6 +2331,11 @@ std::string c_expr2stringt::convert(const exprt &src, unsigned &precedence)
     return src.identifier().as_string();
   }
 
+  else if (src.id() == "member_ref")
+  {
+    return to_member_ref_expr(src).get_component_name().as_string();
+  }
+
   else if (src.id() == "pointer_object")
   {
     return convert_function(src, "POINTER_OBJECT", precedence = 15);

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -2336,6 +2336,11 @@ std::string c_expr2stringt::convert(const exprt &src, unsigned &precedence)
     return to_member_ref_expr(src).get_component_name().as_string();
   }
 
+  else if (src.id() == "ptr_mem")
+  {
+    return convert_binary(src, ".*", precedence = 2, true);
+  }
+
   else if (src.id() == "pointer_object")
   {
     return convert_function(src, "POINTER_OBJECT", precedence = 15);

--- a/src/util/c_typecast.cpp
+++ b/src/util/c_typecast.cpp
@@ -666,6 +666,17 @@ void c_typecastt::implicit_typecast_followed(
       return; // ok
     }
 
+    if (dest_type.find("to-member").is_not_nil())
+    {
+      if (src_type != dest_type)
+      {
+        // pointe-to-member
+        // TODO: take inheritance into account
+        expr = member_ref_exprt(expr.op0().identifier(), expr.type());
+      }
+      return;
+    }
+
     if (
       src_type.id() == "pointer" || src_type.is_array() ||
       src_type.id() == "incomplete_array")

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -369,6 +369,7 @@ irep_idt exprt::deref = dstring("dereference");
 irep_idt exprt::i_if = dstring("if");
 irep_idt exprt::with = dstring("with");
 irep_idt exprt::member = dstring("member");
+irep_idt exprt::member_ref = dstring("member_ref");
 irep_idt exprt::isnan = dstring("isnan");
 irep_idt exprt::ieee_floateq = dstring("ieee_float_equal");
 irep_idt exprt::i_type = dstring("type");

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -370,6 +370,7 @@ irep_idt exprt::i_if = dstring("if");
 irep_idt exprt::with = dstring("with");
 irep_idt exprt::member = dstring("member");
 irep_idt exprt::member_ref = dstring("member_ref");
+irep_idt exprt::ptr_mem = dstring("ptr_mem");
 irep_idt exprt::isnan = dstring("isnan");
 irep_idt exprt::ieee_floateq = dstring("ieee_float_equal");
 irep_idt exprt::i_type = dstring("type");

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -238,6 +238,7 @@ public:
   static irep_idt i_if;
   static irep_idt with;
   static irep_idt member;
+  static irep_idt member_ref;
   static irep_idt isnan;
   static irep_idt ieee_floateq;
   static irep_idt i_type;

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -239,6 +239,7 @@ public:
   static irep_idt with;
   static irep_idt member;
   static irep_idt member_ref;
+  static irep_idt ptr_mem;
   static irep_idt isnan;
   static irep_idt ieee_floateq;
   static irep_idt i_type;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1484,6 +1484,14 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
 
     new_expr_ref = member_ref2tc(type, expr.component_name());
   }
+  else if (expr.id() == exprt::ptr_mem)
+  {
+    type = migrate_type(expr.type());
+    expr2tc source, pointer;
+    convert_operand_pair(expr, source, pointer);
+
+    new_expr_ref = ptr_mem2tc(type, source, pointer);
+  }
   else if (expr.id() == exprt::index)
   {
     type = migrate_type(expr.type());
@@ -3000,6 +3008,15 @@ exprt migrate_expr_back(const expr2tc &ref)
     exprt member_ref("member_ref", thetype);
     member_ref.set("component_name", ref2.member);
     return member_ref;
+  }
+  case expr2t::ptr_mem_id:
+  {
+    const ptr_mem2t &ref2 = to_ptr_mem2t(ref);
+    typet thetype = migrate_type_back(ref->type);
+    exprt ptrmem("ptr_mem", thetype);
+    ptrmem.copy_to_operands(
+      migrate_expr_back(ref2.source_value), migrate_expr_back(ref2.member_pointer));
+    return ptrmem;
   }
   case expr2t::index_id:
   {

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1478,8 +1478,13 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     new_expr_ref = member2tc(type, sourcedata, expr.component_name());
     return;
   }
+  else if (expr.id() == exprt::member_ref)
+  {
+    type = migrate_type(expr.type());
 
-  if (expr.id() == exprt::index)
+    new_expr_ref = member_ref2tc(type, expr.component_name());
+  }
+  else if (expr.id() == exprt::index)
   {
     type = migrate_type(expr.type());
 
@@ -2987,6 +2992,14 @@ exprt migrate_expr_back(const expr2tc &ref)
     exprt member_name("member_name");
     member.copy_to_operands(migrate_expr_back(ref2.source_value));
     return member;
+  }
+  case expr2t::member_ref_id:
+  {
+    const member_ref2t &ref2 = to_member_ref2t(ref);
+    typet thetype = migrate_type_back(ref->type);
+    exprt member_ref("member_ref", thetype);
+    member_ref.set("component_name", ref2.member);
+    return member_ref;
   }
   case expr2t::index_id:
   {

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1478,21 +1478,26 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     new_expr_ref = member2tc(type, sourcedata, expr.component_name());
     return;
   }
-  else if (expr.id() == exprt::member_ref)
+
+  if (expr.id() == exprt::member_ref)
   {
     type = migrate_type(expr.type());
 
     new_expr_ref = member_ref2tc(type, expr.component_name());
+    return;
   }
-  else if (expr.id() == exprt::ptr_mem)
+
+  if (expr.id() == exprt::ptr_mem)
   {
     type = migrate_type(expr.type());
     expr2tc source, pointer;
     convert_operand_pair(expr, source, pointer);
 
     new_expr_ref = ptr_mem2tc(type, source, pointer);
+    return;
   }
-  else if (expr.id() == exprt::index)
+
+  if (expr.id() == exprt::index)
   {
     type = migrate_type(expr.type());
 
@@ -3015,7 +3020,8 @@ exprt migrate_expr_back(const expr2tc &ref)
     typet thetype = migrate_type_back(ref->type);
     exprt ptrmem("ptr_mem", thetype);
     ptrmem.copy_to_operands(
-      migrate_expr_back(ref2.source_value), migrate_expr_back(ref2.member_pointer));
+      migrate_expr_back(ref2.source_value),
+      migrate_expr_back(ref2.member_pointer));
     return ptrmem;
   }
   case expr2t::index_id:

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1007,6 +1007,41 @@ public:
   }
 };
 
+class member_ref_exprt : public exprt
+{
+public:
+  explicit member_ref_exprt(const typet &type) : exprt(exprt::member_ref, type)
+  {
+    operands().resize(1);
+  }
+
+  member_ref_exprt(const irep_idt &component_name) : exprt(exprt::member_ref)
+  {
+    set_component_name(component_name);
+  }
+
+  inline member_ref_exprt(const irep_idt &component_name, const typet &_type)
+    : exprt(exprt::member_ref, _type)
+  {
+    set_component_name(component_name);
+  }
+
+  member_ref_exprt() : exprt(exprt::member_ref)
+  {
+    operands().resize(1);
+  }
+
+  irep_idt get_component_name() const
+  {
+    return get("component_name");
+  }
+
+  void set_component_name(const irep_idt &component_name)
+  {
+    this->component_name(component_name);
+  }
+};
+
 inline const member_exprt &to_member_expr(const exprt &expr)
 {
   assert(expr.id() == exprt::member);
@@ -1017,6 +1052,18 @@ inline member_exprt &to_member_expr(exprt &expr)
 {
   assert(expr.id() == exprt::member);
   return static_cast<member_exprt &>(expr);
+}
+
+inline const member_ref_exprt &to_member_ref_expr(const exprt &expr)
+{
+  assert(expr.id() == exprt::member_ref);
+  return static_cast<const member_ref_exprt &>(expr);
+}
+
+inline member_ref_exprt &to_member_ref_expr(exprt &expr)
+{
+  assert(expr.id() == exprt::member_ref);
+  return static_cast<member_ref_exprt &>(expr);
 }
 
 class type_exprt : public exprt


### PR DESCRIPTION
This PR introduces two new ireps to handle pointer to member. 

We rely on constant propagation to perform the assignment of pointer members.

Support format:

Assignment:
`int S::*pm = &S::x;`
Access:
`s.*pm`

Assignment:
`int S::*pm = &S::x;`
`S *r = &s;`
Access:
`r->*pm`