### PR TITLE
[python] extract lambda operations to dedicated python_lambda class

### DIFF
--- a/regression/python/lambda7/test.desc
+++ b/regression/python/lambda7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
-
+--unwind 12
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(pythonfrontend STATIC
             python_class.cpp
             python_class_builder.cpp
             python_dict_handler.cpp
+            python_lambda.cpp
             python_list.cpp
             python_math.cpp
             python_set.cpp

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -827,6 +827,7 @@ private:
   python_math math_handler_;
   tuple_handler *tuple_handler_;
   python_dict_handler *dict_handler_;
+  python_typechecking *typechecker_ = nullptr;
   python_lambda *lambda_handler_;
 
   bool is_converting_lhs = false;
@@ -847,6 +848,4 @@ private:
   std::vector<std::string> scope_stack_;
 
   exprt extract_type_from_boolean_op(const exprt &bool_op);
-
-  python_typechecking *typechecker_ = nullptr;
 };

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -27,6 +27,7 @@ class module_locator;
 class tuple_handler;
 class python_typechecking;
 class python_class_builder;
+class python_lambda;
 
 /**
  * @class python_converter
@@ -55,6 +56,14 @@ public:
   void set_current_lhs(exprt *value)
   {
     current_lhs = value;
+  }
+  void set_current_func_name(const std::string &name)
+  {
+    current_func_name_ = name;
+  }
+  void set_current_element_type(const typet &type)
+  {
+    current_element_type = type;
   }
   symbolt *add_symbol_and_get_ptr(symbolt &symbol)
   {
@@ -818,6 +827,7 @@ private:
   python_math math_handler_;
   tuple_handler *tuple_handler_;
   python_dict_handler *dict_handler_;
+  python_lambda *lambda_handler_;
 
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -64,6 +64,31 @@ typet python_lambda::infer_lambda_return_type(
   return double_type();
 }
 
+symbolt python_lambda::create_symbol(
+  const std::string &id,
+  const std::string &name,
+  const typet &type,
+  const locationt &location,
+  const std::string &module_name,
+  bool file_local,
+  bool is_parameter)
+{
+  symbolt symbol;
+  symbol.id = id;
+  symbol.name = name;
+  symbol.type = type;
+  symbol.location = location;
+  symbol.mode = "Python";
+  symbol.module = module_name;
+  symbol.lvalue = true;
+  symbol.is_parameter = is_parameter;
+  symbol.file_local = file_local;
+  symbol.static_lifetime = false;
+  symbol.is_extern = false;
+
+  return symbol;
+}
+
 void python_lambda::process_lambda_parameters(
   const nlohmann::json &args_node,
   code_typet &lambda_type,
@@ -94,18 +119,15 @@ void python_lambda::process_lambda_parameters(
     lambda_type.arguments().push_back(argument);
 
     // Create parameter symbol
-    symbolt param_symbol;
-    param_symbol.id = param_id;
-    param_symbol.name = arg_name;
-    param_symbol.type = param_type;
-    param_symbol.location = location;
-    param_symbol.mode = "Python";
-    param_symbol.module = module_name;
-    param_symbol.lvalue = true;
-    param_symbol.is_parameter = true;
-    param_symbol.file_local = true;
-    param_symbol.static_lifetime = false;
-    param_symbol.is_extern = false;
+    symbolt param_symbol = create_symbol(
+      param_id,
+      arg_name,
+      param_type,
+      location,
+      module_name,
+      true,  // file_local
+      true   // is_parameter
+    );
 
     context_.add(param_symbol);
   }
@@ -162,17 +184,15 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
     process_lambda_parameters(element["args"], lambda_type, lambda_id, location);
 
   // Create lambda function symbol
-  symbolt lambda_symbol;
-  lambda_symbol.id = lambda_id;
-  lambda_symbol.name = lambda_name;
-  lambda_symbol.type = lambda_type;
-  lambda_symbol.location = location;
-  lambda_symbol.mode = "Python";
-  lambda_symbol.module = module_name;
-  lambda_symbol.lvalue = true;
-  lambda_symbol.is_extern = false;
-  lambda_symbol.file_local = false;
-  lambda_symbol.static_lifetime = false;
+  symbolt lambda_symbol = create_symbol(
+    lambda_id,
+    lambda_name,
+    lambda_type,
+    location,
+    module_name,
+    false,  // file_local
+    false   // is_parameter
+  );
 
   symbolt *added_symbol = context_.move_symbol_to_context(lambda_symbol);
   assert(added_symbol);

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -12,9 +12,7 @@ python_lambda::python_lambda(
   python_converter &converter,
   contextt &context,
   type_handler &type_handler)
-  : converter_(converter),
-    context_(context),
-    type_handler_(type_handler)
+  : converter_(converter), context_(context), type_handler_(type_handler)
 {
 }
 
@@ -25,8 +23,7 @@ std::string python_lambda::generate_unique_lambda_name()
 
 bool python_lambda::is_lambda_assignment(const nlohmann::json &ast_node) const
 {
-  return ast_node.contains("value") && 
-         ast_node["value"].contains("_type") &&
+  return ast_node.contains("value") && ast_node["value"].contains("_type") &&
          ast_node["value"]["_type"] == "Lambda";
 }
 
@@ -38,13 +35,11 @@ void python_lambda::handle_lambda_assignment(
   if (!lhs_symbol || !rhs.is_symbol())
     return;
 
-  const symbolt *lambda_func_symbol =
-    context_.find_symbol(rhs.identifier());
+  const symbolt *lambda_func_symbol = context_.find_symbol(rhs.identifier());
 
   if (!lambda_func_symbol || !lambda_func_symbol->type.is_code())
   {
-    throw std::runtime_error(
-      "Lambda function symbol does not have code type");
+    throw std::runtime_error("Lambda function symbol does not have code type");
   }
 
   // Create function pointer type
@@ -65,17 +60,16 @@ typet python_lambda::infer_lambda_return_type(
     std::string body_type = body_node["_type"].get<std::string>();
 
     // String concatenation (BinOp with Add and string constant)
-    if (body_type == "BinOp" &&
-        body_node.contains("op") &&
-        body_node["op"].contains("_type") &&
-        body_node["op"]["_type"] == "Add")
+    if (
+      body_type == "BinOp" && body_node.contains("op") &&
+      body_node["op"].contains("_type") && body_node["op"]["_type"] == "Add")
     {
       // Check if the right operand is a string constant
-      if (body_node.contains("right") &&
-          body_node["right"].contains("_type") &&
-          body_node["right"]["_type"] == "Constant" &&
-          body_node["right"].contains("value") &&
-          body_node["right"]["value"].is_string())
+      if (
+        body_node.contains("right") && body_node["right"].contains("_type") &&
+        body_node["right"]["_type"] == "Constant" &&
+        body_node["right"].contains("value") &&
+        body_node["right"]["value"].is_string())
       {
         return gen_pointer_type(signed_char_type());
       }
@@ -157,8 +151,8 @@ void python_lambda::process_lambda_parameters(
       param_type,
       location,
       module_name,
-      true,  // file_local
-      true   // is_parameter
+      true, // file_local
+      true  // is_parameter
     );
 
     context_.add(param_symbol);
@@ -213,7 +207,8 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
 
   // Process lambda parameters
   if (element.contains("args"))
-    process_lambda_parameters(element["args"], lambda_type, lambda_id, location);
+    process_lambda_parameters(
+      element["args"], lambda_type, lambda_id, location);
 
   // Create lambda function symbol
   symbolt lambda_symbol = create_symbol(
@@ -222,8 +217,8 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
     lambda_type,
     location,
     module_name,
-    false,  // file_local
-    false   // is_parameter
+    false, // file_local
+    false  // is_parameter
   );
 
   symbolt *added_symbol = context_.move_symbol_to_context(lambda_symbol);

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -1,0 +1,191 @@
+#include <python-frontend/python_lambda.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/type_handler.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/std_code.h>
+
+// Initialize static counter
+int python_lambda::lambda_counter_ = 0;
+
+python_lambda::python_lambda(
+  python_converter &converter,
+  contextt &context,
+  type_handler &type_handler)
+  : converter_(converter),
+    context_(context),
+    type_handler_(type_handler)
+{
+}
+
+std::string python_lambda::generate_unique_lambda_name()
+{
+  return "lam" + std::to_string(++lambda_counter_);
+}
+
+bool python_lambda::is_lambda_assignment(const nlohmann::json &ast_node) const
+{
+  return ast_node.contains("value") && 
+         ast_node["value"].contains("_type") &&
+         ast_node["value"]["_type"] == "Lambda";
+}
+
+void python_lambda::handle_lambda_assignment(
+  symbolt *lhs_symbol,
+  exprt &lhs,
+  exprt &rhs)
+{
+  if (!lhs_symbol || !rhs.is_symbol())
+    return;
+
+  const symbolt *lambda_func_symbol =
+    context_.find_symbol(rhs.identifier());
+
+  if (!lambda_func_symbol || !lambda_func_symbol->type.is_code())
+  {
+    throw std::runtime_error(
+      "Lambda function symbol does not have code type");
+  }
+
+  // Create function pointer type
+  typet func_ptr_type = gen_pointer_type(lambda_func_symbol->type);
+  lhs_symbol->type = func_ptr_type;
+  lhs.type() = func_ptr_type;
+
+  // Convert lambda symbol to address
+  rhs = address_of_exprt(rhs);
+}
+
+typet python_lambda::infer_lambda_return_type(
+  const nlohmann::json &body_node)
+{
+  // TODO: Implement more sophisticated type inference
+  // For now, default to double for numeric expressions
+  return double_type();
+}
+
+void python_lambda::process_lambda_parameters(
+  const nlohmann::json &args_node,
+  code_typet &lambda_type,
+  const std::string &lambda_id,
+  const locationt &location)
+{
+  if (!args_node.contains("args") || !args_node["args"].is_array())
+    return;
+
+  std::string module_name = location.get_file().as_string();
+
+  for (const auto &arg : args_node["args"])
+  {
+    std::string arg_name = arg["arg"].get<std::string>();
+
+    // Determine parameter type
+    // TODO: Try to infer from usage or annotation
+    typet param_type = double_type();
+
+    // Create function argument
+    code_typet::argumentt argument;
+    argument.type() = param_type;
+    argument.cmt_base_name(arg_name);
+
+    std::string param_id = lambda_id + "@" + arg_name;
+    argument.cmt_identifier(param_id);
+    argument.location() = location;
+    lambda_type.arguments().push_back(argument);
+
+    // Create parameter symbol
+    symbolt param_symbol;
+    param_symbol.id = param_id;
+    param_symbol.name = arg_name;
+    param_symbol.type = param_type;
+    param_symbol.location = location;
+    param_symbol.mode = "Python";
+    param_symbol.module = module_name;
+    param_symbol.lvalue = true;
+    param_symbol.is_parameter = true;
+    param_symbol.file_local = true;
+    param_symbol.static_lifetime = false;
+    param_symbol.is_extern = false;
+
+    context_.add(param_symbol);
+  }
+}
+
+exprt python_lambda::process_lambda_body(
+  const nlohmann::json &body_node,
+  const locationt &location)
+{
+  // Get the body expression through the converter
+  exprt body_expr = converter_.get_expr(body_node);
+
+  // Create return statement
+  code_returnt return_stmt;
+  return_stmt.return_value() = body_expr;
+  return_stmt.location() = location;
+
+  // Wrap in a block
+  code_blockt lambda_block;
+  lambda_block.copy_to_operands(return_stmt);
+
+  return lambda_block;
+}
+
+exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
+{
+  // Generate unique lambda name
+  std::string lambda_name = generate_unique_lambda_name();
+
+  locationt location = converter_.get_location_from_decl(element);
+  std::string module_name = location.get_file().as_string();
+
+  // Save and set lambda context
+  std::string old_func_name = converter_.get_current_func_name();
+  converter_.set_current_func_name(lambda_name);
+
+  // Create function type with inferred return type
+  code_typet lambda_type;
+  typet return_type = double_type();
+
+  if (element.contains("body"))
+  {
+    return_type = infer_lambda_return_type(element["body"]);
+    converter_.set_current_element_type(return_type);
+  }
+
+  lambda_type.return_type() = return_type;
+
+  // Build lambda identifier
+  std::string lambda_id = "py:" + module_name + "@F@" + lambda_name;
+
+  // Process lambda parameters
+  if (element.contains("args"))
+    process_lambda_parameters(element["args"], lambda_type, lambda_id, location);
+
+  // Create lambda function symbol
+  symbolt lambda_symbol;
+  lambda_symbol.id = lambda_id;
+  lambda_symbol.name = lambda_name;
+  lambda_symbol.type = lambda_type;
+  lambda_symbol.location = location;
+  lambda_symbol.mode = "Python";
+  lambda_symbol.module = module_name;
+  lambda_symbol.lvalue = true;
+  lambda_symbol.is_extern = false;
+  lambda_symbol.file_local = false;
+  lambda_symbol.static_lifetime = false;
+
+  symbolt *added_symbol = context_.move_symbol_to_context(lambda_symbol);
+  assert(added_symbol);
+
+  // Process lambda body
+  if (element.contains("body"))
+  {
+    exprt lambda_body = process_lambda_body(element["body"], location);
+    added_symbol->value = lambda_body;
+  }
+
+  // Restore context
+  converter_.set_current_func_name(old_func_name);
+
+  return symbol_expr(*added_symbol);
+}

--- a/src/python-frontend/python_lambda.h
+++ b/src/python-frontend/python_lambda.h
@@ -1,0 +1,56 @@
+#ifndef ESBMC_PYTHON_LAMBDA_H
+#define ESBMC_PYTHON_LAMBDA_H
+
+#include <python-frontend/python_converter.h>
+#include <util/expr.h>
+#include <util/std_code.h>
+#include <nlohmann/json.hpp>
+
+class python_converter;
+class type_handler;
+
+class python_lambda
+{
+public:
+  python_lambda(
+    python_converter &converter,
+    contextt &context,
+    type_handler &type_handler);
+
+  // Main method to create lambda expression from AST
+  exprt get_lambda_expr(const nlohmann::json &element);
+
+  // Check if a variable assignment involves a lambda
+  bool is_lambda_assignment(const nlohmann::json &ast_node) const;
+
+  // Handle lambda assignment type adjustments
+  void handle_lambda_assignment(
+    symbolt *lhs_symbol,
+    exprt &lhs,
+    exprt &rhs);
+
+private:
+  python_converter &converter_;
+  contextt &context_;
+  type_handler &type_handler_;
+
+  // Counter for generating unique lambda names
+  static int lambda_counter_;
+
+  // Helper methods
+  void process_lambda_parameters(
+    const nlohmann::json &args_node,
+    code_typet &lambda_type,
+    const std::string &lambda_id,
+    const locationt &location);
+
+  exprt process_lambda_body(
+    const nlohmann::json &body_node,
+    const locationt &location);
+
+  typet infer_lambda_return_type(const nlohmann::json &body_node);
+
+  std::string generate_unique_lambda_name();
+};
+
+#endif // ESBMC_PYTHON_LAMBDA_H

--- a/src/python-frontend/python_lambda.h
+++ b/src/python-frontend/python_lambda.h
@@ -24,10 +24,7 @@ public:
   bool is_lambda_assignment(const nlohmann::json &ast_node) const;
 
   // Handle lambda assignment type adjustments
-  void handle_lambda_assignment(
-    symbolt *lhs_symbol,
-    exprt &lhs,
-    exprt &rhs);
+  void handle_lambda_assignment(symbolt *lhs_symbol, exprt &lhs, exprt &rhs);
 
 private:
   python_converter &converter_;

--- a/src/python-frontend/python_lambda.h
+++ b/src/python-frontend/python_lambda.h
@@ -51,6 +51,15 @@ private:
   typet infer_lambda_return_type(const nlohmann::json &body_node);
 
   std::string generate_unique_lambda_name();
+
+  symbolt create_symbol(
+    const std::string &id,
+    const std::string &name,
+    const typet &type,
+    const locationt &location,
+    const std::string &module_name,
+    bool file_local,
+    bool is_parameter = false);
 };
 
 #endif // ESBMC_PYTHON_LAMBDA_H


### PR DESCRIPTION
This PR moves lambda expression handling from `python_converter` to a new `python_lambda` class, following the same pattern as `tuple_handler` and `dict_handler`.