### PR TITLE
Fix/GitHub 3608 Fix Python list slicing with oversized upper bounds 

### DIFF
--- a/regression/python/github_3608/main.py
+++ b/regression/python/github_3608/main.py
@@ -1,0 +1,6 @@
+def test_indexing_and_slicing():
+    l = [10, 20, 30, 40, 50]
+    assert l[0:100] == l
+
+
+test_indexing_and_slicing()

--- a/regression/python/github_3608/test.desc
+++ b/regression/python/github_3608/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1280,8 +1280,7 @@ exprt python_list::handle_range_slice(
       const symbolt *size_func =
         converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
       if (!size_func)
-        throw std::runtime_error(
-          "__ESBMC_list_size not found in symbol table");
+        throw std::runtime_error("__ESBMC_list_size not found in symbol table");
 
       side_effect_expr_function_callt size_call;
       size_call.function() = symbol_expr(*size_func);
@@ -1319,8 +1318,7 @@ exprt python_list::handle_range_slice(
     const symbolt *size_func =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
     if (!size_func)
-      throw std::runtime_error(
-        "__ESBMC_list_size not found in symbol table");
+      throw std::runtime_error("__ESBMC_list_size not found in symbol table");
 
     side_effect_expr_function_callt size_call;
     size_call.function() = symbol_expr(*size_func);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1244,7 +1244,9 @@ exprt python_list::handle_range_slice(
         // Compute: list_size + bound_expr  (bound_expr is negative)
         const symbolt *size_func =
           converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
-        assert(size_func);
+        if (!size_func)
+          throw std::runtime_error(
+            "__ESBMC_list_size not found in symbol table");
 
         side_effect_expr_function_callt size_call;
         size_call.function() = symbol_expr(*size_func);
@@ -1277,7 +1279,9 @@ exprt python_list::handle_range_slice(
     {
       const symbolt *size_func =
         converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
-      assert(size_func);
+      if (!size_func)
+        throw std::runtime_error(
+          "__ESBMC_list_size not found in symbol table");
 
       side_effect_expr_function_callt size_call;
       size_call.function() = symbol_expr(*size_func);
@@ -1314,7 +1318,9 @@ exprt python_list::handle_range_slice(
   {
     const symbolt *size_func =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
-    assert(size_func);
+    if (!size_func)
+      throw std::runtime_error(
+        "__ESBMC_list_size not found in symbol table");
 
     side_effect_expr_function_callt size_call;
     size_call.function() = symbol_expr(*size_func);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1309,8 +1309,8 @@ exprt python_list::handle_range_slice(
   const exprt lower_expr = get_list_bound("lower", false);
   exprt upper_expr = get_list_bound("upper", true);
 
-  // Clamp upper bound to the runtime list size to preserve Python slicing
-  // semantics for oversized bounds, e.g., l[0:100].
+  // Clamp upper bound to the current list size to match Python slicing
+  // semantics (e.g., l[0:100] on a 5-element list).
   {
     const symbolt *size_func =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3608.

This PR fixes the Python frontend list-slice handling for oversized upper bounds (e.g., l[0:100]) by clamping slice bounds to the actual list size and adds a regression test for github_3608.