### PR TITLE
Fix len() for f-strings to avoid strlen unwinding

### DIFF
--- a/regression/python/fstring3/test.desc
+++ b/regression/python/fstring3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 14
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <climits>
+#include <optional>
 
 bool function_call_builder::is_nondet_str_call(const nlohmann::json &node) const
 {
@@ -477,10 +478,130 @@ exprt function_call_builder::build() const
 
   if (is_len_call(function_id) && !call_["args"].empty())
   {
+    auto joinedstr_len = [](const nlohmann::json &joined) -> std::optional<BigInt> {
+      if (!joined.contains("values") || !joined["values"].is_array())
+        return std::nullopt;
+
+      BigInt total = BigInt(0);
+      constexpr size_t kPlaceholderLen = 6; // "<expr>"
+
+      for (const auto &part : joined["values"])
+      {
+        if (part["_type"] == "Constant" && part.contains("value") &&
+            part["value"].is_string())
+        {
+          const std::string text = part["value"].get<std::string>();
+          total += BigInt(text.size());
+          continue;
+        }
+
+        if (part["_type"] == "FormattedValue" && part.contains("value"))
+        {
+          const auto &value = part["value"];
+          // Only optimize when formatted value is non-constant, which maps to "<expr>"
+          if (value.contains("_type") && value["_type"] == "Constant")
+            return std::nullopt;
+
+          total += BigInt(kPlaceholderLen);
+          continue;
+        }
+
+        return std::nullopt;
+      }
+
+      return total;
+    };
+
+    // Fast path for literal strings: len("...") is known at compile time.
+    if (
+      call_["args"][0].contains("_type") &&
+      call_["args"][0]["_type"] == "Constant" &&
+      call_["args"][0].contains("value") &&
+      call_["args"][0]["value"].is_string())
+    {
+      const std::string text = call_["args"][0]["value"].get<std::string>();
+      return from_integer(BigInt(text.size()), size_type());
+    }
+
     exprt arg_expr = converter_.get_expr(call_["args"][0]);
 
     if (arg_expr.type().is_signedbv() || arg_expr.type().is_unsignedbv())
       return from_integer(1, long_long_int_type());
+
+    // If the argument is a named variable initialized with a constant string
+    // or f-string, compute its length from the initializer to avoid strlen.
+    if (call_["args"][0].contains("_type") &&
+        call_["args"][0]["_type"] == "Name" &&
+        call_["args"][0].contains("id"))
+    {
+      const std::string var_name = call_["args"][0]["id"].get<std::string>();
+      nlohmann::json var_value = json_utils::get_var_value(
+        var_name,
+        converter_.get_current_func_name(),
+        converter_.get_ast_json());
+
+      if (!var_value.empty() && var_value.contains("value"))
+      {
+        if (
+          var_value["value"].contains("_type") &&
+          var_value["value"]["_type"] == "JoinedStr")
+        {
+          if (auto len = joinedstr_len(var_value["value"]))
+            return from_integer(*len, size_type());
+        }
+        else if (
+          var_value["value"].contains("_type") &&
+          var_value["value"]["_type"] == "Constant" &&
+          var_value["value"].contains("value") &&
+          var_value["value"]["value"].is_string())
+        {
+          const std::string text =
+            var_value["value"]["value"].get<std::string>();
+          return from_integer(BigInt(text.size()), size_type());
+        }
+      }
+    }
+
+    // If this is a symbol with a constant string array value, compute length
+    // directly from the array size to avoid strlen unwinding.
+    if (arg_expr.is_symbol())
+    {
+      symbolt *arg_symbol = converter_.find_symbol(
+        to_symbol_expr(arg_expr).get_identifier().as_string());
+      if (
+        arg_symbol && arg_symbol->value.is_not_nil() &&
+        arg_symbol->value.type().is_array() && arg_symbol->value.is_constant())
+      {
+        const array_typet &arr_type = to_array_type(arg_symbol->value.type());
+        if (type_utils::is_char_type(arr_type.subtype()) &&
+            arr_type.size().is_constant())
+        {
+          BigInt sz;
+          if (!to_integer(arr_type.size(), sz) && sz > 0)
+            return from_integer(sz - 1, size_type());
+        }
+      }
+    }
+
+    // If this is a fixed-size char array, compute length at compile time
+    // to avoid strlen unwinding.
+    typet actual_type = arg_expr.type();
+    if (actual_type.is_pointer())
+      actual_type = actual_type.subtype();
+    if (actual_type.id() == "symbol")
+      actual_type = converter_.ns.follow(actual_type);
+
+    if (actual_type.id() == "array")
+    {
+      const array_typet &arr_type = to_array_type(actual_type);
+      if (type_utils::is_char_type(arr_type.subtype()) &&
+          arr_type.size().is_constant())
+      {
+        BigInt sz;
+        if (!to_integer(arr_type.size(), sz) && sz > 0)
+          return from_integer(sz - 1, size_type());
+      }
+    }
   }
 
   // Special handling for single character len() calls

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -508,8 +508,8 @@ exprt function_call_builder::build() const
     };
 
     auto joinedstr_len =
-      [&const_string_len_from_symbol](const nlohmann::json &joined)
-        -> std::optional<BigInt> {
+      [&const_string_len_from_symbol](
+        const nlohmann::json &joined) -> std::optional<BigInt> {
       if (!joined.contains("values") || !joined["values"].is_array())
         return std::nullopt;
 
@@ -531,8 +531,9 @@ exprt function_call_builder::build() const
           const auto &value = part["value"];
           if (value["_type"] == "Name" && value.contains("id"))
           {
-            if (auto len =
-                  const_string_len_from_symbol(value["id"].get<std::string>()))
+            if (
+              auto len =
+                const_string_len_from_symbol(value["id"].get<std::string>()))
             {
               total += *len;
               continue;
@@ -568,15 +569,16 @@ exprt function_call_builder::build() const
 
     // If the argument is a named variable initialized with a constant string
     // or f-string, compute its length from the initializer to avoid strlen.
-    if (call_["args"][0].contains("_type") &&
-        call_["args"][0]["_type"] == "Name" &&
-        call_["args"][0].contains("id"))
+    if (
+      call_["args"][0].contains("_type") &&
+      call_["args"][0]["_type"] == "Name" && call_["args"][0].contains("id"))
     {
       const std::string var_name = call_["args"][0]["id"].get<std::string>();
       bool has_augassign = false;
-      auto count_assignments = [&](const nlohmann::json &node,
-                                   const std::string &name,
-                                   auto &&self) -> int {
+      auto count_assignments = [&](
+                                 const nlohmann::json &node,
+                                 const std::string &name,
+                                 auto &&self) -> int {
         int count = 0;
         if (!node.is_object() && !node.is_array())
           return 0;
@@ -588,23 +590,26 @@ exprt function_call_builder::build() const
           {
             for (const auto &tgt : node["targets"])
             {
-              if (tgt.contains("_type") && tgt["_type"] == "Name" &&
-                  tgt.contains("id") && tgt["id"] == name)
+              if (
+                tgt.contains("_type") && tgt["_type"] == "Name" &&
+                tgt.contains("id") && tgt["id"] == name)
                 count++;
             }
           }
           else if (type == "AnnAssign" && node.contains("target"))
           {
             const auto &tgt = node["target"];
-            if (tgt.contains("_type") && tgt["_type"] == "Name" &&
-                tgt.contains("id") && tgt["id"] == name)
+            if (
+              tgt.contains("_type") && tgt["_type"] == "Name" &&
+              tgt.contains("id") && tgt["id"] == name)
               count++;
           }
           else if (type == "AugAssign" && node.contains("target"))
           {
             const auto &tgt = node["target"];
-            if (tgt.contains("_type") && tgt["_type"] == "Name" &&
-                tgt.contains("id") && tgt["id"] == name)
+            if (
+              tgt.contains("_type") && tgt["_type"] == "Name" &&
+              tgt.contains("id") && tgt["id"] == name)
             {
               has_augassign = true;
               count++;
@@ -629,7 +634,8 @@ exprt function_call_builder::build() const
       int assign_count = 0;
       const nlohmann::json &ast = converter_.get_ast_json();
       if (converter_.get_current_func_name().empty())
-        assign_count = count_assignments(ast["body"], var_name, count_assignments);
+        assign_count =
+          count_assignments(ast["body"], var_name, count_assignments);
       else
       {
         std::vector<std::string> function_path =
@@ -683,8 +689,9 @@ exprt function_call_builder::build() const
         arg_symbol->value.type().is_array() && arg_symbol->value.is_constant())
       {
         const array_typet &arr_type = to_array_type(arg_symbol->value.type());
-        if (type_utils::is_char_type(arr_type.subtype()) &&
-            arr_type.size().is_constant())
+        if (
+          type_utils::is_char_type(arr_type.subtype()) &&
+          arr_type.size().is_constant())
         {
           BigInt sz;
           if (!to_integer(arr_type.size(), sz) && sz > 0)
@@ -704,8 +711,9 @@ exprt function_call_builder::build() const
     if (actual_type.id() == "array")
     {
       const array_typet &arr_type = to_array_type(actual_type);
-      if (type_utils::is_char_type(arr_type.subtype()) &&
-          arr_type.size().is_constant())
+      if (
+        type_utils::is_char_type(arr_type.subtype()) &&
+        arr_type.size().is_constant())
       {
         BigInt sz;
         if (!to_integer(arr_type.size(), sz) && sz > 0)

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -133,6 +133,11 @@ public:
     return current_python_file;
   }
 
+  const std::string &main_python_filename() const
+  {
+    return main_python_file;
+  }
+
   const std::string &current_function_name() const
   {
     return current_func_name_;


### PR DESCRIPTION
Computes len() at compile time for literal strings and simple f-strings that resolve to placeholders.
Avoids strlen loop unwinding for fstring3.