### PR TITLE
Add --incremental-bmc when test.desc line 3 is empty

### DIFF
--- a/regression/disabled/float4/test.desc
+++ b/regression/disabled/float4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/arg_mismatch/test.desc
+++ b/regression/mopsa/arg_mismatch/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError\: f\(\) missing 1 required positional argument\: \'x\'$

--- a/regression/mopsa/attribute_error/test.desc
+++ b/regression/mopsa/attribute_error/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR\: Attribute \"a\" not found$

--- a/regression/mopsa/basic_types/test.desc
+++ b/regression/mopsa/basic_types/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/broken_loop/test.desc
+++ b/regression/mopsa/broken_loop/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/class_constructor/test.desc
+++ b/regression/mopsa/class_constructor/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/class_inheritance/test.desc
+++ b/regression/mopsa/class_inheritance/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/class_static_method/test.desc
+++ b/regression/mopsa/class_static_method/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/class_static_method_fail/test.desc
+++ b/regression/mopsa/class_static_method_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/mopsa/function_default_args/test.desc
+++ b/regression/mopsa/function_default_args/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/function_side_effect/test.desc
+++ b/regression/mopsa/function_side_effect/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/generator/test.desc
+++ b/regression/mopsa/generator/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/generator_loop/test.desc
+++ b/regression/mopsa/generator_loop/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/generator_loop_2/test.desc
+++ b/regression/mopsa/generator_loop_2/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/generator_rel/test.desc
+++ b/regression/mopsa/generator_rel/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/generator_rel_2/test.desc
+++ b/regression/mopsa/generator_rel_2/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/incorrect_raise2_fail/test.desc
+++ b/regression/mopsa/incorrect_raise2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/mopsa/incorrect_raise3_fail/test.desc
+++ b/regression/mopsa/incorrect_raise3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/mopsa/incorrect_raise4_fail/test.desc
+++ b/regression/mopsa/incorrect_raise4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/mopsa/incorrect_raise_fail/test.desc
+++ b/regression/mopsa/incorrect_raise_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/mopsa/int/test.desc
+++ b/regression/mopsa/int/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/mopsa/lambda/test.desc
+++ b/regression/mopsa/lambda/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/add/test.desc
+++ b/regression/numpy/add/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/array-fail/test.desc
+++ b/regression/numpy/array-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/array-ones/test.desc
+++ b/regression/numpy/array-ones/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/array-out-bounds/test.desc
+++ b/regression/numpy/array-out-bounds/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 array bounds violated: array `arr' upper bound

--- a/regression/numpy/array-zeros/test.desc
+++ b/regression/numpy/array-zeros/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/array/test.desc
+++ b/regression/numpy/array/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/broadcasting/test.desc
+++ b/regression/numpy/broadcasting/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ERROR: operands could not be broadcast together with shapes.*

--- a/regression/numpy/ceil/test.desc
+++ b/regression/numpy/ceil/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ceil2/test.desc
+++ b/regression/numpy/ceil2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/ceil3/test.desc
+++ b/regression/numpy/ceil3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/copysign/test.desc
+++ b/regression/numpy/copysign/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/det/test.desc
+++ b/regression/numpy/det/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/det3/test.desc
+++ b/regression/numpy/det3/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/det4/test.desc
+++ b/regression/numpy/det4/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/div1/test.desc
+++ b/regression/numpy/div1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/div1_fail/test.desc
+++ b/regression/numpy/div1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/divide/test.desc
+++ b/regression/numpy/divide/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot/test.desc
+++ b/regression/numpy/dot/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot2/test.desc
+++ b/regression/numpy/dot2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot3/test.desc
+++ b/regression/numpy/dot3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot3_fail/test.desc
+++ b/regression/numpy/dot3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/dot4/test.desc
+++ b/regression/numpy/dot4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot5/test.desc
+++ b/regression/numpy/dot5/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/dot6/test.desc
+++ b/regression/numpy/dot6/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot7/test.desc
+++ b/regression/numpy/dot7/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/dot8/test.desc
+++ b/regression/numpy/dot8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: ESBMC does not support 3D or higher dimensional arrays\. Found 3D array creation\. Please use 1D or 2D arrays only\.$

--- a/regression/numpy/e/test.desc
+++ b/regression/numpy/e/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/fabs/test.desc
+++ b/regression/numpy/fabs/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/floor/test.desc
+++ b/regression/numpy/floor/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/fmax/test.desc
+++ b/regression/numpy/fmax/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/fmin/test.desc
+++ b/regression/numpy/fmin/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/fmod/test.desc
+++ b/regression/numpy/fmod/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/frexp/test.desc
+++ b/regression/numpy/frexp/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/isclose/test.desc
+++ b/regression/numpy/isclose/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/math/test.desc
+++ b/regression/numpy/math/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/math2/test.desc
+++ b/regression/numpy/math2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/math2_fail/test.desc
+++ b/regression/numpy/math2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/math3/test.desc
+++ b/regression/numpy/math3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/math3_fail/test.desc
+++ b/regression/numpy/math3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: Unsupported Numpy call: fabs

--- a/regression/numpy/matmul/test.desc
+++ b/regression/numpy/matmul/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/modf/test.desc
+++ b/regression/numpy/modf/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/multiply/test.desc
+++ b/regression/numpy/multiply/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/nextafter/test.desc
+++ b/regression/numpy/nextafter/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/remainder/test.desc
+++ b/regression/numpy/remainder/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/rint/test.desc
+++ b/regression/numpy/rint/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/round/test.desc
+++ b/regression/numpy/round/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/round2/test.desc
+++ b/regression/numpy/round2/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/sin_fail/test.desc
+++ b/regression/numpy/sin_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/sqrt/test.desc
+++ b/regression/numpy/sqrt/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/subtract/test.desc
+++ b/regression/numpy/subtract/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose/test.desc
+++ b/regression/numpy/transpose/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose2/test.desc
+++ b/regression/numpy/transpose2/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose3/test.desc
+++ b/regression/numpy/transpose3/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose4/test.desc
+++ b/regression/numpy/transpose4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose5/test.desc
+++ b/regression/numpy/transpose5/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose6/test.desc
+++ b/regression/numpy/transpose6/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose7/test.desc
+++ b/regression/numpy/transpose7/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose8/test.desc
+++ b/regression/numpy/transpose8/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/numpy/transpose8_fail/test.desc
+++ b/regression/numpy/transpose8_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/numpy/trunc/test.desc
+++ b/regression/numpy/trunc/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_11/test.desc
+++ b/regression/python-intensive/problem2_11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_1_fail/test.desc
+++ b/regression/python-intensive/problem2_1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python-intensive/problem2_2/test.desc
+++ b/regression/python-intensive/problem2_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_2_fail/test.desc
+++ b/regression/python-intensive/problem2_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python-intensive/problem2_3/test.desc
+++ b/regression/python-intensive/problem2_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_4/test.desc
+++ b/regression/python-intensive/problem2_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_5/test.desc
+++ b/regression/python-intensive/problem2_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_6/test.desc
+++ b/regression/python-intensive/problem2_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python-intensive/problem2_6_fail/test.desc
+++ b/regression/python-intensive/problem2_6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/AssertionError1/test.desc
+++ b/regression/python/AssertionError1/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/AssertionError1_fail/test.desc
+++ b/regression/python/AssertionError1_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/AssertionError2/test.desc
+++ b/regression/python/AssertionError2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/AssertionError2_fail/test.desc
+++ b/regression/python/AssertionError2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/abs/test.desc
+++ b/regression/python/abs/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/annotate-else/test.desc
+++ b/regression/python/annotate-else/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/annotate-method/test.desc
+++ b/regression/python/annotate-method/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/any-example/test.desc
+++ b/regression/python/any-example/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/any/test.desc
+++ b/regression/python/any/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/any2/test.desc
+++ b/regression/python/any2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert-always-true/test.desc
+++ b/regression/python/assert-always-true/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert-arith/test.desc
+++ b/regression/python/assert-arith/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert-branch_fail/test.desc
+++ b/regression/python/assert-branch_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/assert-class/test.desc
+++ b/regression/python/assert-class/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert-fail/test.desc
+++ b/regression/python/assert-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/assert-list_fail/test.desc
+++ b/regression/python/assert-list_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/assert-logical_fail/test.desc
+++ b/regression/python/assert-logical_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/assert-loop/test.desc
+++ b/regression/python/assert-loop/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert-message_fail/test.desc
+++ b/regression/python/assert-message_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^  x is equal to y$

--- a/regression/python/assert-nested_fail/test.desc
+++ b/regression/python/assert-nested_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/assert/test.desc
+++ b/regression/python/assert/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert2/test.desc
+++ b/regression/python/assert2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert3/test.desc
+++ b/regression/python/assert3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/assert4-fail/test.desc
+++ b/regression/python/assert4-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/assign-fail/test.desc
+++ b/regression/python/assign-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ERROR: Type inference failed at line 1. Variable q not found

--- a/regression/python/binary-ops/test.desc
+++ b/regression/python/binary-ops/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/boolop-len-or/test.desc
+++ b/regression/python/boolop-len-or/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/built-in-functions/test.desc
+++ b/regression/python/built-in-functions/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/builtin1_fail/test.desc
+++ b/regression/python/builtin1_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/builtin2/test.desc
+++ b/regression/python/builtin2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/builtin2_fail/test.desc
+++ b/regression/python/builtin2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/bytes-assert-fail/test.desc
+++ b/regression/python/bytes-assert-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/bytes-bounds-fail/test.desc
+++ b/regression/python/bytes-bounds-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/bytes-neg-index/test.desc
+++ b/regression/python/bytes-neg-index/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes/test.desc
+++ b/regression/python/bytes/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes2-fail/test.desc
+++ b/regression/python/bytes2-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/bytes2/test.desc
+++ b/regression/python/bytes2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes3/test.desc
+++ b/regression/python/bytes3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes4-fail/test.desc
+++ b/regression/python/bytes4-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/bytes4/test.desc
+++ b/regression/python/bytes4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/bytes5_fail/test.desc
+++ b/regression/python/bytes5_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/callable/test.desc
+++ b/regression/python/callable/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/callable2/test.desc
+++ b/regression/python/callable2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/callable2_fail/test.desc
+++ b/regression/python/callable2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/callable3/test.desc
+++ b/regression/python/callable3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/callable3_fail/test.desc
+++ b/regression/python/callable3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/callable4/test.desc
+++ b/regression/python/callable4/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/callable5/test.desc
+++ b/regression/python/callable5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/callable6_fail/test.desc
+++ b/regression/python/callable6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/callable7/test.desc
+++ b/regression/python/callable7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/callable_fail/test.desc
+++ b/regression/python/callable_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting-chr-func/test.desc
+++ b/regression/python/casting-chr-func/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting-chr-multibyte-fail/test.desc
+++ b/regression/python/casting-chr-multibyte-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting-chr-multibyte-reassign/test.desc
+++ b/regression/python/casting-chr-multibyte-reassign/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting-chr-multibyte/test.desc
+++ b/regression/python/casting-chr-multibyte/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting-chr-multibyte2/test.desc
+++ b/regression/python/casting-chr-multibyte2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting-chr-var-multibyte/test.desc
+++ b/regression/python/casting-chr-var-multibyte/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting/test.desc
+++ b/regression/python/casting/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting10/test.desc
+++ b/regression/python/casting10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting11/test.desc
+++ b/regression/python/casting11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting12-fail/test.desc
+++ b/regression/python/casting12-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting14-fail/test.desc
+++ b/regression/python/casting14-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting14/test.desc
+++ b/regression/python/casting14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting15-fail/test.desc
+++ b/regression/python/casting15-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^\s*Throwing an exception of type ValueError but there is not catch for it.$

--- a/regression/python/casting18-fail/test.desc
+++ b/regression/python/casting18-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting2/test.desc
+++ b/regression/python/casting2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting20/test.desc
+++ b/regression/python/casting20/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting21-fail/test.desc
+++ b/regression/python/casting21-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting22-fail/test.desc
+++ b/regression/python/casting22-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^\s*Throwing an exception of type TypeError but there is not catch for it.$

--- a/regression/python/casting23/test.desc
+++ b/regression/python/casting23/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting24-fail/test.desc
+++ b/regression/python/casting24-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^\s*Throwing an exception of type TypeError but there is not catch for it.$

--- a/regression/python/casting25-fail/test.desc
+++ b/regression/python/casting25-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^\s*Throwing an exception of type TypeError but there is not catch for it.$

--- a/regression/python/casting26/test.desc
+++ b/regression/python/casting26/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting26_fail/test.desc
+++ b/regression/python/casting26_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting27/test.desc
+++ b/regression/python/casting27/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting28/test.desc
+++ b/regression/python/casting28/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting29/test.desc
+++ b/regression/python/casting29/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting29_fail/test.desc
+++ b/regression/python/casting29_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting3-fail/test.desc
+++ b/regression/python/casting3-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting30/test.desc
+++ b/regression/python/casting30/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting31/test.desc
+++ b/regression/python/casting31/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting4/test.desc
+++ b/regression/python/casting4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting5-fail/test.desc
+++ b/regression/python/casting5-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/casting6/test.desc
+++ b/regression/python/casting6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/casting7-fail/test.desc
+++ b/regression/python/casting7-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: '<' not supported between instances of 'float' and 'str' at .*main\.py:4$

--- a/regression/python/casting8-fail/test.desc
+++ b/regression/python/casting8-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: '<=' not supported between instances of 'float' and 'str' at .*main\.py:2$

--- a/regression/python/casting9-fail/test.desc
+++ b/regression/python/casting9-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: '<' not supported between instances of 'float' and 'str' at .*main\.py:3$

--- a/regression/python/chained-comparison-fail/test.desc
+++ b/regression/python/chained-comparison-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/chained-comparison/test.desc
+++ b/regression/python/chained-comparison/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/chained-comparison2/test.desc
+++ b/regression/python/chained-comparison2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/chained-comparison2_fail/test.desc
+++ b/regression/python/chained-comparison2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class-attributes-scoped/test.desc
+++ b/regression/python/class-attributes-scoped/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class-attributes/test.desc
+++ b/regression/python/class-attributes/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class-attributes_fail/test.desc
+++ b/regression/python/class-attributes_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class-binding/test.desc
+++ b/regression/python/class-binding/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class-func-fail/test.desc
+++ b/regression/python/class-func-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class-methods-fail/test.desc
+++ b/regression/python/class-methods-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class-methods/test.desc
+++ b/regression/python/class-methods/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class-nested-ctor/test.desc
+++ b/regression/python/class-nested-ctor/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class-super-fail/test.desc
+++ b/regression/python/class-super-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class-super/test.desc
+++ b/regression/python/class-super/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class1/test.desc
+++ b/regression/python/class1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class10/test.desc
+++ b/regression/python/class10/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class11/test.desc
+++ b/regression/python/class11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class12/test.desc
+++ b/regression/python/class12/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class13/test.desc
+++ b/regression/python/class13/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class14/test.desc
+++ b/regression/python/class14/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/class14_fail/test.desc
+++ b/regression/python/class14_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/class15/test.desc
+++ b/regression/python/class15/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/class15_fail/test.desc
+++ b/regression/python/class15_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/class2/test.desc
+++ b/regression/python/class2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class2_fail/test.desc
+++ b/regression/python/class2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class3/test.desc
+++ b/regression/python/class3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class3_fail/test.desc
+++ b/regression/python/class3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class4/test.desc
+++ b/regression/python/class4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class5/test.desc
+++ b/regression/python/class5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class5_fail/test.desc
+++ b/regression/python/class5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class6/test.desc
+++ b/regression/python/class6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class6_fail/test.desc
+++ b/regression/python/class6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class7/test.desc
+++ b/regression/python/class7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/class7_fail/test.desc
+++ b/regression/python/class7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class9-fail/test.desc
+++ b/regression/python/class9-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/class9/test.desc
+++ b/regression/python/class9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/classes/test.desc
+++ b/regression/python/classes/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/combo1/test.desc
+++ b/regression/python/combo1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/combo1_fail/test.desc
+++ b/regression/python/combo1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/combo2/test.desc
+++ b/regression/python/combo2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/combo3/test.desc
+++ b/regression/python/combo3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/combo4/test.desc
+++ b/regression/python/combo4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/compound-assign/test.desc
+++ b/regression/python/compound-assign/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/compound-stmt-fail/test.desc
+++ b/regression/python/compound-stmt-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/compound-stmt/test.desc
+++ b/regression/python/compound-stmt/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/compound-stmt3/test.desc
+++ b/regression/python/compound-stmt3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/compound-stmt4/test.desc
+++ b/regression/python/compound-stmt4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/compound-stmt6/test.desc
+++ b/regression/python/compound-stmt6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/compound-stmt7/test.desc
+++ b/regression/python/compound-stmt7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat8/test.desc
+++ b/regression/python/concat8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/concat8_fail/test.desc
+++ b/regression/python/concat8_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/constants/test.desc
+++ b/regression/python/constants/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict12/test.desc
+++ b/regression/python/dict12/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict13/test.desc
+++ b/regression/python/dict13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict14/test.desc
+++ b/regression/python/dict14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict14_fail/test.desc
+++ b/regression/python/dict14_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/dict15/test.desc
+++ b/regression/python/dict15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict15_fail/test.desc
+++ b/regression/python/dict15_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/dict16/test.desc
+++ b/regression/python/dict16/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict17/test.desc
+++ b/regression/python/dict17/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict25/test.desc
+++ b/regression/python/dict25/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict26/test.desc
+++ b/regression/python/dict26/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict27/test.desc
+++ b/regression/python/dict27/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict28/test.desc
+++ b/regression/python/dict28/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict29/test.desc
+++ b/regression/python/dict29/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict30/test.desc
+++ b/regression/python/dict30/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict31/test.desc
+++ b/regression/python/dict31/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict32/test.desc
+++ b/regression/python/dict32/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict32_fail/test.desc
+++ b/regression/python/dict32_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/dict33_fail/test.desc
+++ b/regression/python/dict33_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/dict37/test.desc
+++ b/regression/python/dict37/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict38/test.desc
+++ b/regression/python/dict38/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict42/test.desc
+++ b/regression/python/dict42/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict43/test.desc
+++ b/regression/python/dict43/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict44_fail/test.desc
+++ b/regression/python/dict44_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/dict9/test.desc
+++ b/regression/python/dict9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_del8/test.desc
+++ b/regression/python/dict_del8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_subscript_typed/test.desc
+++ b/regression/python/dict_subscript_typed/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_subscript_typed_wrong_type_fail/test.desc
+++ b/regression/python/dict_subscript_typed_wrong_type_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/div1/test.desc
+++ b/regression/python/div1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/div1_fail/test.desc
+++ b/regression/python/div1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/div2/test.desc
+++ b/regression/python/div2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/div2_fail/test.desc
+++ b/regression/python/div2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/div3/test.desc
+++ b/regression/python/div3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/div3_fail/test.desc
+++ b/regression/python/div3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/div4/test.desc
+++ b/regression/python/div4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/div5/test.desc
+++ b/regression/python/div5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/div6/test.desc
+++ b/regression/python/div6/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/div6_fail/test.desc
+++ b/regression/python/div6_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/div7_fail/test.desc
+++ b/regression/python/div7_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/divmod_basic/test.desc
+++ b/regression/python/divmod_basic/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_chained/test.desc
+++ b/regression/python/divmod_chained/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_comprehensive/test.desc
+++ b/regression/python/divmod_comprehensive/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_computation/test.desc
+++ b/regression/python/divmod_computation/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_constant/test.desc
+++ b/regression/python/divmod_constant/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_exact/test.desc
+++ b/regression/python/divmod_exact/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_float/test.desc
+++ b/regression/python/divmod_float/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_large/test.desc
+++ b/regression/python/divmod_large/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_mixed/test.desc
+++ b/regression/python/divmod_mixed/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_negative_dividend/test.desc
+++ b/regression/python/divmod_negative_dividend/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_negative_divisor/test.desc
+++ b/regression/python/divmod_negative_divisor/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_negative_float/test.desc
+++ b/regression/python/divmod_negative_float/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_reuse/test.desc
+++ b/regression/python/divmod_reuse/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_small_dividend/test.desc
+++ b/regression/python/divmod_small_dividend/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/divmod_zero_remainder/test.desc
+++ b/regression/python/divmod_zero_remainder/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic-typing/test.desc
+++ b/regression/python/dynamic-typing/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enough-args/test.desc
+++ b/regression/python/enough-args/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enough-args2/test.desc
+++ b/regression/python/enough-args2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enough-args3/test.desc
+++ b/regression/python/enough-args3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate12/test.desc
+++ b/regression/python/enumerate12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate13/test.desc
+++ b/regression/python/enumerate13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate14_fail/test.desc
+++ b/regression/python/enumerate14_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError\: 'float' object cannot be interpreted as an integer$

--- a/regression/python/enumerate3_fail/test.desc
+++ b/regression/python/enumerate3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError\: enumerate\(\) missing required argument 'iterable' \(pos 1\)$

--- a/regression/python/enumerate4_fail/test.desc
+++ b/regression/python/enumerate4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError\: enumerate\(\) takes at most 2 arguments \(3 given\)$

--- a/regression/python/enumerate5_fail/test.desc
+++ b/regression/python/enumerate5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ValueError\: not enough values to unpack \(expected 3, got 2\)$

--- a/regression/python/enumerate8/test.desc
+++ b/regression/python/enumerate8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/enumerate8_fail/test.desc
+++ b/regression/python/enumerate8_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/equivalence/test.desc
+++ b/regression/python/equivalence/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/equivalence_fail/test.desc
+++ b/regression/python/equivalence_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/esbmc-assume-fail/test.desc
+++ b/regression/python/esbmc-assume-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/esbmc-assume/test.desc
+++ b/regression/python/esbmc-assume/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception/test.desc
+++ b/regression/python/exception/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception2/test.desc
+++ b/regression/python/exception2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception2_fail/test.desc
+++ b/regression/python/exception2_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^ERROR\: Exception thrown of type tag-ValueError at file main.py line 5$

--- a/regression/python/exception3_fail/test.desc
+++ b/regression/python/exception3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/exception4/test.desc
+++ b/regression/python/exception4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception5_fail/test.desc
+++ b/regression/python/exception5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/exception6_fail/test.desc
+++ b/regression/python/exception6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/exception7/test.desc
+++ b/regression/python/exception7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception_base_class/test.desc
+++ b/regression/python/exception_base_class/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception_div_zero/test.desc
+++ b/regression/python/exception_div_zero/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception_index_fail/test.desc
+++ b/regression/python/exception_index_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/exception_type_error_fail/test.desc
+++ b/regression/python/exception_type_error_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/expression_statement/test.desc
+++ b/regression/python/expression_statement/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float/test.desc
+++ b/regression/python/float/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float1/test.desc
+++ b/regression/python/float1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float1_fail/test.desc
+++ b/regression/python/float1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^\s*Throwing an exception of type ValueError but there is not catch for it.$

--- a/regression/python/float2/test.desc
+++ b/regression/python/float2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float3/test.desc
+++ b/regression/python/float3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float5/test.desc
+++ b/regression/python/float5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_basic/test.desc
+++ b/regression/python/float_modulo_basic/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_compound_assign/test.desc
+++ b/regression/python/float_modulo_compound_assign/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_edge_cases/test.desc
+++ b/regression/python/float_modulo_edge_cases/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_expression/test.desc
+++ b/regression/python/float_modulo_expression/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_mixed_types/test.desc
+++ b/regression/python/float_modulo_mixed_types/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/float_modulo_python_semantics/test.desc
+++ b/regression/python/float_modulo_python_semantics/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil1/test.desc
+++ b/regression/python/floor_ceil1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil2/test.desc
+++ b/regression/python/floor_ceil2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil3/test.desc
+++ b/regression/python/floor_ceil3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil4/test.desc
+++ b/regression/python/floor_ceil4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil5/test.desc
+++ b/regression/python/floor_ceil5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/floor_ceil6/test.desc
+++ b/regression/python/floor_ceil6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop-fail/test.desc
+++ b/regression/python/for-loop-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop-with-char/test.desc
+++ b/regression/python/for-loop-with-char/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop-with-char_fail/test.desc
+++ b/regression/python/for-loop-with-char_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop/test.desc
+++ b/regression/python/for-loop/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop10/test.desc
+++ b/regression/python/for-loop10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop14/test.desc
+++ b/regression/python/for-loop14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop15/test.desc
+++ b/regression/python/for-loop15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop16_fail/test.desc
+++ b/regression/python/for-loop16_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop17/test.desc
+++ b/regression/python/for-loop17/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop17_fail/test.desc
+++ b/regression/python/for-loop17_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop3/test.desc
+++ b/regression/python/for-loop3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop3_fail/test.desc
+++ b/regression/python/for-loop3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/for-loop6/test.desc
+++ b/regression/python/for-loop6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/for-loop8_fail/test.desc
+++ b/regression/python/for-loop8_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/forward-declaration/test.desc
+++ b/regression/python/forward-declaration/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/forward-declaration2/test.desc
+++ b/regression/python/forward-declaration2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/forward-declaration2_fail/test.desc
+++ b/regression/python/forward-declaration2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/forward-declaration3/test.desc
+++ b/regression/python/forward-declaration3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/forward-declaration4/test.desc
+++ b/regression/python/forward-declaration4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/forward-declaration6_fail/test.desc
+++ b/regression/python/forward-declaration6_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 Unsupported function 'g' is reached
 

--- a/regression/python/forward-declaration_fail/test.desc
+++ b/regression/python/forward-declaration_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/fstring2/test.desc
+++ b/regression/python/fstring2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/func-nested/test.desc
+++ b/regression/python/func-nested/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/func-nested2/test.desc
+++ b/regression/python/func-nested2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/func-nested3/test.desc
+++ b/regression/python/func-nested3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/func-no-params-types-fail/test.desc
+++ b/regression/python/func-no-params-types-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call-var-obj/test.desc
+++ b/regression/python/function-call-var-obj/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call/test.desc
+++ b/regression/python/function-call/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call10-pass/test.desc
+++ b/regression/python/function-call10-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call11-pass/test.desc
+++ b/regression/python/function-call11-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call12-pass/test.desc
+++ b/regression/python/function-call12-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call13-fail/test.desc
+++ b/regression/python/function-call13-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-call14-fail/test.desc
+++ b/regression/python/function-call14-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-call14-pass/test.desc
+++ b/regression/python/function-call14-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call2-fail/test.desc
+++ b/regression/python/function-call2-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-call2/test.desc
+++ b/regression/python/function-call2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call3/test.desc
+++ b/regression/python/function-call3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call4/test.desc
+++ b/regression/python/function-call4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call5-fail/test.desc
+++ b/regression/python/function-call5-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-call5/test.desc
+++ b/regression/python/function-call5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call6-pass/test.desc
+++ b/regression/python/function-call6-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call7-pass/test.desc
+++ b/regression/python/function-call7-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call8-fail/test.desc
+++ b/regression/python/function-call8-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-call8-pass/test.desc
+++ b/regression/python/function-call8-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-call9-pass/test.desc
+++ b/regression/python/function-call9-pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-function-var/test.desc
+++ b/regression/python/function-default-function-var/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-instance-reuse/test.desc
+++ b/regression/python/function-default-instance-reuse/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-int/test.desc
+++ b/regression/python/function-default-int/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-keyword-argument/test.desc
+++ b/regression/python/function-default-keyword-argument/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-missing-arg-fail/test.desc
+++ b/regression/python/function-default-missing-arg-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: returns\_y\(\) missing 1 required positional argument: \'x\'$

--- a/regression/python/function-default-variable-fail/test.desc
+++ b/regression/python/function-default-variable-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-default-variable-mult/test.desc
+++ b/regression/python/function-default-variable-mult/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-variable-obj/test.desc
+++ b/regression/python/function-default-variable-obj/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-default-variable/test.desc
+++ b/regression/python/function-default-variable/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-keyword-argument/test.desc
+++ b/regression/python/function-keyword-argument/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/function-keyword-repeated-fail/test.desc
+++ b/regression/python/function-keyword-repeated-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^SyntaxError: Keyword argument repeated:x$

--- a/regression/python/function-return-if-fail/test.desc
+++ b/regression/python/function-return-if-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/function-return/test.desc
+++ b/regression/python/function-return/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/gb-2812/test.desc
+++ b/regression/python/gb-2812/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/gb-2893/test.desc
+++ b/regression/python/gb-2893/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/gb-2915/test.desc
+++ b/regression/python/gb-2915/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/getrandbits/test.desc
+++ b/regression/python/getrandbits/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_1964/test.desc
+++ b/regression/python/github_1964/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2012/test.desc
+++ b/regression/python/github_2012/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2839/test.desc
+++ b/regression/python/github_2839/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2839_fail/test.desc
+++ b/regression/python/github_2839_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2843/test.desc
+++ b/regression/python/github_2843/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_2/test.desc
+++ b/regression/python/github_2843_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_3/test.desc
+++ b/regression/python/github_2843_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_4/test.desc
+++ b/regression/python/github_2843_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_5/test.desc
+++ b/regression/python/github_2843_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR\: Unsupported return type \'string\' detected$

--- a/regression/python/github_2843_6/test.desc
+++ b/regression/python/github_2843_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_7/test.desc
+++ b/regression/python/github_2843_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2843_fail/test.desc
+++ b/regression/python/github_2843_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2879/test.desc
+++ b/regression/python/github_2879/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2879_2/test.desc
+++ b/regression/python/github_2879_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2879_2_fail/test.desc
+++ b/regression/python/github_2879_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2879_3/test.desc
+++ b/regression/python/github_2879_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2879_3_fail/test.desc
+++ b/regression/python/github_2879_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2879_4/test.desc
+++ b/regression/python/github_2879_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2879_4_fail/test.desc
+++ b/regression/python/github_2879_4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2879_fail/test.desc
+++ b/regression/python/github_2879_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2880/test.desc
+++ b/regression/python/github_2880/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2881/test.desc
+++ b/regression/python/github_2881/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2881_2/test.desc
+++ b/regression/python/github_2881_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2881_3_fail/test.desc
+++ b/regression/python/github_2881_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: Unsupported expression for \'not in\' operation$

--- a/regression/python/github_2881_fail/test.desc
+++ b/regression/python/github_2881_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2885/test.desc
+++ b/regression/python/github_2885/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2885_2/test.desc
+++ b/regression/python/github_2885_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2885_2_fail/test.desc
+++ b/regression/python/github_2885_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2885_3/test.desc
+++ b/regression/python/github_2885_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2885_3_fail/test.desc
+++ b/regression/python/github_2885_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2885_4_fail/test.desc
+++ b/regression/python/github_2885_4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2885_fail/test.desc
+++ b/regression/python/github_2885_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2892/test.desc
+++ b/regression/python/github_2892/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2892_fail/test.desc
+++ b/regression/python/github_2892_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2895/test.desc
+++ b/regression/python/github_2895/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2895_2/test.desc
+++ b/regression/python/github_2895_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2897/test.desc
+++ b/regression/python/github_2897/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2897_2/test.desc
+++ b/regression/python/github_2897_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2897_2_fail/test.desc
+++ b/regression/python/github_2897_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2898/test.desc
+++ b/regression/python/github_2898/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2898_fail/test.desc
+++ b/regression/python/github_2898_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2899/test.desc
+++ b/regression/python/github_2899/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2899_2/test.desc
+++ b/regression/python/github_2899_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2900/test.desc
+++ b/regression/python/github_2900/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2908_2/test.desc
+++ b/regression/python/github_2908_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2910/test.desc
+++ b/regression/python/github_2910/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2910_2/test.desc
+++ b/regression/python/github_2910_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2910_3/test.desc
+++ b/regression/python/github_2910_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2911/test.desc
+++ b/regression/python/github_2911/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2911_2_fail/test.desc
+++ b/regression/python/github_2911_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2911_3/test.desc
+++ b/regression/python/github_2911_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2911_3_fail/test.desc
+++ b/regression/python/github_2911_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2911_fail/test.desc
+++ b/regression/python/github_2911_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2912/test.desc
+++ b/regression/python/github_2912/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2912_fail/test.desc
+++ b/regression/python/github_2912_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2916/test.desc
+++ b/regression/python/github_2916/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2916_2/test.desc
+++ b/regression/python/github_2916_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2916_3/test.desc
+++ b/regression/python/github_2916_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2916_4/test.desc
+++ b/regression/python/github_2916_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: All parameters in function \"bad\" must be type annotated$

--- a/regression/python/github_2916_fail/test.desc
+++ b/regression/python/github_2916_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2929/test.desc
+++ b/regression/python/github_2929/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2931/test.desc
+++ b/regression/python/github_2931/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2933/test.desc
+++ b/regression/python/github_2933/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2933_fail/test.desc
+++ b/regression/python/github_2933_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2934/test.desc
+++ b/regression/python/github_2934/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2934_2/test.desc
+++ b/regression/python/github_2934_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2934_2_fail/test.desc
+++ b/regression/python/github_2934_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2934_3/test.desc
+++ b/regression/python/github_2934_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2934_3_fail/test.desc
+++ b/regression/python/github_2934_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2934_4_fail/test.desc
+++ b/regression/python/github_2934_4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2934_fail/test.desc
+++ b/regression/python/github_2934_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2935/test.desc
+++ b/regression/python/github_2935/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2937_2/test.desc
+++ b/regression/python/github_2937_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2937_2_fail/test.desc
+++ b/regression/python/github_2937_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2943/test.desc
+++ b/regression/python/github_2943/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2943_2/test.desc
+++ b/regression/python/github_2943_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2943_2_fail/test.desc
+++ b/regression/python/github_2943_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2944/test.desc
+++ b/regression/python/github_2944/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2947/test.desc
+++ b/regression/python/github_2947/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2947_2/test.desc
+++ b/regression/python/github_2947_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2947_2_fail/test.desc
+++ b/regression/python/github_2947_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2960/test.desc
+++ b/regression/python/github_2960/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2961/test.desc
+++ b/regression/python/github_2961/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2961_fail/test.desc
+++ b/regression/python/github_2961_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2962/test.desc
+++ b/regression/python/github_2962/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2962_fail/test.desc
+++ b/regression/python/github_2962_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2964/test.desc
+++ b/regression/python/github_2964/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965/test.desc
+++ b/regression/python/github_2965/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_2/test.desc
+++ b/regression/python/github_2965_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_2_fail/test.desc
+++ b/regression/python/github_2965_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2965_3/test.desc
+++ b/regression/python/github_2965_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2965_fail/test.desc
+++ b/regression/python/github_2965_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2966/test.desc
+++ b/regression/python/github_2966/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2966_fail/test.desc
+++ b/regression/python/github_2966_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2974/test.desc
+++ b/regression/python/github_2974/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_2974_1/test.desc
+++ b/regression/python/github_2974_1/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_2974_1_fail/test.desc
+++ b/regression/python/github_2974_1_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_2974_fail/test.desc
+++ b/regression/python/github_2974_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_2975/test.desc
+++ b/regression/python/github_2975/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2975_fail/test.desc
+++ b/regression/python/github_2975_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978/test.desc
+++ b/regression/python/github_2978/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_2/test.desc
+++ b/regression/python/github_2978_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_2_fail/test.desc
+++ b/regression/python/github_2978_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978_3/test.desc
+++ b/regression/python/github_2978_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_4/test.desc
+++ b/regression/python/github_2978_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_4_fail/test.desc
+++ b/regression/python/github_2978_4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978_5/test.desc
+++ b/regression/python/github_2978_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_5_fail/test.desc
+++ b/regression/python/github_2978_5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978_6/test.desc
+++ b/regression/python/github_2978_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_6_fail/test.desc
+++ b/regression/python/github_2978_6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978_7/test.desc
+++ b/regression/python/github_2978_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_7_fail/test.desc
+++ b/regression/python/github_2978_7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978_8/test.desc
+++ b/regression/python/github_2978_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_8_fail/test.desc
+++ b/regression/python/github_2978_8_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2978_9/test.desc
+++ b/regression/python/github_2978_9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2978_fail/test.desc
+++ b/regression/python/github_2978_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2980/test.desc
+++ b/regression/python/github_2980/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2980_fail/test.desc
+++ b/regression/python/github_2980_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2986/test.desc
+++ b/regression/python/github_2986/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2986_2/test.desc
+++ b/regression/python/github_2986_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2986_2_fail/test.desc
+++ b/regression/python/github_2986_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2986_fail/test.desc
+++ b/regression/python/github_2986_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2989/test.desc
+++ b/regression/python/github_2989/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2989_1/test.desc
+++ b/regression/python/github_2989_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2989_1_fail/test.desc
+++ b/regression/python/github_2989_1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2989_fail/test.desc
+++ b/regression/python/github_2989_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2992/test.desc
+++ b/regression/python/github_2992/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2992_islower/test.desc
+++ b/regression/python/github_2992_islower/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2992_lower/test.desc
+++ b/regression/python/github_2992_lower/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2993/test.desc
+++ b/regression/python/github_2993/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2993_2/test.desc
+++ b/regression/python/github_2993_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2993_2_fail/test.desc
+++ b/regression/python/github_2993_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2993_fail/test.desc
+++ b/regression/python/github_2993_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2993_real_world/test.desc
+++ b/regression/python/github_2993_real_world/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997/test.desc
+++ b/regression/python/github_2997/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997_1/test.desc
+++ b/regression/python/github_2997_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997_2/test.desc
+++ b/regression/python/github_2997_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997_3/test.desc
+++ b/regression/python/github_2997_3/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_2997_4/test.desc
+++ b/regression/python/github_2997_4/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_2997_5/test.desc
+++ b/regression/python/github_2997_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997_5_fail/test.desc
+++ b/regression/python/github_2997_5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2997_6/test.desc
+++ b/regression/python/github_2997_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997_6_fail/test.desc
+++ b/regression/python/github_2997_6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2997_7/test.desc
+++ b/regression/python/github_2997_7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2997_7_fail/test.desc
+++ b/regression/python/github_2997_7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_2997_8/test.desc
+++ b/regression/python/github_2997_8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_2999_3/test.desc
+++ b/regression/python/github_2999_3/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_2999_3_fail/test.desc
+++ b/regression/python/github_2999_3_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000/test.desc
+++ b/regression/python/github_3000/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3000_1_fail/test.desc
+++ b/regression/python/github_3000_1_fail/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000_2/test.desc
+++ b/regression/python/github_3000_2/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3000_3/test.desc
+++ b/regression/python/github_3000_3/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3000_3_fail/test.desc
+++ b/regression/python/github_3000_3_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000_4/test.desc
+++ b/regression/python/github_3000_4/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3000_4_fail/test.desc
+++ b/regression/python/github_3000_4_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000_5/test.desc
+++ b/regression/python/github_3000_5/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3000_5_fail/test.desc
+++ b/regression/python/github_3000_5_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000_6/test.desc
+++ b/regression/python/github_3000_6/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3000_6_fail/test.desc
+++ b/regression/python/github_3000_6_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000_7/test.desc
+++ b/regression/python/github_3000_7/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3000_7_fail/test.desc
+++ b/regression/python/github_3000_7_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3000_8_fail/test.desc
+++ b/regression/python/github_3000_8_fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 
 

--- a/regression/python/github_3000_fail/test.desc
+++ b/regression/python/github_3000_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3001_fail/test.desc
+++ b/regression/python/github_3001_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^  AttributeError: object has no attribute 'bar' \(possible types: 'Foo', 'Bar'\)$

--- a/regression/python/github_3003/test.desc
+++ b/regression/python/github_3003/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3003_2/test.desc
+++ b/regression/python/github_3003_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3003_3/test.desc
+++ b/regression/python/github_3003_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3008/test.desc
+++ b/regression/python/github_3008/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3010_2_fail/test.desc
+++ b/regression/python/github_3010_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: foo\(\) missing 1 required positional argument: \'x\'$

--- a/regression/python/github_3010_3_fail/test.desc
+++ b/regression/python/github_3010_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: foo\(\) missing 2 required positional arguments: \'x\' and \'y\'$

--- a/regression/python/github_3010_4_fail/test.desc
+++ b/regression/python/github_3010_4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: foo\(\) missing 1 required positional argument: \'y\'$

--- a/regression/python/github_3010_5_fail/test.desc
+++ b/regression/python/github_3010_5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: foo\(\) missing 1 required keyword-only argument: \'b\'$

--- a/regression/python/github_3010_6_fail/test.desc
+++ b/regression/python/github_3010_6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^  Throwing an exception of type TypeError but there is not catch for it.$

--- a/regression/python/github_3010_7_fail/test.desc
+++ b/regression/python/github_3010_7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^  Throwing an exception of type TypeError but there is not catch for it.$

--- a/regression/python/github_3010_8_pass/test.desc
+++ b/regression/python/github_3010_8_pass/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3010_fail/test.desc
+++ b/regression/python/github_3010_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: foo\(\) missing 1 required positional argument: \'x\'$

--- a/regression/python/github_3012/test.desc
+++ b/regression/python/github_3012/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3012_2/test.desc
+++ b/regression/python/github_3012_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3012_2_fail/test.desc
+++ b/regression/python/github_3012_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3013/test.desc
+++ b/regression/python/github_3013/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3013_2/test.desc
+++ b/regression/python/github_3013_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3014_fail/test.desc
+++ b/regression/python/github_3014_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3015/test.desc
+++ b/regression/python/github_3015/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3015_1_fail/test.desc
+++ b/regression/python/github_3015_1_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^SyntaxError: Multiple values for argument 'x'$
 

--- a/regression/python/github_3015_2_fail/test.desc
+++ b/regression/python/github_3015_2_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^SyntaxError: Multiple values for argument 'y'$
 

--- a/regression/python/github_3015_3_fail/test.desc
+++ b/regression/python/github_3015_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^TypeError: foo\(\) missing 1 required positional argument: \'x\'$

--- a/regression/python/github_3015_4_fail/test.desc
+++ b/regression/python/github_3015_4_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: Unknown keyword argument: z in function foo$
 

--- a/regression/python/github_3015_fail/test.desc
+++ b/regression/python/github_3015_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^SyntaxError: Multiple values for argument 'x'$
 

--- a/regression/python/github_3019/test.desc
+++ b/regression/python/github_3019/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3019_2/test.desc
+++ b/regression/python/github_3019_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3019_2_fail/test.desc
+++ b/regression/python/github_3019_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3019_3/test.desc
+++ b/regression/python/github_3019_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3019_4/test.desc
+++ b/regression/python/github_3019_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3019_5/test.desc
+++ b/regression/python/github_3019_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3019_6/test.desc
+++ b/regression/python/github_3019_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3019_fail/test.desc
+++ b/regression/python/github_3019_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3020_4/test.desc
+++ b/regression/python/github_3020_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3038/test.desc
+++ b/regression/python/github_3038/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3038_2/test.desc
+++ b/regression/python/github_3038_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3038_2_fail/test.desc
+++ b/regression/python/github_3038_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3038_fail/test.desc
+++ b/regression/python/github_3038_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3040/test.desc
+++ b/regression/python/github_3040/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3040_2/test.desc
+++ b/regression/python/github_3040_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3041/test.desc
+++ b/regression/python/github_3041/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3041_2/test.desc
+++ b/regression/python/github_3041_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3041_2_fail/test.desc
+++ b/regression/python/github_3041_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3041_fail/test.desc
+++ b/regression/python/github_3041_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3042/test.desc
+++ b/regression/python/github_3042/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3043/test.desc
+++ b/regression/python/github_3043/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3043_2/test.desc
+++ b/regression/python/github_3043_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3043_2_fail/test.desc
+++ b/regression/python/github_3043_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3044/test.desc
+++ b/regression/python/github_3044/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3044_2/test.desc
+++ b/regression/python/github_3044_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3045/test.desc
+++ b/regression/python/github_3045/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3045_fail/test.desc
+++ b/regression/python/github_3045_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3046_2/test.desc
+++ b/regression/python/github_3046_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3046_2_fail/test.desc
+++ b/regression/python/github_3046_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3052/test.desc
+++ b/regression/python/github_3052/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3054/test.desc
+++ b/regression/python/github_3054/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3056/test.desc
+++ b/regression/python/github_3056/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3056_2/test.desc
+++ b/regression/python/github_3056_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3056_2_fail/test.desc
+++ b/regression/python/github_3056_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3056_fail/test.desc
+++ b/regression/python/github_3056_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3057/test.desc
+++ b/regression/python/github_3057/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3057_fail/test.desc
+++ b/regression/python/github_3057_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3074/test.desc
+++ b/regression/python/github_3074/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3074_fail/test.desc
+++ b/regression/python/github_3074_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3076/test.desc
+++ b/regression/python/github_3076/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3076_2/test.desc
+++ b/regression/python/github_3076_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3076_2_fail/test.desc
+++ b/regression/python/github_3076_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3076_fail/test.desc
+++ b/regression/python/github_3076_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3078/test.desc
+++ b/regression/python/github_3078/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3078_fail/test.desc
+++ b/regression/python/github_3078_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3081/test.desc
+++ b/regression/python/github_3081/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3082/test.desc
+++ b/regression/python/github_3082/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3082_fail/test.desc
+++ b/regression/python/github_3082_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3087/test.desc
+++ b/regression/python/github_3087/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3089/test.desc
+++ b/regression/python/github_3089/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3089_fail/test.desc
+++ b/regression/python/github_3089_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3090/test.desc
+++ b/regression/python/github_3090/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3090_3/test.desc
+++ b/regression/python/github_3090_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3090_3_fail/test.desc
+++ b/regression/python/github_3090_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3090_fail/test.desc
+++ b/regression/python/github_3090_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3091/test.desc
+++ b/regression/python/github_3091/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3091_fail/test.desc
+++ b/regression/python/github_3091_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3106/test.desc
+++ b/regression/python/github_3106/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3106_2/test.desc
+++ b/regression/python/github_3106_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3106_2_fail/test.desc
+++ b/regression/python/github_3106_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3106_3/test.desc
+++ b/regression/python/github_3106_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3106_3_fail/test.desc
+++ b/regression/python/github_3106_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3114/test.desc
+++ b/regression/python/github_3114/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3116/test.desc
+++ b/regression/python/github_3116/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3116_1/test.desc
+++ b/regression/python/github_3116_1/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3119/test.desc
+++ b/regression/python/github_3119/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3119_2/test.desc
+++ b/regression/python/github_3119_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3119_2_fail/test.desc
+++ b/regression/python/github_3119_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3119_fail/test.desc
+++ b/regression/python/github_3119_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3129/test.desc
+++ b/regression/python/github_3129/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3129_fail/test.desc
+++ b/regression/python/github_3129_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3130_fail/test.desc
+++ b/regression/python/github_3130_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3137/test.desc
+++ b/regression/python/github_3137/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3137_fail/test.desc
+++ b/regression/python/github_3137_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3140/test.desc
+++ b/regression/python/github_3140/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3140_1/test.desc
+++ b/regression/python/github_3140_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3140_1_fail/test.desc
+++ b/regression/python/github_3140_1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3140_fail/test.desc
+++ b/regression/python/github_3140_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3145/test.desc
+++ b/regression/python/github_3145/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3150/test.desc
+++ b/regression/python/github_3150/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3150_2/test.desc
+++ b/regression/python/github_3150_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3150_2_fail/test.desc
+++ b/regression/python/github_3150_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3150_fail/test.desc
+++ b/regression/python/github_3150_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3151/test.desc
+++ b/regression/python/github_3151/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3151_fail/test.desc
+++ b/regression/python/github_3151_fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 
 

--- a/regression/python/github_3154/test.desc
+++ b/regression/python/github_3154/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3154_fail/test.desc
+++ b/regression/python/github_3154_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3155/test.desc
+++ b/regression/python/github_3155/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3155_fail/test.desc
+++ b/regression/python/github_3155_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3161/test.desc
+++ b/regression/python/github_3161/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3161_fail/test.desc
+++ b/regression/python/github_3161_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3168/test.desc
+++ b/regression/python/github_3168/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3181/test.desc
+++ b/regression/python/github_3181/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3181_fail/test.desc
+++ b/regression/python/github_3181_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3197/test.desc
+++ b/regression/python/github_3197/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3205_2_fail/test.desc
+++ b/regression/python/github_3205_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3205_fail/test.desc
+++ b/regression/python/github_3205_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^  Assertion on None-returning function$

--- a/regression/python/github_3243/test.desc
+++ b/regression/python/github_3243/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3244/test.desc
+++ b/regression/python/github_3244/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3244_2/test.desc
+++ b/regression/python/github_3244_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3244_fail/test.desc
+++ b/regression/python/github_3244_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3256_2_fail/test.desc
+++ b/regression/python/github_3256_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3256_fail/test.desc
+++ b/regression/python/github_3256_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3286/test.desc
+++ b/regression/python/github_3286/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3286_fail/test.desc
+++ b/regression/python/github_3286_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3287/test.desc
+++ b/regression/python/github_3287/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3287_1/test.desc
+++ b/regression/python/github_3287_1/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3287_1_fail/test.desc
+++ b/regression/python/github_3287_1_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3287_2/test.desc
+++ b/regression/python/github_3287_2/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3287_2_fail/test.desc
+++ b/regression/python/github_3287_2_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3287_fail/test.desc
+++ b/regression/python/github_3287_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3288/test.desc
+++ b/regression/python/github_3288/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3288_2/test.desc
+++ b/regression/python/github_3288_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3288_2_fail/test.desc
+++ b/regression/python/github_3288_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3295/test.desc
+++ b/regression/python/github_3295/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3295_fail/test.desc
+++ b/regression/python/github_3295_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3297/test.desc
+++ b/regression/python/github_3297/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/github_3297_fail/test.desc
+++ b/regression/python/github_3297_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 

--- a/regression/python/github_3305/test.desc
+++ b/regression/python/github_3305/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3305_2/test.desc
+++ b/regression/python/github_3305_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3305_fail/test.desc
+++ b/regression/python/github_3305_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3307/test.desc
+++ b/regression/python/github_3307/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3307_2/test.desc
+++ b/regression/python/github_3307_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3307_2_fail/test.desc
+++ b/regression/python/github_3307_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3307_fail/test.desc
+++ b/regression/python/github_3307_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3313/test.desc
+++ b/regression/python/github_3313/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3313_2/test.desc
+++ b/regression/python/github_3313_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3313_2_fail/test.desc
+++ b/regression/python/github_3313_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3313_3/test.desc
+++ b/regression/python/github_3313_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3313_3_fail/test.desc
+++ b/regression/python/github_3313_3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3313_fail/test.desc
+++ b/regression/python/github_3313_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3338/test.desc
+++ b/regression/python/github_3338/test.desc
@@ -1,4 +1,4 @@
 CORE
 ex.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3339/test.desc
+++ b/regression/python/github_3339/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3339_fail/test.desc
+++ b/regression/python/github_3339_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3431/test.desc
+++ b/regression/python/github_3431/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3431_2/test.desc
+++ b/regression/python/github_3431_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3431_3/test.desc
+++ b/regression/python/github_3431_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3431_4/test.desc
+++ b/regression/python/github_3431_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3432/test.desc
+++ b/regression/python/github_3432/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3432_2/test.desc
+++ b/regression/python/github_3432_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3433/test.desc
+++ b/regression/python/github_3433/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3434/test.desc
+++ b/regression/python/github_3434/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3434_2/test.desc
+++ b/regression/python/github_3434_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3434_3/test.desc
+++ b/regression/python/github_3434_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3434_4/test.desc
+++ b/regression/python/github_3434_4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3434_5/test.desc
+++ b/regression/python/github_3434_5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3434_6/test.desc
+++ b/regression/python/github_3434_6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/global-decl-fail/test.desc
+++ b/regression/python/global-decl-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: Variable x in function modify is uninitialized.$

--- a/regression/python/global-decl/test.desc
+++ b/regression/python/global-decl/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/global-no-decl-fail/test.desc
+++ b/regression/python/global-no-decl-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: Variable x in function modify is uninitialized.$

--- a/regression/python/global-no-decl-fail2/test.desc
+++ b/regression/python/global-no-decl-fail2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: Variable x in function modify is uninitialized.$

--- a/regression/python/global2/test.desc
+++ b/regression/python/global2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/global2_fail/test.desc
+++ b/regression/python/global2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/has-attr/test.desc
+++ b/regression/python/has-attr/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/higher-order1/test.desc
+++ b/regression/python/higher-order1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/higher-order2/test.desc
+++ b/regression/python/higher-order2/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/higher-order3/test.desc
+++ b/regression/python/higher-order3/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/if-else/test.desc
+++ b/regression/python/if-else/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/if-global-var/test.desc
+++ b/regression/python/if-global-var/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-as-fail/test.desc
+++ b/regression/python/import-as-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ERROR: Object "mp" not found.

--- a/regression/python/import-as/test.desc
+++ b/regression/python/import-as/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-class-constructor/test.desc
+++ b/regression/python/import-class-constructor/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/import-class-inheritance/test.desc
+++ b/regression/python/import-class-inheritance/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/import-class-methods/test.desc
+++ b/regression/python/import-class-methods/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/import-class-null-returns/test.desc
+++ b/regression/python/import-class-null-returns/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/import-class-submodule/test.desc
+++ b/regression/python/import-class-submodule/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/import-for-loop/test.desc
+++ b/regression/python/import-for-loop/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-from-all/test.desc
+++ b/regression/python/import-from-all/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-from-class-fail/test.desc
+++ b/regression/python/import-from-class-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ERROR: Function "MyClass" not found.

--- a/regression/python/import-from-class/test.desc
+++ b/regression/python/import-from-class/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-from-function-fail/test.desc
+++ b/regression/python/import-from-function-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/import-from-function/test.desc
+++ b/regression/python/import-from-function/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-from-multiple-fail/test.desc
+++ b/regression/python/import-from-multiple-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/import-from-multiple/test.desc
+++ b/regression/python/import-from-multiple/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-fully-qualified/test.desc
+++ b/regression/python/import-fully-qualified/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-math/test.desc
+++ b/regression/python/import-math/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-multi-files/test.desc
+++ b/regression/python/import-multi-files/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-multi-files2/test.desc
+++ b/regression/python/import-multi-files2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-os/test.desc
+++ b/regression/python/import-os/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-os2_fail/test.desc
+++ b/regression/python/import-os2_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/import-os_fail/test.desc
+++ b/regression/python/import-os_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/import/test.desc
+++ b/regression/python/import/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import_module/test.desc
+++ b/regression/python/import_module/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/import_module_fail/test.desc
+++ b/regression/python/import_module_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR\: Module \'my_module\' not found\.$

--- a/regression/python/indexing11_fail/test.desc
+++ b/regression/python/indexing11_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing12_fail/test.desc
+++ b/regression/python/indexing12_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing13_fail/test.desc
+++ b/regression/python/indexing13_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing14_fail/test.desc
+++ b/regression/python/indexing14_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing15_fail/test.desc
+++ b/regression/python/indexing15_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing2_fail/test.desc
+++ b/regression/python/indexing2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing3_fail/test.desc
+++ b/regression/python/indexing3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing4_fail/test.desc
+++ b/regression/python/indexing4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing5_fail/test.desc
+++ b/regression/python/indexing5_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing7_fail/test.desc
+++ b/regression/python/indexing7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/indexing8/test.desc
+++ b/regression/python/indexing8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/indexing9_fail/test.desc
+++ b/regression/python/indexing9_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/infer-call-annotation/test.desc
+++ b/regression/python/infer-call-annotation/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-no-return_fail/test.desc
+++ b/regression/python/infer-func-no-return_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/infer-func-param/test.desc
+++ b/regression/python/infer-func-param/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param10/test.desc
+++ b/regression/python/infer-func-param10/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param3/test.desc
+++ b/regression/python/infer-func-param3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param3_fail/test.desc
+++ b/regression/python/infer-func-param3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/infer-func-param4/test.desc
+++ b/regression/python/infer-func-param4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param5/test.desc
+++ b/regression/python/infer-func-param5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param5_fail/test.desc
+++ b/regression/python/infer-func-param5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/infer-func-param5_nondet/test.desc
+++ b/regression/python/infer-func-param5_nondet/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param6/test.desc
+++ b/regression/python/infer-func-param6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param7/test.desc
+++ b/regression/python/infer-func-param7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param8/test.desc
+++ b/regression/python/infer-func-param8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param9/test.desc
+++ b/regression/python/infer-func-param9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/infer-func-param_fail/test.desc
+++ b/regression/python/infer-func-param_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/inheritance-fail/test.desc
+++ b/regression/python/inheritance-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/inheritance/test.desc
+++ b/regression/python/inheritance/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/inheritance2/test.desc
+++ b/regression/python/inheritance2/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/input/test.desc
+++ b/regression/python/input/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/input2/test.desc
+++ b/regression/python/input2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/input3/test.desc
+++ b/regression/python/input3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int1/test.desc
+++ b/regression/python/int1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int1_fail/test.desc
+++ b/regression/python/int1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/int2/test.desc
+++ b/regression/python/int2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int2_fail/test.desc
+++ b/regression/python/int2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/int3/test.desc
+++ b/regression/python/int3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int4/test.desc
+++ b/regression/python/int4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_bit_length/test.desc
+++ b/regression/python/int_bit_length/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_bit_length_fail/test.desc
+++ b/regression/python/int_bit_length_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/int_from_bytes/test.desc
+++ b/regression/python/int_from_bytes/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/int_from_bytes_fail/test.desc
+++ b/regression/python/int_from_bytes_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/is-instance-fail/test.desc
+++ b/regression/python/is-instance-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/is-instance/test.desc
+++ b/regression/python/is-instance/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/is-not/test.desc
+++ b/regression/python/is-not/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/is-not_fail/test.desc
+++ b/regression/python/is-not_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/is/test.desc
+++ b/regression/python/is/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/is2-fail/test.desc
+++ b/regression/python/is2-fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/is3/test.desc
+++ b/regression/python/is3/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/is4/test.desc
+++ b/regression/python/is4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/is6/test.desc
+++ b/regression/python/is6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isdigit/test.desc
+++ b/regression/python/isdigit/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isdigit2/test.desc
+++ b/regression/python/isdigit2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isdigit2_fail/test.desc
+++ b/regression/python/isdigit2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/isdigit_fail/test.desc
+++ b/regression/python/isdigit_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/isinstance1/test.desc
+++ b/regression/python/isinstance1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance10/test.desc
+++ b/regression/python/isinstance10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance11/test.desc
+++ b/regression/python/isinstance11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance12/test.desc
+++ b/regression/python/isinstance12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance13/test.desc
+++ b/regression/python/isinstance13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance14/test.desc
+++ b/regression/python/isinstance14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance15/test.desc
+++ b/regression/python/isinstance15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance16/test.desc
+++ b/regression/python/isinstance16/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance17/test.desc
+++ b/regression/python/isinstance17/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance18/test.desc
+++ b/regression/python/isinstance18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance19/test.desc
+++ b/regression/python/isinstance19/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance2/test.desc
+++ b/regression/python/isinstance2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance20/test.desc
+++ b/regression/python/isinstance20/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance20_fail/test.desc
+++ b/regression/python/isinstance20_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/isinstance21/test.desc
+++ b/regression/python/isinstance21/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance22/test.desc
+++ b/regression/python/isinstance22/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance23/test.desc
+++ b/regression/python/isinstance23/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance24/test.desc
+++ b/regression/python/isinstance24/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance25/test.desc
+++ b/regression/python/isinstance25/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance26/test.desc
+++ b/regression/python/isinstance26/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance27/test.desc
+++ b/regression/python/isinstance27/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance28/test.desc
+++ b/regression/python/isinstance28/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance29/test.desc
+++ b/regression/python/isinstance29/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance3/test.desc
+++ b/regression/python/isinstance3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance30/test.desc
+++ b/regression/python/isinstance30/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance31/test.desc
+++ b/regression/python/isinstance31/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance4/test.desc
+++ b/regression/python/isinstance4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance5/test.desc
+++ b/regression/python/isinstance5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance6/test.desc
+++ b/regression/python/isinstance6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance7/test.desc
+++ b/regression/python/isinstance7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance8/test.desc
+++ b/regression/python/isinstance8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/jpl/test.desc
+++ b/regression/python/jpl/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: All parameters in function \"list\_comp\" must be type annotated$

--- a/regression/python/jpl_1/test.desc
+++ b/regression/python/jpl_1/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: All parameters in function "list_comp" must be type annotated$
 

--- a/regression/python/lambda/test.desc
+++ b/regression/python/lambda/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda10/test.desc
+++ b/regression/python/lambda10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda11/test.desc
+++ b/regression/python/lambda11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda12/test.desc
+++ b/regression/python/lambda12/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda13/test.desc
+++ b/regression/python/lambda13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda14/test.desc
+++ b/regression/python/lambda14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda15/test.desc
+++ b/regression/python/lambda15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda16/test.desc
+++ b/regression/python/lambda16/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda16_fail/test.desc
+++ b/regression/python/lambda16_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/lambda17/test.desc
+++ b/regression/python/lambda17/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda17_fail/test.desc
+++ b/regression/python/lambda17_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/lambda18/test.desc
+++ b/regression/python/lambda18/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda19/test.desc
+++ b/regression/python/lambda19/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda2/test.desc
+++ b/regression/python/lambda2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda20/test.desc
+++ b/regression/python/lambda20/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda21/test.desc
+++ b/regression/python/lambda21/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda3/test.desc
+++ b/regression/python/lambda3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda3_fail/test.desc
+++ b/regression/python/lambda3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/lambda4/test.desc
+++ b/regression/python/lambda4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda5/test.desc
+++ b/regression/python/lambda5/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda6_fail/test.desc
+++ b/regression/python/lambda6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/lambda7_fail/test.desc
+++ b/regression/python/lambda7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/lambda8/test.desc
+++ b/regression/python/lambda8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda9/test.desc
+++ b/regression/python/lambda9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/lambda9_fail/test.desc
+++ b/regression/python/lambda9_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/lambda_fail/test.desc
+++ b/regression/python/lambda_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/len-fail/test.desc
+++ b/regression/python/len-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/len/test.desc
+++ b/regression/python/len/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/len2-fail/test.desc
+++ b/regression/python/len2-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/len2/test.desc
+++ b/regression/python/len2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-fail/test.desc
+++ b/regression/python/list-fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/list-mult-dim-out-bounds-fail/test.desc
+++ b/regression/python/list-mult-dim-out-bounds-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: List out of bounds at\b

--- a/regression/python/list-repetition-rhs/test.desc
+++ b/regression/python/list-repetition-rhs/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-repetition2/test.desc
+++ b/regression/python/list-repetition2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-return/test.desc
+++ b/regression/python/list-return/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-var-undef/test.desc
+++ b/regression/python/list-var-undef/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR\: Variable \'l\' is not defined in function \'max\' at line 4.$

--- a/regression/python/list16_fail/test.desc
+++ b/regression/python/list16_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 (?m)^(ERROR:.*)\s*\Z

--- a/regression/python/list17_fail/test.desc
+++ b/regression/python/list17_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 (?m)^.*ERROR: List out of bounds at.*\s*\Z

--- a/regression/python/list18_fail/test.desc
+++ b/regression/python/list18_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/list22/test.desc
+++ b/regression/python/list22/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list22_fail/test.desc
+++ b/regression/python/list22_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/list3/test.desc
+++ b/regression/python/list3/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list4/test.desc
+++ b/regression/python/list4/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list5/test.desc
+++ b/regression/python/list5/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list8/test.desc
+++ b/regression/python/list8/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list9/test.desc
+++ b/regression/python/list9/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_objects/test.desc
+++ b/regression/python/list_objects/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/literal/test.desc
+++ b/regression/python/literal/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/literal_fail/test.desc
+++ b/regression/python/literal_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/logical-and-success/test.desc
+++ b/regression/python/logical-and-success/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/logical-and5/test.desc
+++ b/regression/python/logical-and5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/logical-not-success/test.desc
+++ b/regression/python/logical-not-success/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/logical-or-fail/test.desc
+++ b/regression/python/logical-or-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/logical-or-success/test.desc
+++ b/regression/python/logical-or-success/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/loop-invariant/test.desc
+++ b/regression/python/loop-invariant/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-function/test.desc
+++ b/regression/python/main-function/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-function_fail/test.desc
+++ b/regression/python/main-function_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/main-if-guard/test.desc
+++ b/regression/python/main-if-guard/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-if-guard_fail/test.desc
+++ b/regression/python/main-if-guard_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/main-import/test.desc
+++ b/regression/python/main-import/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/main-import_fail/test.desc
+++ b/regression/python/main-import_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/man_bits/test.desc
+++ b/regression/python/man_bits/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/math/test.desc
+++ b/regression/python/math/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/math1/test.desc
+++ b/regression/python/math1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/math1_fail/test.desc
+++ b/regression/python/math1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/math2/test.desc
+++ b/regression/python/math2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/math2_fail/test.desc
+++ b/regression/python/math2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/math3/test.desc
+++ b/regression/python/math3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/method-instances/test.desc
+++ b/regression/python/method-instances/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/method-keywords/test.desc
+++ b/regression/python/method-keywords/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/min_max_1/test.desc
+++ b/regression/python/min_max_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/min_max_1_fail/test.desc
+++ b/regression/python/min_max_1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/min_max_2/test.desc
+++ b/regression/python/min_max_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/min_max_2_fail/test.desc
+++ b/regression/python/min_max_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return10_fail/test.desc
+++ b/regression/python/missing-return10_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return11_fail/test.desc
+++ b/regression/python/missing-return11_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return12_fail/test.desc
+++ b/regression/python/missing-return12_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return14_fail/test.desc
+++ b/regression/python/missing-return14_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return3_fail/test.desc
+++ b/regression/python/missing-return3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return4/test.desc
+++ b/regression/python/missing-return4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/missing-return5_fail/test.desc
+++ b/regression/python/missing-return5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return6/test.desc
+++ b/regression/python/missing-return6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/missing-return7/test.desc
+++ b/regression/python/missing-return7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/missing-return7_fail/test.desc
+++ b/regression/python/missing-return7_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return8_fail/test.desc
+++ b/regression/python/missing-return8_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return9_fail/test.desc
+++ b/regression/python/missing-return9_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/missing-return_fail/test.desc
+++ b/regression/python/missing-return_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail/test.desc
+++ b/regression/python/mod-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail2/test.desc
+++ b/regression/python/mod-fail2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail3/test.desc
+++ b/regression/python/mod-fail3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail5/test.desc
+++ b/regression/python/mod-fail5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail6/test.desc
+++ b/regression/python/mod-fail6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail8/test.desc
+++ b/regression/python/mod-fail8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod-fail9/test.desc
+++ b/regression/python/mod-fail9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/mod/test.desc
+++ b/regression/python/mod/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/mod2/test.desc
+++ b/regression/python/mod2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/mod3/test.desc
+++ b/regression/python/mod3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment/test.desc
+++ b/regression/python/multiple-assignment/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment2/test.desc
+++ b/regression/python/multiple-assignment2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment3/test.desc
+++ b/regression/python/multiple-assignment3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment5/test.desc
+++ b/regression/python/multiple-assignment5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment6/test.desc
+++ b/regression/python/multiple-assignment6/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment7/test.desc
+++ b/regression/python/multiple-assignment7/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/multiple-assignment8/test.desc
+++ b/regression/python/multiple-assignment8/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-1/test.desc
+++ b/regression/python/nested-attr-1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-10/test.desc
+++ b/regression/python/nested-attr-10/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-11/test.desc
+++ b/regression/python/nested-attr-11/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-12/test.desc
+++ b/regression/python/nested-attr-12/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-13/test.desc
+++ b/regression/python/nested-attr-13/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-14/test.desc
+++ b/regression/python/nested-attr-14/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-15/test.desc
+++ b/regression/python/nested-attr-15/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-1_fail/test.desc
+++ b/regression/python/nested-attr-1_fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$
 
 

--- a/regression/python/nested-attr-2/test.desc
+++ b/regression/python/nested-attr-2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-2_fail/test.desc
+++ b/regression/python/nested-attr-2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/nested-attr-3/test.desc
+++ b/regression/python/nested-attr-3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-4/test.desc
+++ b/regression/python/nested-attr-4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-5/test.desc
+++ b/regression/python/nested-attr-5/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 
 

--- a/regression/python/nested-attr-6/test.desc
+++ b/regression/python/nested-attr-6/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 
 

--- a/regression/python/nested-attr-7/test.desc
+++ b/regression/python/nested-attr-7/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-attr-9/test.desc
+++ b/regression/python/nested-attr-9/test.desc
@@ -1,5 +1,5 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/nested-ctor-calls/test.desc
+++ b/regression/python/nested-ctor-calls/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-ctor-calls_2/test.desc
+++ b/regression/python/nested-ctor-calls_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-ctor-calls_2_fail/test.desc
+++ b/regression/python/nested-ctor-calls_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/nested_func_call/test.desc
+++ b/regression/python/nested_func_call/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested_func_call_fail/test.desc
+++ b/regression/python/nested_func_call_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/neural-net/test.desc
+++ b/regression/python/neural-net/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet-fail/test.desc
+++ b/regression/python/nondet-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/nondet-verifier-fail/test.desc
+++ b/regression/python/nondet-verifier-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/nondet-verifier/test.desc
+++ b/regression/python/nondet-verifier/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet/test.desc
+++ b/regression/python/nondet/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_list19/test.desc
+++ b/regression/python/nondet_list19/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondet_str/test.desc
+++ b/regression/python/nondet_str/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nondetuint/test.desc
+++ b/regression/python/nondetuint/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none-fail/test.desc
+++ b/regression/python/none-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/none/test.desc
+++ b/regression/python/none/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none2/test.desc
+++ b/regression/python/none2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none3/test.desc
+++ b/regression/python/none3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none4/test.desc
+++ b/regression/python/none4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none4_fail/test.desc
+++ b/regression/python/none4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/none_compare1/test.desc
+++ b/regression/python/none_compare1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none_compare2/test.desc
+++ b/regression/python/none_compare2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none_compare3/test.desc
+++ b/regression/python/none_compare3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/none_compare4_fail/test.desc
+++ b/regression/python/none_compare4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/none_compare_is/test.desc
+++ b/regression/python/none_compare_is/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/notin2_fail/test.desc
+++ b/regression/python/notin2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/notin_fail/test.desc
+++ b/regression/python/notin_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/object_passing_comprehensive/test.desc
+++ b/regression/python/object_passing_comprehensive/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/python/optional/test.desc
+++ b/regression/python/optional/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional2/test.desc
+++ b/regression/python/optional2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional3/test.desc
+++ b/regression/python/optional3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional3_fail/test.desc
+++ b/regression/python/optional3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/optional4/test.desc
+++ b/regression/python/optional4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional4_fail/test.desc
+++ b/regression/python/optional4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/optional5/test.desc
+++ b/regression/python/optional5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional5_fail/test.desc
+++ b/regression/python/optional5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/optional6/test.desc
+++ b/regression/python/optional6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional6_fail/test.desc
+++ b/regression/python/optional6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/optional_fail/test.desc
+++ b/regression/python/optional_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/optional_union/test.desc
+++ b/regression/python/optional_union/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ord-var-int-fail/test.desc
+++ b/regression/python/ord-var-int-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 TypeError

--- a/regression/python/ord-var-multi-byte/test.desc
+++ b/regression/python/ord-var-multi-byte/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ord-var/test.desc
+++ b/regression/python/ord-var/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/os1_fail/test.desc
+++ b/regression/python/os1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/pass/test.desc
+++ b/regression/python/pass/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/pass2/test.desc
+++ b/regression/python/pass2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/pass3/test.desc
+++ b/regression/python/pass3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/pass4/test.desc
+++ b/regression/python/pass4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/polymorphism01/test.desc
+++ b/regression/python/polymorphism01/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/polymorphism02-fail/test.desc
+++ b/regression/python/polymorphism02-fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/polymorphism02/test.desc
+++ b/regression/python/polymorphism02/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/power-fail/test.desc
+++ b/regression/python/power-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/power18/test.desc
+++ b/regression/python/power18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/power2/test.desc
+++ b/regression/python/power2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/power3/test.desc
+++ b/regression/python/power3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/power4/test.desc
+++ b/regression/python/power4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/power5-fail/test.desc
+++ b/regression/python/power5-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/power7/test.desc
+++ b/regression/python/power7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/precedence/test.desc
+++ b/regression/python/precedence/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/precedence2/test.desc
+++ b/regression/python/precedence2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/random1-fail/test.desc
+++ b/regression/python/random1-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/random2-fail/test.desc
+++ b/regression/python/random2-fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/random2/test.desc
+++ b/regression/python/random2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/random3/test.desc
+++ b/regression/python/random3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/random4_fail/test.desc
+++ b/regression/python/random4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/random5/test.desc
+++ b/regression/python/random5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/random6_fail/test.desc
+++ b/regression/python/random6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/random7/test.desc
+++ b/regression/python/random7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/randrange/test.desc
+++ b/regression/python/randrange/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/randrange2/test.desc
+++ b/regression/python/randrange2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range-fail/test.desc
+++ b/regression/python/range-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range/test.desc
+++ b/regression/python/range/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range10/test.desc
+++ b/regression/python/range10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range11/test.desc
+++ b/regression/python/range11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range12/test.desc
+++ b/regression/python/range12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range13/test.desc
+++ b/regression/python/range13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range14/test.desc
+++ b/regression/python/range14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range15/test.desc
+++ b/regression/python/range15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range16/test.desc
+++ b/regression/python/range16/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range17/test.desc
+++ b/regression/python/range17/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range18/test.desc
+++ b/regression/python/range18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range18_fail/test.desc
+++ b/regression/python/range18_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range19_2/test.desc
+++ b/regression/python/range19_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range19_2_fail/test.desc
+++ b/regression/python/range19_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range2-fail/test.desc
+++ b/regression/python/range2-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ValueError\: range\(\) arg 3 must not be zero$

--- a/regression/python/range2/test.desc
+++ b/regression/python/range2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range20_fail/test.desc
+++ b/regression/python/range20_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^SyntaxError\: range expected at least 1 argument, got 0$

--- a/regression/python/range21_fail/test.desc
+++ b/regression/python/range21_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^SyntaxError\: range expected at most 3 arguments, got 4$

--- a/regression/python/range22_fail/test.desc
+++ b/regression/python/range22_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ValueError: range\(\) arg 3 must not be zero$

--- a/regression/python/range23_fail/test.desc
+++ b/regression/python/range23_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^  step != 0$

--- a/regression/python/range24/test.desc
+++ b/regression/python/range24/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range24_fail/test.desc
+++ b/regression/python/range24_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range25/test.desc
+++ b/regression/python/range25/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range25_fail/test.desc
+++ b/regression/python/range25_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range26/test.desc
+++ b/regression/python/range26/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range26_fail/test.desc
+++ b/regression/python/range26_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range27/test.desc
+++ b/regression/python/range27/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range27_fail/test.desc
+++ b/regression/python/range27_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range28/test.desc
+++ b/regression/python/range28/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range28_fail/test.desc
+++ b/regression/python/range28_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range29/test.desc
+++ b/regression/python/range29/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range29_fail/test.desc
+++ b/regression/python/range29_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range3-fail/test.desc
+++ b/regression/python/range3-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range3/test.desc
+++ b/regression/python/range3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range30/test.desc
+++ b/regression/python/range30/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range30_fail/test.desc
+++ b/regression/python/range30_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range31/test.desc
+++ b/regression/python/range31/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range31_fail/test.desc
+++ b/regression/python/range31_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range32/test.desc
+++ b/regression/python/range32/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range32_fail/test.desc
+++ b/regression/python/range32_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range33/test.desc
+++ b/regression/python/range33/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range33_fail/test.desc
+++ b/regression/python/range33_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range34/test.desc
+++ b/regression/python/range34/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range34_fail/test.desc
+++ b/regression/python/range34_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/range4/test.desc
+++ b/regression/python/range4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range5/test.desc
+++ b/regression/python/range5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range6/test.desc
+++ b/regression/python/range6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range7/test.desc
+++ b/regression/python/range7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/range8/test.desc
+++ b/regression/python/range8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re1/test.desc
+++ b/regression/python/re1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re10/test.desc
+++ b/regression/python/re10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re10_fail/test.desc
+++ b/regression/python/re10_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/re11/test.desc
+++ b/regression/python/re11/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re12/test.desc
+++ b/regression/python/re12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re13_fail/test.desc
+++ b/regression/python/re13_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/re2/test.desc
+++ b/regression/python/re2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re3/test.desc
+++ b/regression/python/re3/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re4/test.desc
+++ b/regression/python/re4/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re5/test.desc
+++ b/regression/python/re5/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re6/test.desc
+++ b/regression/python/re6/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re7_fail/test.desc
+++ b/regression/python/re7_fail/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/re8/test.desc
+++ b/regression/python/re8/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/re9/test.desc
+++ b/regression/python/re9/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion10_fail/test.desc
+++ b/regression/python/recursion10_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/recursion2/test.desc
+++ b/regression/python/recursion2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion3/test.desc
+++ b/regression/python/recursion3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion4/test.desc
+++ b/regression/python/recursion4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion5/test.desc
+++ b/regression/python/recursion5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion6/test.desc
+++ b/regression/python/recursion6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion7/test.desc
+++ b/regression/python/recursion7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/recursion9_fail/test.desc
+++ b/regression/python/recursion9_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/redundancy/test.desc
+++ b/regression/python/redundancy/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return1/test.desc
+++ b/regression/python/return1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return10/test.desc
+++ b/regression/python/return10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return11/test.desc
+++ b/regression/python/return11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return12/test.desc
+++ b/regression/python/return12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return13-fail/test.desc
+++ b/regression/python/return13-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/return2/test.desc
+++ b/regression/python/return2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return3/test.desc
+++ b/regression/python/return3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return5/test.desc
+++ b/regression/python/return5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return6/test.desc
+++ b/regression/python/return6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return7/test.desc
+++ b/regression/python/return7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return8/test.desc
+++ b/regression/python/return8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/return9-fail/test.desc
+++ b/regression/python/return9-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^ERROR: NameError: name 'UnknownType' is not defined$

--- a/regression/python/reversed1/test.desc
+++ b/regression/python/reversed1/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sequence/test.desc
+++ b/regression/python/sequence/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sequence_2/test.desc
+++ b/regression/python/sequence_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sequence_2_fail/test.desc
+++ b/regression/python/sequence_2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/sequence_fail/test.desc
+++ b/regression/python/sequence_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/single-char1/test.desc
+++ b/regression/python/single-char1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sqrt/test.desc
+++ b/regression/python/sqrt/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sqrt2/test.desc
+++ b/regression/python/sqrt2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sqrt3/test.desc
+++ b/regression/python/sqrt3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sqrt4/test.desc
+++ b/regression/python/sqrt4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sqrt5/test.desc
+++ b/regression/python/sqrt5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/sqrt_fail/test.desc
+++ b/regression/python/sqrt_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/str1/test.desc
+++ b/regression/python/str1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/str2/test.desc
+++ b/regression/python/str2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-annotation/test.desc
+++ b/regression/python/string-annotation/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-1/test.desc
+++ b/regression/python/string-basic-1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-2/test.desc
+++ b/regression/python/string-basic-2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-3/test.desc
+++ b/regression/python/string-basic-3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-4/test.desc
+++ b/regression/python/string-basic-4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-5/test.desc
+++ b/regression/python/string-basic-5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-6/test.desc
+++ b/regression/python/string-basic-6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-7/test.desc
+++ b/regression/python/string-basic-7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-basic-8/test.desc
+++ b/regression/python/string-basic-8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-in/test.desc
+++ b/regression/python/string-in/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing/test.desc
+++ b/regression/python/string-indexing/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing2/test.desc
+++ b/regression/python/string-indexing2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing3_fail/test.desc
+++ b/regression/python/string-indexing3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-indexing4/test.desc
+++ b/regression/python/string-indexing4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-indexing_fail/test.desc
+++ b/regression/python/string-indexing_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-repetition/test.desc
+++ b/regression/python/string-repetition/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-count-big/test.desc
+++ b/regression/python/string-replace-count-big/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-count/test.desc
+++ b/regression/python/string-replace-count/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-count0/test.desc
+++ b/regression/python/string-replace-count0/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-count2/test.desc
+++ b/regression/python/string-replace-count2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-count_fail/test.desc
+++ b/regression/python/string-replace-count_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-replace-empty_fail/test.desc
+++ b/regression/python/string-replace-empty_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-replace-expand/test.desc
+++ b/regression/python/string-replace-expand/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-symbolic2_fail/test.desc
+++ b/regression/python/string-replace-symbolic2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace-symbolic_fail/test.desc
+++ b/regression/python/string-replace-symbolic_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace/test.desc
+++ b/regression/python/string-replace/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace2/test.desc
+++ b/regression/python/string-replace2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace2_fail/test.desc
+++ b/regression/python/string-replace2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-replace3/test.desc
+++ b/regression/python/string-replace3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace3_fail/test.desc
+++ b/regression/python/string-replace3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-replace4/test.desc
+++ b/regression/python/string-replace4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-replace_fail/test.desc
+++ b/regression/python/string-replace_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-slice1/test.desc
+++ b/regression/python/string-slice1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-slice1_fail/test.desc
+++ b/regression/python/string-slice1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-slice2/test.desc
+++ b/regression/python/string-slice2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-slice2_fail/test.desc
+++ b/regression/python/string-slice2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-split-count/test.desc
+++ b/regression/python/string-split-count/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-split-count2/test.desc
+++ b/regression/python/string-split-count2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-split-count_fail/test.desc
+++ b/regression/python/string-split-count_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string-startswith/test.desc
+++ b/regression/python/string-startswith/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string1/test.desc
+++ b/regression/python/string1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string11/test.desc
+++ b/regression/python/string11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string12/test.desc
+++ b/regression/python/string12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string13/test.desc
+++ b/regression/python/string13/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string14/test.desc
+++ b/regression/python/string14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string14/test.desc
+++ b/regression/python/string14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---incremental-bmc
+--unwind 74
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string15/test.desc
+++ b/regression/python/string15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string16/test.desc
+++ b/regression/python/string16/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string17/test.desc
+++ b/regression/python/string17/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string17/test.desc
+++ b/regression/python/string17/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.py
---incremental-bmc
+--unwindset 73:121
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string18/test.desc
+++ b/regression/python/string18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string19/test.desc
+++ b/regression/python/string19/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string19_fail/test.desc
+++ b/regression/python/string19_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string1_fail/test.desc
+++ b/regression/python/string1_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string2/test.desc
+++ b/regression/python/string2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string20/test.desc
+++ b/regression/python/string20/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string23/test.desc
+++ b/regression/python/string23/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string23_fail/test.desc
+++ b/regression/python/string23_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string2_fail/test.desc
+++ b/regression/python/string2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string3/test.desc
+++ b/regression/python/string3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string3_fail/test.desc
+++ b/regression/python/string3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string4/test.desc
+++ b/regression/python/string4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string4_fail/test.desc
+++ b/regression/python/string4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string5/test.desc
+++ b/regression/python/string5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string6/test.desc
+++ b/regression/python/string6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string6_fail/test.desc
+++ b/regression/python/string6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string7/test.desc
+++ b/regression/python/string7/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string8/test.desc
+++ b/regression/python/string8/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string8_fail/test.desc
+++ b/regression/python/string8_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/string9/test.desc
+++ b/regression/python/string9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/string9_fail/test.desc
+++ b/regression/python/string9_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/strings-bounds-fail/test.desc
+++ b/regression/python/strings-bounds-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/strings-easy/test.desc
+++ b/regression/python/strings-easy/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/strings-eq-fail/test.desc
+++ b/regression/python/strings-eq-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/strings/test.desc
+++ b/regression/python/strings/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_comprehensive/test.desc
+++ b/regression/python/ternary_comprehensive/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_operator/test.desc
+++ b/regression/python/ternary_operator/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_operator2/test.desc
+++ b/regression/python/ternary_operator2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_operator3/test.desc
+++ b/regression/python/ternary_operator3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_operator4/test.desc
+++ b/regression/python/ternary_operator4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/ternary_symbolic/test.desc
+++ b/regression/python/ternary_symbolic/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple1/test.desc
+++ b/regression/python/tuple1/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple10/test.desc
+++ b/regression/python/tuple10/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple10_fail/test.desc
+++ b/regression/python/tuple10_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple11/test.desc
+++ b/regression/python/tuple11/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple11_fail/test.desc
+++ b/regression/python/tuple11_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple12/test.desc
+++ b/regression/python/tuple12/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple12_fail/test.desc
+++ b/regression/python/tuple12_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple14/test.desc
+++ b/regression/python/tuple14/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple14_fail/test.desc
+++ b/regression/python/tuple14_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple15/test.desc
+++ b/regression/python/tuple15/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple15_fail/test.desc
+++ b/regression/python/tuple15_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple16-nondet/test.desc
+++ b/regression/python/tuple16-nondet/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple16-nondet_fail/test.desc
+++ b/regression/python/tuple16-nondet_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple17-nondet/test.desc
+++ b/regression/python/tuple17-nondet/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple18/test.desc
+++ b/regression/python/tuple18/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple18_fail/test.desc
+++ b/regression/python/tuple18_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple19/test.desc
+++ b/regression/python/tuple19/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple3/test.desc
+++ b/regression/python/tuple3/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple4/test.desc
+++ b/regression/python/tuple4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple5/test.desc
+++ b/regression/python/tuple5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple6/test.desc
+++ b/regression/python/tuple6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple6_fail/test.desc
+++ b/regression/python/tuple6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/tuple9/test.desc
+++ b/regression/python/tuple9/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/tuple9_fail/test.desc
+++ b/regression/python/tuple9_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/type-annotation2/test.desc
+++ b/regression/python/type-annotation2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/type-annotation3/test.desc
+++ b/regression/python/type-annotation3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/type_annotation2_fail/test.desc
+++ b/regression/python/type_annotation2_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/type_annotation3_fail/test.desc
+++ b/regression/python/type_annotation3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/type_annotation4/test.desc
+++ b/regression/python/type_annotation4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/type_annotation5/test.desc
+++ b/regression/python/type_annotation5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/type_annotation_fail/test.desc
+++ b/regression/python/type_annotation_fail/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/unary+/test.desc
+++ b/regression/python/unary+/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/unary+_fail/test.desc
+++ b/regression/python/unary+_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/unary/test.desc
+++ b/regression/python/unary/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/uniform/test.desc
+++ b/regression/python/uniform/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union/test.desc
+++ b/regression/python/union/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union2/test.desc
+++ b/regression/python/union2/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union2_fail/test.desc
+++ b/regression/python/union2_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/union3/test.desc
+++ b/regression/python/union3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union3_fail/test.desc
+++ b/regression/python/union3_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/union4/test.desc
+++ b/regression/python/union4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union4_fail/test.desc
+++ b/regression/python/union4_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/union5/test.desc
+++ b/regression/python/union5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union5_fail/test.desc
+++ b/regression/python/union5_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/union6/test.desc
+++ b/regression/python/union6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/union6_fail/test.desc
+++ b/regression/python/union6_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/union_fail/test.desc
+++ b/regression/python/union_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/var-declarations/test.desc
+++ b/regression/python/var-declarations/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/verifier-assume-fail/test.desc
+++ b/regression/python/verifier-assume-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/verifier-assume/test.desc
+++ b/regression/python/verifier-assume/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/version/test.desc
+++ b/regression/python/version/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-break-fail/test.desc
+++ b/regression/python/while-break-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/while-break/test.desc
+++ b/regression/python/while-break/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-break2/test.desc
+++ b/regression/python/while-break2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-break3/test.desc
+++ b/regression/python/while-break3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-break4/test.desc
+++ b/regression/python/while-break4/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-break5/test.desc
+++ b/regression/python/while-break5/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-break6/test.desc
+++ b/regression/python/while-break6/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-continue-fail/test.desc
+++ b/regression/python/while-continue-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/while-continue/test.desc
+++ b/regression/python/while-continue/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-random-fail/test.desc
+++ b/regression/python/while-random-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/while-random-fail3/test.desc
+++ b/regression/python/while-random-fail3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/while-random/test.desc
+++ b/regression/python/while-random/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while-random2/test.desc
+++ b/regression/python/while-random2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while/test.desc
+++ b/regression/python/while/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while2/test.desc
+++ b/regression/python/while2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while3/test.desc
+++ b/regression/python/while3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while_GtE/test.desc
+++ b/regression/python/while_GtE/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/while_LtE/test.desc
+++ b/regression/python/while_LtE/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/bitcount/test.desc
+++ b/regression/quixbugs/bitcount/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/breadth_first_search/test.desc
+++ b/regression/quixbugs/breadth_first_search/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/depth_first_search/test.desc
+++ b/regression/quixbugs/depth_first_search/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/detect_cycle/test.desc
+++ b/regression/quixbugs/detect_cycle/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/flatten/test.desc
+++ b/regression/quixbugs/flatten/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/gcd/test.desc
+++ b/regression/quixbugs/gcd/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/hanoi/test.desc
+++ b/regression/quixbugs/hanoi/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/kheapsort/test.desc
+++ b/regression/quixbugs/kheapsort/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/knapsack/test.desc
+++ b/regression/quixbugs/knapsack/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/lcs_length/test.desc
+++ b/regression/quixbugs/lcs_length/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/lis/test.desc
+++ b/regression/quixbugs/lis/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/longest_common_subsequence/test.desc
+++ b/regression/quixbugs/longest_common_subsequence/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/mergesort/test.desc
+++ b/regression/quixbugs/mergesort/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/minimum_spanning_tree/test.desc
+++ b/regression/quixbugs/minimum_spanning_tree/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/possible_change/test.desc
+++ b/regression/quixbugs/possible_change/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/powerset/test.desc
+++ b/regression/quixbugs/powerset/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/reverse_linked_list/test.desc
+++ b/regression/quixbugs/reverse_linked_list/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/shortest_path_length/test.desc
+++ b/regression/quixbugs/shortest_path_length/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/shortest_path_lengths/test.desc
+++ b/regression/quixbugs/shortest_path_lengths/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/shortest_paths/test.desc
+++ b/regression/quixbugs/shortest_paths/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/quixbugs/sqrt_fail/test.desc
+++ b/regression/quixbugs/sqrt_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/quixbugs/topological_ordering/test.desc
+++ b/regression/quixbugs/topological_ordering/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
-
+--incremental-bmc
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
This PR updates regression test descriptors so that when line 3 is empty it is replaced with --incremental-bmc. This applies across regression/ and ensures a consistent default option for affected tests.
