### PR TITLE
Fix/GitHub 3589 handle address_of on constant_struct in SMT encoding

### DIFF
--- a/regression/python/github_3589/main.py
+++ b/regression/python/github_3589/main.py
@@ -1,0 +1,3 @@
+import math
+
+assert math.isclose(math.dist((0, 0), (3, 4)), 5.0)

--- a/regression/python/github_3589/test.desc
+++ b/regression/python/github_3589/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2740,17 +2740,17 @@ function_call_expr::get_dispatch_table()
            // If either argument is a constant struct (tuple literal), store it
            // in a temporary local variable so that the GOTO IR has a proper
            // symbol whose address the solver can track.
-           auto materialize = [&](exprt& arg) {
+           auto materialize = [&](exprt &arg) {
              if (arg.is_constant())
              {
-               symbolt& tmp = converter_.create_tmp_symbol(
+               symbolt &tmp = converter_.create_tmp_symbol(
                  call_, "$dist_arg$", arg.type(), arg);
                code_declt decl(symbol_expr(tmp));
                decl.location() = converter_.get_location_from_decl(call_);
                converter_.current_block->copy_to_operands(decl);
                arg = symbol_expr(tmp);
              }
-             };
+           };
            materialize(lhs_expr);
            materialize(rhs_expr);
            return converter_.get_math_handler().handle_dist(

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2469,7 +2469,7 @@ function_call_expr::get_dispatch_table()
                 func_name == "gamma" || func_name == "ldexp" ||
                 func_name == "lgamma" || func_name == "nextafter" ||
                 func_name == "remainder" || func_name == "sumprod" ||
-                func_name == "ulp")) ||
+                func_name == "ulp" || func_name == "dist")) ||
               is_math_wrapper;
      },
      [this]() -> exprt {
@@ -2730,6 +2730,15 @@ function_call_expr::get_dispatch_table()
          auto [lhs_expr, rhs_expr] = require_two_args();
          return converter_.get_math_handler().handle_hypot(
            lhs_expr, rhs_expr, call_);
+       }
+       else if (func_name == "dist")
+       {
+         auto [lhs_expr, rhs_expr] = require_two_args();
+         // Native handler for tuple arguments; lists use the model
+         if (lhs_expr.type().is_struct() && rhs_expr.type().is_struct())
+           return converter_.get_math_handler().handle_dist(
+             lhs_expr, rhs_expr, call_);
+         return handle_general_function_call();
        }
        else if (
          func_name == "cbrt" || func_name == "erf" || func_name == "erfc" ||

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -1216,10 +1216,7 @@ exprt python_math::handle_hypot(
   return hypot_call;
 }
 
-exprt python_math::handle_dist(
-  exprt p,
-  exprt q,
-  const nlohmann::json &element)
+exprt python_math::handle_dist(exprt p, exprt q, const nlohmann::json &element)
 {
   // Both arguments must be tuples (struct types with tag-tuple prefix)
   if (!p.type().is_struct() || !q.type().is_struct())
@@ -1245,8 +1242,7 @@ exprt python_math::handle_dist(
 
   // Build sum of squared differences: (p[0]-q[0])^2 + (p[1]-q[1])^2 + ...
   // Use ieee_* operations for floating-point arithmetic
-  exprt rounding_mode =
-    symbol_exprt("c:@__ESBMC_rounding_mode", int_type());
+  exprt rounding_mode = symbol_exprt("c:@__ESBMC_rounding_mode", int_type());
 
   exprt total = exprt();
   for (size_t i = 0; i < p_size; i++)

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -5,6 +5,7 @@
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/std_code.h>
+#include <util/std_types.h>
 #include <util/message.h>
 
 #include <cmath>
@@ -1213,4 +1214,89 @@ exprt python_math::handle_hypot(
   hypot_call.location() = converter.get_location_from_decl(element);
 
   return hypot_call;
+}
+
+exprt python_math::handle_dist(
+  exprt p,
+  exprt q,
+  const nlohmann::json &element)
+{
+  // Both arguments must be tuples (struct types with tag-tuple prefix)
+  if (!p.type().is_struct() || !q.type().is_struct())
+    throw std::runtime_error("math.dist() arguments must be tuples");
+
+  const struct_typet &p_type = to_struct_type(p.type());
+  const struct_typet &q_type = to_struct_type(q.type());
+
+  if (
+    p_type.tag().as_string().find("tag-tuple") != 0 ||
+    q_type.tag().as_string().find("tag-tuple") != 0)
+    throw std::runtime_error("math.dist() arguments must be tuples");
+
+  size_t p_size = p_type.components().size();
+  size_t q_size = q_type.components().size();
+
+  if (p_size != q_size)
+    throw std::runtime_error(
+      "math.dist() requires both points to have the same number of dimensions");
+
+  if (p_size == 0)
+    throw std::runtime_error("math.dist() requires non-empty points");
+
+  // Build sum of squared differences: (p[0]-q[0])^2 + (p[1]-q[1])^2 + ...
+  // Use ieee_* operations for floating-point arithmetic
+  exprt rounding_mode =
+    symbol_exprt("c:@__ESBMC_rounding_mode", int_type());
+
+  exprt total = exprt();
+  for (size_t i = 0; i < p_size; i++)
+  {
+    std::string member_name = "element_" + std::to_string(i);
+    const typet &comp_type = p_type.components()[i].type();
+
+    exprt pi = member_exprt(p, member_name, comp_type);
+    exprt qi = member_exprt(q, member_name, q_type.components()[i].type());
+
+    // Cast to double if needed
+    if (!pi.type().is_floatbv())
+    {
+      exprt casted = exprt("typecast", double_type());
+      casted.copy_to_operands(pi);
+      pi = casted;
+    }
+    if (!qi.type().is_floatbv())
+    {
+      exprt casted = exprt("typecast", double_type());
+      casted.copy_to_operands(qi);
+      qi = casted;
+    }
+
+    // d = p[i] - q[i]
+    exprt diff("ieee_sub", double_type());
+    diff.copy_to_operands(pi, qi);
+    diff.add("rounding_mode") = rounding_mode;
+
+    // d * d
+    exprt sq("ieee_mul", double_type());
+    sq.copy_to_operands(diff, diff);
+    sq.add("rounding_mode") = rounding_mode;
+
+    if (i == 0)
+      total = sq;
+    else
+    {
+      exprt sum("ieee_add", double_type());
+      sum.copy_to_operands(total, sq);
+      sum.add("rounding_mode") = rounding_mode;
+      total = sum;
+    }
+  }
+
+  // Return sqrt(total) using ieee_sqrt (SMT-level intrinsic)
+  exprt sqrt_expr("ieee_sqrt", double_type());
+  sqrt_expr.copy_to_operands(total);
+  sqrt_expr.add("rounding_mode") = rounding_mode;
+  sqrt_expr.location() = converter.get_location_from_decl(element);
+
+  return sqrt_expr;
 }

--- a/src/python-frontend/python_math.h
+++ b/src/python-frontend/python_math.h
@@ -401,6 +401,11 @@ public:
    * @brief Handle hypot function (math.hypot)
    */
   exprt handle_hypot(exprt lhs, exprt rhs, const nlohmann::json &element);
+
+  /**
+   * @brief Handle dist function (math.dist) for tuple arguments
+   */
+  exprt handle_dist(exprt p, exprt q, const nlohmann::json &element);
 };
 
 #endif

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -531,17 +531,6 @@ smt_astt smt_convt::convert_addr_of(const expr2tc &expr)
     return convert_identifier_pointer(obj.ptr_obj, ss.str(), nullptr);
   }
 
-  if (is_constant_struct2t(obj.ptr_obj))
-  {
-    // Similar to constant_array above: the frontend may propagate a constant
-    // struct (e.g. a Python tuple) through a pointer/reference, dropping the
-    // original symbol. We assign a unique identifier so SMT can track it.
-    static unsigned int conststruct_num = 0;
-    std::stringstream ss;
-    ss << "address_of_struct_const(" << conststruct_num++ << ")";
-    return convert_identifier_pointer(obj.ptr_obj, ss.str(), nullptr);
-  }
-
   if (is_if2t(obj.ptr_obj))
   {
     // We can't nondeterministically take the address of something; So instead

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -531,6 +531,17 @@ smt_astt smt_convt::convert_addr_of(const expr2tc &expr)
     return convert_identifier_pointer(obj.ptr_obj, ss.str(), nullptr);
   }
 
+  if (is_constant_struct2t(obj.ptr_obj))
+  {
+    // Similar to constant_array above: the frontend may propagate a constant
+    // struct (e.g. a Python tuple) through a pointer/reference, dropping the
+    // original symbol. We assign a unique identifier so SMT can track it.
+    static unsigned int conststruct_num = 0;
+    std::stringstream ss;
+    ss << "address_of_struct_const(" << conststruct_num++ << ")";
+    return convert_identifier_pointer(obj.ptr_obj, ss.str(), nullptr);
+  }
+
   if (is_if2t(obj.ptr_obj))
   {
     // We can't nondeterministically take the address of something; So instead


### PR DESCRIPTION
When passing a tuple literal to a function that expects a pointer parameter (e.g. `math.dist((0, 0), (3, 4))`), the SMT encoder crashes with: ERROR: Unrecognized address_of operand: address_of pointer_obj : constant_struct