### PR TITLE
Fix/GitHub 3592

### DIFF
--- a/regression/python/github_3592/main.py
+++ b/regression/python/github_3592/main.py
@@ -1,0 +1,10 @@
+import math
+
+def test_trigonometry():
+    try:
+        math.acos(2)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+test_trigonometry()

--- a/regression/python/github_3592/test.desc
+++ b/regression/python/github_3592/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The native acos handler bypassed the Python model's ValueError raise for out-of-domain arguments. Added a guard that checks if the operand is outside [-1.0, 1.0] and raises ValueError before calling the C acos, matching the existing sqrt domain check pattern.