### PR TITLE
[python] handle 'not list' truthiness check via list_size() instead of pointer cast

### DIFF
--- a/regression/humaneval/humaneval_5-1/test.desc
+++ b/regression/humaneval/humaneval_5-1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 10 --no-bounds-check --no-pointer-check --no-align-check --smt-during-symex --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2079,8 +2079,7 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
     current_block->copy_to_operands(size_call);
 
     // Return comparison: size == 0 (empty list is falsy, so 'not list' is true when empty)
-    exprt is_empty("=", bool_type());
-    is_empty.copy_to_operands(symbol_expr(size_result), gen_zero(size_type()));
+    exprt is_empty = equality_exprt(symbol_expr(size_result), gen_zero(size_type()));
     is_empty.location() = location;
 
     return is_empty;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2042,8 +2042,10 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
 
   // Handle 'not' operator on list types: convert to emptiness check
   typet list_type = type_handler_.get_list_type();
-  if (op == "Not" && (unary_sub.type() == list_type ||
-                      (unary_sub.type().is_pointer() && unary_sub.type().subtype() == list_type)))
+  if (
+    op == "Not" && (unary_sub.type() == list_type ||
+                    (unary_sub.type().is_pointer() &&
+                     unary_sub.type().subtype() == list_type)))
   {
     if (!current_block)
       throw std::runtime_error(
@@ -2079,7 +2081,8 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
     current_block->copy_to_operands(size_call);
 
     // Return comparison: size == 0 (empty list is falsy, so 'not list' is true when empty)
-    exprt is_empty = equality_exprt(symbol_expr(size_result), gen_zero(size_type()));
+    exprt is_empty =
+      equality_exprt(symbol_expr(size_result), gen_zero(size_type()));
     is_empty.location() = location;
 
     return is_empty;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2040,6 +2040,52 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
     return is_empty;
   }
 
+  // Handle 'not' operator on list types: convert to emptiness check
+  typet list_type = type_handler_.get_list_type();
+  if (op == "Not" && (unary_sub.type() == list_type ||
+                      (unary_sub.type().is_pointer() && unary_sub.type().subtype() == list_type)))
+  {
+    if (!current_block)
+      throw std::runtime_error(
+        "List truthiness check requires a statement context");
+
+    locationt location = get_location_from_decl(element);
+
+    // Find __ESBMC_list_size function
+    const symbolt *size_func =
+      symbol_table_.find_symbol("c:@F@__ESBMC_list_size");
+    if (!size_func)
+      throw std::runtime_error(
+        "__ESBMC_list_size not found for list truthiness check");
+
+    // Create temporary variable to store the size result
+    symbolt &size_result = create_tmp_symbol(
+      element, "$list_size$", size_type(), gen_zero(size_type()));
+    code_declt size_decl(symbol_expr(size_result));
+    size_decl.location() = location;
+    current_block->copy_to_operands(size_decl);
+
+    // Call __ESBMC_list_size(list)
+    code_function_callt size_call;
+    size_call.function() = symbol_expr(*size_func);
+    size_call.lhs() = symbol_expr(size_result);
+    // Pass address if not already a pointer
+    if (unary_sub.type().is_pointer())
+      size_call.arguments().push_back(unary_sub);
+    else
+      size_call.arguments().push_back(address_of_exprt(unary_sub));
+    size_call.type() = size_type();
+    size_call.location() = location;
+    current_block->copy_to_operands(size_call);
+
+    // Return comparison: size == 0 (empty list is falsy, so 'not list' is true when empty)
+    exprt is_empty("=", bool_type());
+    is_empty.copy_to_operands(symbol_expr(size_result), gen_zero(size_type()));
+    is_empty.location() = location;
+
+    return is_empty;
+  }
+
   exprt unary_expr(map_operator(op, type), type);
   unary_expr.operands().push_back(unary_sub);
 


### PR DESCRIPTION
This PR emits a `__ESBMC_list_size()` call and compares the result to zero, consistent with how dict truthiness is handled. Before this PR, translating 'if not numbers:' would cast the list pointer to `_Bool`, which is always true for a non-null pointer regardless of the list's contents.