### PR TITLE
[python] extend type inference for partial generic container annotations

### DIFF
--- a/regression/python/list-var-undef/main.py
+++ b/regression/python/list-var-undef/main.py
@@ -1,0 +1,14 @@
+def my_max(x:list):
+    i = 1
+    m = x[0]
+
+    while i < len(x):
+        if x[i] > m:
+            m = x[i]
+        i = i + 1
+
+    return m
+
+
+l = [1, 2, 3]
+assert my_max(l) == 3

--- a/regression/python/list-var-undef/test.desc
+++ b/regression/python/list-var-undef/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -278,7 +278,9 @@ private:
           if (param["annotation"].contains("id"))
             current_type = param["annotation"]["id"];
           // Check if it's a generic container without element type
-          if (current_type == "list" || current_type == "dict" || current_type == "set")
+          if (
+            current_type == "list" || current_type == "dict" ||
+            current_type == "set")
           {
             has_partial_annotation = true;
             needs_inference = true; // Try to refine with element type
@@ -516,15 +518,18 @@ private:
         // Handle simple type annotations like int, str (Name nodes)
         else if (var_node["annotation"].contains("id"))
         {
-          std::string base_type = var_node["annotation"]["id"].template get<std::string>();
+          std::string base_type =
+            var_node["annotation"]["id"].template get<std::string>();
           // If annotation is just "list"/"dict"/"set" without element type, try to infer from value
           if (
-            (base_type == "list" || base_type == "dict" || base_type == "set") &&
+            (base_type == "list" || base_type == "dict" ||
+             base_type == "set") &&
             var_node.contains("value") && !var_node["value"].is_null())
           {
             if (base_type == "list" && var_node["value"]["_type"] == "List")
             {
-              std::string full_type = get_list_type_from_literal(var_node["value"]);
+              std::string full_type =
+                get_list_type_from_literal(var_node["value"]);
               if (!full_type.empty())
                 return full_type;
             }


### PR DESCRIPTION
This PR infers element types for list/dict/set parameters annotated with no element type (e.g., x:list -> x:list[int]) by examining variable initializations and function call arguments.