### PR TITLE
Revert "[C++ verification] fix the crash caused by the default alignment"

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_3522/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_3522/main.cpp
@@ -1,7 +1,0 @@
-struct __attribute__((__aligned__)) __aligned_storage_max_align_t
-{
-};
-
-int main()
-{
-}

--- a/regression/esbmc-cpp/bug_fixes/github_3522/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_3522/test.desc
@@ -1,4 +1,0 @@
-CORE
-main.cpp
-
-^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -388,14 +388,11 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
         const clang::AlignedAttr &aattr =
           static_cast<const clang::AlignedAttr &>(*attr);
 
-        if (aattr.getAlignmentExpr())
-        {
-          exprt alignment;
-          if (get_expr(*(aattr.getAlignmentExpr()), alignment))
-            return true;
+        exprt alignment;
+        if (get_expr(*(aattr.getAlignmentExpr()), alignment))
+          return true;
 
-          t.set("alignment", alignment);
-        }
+        t.set("alignment", alignment);
       }
     }
   }


### PR DESCRIPTION
The PR didn't actually fix the problem, but just hid it.
See this failing testcase which [works fine on clang](https://godbolt.org/z/sr83jrGjq):
```cpp
#include <assert.h>
#include <string.h>

struct __attribute__((__aligned__)) __aligned_storage_max_align_t {};
struct __aligned_storage_max_align_t2 {};

long align1 = alignof(__aligned_storage_max_align_t);
long sizeof1 = sizeof(__aligned_storage_max_align_t);
long align2 = alignof(__aligned_storage_max_align_t2);
long sizeof2 = sizeof(__aligned_storage_max_align_t2);

int main() {
    struct __aligned_storage_max_align_t test = {};
    char zeroes[16] = {};
    assert(align1 == 16L);   // LIES: only works because this is resolved by
                             // clang and not esbmc
    assert(sizeof1 == 16L);  // LIES: only works because this is resolved by
                             // clang and not esbmc
    assert(align2 == 1L);
    assert(sizeof2 == 1L);
    assert(!memcmp(&test, &zeroes, 16)); // FAILS because the object isn't actually 16 bytes big!
}
```