### PR TITLE
[python] add support for list.copy() method

### DIFF
--- a/regression/python/list_copy_1/main.py
+++ b/regression/python/list_copy_1/main.py
@@ -1,0 +1,10 @@
+def test() -> None:
+    arr: list[int] = [1, 2, 3]
+    copied: list[int] = arr.copy()
+    
+    assert len(copied) == 3
+    assert copied[0] == 1
+    assert copied[1] == 2
+    assert copied[2] == 3
+
+test()

--- a/regression/python/list_copy_1/test.desc
+++ b/regression/python/list_copy_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_10/main.py
+++ b/regression/python/list_copy_10/main.py
@@ -1,0 +1,13 @@
+def make_copy(original: list[int]) -> list[int]:
+    return original.copy()
+
+def test() -> None:
+    arr: list[int] = [5, 10, 15]
+    result: list[int] = make_copy(arr)
+    
+    assert len(result) == 3
+    assert result[0] == 5
+    assert result[1] == 10
+    assert result[2] == 15
+
+test()

--- a/regression/python/list_copy_10/test.desc
+++ b/regression/python/list_copy_10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_11_fail/main.py
+++ b/regression/python/list_copy_11_fail/main.py
@@ -1,0 +1,9 @@
+def test() -> None:
+    arr: list[int] = [1, 2, 3]
+    copied: list[int] = arr.copy()
+    
+    # This should fail - copy is independent
+    copied[0] = 99
+    assert arr[0] == 99
+
+test()

--- a/regression/python/list_copy_11_fail/test.desc
+++ b/regression/python/list_copy_11_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/list_copy_12/main.py
+++ b/regression/python/list_copy_12/main.py
@@ -1,0 +1,8 @@
+def test() -> None:
+    arr: list[int] = [42]
+    copied: list[int] = arr.copy()
+    
+    assert len(copied) == 1
+    assert copied[0] == 42
+
+test()

--- a/regression/python/list_copy_12/test.desc
+++ b/regression/python/list_copy_12/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_13/main.py
+++ b/regression/python/list_copy_13/main.py
@@ -1,0 +1,11 @@
+def test() -> None:
+    original: list[int] = [1, 2, 3]
+    copied: list[int] = original.copy()
+    
+    original.clear()
+    
+    assert len(original) == 0
+    assert len(copied) == 3
+    assert copied[0] == 1
+
+test()

--- a/regression/python/list_copy_13/test.desc
+++ b/regression/python/list_copy_13/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_14/main.py
+++ b/regression/python/list_copy_14/main.py
@@ -1,0 +1,9 @@
+def test() -> None:
+    arr: list[int] = [1, 2, 3]
+    copied: list[int] = arr.copy()
+    
+    assert copied[-1] == 3
+    assert copied[-2] == 2
+    assert copied[-3] == 1
+
+test()

--- a/regression/python/list_copy_14/test.desc
+++ b/regression/python/list_copy_14/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_15/main.py
+++ b/regression/python/list_copy_15/main.py
@@ -1,0 +1,15 @@
+def test() -> None:
+    a: list[int] = [1, 2, 3]
+    b: list[int] = a.copy()
+    c: list[int] = b
+    
+    c[0] = 99
+    
+    # b and c point to same list
+    assert b[0] == 99
+    assert c[0] == 99
+    
+    # a is independent
+    assert a[0] == 1
+
+test()

--- a/regression/python/list_copy_15/test.desc
+++ b/regression/python/list_copy_15/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_2/main.py
+++ b/regression/python/list_copy_2/main.py
@@ -1,0 +1,12 @@
+def test() -> None:
+    original: list[int] = [1, 2, 3]
+    copied: list[int] = original.copy()
+    
+    # Modify the copy
+    copied[0] = 99
+    
+    # Original should be unchanged
+    assert original[0] == 1
+    assert copied[0] == 99
+
+test()

--- a/regression/python/list_copy_2/test.desc
+++ b/regression/python/list_copy_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_3/main.py
+++ b/regression/python/list_copy_3/main.py
@@ -1,0 +1,7 @@
+def test() -> None:
+    arr: list[int] = []
+    copied: list[int] = arr.copy()
+    
+    assert len(copied) == 0
+
+test()

--- a/regression/python/list_copy_3/test.desc
+++ b/regression/python/list_copy_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_4/main.py
+++ b/regression/python/list_copy_4/main.py
@@ -1,0 +1,9 @@
+def test() -> None:
+    arr: list[str] = ["hello", "world"]
+    copied: list[str] = arr.copy()
+    
+    assert len(copied) == 2
+    assert copied[0] == "hello"
+    assert copied[1] == "world"
+
+test()

--- a/regression/python/list_copy_4/test.desc
+++ b/regression/python/list_copy_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_5/main.py
+++ b/regression/python/list_copy_5/main.py
@@ -1,0 +1,10 @@
+def test() -> None:
+    arr: list[float] = [1.5, 2.5, 3.5]
+    copied: list[float] = arr.copy()
+    
+    assert len(copied) == 3
+    assert copied[0] == 1.5
+    assert copied[1] == 2.5
+    assert copied[2] == 3.5
+
+test()

--- a/regression/python/list_copy_5/test.desc
+++ b/regression/python/list_copy_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_6/main.py
+++ b/regression/python/list_copy_6/main.py
@@ -1,0 +1,13 @@
+def test() -> None:
+    original: list[int] = [1, 2, 3]
+    copied: list[int] = original.copy()
+    
+    # Append to copy
+    copied.append(4)
+    
+    # Original should have 3 elements, copy should have 4
+    assert len(original) == 3
+    assert len(copied) == 4
+    assert copied[3] == 4
+
+test()

--- a/regression/python/list_copy_6/test.desc
+++ b/regression/python/list_copy_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_7/main.py
+++ b/regression/python/list_copy_7/main.py
@@ -1,0 +1,13 @@
+def test() -> None:
+    arr: list[int] = [1, 2, 3]
+    copy1: list[int] = arr.copy()
+    copy2: list[int] = arr.copy()
+    
+    copy1[0] = 10
+    copy2[0] = 20
+    
+    assert arr[0] == 1
+    assert copy1[0] == 10
+    assert copy2[0] == 20
+
+test()

--- a/regression/python/list_copy_7/test.desc
+++ b/regression/python/list_copy_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_8/main.py
+++ b/regression/python/list_copy_8/main.py
@@ -1,0 +1,12 @@
+def test() -> None:
+    arr: list[int] = [1, 2, 3]
+    copy1: list[int] = arr.copy()
+    copy2: list[int] = copy1.copy()
+    
+    copy2[0] = 99
+    
+    assert arr[0] == 1
+    assert copy1[0] == 1
+    assert copy2[0] == 99
+
+test()

--- a/regression/python/list_copy_8/test.desc
+++ b/regression/python/list_copy_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_copy_9/main.py
+++ b/regression/python/list_copy_9/main.py
@@ -1,0 +1,10 @@
+def test() -> None:
+    arr: list[bool] = [True, False, True]
+    copied: list[bool] = arr.copy()
+    
+    assert len(copied) == 3
+    assert copied[0] == True
+    assert copied[1] == False
+    assert copied[2] == True
+
+test()

--- a/regression/python/list_copy_9/test.desc
+++ b/regression/python/list_copy_9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -201,7 +201,8 @@ const static std::vector<std::string> python_c_models = {
   "__ESBMC_cos",
   "__ESBMC_sqrt",
   "__ESBMC_exp",
-  "__ESBMC_log"};
+  "__ESBMC_log",
+  "__ESBMC_list_copy"};
 } // namespace
 
 static void generate_symbol_deps(

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -208,7 +208,7 @@ const static std::vector<std::string> python_c_models = {
   "__ESBMC_sqrt",
   "__ESBMC_exp",
   "__ESBMC_log",
-  "__ESBMC_list_copy"};
+  "__ESBMC_list_copy",
   "__ESBMC_tan",
   "__ESBMC_asin",
   "__ESBMC_sinh",

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -555,3 +555,32 @@ bool __ESBMC_dict_eq(
 
   return true;
 }
+
+PyListObject *__ESBMC_list_copy(const PyListObject *l)
+{
+  if (!l)
+    return NULL;
+
+  // Create new list
+  PyListObject *copied = __ESBMC_list_create();
+
+  // Copy all elements
+  size_t i = 0;
+  while (i < l->size)
+  {
+    const PyObject *elem = &l->items[i];
+
+    // Copy the value
+    void *copied_value = __ESBMC_copy_value(elem->value, elem->size);
+
+    // Add to new list
+    copied->items[copied->size].value = copied_value;
+    copied->items[copied->size].type_id = elem->type_id;
+    copied->items[copied->size].size = elem->size;
+    copied->size++;
+
+    ++i;
+  }
+
+  return copied;
+}

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -136,12 +136,9 @@ Below is an overview of ESBMC-Python's key capabilities:
 - **Data Structures**: Supports operations on Python's built-in data structures, including lists, strings, and tuples, with features such as concatenation and bounds checks.
   - **List Operations**:
     - **append()**: Add elements to the end of a list.
-    - **copy()**: Creates a shallow copy of a list (e.g., `copied = original.copy()`).
-      - Returns a new list containing the same elements as the original.
-      - Modifications to the copied list do not affect the original list.
-      - Implements shallow copy semantics: elements themselves are not copied, only references.
-      - Works with lists of any type (int, float, str, bool, etc.).
-      - The copied list maintains the same type information as the original.
+    - **clear()**: Remove all elements from the list (e.g., `my_list.clear()` empties the list).
+    - **pop()**: Remove and return an element at a given index (default is the last element).
+    - **copy()**: Return a shallow copy of the list (e.g., `new_list = old_list.copy()`).
     - **extend()**: Extends a list by appending all elements from an iterable (e.g., `list1.extend(list2)` or `list1.extend([3, 4, 5])`).
     - **insert()**: Insert elements at a specific index position.
       - When the index equals the list length, the element is appended to the end.
@@ -382,7 +379,7 @@ ESBMC-Python provides an optional strict type-checking mode that enforces type c
 The current version of ESBMC-Python has the following limitations:
 
 - Only `for` loops using the `range()` function are supported.
-- List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `copy()`, `extend()`, and `insert()`.
+- List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
 - Dictionaries are not supported at all.
 - `min()` and `max()` currently support only two arguments and do not handle iterables or the key/default parameters.

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -136,6 +136,12 @@ Below is an overview of ESBMC-Python's key capabilities:
 - **Data Structures**: Supports operations on Python's built-in data structures, including lists, strings, and tuples, with features such as concatenation and bounds checks.
   - **List Operations**:
     - **append()**: Add elements to the end of a list.
+    - **copy()**: Creates a shallow copy of a list (e.g., `copied = original.copy()`).
+      - Returns a new list containing the same elements as the original.
+      - Modifications to the copied list do not affect the original list.
+      - Implements shallow copy semantics: elements themselves are not copied, only references.
+      - Works with lists of any type (int, float, str, bool, etc.).
+      - The copied list maintains the same type information as the original.
     - **extend()**: Extends a list by appending all elements from an iterable (e.g., `list1.extend(list2)` or `list1.extend([3, 4, 5])`).
     - **insert()**: Insert elements at a specific index position.
       - When the index equals the list length, the element is appended to the end.
@@ -376,7 +382,7 @@ ESBMC-Python provides an optional strict type-checking mode that enforces type c
 The current version of ESBMC-Python has the following limitations:
 
 - Only `for` loops using the `range()` function are supported.
-- List and String support are partial and limited in functionality. Currently supported list methods include `append()` and `insert()`.
+- List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `copy()`, `extend()`, and `insert()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
 - Dictionaries are not supported at all.
 - `min()` and `max()` currently support only two arguments and do not handle iterables or the key/default parameters.

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1753,6 +1753,30 @@ exprt function_call_expr::handle_dict_method() const
   throw std::runtime_error("Unsupported dict method: " + method_name);
 }
 
+exprt function_call_expr::handle_list_copy() const
+{
+  const auto &args = call_["args"];
+
+  if (!args.empty())
+    throw std::runtime_error("copy() takes no arguments");
+
+  // Get the list object name
+  std::string list_name = get_object_name();
+
+  // Find the list symbol
+  symbol_id list_symbol_id = converter_.create_symbol_id();
+  list_symbol_id.set_object(list_name);
+  const symbolt *list_symbol =
+    converter_.find_symbol(list_symbol_id.to_string());
+
+  if (!list_symbol)
+    throw std::runtime_error("List variable not found: " + list_name);
+
+  // Delegate to python_list to build the copy operation
+  python_list list_helper(converter_, call_);
+  return list_helper.build_copy_list_call(*list_symbol, call_);
+}
+
 bool function_call_expr::is_list_method_call() const
 {
   if (call_["func"]["_type"] != "Attribute")
@@ -1764,7 +1788,7 @@ bool function_call_expr::is_list_method_call() const
   return method_name == "append" || method_name == "pop" ||
          method_name == "insert" || method_name == "remove" ||
          method_name == "clear" || method_name == "extend" ||
-         method_name == "insert";
+         method_name == "insert" || method_name == "copy";
 }
 
 exprt function_call_expr::handle_list_method() const
@@ -1781,6 +1805,8 @@ exprt function_call_expr::handle_list_method() const
     return handle_list_clear();
   if (method_name == "pop")
     return handle_list_pop();
+  if (method_name == "copy")
+    return handle_list_copy();
 
   // Add other methods as needed
 

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1788,7 +1788,7 @@ bool function_call_expr::is_list_method_call() const
   return method_name == "append" || method_name == "pop" ||
          method_name == "insert" || method_name == "remove" ||
          method_name == "clear" || method_name == "extend" ||
-         method_name == "insert" || method_name == "copy";
+         method_name == "copy";
 }
 
 exprt function_call_expr::handle_list_method() const

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -252,6 +252,7 @@ private:
   exprt handle_list_extend() const;
   exprt handle_list_clear() const;
   exprt handle_list_pop() const;
+  exprt handle_list_copy() const;
 
   /*
    * Check if the current function call is to a regular expression module function

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2818,7 +2818,8 @@ exprt python_list::build_copy_list_call(
   // Find the list_copy C function
   const symbolt *copy_func =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_copy");
-  assert(copy_func && "list_copy function not found in symbol table");
+  if (!copy_func)
+    throw std::runtime_error("list_copy function not found in symbol table");
 
   // Create the copied list symbol
   symbolt &copied_list =

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -557,10 +557,10 @@ exprt python_list::build_list_at_call(
   locationt location = converter_.get_location_from_decl(element);
 
   // Check if index is already a constant non-negative value
-  if(index.is_constant() && index.type().is_signedbv())
+  if (index.is_constant() && index.type().is_signedbv())
   {
     BigInt idx_value;
-    if(to_integer(index, idx_value) && idx_value >= 0)
+    if (to_integer(index, idx_value) && idx_value >= 0)
     {
       // Index is constant and non-negative, use directly
       side_effect_expr_function_callt list_at_call;

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -162,6 +162,16 @@ public:
     const nlohmann::json &range_args,
     const nlohmann::json &element);
 
+  /**
+   * @brief Build a list copy operation
+   * @param list The list symbol to copy from
+   * @param element The AST node for location information
+   * @return Expression representing the copied list
+   */
+  exprt build_copy_list_call(
+    const symbolt &list,
+    const nlohmann::json &element);
+
 private:
   friend class python_dict_handler;
 

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -168,9 +168,8 @@ public:
    * @param element The AST node for location information
    * @return Expression representing the copied list
    */
-  exprt build_copy_list_call(
-    const symbolt &list,
-    const nlohmann::json &element);
+  exprt
+  build_copy_list_call(const symbolt &list, const nlohmann::json &element);
 
 private:
   friend class python_dict_handler;

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -199,6 +199,10 @@ private:
 
   exprt remove_function_calls_recursive(exprt &e, const nlohmann::json &node);
 
+  void copy_type_map_entries(
+    const std::string &from_list_id,
+    const std::string &to_list_id);
+
   /**
    * @brief Handle symbolic (non-constant) range arguments
    * @param converter The python converter instance


### PR DESCRIPTION
This PR implements shallow copy semantics for Python lists, allowing users to create independent copies of lists during verification.

In particular, this PR:
- Adds `__ESBMC_list_copy()` function in `python_list.c`.
- Implements `build_copy_list_call()` in `python_list.cpp/h`.
- Adds `handle_list_copy()` dispatcher in `function_call_expr.cpp`.
- Preserves type information when copying lists.
- Adds regression tests covering basic functionality, independence, edge cases, and integration with other list operations.