### PR TITLE
Fix/GitHub 3563 Optional type wrapping for functions with mixed value+None returns

### DIFF
--- a/regression/python/github_3563/main.py
+++ b/regression/python/github_3563/main.py
@@ -1,0 +1,10 @@
+A = [1]
+
+def f():
+    if A[0] == 1:
+        return 0
+    return None
+
+r = f()
+if r is not None:
+    assert A[r] == 1

--- a/regression/python/github_3563/test.desc
+++ b/regression/python/github_3563/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3563_1/main.py
+++ b/regression/python/github_3563_1/main.py
@@ -1,0 +1,10 @@
+A = [nondet_int()]
+
+def f():
+    if A[0] == 1:
+        return 0
+    return None
+
+r = f()
+if r is not None:
+    assert A[r] == 1

--- a/regression/python/github_3563_1/test.desc
+++ b/regression/python/github_3563_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -55,6 +55,7 @@ ignored_dirs=(
   "github_3560_1"
   "github_3560_3"
   "github_3560_4"
+  "github_3563_1"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -287,9 +287,9 @@ private:
   }
 
   // Check if the function body contains any explicit 'return None' statement
-  bool has_return_none(const Json& body)
+  bool has_return_none(const Json &body)
   {
-    for (const Json& stmt : body)
+    for (const Json &stmt : body)
     {
       if (stmt["_type"] == "Return")
       {
@@ -901,8 +901,7 @@ private:
         // Check if there are also None returns (mixed value+None)
         // If so, leave the annotation as null for the converter to handle
         // via Optional wrapping
-        bool has_none_return =
-          has_return_none(function_element["body"]);
+        bool has_none_return = has_return_none(function_element["body"]);
 
         if (!has_none_return)
         {
@@ -916,7 +915,7 @@ private:
             {"end_lineno", function_element["lineno"]},
             {"end_col_offset",
              function_element["col_offset"].template get<int>() +
-               inferred_type.size()} };
+               inferred_type.size()}};
         }
       }
       else if (inferred_type == "NoneType")
@@ -929,7 +928,7 @@ private:
           {"col_offset", function_element["col_offset"]},
           {"end_lineno", function_element["lineno"]},
           {"end_col_offset",
-           function_element["col_offset"].template get<int>() + 4} };
+           function_element["col_offset"].template get<int>() + 4}};
       }
       // If no return type could be inferred, leave returns as null
       // (function has no explicit return statement)

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5795,7 +5795,7 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
               flags.has_none = true;
             else
             {
-              std::string type_name = constant_val.is_string() ? "string"
+              std::string type_name = constant_val.is_string()   ? "string"
                                       : constant_val.is_object() ? "object"
                                       : constant_val.is_array()  ? "array"
                                                                  : "unknown";
@@ -6517,9 +6517,10 @@ void python_converter::get_return_statements(
     // Wrap return value in Optional if the function returns Optional
     if (current_func_return_type_.is_struct())
     {
-      const struct_typet& st = to_struct_type(current_func_return_type_);
+      const struct_typet &st = to_struct_type(current_func_return_type_);
       if (st.tag().as_string().starts_with("tag-Optional_"))
-        return_value = wrap_in_optional(return_value, current_func_return_type_);
+        return_value =
+          wrap_in_optional(return_value, current_func_return_type_);
     }
 
     code_returnt return_code;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5791,10 +5791,11 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
               flags.has_int = true;
             else if (constant_val.is_boolean())
               flags.has_bool = true;
+            else if (constant_val.is_null())
+              flags.has_none = true;
             else
             {
-              std::string type_name = constant_val.is_string()   ? "string"
-                                      : constant_val.is_null()   ? "null"
+              std::string type_name = constant_val.is_string() ? "string"
                                       : constant_val.is_object() ? "object"
                                       : constant_val.is_array()  ? "array"
                                                                  : "unknown";
@@ -6174,8 +6175,33 @@ void python_converter::get_function_definition(
 
   symbolt *added_symbol = symbol_table_.move_symbol_to_context(symbol);
 
+  // Pre-scan: for unannotated functions, detect mixed value+None returns
+  // and set return type to Optional so None checks work correctly at runtime
+  if (type.return_type().is_empty())
+  {
+    TypeFlags return_flags = infer_types_from_returns(function_node["body"]);
+    bool has_value_return =
+      return_flags.has_int || return_flags.has_float || return_flags.has_bool;
+    if (has_value_return && return_flags.has_none)
+    {
+      typet value_type =
+        type_utils::select_widest_type(return_flags, long_long_int_type());
+      typet optional_type = type_handler_.build_optional_type(value_type);
+      type.return_type() = optional_type;
+      current_element_type = optional_type;
+      added_symbol->type = type;
+    }
+  }
+
+  // Save function return type for use in get_return_statements
+  typet saved_func_return_type = current_func_return_type_;
+  current_func_return_type_ = type.return_type();
+
   // Process function body
   exprt function_body = get_block(function_node["body"]);
+
+  // Restore saved function return type (for nested function defs)
+  current_func_return_type_ = saved_func_return_type;
 
   // If return type is empty/unannotated, try to infer from return statements
   if (type.return_type().is_empty())
@@ -6486,6 +6512,14 @@ void python_converter::get_return_statements(
         // For non-constant arrays (variables), convert to pointer
         return_value = string_handler_.get_array_base_address(return_value);
       }
+    }
+
+    // Wrap return value in Optional if the function returns Optional
+    if (current_func_return_type_.is_struct())
+    {
+      const struct_typet& st = to_struct_type(current_func_return_type_);
+      if (st.tag().as_string().starts_with("tag-Optional_"))
+        return_value = wrap_in_optional(return_value, current_func_return_type_);
     }
 
     code_returnt return_code;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -819,6 +819,7 @@ private:
 
   namespacet ns;
   typet current_element_type;
+  typet current_func_return_type_;
   std::string main_python_file;
   std::string current_python_file;
   nlohmann::json imported_module_json;

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1324,6 +1324,7 @@ exprt python_list::handle_index_access(
   }
 
   exprt pos_expr = converter_.get_expr(slice_node);
+  pos_expr = converter_.unwrap_optional_if_needed(pos_expr);
   size_t index = 0;
 
   // Validate index type

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -55,6 +55,7 @@ struct TypeFlags
   bool has_float = false;
   bool has_int = false;
   bool has_bool = false;
+  bool has_none = false;
 };
 
 class type_utils
@@ -306,6 +307,14 @@ private:
         flags.has_int = true;
       else if (type_str == "bool")
         flags.has_bool = true;
+      else if (type_str == "None" || type_str == "NoneType")
+        flags.has_none = true;
+    }
+    else if (
+      node["_type"] == "Constant" && node.contains("value") &&
+      node["value"].is_null())
+    {
+      flags.has_none = true;
     }
   }
 
@@ -314,6 +323,7 @@ private:
     dest.has_float = dest.has_float || src.has_float;
     dest.has_int = dest.has_int || src.has_int;
     dest.has_bool = dest.has_bool || src.has_bool;
+    dest.has_none = dest.has_none || src.has_none;
   }
 
   static const std::map<std::string, std::string> &consensus_func_to_type()


### PR DESCRIPTION
The annotation pass inferred only NoneType for f() (because find_return_node only searched top-level statements, finding return None but missing return 0 inside the if). This gave r an integer type while f() actually needed to represent both int and None causing a struct-to-int typecast crash during SMT encoding.