### PR TITLE
[C verification] add support for volatile checks

### DIFF
--- a/regression/esbmc/volatile_01/main.c
+++ b/regression/esbmc/volatile_01/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+  volatile int flag = 0;
+
+  while (flag != 0)
+  {
+    __ESBMC_assert(0, "");
+  }
+}

--- a/regression/esbmc/volatile_01/test.desc
+++ b/regression/esbmc/volatile_01/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--volatile-check
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/volatile_02/main.c
+++ b/regression/esbmc/volatile_02/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  volatile int flag = 1;
+
+  int read = flag;
+
+  __ESBMC_assert(read, "");
+}

--- a/regression/esbmc/volatile_02/test.desc
+++ b/regression/esbmc/volatile_02/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--volatile-check
+
+^VERIFICATION FAILED$

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -457,6 +457,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "thread interleaving"},
     {"lock-order-check", NULL, "enable for lock acquisition ordering check"},
     {"atomicity-check", NULL, "enable atomicity check at visible assignments"},
+    {"volatile-check", NULL, "enable check for volatile variable"},
     {"stack-limit",
      boost::program_options::value<int>()->default_value(-1)->value_name(
        "bits"),

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -517,6 +517,8 @@ protected:
 
   void simplify_python_builtins(expr2tc &expr);
 
+  void volatile_check(expr2tc &expr);
+
   /* Check if thrown_type in Python inherits from catch_type */
   bool is_python_exception_subtype(
     const irep_idt &thrown_type,

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -334,6 +334,7 @@ void goto_symext::symex_assign(
 
   replace_nondet(lhs);
   replace_nondet(rhs);
+  volatile_check(rhs);
 
   dereference(lhs, dereferencet::WRITE);
   dereference(rhs, dereferencet::READ);
@@ -997,7 +998,7 @@ void goto_symext::replace_nondet(expr2tc &expr)
   if (
     is_sideeffect2t(expr) && to_sideeffect2t(expr).kind == sideeffect2t::nondet)
   {
-    unsigned int &nondet_count = get_dynamic_counter();
+    unsigned int &nondet_count = get_nondet_counter();
     expr =
       symbol2tc(expr->type, "nondet$symex::nondet" + i2string(nondet_count++));
   }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -239,6 +239,7 @@ void goto_symext::symex_step(reachability_treet &art)
   {
     expr2tc tmp(instruction.guard);
     replace_nondet(tmp);
+    volatile_check(tmp);
 
     dereference(tmp, dereferencet::READ);
     replace_dynamic_allocation(tmp);


### PR DESCRIPTION
Type "volatile" indicates that the memory location may be rewritten by the environment at any time, and thus the value read is unpredictable.

In this PR, the `--volatile-check` option will be used to model this type:

```
volatile load → nondet

volatile store → normal assignment
```
An example: 

```
int main()
{
  volatile int flag = 0;

  while (flag != 0)
  {
    __ESBMC_assert(0, "");
  }
}
```
Ideally, the loop is not reachable, but due to factors of the hardware environment, the value may be changed at any time:

`$esbmc main.c --volatile-check`

```
Violated property:
  file main.c line 7 column 5 function main
  assertion 0
  0
```