### PR TITLE
[python] fix crash when raising exceptions without arguments

### DIFF
--- a/regression/mopsa/try_raise/test.desc
+++ b/regression/mopsa/try_raise/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6685,14 +6685,16 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
 
         exprt arg;
         // Check if args exists and is not empty before accessing
-        if (element["exc"].contains("args") &&
-            !element["exc"]["args"].empty() &&
-            !element["exc"]["args"][0].is_null())
+        const auto &exc = element["exc"];
+        if (exc.contains("args") &&
+            !exc["args"].empty() &&
+            !exc["args"][0].is_null())
         {
-          arg = get_expr(element["exc"]["args"][0]);
+          const auto &json_arg = exc["args"][0];
+          exprt tmp = get_expr(json_arg);
           arg = string_constantt(
-            string_handler_.process_format_spec(element["exc"]["args"][0]),
-            arg.type(),
+            string_handler_.process_format_spec(json_arg),
+            tmp.type(),
             string_constantt::k_default);
         }
         else

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6702,7 +6702,7 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
           // No arguments provided, create default empty message
           arg = string_constantt(
             "",
-            array_typet(char_type(), from_integer(1, size_type())),
+            type_handler_.build_array(char_type(), 1),
             string_constantt::k_default);
         }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6686,9 +6686,9 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
         exprt arg;
         // Check if args exists and is not empty before accessing
         const auto &exc = element["exc"];
-        if (exc.contains("args") &&
-            !exc["args"].empty() &&
-            !exc["args"][0].is_null())
+        if (
+          exc.contains("args") && !exc["args"].empty() &&
+          !exc["args"][0].is_null())
         {
           const auto &json_arg = exc["args"][0];
           exprt tmp = get_expr(json_arg);

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6682,11 +6682,27 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
       {
         // Construct a constant struct to throw:
         // raise { .message=&"Error message" }
-        exprt arg = get_expr(element["exc"]["args"][0]);
-        arg = string_constantt(
-          string_handler_.process_format_spec(element["exc"]["args"][0]),
-          arg.type(),
-          string_constantt::k_default);
+
+        exprt arg;
+        // Check if args exists and is not empty before accessing
+        if (element["exc"].contains("args") &&
+            !element["exc"]["args"].empty() &&
+            !element["exc"]["args"][0].is_null())
+        {
+          arg = get_expr(element["exc"]["args"][0]);
+          arg = string_constantt(
+            string_handler_.process_format_spec(element["exc"]["args"][0]),
+            arg.type(),
+            string_constantt::k_default);
+        }
+        else
+        {
+          // No arguments provided, create default empty message
+          arg = string_constantt(
+            "",
+            array_typet(char_type(), from_integer(1, size_type())),
+            string_constantt::k_default);
+        }
 
         raise.id("struct");
         raise.type() = type;


### PR DESCRIPTION
This PR adds proper existence checks before accessing args and provides a default empty string message when no arguments are present. Before this PR, the code was attempting to access `element["exc"]["args"][0]` without
checking if the "args" key exists, causing an assertion failure in `json.hpp` when processing raise statements without arguments (e.g., "raise TypeError").
