### PR TITLE
[python] improve undefined variable error messages

### DIFF
--- a/regression/python/list-var-undef/main.py
+++ b/regression/python/list-var-undef/main.py
@@ -1,0 +1,11 @@
+def max(x):
+    i = 1
+    max = x[0]
+    while i < len(l):
+        if x[i] > max:
+            max = x[i]
+        i = i + 1
+    return max
+
+l = [1, 2, 3]
+assert max(l) == 3

--- a/regression/python/list-var-undef/test.desc
+++ b/regression/python/list-var-undef/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR\: Variable \'l\' is not defined in function \'max\' at line 4.$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2937,7 +2937,26 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       }
       if (!symbol)
       {
-        log_error("Symbol not found {}", sid_str);
+        locationt location = get_location_from_decl(element);
+        std::ostringstream error_msg;
+        if (!current_func_name_.empty())
+        {
+          // Variable referenced inside a function
+          error_msg << "Variable '" << var_name << "' is not defined in function '"
+                    << current_func_name_ << "'";
+          if (!location.get_line().empty())
+            error_msg << " at line " << location.get_line();
+          error_msg << ".";
+        }
+        else
+        {
+          // Variable referenced at global scope
+          error_msg << "Variable '" << var_name << "' is not defined";
+          if (!location.get_line().empty())
+            error_msg << " at line " << location.get_line();
+          error_msg << ".";
+        }
+        log_error("{}", error_msg.str());
         abort();
       }
     }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2942,8 +2942,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         if (!current_func_name_.empty())
         {
           // Variable referenced inside a function
-          error_msg << "Variable '" << var_name << "' is not defined in function '"
-                    << current_func_name_ << "'";
+          error_msg << "Variable '" << var_name
+                    << "' is not defined in function '" << current_func_name_
+                    << "'";
           if (!location.get_line().empty())
             error_msg << " at line " << location.get_line();
           error_msg << ".";


### PR DESCRIPTION
This PR replaces cryptic symbol-table-lookup errors with user-friendly messages that clearly indicate the variable name, function context, and line number.

Before: "Symbol not found py:main.py@l"
After: "Variable 'l' is not defined in function 'max' at line 4."