### PR TITLE
Fix starred unpacking and add regression tests for issue 3588

### DIFF
--- a/regression/python/github_3588_1/main.py
+++ b/regression/python/github_3588_1/main.py
@@ -1,0 +1,3 @@
+a, *b, c = [1, 2, 3]
+assert a == 1
+assert c == 3

--- a/regression/python/github_3588_1/test.desc
+++ b/regression/python/github_3588_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3588_2/main.py
+++ b/regression/python/github_3588_2/main.py
@@ -1,0 +1,5 @@
+def starred_unpack():
+    head, *tail = [1, 2, 3]
+    assert head == 1
+
+starred_unpack()

--- a/regression/python/github_3588_2/test.desc
+++ b/regression/python/github_3588_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--function starred_unpack --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Addresses reviewer feedback on #3588.

Adds two new regression tests covering edge cases flagged during code review:
- `github_3588_1`: validates trailing targets after the starred variable (`a, *b, c = [1, 2, 3]`), exercising the `after_star` indexing logic.
- `github_3588_2`: validates starred unpacking via the `--function` conversion path, ensuring `current_block` is correctly set when `python_list::get()` emits instructions.
