### PR TITLE
Fix URL for ESBMC website announcement

### DIFF
--- a/website/content/news/new-website-announcement.md
+++ b/website/content/news/new-website-announcement.md
@@ -11,7 +11,7 @@ tags:
 ---
 
 🚀 Exciting News! We are pleased to announce our new
-[ESBMC website](esbmc.github.io).
+[ESBMC website](https://esbmc.github.io).
 
 ESBMC 🔍 is a mature, permissively licensed open-source SMT-based bounded model
 checker for C, C++, Python, Rust, and Solidity programs, verifying both single and


### PR DESCRIPTION
Updated the link to the ESBMC website  - without the https, the link fails because it's relative.