### PR TITLE
[python] add enum support with struct-based modeling

### DIFF
--- a/regression/python/github_3642/main.py
+++ b/regression/python/github_3642/main.py
@@ -1,0 +1,35 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+    YELLOW = 2
+    GREEN = 3
+
+
+def can_go(light: TrafficLight) -> bool:
+    if light == TrafficLight.GREEN:
+        return True
+    elif light == TrafficLight.RED:
+        return False
+    elif light == TrafficLight.YELLOW:
+        return False
+    else:
+        assert False, "Unknown traffic light state"
+
+
+def test_traffic_light():
+    assert can_go(TrafficLight.GREEN) is True
+    assert can_go(TrafficLight.RED) is False
+    assert can_go(TrafficLight.YELLOW) is False
+
+    assert TrafficLight.RED.value == 1
+    assert TrafficLight.YELLOW.value == 2
+    assert TrafficLight.GREEN.value == 3
+
+    assert TrafficLight.RED.name == "RED"
+    assert TrafficLight.GREEN.name == "GREEN"
+
+
+if __name__ == "__main__":
+    test_traffic_light()

--- a/regression/python/github_3642/test.desc
+++ b/regression/python/github_3642/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_1/main.py
+++ b/regression/python/github_3642_1/main.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class A(Enum):
+    X = 1
+
+
+class B(Enum):
+    X = 1
+
+
+def test_cross_enum_equality():
+    assert (A.X == B.X) is False

--- a/regression/python/github_3642_1/test.desc
+++ b/regression/python/github_3642_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_10/main.py
+++ b/regression/python/github_3642_10/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def test_symmetry():
+    assert (TrafficLight.RED == TrafficLight.RED)
+    assert not (TrafficLight.RED != TrafficLight.RED)

--- a/regression/python/github_3642_10/test.desc
+++ b/regression/python/github_3642_10/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_11/main.py
+++ b/regression/python/github_3642_11/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def test_dict_usage():
+    d = {TrafficLight.RED: 10}
+    assert d[TrafficLight.RED] == 10

--- a/regression/python/github_3642_11/test.desc
+++ b/regression/python/github_3642_11/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_2/main.py
+++ b/regression/python/github_3642_2/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def test_enum_vs_int():
+    assert (TrafficLight.RED == 1) is False
+    assert (1 == TrafficLight.RED) is False

--- a/regression/python/github_3642_2/test.desc
+++ b/regression/python/github_3642_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_3/main.py
+++ b/regression/python/github_3642_3/main.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+class Dummy:
+    pass
+
+
+def test_enum_vs_object():
+    d = Dummy()
+    assert (TrafficLight.RED == d) is False

--- a/regression/python/github_3642_3/test.desc
+++ b/regression/python/github_3642_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_4/main.py
+++ b/regression/python/github_3642_4/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+    GREEN = 2
+
+
+def test_ordering_not_allowed():
+    assert not (TrafficLight.RED < TrafficLight.GREEN)

--- a/regression/python/github_3642_4/test.desc
+++ b/regression/python/github_3642_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_5/main.py
+++ b/regression/python/github_3642_5/main.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class A(Enum):
+    X = 1
+
+
+class B(Enum):
+    Y = 1
+
+
+def test_hash_collision():
+    assert hash(A.X) != hash(B.Y)

--- a/regression/python/github_3642_5/test.desc
+++ b/regression/python/github_3642_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_6/main.py
+++ b/regression/python/github_3642_6/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def test_name_string_compare():
+    assert TrafficLight.RED.name == "RED"
+    assert TrafficLight.RED.name != "GREEN"

--- a/regression/python/github_3642_6/test.desc
+++ b/regression/python/github_3642_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_7/main.py
+++ b/regression/python/github_3642_7/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def test_invalid_attribute():
+    # Should fail verification
+    assert TrafficLight.RED.invalid == 0

--- a/regression/python/github_3642_7/test.desc
+++ b/regression/python/github_3642_7/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR\: Cannot resolve nested attribute\: invalid$

--- a/regression/python/github_3642_8/main.py
+++ b/regression/python/github_3642_8/main.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def test_nested_access():
+    name = TrafficLight.RED.name
+    assert name == "RED"

--- a/regression/python/github_3642_8/test.desc
+++ b/regression/python/github_3642_8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_9/main.py
+++ b/regression/python/github_3642_9/main.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+
+
+def takes_enum(x: TrafficLight):
+    assert x.name == "RED"
+
+
+def test_struct_integrity():
+    takes_enum(TrafficLight.RED)

--- a/regression/python/github_3642_9/test.desc
+++ b/regression/python/github_3642_9/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_alias/main.py
+++ b/regression/python/github_3642_alias/main.py
@@ -1,0 +1,13 @@
+from enum import Enum as E
+
+
+class A(E):
+    X = 1
+
+
+def test_alias_base():
+    assert A.X.value == 1
+
+
+if __name__ == "__main__":
+    test_alias_base()

--- a/regression/python/github_3642_alias/test.desc
+++ b/regression/python/github_3642_alias/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3642_fail/main.py
+++ b/regression/python/github_3642_fail/main.py
@@ -1,0 +1,35 @@
+from enum import Enum
+
+
+class TrafficLight(Enum):
+    RED = 1
+    YELLOW = 2
+    GREEN = 3
+
+
+def can_go(light: TrafficLight) -> bool:
+    if light == TrafficLight.GREEN:
+        return True
+    elif light == TrafficLight.RED:
+        return False
+    elif light == TrafficLight.YELLOW:
+        return False
+    else:
+        assert False, "Unknown traffic light state"
+
+
+def test_traffic_light():
+    assert can_go(TrafficLight.GREEN) is True
+    assert can_go(TrafficLight.RED) is False
+    assert can_go(TrafficLight.YELLOW) is False
+
+    assert TrafficLight.RED.value == 2
+    assert TrafficLight.YELLOW.value == 2
+    assert TrafficLight.GREEN.value == 3
+
+    assert TrafficLight.RED.name == "RED"
+    assert TrafficLight.GREEN.name == "GREEN"
+
+
+if __name__ == "__main__":
+    test_traffic_light()

--- a/regression/python/github_3642_fail/test.desc
+++ b/regression/python/github_3642_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/nested-attr-13/test.desc
+++ b/regression/python/nested-attr-13/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-13/test.desc
+++ b/regression/python/nested-attr-13/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -12,18 +12,6 @@ class Enum:
     def __hash__(self) -> int:
         return self.value
 
-    def __lt__(self, other: Enum) -> bool:
-        return self.value < other.value
-
-    def __le__(self, other: Enum) -> bool:
-        return self.value <= other.value
-
-    def __gt__(self, other: Enum) -> bool:
-        return self.value > other.value
-
-    def __ge__(self, other: Enum) -> bool:
-        return self.value >= other.value
-
     def __repr__(self) -> str:
         return self.name
 

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -1,4 +1,5 @@
 class Enum:
+
     def __init__(self, value: int, name: str):
         self.value: int = value
         self.name: str = name

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -1,0 +1,31 @@
+class Enum:
+    def __init__(self, value: int, name: str):
+        self.value: int = value
+        self.name: str = name
+
+    def __eq__(self, other: Enum) -> bool:
+        return self.value == other.value
+
+    def __ne__(self, other: Enum) -> bool:
+        return self.value != other.value
+
+    def __hash__(self) -> int:
+        return self.value
+
+    def __lt__(self, other: Enum) -> bool:
+        return self.value < other.value
+
+    def __le__(self, other: Enum) -> bool:
+        return self.value <= other.value
+
+    def __gt__(self, other: Enum) -> bool:
+        return self.value > other.value
+
+    def __ge__(self, other: Enum) -> bool:
+        return self.value >= other.value
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def __str__(self) -> str:
+        return self.name

--- a/src/python-frontend/python_class_builder.cpp
+++ b/src/python-frontend/python_class_builder.cpp
@@ -44,7 +44,10 @@ bool python_class_builder::get_bases(struct_typet &st)
 
   for (const auto &bfull : pc_.bases())
   {
-    std::string base = leaf(bfull);
+    // Resolve any import alias before further processing
+    // e.g. "from enum import Enum as E" → leaf("E") → get_object_alias → "Enum"
+    std::string base =
+      leaf(json_utils::get_object_alias(conv_.ast(), leaf(bfull)));
     if (
       type_utils::is_builtin_type(base) ||
       type_utils::is_consensus_type(base) || type_utils::is_typeddict(base))

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -101,8 +101,14 @@ static bool is_enum_class(
       !class_node["bases"].is_array())
     return false;
   for (const auto &base : class_node["bases"])
-    if (base.is_object() && base.contains("id") && base["id"] == "Enum")
-      return true;
+    if (base.is_object() && base.contains("id"))
+    {
+      // Resolve any import alias (e.g. "from enum import Enum as E" → "Enum")
+      const std::string resolved =
+        get_object_alias(ast_json, base["id"].get<std::string>());
+      if (resolved == "Enum")
+        return true;
+    }
   return false;
 }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -120,11 +120,21 @@ exprt python_converter::make_enum_member_struct_expr(
   // Get the struct type for the enum class (e.g. tag-TrafficLight)
   const symbolt *type_sym = symbol_table_.find_symbol("tag-" + class_name);
   if (!type_sym || !type_sym->type.is_struct())
-    return symbol_expr(int_sym); // fallback: return plain int expression
+  {
+    log_error(
+      "Enum class '{}' has no struct type in symbol table", class_name);
+    abort();
+  }
 
   const struct_typet &st = to_struct_type(type_sym->type);
   if (st.components().size() < 2)
-    return symbol_expr(int_sym);
+  {
+    log_error(
+      "Enum class '{}' struct has fewer than 2 components (expected 'value' "
+      "and 'name')",
+      class_name);
+    abort();
+  }
 
   // Create (or reuse) a static char-array symbol for the member name string.
   const std::string str_id = "py:" + current_python_file + "@C@" + class_name +

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -91,14 +91,13 @@ static StatementType get_statement_type(const nlohmann::json &element)
 }
 
 // Returns true if the named class inherits from Python's Enum
-static bool is_enum_class(
-  const std::string &class_name,
-  const nlohmann::json &ast_json)
+static bool
+is_enum_class(const std::string &class_name, const nlohmann::json &ast_json)
 {
-  const nlohmann::json class_node =
-    find_class(ast_json["body"], class_name);
-  if (class_node.empty() || !class_node.contains("bases") ||
-      !class_node["bases"].is_array())
+  const nlohmann::json class_node = find_class(ast_json["body"], class_name);
+  if (
+    class_node.empty() || !class_node.contains("bases") ||
+    !class_node["bases"].is_array())
     return false;
   for (const auto &base : class_node["bases"])
     if (base.is_object() && base.contains("id"))
@@ -121,8 +120,7 @@ exprt python_converter::make_enum_member_struct_expr(
   const symbolt *type_sym = symbol_table_.find_symbol("tag-" + class_name);
   if (!type_sym || !type_sym->type.is_struct())
   {
-    log_error(
-      "Enum class '{}' has no struct type in symbol table", class_name);
+    log_error("Enum class '{}' has no struct type in symbol table", class_name);
     abort();
   }
 
@@ -137,8 +135,8 @@ exprt python_converter::make_enum_member_struct_expr(
   }
 
   // Create (or reuse) a static char-array symbol for the member name string.
-  const std::string str_id = "py:" + current_python_file + "@C@" + class_name +
-                             "@_name_" + member_name;
+  const std::string str_id =
+    "py:" + current_python_file + "@C@" + class_name + "@_name_" + member_name;
   if (!symbol_table_.find_symbol(str_id))
   {
     exprt str_val = string_builder_->build_string_literal(member_name);
@@ -3570,8 +3568,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         // (enabling reliable constant-folding in string comparisons) even after
         // enum members have been re-typed as their enclosing struct.
         if (
-          element["value"].is_object() &&
-          element["value"].contains("value") &&
+          element["value"].is_object() && element["value"].contains("value") &&
           element["value"]["value"].is_object() &&
           element["value"]["value"].contains("_type") &&
           element["value"]["value"]["_type"] == "Name" &&

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -803,6 +803,17 @@ private:
   /// Wrap values in Optional
   exprt wrap_in_optional(const exprt &value, const typet &optional_type);
 
+  // =========================================================================
+  // Enum support helpers
+  // =========================================================================
+
+  /// Build a struct expression for an enum member (e.g. TrafficLight.GREEN)
+  /// so that it carries the enum class type rather than a raw int.
+  exprt make_enum_member_struct_expr(
+    const symbolt &int_sym,
+    const std::string &class_name,
+    const std::string &member_name);
+
   /// Handle Optional value access
   exprt unwrap_optional_if_needed(const exprt &expr);
 


### PR DESCRIPTION
Fixes #3642.

This PR introduces support for Python’s Enum type in the Python frontend. The implementation models enum members as structured values instead of raw integers, preserving both:
- The integer value (`.value`).
- The member name (`.name`).

This enables correct type propagation, constant folding, and improved semantic accuracy during verification.