### PR TITLE
[bmc] disable --termination when --k-induction is specified

### DIFF
--- a/regression/termination/termination11/test.desc
+++ b/regression/termination/termination11/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --k-induction --termination
 ^VERIFICATION SUCCESSFUL$

--- a/regression/termination/termination12/main.c
+++ b/regression/termination/termination12/main.c
@@ -1,0 +1,13 @@
+extern int __VERIFIER_nondet_int(void);
+
+int main() 
+{
+  int n = __VERIFIER_nondet_int();
+  while (n < 10 ) 
+  {
+    __VERIFIER_assume(n >= 0);
+    n++;
+  }
+
+  return 0;
+}

--- a/regression/termination/termination12/test.desc
+++ b/regression/termination/termination12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--termination
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -400,6 +400,16 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("partial-loops", false);
   }
 
+  // Check for conflicting strategies
+  if (cmdline.isset("k-induction") && cmdline.isset("termination"))
+  {
+    log_warning(
+      "Both --k-induction and --termination specified. "
+      "Using --k-induction (which does not include termination checking).");
+    // Optionally disable termination flag
+    options.set_option("termination", false);
+  }
+
   if (
     cmdline.isset("overflow-check") || cmdline.isset("unsigned-overflow-check"))
     options.set_option("disable-inductive-step", true);


### PR DESCRIPTION
k-induction does not support termination yet, so making the separate `--termination` flag redundant.