### PR TITLE
[C++ verification] fix the crash caused by the default alignment

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_3522/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_3522/main.cpp
@@ -1,0 +1,7 @@
+struct __attribute__((__aligned__)) __aligned_storage_max_align_t
+{
+};
+
+int main()
+{
+}

--- a/regression/esbmc-cpp/bug_fixes/github_3522/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_3522/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -388,11 +388,14 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
         const clang::AlignedAttr &aattr =
           static_cast<const clang::AlignedAttr &>(*attr);
 
-        exprt alignment;
-        if (get_expr(*(aattr.getAlignmentExpr()), alignment))
-          return true;
+        if (aattr.getAlignmentExpr())
+        {
+          exprt alignment;
+          if (get_expr(*(aattr.getAlignmentExpr()), alignment))
+            return true;
 
-        t.set("alignment", alignment);
+          t.set("alignment", alignment);
+        }
       }
     }
   }


### PR DESCRIPTION
fix #3522 