### PR TITLE
Fix/GitHub 3609 Fix constant out-of-bounds list indexing to raise IndexError in Python frontend 

### DIFF
--- a/regression/python/github_3609/main.py
+++ b/regression/python/github_3609/main.py
@@ -1,0 +1,10 @@
+def test_indexing_and_slicing():
+    l = [10, 20, 30, 40, 50]
+    try:
+        _ = l[100]
+        assert False, "IndexError not raised"
+    except IndexError:
+        pass
+
+
+test_indexing_and_slicing()

--- a/regression/python/github_3609/test.desc
+++ b/regression/python/github_3609/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/indexing10_fail/test.desc
+++ b/regression/python/indexing10_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 8
-^ERROR: List out of bounds at\b
+^VERIFICATION FAILED$

--- a/regression/python/list17_fail/test.desc
+++ b/regression/python/list17_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-(?m)^.*ERROR: List out of bounds at.*\s*\Z
+^VERIFICATION FAILED$

--- a/regression/python/list7-fail/test.desc
+++ b/regression/python/list7-fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --unwind 9
-^ERROR: List out of bounds at\b
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1398,10 +1398,16 @@ exprt python_list::handle_range_slice(
     slice_node.contains("lower") && !slice_node["lower"].is_null() &&
     slice_node.contains("upper") && !slice_node["upper"].is_null())
   {
-    const auto &list_node = json_utils::get_var_value(
-      list_value_["value"]["id"],
-      converter_.current_function_name(),
-      converter_.ast());
+    nlohmann::json list_node;
+    if (
+      list_value_.contains("value") && list_value_["value"].is_object() &&
+      list_value_["value"].contains("id") && list_value_["value"]["id"].is_string())
+    {
+      list_node = json_utils::get_var_value(
+        list_value_["value"]["id"],
+        converter_.current_function_name(),
+        converter_.ast());
+    }
 
     const size_t lower_bound = slice_node["lower"]["value"].get<size_t>();
     const size_t upper_bound = slice_node["upper"]["value"].get<size_t>();
@@ -1468,7 +1474,9 @@ exprt python_list::handle_index_access(
 {
   // Find list node for type information
   nlohmann::json list_node;
-  if (list_value_["value"].contains("id"))
+  if (
+    list_value_.contains("value") && list_value_["value"].is_object() &&
+    list_value_["value"].contains("id"))
   {
     list_node = json_utils::find_var_decl(
       list_value_["value"]["id"],
@@ -1552,7 +1560,7 @@ exprt python_list::handle_index_access(
     }
 
     // Determine element type
-    if (list_node["_type"] == "arg")
+    if (list_node.contains("_type") && list_node["_type"] == "arg")
     {
       elem_type =
         get_elem_type_from_annotation(list_node, converter_.get_type_handler());
@@ -1567,18 +1575,27 @@ exprt python_list::handle_index_access(
       if (list_type_map[list_name].empty())
       {
         /* Fall back to annotation for function parameters */
-        const nlohmann::json list_value_node = json_utils::get_var_value(
-          list_value_["value"]["id"],
-          converter_.current_function_name(),
-          converter_.ast());
+        if (
+          list_value_.contains("value") && list_value_["value"].is_object() &&
+          list_value_["value"].contains("id") &&
+          list_value_["value"]["id"].is_string())
+        {
+          const nlohmann::json list_value_node = json_utils::get_var_value(
+            list_value_["value"]["id"],
+            converter_.current_function_name(),
+            converter_.ast());
 
-        elem_type = get_elem_type_from_annotation(
-          list_value_node, converter_.get_type_handler());
+          elem_type = get_elem_type_from_annotation(
+            list_value_node, converter_.get_type_handler());
+        }
       }
       else
       {
         size_t type_index =
-          (!list_node.is_null() && list_node["value"]["_type"] == "BinOp")
+          (!list_node.is_null() && list_node.contains("value") &&
+           list_node["value"].is_object() &&
+           list_node["value"].contains("_type") &&
+           list_node["value"]["_type"] == "BinOp")
             ? 0
             : index;
 
@@ -1685,10 +1702,16 @@ exprt python_list::handle_index_access(
         else if (!list_node.is_null() && list_node.contains("value"))
         {
           // Check if the value is a Subscript (such as d['a'])
-          if (list_node["value"]["_type"] == "Subscript")
+          if (
+            list_node["value"].contains("_type") &&
+            list_node["value"]["_type"] == "Subscript")
           {
             // For ESBMC_iter_0 = d['a'], get element type from dict's actual value
-            if (list_node["value"]["value"]["_type"] == "Name")
+            if (
+              list_node["value"].contains("value") &&
+              list_node["value"]["value"].is_object() &&
+              list_node["value"]["value"].contains("_type") &&
+              list_node["value"]["value"]["_type"] == "Name")
             {
               std::string dict_var_name =
                 list_node["value"]["value"]["id"].get<std::string>();
@@ -1771,6 +1794,64 @@ exprt python_list::handle_index_access(
 
     if (pos_expr == exprt() || elem_type == typet())
     {
+      const bool has_const_index =
+        (slice_node["_type"] == "Constant" && slice_node.contains("value")) ||
+        (slice_node["_type"] == "UnaryOp" && slice_node.contains("op") &&
+         slice_node["op"]["_type"] == "USub" &&
+         slice_node.contains("operand") &&
+         slice_node["operand"]["_type"] == "Constant");
+      if (has_const_index)
+      {
+        const locationt l = converter_.get_location_from_decl(list_value_);
+        throw std::runtime_error(
+          "List out of bounds at " + l.get_file().as_string() + " line: " +
+          l.get_line().as_string());
+      }
+
+      // Keep historical frontend diagnostic for literal lists with
+      // compile-time constant OOB indexing (including nested accesses).
+      if (
+        array.is_symbol() && !list_node.is_null() &&
+        list_node.contains("value") && list_node["value"].is_object() &&
+        list_node["value"].contains("elts") &&
+        list_node["value"]["elts"].is_array())
+      {
+        bool has_const_index = false;
+        bool negative_index = false;
+        size_t index_abs = 0;
+
+        if (slice_node["_type"] == "Constant" && slice_node.contains("value"))
+        {
+          has_const_index = true;
+          index_abs = slice_node["value"].get<size_t>();
+        }
+        else if (
+          slice_node["_type"] == "UnaryOp" && slice_node.contains("op") &&
+          slice_node["op"]["_type"] == "USub" &&
+          slice_node.contains("operand") &&
+          slice_node["operand"]["_type"] == "Constant")
+        {
+          has_const_index = true;
+          negative_index = true;
+          index_abs = slice_node["operand"]["value"].get<size_t>();
+        }
+
+        if (has_const_index)
+        {
+          const size_t list_size = list_node["value"]["elts"].size();
+          const bool out_of_bounds =
+            (!negative_index && index_abs >= list_size) ||
+            (negative_index && index_abs > list_size);
+          if (out_of_bounds)
+          {
+            const locationt l = converter_.get_location_from_decl(list_value_);
+            throw std::runtime_error(
+              "List out of bounds at " + l.get_file().as_string() + " line: " +
+              l.get_line().as_string());
+          }
+        }
+      }
+
       throw std::runtime_error(
         "Invalid list access: could not resolve position or element type");
     }

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1401,7 +1401,8 @@ exprt python_list::handle_range_slice(
     nlohmann::json list_node;
     if (
       list_value_.contains("value") && list_value_["value"].is_object() &&
-      list_value_["value"].contains("id") && list_value_["value"]["id"].is_string())
+      list_value_["value"].contains("id") &&
+      list_value_["value"]["id"].is_string())
     {
       list_node = json_utils::get_var_value(
         list_value_["value"]["id"],
@@ -1804,8 +1805,8 @@ exprt python_list::handle_index_access(
       {
         const locationt l = converter_.get_location_from_decl(list_value_);
         throw std::runtime_error(
-          "List out of bounds at " + l.get_file().as_string() + " line: " +
-          l.get_line().as_string());
+          "List out of bounds at " + l.get_file().as_string() +
+          " line: " + l.get_line().as_string());
       }
 
       // Keep historical frontend diagnostic for literal lists with
@@ -1846,8 +1847,8 @@ exprt python_list::handle_index_access(
           {
             const locationt l = converter_.get_location_from_decl(list_value_);
             throw std::runtime_error(
-              "List out of bounds at " + l.get_file().as_string() + " line: " +
-              l.get_line().as_string());
+              "List out of bounds at " + l.get_file().as_string() +
+              " line: " + l.get_line().as_string());
           }
         }
       }


### PR DESCRIPTION
This PR fixes constant out-of-bounds list indexing in the Python frontend by emitting IndexError (instead of a frontend conversion error), allowing Python try/except IndexError code to verify correctly, and adds a regression test for github_3609.