### PR TITLE
fix/github_3553_p2

### DIFF
--- a/regression/humaneval/humaneval_10/test.desc
+++ b/regression/humaneval/humaneval_10/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 15 --no-bounds-check --no-pointer-check --no-align-check
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3553/test.desc
+++ b/regression/python/github_3553/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 20 --no-bounds-check --no-pointer-check --no-align-check --no-unwinding-assertions
+--unwind 15 --no-bounds-check --no-pointer-check --no-align-check --compact-trace
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/power_large_exponent/main.py
+++ b/regression/python/power_large_exponent/main.py
@@ -1,0 +1,14 @@
+# Test exponentiation with exponent > 64
+# Const-eval should decline (return nullopt) and fallback to runtime evaluation
+
+# Small exponent (within const-eval bounds)
+a = 2 ** 10
+assert a == 1024
+
+# Exponent > 64 with base 1: const-eval declines, runtime handles it
+b = 1 ** 100
+assert b == 1
+
+# Exponent > 64 with base 0: const-eval declines, runtime handles it
+c = 0 ** 100
+assert c == 0

--- a/regression/python/power_large_exponent/test.desc
+++ b/regression/python/power_large_exponent/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/power_large_exponent_fail/main.py
+++ b/regression/python/power_large_exponent_fail/main.py
@@ -1,0 +1,14 @@
+# Test exponentiation with exponent > 64
+# Const-eval should decline (return nullopt) and fallback to runtime evaluation
+
+# Small exponent (within const-eval bounds)
+a = 2 ** 10
+assert a == 1023
+
+# Exponent > 64 with base 1: const-eval declines, runtime handles it
+b = 1 ** 100
+assert b == 1
+
+# Exponent > 64 with base 0: const-eval declines, runtime handles it
+c = 0 ** 100
+assert c == 0

--- a/regression/python/power_large_exponent_fail/test.desc
+++ b/regression/python/power_large_exponent_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(pythonfrontend STATIC
             python_converter.cpp
             python_class.cpp
             python_class_builder.cpp
+            python_consteval.cpp
             python_dict_handler.cpp
             python_exception_handler.cpp
             python_lambda.cpp

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -1,0 +1,914 @@
+#include <python-frontend/python_consteval.h>
+#include <algorithm>
+#include <cmath>
+
+bool PyConstValue::is_truthy() const
+{
+  switch (kind)
+  {
+  case NONE:
+    return false;
+  case BOOL:
+    return bool_val;
+  case INT:
+    return int_val != 0;
+  case FLOAT:
+    return float_val != 0.0;
+  case STRING:
+    return !string_val.empty();
+  }
+  return false;
+}
+
+python_consteval::python_consteval(
+  const nlohmann::json &ast,
+  int max_iterations)
+  : ast_(ast), iteration_budget_(max_iterations)
+{
+}
+
+const nlohmann::json *
+python_consteval::find_function(const std::string &name) const
+{
+  if (!ast_.contains("body") || !ast_["body"].is_array())
+    return nullptr;
+
+  for (const auto &node : ast_["body"])
+  {
+    if (
+      node.contains("_type") && node["_type"] == "FunctionDef" &&
+      node.contains("name") && node["name"] == name)
+      return &node;
+  }
+  return nullptr;
+}
+
+std::optional<PyConstValue> python_consteval::try_eval_call(
+  const std::string &func_name,
+  const std::vector<PyConstValue> &args)
+{
+  const nlohmann::json *func_node = find_function(func_name);
+  if (!func_node)
+    return std::nullopt;
+
+  if (!func_node->contains("args") || !(*func_node)["args"].contains("args"))
+    return std::nullopt;
+
+  const auto &func_args = (*func_node)["args"]["args"];
+  if (func_args.size() != args.size())
+    return std::nullopt;
+
+  // Create environment with parameter bindings
+  Env env;
+  for (size_t i = 0; i < args.size(); ++i)
+  {
+    std::string param_name = func_args[i]["arg"].get<std::string>();
+    env[param_name] = args[i];
+  }
+
+  ++call_depth_;
+  if (call_depth_ > MAX_CALL_DEPTH)
+  {
+    --call_depth_;
+    return std::nullopt;
+  }
+
+  auto result = exec_block((*func_node)["body"], env);
+  --call_depth_;
+
+  if (!result)
+    return std::nullopt;
+
+  if (result->type == StmtResult::RETURN)
+    return result->value;
+
+  // Function didn't return explicitly → returns None
+  return PyConstValue::make_none();
+}
+
+std::optional<python_consteval::StmtResult> python_consteval::exec_block(
+  const nlohmann::json &body,
+  Env &env)
+{
+  for (const auto &stmt : body)
+  {
+    auto result = exec_stmt(stmt, env);
+    if (!result)
+      return std::nullopt;
+    if (result->type != StmtResult::CONTINUE)
+      return result;
+  }
+  return StmtResult{StmtResult::CONTINUE, {}};
+}
+
+std::optional<python_consteval::StmtResult> python_consteval::exec_stmt(
+  const nlohmann::json &stmt,
+  Env &env)
+{
+  if (!stmt.contains("_type"))
+    return std::nullopt;
+
+  const std::string &type = stmt["_type"];
+
+  // Return statement
+  if (type == "Return")
+  {
+    if (!stmt.contains("value") || stmt["value"].is_null())
+      return StmtResult{StmtResult::RETURN, PyConstValue::make_none()};
+
+    auto val = eval_expr(stmt["value"], env);
+    if (!val)
+      return std::nullopt;
+    return StmtResult{StmtResult::RETURN, *val};
+  }
+
+  // Assignment: x = expr  or  x: type = expr
+  if (type == "Assign")
+  {
+    if (
+      !stmt.contains("targets") || stmt["targets"].empty() ||
+      !stmt.contains("value"))
+      return std::nullopt;
+
+    auto val = eval_expr(stmt["value"], env);
+    if (!val)
+      return std::nullopt;
+
+    for (const auto &target : stmt["targets"])
+    {
+      if (target["_type"] != "Name")
+        return std::nullopt; // Only support simple variable assignment
+      env[target["id"].get<std::string>()] = *val;
+    }
+    return StmtResult{StmtResult::CONTINUE, {}};
+  }
+
+  if (type == "AnnAssign")
+  {
+    if (!stmt.contains("target") || stmt["target"]["_type"] != "Name")
+      return std::nullopt;
+
+    if (stmt.contains("value") && !stmt["value"].is_null())
+    {
+      auto val = eval_expr(stmt["value"], env);
+      if (!val)
+        return std::nullopt;
+      env[stmt["target"]["id"].get<std::string>()] = *val;
+    }
+    return StmtResult{StmtResult::CONTINUE, {}};
+  }
+
+  // Augmented assignment: x += expr, x -= expr, etc.
+  if (type == "AugAssign")
+  {
+    if (
+      !stmt.contains("target") || stmt["target"]["_type"] != "Name" ||
+      !stmt.contains("value") || !stmt.contains("op"))
+      return std::nullopt;
+
+    const std::string &var_name = stmt["target"]["id"].get<std::string>();
+    auto it = env.find(var_name);
+    if (it == env.end())
+      return std::nullopt;
+
+    auto rhs = eval_expr(stmt["value"], env);
+    if (!rhs)
+      return std::nullopt;
+
+    const std::string &op = stmt["op"]["_type"];
+    PyConstValue &lhs = it->second;
+
+    if (op == "Add")
+    {
+      if (lhs.kind == PyConstValue::INT && rhs->kind == PyConstValue::INT)
+        lhs.int_val += rhs->int_val;
+      else if (
+        lhs.kind == PyConstValue::STRING && rhs->kind == PyConstValue::STRING)
+        lhs.string_val += rhs->string_val;
+      else
+        return std::nullopt;
+    }
+    else if (op == "Sub")
+    {
+      if (lhs.kind == PyConstValue::INT && rhs->kind == PyConstValue::INT)
+        lhs.int_val -= rhs->int_val;
+      else
+        return std::nullopt;
+    }
+    else if (op == "Mult")
+    {
+      if (lhs.kind == PyConstValue::INT && rhs->kind == PyConstValue::INT)
+        lhs.int_val *= rhs->int_val;
+      else
+        return std::nullopt;
+    }
+    else
+      return std::nullopt;
+
+    return StmtResult{StmtResult::CONTINUE, {}};
+  }
+
+  // If statement
+  if (type == "If")
+  {
+    auto cond = eval_expr(stmt["test"], env);
+    if (!cond)
+      return std::nullopt;
+
+    if (cond->is_truthy())
+      return exec_block(stmt["body"], env);
+    else if (stmt.contains("orelse") && !stmt["orelse"].empty())
+      return exec_block(stmt["orelse"], env);
+
+    return StmtResult{StmtResult::CONTINUE, {}};
+  }
+
+  // While loop
+  if (type == "While")
+  {
+    while (true)
+    {
+      if (--iteration_budget_ <= 0)
+        return std::nullopt; // Prevent infinite loops
+
+      auto cond = eval_expr(stmt["test"], env);
+      if (!cond)
+        return std::nullopt;
+
+      if (!cond->is_truthy())
+        break;
+
+      auto result = exec_block(stmt["body"], env);
+      if (!result)
+        return std::nullopt;
+
+      if (result->type == StmtResult::RETURN)
+        return result;
+      if (result->type == StmtResult::BREAK_STMT)
+        break;
+      // CONTINUE_STMT just continues to next iteration
+    }
+    return StmtResult{StmtResult::CONTINUE, {}};
+  }
+
+  // For loop: for var in iterable
+  if (type == "For")
+  {
+    if (stmt["target"]["_type"] != "Name")
+      return std::nullopt;
+
+    const std::string &var_name = stmt["target"]["id"].get<std::string>();
+    auto iter_val = eval_expr(stmt["iter"], env);
+    if (!iter_val)
+      return std::nullopt;
+
+    // Support for range()
+    if (
+      stmt["iter"]["_type"] == "Call" &&
+      stmt["iter"]["func"]["_type"] == "Name" &&
+      stmt["iter"]["func"]["id"] == "range")
+    {
+      // range() already evaluated — we need the actual range values
+      // We'll handle range in eval_expr and iterate a list
+      return std::nullopt; // TODO: implement range iteration if needed
+    }
+
+    // Iterate over string characters
+    if (iter_val->kind == PyConstValue::STRING)
+    {
+      for (char c : iter_val->string_val)
+      {
+        if (--iteration_budget_ <= 0)
+          return std::nullopt;
+
+        env[var_name] = PyConstValue::make_string(std::string(1, c));
+        auto result = exec_block(stmt["body"], env);
+        if (!result)
+          return std::nullopt;
+        if (result->type == StmtResult::RETURN)
+          return result;
+        if (result->type == StmtResult::BREAK_STMT)
+          break;
+      }
+      return StmtResult{StmtResult::CONTINUE, {}};
+    }
+
+    return std::nullopt;
+  }
+
+  // Expression statement (e.g., standalone function calls)
+  if (type == "Expr")
+  {
+    auto val = eval_expr(stmt["value"], env);
+    if (!val)
+      return std::nullopt;
+    return StmtResult{StmtResult::CONTINUE, {}};
+  }
+
+  // Break/Continue
+  if (type == "Break")
+    return StmtResult{StmtResult::BREAK_STMT, {}};
+  if (type == "Continue")
+    return StmtResult{StmtResult::CONTINUE_STMT, {}};
+
+  // Pass
+  if (type == "Pass")
+    return StmtResult{StmtResult::CONTINUE, {}};
+
+  // Assert — evaluate but don't enforce (we're just computing the result)
+  if (type == "Assert")
+    return StmtResult{StmtResult::CONTINUE, {}};
+
+  return std::nullopt; // Unsupported statement type
+}
+
+std::optional<PyConstValue> python_consteval::eval_expr(
+  const nlohmann::json &node,
+  const Env &env)
+{
+  if (!node.contains("_type"))
+    return std::nullopt;
+
+  const std::string &type = node["_type"];
+
+  // Constants
+  if (type == "Constant")
+  {
+    const auto &val = node["value"];
+    if (val.is_null())
+      return PyConstValue::make_none();
+    if (val.is_boolean())
+      return PyConstValue::make_bool(val.get<bool>());
+    if (val.is_number_integer())
+      return PyConstValue::make_int(val.get<long long>());
+    if (val.is_number_float())
+      return PyConstValue{
+        PyConstValue::FLOAT, false, 0, val.get<double>(), ""};
+    if (val.is_string())
+      return PyConstValue::make_string(val.get<std::string>());
+    return std::nullopt;
+  }
+
+  // Variable lookup
+  if (type == "Name")
+  {
+    const std::string &name = node["id"].get<std::string>();
+
+    // Built-in constants
+    if (name == "True")
+      return PyConstValue::make_bool(true);
+    if (name == "False")
+      return PyConstValue::make_bool(false);
+    if (name == "None")
+      return PyConstValue::make_none();
+
+    auto it = env.find(name);
+    if (it == env.end())
+      return std::nullopt;
+    return it->second;
+  }
+
+  // Unary operations: not, -, +
+  if (type == "UnaryOp")
+  {
+    auto operand = eval_expr(node["operand"], env);
+    if (!operand)
+      return std::nullopt;
+
+    const std::string &op = node["op"]["_type"];
+
+    if (op == "Not")
+      return PyConstValue::make_bool(!operand->is_truthy());
+
+    if (op == "USub")
+    {
+      if (operand->kind == PyConstValue::INT)
+        return PyConstValue::make_int(-operand->int_val);
+      if (operand->kind == PyConstValue::FLOAT)
+        return PyConstValue{
+          PyConstValue::FLOAT, false, 0, -operand->float_val, ""};
+      return std::nullopt;
+    }
+
+    if (op == "UAdd")
+    {
+      if (
+        operand->kind == PyConstValue::INT ||
+        operand->kind == PyConstValue::FLOAT)
+        return operand;
+      return std::nullopt;
+    }
+
+    return std::nullopt;
+  }
+
+  // Binary operations: +, -, *, //, %, **
+  if (type == "BinOp")
+  {
+    auto left = eval_expr(node["left"], env);
+    auto right = eval_expr(node["right"], env);
+    if (!left || !right)
+      return std::nullopt;
+
+    const std::string &op = node["op"]["_type"];
+
+    // String concatenation
+    if (
+      op == "Add" && left->kind == PyConstValue::STRING &&
+      right->kind == PyConstValue::STRING)
+      return PyConstValue::make_string(left->string_val + right->string_val);
+
+    // String repetition
+    if (
+      op == "Mult" && left->kind == PyConstValue::STRING &&
+      right->kind == PyConstValue::INT)
+    {
+      if (right->int_val <= 0)
+        return PyConstValue::make_string("");
+      std::string result;
+      for (long long i = 0;
+           i < right->int_val && result.size() < 10000;
+           ++i)
+        result += left->string_val;
+      return PyConstValue::make_string(result);
+    }
+
+    // Integer arithmetic
+    if (left->kind == PyConstValue::INT && right->kind == PyConstValue::INT)
+    {
+      long long l = left->int_val, r = right->int_val;
+      if (op == "Add")
+        return PyConstValue::make_int(l + r);
+      if (op == "Sub")
+        return PyConstValue::make_int(l - r);
+      if (op == "Mult")
+        return PyConstValue::make_int(l * r);
+      if (op == "FloorDiv")
+      {
+        if (r == 0)
+          return std::nullopt;
+        return PyConstValue::make_int(l / r);
+      }
+      if (op == "Mod")
+      {
+        if (r == 0)
+          return std::nullopt;
+        long long result = l % r;
+        // Python mod always returns non-negative for positive divisor
+        if (result != 0 && ((result < 0) != (r < 0)))
+          result += r;
+        return PyConstValue::make_int(result);
+      }
+      if (op == "Pow")
+      {
+        if (r < 0)
+          return std::nullopt; // Would produce float
+        long long result = 1;
+        for (long long i = 0; i < r && i < 64; ++i)
+          result *= l;
+        return PyConstValue::make_int(result);
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  // Boolean operations: and, or
+  if (type == "BoolOp")
+  {
+    const std::string &op = node["op"]["_type"];
+    const auto &values = node["values"];
+
+    if (op == "And")
+    {
+      PyConstValue result = PyConstValue::make_bool(true);
+      for (const auto &v : values)
+      {
+        auto val = eval_expr(v, env);
+        if (!val)
+          return std::nullopt;
+        if (!val->is_truthy())
+          return val; // Short-circuit: return the falsy value
+        result = *val;
+      }
+      return result; // Return last truthy value
+    }
+
+    if (op == "Or")
+    {
+      PyConstValue result = PyConstValue::make_bool(false);
+      for (const auto &v : values)
+      {
+        auto val = eval_expr(v, env);
+        if (!val)
+          return std::nullopt;
+        if (val->is_truthy())
+          return val; // Short-circuit: return the truthy value
+        result = *val;
+      }
+      return result; // Return last falsy value
+    }
+
+    return std::nullopt;
+  }
+
+  // Comparison: ==, !=, <, >, <=, >=
+  if (type == "Compare")
+  {
+    auto left_val = eval_expr(node["left"], env);
+    if (!left_val)
+      return std::nullopt;
+
+    const auto &ops = node["ops"];
+    const auto &comparators = node["comparators"];
+
+    if (ops.size() != comparators.size())
+      return std::nullopt;
+
+    for (size_t i = 0; i < ops.size(); ++i)
+    {
+      auto right_val = eval_expr(comparators[i], env);
+      if (!right_val)
+        return std::nullopt;
+
+      const std::string &cmp_op = ops[i]["_type"];
+      bool result = false;
+
+      // String comparison
+      if (
+        left_val->kind == PyConstValue::STRING &&
+        right_val->kind == PyConstValue::STRING)
+      {
+        int cmp = left_val->string_val.compare(right_val->string_val);
+        if (cmp_op == "Eq")
+          result = cmp == 0;
+        else if (cmp_op == "NotEq")
+          result = cmp != 0;
+        else if (cmp_op == "Lt")
+          result = cmp < 0;
+        else if (cmp_op == "LtE")
+          result = cmp <= 0;
+        else if (cmp_op == "Gt")
+          result = cmp > 0;
+        else if (cmp_op == "GtE")
+          result = cmp >= 0;
+        else
+          return std::nullopt;
+      }
+      // Integer comparison
+      else if (
+        left_val->kind == PyConstValue::INT &&
+        right_val->kind == PyConstValue::INT)
+      {
+        long long l = left_val->int_val, r = right_val->int_val;
+        if (cmp_op == "Eq")
+          result = l == r;
+        else if (cmp_op == "NotEq")
+          result = l != r;
+        else if (cmp_op == "Lt")
+          result = l < r;
+        else if (cmp_op == "LtE")
+          result = l <= r;
+        else if (cmp_op == "Gt")
+          result = l > r;
+        else if (cmp_op == "GtE")
+          result = l >= r;
+        else
+          return std::nullopt;
+      }
+      // Boolean == None, None == None, etc.
+      else if (
+        left_val->kind == PyConstValue::NONE ||
+        right_val->kind == PyConstValue::NONE)
+      {
+        if (cmp_op == "Is" || cmp_op == "Eq")
+          result = (left_val->kind == right_val->kind);
+        else if (cmp_op == "IsNot" || cmp_op == "NotEq")
+          result = (left_val->kind != right_val->kind);
+        else
+          return std::nullopt;
+      }
+      // Bool comparison
+      else if (
+        left_val->kind == PyConstValue::BOOL &&
+        right_val->kind == PyConstValue::BOOL)
+      {
+        if (cmp_op == "Eq")
+          result = left_val->bool_val == right_val->bool_val;
+        else if (cmp_op == "NotEq")
+          result = left_val->bool_val != right_val->bool_val;
+        else
+          return std::nullopt;
+      }
+      else
+        return std::nullopt;
+
+      if (!result)
+        return PyConstValue::make_bool(false);
+
+      left_val = right_val; // For chained comparisons
+    }
+    return PyConstValue::make_bool(true);
+  }
+
+  // Subscript (string slicing and indexing)
+  if (type == "Subscript")
+  {
+    auto obj = eval_expr(node["value"], env);
+    if (!obj || obj->kind != PyConstValue::STRING)
+      return std::nullopt;
+
+    const auto &slice = node["slice"];
+
+    // Simple index: s[i]
+    if (slice.contains("_type") && slice["_type"] == "Constant")
+    {
+      if (!slice["value"].is_number_integer())
+        return std::nullopt;
+
+      long long idx = slice["value"].get<long long>();
+      long long len = static_cast<long long>(obj->string_val.size());
+
+      if (idx < 0)
+        idx += len;
+      if (idx < 0 || idx >= len)
+        return std::nullopt; // Index out of range
+
+      return PyConstValue::make_string(
+        std::string(1, obj->string_val[static_cast<size_t>(idx)]));
+    }
+
+    // Variable index: s[var]
+    if (slice.contains("_type") && slice["_type"] == "Name")
+    {
+      auto idx_val = eval_expr(slice, env);
+      if (!idx_val || idx_val->kind != PyConstValue::INT)
+        return std::nullopt;
+
+      long long idx = idx_val->int_val;
+      long long len = static_cast<long long>(obj->string_val.size());
+
+      if (idx < 0)
+        idx += len;
+      if (idx < 0 || idx >= len)
+        return std::nullopt;
+
+      return PyConstValue::make_string(
+        std::string(1, obj->string_val[static_cast<size_t>(idx)]));
+    }
+
+    // Slice: s[start:stop:step]
+    if (slice.contains("_type") && slice["_type"] == "Slice")
+    {
+      std::optional<long long> start, stop;
+      long long step = 1;
+
+      if (slice.contains("lower") && !slice["lower"].is_null())
+      {
+        auto v = eval_expr(slice["lower"], env);
+        if (!v || v->kind != PyConstValue::INT)
+          return std::nullopt;
+        start = v->int_val;
+      }
+
+      if (slice.contains("upper") && !slice["upper"].is_null())
+      {
+        auto v = eval_expr(slice["upper"], env);
+        if (!v || v->kind != PyConstValue::INT)
+          return std::nullopt;
+        stop = v->int_val;
+      }
+
+      if (slice.contains("step") && !slice["step"].is_null())
+      {
+        auto v = eval_expr(slice["step"], env);
+        if (!v || v->kind != PyConstValue::INT)
+          return std::nullopt;
+        step = v->int_val;
+        if (step == 0)
+          return std::nullopt; // ValueError in Python
+      }
+
+      return PyConstValue::make_string(
+        slice_string(obj->string_val, start, stop, step));
+    }
+
+    return std::nullopt;
+  }
+
+  // Function call
+  if (type == "Call")
+  {
+    if (!node.contains("func"))
+      return std::nullopt;
+
+    // Only support simple function calls (Name), not methods
+    if (node["func"]["_type"] != "Name")
+      return std::nullopt;
+
+    const std::string &func_name = node["func"]["id"].get<std::string>();
+
+    // Built-in: len()
+    if (func_name == "len")
+    {
+      if (node["args"].size() != 1)
+        return std::nullopt;
+      auto arg = eval_expr(node["args"][0], env);
+      if (!arg)
+        return std::nullopt;
+      if (arg->kind == PyConstValue::STRING)
+        return PyConstValue::make_int(
+          static_cast<long long>(arg->string_val.size()));
+      return std::nullopt;
+    }
+
+    // Built-in: str()
+    if (func_name == "str")
+    {
+      if (node["args"].size() != 1)
+        return std::nullopt;
+      auto arg = eval_expr(node["args"][0], env);
+      if (!arg)
+        return std::nullopt;
+      if (arg->kind == PyConstValue::STRING)
+        return arg;
+      if (arg->kind == PyConstValue::INT)
+        return PyConstValue::make_string(std::to_string(arg->int_val));
+      return std::nullopt;
+    }
+
+    // Built-in: int()
+    if (func_name == "int")
+    {
+      if (node["args"].size() != 1)
+        return std::nullopt;
+      auto arg = eval_expr(node["args"][0], env);
+      if (!arg)
+        return std::nullopt;
+      if (arg->kind == PyConstValue::INT)
+        return arg;
+      if (arg->kind == PyConstValue::BOOL)
+        return PyConstValue::make_int(arg->bool_val ? 1 : 0);
+      return std::nullopt;
+    }
+
+    // Built-in: bool()
+    if (func_name == "bool")
+    {
+      if (node["args"].size() != 1)
+        return std::nullopt;
+      auto arg = eval_expr(node["args"][0], env);
+      if (!arg)
+        return std::nullopt;
+      return PyConstValue::make_bool(arg->is_truthy());
+    }
+
+    // Built-in: abs()
+    if (func_name == "abs")
+    {
+      if (node["args"].size() != 1)
+        return std::nullopt;
+      auto arg = eval_expr(node["args"][0], env);
+      if (!arg)
+        return std::nullopt;
+      if (arg->kind == PyConstValue::INT)
+        return PyConstValue::make_int(
+          arg->int_val < 0 ? -arg->int_val : arg->int_val);
+      return std::nullopt;
+    }
+
+    // Built-in: min(), max() for two int arguments
+    if (func_name == "min" || func_name == "max")
+    {
+      if (node["args"].size() != 2)
+        return std::nullopt;
+      auto a = eval_expr(node["args"][0], env);
+      auto b = eval_expr(node["args"][1], env);
+      if (!a || !b || a->kind != PyConstValue::INT ||
+          b->kind != PyConstValue::INT)
+        return std::nullopt;
+      if (func_name == "min")
+        return PyConstValue::make_int(std::min(a->int_val, b->int_val));
+      return PyConstValue::make_int(std::max(a->int_val, b->int_val));
+    }
+
+    // User-defined function call — recurse
+    std::vector<PyConstValue> args;
+    for (const auto &arg_node : node["args"])
+    {
+      auto arg = eval_expr(arg_node, env);
+      if (!arg)
+        return std::nullopt;
+      args.push_back(*arg);
+    }
+
+    return try_eval_call(func_name, args);
+  }
+
+  // IfExp (ternary): x if cond else y
+  if (type == "IfExp")
+  {
+    auto cond = eval_expr(node["test"], env);
+    if (!cond)
+      return std::nullopt;
+    if (cond->is_truthy())
+      return eval_expr(node["body"], env);
+    return eval_expr(node["orelse"], env);
+  }
+
+  // JoinedStr (f-string)
+  if (type == "JoinedStr")
+  {
+    std::string result;
+    for (const auto &part : node["values"])
+    {
+      if (part["_type"] == "Constant" && part["value"].is_string())
+      {
+        result += part["value"].get<std::string>();
+      }
+      else if (part["_type"] == "FormattedValue")
+      {
+        auto val = eval_expr(part["value"], env);
+        if (!val)
+          return std::nullopt;
+        if (val->kind == PyConstValue::STRING)
+          result += val->string_val;
+        else if (val->kind == PyConstValue::INT)
+          result += std::to_string(val->int_val);
+        else
+          return std::nullopt;
+      }
+      else
+        return std::nullopt;
+    }
+    return PyConstValue::make_string(result);
+  }
+
+  return std::nullopt; // Unsupported expression type
+}
+
+std::string python_consteval::slice_string(
+  const std::string &s,
+  std::optional<long long> start,
+  std::optional<long long> stop,
+  long long step)
+{
+  long long len = static_cast<long long>(s.size());
+
+  long long actual_start, actual_stop;
+
+  if (step > 0)
+  {
+    actual_start = start.value_or(0);
+    actual_stop = stop.value_or(len);
+  }
+  else
+  {
+    actual_start = start.value_or(len - 1);
+    actual_stop = stop.value_or(-(len + 1));
+  }
+
+  // Resolve negative indices
+  if (actual_start < 0)
+    actual_start += len;
+  if (actual_stop < 0)
+    actual_stop += len;
+
+  // Clamp to valid range
+  if (step > 0)
+  {
+    if (actual_start < 0)
+      actual_start = 0;
+    if (actual_start > len)
+      actual_start = len;
+    if (actual_stop < 0)
+      actual_stop = 0;
+    if (actual_stop > len)
+      actual_stop = len;
+  }
+  else
+  {
+    if (actual_start < -1)
+      actual_start = -1;
+    if (actual_start >= len)
+      actual_start = len - 1;
+    if (actual_stop < -1)
+      actual_stop = -1;
+    if (actual_stop >= len)
+      actual_stop = len;
+  }
+
+  std::string result;
+  if (step > 0)
+  {
+    for (long long i = actual_start; i < actual_stop; i += step)
+      result += s[static_cast<size_t>(i)];
+  }
+  else
+  {
+    for (long long i = actual_start; i > actual_stop; i += step)
+      result += s[static_cast<size_t>(i)];
+  }
+
+  return result;
+}

--- a/src/python-frontend/python_consteval.h
+++ b/src/python-frontend/python_consteval.h
@@ -38,7 +38,7 @@ struct PyConstValue
   }
   static PyConstValue make_float(double v)
   {
-    return { FLOAT, false, 0, v, "" };
+    return {FLOAT, false, 0, v, ""};
   }
   static PyConstValue make_string(const std::string &s)
   {
@@ -87,15 +87,10 @@ private:
     PyConstValue value;
   };
 
-  std::optional<StmtResult> exec_block(
-    const nlohmann::json &body,
-    Env &env);
-  std::optional<StmtResult> exec_stmt(
-    const nlohmann::json &stmt,
-    Env &env);
-  std::optional<PyConstValue> eval_expr(
-    const nlohmann::json &node,
-    const Env &env);
+  std::optional<StmtResult> exec_block(const nlohmann::json &body, Env &env);
+  std::optional<StmtResult> exec_stmt(const nlohmann::json &stmt, Env &env);
+  std::optional<PyConstValue>
+  eval_expr(const nlohmann::json &node, const Env &env);
 
   // String slice with full Python semantics
   static std::string slice_string(

--- a/src/python-frontend/python_consteval.h
+++ b/src/python-frontend/python_consteval.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/// Represents a constant Python value for compile-time evaluation.
+struct PyConstValue
+{
+  enum Kind
+  {
+    NONE,
+    BOOL,
+    INT,
+    FLOAT,
+    STRING
+  };
+
+  Kind kind = NONE;
+  bool bool_val = false;
+  long long int_val = 0;
+  double float_val = 0.0;
+  std::string string_val;
+
+  static PyConstValue make_none()
+  {
+    return {NONE, false, 0, 0.0, ""};
+  }
+  static PyConstValue make_bool(bool v)
+  {
+    return {BOOL, v, 0, 0.0, ""};
+  }
+  static PyConstValue make_int(long long v)
+  {
+    return {INT, false, v, 0.0, ""};
+  }
+  static PyConstValue make_string(const std::string &s)
+  {
+    return {STRING, false, 0, 0.0, s};
+  }
+
+  bool is_truthy() const;
+};
+
+/// Lightweight Python AST evaluator for compile-time function evaluation.
+/// When a pure function is called with all-constant arguments, this evaluator
+/// interprets the function body at conversion time and returns the result,
+/// eliminating loops from the GOTO program entirely.
+class python_consteval
+{
+public:
+  explicit python_consteval(
+    const nlohmann::json &ast,
+    int max_iterations = 50000);
+
+  /// Try to evaluate a function call with constant arguments.
+  /// Returns std::nullopt if evaluation cannot be completed
+  /// (unsupported construct, timeout, recursion limit, etc.).
+  std::optional<PyConstValue> try_eval_call(
+    const std::string &func_name,
+    const std::vector<PyConstValue> &args);
+
+private:
+  const nlohmann::json &ast_;
+  int iteration_budget_;
+  int call_depth_ = 0;
+  static constexpr int MAX_CALL_DEPTH = 30;
+
+  using Env = std::unordered_map<std::string, PyConstValue>;
+
+  struct StmtResult
+  {
+    enum Type
+    {
+      CONTINUE,
+      RETURN,
+      BREAK_STMT,
+      CONTINUE_STMT
+    };
+    Type type = CONTINUE;
+    PyConstValue value;
+  };
+
+  std::optional<StmtResult> exec_block(
+    const nlohmann::json &body,
+    Env &env);
+  std::optional<StmtResult> exec_stmt(
+    const nlohmann::json &stmt,
+    Env &env);
+  std::optional<PyConstValue> eval_expr(
+    const nlohmann::json &node,
+    const Env &env);
+
+  // String slice with full Python semantics
+  static std::string slice_string(
+    const std::string &s,
+    std::optional<long long> start,
+    std::optional<long long> stop,
+    long long step);
+
+  // Find function definition in top-level AST body
+  const nlohmann::json *find_function(const std::string &name) const;
+};

--- a/src/python-frontend/python_consteval.h
+++ b/src/python-frontend/python_consteval.h
@@ -36,6 +36,10 @@ struct PyConstValue
   {
     return {INT, false, v, 0.0, ""};
   }
+  static PyConstValue make_float(double v)
+  {
+    return { FLOAT, false, 0, v, "" };
+  }
   static PyConstValue make_string(const std::string &s)
   {
     return {STRING, false, 0, 0.0, s};
@@ -74,12 +78,12 @@ private:
   {
     enum Type
     {
-      CONTINUE,
+      NORMAL,
       RETURN,
       BREAK_STMT,
       CONTINUE_STMT
     };
-    Type type = CONTINUE;
+    Type type = NORMAL;
     PyConstValue value;
   };
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -95,10 +95,9 @@ static std::string map_operator(const std::string &op, const typet &type)
   // Convert the operator to lowercase to allow case-insensitive comparison.
   std::string lower_op = op;
   std::transform(
-    lower_op.begin(),
-    lower_op.end(),
-    lower_op.begin(),
-    [](unsigned char c) { return std::tolower(c); });
+    lower_op.begin(), lower_op.end(), lower_op.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
 
   // If the type is floating-point, use IEEE-specific operators.
   if (type.is_floatbv())
@@ -521,10 +520,9 @@ exprt handle_float_vs_string(exprt &bin_expr, const std::string &op)
     // Python-style error: float < str → TypeError
     std::string lower_op = op;
     std::transform(
-      lower_op.begin(),
-      lower_op.end(),
-      lower_op.begin(),
-      [](unsigned char c) { return std::tolower(c); });
+      lower_op.begin(), lower_op.end(), lower_op.begin(), [](unsigned char c) {
+        return std::tolower(c);
+      });
 
     const auto &loc = bin_expr.location();
     const auto it = operator_map.find(lower_op);
@@ -574,8 +572,7 @@ bool python_converter::has_unsupported_side_effects_internal(
   const exprt &lhs,
   const exprt &rhs)
 {
-  auto has_unsupported_side_effect = [](const exprt &expr)
-  {
+  auto has_unsupported_side_effect = [](const exprt &expr) {
     return expr.id() == "sideeffect" &&
            expr.get("statement") != "function_call";
   };
@@ -780,8 +777,7 @@ exprt python_converter::handle_string_comparison(
   // This avoids introducing strcmp() calls that can inflate branch coverage counts.
   if (op == "Eq" || op == "NotEq")
   {
-    auto extract_single_char = [&](const exprt &expr, char &ch) -> bool
-    {
+    auto extract_single_char = [&](const exprt &expr, char &ch) -> bool {
       const exprt *candidate = &expr;
       if (
         expr.id() == "address_of" && expr.operands().size() == 1 &&
@@ -805,8 +801,7 @@ exprt python_converter::handle_string_comparison(
       return true;
     };
 
-    auto char_at_index = [&](const exprt &expr, int idx) -> exprt
-    {
+    auto char_at_index = [&](const exprt &expr, int idx) -> exprt {
       exprt index = from_integer(idx, index_type());
       if (expr.type().is_array())
         return index_exprt(expr, index, char_type());
@@ -1235,8 +1230,7 @@ void python_converter::convert_function_calls_to_side_effects(
   exprt &lhs,
   exprt &rhs)
 {
-  auto to_side_effect_call = [](exprt &expr)
-  {
+  auto to_side_effect_call = [](exprt &expr) {
     side_effect_expr_function_callt side_effect;
     code_function_callt &code = static_cast<code_function_callt &>(expr);
     side_effect.function() = code.function();
@@ -1432,8 +1426,7 @@ exprt python_converter::handle_type_identity_check(
   auto resolve_type_identifier = [&](
                                    const nlohmann::json &node,
                                    const exprt &expr,
-                                   std::string &out_name) -> bool
-  {
+                                   std::string &out_name) -> bool {
     if (node["_type"] == "Name" && node.contains("id"))
     {
       std::string name = node["id"].get<std::string>();
@@ -1643,10 +1636,10 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     type_utils::is_relational_op(op) || op == "Is" || op == "IsNot" ||
     op == "In" || op == "NotIn")
   {
-    auto is_any_ptr = [](const exprt &e)
-    { return e.type().is_pointer() && e.type().subtype().id() == "empty"; };
-    auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type)
-    {
+    auto is_any_ptr = [](const exprt &e) {
+      return e.type().is_pointer() && e.type().subtype().id() == "empty";
+    };
+    auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type) {
       if (e.type().is_floatbv())
       {
         unsigned width = static_cast<const bv_typet &>(e.type()).get_width();
@@ -1745,8 +1738,7 @@ exprt python_converter::handle_list_operations(
   typet list_type = type_handler_.get_list_type();
 
   // Resolve function calls that return lists to temporary variables
-  auto resolve_list_call = [&](exprt &expr) -> bool
-  {
+  auto resolve_list_call = [&](exprt &expr) -> bool {
     // Check if this is a side effect function call
     if (expr.id().as_string() != "sideeffect")
       return false;
@@ -2429,8 +2421,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         can_fold = false;
     }
 
-    auto returns_list = [](const nlohmann::json &ret) -> bool
-    {
+    auto returns_list = [](const nlohmann::json &ret) -> bool {
       if (ret.is_null())
         return false;
       if (
@@ -2461,8 +2452,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       const std::string input = arg0["value"].get<std::string>();
       std::vector<long long> out;
       std::string token;
-      auto flush_token = [&](const std::string &tok)
-      {
+      auto flush_token = [&](const std::string &tok) {
         if (tok.empty())
           return;
         long long depth = 0;
@@ -2776,8 +2766,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
   }
 
-  auto handle_keywords = [&](exprt &call_expr)
-  {
+  auto handle_keywords = [&](exprt &call_expr) {
     if (!element.contains("keywords") || element["keywords"].empty())
       return;
 
@@ -2835,8 +2824,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
 
     // we need to check if the argument is provided despite being optional
-    auto is_optional_type = [&](const typet &param_type)
-    {
+    auto is_optional_type = [&](const typet &param_type) {
       if (!param_type.is_struct())
         return false;
       const struct_typet &struct_type = to_struct_type(param_type);
@@ -3648,19 +3636,17 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         symbolt *target_class_symbol = nullptr;
 
         // Search all class types in the symbol table to find one that has this attribute
-        symbol_table_.foreach_operand_in_order(
-          [&](const symbolt &s)
-          {
-            if (target_class_symbol)
-              return; // Already found
+        symbol_table_.foreach_operand_in_order([&](const symbolt &s) {
+          if (target_class_symbol)
+            return; // Already found
 
-            if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
-            {
-              const struct_typet &struct_type = to_struct_type(s.type);
-              if (struct_type.has_component(attr_name))
-                target_class_symbol = const_cast<symbolt *>(&s);
-            }
-          });
+          if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
+          {
+            const struct_typet &struct_type = to_struct_type(s.type);
+            if (struct_type.has_component(attr_name))
+              target_class_symbol = const_cast<symbolt *>(&s);
+          }
+        });
 
         if (!target_class_symbol)
         {
@@ -4107,8 +4093,7 @@ void python_converter::handle_assignment_type_adjustments(
       !ast_node.value("_inferred_annotation", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
-      [this]()
-      {
+      [this]() {
         // Check if "from typing import Any" exists in the source file
         const auto &body = (*ast_json)["body"];
         for (const auto &stmt : body)
@@ -5514,10 +5499,8 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
 
     // Reuse a single condition temporary to avoid redeclaring symbols
     // at each iteration of the lowered loop.
-    symbolt cond_symbol = create_return_temp_variable(
-      bool_type(),
-      call_location,
-      "while_cond");
+    symbolt cond_symbol =
+      create_return_temp_variable(bool_type(), call_location, "while_cond");
     symbol_table_.add(cond_symbol);
     exprt cond_tmp = symbol_expr(cond_symbol);
 
@@ -5733,8 +5716,7 @@ std::string
 python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
 {
   std::function<std::string(const nlohmann::json &)> extract_type =
-    [&](const nlohmann::json &node) -> std::string
-  {
+    [&](const nlohmann::json &node) -> std::string {
     if (
       node.contains("_type") && node["_type"] == "Constant" &&
       node.contains("value") && node["value"].is_null())
@@ -5860,8 +5842,7 @@ typet python_converter::get_type_from_annotation(
   if (annotation_node["_type"] == "Subscript")
   {
     // Helper to safely get id from value node
-    auto get_value_id = [&]() -> std::string
-    {
+    auto get_value_id = [&]() -> std::string {
       if (
         annotation_node.contains("value") &&
         annotation_node["value"].is_object() &&
@@ -5884,8 +5865,7 @@ typet python_converter::get_type_from_annotation(
     if (value_id == "Literal")
     {
       // Infer type from a literal constant value
-      auto infer_literal_type = [](const nlohmann::json &value) -> typet
-      {
+      auto infer_literal_type = [](const nlohmann::json &value) -> typet {
         if (value.is_string())
           return gen_pointer_type(char_type());
         else if (value.is_number_integer())
@@ -5902,8 +5882,7 @@ typet python_converter::get_type_from_annotation(
 
       // Resolve a slice element to a constant value
       auto resolve_to_constant =
-        [this](const nlohmann::json &elem) -> nlohmann::json
-      {
+        [this](const nlohmann::json &elem) -> nlohmann::json {
         // Guard: ensure elem is an object with _type
         if (!elem.is_object() || !elem.contains("_type"))
           return nlohmann::json();
@@ -5931,10 +5910,11 @@ typet python_converter::get_type_from_annotation(
       };
 
       // Track type flags from a resolved type
-      auto update_type_flags =
-        [](
-          const typet &type, TypeFlags &flags, bool &has_string, bool &has_none)
-      {
+      auto update_type_flags = [](
+                                 const typet &type,
+                                 TypeFlags &flags,
+                                 bool &has_string,
+                                 bool &has_none) {
         if (type == gen_pointer_type(char_type()))
           has_string = true;
         else if (type == double_type())
@@ -5962,8 +5942,8 @@ typet python_converter::get_type_from_annotation(
           return empty_typet();
 
         // Helper to safely check if node is a Literal subscript
-        auto is_literal_subscript_node = [](const nlohmann::json &node) -> bool
-        {
+        auto is_literal_subscript_node =
+          [](const nlohmann::json &node) -> bool {
           return node.is_object() && node.contains("_type") &&
                  node["_type"] == "Subscript" && node.contains("value") &&
                  node["value"].is_object() && node["value"].contains("id") &&
@@ -6120,8 +6100,7 @@ typet python_converter::get_type_from_annotation(
       const auto &right = annotation_node["right"];
 
       // Helper to check if a node is a Literal subscript
-      auto is_literal_subscript = [](const nlohmann::json &node) -> bool
-      {
+      auto is_literal_subscript = [](const nlohmann::json &node) -> bool {
         return node.contains("_type") && node["_type"] == "Subscript" &&
                node.contains("value") && node["value"].is_object() &&
                node["value"].contains("id") && node["value"]["id"] == "Literal";
@@ -6149,8 +6128,7 @@ typet python_converter::get_type_from_annotation(
     std::set<std::string> type_names;
     std::function<void(const nlohmann::json &)> collect_types;
     bool contains_none = false;
-    collect_types = [&](const nlohmann::json &node)
-    {
+    collect_types = [&](const nlohmann::json &node) {
       // Guard: only process objects
       if (!node.is_object())
         return;
@@ -6231,10 +6209,10 @@ typet python_converter::get_type_from_annotation(
     if (type_string.find('|') != std::string::npos)
     {
       // Split by '|' and trim whitespace
-      auto trim_ws = [](std::string s) -> std::string
-      {
-        const auto not_space = [](unsigned char ch)
-        { return !std::isspace(ch); };
+      auto trim_ws = [](std::string s) -> std::string {
+        const auto not_space = [](unsigned char ch) {
+          return !std::isspace(ch);
+        };
         s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
         s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
         return s;
@@ -6374,9 +6352,8 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
 {
   TypeFlags flags;
 
-  std::function<void(const nlohmann::json &)> scan =
-    [&](const nlohmann::json &body)
-  {
+  std::function<void(const nlohmann::json &)> scan = [&](const nlohmann::json
+                                                           &body) {
     for (const auto &stmt : body)
     {
       if (stmt["_type"] == "Return" && stmt["value"].is_null())
@@ -7306,8 +7283,7 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
       }
 
       // Attach assertion message if present
-      auto attach_assert_message = [&element](code_assertt &assert_code)
-      {
+      auto attach_assert_message = [&element](code_assertt &assert_code) {
         if (element.contains("msg") && !element["msg"].is_null())
         {
           std::string msg;
@@ -7718,9 +7694,9 @@ void python_converter::process_module_imports(
       current_python_file = nested_python_file;
 
       create_builtin_symbols();
-      exprt imported_code = with_ast(
-        &nested_module_json,
-        [&]() { return get_block(nested_module_json["body"]); });
+      exprt imported_code = with_ast(&nested_module_json, [&]() {
+        return get_block(nested_module_json["body"]);
+      });
       convert_expression_to_code(imported_code);
 
       // Accumulate this module's code
@@ -7945,9 +7921,9 @@ void python_converter::convert()
           imported_module_json, const_cast<global_scope &>(global_scope_));
         imported_annotator.add_type_annotation();
 
-        exprt imported_code = with_ast(
-          &imported_module_json,
-          [&]() { return get_block(imported_module_json["body"]); });
+        exprt imported_code = with_ast(&imported_module_json, [&]() {
+          return get_block(imported_module_json["body"]);
+        });
 
         convert_expression_to_code(imported_code);
 
@@ -8060,16 +8036,14 @@ void python_converter::convert()
   code_blockt main_body;
 
   // 1. Initialize static lifetime variables
-  symbol_table_.foreach_operand_in_order(
-    [&main_body](const symbolt &s)
+  symbol_table_.foreach_operand_in_order([&main_body](const symbolt &s) {
+    if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
     {
-      if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
-      {
-        code_assignt assign(symbol_expr(s), s.value);
-        assign.location() = s.location;
-        main_body.copy_to_operands(assign);
-      }
-    });
+      code_assignt assign(symbol_expr(s), s.value);
+      assign.location() = s.location;
+      main_body.copy_to_operands(assign);
+    }
+  });
 
   // 2. Call python_init for initialization
   if (!init_code.operands().empty())

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -95,9 +95,10 @@ static std::string map_operator(const std::string &op, const typet &type)
   // Convert the operator to lowercase to allow case-insensitive comparison.
   std::string lower_op = op;
   std::transform(
-    lower_op.begin(), lower_op.end(), lower_op.begin(), [](unsigned char c) {
-      return std::tolower(c);
-    });
+    lower_op.begin(),
+    lower_op.end(),
+    lower_op.begin(),
+    [](unsigned char c) { return std::tolower(c); });
 
   // If the type is floating-point, use IEEE-specific operators.
   if (type.is_floatbv())
@@ -520,9 +521,10 @@ exprt handle_float_vs_string(exprt &bin_expr, const std::string &op)
     // Python-style error: float < str → TypeError
     std::string lower_op = op;
     std::transform(
-      lower_op.begin(), lower_op.end(), lower_op.begin(), [](unsigned char c) {
-        return std::tolower(c);
-      });
+      lower_op.begin(),
+      lower_op.end(),
+      lower_op.begin(),
+      [](unsigned char c) { return std::tolower(c); });
 
     const auto &loc = bin_expr.location();
     const auto it = operator_map.find(lower_op);
@@ -572,7 +574,8 @@ bool python_converter::has_unsupported_side_effects_internal(
   const exprt &lhs,
   const exprt &rhs)
 {
-  auto has_unsupported_side_effect = [](const exprt &expr) {
+  auto has_unsupported_side_effect = [](const exprt &expr)
+  {
     return expr.id() == "sideeffect" &&
            expr.get("statement") != "function_call";
   };
@@ -777,7 +780,8 @@ exprt python_converter::handle_string_comparison(
   // This avoids introducing strcmp() calls that can inflate branch coverage counts.
   if (op == "Eq" || op == "NotEq")
   {
-    auto extract_single_char = [&](const exprt &expr, char &ch) -> bool {
+    auto extract_single_char = [&](const exprt &expr, char &ch) -> bool
+    {
       const exprt *candidate = &expr;
       if (
         expr.id() == "address_of" && expr.operands().size() == 1 &&
@@ -801,7 +805,8 @@ exprt python_converter::handle_string_comparison(
       return true;
     };
 
-    auto char_at_index = [&](const exprt &expr, int idx) -> exprt {
+    auto char_at_index = [&](const exprt &expr, int idx) -> exprt
+    {
       exprt index = from_integer(idx, index_type());
       if (expr.type().is_array())
         return index_exprt(expr, index, char_type());
@@ -1230,7 +1235,8 @@ void python_converter::convert_function_calls_to_side_effects(
   exprt &lhs,
   exprt &rhs)
 {
-  auto to_side_effect_call = [](exprt &expr) {
+  auto to_side_effect_call = [](exprt &expr)
+  {
     side_effect_expr_function_callt side_effect;
     code_function_callt &code = static_cast<code_function_callt &>(expr);
     side_effect.function() = code.function();
@@ -1426,7 +1432,8 @@ exprt python_converter::handle_type_identity_check(
   auto resolve_type_identifier = [&](
                                    const nlohmann::json &node,
                                    const exprt &expr,
-                                   std::string &out_name) -> bool {
+                                   std::string &out_name) -> bool
+  {
     if (node["_type"] == "Name" && node.contains("id"))
     {
       std::string name = node["id"].get<std::string>();
@@ -1636,10 +1643,10 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     type_utils::is_relational_op(op) || op == "Is" || op == "IsNot" ||
     op == "In" || op == "NotIn")
   {
-    auto is_any_ptr = [](const exprt &e) {
-      return e.type().is_pointer() && e.type().subtype().id() == "empty";
-    };
-    auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type) {
+    auto is_any_ptr = [](const exprt &e)
+    { return e.type().is_pointer() && e.type().subtype().id() == "empty"; };
+    auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type)
+    {
       if (e.type().is_floatbv())
       {
         unsigned width = static_cast<const bv_typet &>(e.type()).get_width();
@@ -1738,7 +1745,8 @@ exprt python_converter::handle_list_operations(
   typet list_type = type_handler_.get_list_type();
 
   // Resolve function calls that return lists to temporary variables
-  auto resolve_list_call = [&](exprt &expr) -> bool {
+  auto resolve_list_call = [&](exprt &expr) -> bool
+  {
     // Check if this is a side effect function call
     if (expr.id().as_string() != "sideeffect")
       return false;
@@ -2421,7 +2429,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         can_fold = false;
     }
 
-    auto returns_list = [](const nlohmann::json &ret) -> bool {
+    auto returns_list = [](const nlohmann::json &ret) -> bool
+    {
       if (ret.is_null())
         return false;
       if (
@@ -2452,7 +2461,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       const std::string input = arg0["value"].get<std::string>();
       std::vector<long long> out;
       std::string token;
-      auto flush_token = [&](const std::string &tok) {
+      auto flush_token = [&](const std::string &tok)
+      {
         if (tok.empty())
           return;
         long long depth = 0;
@@ -2611,8 +2621,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     element.contains("args") &&
     (!element.contains("keywords") || element["keywords"].empty()))
   {
-    const std::string& callee =
-      element["func"]["id"].get<std::string>();
+    const std::string &callee = element["func"]["id"].get<std::string>();
 
     // Check if the callee is shadowed by a local FunctionDef inside
     // the current enclosing function.  Consteval only knows about
@@ -2625,7 +2634,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // Use const ref so the non-throwing find_function overload
       // (returns empty JSON on miss) is selected instead of the
       // mutable-ref overload that throws.
-      const nlohmann::json& ast_body = (*ast_json)["body"];
+      const nlohmann::json &ast_body = (*ast_json)["body"];
       nlohmann::json cur_body = ast_body;
       std::string remaining = current_func_name_;
       while (!remaining.empty() && !locally_shadowed)
@@ -2643,10 +2652,10 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           remaining.clear();
         }
         auto fn =
-          find_function(static_cast<const nlohmann::json&>(cur_body), part);
+          find_function(static_cast<const nlohmann::json &>(cur_body), part);
         if (fn.empty() || !fn.contains("body") || !fn["body"].is_array())
           break;
-        for (const auto& stmt : fn["body"])
+        for (const auto &stmt : fn["body"])
         {
           if (
             stmt.contains("_type") && stmt["_type"] == "FunctionDef" &&
@@ -2669,44 +2678,39 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // Collect constant arguments
       bool all_const = true;
       std::vector<PyConstValue> const_args;
-      for (const auto& arg_node : element["args"])
+      for (const auto &arg_node : element["args"])
       {
-        if (
-          arg_node["_type"] == "Constant" &&
-          arg_node["value"].is_string())
+        if (arg_node["_type"] == "Constant" && arg_node["value"].is_string())
         {
-          const_args.push_back(PyConstValue::make_string(
-            arg_node["value"].get<std::string>()));
+          const_args.push_back(
+            PyConstValue::make_string(arg_node["value"].get<std::string>()));
         }
         else if (
           arg_node["_type"] == "Constant" &&
           arg_node["value"].is_number_integer())
         {
-          const_args.push_back(PyConstValue::make_int(
-            arg_node["value"].get<long long>()));
+          const_args.push_back(
+            PyConstValue::make_int(arg_node["value"].get<long long>()));
         }
         else if (
           arg_node["_type"] == "Constant" &&
           arg_node["value"].is_number_float())
         {
-          const_args.push_back(PyConstValue::make_float(
-            arg_node["value"].get<double>()));
+          const_args.push_back(
+            PyConstValue::make_float(arg_node["value"].get<double>()));
         }
         else if (
-          arg_node["_type"] == "Constant" &&
-          arg_node["value"].is_boolean())
+          arg_node["_type"] == "Constant" && arg_node["value"].is_boolean())
         {
-          const_args.push_back(PyConstValue::make_bool(
-            arg_node["value"].get<bool>()));
+          const_args.push_back(
+            PyConstValue::make_bool(arg_node["value"].get<bool>()));
         }
-        else if (
-          arg_node["_type"] == "Constant" && arg_node["value"].is_null())
+        else if (arg_node["_type"] == "Constant" && arg_node["value"].is_null())
         {
           const_args.push_back(PyConstValue::make_none());
         }
         else if (
-          arg_node["_type"] == "UnaryOp" &&
-          arg_node["op"]["_type"] == "USub" &&
+          arg_node["_type"] == "UnaryOp" && arg_node["op"]["_type"] == "USub" &&
           arg_node["operand"]["_type"] == "Constant" &&
           arg_node["operand"]["value"].is_number_integer())
         {
@@ -2714,8 +2718,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
             -arg_node["operand"]["value"].get<long long>()));
         }
         else if (
-          arg_node["_type"] == "UnaryOp" &&
-          arg_node["op"]["_type"] == "USub" &&
+          arg_node["_type"] == "UnaryOp" && arg_node["op"]["_type"] == "USub" &&
           arg_node["operand"]["_type"] == "Constant" &&
           arg_node["operand"]["value"].is_number_float())
         {
@@ -2736,8 +2739,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         if (result.has_value())
         {
           if (result->kind == PyConstValue::STRING)
-            return string_builder_->build_string_literal(
-              result->string_val);
+            return string_builder_->build_string_literal(result->string_val);
           if (result->kind == PyConstValue::INT)
             return from_integer(result->int_val, long_long_int_type());
           if (result->kind == PyConstValue::BOOL)
@@ -2774,7 +2776,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
   }
 
-  auto handle_keywords = [&](exprt &call_expr) {
+  auto handle_keywords = [&](exprt &call_expr)
+  {
     if (!element.contains("keywords") || element["keywords"].empty())
       return;
 
@@ -2832,7 +2835,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
 
     // we need to check if the argument is provided despite being optional
-    auto is_optional_type = [&](const typet &param_type) {
+    auto is_optional_type = [&](const typet &param_type)
+    {
       if (!param_type.is_struct())
         return false;
       const struct_typet &struct_type = to_struct_type(param_type);
@@ -3644,17 +3648,19 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         symbolt *target_class_symbol = nullptr;
 
         // Search all class types in the symbol table to find one that has this attribute
-        symbol_table_.foreach_operand_in_order([&](const symbolt &s) {
-          if (target_class_symbol)
-            return; // Already found
-
-          if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
+        symbol_table_.foreach_operand_in_order(
+          [&](const symbolt &s)
           {
-            const struct_typet &struct_type = to_struct_type(s.type);
-            if (struct_type.has_component(attr_name))
-              target_class_symbol = const_cast<symbolt *>(&s);
-          }
-        });
+            if (target_class_symbol)
+              return; // Already found
+
+            if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
+            {
+              const struct_typet &struct_type = to_struct_type(s.type);
+              if (struct_type.has_component(attr_name))
+                target_class_symbol = const_cast<symbolt *>(&s);
+            }
+          });
 
         if (!target_class_symbol)
         {
@@ -4101,7 +4107,8 @@ void python_converter::handle_assignment_type_adjustments(
       !ast_node.value("_inferred_annotation", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
-      [this]() {
+      [this]()
+      {
         // Check if "from typing import Any" exists in the source file
         const auto &body = (*ast_json)["body"];
         for (const auto &stmt : body)
@@ -5651,7 +5658,8 @@ std::string
 python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
 {
   std::function<std::string(const nlohmann::json &)> extract_type =
-    [&](const nlohmann::json &node) -> std::string {
+    [&](const nlohmann::json &node) -> std::string
+  {
     if (
       node.contains("_type") && node["_type"] == "Constant" &&
       node.contains("value") && node["value"].is_null())
@@ -5777,7 +5785,8 @@ typet python_converter::get_type_from_annotation(
   if (annotation_node["_type"] == "Subscript")
   {
     // Helper to safely get id from value node
-    auto get_value_id = [&]() -> std::string {
+    auto get_value_id = [&]() -> std::string
+    {
       if (
         annotation_node.contains("value") &&
         annotation_node["value"].is_object() &&
@@ -5800,7 +5809,8 @@ typet python_converter::get_type_from_annotation(
     if (value_id == "Literal")
     {
       // Infer type from a literal constant value
-      auto infer_literal_type = [](const nlohmann::json &value) -> typet {
+      auto infer_literal_type = [](const nlohmann::json &value) -> typet
+      {
         if (value.is_string())
           return gen_pointer_type(char_type());
         else if (value.is_number_integer())
@@ -5817,7 +5827,8 @@ typet python_converter::get_type_from_annotation(
 
       // Resolve a slice element to a constant value
       auto resolve_to_constant =
-        [this](const nlohmann::json &elem) -> nlohmann::json {
+        [this](const nlohmann::json &elem) -> nlohmann::json
+      {
         // Guard: ensure elem is an object with _type
         if (!elem.is_object() || !elem.contains("_type"))
           return nlohmann::json();
@@ -5845,11 +5856,10 @@ typet python_converter::get_type_from_annotation(
       };
 
       // Track type flags from a resolved type
-      auto update_type_flags = [](
-                                 const typet &type,
-                                 TypeFlags &flags,
-                                 bool &has_string,
-                                 bool &has_none) {
+      auto update_type_flags =
+        [](
+          const typet &type, TypeFlags &flags, bool &has_string, bool &has_none)
+      {
         if (type == gen_pointer_type(char_type()))
           has_string = true;
         else if (type == double_type())
@@ -5877,8 +5887,8 @@ typet python_converter::get_type_from_annotation(
           return empty_typet();
 
         // Helper to safely check if node is a Literal subscript
-        auto is_literal_subscript_node =
-          [](const nlohmann::json &node) -> bool {
+        auto is_literal_subscript_node = [](const nlohmann::json &node) -> bool
+        {
           return node.is_object() && node.contains("_type") &&
                  node["_type"] == "Subscript" && node.contains("value") &&
                  node["value"].is_object() && node["value"].contains("id") &&
@@ -6035,7 +6045,8 @@ typet python_converter::get_type_from_annotation(
       const auto &right = annotation_node["right"];
 
       // Helper to check if a node is a Literal subscript
-      auto is_literal_subscript = [](const nlohmann::json &node) -> bool {
+      auto is_literal_subscript = [](const nlohmann::json &node) -> bool
+      {
         return node.contains("_type") && node["_type"] == "Subscript" &&
                node.contains("value") && node["value"].is_object() &&
                node["value"].contains("id") && node["value"]["id"] == "Literal";
@@ -6063,7 +6074,8 @@ typet python_converter::get_type_from_annotation(
     std::set<std::string> type_names;
     std::function<void(const nlohmann::json &)> collect_types;
     bool contains_none = false;
-    collect_types = [&](const nlohmann::json &node) {
+    collect_types = [&](const nlohmann::json &node)
+    {
       // Guard: only process objects
       if (!node.is_object())
         return;
@@ -6144,10 +6156,10 @@ typet python_converter::get_type_from_annotation(
     if (type_string.find('|') != std::string::npos)
     {
       // Split by '|' and trim whitespace
-      auto trim_ws = [](std::string s) -> std::string {
-        const auto not_space = [](unsigned char ch) {
-          return !std::isspace(ch);
-        };
+      auto trim_ws = [](std::string s) -> std::string
+      {
+        const auto not_space = [](unsigned char ch)
+        { return !std::isspace(ch); };
         s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
         s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
         return s;
@@ -6287,8 +6299,9 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
 {
   TypeFlags flags;
 
-  std::function<void(const nlohmann::json &)> scan = [&](const nlohmann::json
-                                                           &body) {
+  std::function<void(const nlohmann::json &)> scan =
+    [&](const nlohmann::json &body)
+  {
     for (const auto &stmt : body)
     {
       if (stmt["_type"] == "Return" && stmt["value"].is_null())
@@ -7218,7 +7231,8 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
       }
 
       // Attach assertion message if present
-      auto attach_assert_message = [&element](code_assertt &assert_code) {
+      auto attach_assert_message = [&element](code_assertt &assert_code)
+      {
         if (element.contains("msg") && !element["msg"].is_null())
         {
           std::string msg;
@@ -7629,9 +7643,9 @@ void python_converter::process_module_imports(
       current_python_file = nested_python_file;
 
       create_builtin_symbols();
-      exprt imported_code = with_ast(&nested_module_json, [&]() {
-        return get_block(nested_module_json["body"]);
-      });
+      exprt imported_code = with_ast(
+        &nested_module_json,
+        [&]() { return get_block(nested_module_json["body"]); });
       convert_expression_to_code(imported_code);
 
       // Accumulate this module's code
@@ -7856,9 +7870,9 @@ void python_converter::convert()
           imported_module_json, const_cast<global_scope &>(global_scope_));
         imported_annotator.add_type_annotation();
 
-        exprt imported_code = with_ast(&imported_module_json, [&]() {
-          return get_block(imported_module_json["body"]);
-        });
+        exprt imported_code = with_ast(
+          &imported_module_json,
+          [&]() { return get_block(imported_module_json["body"]); });
 
         convert_expression_to_code(imported_code);
 
@@ -7971,14 +7985,16 @@ void python_converter::convert()
   code_blockt main_body;
 
   // 1. Initialize static lifetime variables
-  symbol_table_.foreach_operand_in_order([&main_body](const symbolt &s) {
-    if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
+  symbol_table_.foreach_operand_in_order(
+    [&main_body](const symbolt &s)
     {
-      code_assignt assign(symbol_expr(s), s.value);
-      assign.location() = s.location;
-      main_body.copy_to_operands(assign);
-    }
-  });
+      if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
+      {
+        code_assignt assign(symbol_expr(s), s.value);
+        assign.location() = s.location;
+        main_body.copy_to_operands(assign);
+      }
+    });
 
   // 2. Call python_init for initialization
   if (!init_code.operands().empty())

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2641,6 +2641,13 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         }
         else if (
           arg_node["_type"] == "Constant" &&
+          arg_node["value"].is_number_float())
+        {
+          const_args.push_back(PyConstValue::make_float(
+            arg_node["value"].get<double>()));
+        }
+        else if (
+          arg_node["_type"] == "Constant" &&
           arg_node["value"].is_boolean())
         {
           const_args.push_back(PyConstValue::make_bool(
@@ -2660,6 +2667,15 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           const_args.push_back(PyConstValue::make_int(
             -arg_node["operand"]["value"].get<long long>()));
         }
+        else if (
+          arg_node["_type"] == "UnaryOp" &&
+          arg_node["op"]["_type"] == "USub" &&
+          arg_node["operand"]["_type"] == "Constant" &&
+          arg_node["operand"]["value"].is_number_float())
+        {
+          const_args.push_back(PyConstValue::make_float(
+            -arg_node["operand"]["value"].get<double>()));
+        }
         else
         {
           all_const = false;
@@ -2667,7 +2683,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         }
       }
 
-      if (all_const && !const_args.empty())
+      if (all_const)
       {
         python_consteval evaluator(*ast_json);
         auto result = evaluator.try_eval_call(callee, const_args);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -48,7 +48,8 @@ static typet get_elem_type_from_annotation(
   const type_handler &type_handler_)
 {
   // Extract element type from a Subscript node such as list[T]
-  auto extract_subscript_elem = [&](const nlohmann::json &ann) -> typet {
+  auto extract_subscript_elem = [&](const nlohmann::json &ann) -> typet
+  {
     if (
       ann.contains("slice") && ann["slice"].is_object() &&
       ann["slice"].contains("id") && ann["slice"]["id"].is_string())
@@ -397,7 +398,8 @@ exprt python_list::build_concat_list_call(
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
   assert(size_sym && at_sym && push_obj_sym);
 
-  auto copy_list = [&](const exprt &src_list) {
+  auto copy_list = [&](const exprt &src_list)
+  {
     // size_t n = list_size(src_list);
     symbolt &n_sym = converter_.create_tmp_symbol(
       element, "$n$", size_type(), gen_zero(size_type()));
@@ -483,7 +485,8 @@ exprt python_list::build_concat_list_call(
   const std::string dst_id = dst_list.id.as_string();
 
   // Copy type info from source list if it's a symbol
-  auto copy_type_info_from_expr = [&](const exprt &src_list) {
+  auto copy_type_info_from_expr = [&](const exprt &src_list)
+  {
     if (!src_list.is_symbol())
       return;
     copy_type_map_entries(src_list.identifier().as_string(), dst_id);
@@ -633,9 +636,8 @@ exprt python_list::build_split_list(
   if (separator.empty())
   {
     // Whitespace split: split on any whitespace and collapse runs.
-    auto is_space = [](char c) {
-      return std::isspace(static_cast<unsigned char>(c)) != 0;
-    };
+    auto is_space = [](char c)
+    { return std::isspace(static_cast<unsigned char>(c)) != 0; };
 
     if (count == 0)
     {
@@ -676,12 +678,14 @@ exprt python_list::build_split_list(
     size_t i = 0;
     const size_t n = input.size();
 
-    auto skip_ws = [&](size_t &idx) {
+    auto skip_ws = [&](size_t &idx)
+    {
       while (idx < n && is_space(input[idx]))
         ++idx;
     };
 
-    auto scan_token = [&](size_t &idx) {
+    auto scan_token = [&](size_t &idx)
+    {
       while (idx < n && !is_space(input[idx]))
         ++idx;
     };
@@ -911,7 +915,8 @@ exprt python_list::remove_function_calls_recursive(
   const nlohmann::json &node)
 {
   // Bounds might generate intermediate calls, we need to add lhs to all of them.
-  const auto add_lhs_var_bound = [&](exprt &foo) -> exprt {
+  const auto add_lhs_var_bound = [&](exprt &foo) -> exprt
+  {
     if (!foo.is_function_call())
       return foo;
     code_function_callt &call = static_cast<code_function_callt &>(foo);
@@ -1000,7 +1005,8 @@ exprt python_list::handle_range_slice(
 
       // Extract start/end bounds from slice node
       auto get_bound_expr =
-        [&](const std::string &name, long long default_val) -> exprt {
+        [&](const std::string &name, long long default_val) -> exprt
+      {
         if (!slice_node.contains(name) || slice_node[name].is_null())
           return from_integer(default_val, signedbv_typet(64));
 
@@ -1059,7 +1065,8 @@ exprt python_list::handle_range_slice(
 
     // Process slice bounds (handles null, negative indices)
     auto process_bound =
-      [&](const std::string &bound_name, const exprt &default_value) -> exprt {
+      [&](const std::string &bound_name, const exprt &default_value) -> exprt
+    {
       if (!slice_node.contains(bound_name) || slice_node[bound_name].is_null())
         return default_value;
 
@@ -1222,7 +1229,8 @@ exprt python_list::handle_range_slice(
   const locationt location = converter_.get_location_from_decl(list_value_);
 
   auto get_list_bound =
-    [&](const std::string &bound_name, bool is_upper) -> exprt {
+    [&](const std::string &bound_name, bool is_upper) -> exprt
+  {
     if (slice_node.contains(bound_name) && !slice_node[bound_name].is_null())
     {
       const auto &bound_node = slice_node[bound_name];
@@ -1979,7 +1987,8 @@ exprt python_list::compare(
   assert(list_eq_func_sym);
 
   // Convert member expressions into temporary symbols
-  auto materialize_if_needed = [&](const exprt &e) -> exprt {
+  auto materialize_if_needed = [&](const exprt &e) -> exprt
+  {
     if (e.id() == "member")
     {
       // Extract member expression to a temporary variable
@@ -2164,7 +2173,8 @@ exprt python_list::list_repetition(
   exprt list_elem;
   symbolt *list_symbol = nullptr;
 
-  auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool {
+  auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool
+  {
     if (
       size_var->value.is_code() || size_var->value.is_nil() ||
       !size_var->value.is_constant())
@@ -2979,7 +2989,8 @@ typet python_list::check_homogeneous_list_types(
   typet elem_type = type_info[0].second;
 
   // Check whether a type is a string type (char array or char pointer)
-  auto is_string_type = [](const typet &t) -> bool {
+  auto is_string_type = [](const typet &t) -> bool
+  {
     return (t.is_array() && t.subtype() == char_type()) ||
            (t.is_pointer() && t.subtype() == char_type());
   };
@@ -3018,7 +3029,8 @@ exprt python_list::build_list_from_range(
 
   // Extract constant integer, handling UnaryOp for negative numbers
   auto extract_constant =
-    [&](const nlohmann::json &arg) -> std::optional<long long> {
+    [&](const nlohmann::json &arg) -> std::optional<long long>
+  {
     exprt expr = converter.get_expr(arg);
 
     if (expr.is_constant())

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -48,8 +48,7 @@ static typet get_elem_type_from_annotation(
   const type_handler &type_handler_)
 {
   // Extract element type from a Subscript node such as list[T]
-  auto extract_subscript_elem = [&](const nlohmann::json &ann) -> typet
-  {
+  auto extract_subscript_elem = [&](const nlohmann::json &ann) -> typet {
     if (
       ann.contains("slice") && ann["slice"].is_object() &&
       ann["slice"].contains("id") && ann["slice"]["id"].is_string())
@@ -398,8 +397,7 @@ exprt python_list::build_concat_list_call(
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
   assert(size_sym && at_sym && push_obj_sym);
 
-  auto copy_list = [&](const exprt &src_list)
-  {
+  auto copy_list = [&](const exprt &src_list) {
     // size_t n = list_size(src_list);
     symbolt &n_sym = converter_.create_tmp_symbol(
       element, "$n$", size_type(), gen_zero(size_type()));
@@ -485,8 +483,7 @@ exprt python_list::build_concat_list_call(
   const std::string dst_id = dst_list.id.as_string();
 
   // Copy type info from source list if it's a symbol
-  auto copy_type_info_from_expr = [&](const exprt &src_list)
-  {
+  auto copy_type_info_from_expr = [&](const exprt &src_list) {
     if (!src_list.is_symbol())
       return;
     copy_type_map_entries(src_list.identifier().as_string(), dst_id);
@@ -636,8 +633,9 @@ exprt python_list::build_split_list(
   if (separator.empty())
   {
     // Whitespace split: split on any whitespace and collapse runs.
-    auto is_space = [](char c)
-    { return std::isspace(static_cast<unsigned char>(c)) != 0; };
+    auto is_space = [](char c) {
+      return std::isspace(static_cast<unsigned char>(c)) != 0;
+    };
 
     if (count == 0)
     {
@@ -678,14 +676,12 @@ exprt python_list::build_split_list(
     size_t i = 0;
     const size_t n = input.size();
 
-    auto skip_ws = [&](size_t &idx)
-    {
+    auto skip_ws = [&](size_t &idx) {
       while (idx < n && is_space(input[idx]))
         ++idx;
     };
 
-    auto scan_token = [&](size_t &idx)
-    {
+    auto scan_token = [&](size_t &idx) {
       while (idx < n && !is_space(input[idx]))
         ++idx;
     };
@@ -915,8 +911,7 @@ exprt python_list::remove_function_calls_recursive(
   const nlohmann::json &node)
 {
   // Bounds might generate intermediate calls, we need to add lhs to all of them.
-  const auto add_lhs_var_bound = [&](exprt &foo) -> exprt
-  {
+  const auto add_lhs_var_bound = [&](exprt &foo) -> exprt {
     if (!foo.is_function_call())
       return foo;
     code_function_callt &call = static_cast<code_function_callt &>(foo);
@@ -1005,8 +1000,7 @@ exprt python_list::handle_range_slice(
 
       // Extract start/end bounds from slice node
       auto get_bound_expr =
-        [&](const std::string &name, long long default_val) -> exprt
-      {
+        [&](const std::string &name, long long default_val) -> exprt {
         if (!slice_node.contains(name) || slice_node[name].is_null())
           return from_integer(default_val, signedbv_typet(64));
 
@@ -1065,8 +1059,7 @@ exprt python_list::handle_range_slice(
 
     // Process slice bounds (handles null, negative indices)
     auto process_bound =
-      [&](const std::string &bound_name, const exprt &default_value) -> exprt
-    {
+      [&](const std::string &bound_name, const exprt &default_value) -> exprt {
       if (!slice_node.contains(bound_name) || slice_node[bound_name].is_null())
         return default_value;
 
@@ -1229,8 +1222,7 @@ exprt python_list::handle_range_slice(
   const locationt location = converter_.get_location_from_decl(list_value_);
 
   auto get_list_bound =
-    [&](const std::string &bound_name, bool is_upper) -> exprt
-  {
+    [&](const std::string &bound_name, bool is_upper) -> exprt {
     if (slice_node.contains(bound_name) && !slice_node[bound_name].is_null())
     {
       const auto &bound_node = slice_node[bound_name];
@@ -1987,8 +1979,7 @@ exprt python_list::compare(
   assert(list_eq_func_sym);
 
   // Convert member expressions into temporary symbols
-  auto materialize_if_needed = [&](const exprt &e) -> exprt
-  {
+  auto materialize_if_needed = [&](const exprt &e) -> exprt {
     if (e.id() == "member")
     {
       // Extract member expression to a temporary variable
@@ -2173,8 +2164,7 @@ exprt python_list::list_repetition(
   exprt list_elem;
   symbolt *list_symbol = nullptr;
 
-  auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool
-  {
+  auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool {
     if (
       size_var->value.is_code() || size_var->value.is_nil() ||
       !size_var->value.is_constant())
@@ -2989,8 +2979,7 @@ typet python_list::check_homogeneous_list_types(
   typet elem_type = type_info[0].second;
 
   // Check whether a type is a string type (char array or char pointer)
-  auto is_string_type = [](const typet &t) -> bool
-  {
+  auto is_string_type = [](const typet &t) -> bool {
     return (t.is_array() && t.subtype() == char_type()) ||
            (t.is_pointer() && t.subtype() == char_type());
   };
@@ -3029,8 +3018,7 @@ exprt python_list::build_list_from_range(
 
   // Extract constant integer, handling UnaryOp for negative numbers
   auto extract_constant =
-    [&](const nlohmann::json &arg) -> std::optional<long long>
-  {
+    [&](const nlohmann::json &arg) -> std::optional<long long> {
     exprt expr = converter.get_expr(arg);
 
     if (expr.is_constant())


### PR DESCRIPTION
Introduce python_consteval, a lightweight Python AST interpreter that evaluates user-defined functions at conversion time when all arguments are compile-time constants. This eliminates deeply nested loops from the GOTO program, allowing bounded model checking to verify cases like make_palindrome('xyz') without --no-unwinding-assertions.

- Add python_consteval.h/.cpp with support for constants, variables,   arithmetic, string ops, comparisons, slicing, control flow, and   recursive user-defined function calls
- Hook consteval into python_converter::get_function_call() before the normal call path
- Update github_3553 test: remove --no-unwinding-assertions, reduce  unwind bound from 20 to 15"
