### PR TITLE
[python] fix math.sqrt() domain check causing segfault

### DIFF
--- a/regression/python/math22/test.desc
+++ b/regression/python/math22/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2163,7 +2163,8 @@ function_call_expr::get_dispatch_table()
          domain_check.copy_to_operands(double_operand, zero);
 
          // Create the exception raise as a code expression
-         exprt raise_expr = gen_exception_raise("ValueError", "math domain error");
+         exprt raise_expr =
+           gen_exception_raise("ValueError", "math domain error");
          locationt loc = converter_.get_location_from_decl(call_);
          raise_expr.location() = loc;
          raise_expr.location().user_provided(true);

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -126,6 +126,8 @@ def sqrt(x: float) -> float:
     Raises:
         ValueError: If x is negative (math domain error)
     """
+    if x < 0:
+        raise ValueError("math domain error")
 
     return __ESBMC_sqrt(x)
 


### PR DESCRIPTION
This PR adds a `code_ifthenelset` guard that throws the `ValueError` exception if the operand is negative, before computing `sqrt`. This ensures the exception is handled as a control flow statement rather than as part of a conditional expression.