### PR TITLE
[python] infer tuple return type for unannotated functions

### DIFF
--- a/regression/python/tuple18/main.py
+++ b/regression/python/tuple18/main.py
@@ -1,0 +1,9 @@
+def swap(a: int, b: int):
+    return b, a
+
+a = 2
+b = 4
+a, b = swap(a, b)
+
+assert a == 4
+assert b == 2

--- a/regression/python/tuple18/test.desc
+++ b/regression/python/tuple18/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple18_fail/main.py
+++ b/regression/python/tuple18_fail/main.py
@@ -1,0 +1,9 @@
+def swap(a: int, b: int):
+    return b, a
+
+a = 2
+b = 4
+a, b = swap(a, b)
+
+assert a == 2
+assert b == 4

--- a/regression/python/tuple18_fail/test.desc
+++ b/regression/python/tuple18_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/tuple19/main.py
+++ b/regression/python/tuple19/main.py
@@ -1,0 +1,9 @@
+def swap(a, b):
+    return b, a
+
+a = 2
+b = 4
+a, b = swap(a, b)
+
+assert a == 4
+assert b == 2

--- a/regression/python/tuple19/test.desc
+++ b/regression/python/tuple19/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -454,9 +454,8 @@ private:
       if (!has_annotation)
       {
         var_node = find_annotated_assign(var_name, ast_["body"]);
-        has_annotation = !var_node.empty() &&
-                        var_node.contains("annotation") &&
-                        !var_node["annotation"].is_null();
+        has_annotation = !var_node.empty() && var_node.contains("annotation") &&
+                         !var_node["annotation"].is_null();
       }
 
       // Extract type from the found variable node

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -450,6 +450,15 @@ private:
         }
       }
 
+      // If still not found in local/parent scope, check global scope
+      if (!has_annotation)
+      {
+        var_node = find_annotated_assign(var_name, ast_["body"]);
+        has_annotation = !var_node.empty() &&
+                        var_node.contains("annotation") &&
+                        !var_node["annotation"].is_null();
+      }
+
       // Extract type from the found variable node
       if (
         !var_node.empty() && var_node.contains("annotation") &&

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -780,6 +780,15 @@ private:
   void
   promote_ieee_operands(exprt &bin_expr, const exprt &lhs, const exprt &rhs);
 
+  /**
+   * @brief Infers function return type from return statements in the body.
+   *
+   * @param body The JSON AST node representing the function body statements.
+   * @return The inferred return type (struct_typet for tuples), or empty_typet
+   *         if no inferrable return type is found.
+   */
+  typet infer_return_type_from_body(const nlohmann::json &body);
+
   // =========================================================================
   // String method helpers
   // =========================================================================


### PR DESCRIPTION
This PR adds `infer_return_type_from_body()` to detect tuple returns in the function body and update the function symbol's return type accordingly. This enables proper type propagation for unpacking assignments such as `a, b = swap(a, b)`.