### PR TITLE
[python] handle try/except ImportError for missing modules

### DIFF
--- a/regression/python/import-error-fail/main.py
+++ b/regression/python/import-error-fail/main.py
@@ -1,0 +1,8 @@
+try:
+    import non_existent_module
+except ImportError:
+    caught = True
+else:
+    caught = False
+
+assert not caught

--- a/regression/python/import-error-fail/test.desc
+++ b/regression/python/import-error-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/import-error/main.py
+++ b/regression/python/import-error/main.py
@@ -1,0 +1,8 @@
+try:
+    import non_existent_module
+except ImportError:
+    caught = True
+else:
+    caught = False
+
+assert caught

--- a/regression/python/import-error/test.desc
+++ b/regression/python/import-error/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-error2/main.py
+++ b/regression/python/import-error2/main.py
@@ -1,0 +1,12 @@
+try:
+    import non_existent_module
+    try:
+        import another_non_existent_module
+    except ImportError:
+        inner_caught = True
+except ImportError:
+    outer_caught = True
+    inner_caught = False
+
+assert outer_caught
+assert not inner_caught

--- a/regression/python/import-error2/test.desc
+++ b/regression/python/import-error2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-error3/main.py
+++ b/regression/python/import-error3/main.py
@@ -1,0 +1,6 @@
+try:
+    import non_existent_module
+except ImportError as e:
+    caught = True
+
+assert caught

--- a/regression/python/import-error3/test.desc
+++ b/regression/python/import-error3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-error4/main.py
+++ b/regression/python/import-error4/main.py
@@ -1,0 +1,7 @@
+try:
+    import non_existent_module
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+assert not HAS_MODULE

--- a/regression/python/import-error4/test.desc
+++ b/regression/python/import-error4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/import-error5-fail/main.py
+++ b/regression/python/import-error5-fail/main.py
@@ -1,0 +1,6 @@
+try:
+    import non_existent_module
+except ImportError as e:
+    caught = True
+
+assert not caught

--- a/regression/python/import-error5-fail/test.desc
+++ b/regression/python/import-error5-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -349,6 +349,7 @@ ESBMC-Python provides modeling and verification capabilities for Python's os mod
 - **Multiple Exception Handlers**: Supports multiple except clauses to handle different exception types.
 - **Exception Catching**: Supports catching exceptions with variable binding using except ExceptionType as variable syntax.
   - **Improved Variable Scope Handling**: Exception variables are declared and scoped within their catch blocks, ensuring correct symbol table management during verification.
+- **ImportError Handling**: Imports guarded by try/except ImportError are handled statically.
 - **Exception Hierarchy**: Implements Python's exception hierarchy where all exceptions inherit from BaseException.
 - **Built-in Exception Classes**:
   - **BaseException**: Base class for all exceptions.
@@ -359,6 +360,7 @@ ESBMC-Python provides modeling and verification capabilities for Python's os mod
   - **IndexError**: Raised for sequence index out of range.
   - **KeyError**: Raised for missing dictionary keys.
   - **ZeroDivisionError**: Raised for division by zero operations.
+  - **ImportError**: Raised when a module cannot be found or imported.
   - **OSError**: Base class for I/O related errors.
   - **FileNotFoundError**: Raised when a file or directory is not found (inherits from OSError).
   - **FileExistsError**: Raised when trying to create a file or directory that already exists (inherits from OSError).

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -152,3 +152,33 @@ class NotImplementedError(RuntimeError):
 
     def __str__(self) -> str:
         return self.message
+
+
+class ImportError(Exception):
+    """Raised when an import statement fails to find the module"""
+    message: str = ""
+    name: str = ""
+    path: str = ""
+
+    def __init__(self, message: str = "Import error", name: str = "", path: str = ""):
+        self.message: str = message
+        self.name: str = name
+        self.path: str = path
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ModuleNotFoundError(ImportError):
+    """Raised when a module cannot be found"""
+    message: str = ""
+    name: str = ""
+    path: str = ""
+
+    def __init__(self, message: str = "Module not found", name: str = "", path: str = ""):
+        self.message: str = message
+        self.name: str = name
+        self.path: str = path
+
+    def __str__(self) -> str:
+        return self.message

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -78,7 +78,7 @@ def import_module_by_name(module_name, output_dir):
 
         print("ERROR: Module '{}' not found.".format(module_name))
         print("Please install it with: pip3 install {}".format(module_name))
-        sys.exit(4)
+        return None
 
 
 def encode_bytes(value):
@@ -214,7 +214,8 @@ def process_imports(node, output_dir):
         else:
             module = import_module_by_name(module_name, output_dir)
             if module is None:
-                # Module doesn't need processing (e.g., typing) - don't set full_path
+                # Mark this import node so the C++ frontend knows the module was not found
+                node.module_not_found = True
                 continue
 
             # Check if module has __file__ attribute (built-in C extensions don't)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6822,16 +6822,48 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
     }
     case StatementType::TRY:
     {
-      exprt new_expr = codet("cpp-catch");
-      exprt try_block = get_block(element["body"]);
-      exprt handler = get_block(element["handlers"]);
-      new_expr.move_to_operands(try_block);
+        // Check if this try block wraps a failed import (module_not_found = true)
+        // and has an ImportError handler. If so, statically take the except branch.
+        bool has_missing_import = false;
+        for (const auto &stmt : element["body"])
+        {
+            if (
+                (stmt["_type"] == "Import" || stmt["_type"] == "ImportFrom") &&
+                stmt.value("module_not_found", false))
+            {
+                has_missing_import = true;
+                break;
+            }
+        }
 
-      for (const auto &op : handler.operands())
-        new_expr.copy_to_operands(op);
+        if (has_missing_import)
+        {
+            for (const auto &handler : element["handlers"])
+            {
+                if (
+                    !handler["type"].is_null() &&
+                    handler["type"].value("id", "") == "ImportError")
+                {
+                    // Directly emit only the except-handler body
+                    exprt except_body = get_block(handler["body"]);
+                    for (const auto &op : except_body.operands())
+                        block.copy_to_operands(op);
+                    break;
+                }
+            }
+            break;
+        }
 
-      block.move_to_operands(new_expr);
-      break;
+        exprt new_expr = codet("cpp-catch");
+        exprt try_block = get_block(element["body"]);
+        exprt handler = get_block(element["handlers"]);
+        new_expr.move_to_operands(try_block);
+
+        for (const auto &op : handler.operands())
+            new_expr.copy_to_operands(op);
+
+        block.move_to_operands(new_expr);
+        break;
     }
     case StatementType::EXCEPTHANDLER:
     {

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6822,48 +6822,48 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
     }
     case StatementType::TRY:
     {
-        // Check if this try block wraps a failed import (module_not_found = true)
-        // and has an ImportError handler. If so, statically take the except branch.
-        bool has_missing_import = false;
-        for (const auto &stmt : element["body"])
+      // Check if this try block wraps a failed import (module_not_found = true)
+      // and has an ImportError handler. If so, statically take the except branch.
+      bool has_missing_import = false;
+      for (const auto &stmt : element["body"])
+      {
+        if (
+          (stmt["_type"] == "Import" || stmt["_type"] == "ImportFrom") &&
+          stmt.value("module_not_found", false))
         {
-            if (
-                (stmt["_type"] == "Import" || stmt["_type"] == "ImportFrom") &&
-                stmt.value("module_not_found", false))
-            {
-                has_missing_import = true;
-                break;
-            }
+          has_missing_import = true;
+          break;
         }
+      }
 
-        if (has_missing_import)
+      if (has_missing_import)
+      {
+        for (const auto &handler : element["handlers"])
         {
-            for (const auto &handler : element["handlers"])
-            {
-                if (
-                    !handler["type"].is_null() &&
-                    handler["type"].value("id", "") == "ImportError")
-                {
-                    // Directly emit only the except-handler body
-                    exprt except_body = get_block(handler["body"]);
-                    for (const auto &op : except_body.operands())
-                        block.copy_to_operands(op);
-                    break;
-                }
-            }
+          if (
+            !handler["type"].is_null() &&
+            handler["type"].value("id", "") == "ImportError")
+          {
+            // Directly emit only the except-handler body
+            exprt except_body = get_block(handler["body"]);
+            for (const auto &op : except_body.operands())
+              block.copy_to_operands(op);
             break;
+          }
         }
-
-        exprt new_expr = codet("cpp-catch");
-        exprt try_block = get_block(element["body"]);
-        exprt handler = get_block(element["handlers"]);
-        new_expr.move_to_operands(try_block);
-
-        for (const auto &op : handler.operands())
-            new_expr.copy_to_operands(op);
-
-        block.move_to_operands(new_expr);
         break;
+      }
+
+      exprt new_expr = codet("cpp-catch");
+      exprt try_block = get_block(element["body"]);
+      exprt handler = get_block(element["handlers"]);
+      new_expr.move_to_operands(try_block);
+
+      for (const auto &op : handler.operands())
+        new_expr.copy_to_operands(op);
+
+      block.move_to_operands(new_expr);
+      break;
     }
     case StatementType::EXCEPTHANDLER:
     {

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -124,7 +124,8 @@ public:
       name == "ZeroDivisionError" || name == "AssertionError" ||
       name == "NameError" || name == "OSError" || name == "FileNotFoundError" ||
       name == "FileExistsError" || name == "PermissionError" ||
-      name == "NotImplementedError");
+      name == "NotImplementedError" || name == "ImportError" ||
+      name == "ModuleNotFoundError" || name == "RuntimeError");
   }
 
   static bool is_c_model_func(const std::string &func_name)


### PR DESCRIPTION
This PR marks imports within `try/except ImportError` blocks with `module_not_found=true` in the AST, rather than calling `sys.exit()`. Our converter detects this in the TRY handler and takes the except branch; this mirrors Python’s runtime behavior when an `ImportError` is caught.

This PR is required by our AI agent: https://github.com/esbmc/agent-marketplace.

