### PR TITLE
Add set(iterable) support with bounded strnlen and enable humaneval_16

### DIFF
--- a/regression/humaneval/humaneval_16/test.desc
+++ b/regression/humaneval/humaneval_16/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 15 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/set_eq_order/main.py
+++ b/regression/python/set_eq_order/main.py
@@ -1,0 +1,8 @@
+def main():
+    d = {"a": 1, "b": 2}
+    assert set(d.keys()) == {"b", "a"}
+    assert set(d.values()) == {2, 1}
+    assert set(d.keys()) != {"a"}
+
+
+main()

--- a/regression/python/set_eq_order/test.desc
+++ b/regression/python/set_eq_order/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 6 --smt-during-symex --smt-symex-guard --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/set_from_list/main.py
+++ b/regression/python/set_from_list/main.py
@@ -1,0 +1,5 @@
+# Regression: set() from list iterable
+if __name__ == "__main__":
+    s = set([1, 2, 2, 3])
+    assert len(s) == 3
+    print("ok")

--- a/regression/python/set_from_list/test.desc
+++ b/regression/python/set_from_list/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 5
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/set_from_param/main.py
+++ b/regression/python/set_from_param/main.py
@@ -1,0 +1,9 @@
+# Regression: set() from string parameter
+
+def f(s: str) -> int:
+    return len(set(s.lower()))
+
+if __name__ == "__main__":
+    assert f("aAa") == 1
+    assert f("abc") == 3
+    print("ok")

--- a/regression/python/set_from_param/test.desc
+++ b/regression/python/set_from_param/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 6
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/set_from_string/main.py
+++ b/regression/python/set_from_string/main.py
@@ -1,0 +1,7 @@
+# Regression: set() from string iterable
+if __name__ == "__main__":
+    s = set("abca")
+    assert len(s) == 3
+    t = set("aAa".lower())
+    assert len(t) == 1
+    print("ok")

--- a/regression/python/set_from_string/test.desc
+++ b/regression/python/set_from_string/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 5
+
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -115,6 +115,7 @@ const static std::vector<std::string> python_c_models = {
   "__ESBMC_list_size",
   "list_hash_string",
   "__ESBMC_list_eq",
+  "__ESBMC_list_set_eq",
   "strncmp",
   "strcmp",
   "strlen",

--- a/src/c2goto/library/python/python_types.h
+++ b/src/c2goto/library/python/python_types.h
@@ -3,6 +3,12 @@
 
 #include <stddef.h>
 
+// Bounded string length used by Python frontend/runtime helpers.
+// Keeps symbolic loops finite while still respecting '\0' within the bound.
+#ifndef ESBMC_PY_STRNLEN_BOUND
+#define ESBMC_PY_STRNLEN_BOUND 256
+#endif
+
 /**
  * @brief Type object representation for Python-like types.
  */

--- a/src/c2goto/library/python/python_types.h
+++ b/src/c2goto/library/python/python_types.h
@@ -6,7 +6,7 @@
 // Bounded string length used by Python frontend/runtime helpers.
 // Keeps symbolic loops finite while still respecting '\0' within the bound.
 #ifndef ESBMC_PY_STRNLEN_BOUND
-#define ESBMC_PY_STRNLEN_BOUND 256
+#  define ESBMC_PY_STRNLEN_BOUND 256
 #endif
 
 /**

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -11,7 +11,7 @@ __ESBMC_HIDE:;
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 
-static size_t __python_strnlen_bounded(const char *s, size_t max_len)
+size_t __python_strnlen_bounded(const char *s, size_t max_len)
 {
 __ESBMC_HIDE:;
   size_t i = 0;

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -287,6 +287,10 @@ symbol_id function_call_builder::build_function_id() const
         arg.contains("func") && arg["func"].contains("id") &&
         arg["func"]["id"] == "range")
         func_name = kGetObjectSize;
+      else if (
+        arg.contains("func") && arg["func"].contains("id") &&
+        arg["func"]["id"] == "set")
+        func_name = kGetObjectSize;
     }
     else if (arg["_type"] == "List")
       func_name = kGetObjectSize;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2152,6 +2152,16 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     return python_list::build_list_from_range(*this, range_args, element);
   }
 
+  // Handle set(iterable) calls
+  if (
+    element["func"]["_type"] == "Name" && element["func"]["id"] == "set" &&
+    element.contains("args") && element["args"].size() == 1)
+  {
+    exprt iterable_expr = get_expr(element["args"][0]);
+    python_set set_handler(*this, element);
+    return set_handler.get_from_iterable(iterable_expr, element);
+  }
+
   // Handle list(range(...))
   if (
     element["func"]["_type"] == "Name" && element["func"]["id"] == "list" &&

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4445,6 +4445,15 @@ void python_converter::get_var_assign(
       const std::string &lhs_identifier = lhs.identifier().as_string();
       const std::string &rhs_identifier = rhs.identifier().as_string();
       python_list::copy_type_info(rhs_identifier, lhs_identifier);
+
+      if (lhs_symbol)
+      {
+        const symbolt *rhs_symbol = nullptr;
+        if (rhs.is_symbol())
+          rhs_symbol = find_symbol(rhs.identifier().as_string());
+        if (rhs_symbol && rhs_symbol->is_set)
+          lhs_symbol->is_set = true;
+      }
     }
     else if (
       rhs.type() != lhs.type() && lhs.type().is_array() &&

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1592,11 +1592,13 @@ exprt python_list::compare(
     set_eq_call.function() = symbol_expr(*set_eq_func);
     set_eq_call.lhs() = symbol_expr(eq_ret);
     set_eq_call.arguments().push_back(
-      lhs_symbol->type.is_pointer() ? symbol_expr(*lhs_symbol)
-                                    : address_of_exprt(symbol_expr(*lhs_symbol)));
+      lhs_symbol->type.is_pointer()
+        ? symbol_expr(*lhs_symbol)
+        : address_of_exprt(symbol_expr(*lhs_symbol)));
     set_eq_call.arguments().push_back(
-      rhs_symbol->type.is_pointer() ? symbol_expr(*rhs_symbol)
-                                    : address_of_exprt(symbol_expr(*rhs_symbol)));
+      rhs_symbol->type.is_pointer()
+        ? symbol_expr(*rhs_symbol)
+        : address_of_exprt(symbol_expr(*rhs_symbol)));
     set_eq_call.type() = bool_type();
     set_eq_call.location() = loc;
     converter_.add_instruction(set_eq_call);

--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -124,15 +124,14 @@ exprt python_set::get_from_iterable(
 
     length_expr = symbol_expr(len_sym);
   }
-  else if (iterable.type().is_array() &&
-           iterable.type().subtype() == char_type())
+  else if (
+    iterable.type().is_array() && iterable.type().subtype() == char_type())
   {
     const array_typet &arr_type = to_array_type(iterable.type());
     length_expr = minus_exprt(arr_type.size(), gen_one(size_type()));
   }
   else if (
-    iterable.type().is_pointer() &&
-    iterable.type().subtype() == char_type())
+    iterable.type().is_pointer() && iterable.type().subtype() == char_type())
   {
     // Use bounded length from runtime to avoid unbounded strlen
     const symbolt *strlen_bounded =
@@ -162,8 +161,7 @@ exprt python_set::get_from_iterable(
   else
   {
     throw std::runtime_error(
-      "Unsupported iterable type in set(): " +
-      iterable.type().id_string());
+      "Unsupported iterable type in set(): " + iterable.type().id_string());
   }
 
   // Loop counter
@@ -233,17 +231,16 @@ exprt python_set::get_from_iterable(
 
     if (elem_type != typet())
     {
-      const std::string elem_id =
-        elem_expr.is_symbol() ? elem_expr.identifier().as_string()
-                              : std::string();
+      const std::string elem_id = elem_expr.is_symbol()
+                                    ? elem_expr.identifier().as_string()
+                                    : std::string();
       list_helper.add_type_info(set_id, elem_id, elem_expr.type());
     }
   }
   else if (
     iterable.type().is_array() && iterable.type().subtype() == char_type())
   {
-    index_exprt array_index(
-      iterable, symbol_expr(idx_sym), char_type());
+    index_exprt array_index(iterable, symbol_expr(idx_sym), char_type());
     elem_expr = array_index;
     list_helper.add_type_info(set_id, std::string(), elem_expr.type());
   }
@@ -273,7 +270,8 @@ exprt python_set::get_from_iterable(
   not_exprt not_contains(contains_expr);
 
   code_blockt push_block;
-  exprt push_call = list_helper.build_push_list_call(set_symbol, element, elem_expr);
+  exprt push_call =
+    list_helper.build_push_list_call(set_symbol, element, elem_expr);
   push_block.copy_to_operands(push_call);
 
   code_ifthenelset push_if;

--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -252,8 +252,8 @@ exprt python_set::get_from_iterable(
         use_pyobject = true;
         contains_func =
           converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_contains");
-        push_obj_func =
-          converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
+        push_obj_func = converter_.symbol_table().find_symbol(
+          "c:@F@__ESBMC_list_push_object");
         if (!contains_func || !push_obj_func)
           throw std::runtime_error(
             "__ESBMC_list_contains/__ESBMC_list_push_object not found");
@@ -313,8 +313,9 @@ exprt python_set::get_from_iterable(
       contains_call.function() = symbol_expr(*contains_func);
       contains_call.lhs() = symbol_expr(contains_result);
       contains_call.arguments().push_back(
-        set_symbol.type.is_pointer() ? symbol_expr(set_symbol)
-                                     : address_of_exprt(symbol_expr(set_symbol)));
+        set_symbol.type.is_pointer()
+          ? symbol_expr(set_symbol)
+          : address_of_exprt(symbol_expr(set_symbol)));
 
       member_exprt elem_value(
         symbol_expr(*elem_obj_sym), "value", pointer_typet(empty_typet()));
@@ -338,8 +339,7 @@ exprt python_set::get_from_iterable(
       }
       contains_call.arguments().push_back(elem_type_id);
 
-      member_exprt elem_size(
-        symbol_expr(*elem_obj_sym), "size", size_type());
+      member_exprt elem_size(symbol_expr(*elem_obj_sym), "size", size_type());
       {
         exprt &base = elem_size.struct_op();
         exprt deref("dereference");
@@ -359,8 +359,9 @@ exprt python_set::get_from_iterable(
       side_effect_expr_function_callt push_call;
       push_call.function() = symbol_expr(*push_obj_func);
       push_call.arguments().push_back(
-        set_symbol.type.is_pointer() ? symbol_expr(set_symbol)
-                                     : address_of_exprt(symbol_expr(set_symbol)));
+        set_symbol.type.is_pointer()
+          ? symbol_expr(set_symbol)
+          : address_of_exprt(symbol_expr(set_symbol)));
       push_call.arguments().push_back(symbol_expr(*elem_obj_sym));
       push_call.type() = bool_type();
       push_call.location() = loc;

--- a/src/python-frontend/python_set.h
+++ b/src/python-frontend/python_set.h
@@ -41,9 +41,7 @@ public:
    * @param element AST node for location info
    * @return Expression representing the set
    */
-  exprt get_from_iterable(
-    const exprt &iterable,
-    const nlohmann::json &element);
+  exprt get_from_iterable(const exprt &iterable, const nlohmann::json &element);
 
   /**
    * @brief Build set difference operation (set1 - set2)

--- a/src/python-frontend/python_set.h
+++ b/src/python-frontend/python_set.h
@@ -36,6 +36,16 @@ public:
   exprt get_empty_set();
 
   /**
+   * @brief Create a set from an iterable (e.g., set(list) or set(str))
+   * @param iterable Expression for the iterable
+   * @param element AST node for location info
+   * @return Expression representing the set
+   */
+  exprt get_from_iterable(
+    const exprt &iterable,
+    const nlohmann::json &element);
+
+  /**
    * @brief Build set difference operation (set1 - set2)
    * @param lhs Left operand (set expression)
    * @param rhs Right operand (set expression)

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -564,6 +564,8 @@ exprt string_handler::handle_string_operations(
 
 exprt string_handler::get_array_base_address(const exprt &arr)
 {
+  if (arr.type().is_pointer())
+    return arr;
   exprt index = index_exprt(arr, from_integer(0, index_type()));
   return address_of_exprt(index);
 }


### PR DESCRIPTION
Adds frontend support for set(iterable) and uses a bounded strnlen helper for char* strings. 
Exposes the runtime bounded strnlen and a shared constant. 
Updates len(set(...)) handling, adds set() regression tests, and marks humaneval_16 as CORE.
