### PR TITLE
Fix/GitHub 3621 Fail fast on invalid relational comparisons before SMT

### DIFF
--- a/regression/python/github_3621/main.py
+++ b/regression/python/github_3621/main.py
@@ -1,0 +1,3 @@
+lst = []
+v = nondet_int()
+assert lst[-1] == v

--- a/regression/python/github_3621/test.desc
+++ b/regression/python/github_3621/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3621_fail/main.py
+++ b/regression/python/github_3621_fail/main.py
@@ -1,5 +1,5 @@
-def test_negative_index_empty_list() -> None:
-    lst: list[int] = []
+def test_negative_index_non_empty_list() -> None:
+    lst: list[int] = [1]
     try:
         _ = lst[-1]
         assert False, "IndexError not raised"
@@ -7,4 +7,4 @@ def test_negative_index_empty_list() -> None:
         pass
 
 
-test_negative_index_empty_list()
+test_negative_index_non_empty_list()

--- a/regression/python/github_3621_fail/test.desc
+++ b/regression/python/github_3621_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -174,10 +174,9 @@ static std::string map_operator(const std::string &op, const typet &type)
   // Convert the operator to lowercase to allow case-insensitive comparison.
   std::string lower_op = op;
   std::transform(
-    lower_op.begin(),
-    lower_op.end(),
-    lower_op.begin(),
-    [](unsigned char c) { return std::tolower(c); });
+    lower_op.begin(), lower_op.end(), lower_op.begin(), [](unsigned char c) {
+      return std::tolower(c);
+    });
 
   // If the type is floating-point, use IEEE-specific operators.
   if (type.is_floatbv())
@@ -600,10 +599,9 @@ exprt handle_float_vs_string(exprt &bin_expr, const std::string &op)
     // Python-style error: float < str → TypeError
     std::string lower_op = op;
     std::transform(
-      lower_op.begin(),
-      lower_op.end(),
-      lower_op.begin(),
-      [](unsigned char c) { return std::tolower(c); });
+      lower_op.begin(), lower_op.end(), lower_op.begin(), [](unsigned char c) {
+        return std::tolower(c);
+      });
 
     const auto &loc = bin_expr.location();
     const auto it = operator_map.find(lower_op);
@@ -653,8 +651,7 @@ bool python_converter::has_unsupported_side_effects_internal(
   const exprt &lhs,
   const exprt &rhs)
 {
-  auto has_unsupported_side_effect = [](const exprt &expr)
-  {
+  auto has_unsupported_side_effect = [](const exprt &expr) {
     return expr.id() == "sideeffect" &&
            expr.get("statement") != "function_call";
   };
@@ -859,8 +856,7 @@ exprt python_converter::handle_string_comparison(
   // This avoids introducing strcmp() calls that can inflate branch coverage counts.
   if (op == "Eq" || op == "NotEq")
   {
-    auto extract_single_char = [&](const exprt &expr, char &ch) -> bool
-    {
+    auto extract_single_char = [&](const exprt &expr, char &ch) -> bool {
       const exprt *candidate = &expr;
       if (
         expr.id() == "address_of" && expr.operands().size() == 1 &&
@@ -884,8 +880,7 @@ exprt python_converter::handle_string_comparison(
       return true;
     };
 
-    auto char_at_index = [&](const exprt &expr, int idx) -> exprt
-    {
+    auto char_at_index = [&](const exprt &expr, int idx) -> exprt {
       exprt index = from_integer(idx, index_type());
       if (expr.type().is_array())
         return index_exprt(expr, index, char_type());
@@ -1314,8 +1309,7 @@ void python_converter::convert_function_calls_to_side_effects(
   exprt &lhs,
   exprt &rhs)
 {
-  auto to_side_effect_call = [](exprt &expr)
-  {
+  auto to_side_effect_call = [](exprt &expr) {
     side_effect_expr_function_callt side_effect;
     code_function_callt &code = static_cast<code_function_callt &>(expr);
     side_effect.function() = code.function();
@@ -1511,8 +1505,7 @@ exprt python_converter::handle_type_identity_check(
   auto resolve_type_identifier = [&](
                                    const nlohmann::json &node,
                                    const exprt &expr,
-                                   std::string &out_name) -> bool
-  {
+                                   std::string &out_name) -> bool {
     if (node["_type"] == "Name" && node.contains("id"))
     {
       std::string name = node["id"].get<std::string>();
@@ -1722,10 +1715,10 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     type_utils::is_relational_op(op) || op == "Is" || op == "IsNot" ||
     op == "In" || op == "NotIn")
   {
-    auto is_any_ptr = [](const exprt &e)
-    { return e.type().is_pointer() && e.type().subtype().id() == "empty"; };
-    auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type)
-    {
+    auto is_any_ptr = [](const exprt &e) {
+      return e.type().is_pointer() && e.type().subtype().id() == "empty";
+    };
+    auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type) {
       if (e.type().is_floatbv())
       {
         unsigned width = static_cast<const bv_typet &>(e.type()).get_width();
@@ -1851,8 +1844,7 @@ exprt python_converter::handle_list_operations(
   typet list_type = type_handler_.get_list_type();
 
   // Resolve function calls that return lists to temporary variables
-  auto resolve_list_call = [&](exprt &expr) -> bool
-  {
+  auto resolve_list_call = [&](exprt &expr) -> bool {
     // Check if this is a side effect function call
     if (expr.id().as_string() != "sideeffect")
       return false;
@@ -2059,10 +2051,10 @@ exprt python_converter::build_binary_expression(
   exprt &lhs,
   exprt &rhs)
 {
-  auto is_bv_or_bool = [](const typet &t)
-  { return t.is_signedbv() || t.is_unsignedbv() || t.is_bool(); };
-  auto bit_width = [](const typet &t) -> unsigned
-  {
+  auto is_bv_or_bool = [](const typet &t) {
+    return t.is_signedbv() || t.is_unsignedbv() || t.is_bool();
+  };
+  auto bit_width = [](const typet &t) -> unsigned {
     if (t.is_bool())
       return 1;
     return static_cast<const bv_typet &>(t).get_width();
@@ -2579,8 +2571,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         can_fold = false;
     }
 
-    auto returns_list = [](const nlohmann::json &ret) -> bool
-    {
+    auto returns_list = [](const nlohmann::json &ret) -> bool {
       if (ret.is_null())
         return false;
       if (
@@ -2611,8 +2602,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       const std::string input = arg0["value"].get<std::string>();
       std::vector<long long> out;
       std::string token;
-      auto flush_token = [&](const std::string &tok)
-      {
+      auto flush_token = [&](const std::string &tok) {
         if (tok.empty())
           return;
         long long depth = 0;
@@ -2926,8 +2916,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
   }
 
-  auto handle_keywords = [&](exprt &call_expr)
-  {
+  auto handle_keywords = [&](exprt &call_expr) {
     if (!element.contains("keywords") || element["keywords"].empty())
       return;
 
@@ -2985,8 +2974,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     }
 
     // we need to check if the argument is provided despite being optional
-    auto is_optional_type = [&](const typet &param_type)
-    {
+    auto is_optional_type = [&](const typet &param_type) {
       if (!param_type.is_struct())
         return false;
       const struct_typet &struct_type = to_struct_type(param_type);
@@ -3862,19 +3850,17 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         symbolt *target_class_symbol = nullptr;
 
         // Search all class types in the symbol table to find one that has this attribute
-        symbol_table_.foreach_operand_in_order(
-          [&](const symbolt &s)
-          {
-            if (target_class_symbol)
-              return; // Already found
+        symbol_table_.foreach_operand_in_order([&](const symbolt &s) {
+          if (target_class_symbol)
+            return; // Already found
 
-            if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
-            {
-              const struct_typet &struct_type = to_struct_type(s.type);
-              if (struct_type.has_component(attr_name))
-                target_class_symbol = const_cast<symbolt *>(&s);
-            }
-          });
+          if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
+          {
+            const struct_typet &struct_type = to_struct_type(s.type);
+            if (struct_type.has_component(attr_name))
+              target_class_symbol = const_cast<symbolt *>(&s);
+          }
+        });
 
         if (!target_class_symbol)
         {
@@ -4321,8 +4307,7 @@ void python_converter::handle_assignment_type_adjustments(
       !ast_node.value("_inferred_annotation", false) && has_annotation &&
       ast_node["annotation"].contains("id") &&
       ast_node["annotation"]["id"] == "Any" && lhs.type().is_pointer() &&
-      [this]()
-      {
+      [this]() {
         // Check if "from typing import Any" exists in the source file
         const auto &body = (*ast_json)["body"];
         for (const auto &stmt : body)
@@ -5945,8 +5930,7 @@ std::string
 python_converter::extract_non_none_type(const nlohmann::json &annotation_node)
 {
   std::function<std::string(const nlohmann::json &)> extract_type =
-    [&](const nlohmann::json &node) -> std::string
-  {
+    [&](const nlohmann::json &node) -> std::string {
     if (
       node.contains("_type") && node["_type"] == "Constant" &&
       node.contains("value") && node["value"].is_null())
@@ -6072,8 +6056,7 @@ typet python_converter::get_type_from_annotation(
   if (annotation_node["_type"] == "Subscript")
   {
     // Helper to safely get id from value node
-    auto get_value_id = [&]() -> std::string
-    {
+    auto get_value_id = [&]() -> std::string {
       if (
         annotation_node.contains("value") &&
         annotation_node["value"].is_object() &&
@@ -6096,8 +6079,7 @@ typet python_converter::get_type_from_annotation(
     if (value_id == "Literal")
     {
       // Infer type from a literal constant value
-      auto infer_literal_type = [](const nlohmann::json &value) -> typet
-      {
+      auto infer_literal_type = [](const nlohmann::json &value) -> typet {
         if (value.is_string())
           return gen_pointer_type(char_type());
         else if (value.is_number_integer())
@@ -6114,8 +6096,7 @@ typet python_converter::get_type_from_annotation(
 
       // Resolve a slice element to a constant value
       auto resolve_to_constant =
-        [this](const nlohmann::json &elem) -> nlohmann::json
-      {
+        [this](const nlohmann::json &elem) -> nlohmann::json {
         // Guard: ensure elem is an object with _type
         if (!elem.is_object() || !elem.contains("_type"))
           return nlohmann::json();
@@ -6143,10 +6124,11 @@ typet python_converter::get_type_from_annotation(
       };
 
       // Track type flags from a resolved type
-      auto update_type_flags =
-        [](
-          const typet &type, TypeFlags &flags, bool &has_string, bool &has_none)
-      {
+      auto update_type_flags = [](
+                                 const typet &type,
+                                 TypeFlags &flags,
+                                 bool &has_string,
+                                 bool &has_none) {
         if (type == gen_pointer_type(char_type()))
           has_string = true;
         else if (type == double_type())
@@ -6174,8 +6156,8 @@ typet python_converter::get_type_from_annotation(
           return empty_typet();
 
         // Helper to safely check if node is a Literal subscript
-        auto is_literal_subscript_node = [](const nlohmann::json &node) -> bool
-        {
+        auto is_literal_subscript_node =
+          [](const nlohmann::json &node) -> bool {
           return node.is_object() && node.contains("_type") &&
                  node["_type"] == "Subscript" && node.contains("value") &&
                  node["value"].is_object() && node["value"].contains("id") &&
@@ -6332,8 +6314,7 @@ typet python_converter::get_type_from_annotation(
       const auto &right = annotation_node["right"];
 
       // Helper to check if a node is a Literal subscript
-      auto is_literal_subscript = [](const nlohmann::json &node) -> bool
-      {
+      auto is_literal_subscript = [](const nlohmann::json &node) -> bool {
         return node.contains("_type") && node["_type"] == "Subscript" &&
                node.contains("value") && node["value"].is_object() &&
                node["value"].contains("id") && node["value"]["id"] == "Literal";
@@ -6361,8 +6342,7 @@ typet python_converter::get_type_from_annotation(
     std::set<std::string> type_names;
     std::function<void(const nlohmann::json &)> collect_types;
     bool contains_none = false;
-    collect_types = [&](const nlohmann::json &node)
-    {
+    collect_types = [&](const nlohmann::json &node) {
       // Guard: only process objects
       if (!node.is_object())
         return;
@@ -6443,10 +6423,10 @@ typet python_converter::get_type_from_annotation(
     if (type_string.find('|') != std::string::npos)
     {
       // Split by '|' and trim whitespace
-      auto trim_ws = [](std::string s) -> std::string
-      {
-        const auto not_space = [](unsigned char ch)
-        { return !std::isspace(ch); };
+      auto trim_ws = [](std::string s) -> std::string {
+        const auto not_space = [](unsigned char ch) {
+          return !std::isspace(ch);
+        };
         s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
         s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
         return s;
@@ -6586,9 +6566,8 @@ python_converter::infer_types_from_returns(const nlohmann::json &function_body)
 {
   TypeFlags flags;
 
-  std::function<void(const nlohmann::json &)> scan =
-    [&](const nlohmann::json &body)
-  {
+  std::function<void(const nlohmann::json &)> scan = [&](const nlohmann::json
+                                                           &body) {
     for (const auto &stmt : body)
     {
       if (stmt["_type"] == "Return" && stmt["value"].is_null())
@@ -7540,8 +7519,7 @@ exprt python_converter::get_block(const nlohmann::json &ast_block)
       }
 
       // Attach assertion message if present
-      auto attach_assert_message = [&element](code_assertt &assert_code)
-      {
+      auto attach_assert_message = [&element](code_assertt &assert_code) {
         if (element.contains("msg") && !element["msg"].is_null())
         {
           std::string msg;
@@ -7952,9 +7930,9 @@ void python_converter::process_module_imports(
       current_python_file = nested_python_file;
 
       create_builtin_symbols();
-      exprt imported_code = with_ast(
-        &nested_module_json,
-        [&]() { return get_block(nested_module_json["body"]); });
+      exprt imported_code = with_ast(&nested_module_json, [&]() {
+        return get_block(nested_module_json["body"]);
+      });
       convert_expression_to_code(imported_code);
 
       // Accumulate this module's code
@@ -8179,9 +8157,9 @@ void python_converter::convert()
           imported_module_json, const_cast<global_scope &>(global_scope_));
         imported_annotator.add_type_annotation();
 
-        exprt imported_code = with_ast(
-          &imported_module_json,
-          [&]() { return get_block(imported_module_json["body"]); });
+        exprt imported_code = with_ast(&imported_module_json, [&]() {
+          return get_block(imported_module_json["body"]);
+        });
 
         convert_expression_to_code(imported_code);
 
@@ -8294,16 +8272,14 @@ void python_converter::convert()
   code_blockt main_body;
 
   // 1. Initialize static lifetime variables
-  symbol_table_.foreach_operand_in_order(
-    [&main_body](const symbolt &s)
+  symbol_table_.foreach_operand_in_order([&main_body](const symbolt &s) {
+    if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
     {
-      if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
-      {
-        code_assignt assign(symbol_expr(s), s.value);
-        assign.location() = s.location;
-        main_body.copy_to_operands(assign);
-      }
-    });
+      code_assignt assign(symbol_expr(s), s.value);
+      assign.location() = s.location;
+      main_body.copy_to_operands(assign);
+    }
+  });
 
   // 2. Call python_init for initialization
   if (!init_code.operands().empty())

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -48,8 +48,7 @@ static typet get_elem_type_from_annotation(
   const type_handler &type_handler_)
 {
   // Extract element type from a Subscript node such as list[T]
-  auto extract_subscript_elem = [&](const nlohmann::json &ann) -> typet
-  {
+  auto extract_subscript_elem = [&](const nlohmann::json &ann) -> typet {
     if (
       ann.contains("slice") && ann["slice"].is_object() &&
       ann["slice"].contains("id") && ann["slice"]["id"].is_string())
@@ -398,8 +397,7 @@ exprt python_list::build_concat_list_call(
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
   assert(size_sym && at_sym && push_obj_sym);
 
-  auto copy_list = [&](const exprt &src_list)
-  {
+  auto copy_list = [&](const exprt &src_list) {
     // size_t n = list_size(src_list);
     symbolt &n_sym = converter_.create_tmp_symbol(
       element, "$n$", size_type(), gen_zero(size_type()));
@@ -485,8 +483,7 @@ exprt python_list::build_concat_list_call(
   const std::string dst_id = dst_list.id.as_string();
 
   // Copy type info from source list if it's a symbol
-  auto copy_type_info_from_expr = [&](const exprt &src_list)
-  {
+  auto copy_type_info_from_expr = [&](const exprt &src_list) {
     if (!src_list.is_symbol())
       return;
     copy_type_map_entries(src_list.identifier().as_string(), dst_id);
@@ -640,8 +637,9 @@ exprt python_list::build_split_list(
   if (separator.empty())
   {
     // Whitespace split: split on any whitespace and collapse runs.
-    auto is_space = [](char c)
-    { return std::isspace(static_cast<unsigned char>(c)) != 0; };
+    auto is_space = [](char c) {
+      return std::isspace(static_cast<unsigned char>(c)) != 0;
+    };
 
     if (count == 0)
     {
@@ -682,14 +680,12 @@ exprt python_list::build_split_list(
     size_t i = 0;
     const size_t n = input.size();
 
-    auto skip_ws = [&](size_t &idx)
-    {
+    auto skip_ws = [&](size_t &idx) {
       while (idx < n && is_space(input[idx]))
         ++idx;
     };
 
-    auto scan_token = [&](size_t &idx)
-    {
+    auto scan_token = [&](size_t &idx) {
       while (idx < n && !is_space(input[idx]))
         ++idx;
     };
@@ -919,8 +915,7 @@ exprt python_list::remove_function_calls_recursive(
   const nlohmann::json &node)
 {
   // Bounds might generate intermediate calls, we need to add lhs to all of them.
-  const auto add_lhs_var_bound = [&](exprt &foo) -> exprt
-  {
+  const auto add_lhs_var_bound = [&](exprt &foo) -> exprt {
     if (!foo.is_function_call())
       return foo;
     code_function_callt &call = static_cast<code_function_callt &>(foo);
@@ -1009,8 +1004,7 @@ exprt python_list::handle_range_slice(
 
       // Extract start/end bounds from slice node
       auto get_bound_expr =
-        [&](const std::string &name, long long default_val) -> exprt
-      {
+        [&](const std::string &name, long long default_val) -> exprt {
         if (!slice_node.contains(name) || slice_node[name].is_null())
           return from_integer(default_val, signedbv_typet(64));
 
@@ -1069,8 +1063,7 @@ exprt python_list::handle_range_slice(
 
     // Process slice bounds (handles null, negative indices)
     auto process_bound =
-      [&](const std::string &bound_name, const exprt &default_value) -> exprt
-    {
+      [&](const std::string &bound_name, const exprt &default_value) -> exprt {
       if (!slice_node.contains(bound_name) || slice_node[bound_name].is_null())
         return default_value;
 
@@ -1233,8 +1226,7 @@ exprt python_list::handle_range_slice(
   const locationt location = converter_.get_location_from_decl(list_value_);
 
   auto get_list_bound =
-    [&](const std::string &bound_name, bool is_upper) -> exprt
-  {
+    [&](const std::string &bound_name, bool is_upper) -> exprt {
     if (slice_node.contains(bound_name) && !slice_node[bound_name].is_null())
     {
       const auto &bound_node = slice_node[bound_name];
@@ -2052,8 +2044,7 @@ exprt python_list::compare(
   assert(list_eq_func_sym);
 
   // Convert member expressions into temporary symbols
-  auto materialize_if_needed = [&](const exprt &e) -> exprt
-  {
+  auto materialize_if_needed = [&](const exprt &e) -> exprt {
     if (e.id() == "member")
     {
       // Extract member expression to a temporary variable
@@ -2238,8 +2229,7 @@ exprt python_list::list_repetition(
   exprt list_elem;
   symbolt *list_symbol = nullptr;
 
-  auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool
-  {
+  auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool {
     if (
       size_var->value.is_code() || size_var->value.is_nil() ||
       !size_var->value.is_constant())
@@ -3054,8 +3044,7 @@ typet python_list::check_homogeneous_list_types(
   typet elem_type = type_info[0].second;
 
   // Check whether a type is a string type (char array or char pointer)
-  auto is_string_type = [](const typet &t) -> bool
-  {
+  auto is_string_type = [](const typet &t) -> bool {
     return (t.is_array() && t.subtype() == char_type()) ||
            (t.is_pointer() && t.subtype() == char_type());
   };
@@ -3094,8 +3083,7 @@ exprt python_list::build_list_from_range(
 
   // Extract constant integer, handling UnaryOp for negative numbers
   auto extract_constant =
-    [&](const nlohmann::json &arg) -> std::optional<long long>
-  {
+    [&](const nlohmann::json &arg) -> std::optional<long long> {
     exprt expr = converter.get_expr(arg);
 
     if (expr.is_constant())


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3621.

Add frontend guards for unresolved and pointer-vs-non-pointer relational operands, plus defensive BV/bool width normalization, to prevent internal solver crashes and provide clear diagnostics without false verification.