### PR TITLE
Support list literals in str.join() (#3567)

### DIFF
--- a/regression/python/github_3000_1/test.desc
+++ b/regression/python/github_3000_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 7
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3000_1_fail/test.desc
+++ b/regression/python/github_3000_1_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3567/main.py
+++ b/regression/python/github_3567/main.py
@@ -1,0 +1,1 @@
+assert ",".join(["a", "b", "c"]) == "a,b,c"

--- a/regression/python/github_3567/test.desc
+++ b/regression/python/github_3567/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
str.join()` previously only accepted variable references (`Name` AST nodes) as the iterable argument. Calling it with a direct list literal — e.g. `",".join(["a", "b", "c"])`