### PR TITLE
Fix/GitHub 3566 raise IndexError on out-of-bounds string indexing

### DIFF
--- a/regression/python/github_3566/main.py
+++ b/regression/python/github_3566/main.py
@@ -1,0 +1,9 @@
+s = "abc"
+assert s[0] == "a"
+assert s[-1] == "c"
+
+try:
+    _ = s[3]
+    assert False, "IndexError expected"
+except IndexError:
+    pass

--- a/regression/python/github_3566/test.desc
+++ b/regression/python/github_3566/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION

Replace the safe-null-fallback `if_exprt` in `handle_index_access()` with a bounds check that emits `cpp-throw IndexError` when the index >= logical string length (array size minus null terminator).