### PR TITLE
[python] extract exception handling into python_exception_handler

### DIFF
--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(pythonfrontend STATIC
             python_class.cpp
             python_class_builder.cpp
             python_dict_handler.cpp
+            python_exception_handler.cpp
             python_lambda.cpp
             python_list.cpp
             python_math.cpp

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -672,7 +672,8 @@ exprt function_call_expr::handle_chr(nlohmann::json &arg) const
       is_constant = true;
     }
     else
-      return converter_.get_exception_handler().gen_exception_raise("TypeError", "Unsupported UnaryOp in chr()");
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", "Unsupported UnaryOp in chr()");
   }
 
   // Handle integer input
@@ -698,7 +699,8 @@ exprt function_call_expr::handle_chr(nlohmann::json &arg) const
     }
     catch (const std::invalid_argument &)
     {
-      return converter_.get_exception_handler().gen_exception_raise("TypeError", "invalid string passed to chr()");
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", "invalid string passed to chr()");
     }
   }
 
@@ -756,7 +758,8 @@ exprt function_call_expr::handle_chr(nlohmann::json &arg) const
     }
     catch (std::invalid_argument &)
     {
-      return converter_.get_exception_handler().gen_exception_raise("TypeError", "must be of type int");
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", "must be of type int");
     }
 
     arg["_type"] = "Constant";
@@ -775,7 +778,8 @@ exprt function_call_expr::handle_chr(nlohmann::json &arg) const
     }
     catch (const std::out_of_range &e)
     {
-      return converter_.get_exception_handler().gen_exception_raise("ValueError", "chr()");
+      return converter_.get_exception_handler().gen_exception_raise(
+        "ValueError", "chr()");
     }
 
     // Build a proper character array, not a single char
@@ -940,7 +944,8 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
         return typecast_exprt(var_expr, int_type());
       }
 
-      return converter_.get_exception_handler().gen_exception_raise("ValueError", "ord() requires a character");
+      return converter_.get_exception_handler().gen_exception_raise(
+        "ValueError", "ord() requires a character");
     }
 
     // Compile-time extraction for constant symbols
@@ -959,7 +964,8 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     arg.erase("ctx");
   }
   else
-    return converter_.get_exception_handler().gen_exception_raise("TypeError", "ord() argument must be a string");
+    return converter_.get_exception_handler().gen_exception_raise(
+      "TypeError", "ord() argument must be a string");
 
   // Replace the arg with the integer value
   arg["value"] = code_point;
@@ -1412,13 +1418,15 @@ exprt function_call_expr::build_constant_from_arg() const
       {
         std::string m = "could not convert string to float : '" +
                         arg["value"].get<std::string>() + "'";
-        return converter_.get_exception_handler().gen_exception_raise("ValueError", m);
+        return converter_.get_exception_handler().gen_exception_raise(
+          "ValueError", m);
       }
       catch (const std::out_of_range &)
       {
         std::string m = "could not convert string to float : '" +
                         arg["value"].get<std::string>() + "' (out of range)";
-        return converter_.get_exception_handler().gen_exception_raise("ValueError", m);
+        return converter_.get_exception_handler().gen_exception_raise(
+          "ValueError", m);
       }
     }
   }
@@ -1439,7 +1447,8 @@ exprt function_call_expr::build_constant_from_arg() const
         std::string m = "float() conversion may fail - variable" + var_name +
                         "may contain non-float string";
 
-        return converter_.get_exception_handler().gen_exception_raise("ValueError", m);
+        return converter_.get_exception_handler().gen_exception_raise(
+          "ValueError", m);
       }
     }
   }
@@ -2061,7 +2070,8 @@ exprt function_call_expr::validate_re_module_args() const
       std::ostringstream msg;
       msg << "expected string or bytes-like object, got '"
           << type_handler_.type_to_string(arg_type) << "'";
-      return converter_.get_exception_handler().gen_exception_raise("TypeError", msg.str());
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", msg.str());
     }
   }
 
@@ -2405,7 +2415,8 @@ function_call_expr::get_dispatch_table()
 
          // Create the exception raise as a code expression
          exprt raise_expr =
-           converter_.get_exception_handler().gen_exception_raise("ValueError", "math domain error");
+           converter_.get_exception_handler().gen_exception_raise(
+             "ValueError", "math domain error");
          locationt loc = converter_.get_location_from_decl(call_);
          raise_expr.location() = loc;
          raise_expr.location().user_provided(true);
@@ -3392,7 +3403,9 @@ exprt function_call_expr::handle_general_function_call()
         msg << func_name << "() missing required positional argument: '"
             << param_name << "'";
 
-        exprt exception = converter_.get_exception_handler().gen_exception_raise("TypeError", msg.str());
+        exprt exception =
+          converter_.get_exception_handler().gen_exception_raise(
+            "TypeError", msg.str());
         locationt loc = converter_.get_location_from_decl(call_);
         exception.location() = loc;
         exception.location().user_provided(true);
@@ -3680,7 +3693,8 @@ exprt function_call_expr::check_argument_types(
       msg << "TypeError: Argument " << (i + 1) << " has incompatible type '"
           << actual_str << "'; expected '" << expected_str << "'";
 
-      exprt exception = converter_.get_exception_handler().gen_exception_raise("TypeError", msg.str());
+      exprt exception = converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", msg.str());
 
       // Add location information from the call
       locationt loc = converter_.get_location_from_decl(call_);
@@ -3727,7 +3741,9 @@ exprt function_call_expr::check_argument_types(
             << "' has incompatible type '" << actual_str << "'; expected '"
             << expected_str << "'";
 
-        exprt exception = converter_.get_exception_handler().gen_exception_raise("TypeError", msg.str());
+        exprt exception =
+          converter_.get_exception_handler().gen_exception_raise(
+            "TypeError", msg.str());
 
         locationt loc = converter_.get_location_from_decl(call_);
         exception.location() = loc;

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -234,12 +234,6 @@ private:
   exprt
   handle_min_max(const std::string &func_name, irep_idt comparison_op) const;
 
-  /*
-   * Convert the exception type to the constructor call
-   * Returns cpp-throw
-   */
-  exprt gen_exception_raise(std::string exc, std::string message) const;
-
   // Dict method detection and handling
   bool is_dict_method_call() const;
   exprt handle_dict_method() const;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -8,6 +8,7 @@
 #include <python-frontend/python_class_builder.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_dict_handler.h>
+#include <python-frontend/python_exception_handler.h>
 #include <python-frontend/python_lambda.h>
 #include <python-frontend/python_list.h>
 #include <python-frontend/python_typechecking.h>
@@ -6446,166 +6447,6 @@ void python_converter::get_return_statements(
   }
 }
 
-symbolt python_converter::create_assert_temp_variable(const locationt &location)
-{
-  symbol_id temp_sid = create_symbol_id();
-  temp_sid.set_object("__assert_temp");
-  std::string temp_sid_str = temp_sid.to_string();
-
-  symbolt temp_symbol;
-  temp_symbol.id = temp_sid_str;
-  temp_symbol.name = temp_sid_str;
-  temp_symbol.type = bool_type();
-  temp_symbol.lvalue = true;
-  temp_symbol.static_lifetime = false;
-  temp_symbol.location = location;
-
-  return temp_symbol;
-}
-
-// function to create function call statement from function call expression
-code_function_callt create_function_call_statement(
-  const exprt &func_call_expr,
-  const exprt &lhs_var,
-  const locationt &location)
-{
-  code_function_callt function_call;
-  function_call.lhs() = lhs_var;
-  function_call.function() = func_call_expr.operands()[1];
-
-  const exprt &args_operand = func_call_expr.operands()[2];
-  code_function_callt::argumentst arguments;
-  for (const auto &arg : args_operand.operands())
-  {
-    arguments.push_back(arg);
-  }
-  function_call.arguments() = arguments;
-  function_call.location() = location;
-
-  return function_call;
-}
-
-void python_converter::handle_list_assertion(
-  const nlohmann::json &element,
-  const exprt &test,
-  code_blockt &block,
-  const std::function<void(code_assertt &)> &attach_assert_message)
-{
-  locationt location = get_location_from_decl(element);
-
-  // Materialize function call if needed
-  exprt list_expr = test;
-  if (test.is_function_call())
-  {
-    // Create temp variable to store function result (pointer to list)
-    symbolt &list_temp =
-      create_tmp_symbol(element, "$list_assert_temp$", test.type(), exprt());
-    code_declt list_decl(symbol_expr(list_temp));
-    list_decl.location() = location;
-    block.move_to_operands(list_decl);
-
-    // Execute function call
-    code_function_callt &func_call =
-      static_cast<code_function_callt &>(const_cast<exprt &>(test));
-    func_call.lhs() = symbol_expr(list_temp);
-    block.move_to_operands(func_call);
-
-    list_expr = symbol_expr(list_temp);
-  }
-
-  // Get list size using __ESBMC_list_size
-  const symbolt *size_sym = symbol_table_.find_symbol("c:@F@__ESBMC_list_size");
-  if (!size_sym)
-    throw std::runtime_error("__ESBMC_list_size function not found");
-
-  // Create temp var to store size
-  symbolt &size_result = create_tmp_symbol(
-    element, "$list_size_result$", size_type(), gen_zero(size_type()));
-  code_declt size_decl(symbol_expr(size_result));
-  size_decl.location() = location;
-  block.move_to_operands(size_decl);
-
-  // Call list_size(list)
-  code_function_callt size_func_call;
-  size_func_call.function() = symbol_expr(*size_sym);
-  if (list_expr.type().is_pointer())
-    size_func_call.arguments().push_back(list_expr);
-  else
-    size_func_call.arguments().push_back(address_of_exprt(list_expr));
-  size_func_call.lhs() = symbol_expr(size_result);
-  size_func_call.type() = size_type();
-  size_func_call.location() = location;
-  block.move_to_operands(size_func_call);
-
-  // Assert size > 0
-  exprt assertion(">", bool_type());
-  assertion.copy_to_operands(symbol_expr(size_result), gen_zero(size_type()));
-
-  code_assertt assert_code;
-  assert_code.assertion() = assertion;
-  assert_code.location() = location;
-  attach_assert_message(assert_code);
-  block.move_to_operands(assert_code);
-}
-
-void python_converter::handle_function_call_assertion(
-  const nlohmann::json &element,
-  const exprt &func_call_expr,
-  bool is_negated,
-  code_blockt &block,
-  const std::function<void(code_assertt &)> &attach_assert_message)
-{
-  locationt location = get_location_from_decl(element);
-
-  // Check if function returns None
-  const typet &return_type = func_call_expr.type();
-
-  if (return_type == none_type() || return_type.id() == "empty")
-  {
-    // Function returns None: execute call and assert False
-    exprt func_call_copy = func_call_expr;
-    codet code_stmt = convert_expression_to_code(func_call_copy);
-    block.move_to_operands(code_stmt);
-
-    code_assertt assert_code;
-    assert_code.assertion() = false_exprt();
-    assert_code.location() = location;
-    assert_code.location().comment("Assertion on None-returning function");
-    attach_assert_message(assert_code);
-    block.move_to_operands(assert_code);
-    return;
-  }
-
-  // Create temporary variable
-  symbolt temp_symbol = create_assert_temp_variable(location);
-  symbol_table_.add(temp_symbol);
-  exprt temp_var_expr = symbol_expr(temp_symbol);
-
-  // Create function call statement
-  code_function_callt function_call =
-    create_function_call_statement(func_call_expr, temp_var_expr, location);
-  block.move_to_operands(function_call);
-
-  // Create assertion based on negation
-  exprt assertion_expr;
-  if (is_negated)
-  {
-    assertion_expr = not_exprt(temp_var_expr);
-  }
-  else
-  {
-    exprt cast_expr = typecast_exprt(temp_var_expr, signedbv_typet(32));
-    exprt one_expr = constant_exprt("1", signedbv_typet(32));
-    assertion_expr = equality_exprt(cast_expr, one_expr);
-  }
-
-  code_assertt assert_code;
-  assert_code.assertion() = assertion_expr;
-  assert_code.location() = location;
-  attach_assert_message(assert_code);
-  block.move_to_operands(assert_code);
-}
-
 exprt python_converter::get_block(const nlohmann::json &ast_block)
 {
   code_blockt block, *old_block = current_block;
@@ -6735,9 +6576,10 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
       if (
         test.type() == type_handler_.get_list_type() ||
         (test.type().is_pointer() &&
-         test.type().subtype() == type_handler_.get_list_type()))
+        test.type().subtype() == type_handler_.get_list_type()))
       {
-        handle_list_assertion(element, test, block, attach_assert_message);
+        exception_handler_->handle_list_assertion(
+          element, test, block, attach_assert_message);
         break;
       }
 
@@ -6763,7 +6605,7 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
 
       if (func_call_expr != nullptr)
       {
-        handle_function_call_assertion(
+        exception_handler_->handle_function_call_assertion(
           element, *func_call_expr, is_negated, block, attach_assert_message);
       }
       else
@@ -6822,208 +6664,17 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
     }
     case StatementType::TRY:
     {
-      // Check if this try block wraps a failed import (module_not_found = true)
-      // and has an ImportError handler. If so, statically take the except branch.
-      bool has_missing_import = false;
-      for (const auto &stmt : element["body"])
-      {
-        if (
-          (stmt["_type"] == "Import" || stmt["_type"] == "ImportFrom") &&
-          stmt.value("module_not_found", false))
-        {
-          has_missing_import = true;
-          break;
-        }
-      }
-
-      if (has_missing_import)
-      {
-        for (const auto &handler : element["handlers"])
-        {
-          if (
-            !handler["type"].is_null() &&
-            handler["type"].value("id", "") == "ImportError")
-          {
-            // Directly emit only the except-handler body
-            exprt except_body = get_block(handler["body"]);
-            for (const auto &op : except_body.operands())
-              block.copy_to_operands(op);
-            break;
-          }
-        }
-        break;
-      }
-
-      exprt new_expr = codet("cpp-catch");
-      exprt try_block = get_block(element["body"]);
-      exprt handler = get_block(element["handlers"]);
-      new_expr.move_to_operands(try_block);
-
-      for (const auto &op : handler.operands())
-        new_expr.copy_to_operands(op);
-
-      block.move_to_operands(new_expr);
+      exception_handler_->get_try_statement(element, block);
       break;
     }
     case StatementType::EXCEPTHANDLER:
     {
-      symbolt *exception_symbol = nullptr;
-      typet exception_type;
-
-      // Create exception variable symbol before processing body
-      if (!element["type"].is_null())
-      {
-        exception_type =
-          type_handler_.get_typet(element["type"]["id"].get<std::string>());
-
-        std::string name;
-        symbol_id sid = create_symbol_id();
-        locationt location = get_location_from_decl(element);
-        std::string module_name = location.get_file().as_string();
-        // Check if the exception handler binds the exception to a variable
-        if (!element["name"].is_null())
-          name = element["name"].get<std::string>();
-        else
-          name = "__anon_exc_var_" + location.get_line().as_string();
-
-        sid.set_object(name);
-        // Create and add symbol to symbol table
-        symbolt symbol = create_symbol(
-          module_name,
-          current_func_name_,
-          sid.to_string(),
-          location,
-          exception_type);
-        symbol.name = name;
-        symbol.lvalue = true;
-        symbol.is_extern = false;
-        symbol.file_local = false;
-        exception_symbol = symbol_table_.move_symbol_to_context(symbol);
-      }
-
-      // Process exception handler body (symbol now exists)
-      exprt catch_block = get_block(element["body"]);
-
-      // Add type and declaration if exception variable was created
-      if (exception_symbol != nullptr)
-      {
-        catch_block.type() = exception_type;
-        exprt sym = symbol_expr(*exception_symbol);
-        code_declt decl(sym);
-        exprt decl_code = convert_expression_to_code(decl);
-        decl_code.location() = exception_symbol->location;
-
-        codet::operandst &ops = catch_block.operands();
-        ops.insert(ops.begin(), decl_code);
-      }
-
-      block.move_to_operands(catch_block);
+      exception_handler_->get_except_handler_statement(element, block);
       break;
     }
     case StatementType::RAISE:
     {
-      std::string exc_name;
-      // Try to extract the exception name from different AST shapes
-      if (
-        element["exc"].contains("func") &&
-        element["exc"]["func"].contains("id"))
-        exc_name = element["exc"]["func"]["id"].get<std::string>();
-      else if (element["exc"].contains("id"))
-        exc_name = element["exc"]["id"].get<std::string>();
-      else if (element["exc"].is_string())
-        exc_name = element["exc"].get<std::string>();
-      else
-        exc_name = ""; // fallback
-
-      locationt location = get_location_from_decl(element);
-      typet type = type_handler_.get_typet(exc_name);
-
-      if (exc_name == "AssertionError")
-      {
-        code_assertt assert_code{false_exprt()};
-        assert_code.location() = location;
-        if (
-          element["exc"].contains("args") && !element["exc"]["args"].empty() &&
-          !element["exc"]["args"][0].is_null())
-        {
-          const std::string msg =
-            string_handler_.process_format_spec(element["exc"]["args"][0]);
-          assert_code.location().comment(msg);
-        }
-        block.move_to_operands(assert_code);
-        break;
-      }
-
-      exprt raise;
-      if (type_utils::is_python_exceptions(exc_name))
-      {
-        // Construct a constant struct to throw:
-        // raise { .message=&"Error message" }
-
-        exprt arg;
-        // Check if args exists and is not empty before accessing
-        const auto &exc = element["exc"];
-        if (
-          exc.contains("args") && !exc["args"].empty() &&
-          !exc["args"][0].is_null())
-        {
-          const auto &json_arg = exc["args"][0];
-          exprt tmp = get_expr(json_arg);
-          arg = string_constantt(
-            string_handler_.process_format_spec(json_arg),
-            tmp.type(),
-            string_constantt::k_default);
-        }
-        else
-        {
-          // No arguments provided, create default empty message
-          arg = string_constantt(
-            "",
-            type_handler_.build_array(char_type(), 1),
-            string_constantt::k_default);
-        }
-
-        raise.id("struct");
-        raise.type() = type;
-        raise.copy_to_operands(address_of_exprt(arg));
-      }
-      else
-      {
-        // For custom exceptions:
-        // DECL MyException return_value;
-        // FUNCTION_CALL:  MyException(&return_value, &"message");
-        // Throw MyException return_value;
-        raise = get_expr(element["exc"]);
-        // Check if this is a constructor call
-        if (raise.is_code() && raise.get("statement") == "function_call")
-        {
-          code_function_callt call =
-            to_code_function_call(convert_expression_to_code(raise));
-          side_effect_expr_function_callt tmp;
-          tmp.function() = call.function();
-          tmp.arguments() = call.arguments();
-          tmp.type() = type;
-          tmp.location() = location;
-          raise = tmp;
-        }
-        else
-        {
-          // Use a generic type if no specific type was found
-          if (type.is_empty())
-            type = any_type();
-          // Typecast to match throw type
-          if (raise.type() != type)
-            raise = typecast_exprt(raise, type);
-        }
-      }
-
-      side_effect_exprt side("cpp-throw", type);
-      side.location() = location;
-      side.move_to_operands(raise);
-
-      codet code_expr("expression");
-      code_expr.operands().push_back(side);
-      block.move_to_operands(code_expr);
+      exception_handler_->get_raise_statement(element, block);
       break;
     }
     case StatementType::DELETE:
@@ -7096,7 +6747,8 @@ python_converter::python_converter(
     tuple_handler_(new tuple_handler(*this, type_handler_)),
     dict_handler_(new python_dict_handler(*this, symbol_table_, type_handler_)),
     typechecker_(new python_typechecking(*this)),
-    lambda_handler_(new python_lambda(*this, _context, type_handler_))
+    lambda_handler_(new python_lambda(*this, _context, type_handler_)),
+    exception_handler_(new python_exception_handler(*this, type_handler_))
 {
 }
 
@@ -7107,6 +6759,7 @@ python_converter::~python_converter()
   delete dict_handler_;
   delete typechecker_;
   delete lambda_handler_;
+  delete exception_handler_;
 }
 
 python_typechecking &python_converter::get_typechecker()

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6576,7 +6576,7 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
       if (
         test.type() == type_handler_.get_list_type() ||
         (test.type().is_pointer() &&
-        test.type().subtype() == type_handler_.get_list_type()))
+         test.type().subtype() == type_handler_.get_list_type()))
       {
         exception_handler_->handle_list_assertion(
           element, test, block, attach_assert_message);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -28,6 +28,7 @@ class tuple_handler;
 class python_typechecking;
 class python_class_builder;
 class python_lambda;
+class python_exception_handler;
 
 /**
  * @class python_converter
@@ -94,6 +95,16 @@ public:
   python_dict_handler *get_dict_handler()
   {
     return dict_handler_;
+  }
+
+  python_exception_handler &get_exception_handler()
+  {
+    return *exception_handler_;
+  }
+
+  const python_exception_handler &get_exception_handler() const
+  {
+    return *exception_handler_;
   }
 
   python_math &get_math_handler()
@@ -219,6 +230,7 @@ private:
   friend class python_class_builder;
   friend class python_dict_handler;
   friend class python_set;
+  friend class python_exception_handler;
 
   template <typename Func>
   decltype(auto) with_ast(const nlohmann::json *new_ast, Func &&f)
@@ -262,8 +274,6 @@ private:
   exprt get_function_constant_return(const exprt &func_value);
 
   exprt resolve_function_call(const exprt &func_expr, const exprt &args_expr);
-
-  symbolt create_assert_temp_variable(const locationt &location);
 
   exprt get_lambda_expr(const nlohmann::json &element);
 
@@ -435,48 +445,6 @@ private:
 
   void
   get_delete_statement(const nlohmann::json &ast_node, codet &target_block);
-
-  // =========================================================================
-  // Assertion helper methods
-  // =========================================================================
-
-  /**
-   * @brief Handles assertions on list expressions.
-   *
-   * In Python, empty lists are falsy, so `assert []` should fail.
-   * This method converts `assert list_var` to `assert len(list_var) > 0`
-   * by calling __ESBMC_list_size and checking the result.
-   *
-   * @param element The assertion AST node.
-   * @param test The test expression (a list or list-returning function call).
-   * @param block The code block to add generated statements to.
-   * @param attach_assert_message Lambda to attach user assertion messages.
-   */
-  void handle_list_assertion(
-    const nlohmann::json &element,
-    const exprt &test,
-    code_blockt &block,
-    const std::function<void(code_assertt &)> &attach_assert_message);
-
-  /**
-   * @brief Handles assertions on function call expressions.
-   *
-   * Materializes function calls in assertions.
-   * For None-returning functions, executes the call and asserts False.
-   * For other functions, stores result in temp var and asserts on that.
-   *
-   * @param element The assertion AST node.
-   * @param func_call_expr The function call expression to assert on.
-   * @param is_negated Whether the assertion is negated (assert not func()).
-   * @param block The code block to add generated statements to.
-   * @param attach_assert_message Lambda to attach user assertion messages.
-   */
-  void handle_function_call_assertion(
-    const nlohmann::json &element,
-    const exprt &func_call_expr,
-    bool is_negated,
-    code_blockt &block,
-    const std::function<void(code_assertt &)> &attach_assert_message);
 
   // =========================================================================
   // Helper methods for get_var_assign
@@ -864,6 +832,7 @@ private:
   python_dict_handler *dict_handler_;
   python_typechecking *typechecker_ = nullptr;
   python_lambda *lambda_handler_;
+  python_exception_handler *exception_handler_;
 
   bool is_converting_lhs = false;
   bool is_converting_rhs = false;

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -83,9 +83,7 @@ void python_exception_handler::get_raise_statement(
   std::string exc_name;
 
   // Try to extract the exception name from different AST shapes
-  if (
-    element["exc"].contains("func") &&
-    element["exc"]["func"].contains("id"))
+  if (element["exc"].contains("func") && element["exc"]["func"].contains("id"))
     exc_name = element["exc"]["func"]["id"].get<std::string>();
   else if (element["exc"].contains("id"))
     exc_name = element["exc"]["id"].get<std::string>();
@@ -122,8 +120,7 @@ void python_exception_handler::get_raise_statement(
     exprt arg;
     const auto &exc = element["exc"];
     if (
-      exc.contains("args") && !exc["args"].empty() &&
-      !exc["args"][0].is_null())
+      exc.contains("args") && !exc["args"].empty() && !exc["args"][0].is_null())
     {
       const auto &json_arg = exc["args"][0];
       exprt tmp = converter_.get_expr(json_arg);

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -1,0 +1,409 @@
+#include <python-frontend/python_exception_handler.h>
+#include <python-frontend/exception_utils.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/python_list.h>
+#include <python-frontend/string_builder.h>
+#include <python-frontend/symbol_id.h>
+#include <python-frontend/type_handler.h>
+#include <python-frontend/type_utils.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/expr_util.h>
+#include <util/message.h>
+#include <util/python_types.h>
+#include <util/std_code.h>
+#include <util/string_constant.h>
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+python_exception_handler::python_exception_handler(
+  python_converter &converter,
+  type_handler &type_handler)
+  : converter_(converter), type_handler_(type_handler)
+{
+}
+
+// ---------------------------------------------------------------------------
+// Statement converters
+// ---------------------------------------------------------------------------
+
+void python_exception_handler::get_try_statement(
+  const nlohmann::json &element,
+  codet &block)
+{
+  // Check if this try block wraps a failed import (module_not_found = true)
+  // and has an ImportError handler.  If so, statically take the except branch.
+  bool has_missing_import = false;
+  for (const auto &stmt : element["body"])
+  {
+    if (
+      (stmt["_type"] == "Import" || stmt["_type"] == "ImportFrom") &&
+      stmt.value("module_not_found", false))
+    {
+      has_missing_import = true;
+      break;
+    }
+  }
+
+  if (has_missing_import)
+  {
+    for (const auto &handler : element["handlers"])
+    {
+      if (
+        !handler["type"].is_null() &&
+        handler["type"].value("id", "") == "ImportError")
+      {
+        // Directly emit only the except-handler body
+        exprt except_body = converter_.get_block(handler["body"]);
+        for (const auto &op : except_body.operands())
+          block.copy_to_operands(op);
+        break;
+      }
+    }
+    return;
+  }
+
+  exprt new_expr = codet("cpp-catch");
+  exprt try_block = converter_.get_block(element["body"]);
+  exprt handler = converter_.get_block(element["handlers"]);
+  new_expr.move_to_operands(try_block);
+
+  for (const auto &op : handler.operands())
+    new_expr.copy_to_operands(op);
+
+  block.move_to_operands(new_expr);
+}
+
+void python_exception_handler::get_raise_statement(
+  const nlohmann::json &element,
+  codet &block)
+{
+  std::string exc_name;
+
+  // Try to extract the exception name from different AST shapes
+  if (
+    element["exc"].contains("func") &&
+    element["exc"]["func"].contains("id"))
+    exc_name = element["exc"]["func"]["id"].get<std::string>();
+  else if (element["exc"].contains("id"))
+    exc_name = element["exc"]["id"].get<std::string>();
+  else if (element["exc"].is_string())
+    exc_name = element["exc"].get<std::string>();
+  else
+    exc_name = ""; // fallback
+
+  locationt location = converter_.get_location_from_decl(element);
+  typet type = type_handler_.get_typet(exc_name);
+
+  // AssertionError is special-cased to a clean assert(false)
+  if (exc_name == "AssertionError")
+  {
+    code_assertt assert_code{false_exprt()};
+    assert_code.location() = location;
+    if (
+      element["exc"].contains("args") && !element["exc"]["args"].empty() &&
+      !element["exc"]["args"][0].is_null())
+    {
+      const std::string msg =
+        converter_.get_string_handler().process_format_spec(
+          element["exc"]["args"][0]);
+      assert_code.location().comment(msg);
+    }
+    block.move_to_operands(assert_code);
+    return;
+  }
+
+  exprt raise;
+  if (type_utils::is_python_exceptions(exc_name))
+  {
+    // Construct a constant struct to throw: raise { .message=&"Error message" }
+    exprt arg;
+    const auto &exc = element["exc"];
+    if (
+      exc.contains("args") && !exc["args"].empty() &&
+      !exc["args"][0].is_null())
+    {
+      const auto &json_arg = exc["args"][0];
+      exprt tmp = converter_.get_expr(json_arg);
+      arg = string_constantt(
+        converter_.get_string_handler().process_format_spec(json_arg),
+        tmp.type(),
+        string_constantt::k_default);
+    }
+    else
+    {
+      // No arguments: create default empty message
+      arg = string_constantt(
+        "",
+        type_handler_.build_array(char_type(), 1),
+        string_constantt::k_default);
+    }
+
+    raise.id("struct");
+    raise.type() = type;
+    raise.copy_to_operands(address_of_exprt(arg));
+  }
+  else
+  {
+    // For custom exceptions:
+    // DECL MyException return_value;
+    // FUNCTION_CALL:  MyException(&return_value, &"message");
+    // Throw MyException return_value;
+    raise = converter_.get_expr(element["exc"]);
+    if (raise.is_code() && raise.get("statement") == "function_call")
+    {
+      code_function_callt call =
+        to_code_function_call(converter_.convert_expression_to_code(raise));
+      side_effect_expr_function_callt tmp;
+      tmp.function() = call.function();
+      tmp.arguments() = call.arguments();
+      tmp.type() = type;
+      tmp.location() = location;
+      raise = tmp;
+    }
+    else
+    {
+      if (type.is_empty())
+        type = any_type();
+      if (raise.type() != type)
+        raise = typecast_exprt(raise, type);
+    }
+  }
+
+  side_effect_exprt side("cpp-throw", type);
+  side.location() = location;
+  side.move_to_operands(raise);
+
+  codet code_expr("expression");
+  code_expr.operands().push_back(side);
+  block.move_to_operands(code_expr);
+}
+
+void python_exception_handler::get_except_handler_statement(
+  const nlohmann::json &element,
+  codet &block)
+{
+  symbolt *exception_symbol = nullptr;
+  typet exception_type;
+
+  // Create exception variable symbol before processing body
+  if (!element["type"].is_null())
+  {
+    exception_type =
+      type_handler_.get_typet(element["type"]["id"].get<std::string>());
+
+    std::string name;
+    symbol_id sid = converter_.create_symbol_id();
+    locationt location = converter_.get_location_from_decl(element);
+    std::string module_name = location.get_file().as_string();
+
+    // Check if the exception handler binds the exception to a variable
+    if (!element["name"].is_null())
+      name = element["name"].get<std::string>();
+    else
+      name = "__anon_exc_var_" + location.get_line().as_string();
+
+    sid.set_object(name);
+
+    symbolt symbol = converter_.create_symbol(
+      module_name,
+      converter_.current_function_name(),
+      sid.to_string(),
+      location,
+      exception_type);
+    symbol.name = name;
+    symbol.lvalue = true;
+    symbol.is_extern = false;
+    symbol.file_local = false;
+    exception_symbol = converter_.symbol_table().move_symbol_to_context(symbol);
+  }
+
+  // Process exception handler body (symbol now exists)
+  exprt catch_block = converter_.get_block(element["body"]);
+
+  // Add type and declaration if exception variable was created
+  if (exception_symbol != nullptr)
+  {
+    catch_block.type() = exception_type;
+    exprt sym = symbol_expr(*exception_symbol);
+    code_declt decl(sym);
+    exprt decl_code = converter_.convert_expression_to_code(decl);
+    decl_code.location() = exception_symbol->location;
+
+    codet::operandst &ops = catch_block.operands();
+    ops.insert(ops.begin(), decl_code);
+  }
+
+  block.move_to_operands(catch_block);
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
+
+void python_exception_handler::handle_list_assertion(
+  const nlohmann::json &element,
+  const exprt &test,
+  code_blockt &block,
+  const std::function<void(code_assertt &)> &attach_assert_message)
+{
+  locationt location = converter_.get_location_from_decl(element);
+
+  // Materialise function call if needed
+  exprt list_expr = test;
+  if (test.is_function_call())
+  {
+    symbolt &list_temp = converter_.create_tmp_symbol(
+      element, "$list_assert_temp$", test.type(), exprt());
+    code_declt list_decl(symbol_expr(list_temp));
+    list_decl.location() = location;
+    block.move_to_operands(list_decl);
+
+    code_function_callt &func_call =
+      static_cast<code_function_callt &>(const_cast<exprt &>(test));
+    func_call.lhs() = symbol_expr(list_temp);
+    block.move_to_operands(func_call);
+
+    list_expr = symbol_expr(list_temp);
+  }
+
+  // Get list size via __ESBMC_list_size
+  const symbolt *size_sym =
+    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
+  if (!size_sym)
+    throw std::runtime_error("__ESBMC_list_size function not found");
+
+  symbolt &size_result = converter_.create_tmp_symbol(
+    element, "$list_size_result$", size_type(), gen_zero(size_type()));
+  code_declt size_decl(symbol_expr(size_result));
+  size_decl.location() = location;
+  block.move_to_operands(size_decl);
+
+  code_function_callt size_func_call;
+  size_func_call.function() = symbol_expr(*size_sym);
+  if (list_expr.type().is_pointer())
+    size_func_call.arguments().push_back(list_expr);
+  else
+    size_func_call.arguments().push_back(address_of_exprt(list_expr));
+  size_func_call.lhs() = symbol_expr(size_result);
+  size_func_call.type() = size_type();
+  size_func_call.location() = location;
+  block.move_to_operands(size_func_call);
+
+  // Assert size > 0
+  exprt assertion(">", bool_type());
+  assertion.copy_to_operands(symbol_expr(size_result), gen_zero(size_type()));
+
+  code_assertt assert_code;
+  assert_code.assertion() = assertion;
+  assert_code.location() = location;
+  attach_assert_message(assert_code);
+  block.move_to_operands(assert_code);
+}
+
+void python_exception_handler::handle_function_call_assertion(
+  const nlohmann::json &element,
+  const exprt &func_call_expr,
+  bool is_negated,
+  code_blockt &block,
+  const std::function<void(code_assertt &)> &attach_assert_message)
+{
+  locationt location = converter_.get_location_from_decl(element);
+  const typet &return_type = func_call_expr.type();
+
+  if (return_type == none_type() || return_type.id() == "empty")
+  {
+    // Function returns None: execute call and assert False
+    exprt func_call_copy = func_call_expr;
+    codet code_stmt = converter_.convert_expression_to_code(func_call_copy);
+    block.move_to_operands(code_stmt);
+
+    code_assertt assert_code;
+    assert_code.assertion() = false_exprt();
+    assert_code.location() = location;
+    assert_code.location().comment("Assertion on None-returning function");
+    attach_assert_message(assert_code);
+    block.move_to_operands(assert_code);
+    return;
+  }
+
+  symbolt temp_symbol = create_assert_temp_variable(location);
+  converter_.symbol_table().add(temp_symbol);
+  exprt temp_var_expr = symbol_expr(temp_symbol);
+
+  code_function_callt function_call =
+    create_function_call_statement(func_call_expr, temp_var_expr, location);
+  block.move_to_operands(function_call);
+
+  exprt assertion_expr;
+  if (is_negated)
+  {
+    assertion_expr = not_exprt(temp_var_expr);
+  }
+  else
+  {
+    exprt cast_expr = typecast_exprt(temp_var_expr, signedbv_typet(32));
+    exprt one_expr = constant_exprt("1", signedbv_typet(32));
+    assertion_expr = equality_exprt(cast_expr, one_expr);
+  }
+
+  code_assertt assert_code;
+  assert_code.assertion() = assertion_expr;
+  assert_code.location() = location;
+  attach_assert_message(assert_code);
+  block.move_to_operands(assert_code);
+}
+
+// ---------------------------------------------------------------------------
+// Expression helper
+// ---------------------------------------------------------------------------
+
+exprt python_exception_handler::gen_exception_raise(
+  const std::string &exc,
+  const std::string &message) const
+{
+  return python_exception_utils::make_exception_raise(
+    type_handler_, exc, message, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+symbolt python_exception_handler::create_assert_temp_variable(
+  const locationt &location) const
+{
+  symbol_id temp_sid = converter_.create_symbol_id();
+  temp_sid.set_object("__assert_temp");
+  const std::string temp_sid_str = temp_sid.to_string();
+
+  symbolt temp_symbol;
+  temp_symbol.id = temp_sid_str;
+  temp_symbol.name = temp_sid_str;
+  temp_symbol.type = bool_type();
+  temp_symbol.lvalue = true;
+  temp_symbol.static_lifetime = false;
+  temp_symbol.location = location;
+  return temp_symbol;
+}
+
+code_function_callt python_exception_handler::create_function_call_statement(
+  const exprt &func_call_expr,
+  const exprt &lhs_var,
+  const locationt &location)
+{
+  code_function_callt function_call;
+  function_call.lhs() = lhs_var;
+  function_call.function() = func_call_expr.operands()[1];
+
+  const exprt &args_operand = func_call_expr.operands()[2];
+  code_function_callt::argumentst arguments;
+  for (const auto &arg : args_operand.operands())
+    arguments.push_back(arg);
+
+  function_call.arguments() = arguments;
+  function_call.location() = location;
+  return function_call;
+}

--- a/src/python-frontend/python_exception_handler.h
+++ b/src/python-frontend/python_exception_handler.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <util/std_code.h>
+#include <util/expr.h>
+#include <util/message.h>
+
+#include <nlohmann/json.hpp>
+#include <functional>
+#include <string>
+
+class python_converter;
+class type_handler;
+
+/**
+ * @brief Handles Python exception-related statement conversion.
+ *
+ * Centralises all try/except/raise statement conversion and exception
+ * expression helpers that were previously scattered across python_converter
+ * and function_call_expr.  Keeping exception logic here makes python_converter
+ * easier to read and makes it straightforward to extend exception support in
+ * one place.
+ */
+class python_exception_handler
+{
+public:
+  explicit python_exception_handler(
+    python_converter &converter,
+    type_handler &type_handler);
+
+  // -----------------------------------------------------------------------
+  // Statement converters (called from python_converter::get_block)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Convert a Python try/except block.
+   *
+   * Handles the special case where the try body contains a failed import
+   * (module_not_found flag set by the pre-processor) and statically selects
+   * only the ImportError handler body.  For all other cases the full
+   * cpp-catch IR node is produced.
+   *
+   * @param element  The AST node with _type == "Try".
+   * @param block    The target code block to receive the converted statement.
+   */
+  void get_try_statement(const nlohmann::json &element, codet &block);
+
+  /**
+   * Convert a Python raise statement.
+   *
+   * Raises are lowered to side-effect cpp-throw expressions.  AssertionError
+   * is special-cased to a code_assertt(false) for cleaner verification output.
+   *
+   * @param element  The AST node with _type == "Raise".
+   * @param block    The target code block to receive the converted statement.
+   */
+  void get_raise_statement(const nlohmann::json &element, codet &block);
+
+  /**
+   * Convert a Python except-handler clause.
+   *
+   * Creates a symbol for the bound exception variable (if any), processes the
+   * handler body and prepends the declaration.
+   *
+   * @param element  The AST node with _type == "ExceptHandler".
+   * @param block    The target code block to receive the converted statement.
+   */
+  void get_except_handler_statement(
+    const nlohmann::json &element,
+    codet &block);
+
+  // -----------------------------------------------------------------------
+  // Assertion helpers (previously python_converter private methods)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Emit a truthiness assertion on a list value.
+   *
+   * Materialises the list (handling function-call RHS), calls
+   * __ESBMC_list_size and asserts size > 0.
+   *
+   * @param element              AST node used for location information.
+   * @param test                 Expression representing the list.
+   * @param block                Target block.
+   * @param attach_assert_message Callback that sets the comment on the
+   *                             produced code_assertt.
+   */
+  void handle_list_assertion(
+    const nlohmann::json &element,
+    const exprt &test,
+    code_blockt &block,
+    const std::function<void(code_assertt &)> &attach_assert_message);
+
+  /**
+   * Emit an assertion whose condition depends on a function-call result.
+   *
+   * Creates a temporary boolean variable, executes the call and asserts the
+   * result (or its negation when @p is_negated is true).  For functions that
+   * return None the call is executed and then False is asserted.
+   *
+   * @param element              AST node used for location information.
+   * @param func_call_expr       The function-call expression.
+   * @param is_negated           True when the test was wrapped in a UnaryOp Not.
+   * @param block                Target block.
+   * @param attach_assert_message Callback to set the assertion comment.
+   */
+  void handle_function_call_assertion(
+    const nlohmann::json &element,
+    const exprt &func_call_expr,
+    bool is_negated,
+    code_blockt &block,
+    const std::function<void(code_assertt &)> &attach_assert_message);
+
+  // -----------------------------------------------------------------------
+  // Expression helpers (previously function_call_expr / exception_utils)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Build a cpp-throw side-effect expression for a named Python exception.
+   *
+   * @param exc     Exception class name, e.g. "TypeError".
+   * @param message Human-readable message string.
+   * @return        A side_effect_exprt of type cpp-throw.
+   */
+  exprt gen_exception_raise(
+    const std::string &exc,
+    const std::string &message) const;
+
+private:
+  python_converter &converter_;
+  type_handler &type_handler_;
+
+  // ------------------------------------------------------------------
+  // Internal helpers
+  // ------------------------------------------------------------------
+
+  /** Create a temporary boolean symbol used by assertion helpers. */
+  symbolt create_assert_temp_variable(const locationt &location) const;
+
+  /**
+   * Build a code_function_callt for a function-call expression, setting the
+   * provided @p lhs_var as the return destination.
+   */
+  static code_function_callt create_function_call_statement(
+    const exprt &func_call_expr,
+    const exprt &lhs_var,
+    const locationt &location);
+};

--- a/src/python-frontend/python_exception_handler.h
+++ b/src/python-frontend/python_exception_handler.h
@@ -64,9 +64,8 @@ public:
    * @param element  The AST node with _type == "ExceptHandler".
    * @param block    The target code block to receive the converted statement.
    */
-  void get_except_handler_statement(
-    const nlohmann::json &element,
-    codet &block);
+  void
+  get_except_handler_statement(const nlohmann::json &element, codet &block);
 
   // -----------------------------------------------------------------------
   // Assertion helpers (previously python_converter private methods)
@@ -121,9 +120,8 @@ public:
    * @param message Human-readable message string.
    * @return        A side_effect_exprt of type cpp-throw.
    */
-  exprt gen_exception_raise(
-    const std::string &exc,
-    const std::string &message) const;
+  exprt
+  gen_exception_raise(const std::string &exc, const std::string &message) const;
 
 private:
   python_converter &converter_;


### PR DESCRIPTION
This PR moves `try/except/raise` conversion, assertion helpers, and `gen_exception_raise` out of `python_converter` and `function_call_expr` into a dedicated `python_exception_handler` class, consistent with the existing handler pattern.