### PR TITLE
fix: prevent crash on LoopHintAttr with unsafe value pointer

### DIFF
--- a/regression/esbmc/pragma_unroll_dowhile_true/test.desc
+++ b/regression/esbmc/pragma_unroll_dowhile_true/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 5 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_for_true/test.desc
+++ b/regression/esbmc/pragma_unroll_for_true/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 5 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_macro_true/test.desc
+++ b/regression/esbmc/pragma_unroll_macro_true/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 6 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_nested_complete_true/test.desc
+++ b/regression/esbmc/pragma_unroll_nested_complete_true/test.desc
@@ -1,4 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 3 to loop
+^Applying #pragma unroll 5 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_nested_dowhile_true/test.desc
+++ b/regression/esbmc/pragma_unroll_nested_dowhile_true/test.desc
@@ -1,4 +1,7 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 3 to loop
+^Applying #pragma unroll 4 to loop
+^Applying #pragma unroll 5 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_nested_true/test.desc
+++ b/regression/esbmc/pragma_unroll_nested_true/test.desc
@@ -1,4 +1,6 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 3 to loop
+^Applying #pragma unroll 5 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_override_unwindset_true/test.desc
+++ b/regression/esbmc/pragma_unroll_override_unwindset_true/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --unwindset 2:2 --no-unwinding-assertions
+^Applying #pragma unroll 8 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_unlimited_true/test.desc
+++ b/regression/esbmc/pragma_unroll_unlimited_true/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --unwind 3 --no-unwinding-assertions
+^Applying #pragma unroll \(unlimited\) to loop
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/pragma_unroll_while_true/test.desc
+++ b/regression/esbmc/pragma_unroll_while_true/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --no-unwinding-assertions
+^Applying #pragma unroll 5 to loop
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2828,6 +2828,11 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     // Check for loop unroll attributes
     for (const auto *attr : astmt.getAttrs())
     {
+      // Skip implicit (compiler-synthesized) attributes, we only consider
+      // explicitly defined attributes.
+      if (attr->isImplicit())
+        continue;
+
       if (const auto *lha = llvm::dyn_cast<clang::LoopHintAttr>(attr))
       {
         if (

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2848,8 +2848,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
           {
             if (clang::Expr *val = lha->getValue())
             {
-              if (const auto *lit =
-                    llvm::dyn_cast<clang::IntegerLiteral>(val))
+              if (const auto *lit = llvm::dyn_cast<clang::IntegerLiteral>(val))
                 unroll_count = lit->getValue().getZExtValue();
               else
               {

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2828,11 +2828,6 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     // Check for loop unroll attributes
     for (const auto *attr : astmt.getAttrs())
     {
-      // Skip implicit (compiler-synthesized) attributes, we only consider
-      // explicitly defined attributes.
-      if (attr->isImplicit())
-        continue;
-
       if (const auto *lha = llvm::dyn_cast<clang::LoopHintAttr>(attr))
       {
         if (
@@ -2853,9 +2848,15 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
           {
             if (clang::Expr *val = lha->getValue())
             {
-              clang::Expr::EvalResult result;
-              if (val->EvaluateAsInt(result, *ASTContext))
-                unroll_count = result.Val.getInt().getZExtValue();
+              if (const auto *lit =
+                    llvm::dyn_cast<clang::IntegerLiteral>(val))
+                unroll_count = lit->getValue().getZExtValue();
+              else
+              {
+                clang::Expr::EvalResult result;
+                if (val->EvaluateAsInt(result, *ASTContext))
+                  unroll_count = result.Val.getInt().getZExtValue();
+              }
             }
           }
 


### PR DESCRIPTION
## Summary

- Guard the `LoopHintAttr` value read in pragma unroll handling with a safe `dyn_cast<IntegerLiteral>` check instead of calling `EvaluateAsInt` directly on a potentially dangling pointer
- Strengthen 9 pragma unroll regression tests to also assert the `Applying #pragma unroll` output line

## Problem

When processing `#pragma unroll` directives, the `LoopHintAttr::getValue()` pointer can be dangling or point to an unexpected expression node on some Clang versions. Calling `EvaluateAsInt` on such a pointer causes a segfault.

## Fix

In the `Numeric` state branch, validate the value pointer using `dyn_cast<clang::IntegerLiteral>` before reading it. The `dyn_cast` checks the `StmtClass` discriminator, which safely rejects corrupt or unexpected expression pointers. If the value is a proper `IntegerLiteral`, its value is read directly. For non-literal constant expressions, the existing `EvaluateAsInt` path is used as a fallback.