### PR TITLE
[build] check for x86/x86_64 in breakpoint.h instead of excluding ARM

### DIFF
--- a/src/util/breakpoint.h
+++ b/src/util/breakpoint.h
@@ -3,10 +3,10 @@
 static void breakpoint()
 {
 #ifndef _WIN32
-#  if !(defined(__arm__) || defined(__aarch64__))
+#  if defined(__i386__) || defined(__x86_64__)
   __asm__("int $3");
 #  else
-  log_error("Can't trap on ARM, sorry");
+  log_error("Can't trap on this platform, sorry");
   abort();
 #  endif
 #else


### PR DESCRIPTION
The previous guard excluded only ARM and AArch64, which meant the x86 "int $3" instruction would be emitted on PowerPC, RISC-V, and other non-x86 architectures. Change the condition to positively check for `__i386__` or `__x86_64__` so it only emits the x86 breakpoint on x86 platforms and falls back to abort() everywhere else.

This PR is only about fixing the build failure. If you want proper implementations of these, I can do that. I would also recommend detecting and using `__builtin_debugtrap` where available.

AI Disclosure: This change was created by Claude as part of packaging ESMBC for Yggdrasil, the Julia project's binary packaging project (https://github.com/JuliaPackaging/Yggdrasil/pull/13150).