### PR TITLE
Fix/GitHub 3578 Fix string slicing with out-of-bounds indices and pointer parameters

### DIFF
--- a/regression/python/github_3578/main.py
+++ b/regression/python/github_3578/main.py
@@ -1,0 +1,5 @@
+def test_slicing():
+    s = "abcdef"
+    assert s[10:] == ""
+
+test_slicing()

--- a/regression/python/github_3578/test.desc
+++ b/regression/python/github_3578/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1035,15 +1035,13 @@ exprt python_list::handle_range_slice(
       // lower = max(0, min(lower, logical_len))
       exprt lower_ge_len(">=", bool_type());
       lower_ge_len.copy_to_operands(lower_expr, logical_len);
-      lower_expr =
-        if_exprt(lower_ge_len, logical_len, lower_expr);
+      lower_expr = if_exprt(lower_ge_len, logical_len, lower_expr);
       lower_expr.type() = size_type();
 
       // upper = max(0, min(upper, logical_len))
       exprt upper_ge_len(">=", bool_type());
       upper_ge_len.copy_to_operands(upper_expr, logical_len);
-      upper_expr =
-        if_exprt(upper_ge_len, logical_len, upper_expr);
+      upper_expr = if_exprt(upper_ge_len, logical_len, upper_expr);
       upper_expr.type() = size_type();
     }
 

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -966,8 +966,8 @@ exprt python_list::handle_range_slice(
     else // pointer case
     {
       elem_type = array.type().subtype();
-      array_len = exprt();   // Not used for pointers
-      logical_len = exprt(); // Will use explicit bounds only
+      array_len = nil_exprt();   // Not used for pointers
+      logical_len = nil_exprt(); // Will use explicit bounds only
     }
 
     // Process slice bounds (handles null, negative indices)
@@ -1026,6 +1026,26 @@ exprt python_list::handle_range_slice(
     }
     else
       upper_expr = process_bound("upper", logical_len);
+
+    // Clamp bounds to [0, logical_len] to match Python semantics.
+    // In Python, slice indices are silently clamped to the valid range,
+    // so s[10:] on a 6-char string returns "" (lower clamped to 6).
+    if (!logical_len.is_nil())
+    {
+      // lower = max(0, min(lower, logical_len))
+      exprt lower_ge_len(">=", bool_type());
+      lower_ge_len.copy_to_operands(lower_expr, logical_len);
+      lower_expr =
+        if_exprt(lower_ge_len, logical_len, lower_expr);
+      lower_expr.type() = size_type();
+
+      // upper = max(0, min(upper, logical_len))
+      exprt upper_ge_len(">=", bool_type());
+      upper_ge_len.copy_to_operands(upper_expr, logical_len);
+      upper_expr =
+        if_exprt(upper_ge_len, logical_len, upper_expr);
+      upper_expr.type() = size_type();
+    }
 
     // Calculate slice length
     minus_exprt slice_len(upper_expr, lower_expr);


### PR DESCRIPTION
Fix two string slicing bugs in the Python frontend:

1. **Out-of-bounds slice indices (#3578):** `s[10:]` on `"abcdef"` caused
   "array bounds violated" instead of returning `""` as Python semantics require.
2. **Crash on pointer string slicing (#3043, #3082, #3295):** Slicing a string
   passed as a function parameter (`def foo(s: str): ss = s[1:3]`) caused
   `migrate expr failed` abort during GOTO program generation.
