### PR TITLE
Fix/GitHub 3563 p2 

### DIFF
--- a/regression/python/github_3563_2/main.py
+++ b/regression/python/github_3563_2/main.py
@@ -1,0 +1,13 @@
+A = [nondet_int()]
+
+def g():
+    return 0
+
+def f():
+    if A[0] == 1:
+        return g()
+    return None
+
+r = f()
+if r is not None:
+    assert A[r] == 1

--- a/regression/python/github_3563_2/test.desc
+++ b/regression/python/github_3563_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3563_3/main.py
+++ b/regression/python/github_3563_3/main.py
@@ -1,0 +1,10 @@
+A = [nondet_int()]
+
+def f():
+    if A[0] == 1:
+        return 42
+    return
+
+r = f()
+if r is not None:
+    assert r == 42

--- a/regression/python/github_3563_3/test.desc
+++ b/regression/python/github_3563_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -58,6 +58,8 @@ ignored_dirs=(
   "github_3560_1"
   "github_3560_3"
   "github_3560_4"
+  "github_3563_2"
+  "github_3563_3"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5940,99 +5940,97 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
 {
   TypeFlags flags;
 
-  std::function<void(const nlohmann::json &)> scan =
-    [&](const nlohmann::json &body) {
-      for (const auto &stmt : body)
+  std::function<void(const nlohmann::json &)> scan = [&](const nlohmann::json
+                                                           &body) {
+    for (const auto &stmt : body)
+    {
+      if (stmt["_type"] == "Return" && stmt["value"].is_null())
       {
-        if (stmt["_type"] == "Return" && stmt["value"].is_null())
-        {
-          // Bare "return" (no value) is semantically "return None"
-          flags.has_none = true;
-        }
-        else if (stmt["_type"] == "Return" && !stmt["value"].is_null())
-        {
-          const auto &val = stmt["value"];
+        // Bare "return" (no value) is semantically "return None"
+        flags.has_none = true;
+      }
+      else if (stmt["_type"] == "Return" && !stmt["value"].is_null())
+      {
+        const auto &val = stmt["value"];
 
-          if (val["_type"] == "Constant")
+        if (val["_type"] == "Constant")
+        {
+          const auto &constant_val = val["value"];
+          if (constant_val.is_number_float())
+            flags.has_float = true;
+          else if (constant_val.is_number_integer())
+            flags.has_int = true;
+          else if (constant_val.is_boolean())
+            flags.has_bool = true;
+          else if (constant_val.is_null())
+            flags.has_none = true;
+          else
           {
-            const auto &constant_val = val["value"];
-            if (constant_val.is_number_float())
-              flags.has_float = true;
-            else if (constant_val.is_number_integer())
-              flags.has_int = true;
-            else if (constant_val.is_boolean())
-              flags.has_bool = true;
-            else if (constant_val.is_null())
-              flags.has_none = true;
-            else
-            {
-              std::string type_name = constant_val.is_string()   ? "string"
-                                      : constant_val.is_object() ? "object"
-                                      : constant_val.is_array()  ? "array"
-                                                                 : "unknown";
-              throw std::runtime_error(
-                "Unsupported return type '" + type_name + "' detected");
-            }
+            std::string type_name = constant_val.is_string()   ? "string"
+                                    : constant_val.is_object() ? "object"
+                                    : constant_val.is_array()  ? "array"
+                                                               : "unknown";
+            throw std::runtime_error(
+              "Unsupported return type '" + type_name + "' detected");
           }
-          else if (val["_type"] == "BinOp" || val["_type"] == "UnaryOp")
+        }
+        else if (val["_type"] == "BinOp" || val["_type"] == "UnaryOp")
+        {
+          flags.has_float = true; // Default for expressions
+        }
+        else if (val["_type"] == "Call")
+        {
+          // For return <func_call>(), look up the called function's returns
+          // to infer the value type being propagated through the call
+          const auto &func = val["func"];
+          bool resolved = false;
+          if (func.contains("id") && ast_json)
           {
-            flags.has_float = true; // Default for expressions
-          }
-          else if (val["_type"] == "Call")
-          {
-            // For return <func_call>(), look up the called function's returns
-            // to infer the value type being propagated through the call
-            const auto& func = val["func"];
-            bool resolved = false;
-            if (func.contains("id") && ast_json)
+            std::string called_name = func["id"].get<std::string>();
+            const auto &module_body = (*ast_json)["body"];
+            for (const auto &item : module_body)
             {
-              std::string called_name = func["id"].get<std::string>();
-              const auto& module_body = (*ast_json)["body"];
-              for (const auto& item : module_body)
+              if (item["_type"] == "FunctionDef" && item["name"] == called_name)
               {
-                if (
-                  item["_type"] == "FunctionDef" &&
-                  item["name"] == called_name)
+                // Scan the called function's return statements directly
+                // (one level only to avoid infinite recursion)
+                for (const auto &s : item["body"])
                 {
-                  // Scan the called function's return statements directly
-                  // (one level only to avoid infinite recursion)
-                  for (const auto& s : item["body"])
+                  if (
+                    s["_type"] == "Return" && !s["value"].is_null() &&
+                    s["value"]["_type"] == "Constant" &&
+                    !s["value"]["value"].is_null())
                   {
-                    if (
-                      s["_type"] == "Return" && !s["value"].is_null() &&
-                      s["value"]["_type"] == "Constant" &&
-                      !s["value"]["value"].is_null())
-                    {
-                      const auto& cv = s["value"]["value"];
-                      if (cv.is_number_float())
-                        flags.has_float = true;
-                      else if (cv.is_number_integer())
-                        flags.has_int = true;
-                      else if (cv.is_boolean())
-                        flags.has_bool = true;
-                      resolved = true;
-                    }
+                    const auto &cv = s["value"]["value"];
+                    if (cv.is_number_float())
+                      flags.has_float = true;
+                    else if (cv.is_number_integer())
+                      flags.has_int = true;
+                    else if (cv.is_boolean())
+                      flags.has_bool = true;
+                    resolved = true;
                   }
-                  break;
                 }
+                break;
               }
             }
-            if (!resolved)
-              flags.has_int = true; // Default to int for unresolvable calls
           }
-          else if (val["_type"] == "Name")
-          {
-            // return <variable> — indicates a value return of unknown type
-            flags.has_int = true;
-          }
+          if (!resolved)
+            flags.has_int = true; // Default to int for unresolvable calls
         }
-
-        if (stmt.contains("body") && stmt["body"].is_array())
-          scan(stmt["body"]);
-        if (stmt.contains("orelse") && stmt["orelse"].is_array())
-          scan(stmt["orelse"]);
+        else if (val["_type"] == "Name")
+        {
+          // return <variable> — indicates a value return of unknown type
+          flags.has_int = true;
+        }
       }
-    };
+
+      if (stmt.contains("body") && stmt["body"].is_array())
+        scan(stmt["body"]);
+      if (stmt.contains("orelse") && stmt["orelse"].is_array())
+        scan(stmt["orelse"]);
+    }
+  };
 
   scan(function_body);
   return flags;
@@ -6606,7 +6604,7 @@ void python_converter::get_return_statements(
     // If the function returns Optional, wrap None in Optional struct
     if (current_func_return_type_.is_struct())
     {
-      const struct_typet& st = to_struct_type(current_func_return_type_);
+      const struct_typet &st = to_struct_type(current_func_return_type_);
       if (st.tag().as_string().starts_with("tag-Optional_"))
       {
         constant_exprt none_expr(none_type());
@@ -6703,7 +6701,7 @@ void python_converter::get_return_statements(
     exprt ret_expr = temp_var_expr;
     if (current_func_return_type_.is_struct())
     {
-      const struct_typet& st = to_struct_type(current_func_return_type_);
+      const struct_typet &st = to_struct_type(current_func_return_type_);
       if (st.tag().as_string().starts_with("tag-Optional_"))
         ret_expr = wrap_in_optional(ret_expr, current_func_return_type_);
     }


### PR DESCRIPTION
Addresses two remaining edge cases in the Optional return type inference for unannotated functions with mixed value+None returns.
## Problem

After #3585, two patterns were still not handled:

1. **`return g()`** — `infer_types_from_returns` only recognized `Constant`,
   `BinOp`, and `UnaryOp` return values. A function call return was silently
   ignored, so `f()` with `return g()` + `return None` was not detected as
   mixed-return → no Optional wrapping → `SAME-OBJECT` violation.

2. **Bare `return`** (no value) — semantically equivalent to `return None`,
   but `infer_types_from_returns` only inspected returns with non-null values.
   A function with `return 42` + bare `return` was not detected as mixed-return
   → no Optional wrapping → solver assertion failure on type width mismatch.

Fixes #3563