### PR TITLE
[python] add intrinsic stubs for the AI agent

### DIFF
--- a/regression/python/esbmc-module-nondet/main.py
+++ b/regression/python/esbmc-module-nondet/main.py
@@ -1,0 +1,23 @@
+from esbmc import nondet_int, __ESBMC_assume
+
+def absolute_value(x: int) -> int:
+    """Compute absolute value."""
+    if x < 0:
+        return -x
+    return x
+
+
+def test_absolute_value() -> None:
+    """Verify absolute value properties."""
+    x: int = nondet_int()
+    __ESBMC_assume(x > -1000 and x < 1000)  # Avoid overflow
+
+    result = absolute_value(x)
+
+    # Property: result is always non-negative
+    assert result >= 0, "Absolute value is non-negative"
+
+    # Property: result equals x or -x
+    assert result == x or result == -x, "Result is x or -x"
+
+test_absolute_value()

--- a/regression/python/esbmc-module-nondet/test.desc
+++ b/regression/python/esbmc-module-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/esbmc-module-nondet2/main.py
+++ b/regression/python/esbmc-module-nondet2/main.py
@@ -1,0 +1,16 @@
+from esbmc import nondet_list, __ESBMC_assume, __ESBMC_assert
+
+def test_symbolic_list() -> None:
+    lst = nondet_list()
+    __ESBMC_assume(len(lst) >= 0 and len(lst) <= 5)  # constrain length
+
+    # If list is non-empty, ensure first element is int
+    if len(lst) > 0:
+        x = lst[0]  # symbolic element
+        __ESBMC_assert(isinstance(x, int) or isinstance(x, float) or isinstance(x, str),
+                       "First element has valid type")
+
+    # Property: length constraint holds
+    __ESBMC_assert(len(lst) >= 0 and len(lst) <= 5, "List length within bounds")
+
+test_symbolic_list()

--- a/regression/python/esbmc-module-nondet2/test.desc
+++ b/regression/python/esbmc-module-nondet2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/esbmc-module-nondet3/main.py
+++ b/regression/python/esbmc-module-nondet3/main.py
@@ -1,0 +1,17 @@
+from esbmc import nondet_dict, __ESBMC_assume, __ESBMC_assert
+
+def test_symbolic_dict() -> None:
+    d = nondet_dict()
+    __ESBMC_assume(len(d) <= 3)  # constrain size
+
+    # If key exists, check type of value
+    if "key1" in d:
+        v = d["key1"]
+        __ESBMC_assert(isinstance(v, int) or isinstance(v, str),
+                       "Dict value type valid")
+
+    # Property: all keys are strings
+    for k in d.keys():
+        __ESBMC_assert(isinstance(k, str), "All keys are strings")
+
+test_symbolic_dict()

--- a/regression/python/esbmc-module-nondet3/test.desc
+++ b/regression/python/esbmc-module-nondet3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/esbmc-module-nondet4/main.py
+++ b/regression/python/esbmc-module-nondet4/main.py
@@ -1,0 +1,10 @@
+from esbmc import nondet_str, __ESBMC_assume, __ESBMC_assert
+
+def test_symbolic_string() -> None:
+    s = nondet_str()
+    __ESBMC_assume(len(s) <= 10)  # constrain length
+
+    # Property: string length is within bounds
+    __ESBMC_assert(len(s) >= 0 and len(s) <= 10, "String length constraint")
+
+test_symbolic_string()

--- a/regression/python/esbmc-module-nondet4/test.desc
+++ b/regression/python/esbmc-module-nondet4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 16
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/esbmc-module-nondet5/main.py
+++ b/regression/python/esbmc-module-nondet5/main.py
@@ -9,12 +9,12 @@ def test_nondet_all() -> None:
     # --- Integer ---
     x = nondet_int()
     __ESBMC_assume(x > -1000 and x < 1000)
-    __ESBMC_assert(x >= -1000 and x < 1000, "Symbolic int in bounds")
+    __ESBMC_assert(x > -1000 and x < 1000, "Symbolic int in bounds")
 
     # --- Float ---
     f = nondet_float()
     __ESBMC_assume(f > -1000.0 and f < 1000.0)
-    __ESBMC_assert(f > -1000.0 and f < 1000.0, "Symbolic float in bounds")
+    __ESBMC_assert(f >= -1000.0 and f < 1000.0, "Symbolic float in bounds")
 
     # --- Boolean ---
     b = nondet_bool()
@@ -34,6 +34,15 @@ def test_nondet_all() -> None:
         # Type check: allow int, float, or string
         __ESBMC_assert(isinstance(elem, int) or isinstance(elem, float) or isinstance(elem, str),
                        "List element type valid")
+
+    # --- Dict ---
+    d = nondet_dict()
+    __ESBMC_assume(len(d) <= 5)
+    __ESBMC_assert(len(d) >= 0 and len(d) <= 5, "Symbolic dict size")
+    if len(d) > 0:
+        for k in d.keys():
+            # Keys are expected to be strings
+            __ESBMC_assert(isinstance(k, str), "Dict key type valid")
 
 # Run the test
 test_nondet_all()

--- a/regression/python/esbmc-module-nondet5/main.py
+++ b/regression/python/esbmc-module-nondet5/main.py
@@ -1,0 +1,39 @@
+from esbmc import (
+    nondet_int, nondet_float, nondet_bool, nondet_str, nondet_list, nondet_dict,
+    __ESBMC_assume, __ESBMC_assert
+)
+
+def test_nondet_all() -> None:
+    """Verify all symbolic intrinsics in one unified regression."""
+
+    # --- Integer ---
+    x = nondet_int()
+    __ESBMC_assume(x > -1000 and x < 1000)
+    __ESBMC_assert(x >= -1000 and x < 1000, "Symbolic int in bounds")
+
+    # --- Float ---
+    f = nondet_float()
+    __ESBMC_assume(f > -1000.0 and f < 1000.0)
+    __ESBMC_assert(f > -1000.0 and f < 1000.0, "Symbolic float in bounds")
+
+    # --- Boolean ---
+    b = nondet_bool()
+    __ESBMC_assert(b is True or b is False, "Symbolic bool is boolean")
+
+    # --- String ---
+    s = nondet_str()
+    __ESBMC_assume(len(s) <= 10)
+    __ESBMC_assert(len(s) >= 0 and len(s) <= 10, "Symbolic string length")
+
+    # --- List ---
+    lst = nondet_list()
+    __ESBMC_assume(len(lst) <= 5)
+    __ESBMC_assert(len(lst) >= 0 and len(lst) <= 5, "Symbolic list length")
+    if len(lst) > 0:
+        elem = lst[0]
+        # Type check: allow int, float, or string
+        __ESBMC_assert(isinstance(elem, int) or isinstance(elem, float) or isinstance(elem, str),
+                       "List element type valid")
+
+# Run the test
+test_nondet_all()

--- a/regression/python/esbmc-module-nondet5/test.desc
+++ b/regression/python/esbmc-module-nondet5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 16
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/esbmc.py
+++ b/src/python-frontend/models/esbmc.py
@@ -1,0 +1,39 @@
+"""
+ESBMC Python intrinsic stubs.
+
+These functions have no runtime semantics.
+They are intercepted by the ESBMC Python frontend
+and translated into symbolic operations.
+"""
+
+def nondet_int() -> int:
+    """ESBMC intrinsic: returns symbolic int"""
+    pass
+
+def nondet_float() -> float:
+    """ESBMC intrinsic: returns symbolic float"""
+    pass
+
+def nondet_bool() -> bool:
+    """ESBMC intrinsic: returns symbolic bool"""
+    pass
+
+def nondet_str() -> str:
+    """ESBMC intrinsic: returns symbolic string"""
+    pass
+
+def nondet_list() -> list:
+    """ESBMC intrinsic: returns symbolic list"""
+    pass
+
+def nondet_dict() -> dict:
+    """ESBMC intrinsic: returns symbolic dict"""
+    pass
+
+def __ESBMC_assume(cond: bool) -> None:
+    """ESBMC intrinsic: path constraint"""
+    pass
+
+def __ESBMC_assert(cond: bool, msg: str) -> None:
+    """ESBMC intrinsic: verification assertion"""
+    pass

--- a/src/python-frontend/models/esbmc.py
+++ b/src/python-frontend/models/esbmc.py
@@ -1,9 +1,9 @@
 """
 ESBMC Python intrinsic stubs.
 
-These functions have no runtime semantics.
-They are intercepted by the ESBMC Python frontend
-and translated into symbolic operations.
+These functions are replaced with symbolic operations during ESBMC
+verification. The ESBMC Python frontend intercepts them and
+translates them into symbolic operations.
 """
 
 def nondet_int() -> int:

--- a/src/python-frontend/models/esbmc.py
+++ b/src/python-frontend/models/esbmc.py
@@ -6,33 +6,41 @@ verification. The ESBMC Python frontend intercepts them and
 translates them into symbolic operations.
 """
 
+
 def nondet_int() -> int:
     """ESBMC intrinsic: returns symbolic int"""
     pass
+
 
 def nondet_float() -> float:
     """ESBMC intrinsic: returns symbolic float"""
     pass
 
+
 def nondet_bool() -> bool:
     """ESBMC intrinsic: returns symbolic bool"""
     pass
+
 
 def nondet_str() -> str:
     """ESBMC intrinsic: returns symbolic string"""
     pass
 
+
 def nondet_list() -> list:
     """ESBMC intrinsic: returns symbolic list"""
     pass
+
 
 def nondet_dict() -> dict:
     """ESBMC intrinsic: returns symbolic dict"""
     pass
 
+
 def __ESBMC_assume(cond: bool) -> None:
     """ESBMC intrinsic: path constraint"""
     pass
+
 
 def __ESBMC_assert(cond: bool, msg: str) -> None:
     """ESBMC intrinsic: verification assertion"""

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -25,7 +25,7 @@ def check_usage():
         sys.exit(2)
 
 def is_imported_model(module_name):
-    models = ["math", "os", "numpy"]
+    models = ["math", "os", "numpy", "esbmc"]
     return module_name in models
 
 def is_unsupported_module(module_name):


### PR DESCRIPTION
This PR introduces Python frontend support for ESBMC symbolic intrinsics and adds regression tests to validate their behavior. This is needed for our AI agent: https://github.com/esbmc/agent-marketplace.