### PR TITLE
[python] implement sorted() built-in function

### DIFF
--- a/regression/python/sorted/main.py
+++ b/regression/python/sorted/main.py
@@ -1,0 +1,8 @@
+l = [3, 2, 1]
+result = sorted(l)
+assert result[0] == 1  # Check the sorted result
+assert result[1] == 2
+assert result[2] == 3
+assert l[0] == 3  # Original list unchanged
+assert l[1] == 2
+assert l[2] == 1

--- a/regression/python/sorted/test.desc
+++ b/regression/python/sorted/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted2/main.py
+++ b/regression/python/sorted2/main.py
@@ -1,0 +1,43 @@
+def test_sorted_basic():
+    l = [3, 2, 1]
+    result = sorted(l)
+    assert result[0] == 1
+    assert result[1] == 2
+    assert result[2] == 3
+    # Original unchanged
+    assert l[0] == 3
+    assert l[1] == 2
+    assert l[2] == 1
+
+def test_sorted_already_sorted():
+    l = [1, 2, 3, 4, 5]
+    result = sorted(l)
+    assert result[0] == 1
+    assert result[4] == 5
+
+def test_sorted_reverse():
+    l = [5, 4, 3, 2, 1]
+    result = sorted(l)
+    assert result[0] == 1
+    assert result[4] == 5
+
+def test_sorted_duplicates():
+    l = [3, 1, 2, 1, 3]
+    result = sorted(l)
+    assert result[0] == 1
+    assert result[1] == 1
+    assert result[2] == 2
+    assert result[3] == 3
+    assert result[4] == 3
+
+def test_sorted_single():
+    l = [42]
+    result = sorted(l)
+    assert result[0] == 42
+    assert l[0] == 42
+
+test_sorted_basic()
+test_sorted_already_sorted()
+test_sorted_reverse()
+test_sorted_duplicates()
+test_sorted_single()

--- a/regression/python/sorted2/test.desc
+++ b/regression/python/sorted2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
---unwind 6 --no-standard-check
+--unwind 6 --no-standard-checks
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted2/test.desc
+++ b/regression/python/sorted2/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 6 --no-standard-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted3/main.py
+++ b/regression/python/sorted3/main.py
@@ -1,0 +1,9 @@
+def test_sorted_float():
+    l = [3.5, 1.2, 2.8, 0.5]
+    result = sorted(l)
+    assert result[0] == 0.5
+    assert result[1] == 1.2
+    assert result[2] == 2.8
+    assert result[3] == 3.5
+
+test_sorted_float()

--- a/regression/python/sorted3/test.desc
+++ b/regression/python/sorted3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted3_fail/main.py
+++ b/regression/python/sorted3_fail/main.py
@@ -1,0 +1,9 @@
+def test_sorted_float():
+    l = [3.5, 1.2, 2.8, 0.5]
+    result = sorted(l)
+    assert result[0] == 0.5
+    assert result[1] == 1.2
+    assert result[2] == 2.8
+    assert result[3] == 3.6
+
+test_sorted_float()

--- a/regression/python/sorted3_fail/test.desc
+++ b/regression/python/sorted3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/regression/python/sorted4/main.py
+++ b/regression/python/sorted4/main.py
@@ -1,0 +1,9 @@
+def test_sorted_string():
+    l = ["dog", "cat", "apple", "zebra"]
+    result = sorted(l)
+    assert result[0] == "apple"
+    assert result[1] == "cat"
+    assert result[2] == "dog"
+    assert result[3] == "zebra"
+
+test_sorted_string()

--- a/regression/python/sorted4/test.desc
+++ b/regression/python/sorted4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 7 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted4_fail/main.py
+++ b/regression/python/sorted4_fail/main.py
@@ -1,0 +1,9 @@
+def test_sorted_string():
+    l = ["dog", "cat", "apple", "zebra"]
+    result = sorted(l)
+    assert result[0] == "apple"
+    assert result[1] == "cat"
+    assert result[2] == "zebra"
+    assert result[3] == "dog"
+
+test_sorted_string()

--- a/regression/python/sorted4_fail/test.desc
+++ b/regression/python/sorted4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 7 --no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/python/sorted5/main.py
+++ b/regression/python/sorted5/main.py
@@ -1,0 +1,4 @@
+l = []
+result = sorted(l)
+assert len(result) == 0
+assert len(l) == 0

--- a/regression/python/sorted5/test.desc
+++ b/regression/python/sorted5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted6/main.py
+++ b/regression/python/sorted6/main.py
@@ -1,0 +1,7 @@
+l = [-3, 1, -2, 0]
+result = sorted(l)
+
+assert result[0] == -3
+assert result[1] == -2
+assert result[2] == 0
+assert result[3] == 1

--- a/regression/python/sorted6/test.desc
+++ b/regression/python/sorted6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted7/main.py
+++ b/regression/python/sorted7/main.py
@@ -1,0 +1,7 @@
+l = [1.5, -2.0, 1.5, 0.0]
+result = sorted(l)
+
+assert result[0] == -2.0
+assert result[1] == 0.0
+assert result[2] == 1.5
+assert result[3] == 1.5

--- a/regression/python/sorted7/test.desc
+++ b/regression/python/sorted7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/sorted_fail/main.py
+++ b/regression/python/sorted_fail/main.py
@@ -1,0 +1,8 @@
+l = [3, 2, 1]
+result = sorted(l)
+assert result[0] == 3  # Check the sorted result
+assert result[1] == 2
+assert result[2] == 1
+assert l[0] == 3  # Original list unchanged
+assert l[1] == 2
+assert l[2] == 1

--- a/regression/python/sorted_fail/test.desc
+++ b/regression/python/sorted_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2218,8 +2218,7 @@ exprt function_call_expr::handle_general_function_call()
   const std::string &func_name = function_id_.get_function();
   std::string actual_func_name = func_name;
 
-  if ((func_name == "min" || func_name == "max") && call_["args"].size() == 1)
-  {
+  if ((func_name == "min" || func_name == "max" || func_name == "sorted") && call_["args"].size() == 1)  {
     exprt list_arg = converter_.get_expr(call_["args"][0]);
     typet elem_type;
     if (list_arg.is_symbol())

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2218,7 +2218,7 @@ exprt function_call_expr::handle_general_function_call()
   const std::string &func_name = function_id_.get_function();
   std::string actual_func_name = func_name;
 
- if (
+  if (
     (func_name == "min" || func_name == "max" || func_name == "sorted") &&
     call_["args"].size() == 1)
   {

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2218,7 +2218,10 @@ exprt function_call_expr::handle_general_function_call()
   const std::string &func_name = function_id_.get_function();
   std::string actual_func_name = func_name;
 
-  if ((func_name == "min" || func_name == "max" || func_name == "sorted") && call_["args"].size() == 1)  {
+ if (
+    (func_name == "min" || func_name == "max" || func_name == "sorted") &&
+    call_["args"].size() == 1)
+  {
     exprt list_arg = converter_.get_expr(call_["args"][0]);
     typet elem_type;
     if (list_arg.is_symbol())

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -141,3 +141,81 @@ def min_str(iterable: list[str]) -> str:
 #             return True
 #         i = i + 1
 #     return False
+
+def sorted(iterable: list[int]) -> list[int]:
+    """Return a new sorted list from the items in iterable."""
+    # Create a copy of the list
+    result: list[int] = []
+    i: int = 0
+    length: int = len(iterable)
+
+    # Copy all elements
+    while i < length:
+        result.append(iterable[i])
+        i = i + 1
+
+    # Bubble sort (simple and verifier-friendly)
+    n: int = len(result)
+    i = 0
+    while i < n:
+        j: int = 0
+        while j < n - 1 - i:
+            if result[j] > result[j + 1]:
+                # Swap
+                temp: int = result[j]
+                result[j] = result[j + 1]
+                result[j + 1] = temp
+            j = j + 1
+        i = i + 1
+
+    return result
+
+
+def sorted_float(iterable: list[float]) -> list[float]:
+    """Return a new sorted list from the items in iterable."""
+    result: list[float] = []
+    i: int = 0
+    length: int = len(iterable)
+
+    while i < length:
+        result.append(iterable[i])
+        i = i + 1
+
+    n: int = len(result)
+    i = 0
+    while i < n:
+        j: int = 0
+        while j < n - 1 - i:
+            if result[j] > result[j + 1]:
+                temp: float = result[j]
+                result[j] = result[j + 1]
+                result[j + 1] = temp
+            j = j + 1
+        i = i + 1
+
+    return result
+
+
+def sorted_str(iterable: list[str]) -> list[str]:
+    """Return a new sorted list from the items in iterable."""
+    result: list[str] = []
+    i: int = 0
+    length: int = len(iterable)
+
+    while i < length:
+        result.append(iterable[i])
+        i = i + 1
+
+    n: int = len(result)
+    i = 0
+    while i < n:
+        j: int = 0
+        while j < n - 1 - i:
+            if result[j] > result[j + 1]:
+                temp: str = result[j]
+                result[j] = result[j + 1]
+                result[j + 1] = temp
+            j = j + 1
+        i = i + 1
+
+    return result

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -142,6 +142,7 @@ def min_str(iterable: list[str]) -> str:
 #         i = i + 1
 #     return False
 
+
 def sorted(iterable: list[int]) -> list[int]:
     """Return a new sorted list from the items in iterable."""
     # Create a copy of the list

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2430,12 +2430,22 @@ typet python_list::check_homogeneous_list_types(
   // Get the first element's type
   typet elem_type = type_info[0].second;
 
+  // Check whether a type is a string type (char array or char pointer)
+  auto is_string_type = [](const typet &t) -> bool {
+    return (t.is_array() && t.subtype() == char_type()) ||
+           (t.is_pointer() && t.subtype() == char_type());
+  };
+
   // Check all other elements have the same type
   for (size_t i = 1; i < list_size; i++)
   {
     const typet &current_elem_type = type_info[i].second;
 
-    // Compare types
+    // For string types, all char arrays and char pointers are considered compatible
+    if (is_string_type(elem_type) && is_string_type(current_elem_type))
+      continue;
+
+    // For non-string types, require exact match
     if (elem_type != current_elem_type)
     {
       throw std::runtime_error(


### PR DESCRIPTION
This PR adds `sorted()` support for int/float/str lists with type dispatch. It returns a new list without modifying the original (Python semantics). Additionally, this PR uses bubble sort for verifier-friendly code generation.