### PR TITLE
[python] add proper support for type objects, identity comparisons, and isinstance semantics

### DIFF
--- a/regression/python/github_3520/main.py
+++ b/regression/python/github_3520/main.py
@@ -1,0 +1,17 @@
+x = 10
+
+if isinstance(x, int):
+    print("x is an int")
+
+key_type = str  # key_type stores a type
+
+if key_type is str:
+    print("key_type represents the 'str' type")
+
+y = 5
+
+if y is int:
+    print("This will never print")
+else:
+    print("y is int -> False (wrong way to check)")
+

--- a/regression/python/github_3520/test.desc
+++ b/regression/python/github_3520/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_1/main.py
+++ b/regression/python/github_3520_1/main.py
@@ -1,0 +1,7 @@
+y = 5
+
+if y is int:
+    assert False
+else:
+    assert True
+

--- a/regression/python/github_3520_1/test.desc
+++ b/regression/python/github_3520_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_1_fail/main.py
+++ b/regression/python/github_3520_1_fail/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = int
+    assert x == "int"
+f()

--- a/regression/python/github_3520_1_fail/test.desc
+++ b/regression/python/github_3520_1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_2/main.py
+++ b/regression/python/github_3520_2/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = int
+    assert isinstance(x, type)
+f()

--- a/regression/python/github_3520_2/test.desc
+++ b/regression/python/github_3520_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_2_fail/main.py
+++ b/regression/python/github_3520_2_fail/main.py
@@ -1,0 +1,11 @@
+def f():
+    x = int
+    y = str
+    z = float
+    w = bool
+    
+    assert x == "int"
+    assert y == "str"
+    assert z == "float"
+    assert w == "bool"
+f()

--- a/regression/python/github_3520_2_fail/test.desc
+++ b/regression/python/github_3520_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_3/main.py
+++ b/regression/python/github_3520_3/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = 5
+    assert isinstance(x, int)
+f()

--- a/regression/python/github_3520_3/test.desc
+++ b/regression/python/github_3520_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_3_fail/main.py
+++ b/regression/python/github_3520_3_fail/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = int
+    assert isinstance(x, str)
+f()

--- a/regression/python/github_3520_3_fail/test.desc
+++ b/regression/python/github_3520_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_4/main.py
+++ b/regression/python/github_3520_4/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = int
+    assert not isinstance(x, str)
+f()

--- a/regression/python/github_3520_4/test.desc
+++ b/regression/python/github_3520_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_4_fail/main.py
+++ b/regression/python/github_3520_4_fail/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = str
+    assert isinstance(x, int)
+f()

--- a/regression/python/github_3520_4_fail/test.desc
+++ b/regression/python/github_3520_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_5/main.py
+++ b/regression/python/github_3520_5/main.py
@@ -1,0 +1,7 @@
+def f():
+    x = int
+    if isinstance(x, str):
+        assert False  # Should not reach here
+    else:
+        assert True   # Should reach here
+f()

--- a/regression/python/github_3520_5/test.desc
+++ b/regression/python/github_3520_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_5_fail/main.py
+++ b/regression/python/github_3520_5_fail/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = float
+    assert isinstance(x, bool)
+f()

--- a/regression/python/github_3520_5_fail/test.desc
+++ b/regression/python/github_3520_5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_6/main.py
+++ b/regression/python/github_3520_6/main.py
@@ -1,0 +1,6 @@
+def f():
+    x = str
+    y = int
+    assert isinstance(x, type)
+    assert isinstance(y, type)
+f()

--- a/regression/python/github_3520_6/test.desc
+++ b/regression/python/github_3520_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_6_fail/main.py
+++ b/regression/python/github_3520_6_fail/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = "hello"
+    assert isinstance(x, int)
+f()

--- a/regression/python/github_3520_6_fail/test.desc
+++ b/regression/python/github_3520_6_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_7_fail/main.py
+++ b/regression/python/github_3520_7_fail/main.py
@@ -1,0 +1,4 @@
+def f():
+    x = bool
+    assert isinstance(x, str)
+f()

--- a/regression/python/github_3520_7_fail/test.desc
+++ b/regression/python/github_3520_7_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_8/main.py
+++ b/regression/python/github_3520_8/main.py
@@ -1,0 +1,3 @@
+x = int
+y = int
+assert x is y   # must succeed

--- a/regression/python/github_3520_8/test.desc
+++ b/regression/python/github_3520_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_8_fail/main.py
+++ b/regression/python/github_3520_8_fail/main.py
@@ -1,0 +1,3 @@
+x = int
+z = str
+assert x is z              # False (different types)

--- a/regression/python/github_3520_8_fail/test.desc
+++ b/regression/python/github_3520_8_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3520_9/main.py
+++ b/regression/python/github_3520_9/main.py
@@ -1,0 +1,7 @@
+assert int is int           # True (direct comparison)
+x = int
+assert x is int            # True (variable vs direct)
+y = int
+assert x is y              # True (both variables hold same type)
+z = str
+assert x is not z          # True (different types with IsNot)

--- a/regression/python/github_3520_9/test.desc
+++ b/regression/python/github_3520_9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3520_fail/main.py
+++ b/regression/python/github_3520_fail/main.py
@@ -1,5 +1,4 @@
 def f():
     x = int
-    assert isinstance(x, str)
     assert x == "int"
 f()

--- a/regression/python/github_3520_fail/main.py
+++ b/regression/python/github_3520_fail/main.py
@@ -1,0 +1,5 @@
+def f():
+    x = int
+    assert isinstance(x, str)
+    assert x == "int"
+f()

--- a/regression/python/github_3520_fail/test.desc
+++ b/regression/python/github_3520_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -129,11 +129,11 @@ static void segfault_handler(int sig)
 {
   ::signal(sig, SIG_DFL);
   void *buffer[BT_BUF_SIZE];
-#ifdef __GLIBC__
+#  ifdef __GLIBC__
   int n = backtrace(buffer, BT_BUF_SIZE);
   dprintf(STDERR_FILENO, "\nSignal %d, backtrace:\n", sig);
   backtrace_symbols_fd(buffer, n, STDERR_FILENO);
-#endif
+#  endif
   int fd = open("/proc/self/maps", O_RDONLY);
   if (fd != -1)
   {

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2703,6 +2703,21 @@ private:
 
       std::string inferred_type("");
 
+      // Check if RHS is a type identifier
+      if (element["value"]["_type"] == "Name")
+      {
+        const std::string &rhs_name = element["value"]["id"];
+        if (type_utils::is_builtin_type(rhs_name))
+        {
+          // This is a type object assignment: x = int
+          inferred_type = "type";
+          update_assignment_node(element, inferred_type);
+          if (itr != referenced_global_elements.end())
+            *itr = element;
+          continue;
+        }
+      }
+
       // Check if LHS was previously annotated
       if (
         element.contains("targets") && element["targets"][0]["_type"] == "Name")

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2707,7 +2707,7 @@ private:
       if (element["value"]["_type"] == "Name")
       {
         const std::string &rhs_name = element["value"]["id"];
-        if (type_utils::is_builtin_type(rhs_name))
+        if (type_utils::is_type_identifier(rhs_name))
         {
           // This is a type object assignment: x = int
           inferred_type = "type";

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1409,10 +1409,10 @@ exprt python_converter::handle_type_identity_check(
     return nil_exprt();
 
   // Resolve type identifiers from either direct names or symbol values
-  auto resolve_type_identifier = [&](const nlohmann::json &node,
-                                     const exprt &expr,
-                                     std::string &out_name) -> bool
-  {
+  auto resolve_type_identifier = [&](
+                                   const nlohmann::json &node,
+                                   const exprt &expr,
+                                   std::string &out_name) -> bool {
     if (node["_type"] == "Name" && node.contains("id"))
     {
       std::string name = node["id"].get<std::string>();
@@ -1429,7 +1429,8 @@ exprt python_converter::handle_type_identity_check(
         const symbolt *symbol = ns.lookup(sym.get_identifier());
         if (symbol && symbol->value.is_constant())
         {
-          std::string val = to_constant_expr(symbol->value).get_value().as_string();
+          std::string val =
+            to_constant_expr(symbol->value).get_value().as_string();
 
           if (type_utils::is_type_identifier(val))
           {
@@ -3069,7 +3070,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       {
         // Create a string constant containing the type name
         std::string type_name = var_name;
-        typet str_type = type_handler_.build_array(char_type(), type_name.size() + 1);
+        typet str_type =
+          type_handler_.build_array(char_type(), type_name.size() + 1);
         constant_exprt type_str(type_name, type_name, str_type);
         expr = type_str;
         break;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2975,6 +2975,18 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     if (element["_type"] == "Name")
     {
       var_name = element["id"].get<std::string>();
+
+      // Handle type identifiers (int, str, float, bool, etc.)
+      // When user writes x = int, we convert it to x = "int" (a string constant)
+      if (type_utils::is_builtin_type(var_name))
+      {
+        // Create a string constant containing the type name
+        std::string type_name = var_name;
+        typet str_type = type_handler_.build_array(char_type(), type_name.size() + 1);
+        constant_exprt type_str(type_name, type_name, str_type);
+        expr = type_str;
+        break;
+      }
     }
     else if (element["_type"] == "Attribute")
     {

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1415,13 +1415,13 @@ exprt python_converter::handle_type_identity_check(
   if (left["_type"] == "Name" && left.contains("id"))
   {
     std::string lhs_name = left["id"].get<std::string>();
-    lhs_is_type = type_utils::is_builtin_type(lhs_name);
+    lhs_is_type = type_utils::is_type_identifier(lhs_name);
   }
 
   if (right["_type"] == "Name" && right.contains("id"))
   {
     std::string rhs_name = right["id"].get<std::string>();
-    rhs_is_type = type_utils::is_builtin_type(rhs_name);
+    rhs_is_type = type_utils::is_type_identifier(rhs_name);
   }
 
   // If neither operand is a type identifier, not a type identity check
@@ -3016,10 +3016,8 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     if (element["_type"] == "Name")
     {
       var_name = element["id"].get<std::string>();
-
       // Handle type identifiers (int, str, float, bool, etc.)
-      // When user writes x = int, we convert it to x = "int" (a string constant)
-      if (type_utils::is_builtin_type(var_name))
+      if (type_utils::is_type_identifier(var_name))
       {
         // Create a string constant containing the type name
         std::string type_name = var_name;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -645,6 +645,28 @@ private:
   // =========================================================================
 
   /**
+   * @brief Handles type identity checks (value is type_identifier).
+   *
+   * In Python, checking if a value "is" a type object is always False
+   * because runtime values are never identical to type objects.
+   * This method detects such comparisons and returns the appropriate
+   * boolean result without generating a comparison expression.
+   *
+   * @param op The operator string ("Is" or "IsNot").
+   * @param lhs The left operand expression.
+   * @param rhs The right operand expression.
+   * @param left The left operand JSON AST node.
+   * @param right The right operand JSON AST node.
+   * @return Boolean result expression, or nil_exprt if not a type identity check.
+   */
+  exprt handle_type_identity_check(
+    const std::string &op,
+    const exprt &lhs,
+    const exprt &rhs,
+    const nlohmann::json &left,
+    const nlohmann::json &right);
+
+  /**
    * @brief Converts function calls in binary operands to side effects.
    * @param lhs Left operand expression (may be modified).
    * @param rhs Right operand expression (may be modified).

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -647,10 +647,9 @@ private:
   /**
    * @brief Handles type identity checks (value is type_identifier).
    *
-   * In Python, checking if a value "is" a type object is always False
-   * because runtime values are never identical to type objects.
-   * This method detects such comparisons and returns the appropriate
-   * boolean result without generating a comparison expression.
+   * Handles identity checks involving Python type objects.
+   * Type objects are singletons, so identity comparisons between
+   * type objects can be resolved by comparing their identifiers.
    *
    * @param op The operator string ("Is" or "IsNot").
    * @param lhs The left operand expression.

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -283,6 +283,11 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
     return get_typet(base_type, type_size);
   }
 
+  // type: represents Python type objects (int, str, float, bool, etc.)
+  // Type objects are used for dynamic type checking and introspection
+  if (ast_type == "type")
+    return build_array(char_type(), type_size > 0 ? type_size : 10);
+
   // Typing module types should be treated as transparent
   // These are type hints only and don't enforce runtime type checking
   if (ast_type == "BinaryIO" || ast_type == "TextIO" || ast_type == "IO")

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -274,6 +274,13 @@ public:
            element.contains("value");
   }
 
+  static inline bool is_type_identifier(const std::string &name)
+  {
+    static const std::unordered_set<std::string> type_identifiers = {
+      "int", "float", "str", "bool", "bytes"};
+    return type_identifiers.find(name) != type_identifiers.end();
+  }
+
 private:
   static void
   update_type_flags_from_node(const nlohmann::json &node, TypeFlags &flags)

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -277,7 +277,10 @@ public:
   static inline bool is_type_identifier(const std::string &name)
   {
     static const std::unordered_set<std::string> type_identifiers = {
-      "int", "float", "str", "bool", "bytes"};
+      "int", "float", "str", "bool", "bytes",
+      "list", "set", "tuple", "type",
+      "object", "complex", "frozenset"
+    };
     return type_identifiers.find(name) != type_identifiers.end();
   }
 

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -277,10 +277,18 @@ public:
   static inline bool is_type_identifier(const std::string &name)
   {
     static const std::unordered_set<std::string> type_identifiers = {
-      "int", "float", "str", "bool", "bytes",
-      "list", "set", "tuple", "type",
-      "object", "complex", "frozenset"
-    };
+      "int",
+      "float",
+      "str",
+      "bool",
+      "bytes",
+      "list",
+      "set",
+      "tuple",
+      "type",
+      "object",
+      "complex",
+      "frozenset"};
     return type_identifiers.find(name) != type_identifiers.end();
   }
 


### PR DESCRIPTION
Fixes #3520.

This PR adds full support for Python type objects (int, str, float, bool, bytes) in the Python frontend, including correct handling of:
- Type object assignments (e.g., `x = int`).
- Identity comparisons involving type objects (`is`, `is not`).
- `isinstance()` when used with type objects and values.
- Proper distinction between type objects and regular values.
