### PR TITLE
Refactor build.sh and migrate ARM ci to GitHub's ARM runner

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Runs testing tool unit test
       run: cd regression && python3 testing_tool_test.py
- 
+
   # Build developer doc
   build-developer-doc:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Developer-Manual
-        path: manual.pdf    
+        path: manual.pdf
 
   build-ubuntu:
     uses: ./.github/workflows/build-unix.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/build-unix.yml
     name: ARM64 linux build
     with:
-      operating-system: ARM64
+      operating-system: ubuntu-24.04-arm
       build-flags: '-b DebugOpt -S OFF -B OFF -c 13'
       testing: false
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,7 +49,7 @@ jobs:
     name: ARM64 linux build
     with:
       operating-system: ubuntu-24.04-arm
-      build-flags: '-b DebugOpt -S OFF -B OFF -c 13'
+      build-flags: '-b DebugOpt -S OFF -B OFF'
       testing: false
 
   build-macos-arm:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
     name: static llvm-21 DebugOpt
     with:
       operating-system: ubuntu-24.04
-      build-flags: '-b DebugOpt -e On'
+      build-flags: '-b DebugOpt -e ON'
       testing: true
 
   build-windows:
@@ -41,7 +41,7 @@ jobs:
     name: static llvm-16 DebugOpt
     with:
       operating-system: windows-latest
-      build-flags: '-b DebugOpt -e On'
+      build-flags: '-b DebugOpt -e ON'
       testing: true
 
   build-arm:
@@ -57,7 +57,7 @@ jobs:
     name: arm64 darwin build
     with:
       operating-system: macos-latest
-      build-flags: '-c 21'
+      build-flags: '-b DebugOpt -c 21'
       testing: true
 
   # Check project with clang-format

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tags
 release
 .gdbinit
 compile_commands.json
+.deps/
 
 # custom init scripts
 init.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -171,7 +171,6 @@ prepare_platform_config() {
         log "Detected ARM64 Linux"
         SOLVER_FLAGS="$SOLVER_FLAGS \
             -DENABLE_GOTO_CONTRACTOR=OFF \
-            -DENABLE_BITWUZLA=OFF \
         "
       fi
       ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -81,6 +81,14 @@ validate_clang_version() {
   fi
 }
 
+require_on_off() {
+  local opt_name="$1"
+  local opt_value="$2"
+  if [[ "$opt_value" != "ON" && "$opt_value" != "OFF" ]]; then
+    error "invalid value '$opt_value' for $opt_name: expected ON or OFF"
+  fi
+}
+
 run_with_sudo() {
   if [[ -n "$SUDO" ]]; then
     "$SUDO" "$@"
@@ -566,9 +574,11 @@ while getopts "hb:s:e:r:dS:c:CB:x:" flag; do
       COMPILER_ENV=(CC=clang CXX=clang++)
       ;;
     e)
+      require_on_off "-e" "$OPTARG"
       BASE_ARGS+=("-DENABLE_WERROR=${OPTARG}")
       ;;
     r)
+      require_on_off "-r" "$OPTARG"
       BASE_ARGS+=("-DBENCHBRINGUP=${OPTARG}")
       ;;
     d)
@@ -576,6 +586,7 @@ while getopts "hb:s:e:r:dS:c:CB:x:" flag; do
       export ESBMC_OPTS='--verbosity 9'
       ;;
     S)
+      require_on_off "-S" "$OPTARG"
       STATIC="$OPTARG"
       ;;
     c)
@@ -595,9 +606,11 @@ while getopts "hb:s:e:r:dS:c:CB:x:" flag; do
       )
       ;;
     B)
+      require_on_off "-B" "$OPTARG"
       BASE_ARGS+=("-DESBMC_BUNDLE_LIBC=$OPTARG")
       ;;
     x)
+      require_on_off "-x" "$OPTARG"
       BASE_ARGS+=("-DESBMC_CHERI=$OPTARG")
       if [[ "$OPTARG" == "ON" ]]; then
         BASE_ARGS+=(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -360,11 +360,6 @@ install_system_dependencies() {
 }
 
 install_gmp_linux() {
-  if [[ "$ARCH" == "aarch64" ]]; then
-    log "Skipping GMP source build on ARM64 Linux"
-    return
-  fi
-
   if command -v pkg-config >/dev/null 2>&1; then
     local installed_version
     installed_version="$(pkg-config --modversion gmp 2>/dev/null || true)"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -171,6 +171,7 @@ prepare_platform_config() {
         log "Detected ARM64 Linux"
         SOLVER_FLAGS="$SOLVER_FLAGS \
             -DENABLE_GOTO_CONTRACTOR=OFF \
+            -DENABLE_CVC5=Off \
         "
       fi
       ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -221,7 +221,6 @@ collect_ubuntu_packages() {
     cmake
     bison
     flex
-    g++-multilib
     linux-libc-dev
     libboost-date-time-dev
     libboost-program-options-dev
@@ -237,6 +236,12 @@ collect_ubuntu_packages() {
     tar
     xz-utils
   )
+
+  if [[ "$ARCH" != "aarch64" ]]; then
+    UBUNTU_PACKAGES+=(g++-multilib)
+  else
+    log "Skipping g++-multilib on aarch64"
+  fi
 
   if [[ "$STATIC" == "OFF" ]]; then
     UBUNTU_PACKAGES+=(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -193,12 +193,7 @@ prepare_platform_config() {
         -DCMAKE_INSTALL_PREFIX:PATH=$ROOT_DIR/release \
       "
 
-      SOLVER_FLAGS="\
-        -DENABLE_Z3=On \
-        -DENABLE_BOOLECTOR=Off \
-        -DENABLE_BITWUZLA=Off \
-        -DENABLE_GOTO_CONTRACTOR=Off \
-      "
+      SOLVER_FLAGS="$SOLVER_FLAGS -DENABLE_GOTO_CONTRACTOR=OFF -DENABLE_Z3=ON"
       ;;
 
     *)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -213,7 +213,7 @@ collect_ubuntu_packages() {
     libboost-filesystem-dev
     ninja-build
     python3-setuptools
-    libtinfo-dev
+    libncurses-dev
     python3-pip
     python3-toml
     openjdk-11-jdk

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -209,7 +209,6 @@ prepare_platform_config() {
         "-DLLVM_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
         "-DClang_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
         "-DC2GOTO_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-        "-DCMAKE_BUILD_TYPE=Debug"
         "-DCMAKE_INSTALL_PREFIX:PATH=$ROOT_DIR/release"
       )
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -598,16 +598,18 @@ while getopts "hb:s:e:r:dS:c:CB:x:" flag; do
       BASE_ARGS+=("-DESBMC_BUNDLE_LIBC=$OPTARG")
       ;;
     x)
-      BASE_ARGS+=(
-        "-DENABLE_SOLIDITY_FRONTEND=OFF"
-        "-DENABLE_JIMPLE_FRONTEND=OFF"
-        "-DENABLE_PYTHON_FRONTEND=OFF"
-        "-DESBMC_CHERI=ON"
-      )
-      SOLVER_FLAGS=(
-        "-DENABLE_BOOLECTOR=On"
-        "-DENABLE_Z3=On"
-      )
+      BASE_ARGS+=("-DESBMC_CHERI=$OPTARG")
+      if [[ "$OPTARG" == "ON" ]]; then
+        BASE_ARGS+=(
+          "-DENABLE_SOLIDITY_FRONTEND=OFF"
+          "-DENABLE_JIMPLE_FRONTEND=OFF"
+          "-DENABLE_PYTHON_FRONTEND=OFF"
+        )
+        SOLVER_FLAGS=(
+          "-DENABLE_BOOLECTOR=On"
+          "-DENABLE_Z3=On"
+        )
+      fi
       ;;
     *)
       error "invalid option"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -374,14 +374,15 @@ install_gmp_linux() {
   log "Installing GMP $GMP_VERSION from source"
   local build_root
   build_root="$(mktemp -d)"
-  tar -xf "$GMP_ARCHIVE_PATH" -C "$build_root"
-  cd "$build_root/gmp-$GMP_VERSION"
-  ./configure --prefix=/usr/local --enable-cxx --enable-static
-  make -j"$(nproc)"
-  run_with_sudo make install
-  run_with_sudo ldconfig || true
-  cd "$ROOT_DIR"
-  rm -rf "$build_root"
+  (
+    trap 'rm -rf -- "$build_root"' EXIT
+    tar -xf "$GMP_ARCHIVE_PATH" -C "$build_root"
+    cd "$build_root/gmp-$GMP_VERSION"
+    ./configure --prefix=/usr/local --enable-cxx --enable-static
+    make -j"$(nproc)"
+    run_with_sudo make install
+    run_with_sudo ldconfig || true
+  )
 }
 
 install_python_deps_linux() {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -216,7 +216,7 @@ collect_ubuntu_packages() {
     libncurses-dev
     python3-pip
     python3-toml
-    openjdk-11-jdk
+    default-jdk
     tar
     xz-utils
   )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -209,7 +209,6 @@ prepare_platform_config() {
         "-DLLVM_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
         "-DClang_DIR=/opt/homebrew/opt/llvm@$CLANG_VERSION"
         "-DC2GOTO_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-        "-DCMAKE_INSTALL_PREFIX:PATH=$ROOT_DIR/release"
       )
 
       SOLVER_FLAGS+=("-DENABLE_GOTO_CONTRACTOR=OFF" "-DENABLE_Z3=ON")

--- a/src/goto-programs/goto_contractor.cpp
+++ b/src/goto-programs/goto_contractor.cpp
@@ -251,7 +251,7 @@ bool goto_contractort::initialize_main_function_loops()
 
 void goto_contractort::insert_assume_at(
   goto_functiont goto_function,
-  std::_List_iterator<goto_programt::instructiont> instruction)
+  goto_programt::targett instruction)
 {
   /// Here we build an assume instruction with a conjunction of multiple conditions.
   /// We start with a true expression and add other conditions with and2tc

--- a/src/goto-programs/goto_contractor.h
+++ b/src/goto-programs/goto_contractor.h
@@ -614,7 +614,7 @@ private:
 
   void insert_assume_at(
     goto_functiont goto_function,
-    std::_List_iterator<goto_programt::instructiont> instruction);
+    goto_programt::targett instruction);
 };
 //-----------------------------------------------------------------------------------------------------------------
 class interval_analysis_ibex_contractor


### PR DESCRIPTION
Commit by commit review encouraged!

Original motivation for the splitting of build.sh into "deps", "build", and "install" was to cut down the run time when _potentially_ using CodeQL static analysis (probably not happening anytime soon).
(Otherwise it would trace building the dependencies and perform analysis on them as well)

Migrated to GitHub's ARM runner as the existing runner apparently didn't support sudo.