### PR TITLE
Add missing math functions to Python frontend models and regressions

### DIFF
--- a/regression/python/math30_cbrt/main.py
+++ b/regression/python/math30_cbrt/main.py
@@ -1,0 +1,4 @@
+import math
+
+r = math.cbrt(27.0)
+assert math.fabs(r - 3.0) < 1e-6

--- a/regression/python/math30_cbrt/test.desc
+++ b/regression/python/math30_cbrt/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math31_erf/main.py
+++ b/regression/python/math31_erf/main.py
@@ -1,0 +1,4 @@
+import math
+
+r = math.erf(1.0)
+assert math.fabs(r - 0.84270079) < 1e-6

--- a/regression/python/math31_erf/test.desc
+++ b/regression/python/math31_erf/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math32_erfc/main.py
+++ b/regression/python/math32_erfc/main.py
@@ -1,0 +1,4 @@
+import math
+
+r = math.erfc(1.0)
+assert math.fabs(r - 0.15729921) < 1e-6

--- a/regression/python/math32_erfc/test.desc
+++ b/regression/python/math32_erfc/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math33_frexp/main.py
+++ b/regression/python/math33_frexp/main.py
@@ -1,0 +1,5 @@
+import math
+
+m, e = math.frexp(8.0)
+assert math.fabs(m - 0.5) < 1e-12
+assert e == 4

--- a/regression/python/math33_frexp/test.desc
+++ b/regression/python/math33_frexp/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math34_fsum/main.py
+++ b/regression/python/math34_fsum/main.py
@@ -1,0 +1,5 @@
+import math
+
+values = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+result = math.fsum(values)
+assert math.fabs(result - 1.0) < 1e-12

--- a/regression/python/math34_fsum/test.desc
+++ b/regression/python/math34_fsum/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math35_gamma/main.py
+++ b/regression/python/math35_gamma/main.py
@@ -1,0 +1,4 @@
+import math
+
+r = math.gamma(5.0)
+assert math.fabs(r - 24.0) < 1e-6

--- a/regression/python/math35_gamma/test.desc
+++ b/regression/python/math35_gamma/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math36_ldexp/main.py
+++ b/regression/python/math36_ldexp/main.py
@@ -1,0 +1,4 @@
+import math
+
+r = math.ldexp(0.5, 4)
+assert math.fabs(r - 8.0) < 1e-12

--- a/regression/python/math36_ldexp/test.desc
+++ b/regression/python/math36_ldexp/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math37_lgamma/main.py
+++ b/regression/python/math37_lgamma/main.py
@@ -1,0 +1,5 @@
+import math
+
+r = math.lgamma(5.0)
+expected = math.log(24.0)
+assert math.fabs(r - expected) < 1e-6

--- a/regression/python/math37_lgamma/test.desc
+++ b/regression/python/math37_lgamma/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math38_nextafter/main.py
+++ b/regression/python/math38_nextafter/main.py
@@ -1,0 +1,6 @@
+import math
+
+r1 = math.nextafter(0.0, 1.0)
+assert r1 > 0.0
+r2 = math.nextafter(1.0, 2.0)
+assert r2 > 1.0

--- a/regression/python/math38_nextafter/test.desc
+++ b/regression/python/math38_nextafter/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math39_remainder/main.py
+++ b/regression/python/math39_remainder/main.py
@@ -1,0 +1,4 @@
+import math
+
+r = math.remainder(7.0, 2.0)
+assert math.fabs(r - (-1.0)) < 1e-12

--- a/regression/python/math39_remainder/test.desc
+++ b/regression/python/math39_remainder/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math40_sumprod/main.py
+++ b/regression/python/math40_sumprod/main.py
@@ -1,0 +1,6 @@
+import math
+
+a = [1.0, 2.0, 3.0]
+b = [4.0, 5.0, 6.0]
+result = math.sumprod(a, b)
+assert math.fabs(result - 32.0) < 1e-12

--- a/regression/python/math40_sumprod/test.desc
+++ b/regression/python/math40_sumprod/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/math41_ulp/main.py
+++ b/regression/python/math41_ulp/main.py
@@ -1,0 +1,6 @@
+import math
+
+u = math.ulp(1.0)
+expected = math.pow(2.0, -52.0)
+assert u > 0.0
+assert math.fabs(u - expected) < 1e-12

--- a/regression/python/math41_ulp/test.desc
+++ b/regression/python/math41_ulp/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2281,7 +2281,13 @@ function_call_expr::get_dispatch_table()
                 func_name == "expm1" || func_name == "log1p" ||
                 func_name == "exp2" || func_name == "asinh" ||
                 func_name == "acosh" || func_name == "atanh" ||
-                func_name == "hypot")) ||
+                func_name == "hypot" || func_name == "cbrt" ||
+                func_name == "erf" || func_name == "erfc" ||
+                func_name == "frexp" || func_name == "fsum" ||
+                func_name == "gamma" || func_name == "ldexp" ||
+                func_name == "lgamma" || func_name == "nextafter" ||
+                func_name == "remainder" || func_name == "sumprod" ||
+                func_name == "ulp")) ||
               is_math_wrapper;
      },
      [this]() -> exprt {
@@ -2478,6 +2484,15 @@ function_call_expr::get_dispatch_table()
          auto [lhs_expr, rhs_expr] = require_two_args();
          return converter_.get_math_handler().handle_hypot(
            lhs_expr, rhs_expr, call_);
+       }
+       else if (
+         func_name == "cbrt" || func_name == "erf" || func_name == "erfc" ||
+         func_name == "frexp" || func_name == "fsum" || func_name == "gamma" ||
+         func_name == "ldexp" || func_name == "lgamma" ||
+         func_name == "nextafter" || func_name == "remainder" ||
+         func_name == "sumprod" || func_name == "ulp")
+       {
+         return handle_general_function_call();
        }
 
        throw std::runtime_error("Unsupported math function: " + func_name);

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -519,9 +519,8 @@ def erf(x: float) -> float:
         abs_x = 0.0 - abs_x
 
     t: float = 1.0 / (1.0 + p * abs_x)
-    y: float = 1.0 - (
-        (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t
-    ) * exp(0.0 - abs_x * abs_x)
+    y: float = 1.0 - (((((
+        (a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t) * exp(0.0 - abs_x * abs_x)
     return sign * y
 
 

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -487,3 +487,233 @@ def modf(x: float) -> tuple[float, float]:
     int_part: float = float(int(x))
     frac_part: float = x - int_part
     return (frac_part, int_part)
+
+
+def cbrt(x: float) -> float:
+    """
+    Calculate the cube root of x
+    """
+    if x == 0.0:
+        return 0.0
+    if x < 0.0:
+        return 0.0 - pow(0.0 - x, 1.0 / 3.0)
+    return pow(x, 1.0 / 3.0)
+
+
+def erf(x: float) -> float:
+    """
+    Calculate the error function of x
+    """
+    # Abramowitz and Stegun 7.1.26 approximation
+    p: float = 0.3275911
+    a1: float = 0.254829592
+    a2: float = -0.284496736
+    a3: float = 1.421413741
+    a4: float = -1.453152027
+    a5: float = 1.061405429
+
+    sign: float = 1.0
+    if x < 0.0:
+        sign = 0.0 - 1.0
+        x = 0.0 - x
+
+    t: float = 1.0 / (1.0 + p * x)
+    y: float = 1.0 - (
+        (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t
+    ) * exp(-x * x)
+    return sign * y
+
+
+def erfc(x: float) -> float:
+    """
+    Calculate the complementary error function of x
+    """
+    return 1.0 - erf(x)
+
+
+def frexp(x: float) -> tuple[float, int]:
+    """
+    Split x into mantissa and exponent (x = m * 2**e),
+    with m in [0.5, 1.0) (or 0.0 if x == 0)
+    """
+    if x == 0.0:
+        return (0.0, 0)
+
+    e: int = 0
+    ax: float = x
+    if ax < 0.0:
+        ax = 0.0 - ax
+
+    while ax < 0.5:
+        ax = ax * 2.0
+        e = e - 1
+
+    while ax >= 1.0:
+        ax = ax / 2.0
+        e = e + 1
+
+    if x < 0.0:
+        ax = 0.0 - ax
+    return (ax, e)
+
+
+def fsum(values: list[float]) -> float:
+    """
+    Return an accurate floating point sum of values
+    """
+    total: float = 0.0
+    c: float = 0.0
+    i: int = 0
+    n: int = len(values)
+    while i < n:
+        y: float = values[i] - c
+        t: float = total + y
+        c = (t - total) - y
+        total = t
+        i = i + 1
+    return total
+
+
+def gamma(x: float) -> float:
+    """
+    Calculate the gamma function of x
+    """
+    if x == int(x):
+        xi: int = int(x)
+        if xi <= 0:
+            raise ValueError("math domain error")
+        result_int: int = 1
+        i: int = 2
+        while i <= xi - 1:
+            result_int = result_int * i
+            i = i + 1
+        return float(result_int)
+
+    if x <= 0.0:
+        raise ValueError("math domain error")
+
+    # Lanczos approximation (no reflection, valid for x > 0)
+    z: float = x - 1.0
+    a: float = 0.99999999999980993
+    a = a + 676.5203681218851 / (z + 1.0)
+    a = a + -1259.1392167224028 / (z + 2.0)
+    a = a + 771.3234287776531 / (z + 3.0)
+    a = a + -176.6150291621406 / (z + 4.0)
+    a = a + 12.507343278686905 / (z + 5.0)
+    a = a + -0.13857109526572012 / (z + 6.0)
+    a = a + 0.000009984369578019572 / (z + 7.0)
+    a = a + 0.00000015056327351493116 / (z + 8.0)
+
+    t: float = z + 7.0 + 0.5
+    return sqrt(2.0 * pi) * pow(t, z + 0.5) * exp(0.0 - t) * a
+
+
+def ldexp(x: float, i: int) -> float:
+    """
+    Return x * (2**i)
+    """
+    if not isinstance(i, int):
+        raise TypeError("i must be an integer")
+    return x * pow(2.0, float(i))
+
+
+def lgamma(x: float) -> float:
+    """
+    Calculate the natural logarithm of the absolute value of the gamma function
+    """
+    if x == int(x):
+        xi: int = int(x)
+        if xi <= 0:
+            raise ValueError("math domain error")
+        result: float = 0.0
+        i: int = 2
+        while i <= xi - 1:
+            result = result + log(i * 1.0)
+            i = i + 1
+        return result
+
+    if x <= 0.0:
+        raise ValueError("math domain error")
+
+    z: float = x - 1.0
+    a: float = 0.99999999999980993
+    a = a + 676.5203681218851 / (z + 1.0)
+    a = a + -1259.1392167224028 / (z + 2.0)
+    a = a + 771.3234287776531 / (z + 3.0)
+    a = a + -176.6150291621406 / (z + 4.0)
+    a = a + 12.507343278686905 / (z + 5.0)
+    a = a + -0.13857109526572012 / (z + 6.0)
+    a = a + 0.000009984369578019572 / (z + 7.0)
+    a = a + 0.00000015056327351493116 / (z + 8.0)
+
+    t: float = z + 7.0 + 0.5
+    return 0.5 * log(2.0 * pi) + (z + 0.5) * log(t) - t + log(a)
+
+
+def remainder(x: float, y: float) -> float:
+    """
+    Return IEEE 754-style remainder of x with respect to y
+    """
+    if y == 0.0:
+        raise ValueError("math domain error")
+
+    q: float = x / y
+    n_int: int = trunc(q)
+    n: float = n_int * 1.0
+    frac: float = q - n
+
+    if frac > 0.5:
+        n = n + 1.0
+    elif frac < -0.5:
+        n = n - 1.0
+    elif frac == 0.5 or frac == -0.5:
+        if fmod(n, 2.0) != 0.0:
+            if q > 0.0:
+                n = n + 1.0
+            else:
+                n = n - 1.0
+
+    return x - n * y
+
+
+def sumprod(a: list[float], b: list[float]) -> float:
+    """
+    Return the sum of products of two sequences
+    """
+    if len(a) != len(b):
+        raise ValueError("sumprod() requires sequences of the same length")
+
+    total: float = 0.0
+    i: int = 0
+    n: int = len(a)
+    while i < n:
+        total = total + a[i] * b[i]
+        i = i + 1
+    return total
+
+
+def ulp(x: float) -> float:
+    """
+    Return the value of the least significant bit of the float x
+    """
+    if x == 0.0:
+        return pow(2.0, -1074.0)
+
+    ax: float = fabs(x)
+    _, e = frexp(ax)
+    return ldexp(1.0, e - 53)
+
+
+def nextafter(x: float, y: float) -> float:
+    """
+    Return the next floating-point value after x towards y
+    """
+    if x == y:
+        return x
+    if x == 0.0:
+        return copysign(pow(2.0, -1074.0), y)
+
+    step: float = ulp(x)
+    if y > x:
+        return x + step
+    return x - step

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -551,14 +551,16 @@ def frexp(x: float) -> tuple[float, int]:
         ax = ax * 2.0
         e = e - 1
         iter_count = iter_count + 1
-    assert iter_count < max_iter, "frexp loop bound exceeded"
+    if iter_count >= max_iter:
+        raise ValueError("frexp loop bound exceeded")
 
     iter_count = 0
     while ax >= 1.0 and iter_count < max_iter:
         ax = ax / 2.0
         e = e + 1
         iter_count = iter_count + 1
-    assert iter_count < max_iter, "frexp loop bound exceeded"
+    if iter_count >= max_iter:
+        raise ValueError("frexp loop bound exceeded")
 
     if x < 0.0:
         ax = 0.0 - ax


### PR DESCRIPTION
Implemented math functions and test in the Python frontend: cbrt, erf, erfc, frexp, fsum, gamma, ldexp, lgamma, nextafter, remainder, sumprod, ulp