### PR TITLE
[python] add support for list.reverse() method

### DIFF
--- a/regression/python/list-reverse1/main.py
+++ b/regression/python/list-reverse1/main.py
@@ -1,0 +1,6 @@
+def test_sort_and_reverse():
+    l = [1, 2, 3]
+    l.reverse()
+    assert l == [3, 2, 1]
+
+test_sort_and_reverse()

--- a/regression/python/list-reverse1/test.desc
+++ b/regression/python/list-reverse1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse2/main.py
+++ b/regression/python/list-reverse2/main.py
@@ -1,0 +1,6 @@
+def test_reverse_single_element():
+    l = [42]
+    l.reverse()
+    assert l == [42]
+
+test_reverse_single_element()

--- a/regression/python/list-reverse2/test.desc
+++ b/regression/python/list-reverse2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse3/main.py
+++ b/regression/python/list-reverse3/main.py
@@ -1,0 +1,6 @@
+def test_reverse_empty():
+    l = []
+    l.reverse()
+    assert l == []
+
+test_reverse_empty()

--- a/regression/python/list-reverse3/test.desc
+++ b/regression/python/list-reverse3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse4/main.py
+++ b/regression/python/list-reverse4/main.py
@@ -1,0 +1,6 @@
+def test_reverse_two_elements():
+    l = [10, 20]
+    l.reverse()
+    assert l == [20, 10]
+
+test_reverse_two_elements()

--- a/regression/python/list-reverse4/test.desc
+++ b/regression/python/list-reverse4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse5/main.py
+++ b/regression/python/list-reverse5/main.py
@@ -1,0 +1,8 @@
+def test_reverse_twice_is_identity():
+    l = [1, 2, 3, 4, 5]
+    l.reverse()
+    l.reverse()
+    assert l == [1, 2, 3, 4, 5]
+
+test_reverse_twice_is_identity()
+

--- a/regression/python/list-reverse5/test.desc
+++ b/regression/python/list-reverse5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse6/main.py
+++ b/regression/python/list-reverse6/main.py
@@ -1,0 +1,6 @@
+def test_reverse_floats():
+    l = [1.1, 2.2, 3.3]
+    l.reverse()
+    assert l == [3.3, 2.2, 1.1]
+
+test_reverse_floats()

--- a/regression/python/list-reverse6/test.desc
+++ b/regression/python/list-reverse6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse7-nondet/main.py
+++ b/regression/python/list-reverse7-nondet/main.py
@@ -1,0 +1,12 @@
+def test_reverse_preserves_values():
+    x = nondet_int()
+    y = nondet_int()
+    z = nondet_int()
+    l = [x, y, z]
+    l.reverse()
+    assert l[0] == z
+    assert l[1] == y
+    assert l[2] == x
+
+test_reverse_preserves_values()
+

--- a/regression/python/list-reverse7-nondet/test.desc
+++ b/regression/python/list-reverse7-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-reverse8-nondet/main.py
+++ b/regression/python/list-reverse8-nondet/main.py
@@ -1,0 +1,12 @@
+def test_reverse_preserves_values():
+    x = nondet_bool()
+    y = nondet_bool()
+    z = nondet_bool()
+    l = [x, y, z]
+    l.reverse()
+    assert l[0] == z
+    assert l[1] == y
+    assert l[2] == x
+
+test_reverse_preserves_values()
+

--- a/regression/python/list-reverse8-nondet/test.desc
+++ b/regression/python/list-reverse8-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -242,7 +242,8 @@ const static std::vector<std::string> python_c_models = {
   "__ESBMC_fmod",
   "__ESBMC_copysign",
   "__ESBMC_list_remove",
-  "__ESBMC_list_sort"};
+  "__ESBMC_list_sort",
+  "__ESBMC_list_reverse"};
 } // namespace
 
 static void generate_symbol_deps(

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -711,3 +711,23 @@ void __ESBMC_list_sort(PyListObject *l, int type_flag, uint64_t float_type_id)
     i++;
   }
 }
+
+void __ESBMC_list_reverse(PyListObject *l)
+{
+  if (!l || l->size <= 1)
+    return;
+
+  size_t left = 0;
+  size_t right = l->size - 1;
+
+  while (left < right)
+  {
+    /* Swap items[left] and items[right] in place */
+    PyObject tmp = l->items[left];
+    l->items[left] = l->items[right];
+    l->items[right] = tmp;
+
+    left++;
+    right--;
+  }
+}

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -249,6 +249,7 @@ private:
   exprt handle_list_copy() const;
   exprt handle_list_remove() const;
   exprt handle_list_sort() const;
+  exprt handle_list_reverse() const;
 
   /*
    * Check if the current function call is to a regular expression module function

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3313,3 +3313,11 @@ size_t python_list::get_list_type_map_size(const std::string &list_id)
     return 0;
   return it->second.size();
 }
+
+void python_list::reverse_type_info(const std::string &list_id)
+{
+  auto it = list_type_map.find(list_id);
+  if (it == list_type_map.end() || it->second.size() <= 1)
+    return;
+  std::reverse(it->second.begin(), it->second.end());
+}

--- a/src/python-frontend/python_list.h
+++ b/src/python-frontend/python_list.h
@@ -193,6 +193,22 @@ public:
    */
   static size_t get_list_type_map_size(const std::string &list_id);
 
+  /**
+   * @brief Reverse the compile-time type-info vector for a list.
+   *
+   * Mirrors the runtime element reordering performed by
+   * __ESBMC_list_reverse, so that subsequent index-based type lookups
+   * (e.g. list[0]) continue to resolve to the correct element type
+   * after an in-place reversal.
+   *
+   * Has no effect if the list is unknown, empty, or contains only one
+   * element (those cases are already trivially reversed).
+   *
+   * @param list_id  The internal symbol identifier of the list (e.g.
+   *                 "c:main.py@42@F@main@lst").
+   */
+  static void reverse_type_info(const std::string &list_id);
+
 private:
   friend class python_dict_handler;
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3620.

This PR implements in-place list reversal by adding the `__ESBMC_list_reverse` C model function and wiring it up through the Python frontend. Also, reverse the compile-time type-info vector so that post-reversal index lookups resolve to the correct element types.