### PR TITLE
[build] Disable backtrace functionality on non-GLIBC platforms.

### DIFF
--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -59,8 +59,10 @@ extern "C"
 
 #ifndef _WIN32
 #  include <sys/wait.h>
-#  include <execinfo.h>
 #  include <fcntl.h>
+#  ifdef __GLIBC__
+#    include <execinfo.h>
+#  endif
 #endif
 
 #ifdef ENABLE_GOTO_CONTRACTOR
@@ -127,9 +129,11 @@ static void segfault_handler(int sig)
 {
   ::signal(sig, SIG_DFL);
   void *buffer[BT_BUF_SIZE];
+#ifdef __GLIBC__
   int n = backtrace(buffer, BT_BUF_SIZE);
   dprintf(STDERR_FILENO, "\nSignal %d, backtrace:\n", sig);
   backtrace_symbols_fd(buffer, n, STDERR_FILENO);
+#endif
   int fd = open("/proc/self/maps", O_RDONLY);
   if (fd != -1)
   {


### PR DESCRIPTION
<execinfo.h> and the backtrace()/backtrace_symbols_fd() functions are glibc extensions not available on musl libc or FreeBSD. Guard them with #ifdef __GLIBC__ so the signal handler still compiles on non-glibc platforms. The handler continues to function without backtrace support — it resets to SIG_DFL, dumps /proc/self/maps if available, and re-raises the signal.

This PR fixes the build failure. To restore functionality, we would need to add a dependency on a third party execinfo implementation or on libunwind (with a manual implementation for the printing).

AI Disclosure: This change was created by Claude as part of packaging ESMBC for Yggdrasil, the Julia project's binary packaging project (https://github.com/JuliaPackaging/Yggdrasil/pull/13150).