### PR TITLE
Fix string repetition handling in Python frontend

### DIFF
--- a/regression/python/string-repetition/test.desc
+++ b/regression/python/string-repetition/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -203,6 +203,7 @@ const static std::vector<std::string> python_c_models = {
   "__python_int",
   "__python_chr",
   "__python_str_concat",
+  "__python_str_repeat",
   "__ESBMC_list_find_index",
   "__ESBMC_list_remove_at",
   "__ESBMC_list_set_at",

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -1115,12 +1115,16 @@ __ESBMC_HIDE:;
   char *buffer = __ESBMC_alloca(total + 1);
 
   size_t pos = 0;
-  for (size_t i = 0; i < count_u; ++i)
+  size_t i = 0;
+  while (i < count_u)
   {
-    for (size_t j = 0; j < len; ++j)
+    size_t j = 0;
+    while (j < len)
     {
       buffer[pos++] = s[j];
+      ++j;
     }
+    ++i;
   }
 
   buffer[pos] = '\0';

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -1104,13 +1104,11 @@ __ESBMC_HIDE:;
 
   // Bound checks to keep buffers finite
   __ESBMC_assert(
-    count_u <= ESBMC_PY_STRNLEN_BOUND,
-    "String repetition count too large");
+    count_u <= ESBMC_PY_STRNLEN_BOUND, "String repetition count too large");
 
   size_t total = len * count_u;
   __ESBMC_assert(
-    total <= ESBMC_PY_STRNLEN_BOUND,
-    "String repetition result too large");
+    total <= ESBMC_PY_STRNLEN_BOUND, "String repetition result too large");
 
   char *buffer = __ESBMC_alloca(total + 1);
 

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -1084,3 +1084,45 @@ __ESBMC_HIDE:;
   buffer[pos] = '\0';
   return buffer;
 }
+
+// Python string repetition - repeats a string count times
+char *__python_str_repeat(const char *s, long long count)
+{
+__ESBMC_HIDE:;
+  if (!s)
+    return (char *)0;
+
+  if (count <= 0)
+  {
+    char *empty = __ESBMC_alloca(1);
+    empty[0] = '\0';
+    return empty;
+  }
+
+  size_t len = __python_strnlen_bounded(s, ESBMC_PY_STRNLEN_BOUND);
+  size_t count_u = (size_t)count;
+
+  // Bound checks to keep buffers finite
+  __ESBMC_assert(
+    count_u <= ESBMC_PY_STRNLEN_BOUND,
+    "String repetition count too large");
+
+  size_t total = len * count_u;
+  __ESBMC_assert(
+    total <= ESBMC_PY_STRNLEN_BOUND,
+    "String repetition result too large");
+
+  char *buffer = __ESBMC_alloca(total + 1);
+
+  size_t pos = 0;
+  for (size_t i = 0; i < count_u; ++i)
+  {
+    for (size_t j = 0; j < len; ++j)
+    {
+      buffer[pos++] = s[j];
+    }
+  }
+
+  buffer[pos] = '\0';
+  return buffer;
+}

--- a/src/python-frontend/python_frontend_limits.h
+++ b/src/python-frontend/python_frontend_limits.h
@@ -1,0 +1,11 @@
+// Copyright (C) 2024-2026 Diffblue Ltd and
+// University of Manchester, University of Oxford.
+// SPDX-License-Identifier: BSD-4-Clause
+#ifndef ESBMC_PYTHON_FRONTEND_LIMITS_H
+#define ESBMC_PYTHON_FRONTEND_LIMITS_H
+
+// Upper bound for expanding symbolic/implicit sequences to keep model checking
+// tractable (e.g., range() materialization, string repetition folding).
+constexpr long long kMaxSequenceExpansion = 10000;
+
+#endif // ESBMC_PYTHON_FRONTEND_LIMITS_H

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -9,6 +9,7 @@
 #include <util/symbol.h>
 #include <util/expr_util.h>
 #include <util/arith_tools.h>
+#include <python-frontend/python_frontend_limits.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
 #include <util/mp_arith.h>
@@ -2780,12 +2781,11 @@ exprt python_list::build_concrete_range(
   else
     range_size = std::max(0LL, (stop - start + step + 1) / step);
 
-  constexpr long long MAX_RANGE_SIZE = 10000;
-  if (range_size > MAX_RANGE_SIZE)
+  if (range_size > kMaxSequenceExpansion)
   {
     throw std::runtime_error(
       "range() size too large for expansion: " + std::to_string(range_size) +
-      " elements (max: " + std::to_string(MAX_RANGE_SIZE) + ")");
+      " elements (max: " + std::to_string(kMaxSequenceExpansion) + ")");
   }
 
   // Build the list of elements

--- a/src/python-frontend/string_builder.cpp
+++ b/src/python-frontend/string_builder.cpp
@@ -327,7 +327,7 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
     if (e.is_constant())
     {
       BigInt val;
-      if (!to_integer(e, val))
+      if (!to_integer(e, val) && val.is_int64())
         return val.to_int64();
       return std::nullopt;
     }
@@ -339,7 +339,7 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
       if (sym && sym->value.is_constant())
       {
         BigInt val;
-        if (!to_integer(sym->value, val))
+        if (!to_integer(sym->value, val) && val.is_int64())
           return val.to_int64();
       }
     }

--- a/src/python-frontend/string_builder.cpp
+++ b/src/python-frontend/string_builder.cpp
@@ -4,6 +4,7 @@
 #include <util/arith_tools.h>
 #include <util/std_code.h>
 #include <util/expr_util.h>
+#include <python-frontend/python_frontend_limits.h>
 #include <optional>
 #include <stdexcept>
 #include <limits>
@@ -303,7 +304,6 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
   size_t size = 0;
   exprt str;
   exprt count_expr;
-  constexpr long long kMaxRepeatSize = 10000;
 
   auto get_repeat_count = [this](const exprt &e) -> std::optional<long long> {
     if (e.type().is_bool())
@@ -418,7 +418,7 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
     {
       if (
         *count > static_cast<long long>(std::numeric_limits<size_t>::max()) ||
-        *count > kMaxRepeatSize)
+        *count > kMaxSequenceExpansion)
       {
         str_handler_->ensure_string_array(lhs);
         return make_repeat_call(lhs, rhs);
@@ -445,7 +445,7 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
     {
       if (
         *count > static_cast<long long>(std::numeric_limits<size_t>::max()) ||
-        *count > kMaxRepeatSize)
+        *count > kMaxSequenceExpansion)
       {
         str_handler_->ensure_string_array(rhs);
         return make_repeat_call(rhs, lhs);

--- a/src/python-frontend/string_builder.cpp
+++ b/src/python-frontend/string_builder.cpp
@@ -337,8 +337,8 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
 
     if (e.is_symbol())
     {
-      symbolt *sym = converter_.find_symbol(
-        to_symbol_expr(e).get_identifier().as_string());
+      symbolt *sym =
+        converter_.find_symbol(to_symbol_expr(e).get_identifier().as_string());
       if (sym && sym->value.is_constant())
       {
         BigInt val;
@@ -462,9 +462,8 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
 
   std::vector<exprt> chars = extract_string_chars(str);
   if (
-    size > 0 &&
-    chars.size() >
-      (std::numeric_limits<size_t>::max() / static_cast<size_t>(size)))
+    size > 0 && chars.size() > (std::numeric_limits<size_t>::max() /
+                                static_cast<size_t>(size)))
   {
     return make_repeat_call(str, count_expr);
   }

--- a/src/python-frontend/string_builder.cpp
+++ b/src/python-frontend/string_builder.cpp
@@ -307,6 +307,19 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
     {
       if (e.is_constant())
         return e.is_true() ? 1 : 0;
+      if (e.is_symbol())
+      {
+        symbolt *sym = converter_.find_symbol(
+          to_symbol_expr(e).get_identifier().as_string());
+        if (sym && sym->value.is_constant())
+        {
+          if (sym->value.type().is_bool())
+            return sym->value.is_true() ? 1 : 0;
+          BigInt val;
+          if (!to_integer(sym->value, val))
+            return val.to_int64();
+        }
+      }
       // Unknown boolean: treat as nondet -> do not fold
       return std::nullopt;
     }


### PR DESCRIPTION
Promote regression/python/string-repetition to CORE.
Fix string repetition in the Python frontend for non-constant counts, avoiding std::stoi and handling invalid/negative values safely.