### PR TITLE
[python] fix nested lambda closure variable access

### DIFF
--- a/regression/python/lambda13/main.py
+++ b/regression/python/lambda13/main.py
@@ -1,0 +1,5 @@
+def test() -> None:
+    outer:int = lambda x: (lambda y: x + y)
+    inner:int = outer(5)
+
+test()

--- a/regression/python/lambda13/main.py
+++ b/regression/python/lambda13/main.py
@@ -1,5 +1,5 @@
 def test() -> None:
-    outer:int = lambda x: (lambda y: x + y)
-    inner:int = outer(5)
+    outer = lambda x: (lambda y: x + y)
+    inner = outer(5)
 
 test()

--- a/regression/python/lambda13/test.desc
+++ b/regression/python/lambda13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -108,7 +108,7 @@ symbolt python_lambda::create_symbol(
 void python_lambda::process_lambda_parameters(
   const nlohmann::json &args_node,
   code_typet &lambda_type,
-  const std::string &lambda_id,
+  [[maybe_unused]] const std::string &lambda_id,
   const std::string &param_scope_id,
   const locationt &location)
 {

--- a/src/python-frontend/python_lambda.h
+++ b/src/python-frontend/python_lambda.h
@@ -39,6 +39,7 @@ private:
     const nlohmann::json &args_node,
     code_typet &lambda_type,
     const std::string &lambda_id,
+    const std::string &param_scope_id,
     const locationt &location);
 
   exprt process_lambda_body(


### PR DESCRIPTION
This PR maintains the function context when processing nested lambdas and uses a shared parameter scope, allowing inner lambdas to find variables from outer lambda scopes during symbol resolution. 

Nested lambdas now access variables from enclosing lambda scopes by placing all nested lambda parameters in the parent lambda's scope. This enables closures such as `lambda x: (lambda y: x + y)` to work correctly and avoid "ERROR: Symbol not found py:main.py@x".