### PR TITLE
[python] add support for list.remove() method

### DIFF
--- a/regression/python/list8/test.desc
+++ b/regression/python/list8/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
---incremental-bmc
+--unwind 9 --no-standard-checks
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list8/test.desc
+++ b/regression/python/list8/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
---unwind 9 --no-standard-checks
+--unwind 5 --no-standard-checks
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove1/main.py
+++ b/regression/python/list_remove1/main.py
@@ -1,0 +1,6 @@
+l = [1, 2, 3, 2, 4]
+l.remove(2)
+assert l[0] == 1
+assert l[1] == 3   # first '2' removed; second '2' still there
+assert l[2] == 2
+assert l[3] == 4

--- a/regression/python/list_remove1/test.desc
+++ b/regression/python/list_remove1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove2/main.py
+++ b/regression/python/list_remove2/main.py
@@ -1,0 +1,5 @@
+# Verifies only the FIRST occurrence is removed
+l = [5, 5, 5]
+l.remove(5)
+assert l[0] == 5
+assert l[1] == 5

--- a/regression/python/list_remove2/test.desc
+++ b/regression/python/list_remove2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove3/main.py
+++ b/regression/python/list_remove3/main.py
@@ -1,0 +1,4 @@
+# Remove from single-element list
+l = [42]
+l.remove(42)
+assert len(l) == 0

--- a/regression/python/list_remove3/test.desc
+++ b/regression/python/list_remove3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove4/main.py
+++ b/regression/python/list_remove4/main.py
@@ -1,0 +1,5 @@
+# Remove a string element
+l = ["hello", "world", "hello"]
+l.remove("hello")
+assert l[0] == "world"
+assert l[1] == "hello"

--- a/regression/python/list_remove4/test.desc
+++ b/regression/python/list_remove4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove5_fail/main.py
+++ b/regression/python/list_remove5_fail/main.py
@@ -1,0 +1,4 @@
+# Should raise ValueError (ESBMC: assert(0) fires)
+l = [1, 2, 3]
+l.remove(99)   # ESBMC should report a violation here
+assert False   # unreachable

--- a/regression/python/list_remove5_fail/test.desc
+++ b/regression/python/list_remove5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/list_remove6-nondet/main.py
+++ b/regression/python/list_remove6-nondet/main.py
@@ -1,0 +1,10 @@
+# Verify that after remove, the element count decreases by exactly 1
+def nondet_int() -> int: ...
+
+x: int = nondet_int()
+l = [1, 2, 3]
+
+# Only remove if present to avoid ValueError
+if x == 1 or x == 2 or x == 3:
+    l.remove(x)
+    assert len(l) == 2

--- a/regression/python/list_remove6-nondet/test.desc
+++ b/regression/python/list_remove6-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove7-nondet/main.py
+++ b/regression/python/list_remove7-nondet/main.py
@@ -1,0 +1,17 @@
+x: int = nondet_int()
+
+l = [1, 2, 3, 2, 4]
+
+# Only allow valid removals to avoid ValueError
+if x == 1 or x == 2 or x == 3 or x == 4:
+    old_len = len(l)
+    l.remove(x)
+
+    # Length decreases exactly by 1
+    assert len(l) == old_len - 1
+
+    # List still contains valid elements
+    i: int = 0
+    while i < len(l):
+        assert l[i] == 1 or l[i] == 2 or l[i] == 3 or l[i] == 4
+        i += 1

--- a/regression/python/list_remove7-nondet/test.desc
+++ b/regression/python/list_remove7-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove8-nondet/main.py
+++ b/regression/python/list_remove8-nondet/main.py
@@ -1,0 +1,14 @@
+b: bool = nondet_bool()
+
+l = ["hello", "world", "hello"]
+
+if b:
+    l.remove("hello")
+
+    assert len(l) == 2
+
+    # First hello removed
+    assert l[0] == "world"
+    assert l[1] == "hello"
+else:
+    assert len(l) == 3

--- a/regression/python/list_remove8-nondet/test.desc
+++ b/regression/python/list_remove8-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove9_fail-nondet/main.py
+++ b/regression/python/list_remove9_fail-nondet/main.py
@@ -1,0 +1,8 @@
+x: int = nondet_int()
+
+l = [1, 2, 3]
+
+if x != 1 and x != 2 and x != 3:
+    # This must fail
+    l.remove(x)
+    assert False  # unreachable, ESBMC should report violation

--- a/regression/python/list_remove9_fail-nondet/test.desc
+++ b/regression/python/list_remove9_fail-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -238,7 +238,8 @@ const static std::vector<std::string> python_c_models = {
   "__ESBMC_fabs",
   "__ESBMC_trunc",
   "__ESBMC_fmod",
-  "__ESBMC_copysign"};
+  "__ESBMC_copysign",
+  "__ESBMC_list_remove"};
 } // namespace
 
 static void generate_symbol_deps(

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -584,3 +584,39 @@ PyListObject *__ESBMC_list_copy(const PyListObject *l)
 
   return copied;
 }
+
+bool __ESBMC_list_remove(
+  PyListObject *l,
+  const void *item,
+  size_t item_type_id,
+  size_t item_size)
+{
+  __ESBMC_assert(l != NULL, "ValueError: list is null");
+
+  size_t i = 0;
+  while (i < l->size)
+  {
+    const PyObject *elem = &l->items[i];
+
+    if (elem->type_id == item_type_id && elem->size == item_size)
+    {
+      if (__ESBMC_values_equal(elem->value, item, item_size))
+      {
+        /* Shift elements left to fill the gap */
+        size_t j = i;
+        while (j < l->size - 1)
+        {
+          l->items[j] = l->items[j + 1];
+          j++;
+        }
+        l->size--;
+        return true; /* found and removed */
+      }
+    }
+    i++;
+  }
+
+  /* Item not found */
+  __ESBMC_assert(0, "ValueError: list.remove(x): x not in list");
+  return false;
+}

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -138,6 +138,7 @@ Below is an overview of ESBMC-Python's key capabilities:
     - **append()**: Add elements to the end of a list.
     - **clear()**: Remove all elements from the list (e.g., `my_list.clear()` empties the list).
     - **pop()**: Remove and return an element at a given index (default is the last element).
+    - **remove()**: Remove the first occurrence of a value from the list (e.g., `l.remove(x)`).
     - **copy()**: Return a shallow copy of the list (e.g., `new_list = old_list.copy()`).
     - **extend()**: Extends a list by appending all elements from an iterable (e.g., `list1.extend(list2)` or `list1.extend([3, 4, 5])`).
     - **insert()**: Insert elements at a specific index position.
@@ -390,7 +391,7 @@ ESBMC-Python provides an optional strict type-checking mode that enforces type c
 The current version of ESBMC-Python has the following limitations:
 
 - Only `for` loops using the `range()` function are supported.
-- List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, and `copy()`.
+- List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, `remove()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
 - Dictionaries are not supported at all.
 - `min()` and `max()` currently support only two arguments and do not handle iterables or the key/default parameters.

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1777,6 +1777,34 @@ exprt function_call_expr::handle_list_copy() const
   return list_helper.build_copy_list_call(*list_symbol, call_);
 }
 
+exprt function_call_expr::handle_list_remove() const
+{
+  const auto &args = call_["args"];
+
+  if (args.size() != 1)
+    throw std::runtime_error("remove() takes exactly one argument");
+
+  std::string list_name = get_object_name();
+
+  symbol_id list_symbol_id = converter_.create_symbol_id();
+  list_symbol_id.set_object(list_name);
+  const symbolt *list_symbol =
+    converter_.find_symbol(list_symbol_id.to_string());
+
+  if (!list_symbol)
+    throw std::runtime_error("List variable not found: " + list_name);
+
+  exprt value_to_remove = converter_.get_expr(args[0]);
+
+  python_list list_helper(converter_, call_);
+  exprt result =
+    list_helper.build_remove_list_call(*list_symbol, call_, value_to_remove);
+
+  python_list::remove_last_type_entry(list_symbol->id.as_string());
+
+  return result;
+}
+
 bool function_call_expr::is_list_method_call() const
 {
   if (call_["func"]["_type"] != "Attribute")
@@ -1807,6 +1835,8 @@ exprt function_call_expr::handle_list_method() const
     return handle_list_pop();
   if (method_name == "copy")
     return handle_list_copy();
+  if (method_name == "remove")
+    return handle_list_remove();
 
   // Add other methods as needed
 

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -253,6 +253,7 @@ private:
   exprt handle_list_clear() const;
   exprt handle_list_pop() const;
   exprt handle_list_copy() const;
+  exprt handle_list_remove() const;
 
   /*
    * Check if the current function call is to a regular expression module function

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2884,11 +2884,11 @@ exprt python_list::build_remove_list_call(
 
   code_function_callt remove_call;
   remove_call.function() = symbol_expr(*remove_func);
-  remove_call.arguments().push_back(symbol_expr(list));            // list
-  remove_call.arguments().push_back(element_arg);                  // &value or ptr
+  remove_call.arguments().push_back(symbol_expr(list)); // list
+  remove_call.arguments().push_back(element_arg);       // &value or ptr
   remove_call.arguments().push_back(
-    symbol_expr(*elem_info.elem_type_sym));                         // type_id
-  remove_call.arguments().push_back(elem_info.elem_size);          // size
+    symbol_expr(*elem_info.elem_type_sym));               // type_id
+  remove_call.arguments().push_back(elem_info.elem_size); // size
   remove_call.type() = bool_type();
   remove_call.location() = elem_info.location;
 

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -171,6 +171,26 @@ public:
   exprt
   build_copy_list_call(const symbolt &list, const nlohmann::json &element);
 
+  /**
+   * @brief Remove the first occurrence of an item from the list type map.
+   * Used by handle_list_remove() to keep the type map consistent.
+   */
+  static void remove_last_type_entry(const std::string &list_id)
+  {
+    auto it = list_type_map.find(list_id);
+    if (it != list_type_map.end() && !it->second.empty())
+      it->second.pop_back();
+  }
+
+  /**
+   * @brief Build a list remove operation (removes first matching element).
+   * Raises ValueError (via assertion) if element is not found.
+   */
+  exprt build_remove_list_call(
+    const symbolt &list,
+    const nlohmann::json &op,
+    const exprt &elem);
+
 private:
   friend class python_dict_handler;
 


### PR DESCRIPTION
This PR implements `list.remove(x)` built-in method, which removes the first occurrence of `x` from the list and raises `ValueError` if not found.

In particular, this PR:
- adds `__ESBMC_list_remove()` C function that shifts elements left after the first match and asserts on missing items.
- adds `build_remove_list_call()` and the public static helper `remove_last_type_entry()` to encapsulate private member access.
- adds `handle_list_remove()` and wire it into the existing list method dispatch table.