### PR TITLE
Fix string-annotation regression by supporting PEP 604 in string annotation

### DIFF
--- a/regression/python/string-annotation/test.desc
+++ b/regression/python/string-annotation/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -29,6 +29,7 @@
 #include <util/symbolic_types.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <fstream>
@@ -5577,6 +5578,72 @@ typet python_converter::get_type_from_annotation(
     // Handle string annotations like "CoordinateData | None" (forward references)
     std::string type_string = annotation_node["value"].get<std::string>();
     type_string = type_utils::remove_quotes(type_string);
+    // Support PEP 604 unions inside string annotations: "T | None"
+    if (type_string.find('|') != std::string::npos)
+    {
+      // Split by '|' and trim whitespace
+      auto trim_ws = [](std::string s) -> std::string {
+        const auto not_space = [](unsigned char ch) {
+          return !std::isspace(ch);
+        };
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+        s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+        return s;
+      };
+      std::vector<std::string> parts;
+      std::string current;
+      for (char c : type_string)
+      {
+        if (c == '|')
+        {
+          parts.push_back(trim_ws(current));
+          current.clear();
+        }
+        else
+        {
+          current.push_back(c);
+        }
+      }
+      parts.push_back(trim_ws(current));
+
+      // Remove None/NoneType and keep first non-none type
+      std::string base_type_name;
+      bool contains_none = false;
+      for (const auto &p : parts)
+      {
+        if (p == "None" || p == "NoneType")
+        {
+          contains_none = true;
+          continue;
+        }
+        if (base_type_name.empty())
+          base_type_name = p;
+      }
+
+      if (base_type_name.empty())
+        return any_type();
+
+      typet base_type = type_handler_.get_typet(base_type_name);
+
+      // Single type + None: use Optional wrapper for primitives only
+      if (
+        contains_none &&
+        (base_type == long_long_int_type() ||
+         base_type == long_long_uint_type() || base_type == double_type() ||
+         base_type == bool_type()))
+      {
+        return type_handler_.build_optional_type(base_type);
+      }
+
+      if (base_type == type_handler_.get_list_type())
+        return base_type;
+
+      if (contains_none)
+        return gen_pointer_type(base_type);
+
+      return base_type;
+    }
+
     return type_handler_.get_typet(type_string);
   }
   else if (

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -293,6 +293,10 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "BinaryIO" || ast_type == "TextIO" || ast_type == "IO")
     return any_type();
 
+  // object — top type in Python; accept any value
+  if (ast_type == "object")
+    return any_type();
+
   // NoneType — represents Python's None value
   // Use a pointer type to void to represent None/null properly
   if (ast_type == "NoneType")


### PR DESCRIPTION
Treats "T | None" string annotations as unions and maps to Optional/pointer types.
Treats object annotations as any_type() to avoid argument type mismatches