### PR TITLE
Prevent crash on incompatible type reassignment

### DIFF
--- a/regression/python/type-annotation-reassign-check-1/main.py
+++ b/regression/python/type-annotation-reassign-check-1/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    count: int = 10
+    assert count == 10
+
+main()

--- a/regression/python/type-annotation-reassign-check-1/test.desc
+++ b/regression/python/type-annotation-reassign-check-1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--is-instance-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/type-annotation-reassign-check-2/main.py
+++ b/regression/python/type-annotation-reassign-check-2/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    count: int = 10
+    count = 20
+    assert count == 20
+
+main()

--- a/regression/python/type-annotation-reassign-check-2/test.desc
+++ b/regression/python/type-annotation-reassign-check-2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--is-instance-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/type-annotation-reassign-check/test.desc
+++ b/regression/python/type-annotation-reassign-check/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --is-instance-check
 ^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -318,7 +318,8 @@ void python_converter::update_symbol(const exprt &expr) const
     // solely of '0' and '1' characters (i.e., it is a valid binary string).
     // Character or decimal values stored in the symbol will not satisfy this
     // check and must be left unchanged to avoid a stoll conversion failure.
-    bool is_binary_string = !binary_value_str.empty() &&
+    bool is_binary_string =
+      !binary_value_str.empty() &&
       binary_value_str.find_first_not_of("01") == std::string::npos;
 
     if (is_binary_string)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4604,10 +4604,10 @@ void python_converter::get_var_assign(
     // which would coerce rhs type to match lhs, hiding the mismatch.
     // Only enforce when type assertions are enabled (--is-instance-check).
     if (
-      type_assertions_enabled() &&
-      lhs.type() != rhs.type() && !rhs.type().is_code() &&
-      !rhs.type().is_empty() && rhs.type().is_array() &&
-      !lhs.type().is_array() && !lhs.type().is_pointer())
+      type_assertions_enabled() && lhs.type() != rhs.type() &&
+      !rhs.type().is_code() && !rhs.type().is_empty() &&
+      rhs.type().is_array() && !lhs.type().is_array() &&
+      !lhs.type().is_pointer())
     {
       code_assertt type_assert(gen_boolean(false));
       type_assert.location() = location_begin;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -314,25 +314,35 @@ void python_converter::update_symbol(const exprt &expr) const
   {
     const std::string &binary_value_str = sym->value.value().c_str();
 
-    try
-    {
-      // Convert binary string to integer.
-      int64_t int_val = std::stoll(binary_value_str, nullptr, 2);
+    // Only attempt binary conversion if the string is non-empty and consists
+    // solely of '0' and '1' characters (i.e., it is a valid binary string).
+    // Character or decimal values stored in the symbol will not satisfy this
+    // check and must be left unchanged to avoid a stoll conversion failure.
+    bool is_binary_string = !binary_value_str.empty() &&
+      binary_value_str.find_first_not_of("01") == std::string::npos;
 
-      // Create a new constant expression with the converted value and type.
-      exprt new_value = from_integer(int_val, expr_type);
-
-      // Assign the new value to the symbol.
-      sym->value = new_value;
-    }
-    catch (const std::exception &e)
+    if (is_binary_string)
     {
-      log_error(
-        "update_symbol: Failed to convert binary value '{}' to integer for "
-        "symbol '{}'. Error: {}",
-        binary_value_str,
-        sid.to_string(),
-        e.what());
+      try
+      {
+        // Convert binary string to integer.
+        int64_t int_val = std::stoll(binary_value_str, nullptr, 2);
+
+        // Create a new constant expression with the converted value and type.
+        exprt new_value = from_integer(int_val, expr_type);
+
+        // Assign the new value to the symbol.
+        sym->value = new_value;
+      }
+      catch (const std::exception &e)
+      {
+        log_error(
+          "update_symbol: Failed to convert binary value '{}' to integer for "
+          "symbol '{}'. Error: {}",
+          binary_value_str,
+          sid.to_string(),
+          e.what());
+      }
     }
   }
 }


### PR DESCRIPTION
Fix crash (assertion failure in value_set.cpp) when a type-annotated variable is reassigned to an incompatible type (e.g., [int]. Guard the symbol type update in for type-incompatible assignments instead of generating ill-typed GOTO code. Add regression tests for annotation baseline and same-type reassignment.