### PR TITLE
Fix/GitHub 3551

### DIFF
--- a/regression/python/github_3551/main.py
+++ b/regression/python/github_3551/main.py
@@ -1,0 +1,25 @@
+from typing import List
+
+
+def mean_absolute_deviation(numbers: List[float]) -> float:
+    total: float = 0.0
+    i: int = 0
+    length: int = len(numbers)
+    while i < length:
+        total = total + numbers[i]
+        i = i + 1
+    mean: float = total / length
+
+    mad: float = 0.0
+    i = 0
+    while i < length:
+        diff: float = numbers[i] - mean
+        if diff < 0.0:
+            diff = -diff
+        mad = mad + diff
+        i = i + 1
+    return mad / length
+
+
+if __name__ == "__main__":
+    assert abs(mean_absolute_deviation([1.0, 2.0, 3.0]) - 2.0/3.0) < 1e-6

--- a/regression/python/github_3551/test.desc
+++ b/regression/python/github_3551/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2779,8 +2779,7 @@ private:
 
       Json updated = element;
       update_assignment_node(updated, inferred_type);
-      pending_updates.push_back(
-        {body_index, std::move(updated), ref_index});
+      pending_updates.push_back({body_index, std::move(updated), ref_index});
     }
 
     for (const auto &update : pending_updates)


### PR DESCRIPTION
Avoid self-referential inference crashes in Python annotation pass, Fix Python frontend annotation to avoid in-place AST mutation and guard self-referential RHS inference; add regression cases for github_3551 (one success, one expected error)