### PR TITLE
[python] treat typing module types as transparent

### DIFF
--- a/regression/python/github_3432/main.py
+++ b/regression/python/github_3432/main.py
@@ -1,0 +1,8 @@
+from typing import BinaryIO
+
+class API:
+    def upload(self, file: BinaryIO) -> None:
+        pass
+
+api = API()
+api.upload({"data": "not a file"})

--- a/regression/python/github_3432/test.desc
+++ b/regression/python/github_3432/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3432_2/main.py
+++ b/regression/python/github_3432_2/main.py
@@ -1,0 +1,32 @@
+from typing import BinaryIO
+
+class API:
+    def __init__(self):
+        self.upload_count: int = 0
+        self.last_upload_size: int = 0
+    
+    def upload(self, file: BinaryIO) -> None:
+        # Duck typing - accepts any object
+        # Simple operation that works with any type
+        self.upload_count += 1
+    
+    def get_upload_count(self) -> int:
+        return self.upload_count
+
+api = API()
+assert api.upload_count == 0
+
+api.upload({"data": "not a file"})
+assert api.upload_count == 1
+
+api.upload({"data": "second upload"})
+assert api.upload_count == 2
+
+api.upload({"other_key": "value"})
+assert api.upload_count == 3
+
+api.upload({})
+assert api.upload_count == 4
+
+count = api.get_upload_count()
+assert count == 4

--- a/regression/python/github_3432_2/test.desc
+++ b/regression/python/github_3432_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -5,6 +5,7 @@ class List:
 class Tuple:
     pass
 
+
 # Abstract I/O types
 class IO:
     pass

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -4,3 +4,13 @@ class List:
 
 class Tuple:
     pass
+
+# Abstract I/O types
+class IO:
+    pass
+
+class BinaryIO(IO):
+    pass
+
+class TextIO(IO):
+    pass

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -9,8 +9,10 @@ class Tuple:
 class IO:
     pass
 
+
 class BinaryIO(IO):
     pass
+
 
 class TextIO(IO):
     pass

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -283,6 +283,11 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     return get_typet(base_type, type_size);
   }
 
+  // Typing module types should be treated as transparent
+  // These are type hints only and don't enforce runtime type checking
+  if (ast_type == "BinaryIO" || ast_type == "TextIO" || ast_type == "IO")
+    return any_type();
+
   // NoneType — represents Python's None value
   // Use a pointer type to void to represent None/null properly
   if (ast_type == "NoneType")


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3432.