### PR TITLE
[build] prioritize build-dir includes over source-dir for gen-headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Modules                       #
 #################################
 
+include_directories(${CMAKE_BINARY_DIR}/src)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 add_subdirectory (util)
 add_subdirectory (irep2)

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -14,8 +14,8 @@ add_subdirectory(smt)
 add_library(solve solve.cpp)
 target_link_libraries(solve fmt::fmt)
 target_include_directories(solve
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${Boost_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
Stale copies of generated headers (ac_config.h, solver_config.h) in the source tree would shadow the correctly configured ones from the build tree, causing solver backends to silently not register. Put build-directory include paths before source-directory paths so configure_file() outputs always take precedence.