### PR TITLE
[python] add type checking for math.comb()

### DIFF
--- a/regression/python/math1_fail/main.py
+++ b/regression/python/math1_fail/main.py
@@ -1,0 +1,3 @@
+import math
+
+result = math.comb(5, -2)

--- a/regression/python/math1_fail/test.desc
+++ b/regression/python/math1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/math2/main.py
+++ b/regression/python/math2/main.py
@@ -1,0 +1,87 @@
+import math
+
+def test_comb_type_errors():
+    """Test TypeError cases"""
+    # Test with float arguments
+    try:
+        result = math.comb(5.5, 2)
+        assert False, "Expected TypeError for float n"
+    except TypeError:
+        pass  # Expected
+    
+    try:
+        result = math.comb(5, 2.5)
+        assert False, "Expected TypeError for float k"
+    except TypeError:
+        pass  # Expected
+    
+    # Test with string arguments
+    try:
+        result = math.comb("5", 2)
+        assert False, "Expected TypeError for string n"
+    except TypeError:
+        pass  # Expected
+    
+    try:
+        result = math.comb(5, "2")
+        assert False, "Expected TypeError for string k"
+    except TypeError:
+        pass  # Expected
+    
+    # Test with None arguments
+    try:
+        result = math.comb(None, 2)
+        assert False, "Expected TypeError for None n"
+    except TypeError:
+        pass  # Expected
+    
+    try:
+        result = math.comb(5, None)
+        assert False, "Expected TypeError for None k"
+    except TypeError:
+        pass  # Expected
+
+def test_comb_value_errors():
+    """Test ValueError cases"""
+    # Test with negative n
+    try:
+        result = math.comb(-5, 2)
+        assert False, "Expected ValueError for negative n"
+    except ValueError:
+        pass  # Expected
+    
+    # Test with negative k
+    try:
+        result = math.comb(5, -2)
+        assert False, "Expected ValueError for negative k"
+    except ValueError:
+        pass  # Expected
+    
+    # Test with both negative
+    try:
+        result = math.comb(-5, -2)
+        assert False, "Expected ValueError for both negative"
+    except ValueError:
+        pass  # Expected
+
+def test_comb_valid_cases():
+    """Test that valid inputs still work correctly"""
+    # Basic cases
+    assert math.comb(5, 2) == 10
+    assert math.comb(10, 3) == 120
+    
+    # Edge cases
+    assert math.comb(5, 0) == 1
+    assert math.comb(5, 5) == 1
+    assert math.comb(5, 1) == 5
+    assert math.comb(5, 4) == 5
+    
+    # k > n should return 0
+    assert math.comb(3, 5) == 0
+    
+    # Symmetry property
+    assert math.comb(7, 3) == math.comb(7, 4)
+
+test_comb_type_errors()
+test_comb_value_errors()
+test_comb_valid_cases()

--- a/regression/python/math2/test.desc
+++ b/regression/python/math2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2060,14 +2060,16 @@ exprt function_call_expr::handle_math_comb() const
   {
     return gen_exception_raise(
       "TypeError",
-      "'float' object cannot be interpreted as an integer");
+      "'" + type_handler_.type_to_string(n_expr.type()) +
+        "' object cannot be interpreted as an integer");
   }
 
   if (!k_expr.type().is_signedbv() && !k_expr.type().is_unsignedbv())
   {
     return gen_exception_raise(
       "TypeError",
-      "'float' object cannot be interpreted as an integer");
+      "'" + type_handler_.type_to_string(k_expr.type()) +
+        "' object cannot be interpreted as an integer");
   }
 
   // Find the actual comb implementation function

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -46,6 +46,20 @@ public:
 
 private:
   /*
+  * Check if the current function call is to math.comb() function
+  * Returns true if this is a call to math.comb
+  */
+  bool is_math_comb_call() const;
+
+  /*
+  * Handles math.comb() function calls with type checking.
+  * Validates that both arguments are integers (not floats).
+  * Returns TypeError exception if arguments are not integers.
+  * Otherwise delegates to the comb implementation function.
+  */
+  exprt handle_math_comb() const;
+
+  /*
    * Validates that function call arguments match expected parameter types.
    * Returns TypeError exception if type mismatch is detected, nil_exprt otherwise.
    */

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -20,10 +20,10 @@ def comb(n: int, k: int) -> int:
     """
     # Type checking
     if not isinstance(n, int) or not isinstance(k, int):
-        assert False
+        raise TypeError("Both n and k must be integers")
     # Handle negative inputs
     if n < 0 or k < 0:
-        assert False
+        raise ValueError("Both n and k must be non-negative integers")
 
     # Handle edge cases
     if k > n:


### PR DESCRIPTION
This PR adds `is_math_comb_call()` and `handle_math_comb()` to validate argument types and raise `TypeError` for non-integer inputs before delegating to the comb implementation.