### PR TITLE
[C/CPP] Linking and extern cleanup

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1232,8 +1232,7 @@ Being a variable means that malloc'd items of data can be treated like any other
 piece of data in ESBMC. The complexity occurs when we have to perform assertions
 and checks to see whether or not pointers have been freed or point in bounds.
 A series of arrays of data are used to model that information. These are
-\url{__ESBMC_alloc}, \url{__ESBMC_deallocated},
-\url{__ESBMC_is_dynamic} and \url{__ESBMC_alloc_size}.
+\url{__ESBMC_alloc}, \url{__ESBMC_is_dynamic} and \url{__ESBMC_alloc_size}.
 The index of the array is the pointer object ID number, see the section on
 SMT encoding. Here, the boolean arrays \url{alloc} and \url{deallocated}
 store whether or not the pointer is valid and has been deallocated,

--- a/regression/esbmc/linking-1/test.desc
+++ b/regression/esbmc/linking-1/test.desc
@@ -1,0 +1,5 @@
+CORE
+../linking-common/main_uninit.c
+-DEXPECTED_VALUE=0
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/linking-2/test.desc
+++ b/regression/esbmc/linking-2/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_uninit.c
+../linking-common/another_def.c -DEXPECTED_VALUE=1234
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/linking-3/test.desc
+++ b/regression/esbmc/linking-3/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_uninit_extern.c
+-DEXPECTED_VALUE=-1
+^VERIFICATION FAILED$

--- a/regression/esbmc/linking-4/test.desc
+++ b/regression/esbmc/linking-4/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_uninit_extern.c
+../linking-common/another_def.c -DEXPECTED_VALUE=1234
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/linking-5/test.desc
+++ b/regression/esbmc/linking-5/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_init_weak.c
+-DEXPECTED_VALUE=999
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/linking-6/test.desc
+++ b/regression/esbmc/linking-6/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_init_weak.c
+../linking-common/another_def.c -DEXPECTED_VALUE=1234
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/linking-7/test.desc
+++ b/regression/esbmc/linking-7/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+../linking-common/main_init.c
+../linking-common/another_def.c -DEXPECTED_VALUE=-1 -DDUPLICATE_SYMBOLS_SHOULD_FAIL
+ERROR

--- a/regression/esbmc/linking-8/test.desc
+++ b/regression/esbmc/linking-8/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_init_extern.c
+ -DEXPECTED_VALUE=222
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/linking-common/another_def.c
+++ b/regression/esbmc/linking-common/another_def.c
@@ -1,0 +1,1 @@
+int global = 1234;

--- a/regression/esbmc/linking-common/main_init.c
+++ b/regression/esbmc/linking-common/main_init.c
@@ -1,0 +1,5 @@
+#include <assert.h>
+
+int global = 999;
+
+int main(void) { assert(global == EXPECTED_VALUE); return 0; }

--- a/regression/esbmc/linking-common/main_init_extern.c
+++ b/regression/esbmc/linking-common/main_init_extern.c
@@ -1,0 +1,5 @@
+#include <assert.h>
+
+extern int global = 222;
+
+int main(void) { assert(global == EXPECTED_VALUE); return 0; }

--- a/regression/esbmc/linking-common/main_init_weak.c
+++ b/regression/esbmc/linking-common/main_init_weak.c
@@ -1,0 +1,5 @@
+#include <assert.h>
+
+int global __attribute__((weak)) = 999;
+
+int main(void) { assert(global == EXPECTED_VALUE); return 0; }

--- a/regression/esbmc/linking-common/main_uninit.c
+++ b/regression/esbmc/linking-common/main_uninit.c
@@ -1,0 +1,5 @@
+#include <assert.h>
+
+int global;
+
+int main(void) { assert(global == EXPECTED_VALUE); return 0; }

--- a/regression/esbmc/linking-common/main_uninit_extern.c
+++ b/regression/esbmc/linking-common/main_uninit_extern.c
@@ -1,0 +1,5 @@
+#include <assert.h>
+
+extern int global;
+
+int main(void) { assert(global == EXPECTED_VALUE); return 0; }

--- a/regression/esbmc/linking-common/test.desc
+++ b/regression/esbmc/linking-common/test.desc
@@ -1,0 +1,4 @@
+CORE
+../linking-common/main_init_weak.c
+../linking-common/another_def.c -DEXPECTED_VALUE=1234
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -1,4 +1,7 @@
 #include <c2goto/cprover_library.h>
+
+#include "util/symbolic_types.h"
+
 #include <ac_config.h>
 #include <boost/filesystem.hpp>
 #include <cstdlib>
@@ -440,4 +443,33 @@ void add_cprover_library(contextt &context, const languaget *language)
     log_error("Failed to merge C library");
     abort();
   }
+  // We basically need a place where we know that ESBMC produces the "main" executable that will be run.
+  // This is the best place that I've found and mimics how a real compiler would work:
+  // First compile all source files to objects files, then link them together and then link with the libc
+  // library. Only when linking to the libc library, we know that all unresolved extern symbols (those whose
+  // value is nil) will stay unresolved. A normal linker would reject such files, but we provide some compatibility with
+  // those and initialize the extern variables to nondet.
+  context.Foreach_operand(
+    [&context](symbolt &s)
+    {
+      if (s.is_extern && !s.type.is_code())
+      {
+        if (s.value.is_nil())
+        {
+          log_warning(
+            "extern variable with id {} not found, initializing value to nondet! This code would not compile with an actual compiler.",
+            s.id);
+          exprt value =
+            exprt("sideeffect", get_complete_type(s.type, namespacet{context}));
+          value.statement("nondet");
+          s.value = value;
+        }
+        else
+        {
+          log_error("extern variable with id {} is not nil.", s.id);
+          s.dump();
+          abort();
+        }
+      }
+    });
 }

--- a/src/c2goto/library/builtin_libs.c
+++ b/src/c2goto/library/builtin_libs.c
@@ -243,3 +243,12 @@ __SIZE_TYPE__ __esbmc_cheri_length_get(void *__capability cap)
 }
 
 #endif
+
+__attribute__((annotate("__ESBMC_inf_size")))
+_Bool __ESBMC_alloc[1];
+
+__attribute__((annotate("__ESBMC_inf_size")))
+_Bool __ESBMC_is_dynamic[1];
+
+__attribute__((annotate("__ESBMC_inf_size")))
+__SIZE_TYPE__ __ESBMC_alloc_size[1];

--- a/src/c2goto/library/builtin_libs.c
+++ b/src/c2goto/library/builtin_libs.c
@@ -244,11 +244,9 @@ __SIZE_TYPE__ __esbmc_cheri_length_get(void *__capability cap)
 
 #endif
 
-__attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_alloc[1];
+__attribute__((annotate("__ESBMC_inf_size"))) _Bool __ESBMC_alloc[1];
 
-__attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_is_dynamic[1];
+__attribute__((annotate("__ESBMC_inf_size"))) _Bool __ESBMC_is_dynamic[1];
 
 __attribute__((annotate("__ESBMC_inf_size")))
 __SIZE_TYPE__ __ESBMC_alloc_size[1];

--- a/src/c2goto/library/fenv.c
+++ b/src/c2goto/library/fenv.c
@@ -1,6 +1,6 @@
 #include <fenv.h>
 
-extern int __ESBMC_rounding_mode;
+int __ESBMC_rounding_mode = 0;
 
 inline int fegetround(void)
 {

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -515,7 +515,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   symbol.is_thread_local = vd.getTLSKind() != clang::VarDecl::TLS_None;
 
   if (
-    symbol.static_lifetime &&
+    symbol.static_lifetime && !symbol.is_extern &&
     (!vd.hasInit() || is_aggregate_type(vd.getType())))
   {
     // the type might contains symbolic types,
@@ -523,17 +523,8 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
     // Initialize with zero value, if the symbol has initial value,
     // it will be added later on in this method
-    if (symbol.is_extern)
-    {
-      exprt value = exprt("sideeffect", get_complete_type(t, ns));
-      value.statement("nondet");
-      symbol.value = value;
-    }
-    else
-    {
-      symbol.value = gen_zero(get_complete_type(t, ns), true);
-      symbol.value.zero_initializer(true);
-    }
+    symbol.value = gen_zero(get_complete_type(t, ns), true);
+    symbol.value.zero_initializer(true);
   }
 
   symbolt *added_symbol = nullptr;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -509,7 +509,10 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
   symbol.lvalue = true;
   symbol.static_lifetime =
     (vd.getStorageClass() == clang::SC_Static) || vd.hasGlobalStorage();
-  symbol.is_extern = vd.hasExternalStorage();
+  // extern variables with initializers are no longer considered extern
+  // in the resulting object file by at least gcc.
+  // See TC linking-8 or try readelf -s on main_init_extern.o
+  symbol.is_extern = vd.hasExternalStorage() && !vd.hasInit();
   symbol.file_local = (vd.getStorageClass() == clang::SC_Static) ||
                       (!vd.isExternallyVisible() && !vd.hasGlobalStorage());
   symbol.is_thread_local = vd.getTLSKind() != clang::VarDecl::TLS_None;

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -379,20 +379,20 @@ __PTRDIFF_TYPE__ __ESBMC_POINTER_OFFSET(const void *);
 
 // malloc
 __attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_alloc[1];
+extern _Bool __ESBMC_alloc[1];
 
 __attribute__((annotate("__ESBMC_inf_size")))
-_Bool __ESBMC_is_dynamic[1];
+extern _Bool __ESBMC_is_dynamic[1];
 
 __attribute__((annotate("__ESBMC_inf_size")))
-__SIZE_TYPE__ __ESBMC_alloc_size[1];
+extern __SIZE_TYPE__ __ESBMC_alloc_size[1];
 
 // Get object size
 __SIZE_TYPE__ __ESBMC_get_object_size(const void *);
 
 _Bool __ESBMC_is_little_endian();
 
-int __ESBMC_rounding_mode = 0;
+extern int __ESBMC_rounding_mode;
 
 void *__ESBMC_memset(void *, int, __SIZE_TYPE__);
       void *__ESBMC_memcpy(void *, const void *, __SIZE_TYPE__);

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -111,14 +111,7 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
 
 void jimple_languaget::add_intrinsics(contextt &context)
 {
-  auto type1 = array_typet(bool_type(), exprt("infinity"));
-  add_global_static_variable(context, type1, "__ESBMC_alloc");
-  add_global_static_variable(context, type1, "__ESBMC_is_dynamic");
 
-  auto type2 = array_typet(size_type(), exprt("infinity"));
-  add_global_static_variable(context, type2, "__ESBMC_alloc_size");
-
-  add_global_static_variable(context, int_type(), "__ESBMC_rounding_mode");
 }
 
 void jimple_languaget::setup_main(contextt &context)

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -111,6 +111,14 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
 
 void jimple_languaget::add_intrinsics(contextt &context)
 {
+  auto type1 = array_typet(bool_type(), exprt("infinity"));
+  add_global_static_variable(context, type1, "__ESBMC_alloc");
+  add_global_static_variable(context, type1, "__ESBMC_is_dynamic");
+
+  auto type2 = array_typet(size_type(), exprt("infinity"));
+  add_global_static_variable(context, type2, "__ESBMC_alloc_size");
+
+  add_global_static_variable(context, int_type(), "__ESBMC_rounding_mode");
 }
 
 void jimple_languaget::setup_main(contextt &context)

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -113,7 +113,6 @@ void jimple_languaget::add_intrinsics(contextt &context)
 {
   auto type1 = array_typet(bool_type(), exprt("infinity"));
   add_global_static_variable(context, type1, "__ESBMC_alloc");
-  add_global_static_variable(context, type1, "__ESBMC_deallocated");
   add_global_static_variable(context, type1, "__ESBMC_is_dynamic");
 
   auto type2 = array_typet(size_type(), exprt("infinity"));

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -111,7 +111,6 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
 
 void jimple_languaget::add_intrinsics(contextt &context)
 {
-
 }
 
 void jimple_languaget::setup_main(contextt &context)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6844,7 +6844,6 @@ void python_converter::load_c_intrisics(code_blockt &block)
 
   auto type1 = array_typet(bool_type(), exprt("infinity"));
   add_global_static_variable(symbol_table_, type1, "__ESBMC_alloc");
-  add_global_static_variable(symbol_table_, type1, "__ESBMC_deallocated");
   add_global_static_variable(symbol_table_, type1, "__ESBMC_is_dynamic");
 
   auto type2 = array_typet(size_type(), exprt("infinity"));

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6838,32 +6838,6 @@ static void add_global_static_variable(
 void python_converter::load_c_intrisics(code_blockt &block)
 {
   // Add symbols required by the C models
-
-  add_global_static_variable(
-    symbol_table_, int_type(), "__ESBMC_rounding_mode");
-
-  auto type1 = array_typet(bool_type(), exprt("infinity"));
-  add_global_static_variable(symbol_table_, type1, "__ESBMC_alloc");
-  add_global_static_variable(symbol_table_, type1, "__ESBMC_is_dynamic");
-
-  auto type2 = array_typet(size_type(), exprt("infinity"));
-  add_global_static_variable(symbol_table_, type2, "__ESBMC_alloc_size");
-
-  // Initialize intrinsic variables to match C frontend behavior
-  locationt location;
-  location.set_file("esbmc_intrinsics.h");
-
-  // ASSIGN __ESBMC_rounding_mode = 0;
-  symbol_exprt rounding_symbol("c:@__ESBMC_rounding_mode", int_type());
-  code_assignt rounding_assign(rounding_symbol, gen_zero(int_type()));
-  rounding_assign.location() = location;
-  block.copy_to_operands(rounding_assign);
-
-  // TODO: Consider initializing other intrinsic variables if needed:
-  // - __ESBMC_alloc
-  // - __ESBMC_deallocated
-  // - __ESBMC_is_dynamic
-  // - __ESBMC_alloc_size
 }
 
 ///  Only addresses __name__; other Python built-ins such as

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6835,9 +6835,17 @@ static void add_global_static_variable(
   assert(added_symbol);
 }
 
-void python_converter::load_c_intrisics(code_blockt &block)
+void python_converter::load_c_intrisics(code_blockt &)
 {
   // Add symbols required by the C models
+  // __ESBMC_rounding_mode is pulled in indirectly via fesetround in cprover_library.cpp
+
+  auto type1 = array_typet(bool_type(), exprt("infinity"));
+  add_global_static_variable(symbol_table_, type1, "__ESBMC_alloc");
+  add_global_static_variable(symbol_table_, type1, "__ESBMC_is_dynamic");
+
+  auto type2 = array_typet(size_type(), exprt("infinity"));
+  add_global_static_variable(symbol_table_, type2, "__ESBMC_alloc_size");
 }
 
 ///  Only addresses __name__; other Python built-ins such as

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -60,7 +60,6 @@ protected:
   void move(symbolt &new_symbol);
 
   // overload to use language specific syntax
-  std::string to_string(const exprt &expr);
   std::string to_string(const typet &type);
 
   contextt &context;
@@ -75,11 +74,6 @@ protected:
 
   unsigned type_counter;
 };
-
-std::string c_linkt::to_string(const exprt &expr)
-{
-  return c_expr2string(expr, ns);
-}
 
 std::string c_linkt::to_string(const typet &type)
 {


### PR DESCRIPTION
Commit by commit review encouraged.

One foot gun that this includes is that __ESBMC_deallocated and friends won't be properly initialized when running in `--no-library` mode.
This should be solvable by splitting the libc-like cprover binary into two parts, one part that is the existing libc-like part and the other part is the one that just initializes __ESBMC_deallocated, __ESBMC_rounding_mode and friends without which the core functionality wouldn't work.
Left as future work or until someone encounters this problem in practice which should be quite rare :)

Also more or less reverts https://github.com/esbmc/esbmc/pull/2575 and moves this part to the stage where we "link to main".
This allows us to properly log warnings for `extern` symbols for which we didn't get a definition.
We initialize those symbols then with nondet even when an actual compiler would reject such files.

Currently, one limitation of our approach of using AstImporter to merge multiple source files is that the importer is quite liberal and doesn't complain about e.g. duplicate global symbols.
It would be more C like to actually produce one "object" file for every input file and then link those together like an actual compiler would do.