### PR TITLE
[python] fix list_remove mutating type_map across branches

### DIFF
--- a/regression/python/list_remove10-nondet/main.py
+++ b/regression/python/list_remove10-nondet/main.py
@@ -1,0 +1,19 @@
+b: bool = nondet_bool()
+
+l = [5, 5, 5]
+
+if b:
+    l.remove(5)
+
+    # Length reduced by 1
+    assert len(l) == 2
+
+    # Remaining elements still equal to 5
+    assert l[0] == 5
+    assert l[1] == 5
+else:
+    # No removal
+    assert len(l) == 3
+    assert l[0] == 5
+    assert l[1] == 5
+    assert l[2] == 5

--- a/regression/python/list_remove10-nondet/test.desc
+++ b/regression/python/list_remove10-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove10-nondet_fail/main.py
+++ b/regression/python/list_remove10-nondet_fail/main.py
@@ -1,0 +1,15 @@
+b: bool = nondet_bool()
+
+l = [5, 5, 5]
+
+if b:
+    l.remove(5)
+    assert len(l) == 2
+    assert l[0] == 5
+    assert l[1] == 5
+    assert l[2] == 5
+else:
+    assert len(l) == 3
+    assert l[0] == 5
+    assert l[1] == 5
+    assert l[2] == 5

--- a/regression/python/list_remove10-nondet_fail/test.desc
+++ b/regression/python/list_remove10-nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/list_remove11-nondet/main.py
+++ b/regression/python/list_remove11-nondet/main.py
@@ -1,0 +1,10 @@
+b: bool = nondet_bool()
+
+l = [42]
+
+if b:
+    l.remove(42)
+    assert len(l) == 0
+else:
+    assert len(l) == 1
+    assert l[0] == 42

--- a/regression/python/list_remove11-nondet/test.desc
+++ b/regression/python/list_remove11-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list_remove11-nondet_fail/main.py
+++ b/regression/python/list_remove11-nondet_fail/main.py
@@ -1,0 +1,10 @@
+b: bool = nondet_bool()
+
+l = [42]
+
+if b:
+    l.remove(42)
+    assert len(l) == 0
+else:
+    assert len(l) == 1
+    assert l[0] == 41

--- a/regression/python/list_remove11-nondet_fail/test.desc
+++ b/regression/python/list_remove11-nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1800,8 +1800,6 @@ exprt function_call_expr::handle_list_remove() const
   exprt result =
     list_helper.build_remove_list_call(*list_symbol, call_, value_to_remove);
 
-  python_list::remove_last_type_entry(list_symbol->id.as_string());
-
   return result;
 }
 

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -172,17 +172,6 @@ public:
   build_copy_list_call(const symbolt &list, const nlohmann::json &element);
 
   /**
-   * @brief Remove the first occurrence of an item from the list type map.
-   * Used by handle_list_remove() to keep the type map consistent.
-   */
-  static void remove_last_type_entry(const std::string &list_id)
-  {
-    auto it = list_type_map.find(list_id);
-    if (it != list_type_map.end() && !it->second.empty())
-      it->second.pop_back();
-  }
-
-  /**
    * @brief Build a list remove operation (removes first matching element).
    * Raises ValueError (via assertion) if element is not found.
    */


### PR DESCRIPTION
This PR removes the `remove_last_type_entry()` call from `handle_list_remove()`. The static `list_type_map` is used only for compile-time type inference; mutating it during codegen for one branch of a conditional incorrectly affects type resolution in all other branches.