### PR TITLE
Fix/GitHub 3579 Fix `join()` failing with `"join() argument must be a list of strings"` when the argument comes from a `split()` call.

### DIFF
--- a/regression/python/github_3579/main.py
+++ b/regression/python/github_3579/main.py
@@ -1,0 +1,6 @@
+def test_split_and_join():
+    s = "a,b,c"
+    parts = s.split(",")
+    assert ",".join(parts) == s
+
+test_split_and_join()

--- a/regression/python/github_3579/test.desc
+++ b/regression/python/github_3579/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -3059,14 +3059,13 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
   // Handle split() calls: resolve the result to a JSON List at compile time
   nlohmann::json resolved_split_list;
   {
-    const nlohmann::json* call_to_resolve = nullptr;
+    const nlohmann::json *call_to_resolve = nullptr;
     if (
       list_node && list_node->contains("_type") &&
       (*list_node)["_type"] == "Call")
       call_to_resolve = list_node;
     else if (
-      !list_node && list_arg.contains("_type") &&
-      list_arg["_type"] == "Call")
+      !list_node && list_arg.contains("_type") && list_arg["_type"] == "Call")
       call_to_resolve = &list_arg;
 
     if (
@@ -3079,7 +3078,7 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
     {
       std::string input;
       if (extract_constant_string(
-        (*call_to_resolve)["func"]["value"], converter_, input))
+            (*call_to_resolve)["func"]["value"], converter_, input))
       {
         std::string sep;
         if (
@@ -3094,16 +3093,14 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
           size_t i = 0;
           while (i < input.size())
           {
-            while (
-              i < input.size() &&
-              std::isspace(static_cast<unsigned char>(input[i])))
+            while (i < input.size() &&
+                   std::isspace(static_cast<unsigned char>(input[i])))
               i++;
             if (i >= input.size())
               break;
             size_t start = i;
-            while (
-              i < input.size() &&
-              !std::isspace(static_cast<unsigned char>(input[i])))
+            while (i < input.size() &&
+                   !std::isspace(static_cast<unsigned char>(input[i])))
               i++;
             parts.push_back(input.substr(start, i - start));
           }
@@ -3126,7 +3123,7 @@ exprt string_handler::handle_str_join(const nlohmann::json &call_json)
 
         resolved_split_list["_type"] = "List";
         resolved_split_list["elts"] = nlohmann::json::array();
-        for (const auto& part : parts)
+        for (const auto &part : parts)
         {
           nlohmann::json elem;
           elem["_type"] = "Constant";


### PR DESCRIPTION
The `join()` handler only accepted two argument forms:
1. A direct `List` literal (e.g. `",".join(["a", "b", "c"])`)
2. A `Name` reference whose AST declaration value is a `List` node

When the argument is the result of `split()` (e.g. `parts = s.split(",")` then `",".join(parts)`), the variable's value in the AST is a `Call` node — not a `List` — causing the handler to reject it.
