### PR TITLE
[python] improve exception hierarchy to match standard library

### DIFF
--- a/regression/mopsa/try_super_raise/main.py
+++ b/regression/mopsa/try_super_raise/main.py
@@ -1,0 +1,7 @@
+res = 1
+
+try:
+  raise TypeError
+except Exception:
+  res = 2
+

--- a/regression/mopsa/try_super_raise/test.desc
+++ b/regression/mopsa/try_super_raise/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception10/main.py
+++ b/regression/python/exception10/main.py
@@ -1,0 +1,17 @@
+class CustomError(Exception):
+    message: str = ""
+    def __init__(self, message: str):
+        self.message = message
+
+class SpecificError(CustomError):
+    message: str = ""
+    def __init__(self, message: str):
+        self.message = message
+
+def process() -> None:
+    raise SpecificError("Specific issue")
+
+try:
+    process()
+except CustomError as e:
+    print("Caught by CustomError:", e)

--- a/regression/python/exception10/test.desc
+++ b/regression/python/exception10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception10_fail/main.py
+++ b/regression/python/exception10_fail/main.py
@@ -1,0 +1,5 @@
+def fail() -> int:
+    raise ValueError("Error")
+    return 0
+
+result = fail()

--- a/regression/python/exception10_fail/test.desc
+++ b/regression/python/exception10_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/exception3/main.py
+++ b/regression/python/exception3/main.py
@@ -1,0 +1,11 @@
+def process_data(x: int) -> int:
+    if x < 0:
+        raise ValueError("Negative value")
+    elif x == 0:
+        raise ZeroDivisionError("Zero value")
+    return x
+
+try:
+    process_data(-1)
+except Exception as e:
+    print("Caught:", e)

--- a/regression/python/exception3/test.desc
+++ b/regression/python/exception3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception6/main.py
+++ b/regression/python/exception6/main.py
@@ -1,0 +1,11 @@
+def test_value(x: int) -> int:
+    if x < 0:
+        raise ValueError("Negative")
+    return x
+
+try:
+    test_value(-1)
+except ValueError as e:
+    print("Caught by ValueError:", e)
+except Exception as e:
+    print("Caught by Exception:", e)

--- a/regression/python/exception6/test.desc
+++ b/regression/python/exception6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception8/main.py
+++ b/regression/python/exception8/main.py
@@ -1,0 +1,8 @@
+def open_file(filename: str) -> None:
+    if filename == "":
+        raise FileNotFoundError("Empty filename")
+
+try:
+    open_file("")
+except OSError as e:
+    print("Caught by OSError:", e)

--- a/regression/python/exception8/test.desc
+++ b/regression/python/exception8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/exception9/main.py
+++ b/regression/python/exception9/main.py
@@ -1,0 +1,9 @@
+def read_file(path: str) -> str:
+    if not path:
+        raise FileNotFoundError("No path provided")
+    return "content"
+
+try:
+    read_file("")
+except Exception as e:
+    print("Caught:", e)

--- a/regression/python/exception9/test.desc
+++ b/regression/python/exception9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -521,6 +521,11 @@ protected:
 
   void simplify_python_builtins(expr2tc &expr);
 
+  /* Check if thrown_type in Python inherits from catch_type */
+  bool is_python_exception_subtype(
+    const irep_idt &thrown_type,
+    const irep_idt &catch_type);
+
   /** Walk back up stack frame looking for exception handler. */
   bool symex_throw();
 

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -164,6 +164,9 @@ bool goto_symext::symex_throw()
     goto_symex_statet::exceptiont::catch_mapt::const_iterator c_it =
       except->catch_map.find(it);
 
+    // Track which catch type was matched (might be a base class)
+    irep_idt matched_catch_type = it;
+
     // If no exact match, check inheritance hierarchy for Python exceptions
     if (c_it == except->catch_map.end())
     {
@@ -172,6 +175,7 @@ bool goto_symext::symex_throw()
         if (is_python_exception_subtype(it, catch_entry.first))
         {
           c_it = except->catch_map.find(catch_entry.first);
+          matched_catch_type = catch_entry.first;  // Track the actual catch type
           break;
         }
       }
@@ -183,7 +187,8 @@ bool goto_symext::symex_throw()
       // We do!
 
       // Get current catch number and update if needed
-      new_id_number = (*except->catch_order.find(it)).second;
+      // Use matched_catch_type instead of it for the lookup
+      new_id_number = (*except->catch_order.find(matched_catch_type)).second;
 
       if (new_id_number < old_id_number)
       {

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -175,7 +175,7 @@ bool goto_symext::symex_throw()
         if (is_python_exception_subtype(it, catch_entry.first))
         {
           c_it = except->catch_map.find(catch_entry.first);
-          matched_catch_type = catch_entry.first;  // Track the actual catch type
+          matched_catch_type = catch_entry.first; // Track the actual catch type
           break;
         }
       }

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -46,6 +46,48 @@ void goto_symext::symex_catch()
   }
 }
 
+bool goto_symext::is_python_exception_subtype(
+  const irep_idt &thrown_type,
+  const irep_idt &catch_type)
+{
+  std::string thrown = thrown_type.as_string();
+  std::string catch_t = catch_type.as_string();
+
+  // Exact match
+  if (thrown == catch_t)
+    return true;
+
+  // Look up the thrown exception class in the symbol table
+  const symbolt *thrown_symbol = ns.lookup("tag-" + thrown);
+  if (!thrown_symbol)
+    return false;
+
+  // Get the bases from the type metadata
+  const irept &bases = thrown_symbol->type.find("bases");
+
+  if (bases.is_nil())
+    return false;
+
+  const irept::subt &base_list = bases.get_sub();
+
+  // Iterate through base classes
+  for (const auto &base : base_list)
+  {
+    // The base class is stored with id() == "tag-BaseClassName"
+    std::string base_name = base.id().as_string();
+
+    // Remove "tag-" prefix to get the class name
+    if (base_name.find("tag-") == 0)
+      base_name = base_name.substr(4);
+
+    // Recursively check if this base class matches or inherits from catch_type
+    if (is_python_exception_subtype(irep_idt(base_name), catch_type))
+      return true;
+  }
+
+  return false;
+}
+
 bool goto_symext::symex_throw()
 {
   irep_idt catch_name = "missing";
@@ -118,9 +160,22 @@ bool goto_symext::symex_throw()
       break;
     }
 
-    // Search for a catch with a matching type
+    // Search for a catch with a matching type (including base classes)
     goto_symex_statet::exceptiont::catch_mapt::const_iterator c_it =
       except->catch_map.find(it);
+
+    // If no exact match, check inheritance hierarchy for Python exceptions
+    if (c_it == except->catch_map.end())
+    {
+      for (const auto &catch_entry : except->catch_map)
+      {
+        if (is_python_exception_subtype(it, catch_entry.first))
+        {
+          c_it = except->catch_map.find(catch_entry.first);
+          break;
+        }
+      }
+    }
 
     // Do we have a catch for it?
     if (c_it != except->catch_map.end())

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -8,7 +8,7 @@ class BaseException:
         return self.message
 
 
-class ValueError(BaseException):
+class Exception(BaseException):
     message: str = ""
 
     def __init__(self, message: str):
@@ -18,7 +18,7 @@ class ValueError(BaseException):
         return self.message
 
 
-class TypeError(BaseException):
+class ValueError(Exception):
     message: str = ""
 
     def __init__(self, message: str):
@@ -28,7 +28,7 @@ class TypeError(BaseException):
         return self.message
 
 
-class IndexError(BaseException):
+class TypeError(Exception):
     message: str = ""
 
     def __init__(self, message: str):
@@ -38,7 +38,7 @@ class IndexError(BaseException):
         return self.message
 
 
-class KeyError(BaseException):
+class IndexError(Exception):
     message: str = ""
 
     def __init__(self, message: str):
@@ -48,7 +48,17 @@ class KeyError(BaseException):
         return self.message
 
 
-class ZeroDivisionError(BaseException):
+class KeyError(Exception):
+    message: str = ""
+
+    def __init__(self, message: str):
+        self.message: str = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ZeroDivisionError(Exception):
     message: str = ""
 
     def __init__(self, message: str):
@@ -68,17 +78,7 @@ class AssertionError(BaseException):
         return self.message
 
 
-class Exception(BaseException):
-    message: str = ""
-
-    def __init__(self, message: str):
-        self.message: str = message
-
-    def __str__(self) -> str:
-        return self.message
-
-
-class NameError(BaseException):
+class NameError(Exception):
     message: str = ""
 
     def __init__(self, message: str):

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -68,7 +68,7 @@ class ZeroDivisionError(Exception):
         return self.message
 
 
-class AssertionError(BaseException):
+class AssertionError(Exception):
     message: str = ""
 
     def __init__(self, message: str):


### PR DESCRIPTION
This PR updates `ValueError`, `TypeError`, `IndexError`, `KeyError`, `ZeroDivisionError`, and `NameError` to inherit from `Exception` instead of `BaseException`, matching Python's actual exception hierarchy.