### PR TITLE
Fix/GitHub 3552

### DIFF
--- a/regression/python/github_3552/main.py
+++ b/regression/python/github_3552/main.py
@@ -1,0 +1,3 @@
+s5 = "café"
+assert s5 == "café"
+assert len(s5) == 4

--- a/regression/python/github_3552/test.desc
+++ b/regression/python/github_3552/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3552_1/main.py
+++ b/regression/python/github_3552_1/main.py
@@ -1,0 +1,2 @@
+s = f"café"
+assert len(s) == 4

--- a/regression/python/github_3552_1/test.desc
+++ b/regression/python/github_3552_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -14,6 +14,17 @@
 #include <climits>
 #include <optional>
 
+static size_t utf8_codepoint_count(const std::string &text)
+{
+  size_t count = 0;
+  for (unsigned char c : text)
+  {
+    if ((c & 0xC0) != 0x80)
+      ++count;
+  }
+  return count;
+}
+
 bool function_call_builder::is_nondet_str_call(const nlohmann::json &node) const
 {
   return node.contains("_type") && node["_type"] == "Call" &&
@@ -522,7 +533,7 @@ exprt function_call_builder::build() const
           part["value"].is_string())
         {
           const std::string text = part["value"].get<std::string>();
-          total += BigInt(text.size());
+          total += BigInt(utf8_codepoint_count(text));
           continue;
         }
 
@@ -559,7 +570,7 @@ exprt function_call_builder::build() const
       call_["args"][0]["value"].is_string())
     {
       const std::string text = call_["args"][0]["value"].get<std::string>();
-      return from_integer(BigInt(text.size()), size_type());
+      return from_integer(BigInt(utf8_codepoint_count(text)), size_type());
     }
 
     exprt arg_expr = converter_.get_expr(call_["args"][0]);
@@ -672,7 +683,7 @@ exprt function_call_builder::build() const
           {
             const std::string text =
               var_value["value"]["value"].get<std::string>();
-            return from_integer(BigInt(text.size()), size_type());
+            return from_integer(BigInt(utf8_codepoint_count(text)), size_type());
           }
         }
       }

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -683,7 +683,8 @@ exprt function_call_builder::build() const
           {
             const std::string text =
               var_value["value"]["value"].get<std::string>();
-            return from_integer(BigInt(utf8_codepoint_count(text)), size_type());
+            return from_integer(
+              BigInt(utf8_codepoint_count(text)), size_type());
           }
         }
       }

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -515,7 +515,7 @@ exprt function_call_builder::build() const
           name_value = file;
       }
 
-      return BigInt(name_value.size());
+      return BigInt(utf8_codepoint_count(name_value));
     };
 
     auto joinedstr_len =


### PR DESCRIPTION

Compute len() for constant strings/JoinedStr using UTF-8 codepoint count
to avoid byte-length mismatch (e.g., "café").
 Added regression test github_3552. String suite passes.
