### PR TITLE
[python] add support for math.sin() and math.cos()

### DIFF
--- a/regression/python/math1/main.py
+++ b/regression/python/math1/main.py
@@ -1,0 +1,25 @@
+import math
+from math import sin, cos
+
+y = math.cos(0)
+assert y == 1.0
+
+w = math.cos(0)
+assert w == 1.0
+
+angle = 1.5708
+result = math.sin(angle)
+assert result > 0.99 and result < 1.01
+
+result2 = math.cos(angle)
+assert result2 > -0.01 and result2 < 0.01
+
+a = math.sin(math.cos(0))
+assert a > 0.84 and a < 0.85
+
+b = math.sin(1)
+assert b > 0.84 and b < 0.85
+
+c = math.sqrt(2)
+d = math.sin(c)
+assert d > 0.98 and d < 0.99

--- a/regression/python/math1/test.desc
+++ b/regression/python/math1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math2_fail/main.py
+++ b/regression/python/math2_fail/main.py
@@ -1,0 +1,7 @@
+import math
+from math import sin
+
+x = 0.5
+result = math.sin(x)
+
+assert result > 2.0

--- a/regression/python/math2_fail/test.desc
+++ b/regression/python/math2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/math3/main.py
+++ b/regression/python/math3/main.py
@@ -1,0 +1,13 @@
+import math
+import math
+
+a = math.sin(0)
+b = math.sin(0)
+c = math.cos(0)  
+d = math.cos(0)
+e = math.sqrt(2)
+f = math.sqrt(2)
+
+assert a == b        # Both should be 0
+assert c == d        # Both should be 1
+assert e == f        # Both should be sqrt(2)

--- a/regression/python/math3/test.desc
+++ b/regression/python/math3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2166,27 +2166,27 @@ function_call_expr::get_dispatch_table()
      "math.sqrt()"},
     // Math module functions (sin, cos)
     {[this]() {
-      const std::string &func_name = function_id_.get_function();
-      bool is_math_module = false;
-      if (call_["func"]["_type"] == "Attribute")
-      {
-        std::string caller = get_object_name();
-        is_math_module = (caller == "math");
-      }
-      return is_math_module && (func_name == "sin" || func_name == "cos");
-    },
-    [this]() {
-      const std::string &func_name = function_id_.get_function();
-      const auto &args = call_["args"];
-      if (args.size() != 1)
-        throw std::runtime_error(func_name + "() expects exactly 1 argument");
-      exprt arg_expr = converter_.get_expr(args[0]);
-      if (func_name == "sin")
-        return converter_.get_math_handler().handle_sin(arg_expr, call_);
-      else // cos
-        return converter_.get_math_handler().handle_cos(arg_expr, call_);
-    },
-    "math.sin/cos()"},
+       const std::string &func_name = function_id_.get_function();
+       bool is_math_module = false;
+       if (call_["func"]["_type"] == "Attribute")
+       {
+         std::string caller = get_object_name();
+         is_math_module = (caller == "math");
+       }
+       return is_math_module && (func_name == "sin" || func_name == "cos");
+     },
+     [this]() {
+       const std::string &func_name = function_id_.get_function();
+       const auto &args = call_["args"];
+       if (args.size() != 1)
+         throw std::runtime_error(func_name + "() expects exactly 1 argument");
+       exprt arg_expr = converter_.get_expr(args[0]);
+       if (func_name == "sin")
+         return converter_.get_math_handler().handle_sin(arg_expr, call_);
+       else // cos
+         return converter_.get_math_handler().handle_cos(arg_expr, call_);
+     },
+     "math.sin/cos()"},
 
     // divmod function
     {[this]() {

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2164,6 +2164,29 @@ function_call_expr::get_dispatch_table()
        return conditional;
      },
      "math.sqrt()"},
+    // Math module functions (sin, cos)
+    {[this]() {
+      const std::string &func_name = function_id_.get_function();
+      bool is_math_module = false;
+      if (call_["func"]["_type"] == "Attribute")
+      {
+        std::string caller = get_object_name();
+        is_math_module = (caller == "math");
+      }
+      return is_math_module && (func_name == "sin" || func_name == "cos");
+    },
+    [this]() {
+      const std::string &func_name = function_id_.get_function();
+      const auto &args = call_["args"];
+      if (args.size() != 1)
+        throw std::runtime_error(func_name + "() expects exactly 1 argument");
+      exprt arg_expr = converter_.get_expr(args[0]);
+      if (func_name == "sin")
+        return converter_.get_math_handler().handle_sin(arg_expr, call_);
+      else // cos
+        return converter_.get_math_handler().handle_cos(arg_expr, call_);
+    },
+    "math.sin/cos()"},
 
     // divmod function
     {[this]() {

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -517,3 +517,53 @@ exprt python_math::handle_divmod(
 
   return tuple_expr;
 }
+
+exprt python_math::handle_sin(exprt operand, const nlohmann::json &element)
+{
+  // Find the sin function symbol from C math library
+  symbolt *sin_symbol = symbol_table.find_symbol("c:@F@sin");
+  if (!sin_symbol)
+    throw std::runtime_error("sin function not found in symbol table");
+
+  // Promote operand to double if needed (sin always works with doubles)
+  exprt double_operand = operand;
+  if (!operand.type().is_floatbv())
+  {
+    double_operand = exprt("typecast", double_type());
+    double_operand.copy_to_operands(operand);
+  }
+
+  // Create the function call expression
+  side_effect_expr_function_callt sin_call;
+  sin_call.function() = symbol_expr(*sin_symbol);
+  sin_call.arguments() = {double_operand};
+  sin_call.type() = double_type();
+  sin_call.location() = converter.get_location_from_decl(element);
+
+  return sin_call;
+}
+
+exprt python_math::handle_cos(exprt operand, const nlohmann::json &element)
+{
+  // Find the cos function symbol from C math library
+  symbolt *cos_symbol = symbol_table.find_symbol("c:@F@cos");
+  if (!cos_symbol)
+    throw std::runtime_error("cos function not found in symbol table");
+
+  // Promote operand to double if needed (cos always works with doubles)
+  exprt double_operand = operand;
+  if (!operand.type().is_floatbv())
+  {
+    double_operand = exprt("typecast", double_type());
+    double_operand.copy_to_operands(operand);
+  }
+
+  // Create the function call expression
+  side_effect_expr_function_callt cos_call;
+  cos_call.function() = symbol_expr(*cos_symbol);
+  cos_call.arguments() = {double_operand};
+  cos_call.type() = double_type();
+  cos_call.location() = converter.get_location_from_decl(element);
+
+  return cos_call;
+}

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -172,6 +172,46 @@ public:
    */
   exprt handle_sqrt(exprt operand, const nlohmann::json &element);
 
+    /**
+   * @brief Handle sine function (math.sin)
+   *
+   * Implements Python's math.sin() function by creating a call to C's sin().
+   * Always returns a float (double) result representing the sine of the angle
+   * in radians.
+   *
+   * @param operand The angle in radians (promoted to float if needed)
+   * @param element JSON AST node for location information
+   * @return Function call expression to sin()
+   * @throws std::runtime_error if sin symbol not found in symbol table
+   *
+   * Examples:
+   *   math.sin(0) -> 0.0
+   *   math.sin(math.pi/2) -> 1.0
+   *   math.sin(math.pi) -> 0.0 (approximately)
+   *   math.sin(-math.pi/2) -> -1.0
+   */
+  exprt handle_sin(exprt operand, const nlohmann::json &element);
+
+  /**
+   * @brief Handle cosine function (math.cos)
+   *
+   * Implements Python's math.cos() function by creating a call to C's cos().
+   * Always returns a float (double) result representing the cosine of the angle
+   * in radians.
+   *
+   * @param operand The angle in radians (promoted to float if needed)
+   * @param element JSON AST node for location information
+   * @return Function call expression to cos()
+   * @throws std::runtime_error if cos symbol not found in symbol table
+   *
+   * Examples:
+   *   math.cos(0) -> 1.0
+   *   math.cos(math.pi/2) -> 0.0 (approximately)
+   *   math.cos(math.pi) -> -1.0
+   *   math.cos(2*math.pi) -> 1.0
+   */
+  exprt handle_cos(exprt operand, const nlohmann::json &element);
+
   /**
    * @brief Handle divmod() built-in function
    * 

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -172,7 +172,7 @@ public:
    */
   exprt handle_sqrt(exprt operand, const nlohmann::json &element);
 
-    /**
+  /**
    * @brief Handle sine function (math.sin)
    *
    * Implements Python's math.sin() function by creating a call to C's sin().


### PR DESCRIPTION
This PR extends ESBMC's Python frontend to handle trigonometric functions `sin()` and `cos()` from the `math` module.