### PR TITLE
[python] support type inference for nondet_* and Call nodes in list elements

### DIFF
--- a/regression/python/list-nondet/main.py
+++ b/regression/python/list-nondet/main.py
@@ -1,0 +1,9 @@
+A = [nondet_int()]
+
+def f():
+    if A[0] == 1:
+        return 0
+    return None
+
+r = f()
+assert A[r] != 1 or A[r] == 1

--- a/regression/python/list-nondet/test.desc
+++ b/regression/python/list-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-nondet2/main.py
+++ b/regression/python/list-nondet2/main.py
@@ -1,0 +1,11 @@
+x = nondet_int()
+A = [x]
+
+def f():
+    if A[0] == 1:
+        return 0
+    return -2
+
+r = f()
+__ESBMC_assume(r == 0)
+assert A[r] == x

--- a/regression/python/list-nondet2/test.desc
+++ b/regression/python/list-nondet2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-nondet2_fail/main.py
+++ b/regression/python/list-nondet2_fail/main.py
@@ -1,0 +1,10 @@
+x = nondet_int()
+A = [x]
+
+def f():
+    if A[0] == 1:
+        return 0
+    return 2
+
+r = f()
+assert A[r] == x

--- a/regression/python/list-nondet2_fail/test.desc
+++ b/regression/python/list-nondet2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/list-nondet_fail/main.py
+++ b/regression/python/list-nondet_fail/main.py
@@ -1,0 +1,9 @@
+A = [nondet_int()]
+
+def f():
+    if A[0] == 1:
+        return 0
+    return None
+
+r = f()
+assert A[r] == 1

--- a/regression/python/list-nondet_fail/test.desc
+++ b/regression/python/list-nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -453,6 +453,37 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   return empty_typet();
 }
 
+typet type_handler::get_typet_from_call_func(const nlohmann::json &func) const
+{
+  std::string func_name;
+  if (func.contains("id"))
+  {
+    func_name = func["id"].get<std::string>();
+    if (type_utils::is_builtin_type(func_name))
+      return get_typet(func_name);
+  }
+  else if (func["_type"] == "Attribute" && func.contains("attr"))
+  {
+    func_name = func["attr"].get<std::string>();
+    if (func_name == "randint" || func_name == "randrange")
+      return long_long_int_type();
+    if (func_name == "random" || func_name == "uniform")
+      return double_type();
+    if (type_utils::is_builtin_type(func_name))
+      return get_typet(func_name);
+  }
+
+  const std::string nondet_prefix = "nondet_";
+  if (!func_name.empty() && func_name.rfind(nondet_prefix, 0) == 0)
+  {
+    typet t = get_typet(func_name.substr(nondet_prefix.size()));
+    if (t != empty_typet())
+      return t;
+  }
+
+  throw std::runtime_error("Invalid type");
+}
+
 typet type_handler::get_typet(const nlohmann::json &elem) const
 {
   // Handle null/empty values
@@ -549,38 +580,19 @@ typet type_handler::get_typet(const nlohmann::json &elem) const
 
     if (!var.empty() && var.contains("value") && !var["value"].is_null())
     {
-      if (var["value"]["_type"] == "Call")
-      {
-        // Try to handle known patterns before giving up
-        if (var["value"].contains("func"))
-        {
-          const auto &func = var["value"]["func"];
+      if (var["value"]["_type"] != "Call")
+        return get_typet(var["value"]["value"]);
 
-          // Handle simple function calls: func_name()
-          if (func.contains("id") && type_utils::is_builtin_type(func["id"]))
-            return get_typet(func["id"].get<std::string>());
+      if (var["value"].contains("func"))
+        return get_typet_from_call_func(var["value"]["func"]);
 
-          // Handle attribute calls: module.func_name()
-          if (func["_type"] == "Attribute" && func.contains("attr"))
-          {
-            std::string attr_name = func["attr"].get<std::string>();
-            // Handle common cases like random.randint, math.sqrt, etc.
-            if (attr_name == "randint" || attr_name == "randrange")
-              return long_long_int_type();
-            if (attr_name == "random" || attr_name == "uniform")
-              return double_type();
-            if (type_utils::is_builtin_type(attr_name))
-              return get_typet(attr_name);
-          }
-        }
-        throw std::runtime_error("Invalid type");
-      }
-      return get_typet(var["value"]["value"]);
+      throw std::runtime_error("Invalid type");
     }
-
-    // Fallback for cases where variable declaration has no value or is null
     return empty_typet();
   }
+
+  if (elem["_type"] == "Call")
+    return get_typet_from_call_func(elem["func"]);
 
   throw std::runtime_error("Invalid type");
 }

--- a/src/python-frontend/type_handler.h
+++ b/src/python-frontend/type_handler.h
@@ -132,5 +132,8 @@ private:
   /// Get a normalized/canonical type for list element type inference
   typet get_canonical_string_type(const typet &t) const;
 
+  /// Resolves a Call's func node (id or Attribute) to a typet
+  typet get_typet_from_call_func(const nlohmann::json &func) const;
+
   const python_converter &converter_;
 };


### PR DESCRIPTION
This PR refactors `get_typet(const nlohmann::json &)` to resolve the type of list elements initialised with function calls such as `nondet_int()`. 

In particular, it extracts a helper `get_typet_from_call_func()` that handles the func node of a Call AST node, covering:
- builtin type constructors (int(), str(), …)
- common attribute calls (random.randint, random.uniform, …)
- nondet_* functions, inferring the type from the suffix (nondet_int → int)