### PR TITLE
Fix/GitHub 3638

### DIFF
--- a/regression/python/github_3638/main.py
+++ b/regression/python/github_3638/main.py
@@ -1,0 +1,7 @@
+import math
+
+def test_rounding():
+    assert round(3.6) == 4
+    assert round(3.14159, 2) == 3.14
+
+test_rounding()

--- a/regression/python/github_3638/test.desc
+++ b/regression/python/github_3638/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -18,6 +18,7 @@
 #include <util/string_constant.h>
 
 #include <regex>
+#include <cmath>
 #include <stdexcept>
 
 using namespace json_utils;
@@ -37,6 +38,58 @@ constexpr unsigned int SURROGATE_END = 0xDFFF;
 // Constants for symbol parsing
 constexpr const char *CLASS_MARKER = "@C@";
 constexpr const char *FUNCTION_MARKER = "@F@";
+
+double round_ties_to_even(const double value)
+{
+  const double lower = std::floor(value);
+  const double diff = value - lower;
+  constexpr double tie_eps = 1e-12;
+
+  if (diff < 0.5 - tie_eps)
+    return lower;
+  if (diff > 0.5 + tie_eps)
+    return lower + 1.0;
+
+  const double parity = std::fmod(std::fabs(lower), 2.0);
+  const bool lower_is_even =
+    parity < tie_eps || std::fabs(parity - 2.0) < tie_eps;
+  return lower_is_even ? lower : lower + 1.0;
+}
+
+double round_to_ndigits_ties_even(const double value, const int ndigits)
+{
+  auto round_ld_ties_even = [](const long double v) -> long double
+  {
+    const long double lower = std::floor(v);
+    const long double diff = v - lower;
+    constexpr long double tie_eps = 1e-15L;
+
+    if (diff < 0.5L - tie_eps)
+      return lower;
+    if (diff > 0.5L + tie_eps)
+      return lower + 1.0L;
+
+    const long double parity = std::fmod(std::fabs(lower), 2.0L);
+    const bool lower_is_even =
+      parity < tie_eps || std::fabs(parity - 2.0L) < tie_eps;
+    return lower_is_even ? lower : lower + 1.0L;
+  };
+
+  // Keep scaling deterministic across libm implementations.
+  long double scale = 1.0L;
+  if (ndigits >= 0)
+  {
+    for (int i = 0; i < ndigits; ++i)
+      scale *= 10.0L;
+    return static_cast<double>(
+      round_ld_ties_even(static_cast<long double>(value) * scale) / scale);
+  }
+
+  for (int i = 0; i < -ndigits; ++i)
+    scale *= 10.0L;
+  return static_cast<double>(
+    round_ld_ties_even(static_cast<long double>(value) / scale) * scale);
+}
 } // namespace
 
 function_call_expr::function_call_expr(
@@ -367,7 +420,8 @@ exprt function_call_expr::handle_isinstance() const
       // Check if this constant value is a type name
       if (type_utils::is_type_identifier(value_str))
       {
-        auto extract_type_name = [](const nlohmann::json &node) -> std::string {
+        auto extract_type_name = [](const nlohmann::json &node) -> std::string
+        {
           const std::string node_type = node["_type"];
           if (node_type == "Name")
             return node["id"];
@@ -383,7 +437,8 @@ exprt function_call_expr::handle_isinstance() const
   }
 
   // Extract type name from various AST node formats
-  auto extract_type_name = [](const nlohmann::json &node) -> std::string {
+  auto extract_type_name = [](const nlohmann::json &node) -> std::string
+  {
     const std::string node_type = node["_type"];
 
     if (node_type == "Name")
@@ -444,7 +499,8 @@ exprt function_call_expr::handle_isinstance() const
   };
 
   // Build isinstance check for a given type name
-  auto build_isinstance = [&](const std::string &type_name) -> exprt {
+  auto build_isinstance = [&](const std::string &type_name) -> exprt
+  {
     // Special case: Check if object is None (null pointer)
     if (type_name == "NoneType")
     {
@@ -990,7 +1046,8 @@ function_call_expr::extract_string_from_symbol(const symbolt *sym) const
   const exprt &val = sym->value;
   std::string result;
 
-  auto decode_char = [](const exprt &expr) -> std::optional<char> {
+  auto decode_char = [](const exprt &expr) -> std::optional<char>
+  {
     try
     {
       const auto &const_expr = to_constant_expr(expr);
@@ -1227,6 +1284,108 @@ exprt function_call_expr::handle_abs(nlohmann::json &arg) const
   // Fallback for unsupported symbolic expressions (e.g., complex)
   // Currently returns a nil expression to signal unsupported cases
   log_warning("Returning nil expression for abs() with type: {}", arg_type);
+  return nil_exprt();
+}
+
+exprt function_call_expr::handle_round(nlohmann::json &arg) const
+{
+  const auto &args = call_["args"];
+  bool has_ndigits = args.size() >= 2;
+
+  // Reject strings early
+  if (is_string_arg(arg))
+    return converter_.get_exception_handler().gen_exception_raise(
+      "TypeError", "type str doesn't define __round__ method");
+
+  // Handle unary minus (e.g., round(-3.6))
+  // Unlike abs(), round() must preserve the sign.
+  bool is_negated = false;
+  if (arg.contains("_type") && arg["_type"] == "UnaryOp")
+  {
+    const auto &op = arg["op"];
+    const auto &operand = arg["operand"];
+    if (op["_type"] == "USub" && operand.contains("value"))
+    {
+      arg = operand;
+      is_negated = true;
+    }
+  }
+
+  // Compile-time evaluation for numeric literals
+  if (arg.contains("value") && arg["value"].is_number())
+  {
+    if (!has_ndigits)
+    {
+      // round(x) -> nearest integer (returns int)
+      if (arg["value"].is_number_integer())
+      {
+        int val = arg["value"].get<int>();
+        if (is_negated)
+          val = -val;
+        arg["value"] = val;
+        arg["type"] = "int";
+      }
+      else
+      {
+        double val = arg["value"].get<double>();
+        if (is_negated)
+          val = -val;
+        arg["value"] = static_cast<int>(round_ties_to_even(val));
+        arg["type"] = "int";
+      }
+      typet t = type_handler_.get_typet("int", 0);
+      exprt expr = converter_.get_expr(arg);
+      expr.type() = t;
+      return expr;
+    }
+    else
+    {
+      // round(x, n) -> float rounded to n decimals
+      auto ndigits_arg = args[1];
+      if (
+        ndigits_arg.contains("value") &&
+        ndigits_arg["value"].is_number_integer())
+      {
+        int n = ndigits_arg["value"].get<int>();
+        double val = arg["value"].is_number_integer()
+                       ? static_cast<double>(arg["value"].get<int>())
+                       : arg["value"].get<double>();
+        if (is_negated)
+          val = -val;
+        double rounded = round_to_ndigits_ties_even(val, n);
+        arg["value"] = rounded;
+        arg["type"] = "float";
+        typet t = type_handler_.get_typet("float", 0);
+        exprt expr = converter_.get_expr(arg);
+        expr.type() = t;
+        return expr;
+      }
+    }
+  }
+
+  // Symbolic: try to build an expression for round(x)
+  if (!has_ndigits)
+  {
+    try
+    {
+      exprt operand_expr = converter_.get_expr(arg);
+      typet float_type = type_handler_.get_typet("float", 0);
+      typet int_type = type_handler_.get_typet("int", 0);
+
+      // Use nearbyint (round-to-nearest-even) on the float operand,
+      // then typecast to int — matching Python's round() semantics.
+      exprt nearbyint_expr("nearbyint", float_type);
+      nearbyint_expr.copy_to_operands(operand_expr);
+      return typecast_exprt(nearbyint_expr, int_type);
+    }
+    catch (const std::exception &)
+    {
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", "failed to infer operand type for round()");
+    }
+  }
+
+  log_warning("round() with symbolic arguments not fully supported");
   return nil_exprt();
 }
 
@@ -2446,7 +2605,8 @@ function_call_expr::get_dispatch_table()
 
     // Introspection functions (isinstance, hasattr)
     {[this]() { return is_introspection_call(); },
-     [this]() {
+     [this]()
+     {
        if (function_id_.get_function() == "isinstance")
          return handle_isinstance();
        else
@@ -2466,7 +2626,8 @@ function_call_expr::get_dispatch_table()
 
     // Min/Max functions
     {[this]() { return is_min_max_call(); },
-     [this]() {
+     [this]()
+     {
        const std::string &func_name = function_id_.get_function();
        if (func_name == "min")
          return handle_min_max("min", exprt::i_lt);
@@ -2486,11 +2647,13 @@ function_call_expr::get_dispatch_table()
      "dict methods"},
 
     // Math module functions (isnan, isinf)
-    {[this]() {
+    {[this]()
+     {
        const std::string &func_name = function_id_.get_function();
        return func_name == "__ESBMC_isnan" || func_name == "__ESBMC_isinf";
      },
-     [this]() {
+     [this]()
+     {
        const std::string &func_name = function_id_.get_function();
        const auto &args = call_["args"];
 
@@ -2518,7 +2681,8 @@ function_call_expr::get_dispatch_table()
      "isnan/isinf"},
 
     // Math module functions (sin, cos, sqrt, exp, log, etc.)
-    {[this]() {
+    {[this]()
+     {
        const std::string &func_name = function_id_.get_function();
        bool is_math_module = false;
        if (call_["func"]["_type"] == "Attribute")
@@ -2566,18 +2730,21 @@ function_call_expr::get_dispatch_table()
                 func_name == "ulp" || func_name == "dist")) ||
               is_math_wrapper;
      },
-     [this]() -> exprt {
+     [this]() -> exprt
+     {
        const std::string &func_name = function_id_.get_function();
        const auto &args = call_["args"];
 
-       auto require_one_arg = [&]() -> exprt {
+       auto require_one_arg = [&]() -> exprt
+       {
          if (args.size() != 1)
            throw std::runtime_error(
              func_name + "() expects exactly 1 argument");
          return converter_.get_expr(args[0]);
        };
 
-       auto require_two_args = [&]() -> std::pair<exprt, exprt> {
+       auto require_two_args = [&]() -> std::pair<exprt, exprt>
+       {
          if (args.size() != 2)
            throw std::runtime_error(
              func_name + "() expects exactly 2 arguments");
@@ -2834,7 +3001,8 @@ function_call_expr::get_dispatch_table()
            // If either argument is a constant struct (tuple literal), store it
            // in a temporary local variable so that the GOTO IR has a proper
            // symbol whose address the solver can track.
-           auto materialize = [&](exprt &arg) {
+           auto materialize = [&](exprt &arg)
+           {
              if (arg.is_constant())
              {
                symbolt &tmp = converter_.create_tmp_symbol(
@@ -2872,15 +3040,33 @@ function_call_expr::get_dispatch_table()
      "math.comb"},
 
     // divmod function
-    {[this]() {
+    {[this]()
+     {
        const std::string &func_name = function_id_.get_function();
        return func_name == "divmod";
      },
      [this]() { return handle_divmod(); },
      "divmod"},
 
+    // round() builtin function
+    {[this]()
+     {
+       const std::string &func_name = function_id_.get_function();
+       return func_name == "round" && function_id_.get_prefix() == "py:";
+     },
+     [this]()
+     {
+       if (call_["args"].empty())
+         return converter_.get_exception_handler().gen_exception_raise(
+           "TypeError", "round() missing required argument");
+       auto arg = call_["args"][0];
+       return handle_round(arg);
+     },
+     "round() builtin"},
+
     // Built-in type constructors (int, float, str, bool, etc.)
-    {[this]() {
+    {[this]()
+     {
        const std::string &func_name = function_id_.get_function();
        return type_utils::is_builtin_type(func_name) ||
               type_utils::is_consensus_type(func_name);
@@ -2890,7 +3076,8 @@ function_call_expr::get_dispatch_table()
 
     // Regex module validation
     {[this]() { return is_re_module_call(); },
-     [this]() {
+     [this]()
+     {
        exprt validation_result = validate_re_module_args();
        if (!validation_result.is_nil())
          return validation_result;
@@ -2923,6 +3110,19 @@ exprt function_call_expr::handle_general_function_call()
   // Handle single-argument min/max by dispatching to typed builtins
   const std::string &func_name = function_id_.get_function();
   std::string actual_func_name = func_name;
+
+  const bool has_user_round =
+    !find_function(converter_.ast()["body"], func_name).empty();
+  if (
+    func_name == "round" && call_.contains("func") &&
+    call_["func"].value("_type", "") == "Name" && !has_user_round)
+  {
+    if (call_["args"].empty())
+      return converter_.get_exception_handler().gen_exception_raise(
+        "TypeError", "round() missing required argument");
+    auto arg = call_["args"][0];
+    return handle_round(arg);
+  }
 
   if (
     (func_name == "min" || func_name == "max" || func_name == "sorted") &&
@@ -3850,7 +4050,8 @@ function_call_expr::find_possible_class_types(const symbolt *obj_symbol) const
   if (return_type == "Any" && func_node.contains("body"))
   {
     std::function<void(const nlohmann::json &)> find_returns;
-    find_returns = [&](const nlohmann::json &node) {
+    find_returns = [&](const nlohmann::json &node)
+    {
       if (!node.is_object())
         return;
 
@@ -3990,7 +4191,8 @@ exprt function_call_expr::check_argument_types(
     }
   }
 
-  auto types_match = [&](const typet &expected, const typet &actual) {
+  auto types_match = [&](const typet &expected, const typet &actual)
+  {
     return base_type_eq(expected, actual, converter_.ns) ||
            (type_utils::is_string_type(expected) &&
             type_utils::is_string_type(actual));

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -58,8 +58,7 @@ double round_ties_to_even(const double value)
 
 double round_to_ndigits_ties_even(const double value, const int ndigits)
 {
-  auto round_ld_ties_even = [](const long double v) -> long double
-  {
+  auto round_ld_ties_even = [](const long double v) -> long double {
     const long double lower = std::floor(v);
     const long double diff = v - lower;
     constexpr long double tie_eps = 1e-15L;
@@ -420,8 +419,7 @@ exprt function_call_expr::handle_isinstance() const
       // Check if this constant value is a type name
       if (type_utils::is_type_identifier(value_str))
       {
-        auto extract_type_name = [](const nlohmann::json &node) -> std::string
-        {
+        auto extract_type_name = [](const nlohmann::json &node) -> std::string {
           const std::string node_type = node["_type"];
           if (node_type == "Name")
             return node["id"];
@@ -437,8 +435,7 @@ exprt function_call_expr::handle_isinstance() const
   }
 
   // Extract type name from various AST node formats
-  auto extract_type_name = [](const nlohmann::json &node) -> std::string
-  {
+  auto extract_type_name = [](const nlohmann::json &node) -> std::string {
     const std::string node_type = node["_type"];
 
     if (node_type == "Name")
@@ -499,8 +496,7 @@ exprt function_call_expr::handle_isinstance() const
   };
 
   // Build isinstance check for a given type name
-  auto build_isinstance = [&](const std::string &type_name) -> exprt
-  {
+  auto build_isinstance = [&](const std::string &type_name) -> exprt {
     // Special case: Check if object is None (null pointer)
     if (type_name == "NoneType")
     {
@@ -1046,8 +1042,7 @@ function_call_expr::extract_string_from_symbol(const symbolt *sym) const
   const exprt &val = sym->value;
   std::string result;
 
-  auto decode_char = [](const exprt &expr) -> std::optional<char>
-  {
+  auto decode_char = [](const exprt &expr) -> std::optional<char> {
     try
     {
       const auto &const_expr = to_constant_expr(expr);
@@ -2605,8 +2600,7 @@ function_call_expr::get_dispatch_table()
 
     // Introspection functions (isinstance, hasattr)
     {[this]() { return is_introspection_call(); },
-     [this]()
-     {
+     [this]() {
        if (function_id_.get_function() == "isinstance")
          return handle_isinstance();
        else
@@ -2626,8 +2620,7 @@ function_call_expr::get_dispatch_table()
 
     // Min/Max functions
     {[this]() { return is_min_max_call(); },
-     [this]()
-     {
+     [this]() {
        const std::string &func_name = function_id_.get_function();
        if (func_name == "min")
          return handle_min_max("min", exprt::i_lt);
@@ -2647,13 +2640,11 @@ function_call_expr::get_dispatch_table()
      "dict methods"},
 
     // Math module functions (isnan, isinf)
-    {[this]()
-     {
+    {[this]() {
        const std::string &func_name = function_id_.get_function();
        return func_name == "__ESBMC_isnan" || func_name == "__ESBMC_isinf";
      },
-     [this]()
-     {
+     [this]() {
        const std::string &func_name = function_id_.get_function();
        const auto &args = call_["args"];
 
@@ -2681,8 +2672,7 @@ function_call_expr::get_dispatch_table()
      "isnan/isinf"},
 
     // Math module functions (sin, cos, sqrt, exp, log, etc.)
-    {[this]()
-     {
+    {[this]() {
        const std::string &func_name = function_id_.get_function();
        bool is_math_module = false;
        if (call_["func"]["_type"] == "Attribute")
@@ -2730,21 +2720,18 @@ function_call_expr::get_dispatch_table()
                 func_name == "ulp" || func_name == "dist")) ||
               is_math_wrapper;
      },
-     [this]() -> exprt
-     {
+     [this]() -> exprt {
        const std::string &func_name = function_id_.get_function();
        const auto &args = call_["args"];
 
-       auto require_one_arg = [&]() -> exprt
-       {
+       auto require_one_arg = [&]() -> exprt {
          if (args.size() != 1)
            throw std::runtime_error(
              func_name + "() expects exactly 1 argument");
          return converter_.get_expr(args[0]);
        };
 
-       auto require_two_args = [&]() -> std::pair<exprt, exprt>
-       {
+       auto require_two_args = [&]() -> std::pair<exprt, exprt> {
          if (args.size() != 2)
            throw std::runtime_error(
              func_name + "() expects exactly 2 arguments");
@@ -3001,8 +2988,7 @@ function_call_expr::get_dispatch_table()
            // If either argument is a constant struct (tuple literal), store it
            // in a temporary local variable so that the GOTO IR has a proper
            // symbol whose address the solver can track.
-           auto materialize = [&](exprt &arg)
-           {
+           auto materialize = [&](exprt &arg) {
              if (arg.is_constant())
              {
                symbolt &tmp = converter_.create_tmp_symbol(
@@ -3040,8 +3026,7 @@ function_call_expr::get_dispatch_table()
      "math.comb"},
 
     // divmod function
-    {[this]()
-     {
+    {[this]() {
        const std::string &func_name = function_id_.get_function();
        return func_name == "divmod";
      },
@@ -3049,13 +3034,11 @@ function_call_expr::get_dispatch_table()
      "divmod"},
 
     // round() builtin function
-    {[this]()
-     {
+    {[this]() {
        const std::string &func_name = function_id_.get_function();
        return func_name == "round" && function_id_.get_prefix() == "py:";
      },
-     [this]()
-     {
+     [this]() {
        if (call_["args"].empty())
          return converter_.get_exception_handler().gen_exception_raise(
            "TypeError", "round() missing required argument");
@@ -3065,8 +3048,7 @@ function_call_expr::get_dispatch_table()
      "round() builtin"},
 
     // Built-in type constructors (int, float, str, bool, etc.)
-    {[this]()
-     {
+    {[this]() {
        const std::string &func_name = function_id_.get_function();
        return type_utils::is_builtin_type(func_name) ||
               type_utils::is_consensus_type(func_name);
@@ -3076,8 +3058,7 @@ function_call_expr::get_dispatch_table()
 
     // Regex module validation
     {[this]() { return is_re_module_call(); },
-     [this]()
-     {
+     [this]() {
        exprt validation_result = validate_re_module_args();
        if (!validation_result.is_nil())
          return validation_result;
@@ -4050,8 +4031,7 @@ function_call_expr::find_possible_class_types(const symbolt *obj_symbol) const
   if (return_type == "Any" && func_node.contains("body"))
   {
     std::function<void(const nlohmann::json &)> find_returns;
-    find_returns = [&](const nlohmann::json &node)
-    {
+    find_returns = [&](const nlohmann::json &node) {
       if (!node.is_object())
         return;
 
@@ -4191,8 +4171,7 @@ exprt function_call_expr::check_argument_types(
     }
   }
 
-  auto types_match = [&](const typet &expected, const typet &actual)
-  {
+  auto types_match = [&](const typet &expected, const typet &actual) {
     return base_type_eq(expected, actual, converter_.ns) ||
            (type_utils::is_string_type(expected) &&
             type_utils::is_string_type(actual));

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -228,6 +228,13 @@ private:
   exprt handle_abs(nlohmann::json &arg) const;
 
   /*
+   * Handles round() function calls by rounding a numeric value.
+   * round(x) returns the nearest integer (as int).
+   * round(x, n) returns x rounded to n decimal places (as float).
+   */
+  exprt handle_round(nlohmann::json &arg) const;
+
+  /*
    * Checks if the current function call is a min() or max() built-in function.
    * Returns true if the function name matches "min" or "max", false otherwise.
    */

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -358,8 +358,7 @@ exprt numpy_call_expr::create_expr_from_call()
   nlohmann::json expr;
 
   // Resolve variables if they are names
-  auto resolve_var = [this](nlohmann::json &var)
-  {
+  auto resolve_var = [this](nlohmann::json &var) {
     if (var["_type"] == "Name")
     {
       var = json_utils::find_var_decl(
@@ -799,8 +798,7 @@ exprt numpy_call_expr::get()
   // Handle math function calls
   if (is_math_function())
   {
-    auto is_scalar_node = [](const nlohmann::json &node)
-    {
+    auto is_scalar_node = [](const nlohmann::json &node) {
       const std::string type = node["_type"];
       return type == "Constant" || type == "UnaryOp";
     };
@@ -827,8 +825,7 @@ exprt numpy_call_expr::get()
       exprt expr = converter_.get_expr(result);
 
       auto compute_scalar_result =
-        [&](double left, double right, double &out) -> bool
-      {
+        [&](double left, double right, double &out) -> bool {
         if (function == "add")
         {
           out = left + right;

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -8,6 +8,7 @@
 #include <util/expr_util.h>
 #include <util/message.h>
 
+#include <cmath>
 #include <ostream>
 
 const char *kConstant = "Constant";
@@ -34,6 +35,50 @@ static double to_double(const numeric_value &value)
 {
   return value.is_int ? static_cast<double>(value.int_value)
                       : value.double_value;
+}
+
+static numeric_value extract_value(const nlohmann::json &arg);
+
+static bool
+try_extract_numeric_constant(const nlohmann::json &node, numeric_value &out)
+{
+  if (!node.is_object() || !node.contains("_type"))
+    return false;
+
+  const std::string type = node["_type"];
+  if (type != "Constant" && type != "UnaryOp")
+    return false;
+
+  try
+  {
+    out = extract_value(node);
+    return true;
+  }
+  catch (const std::exception &)
+  {
+    return false;
+  }
+}
+
+static bool try_extract_numeric_1d_list(
+  const nlohmann::json &list_node,
+  std::vector<numeric_value> &values)
+{
+  if (
+    !list_node.is_object() || !list_node.contains("_type") ||
+    list_node["_type"] != "List" || !list_node.contains("elts"))
+    return false;
+
+  values.clear();
+  values.reserve(list_node["elts"].size());
+  for (const auto &elem : list_node["elts"])
+  {
+    numeric_value value;
+    if (!try_extract_numeric_constant(elem, value))
+      return false;
+    values.push_back(value);
+  }
+  return true;
 }
 
 static numeric_value extract_value(const nlohmann::json &arg)
@@ -313,7 +358,8 @@ exprt numpy_call_expr::create_expr_from_call()
   nlohmann::json expr;
 
   // Resolve variables if they are names
-  auto resolve_var = [this](nlohmann::json &var) {
+  auto resolve_var = [this](nlohmann::json &var)
+  {
     if (var["_type"] == "Name")
     {
       var = json_utils::find_var_decl(
@@ -338,6 +384,82 @@ exprt numpy_call_expr::create_expr_from_call()
       const std::string &operation = function_id_.get_function();
       if (operation == "transpose")
       {
+        // Constant-fold transpose for fully constant 2D numeric lists.
+        // This avoids forcing integer-only backend transpose for float literals.
+        const auto &list_arg = call_["args"][0];
+        if (
+          list_arg.contains("elts") && !list_arg["elts"].empty() &&
+          list_arg["elts"][0].is_object() &&
+          list_arg["elts"][0].contains("_type") &&
+          list_arg["elts"][0]["_type"] == "List")
+        {
+          const auto &rows = list_arg["elts"];
+          const std::size_t row_count = rows.size();
+          const std::size_t col_count =
+            rows[0].contains("elts") ? rows[0]["elts"].size() : 0;
+          bool is_rectangular = col_count > 0;
+
+          for (const auto &row : rows)
+          {
+            if (
+              !row.is_object() || !row.contains("_type") ||
+              row["_type"] != "List" || !row.contains("elts") ||
+              row["elts"].size() != col_count)
+            {
+              is_rectangular = false;
+              break;
+            }
+          }
+
+          if (is_rectangular)
+          {
+            nlohmann::json transposed;
+            transposed["_type"] = "List";
+            transposed["elts"] = nlohmann::json::array();
+
+            bool all_numeric_constants = true;
+            bool has_float_literal = false;
+            for (std::size_t c = 0; c < col_count && all_numeric_constants; ++c)
+            {
+              nlohmann::json out_row;
+              out_row["_type"] = "List";
+              out_row["elts"] = nlohmann::json::array();
+
+              for (std::size_t r = 0; r < row_count; ++r)
+              {
+                numeric_value value;
+                if (!try_extract_numeric_constant(rows[r]["elts"][c], value))
+                {
+                  all_numeric_constants = false;
+                  break;
+                }
+                has_float_literal = has_float_literal || !value.is_int;
+
+                nlohmann::json elem;
+                elem["_type"] = "Constant";
+                elem["value"] = value.is_int
+                                  ? nlohmann::json(value.int_value)
+                                  : nlohmann::json(value.double_value);
+                out_row["elts"].push_back(elem);
+              }
+
+              if (all_numeric_constants)
+                transposed["elts"].push_back(out_row);
+            }
+
+            if (all_numeric_constants && has_float_literal)
+            {
+              exprt folded = converter_.get_expr(transposed);
+              if (converter_.current_lhs)
+              {
+                converter_.current_lhs->type() = folded.type();
+                converter_.update_symbol(*converter_.current_lhs);
+              }
+              return folded;
+            }
+          }
+        }
+
         code_function_callt call =
           to_code_function_call(to_code(function_call_expr::get()));
         typet t = call.arguments().at(0).type().subtype();
@@ -358,6 +480,33 @@ exprt numpy_call_expr::create_expr_from_call()
       // Handle calls with arrays as parameters; e.g. np.ceil([1, 2, 3])
       if (arg["_type"] == "List")
       {
+        // Constant-fold np.ceil for concrete 1D numeric lists.
+        if (function_id_.get_function() == "ceil")
+        {
+          std::vector<numeric_value> input_values;
+          if (try_extract_numeric_1d_list(arg, input_values))
+          {
+            nlohmann::json out;
+            out["_type"] = "List";
+            out["elts"] = nlohmann::json::array();
+
+            for (const auto &value : input_values)
+            {
+              nlohmann::json elem;
+              elem["_type"] = "Constant";
+              elem["value"] = std::ceil(to_double(value));
+              out["elts"].push_back(elem);
+            }
+            exprt folded = converter_.get_expr(out);
+            if (converter_.current_lhs)
+            {
+              converter_.current_lhs->type() = folded.type();
+              converter_.update_symbol(*converter_.current_lhs);
+            }
+            return folded;
+          }
+        }
+
         // Append array postfix to call array variants, e.g., ceil_array instead of ceil
         std::string func_name = function_id_.get_function();
         if (func_name == "ceil")
@@ -650,7 +799,8 @@ exprt numpy_call_expr::get()
   // Handle math function calls
   if (is_math_function())
   {
-    auto is_scalar_node = [](const nlohmann::json &node) {
+    auto is_scalar_node = [](const nlohmann::json &node)
+    {
       const std::string type = node["_type"];
       return type == "Constant" || type == "UnaryOp";
     };
@@ -677,7 +827,8 @@ exprt numpy_call_expr::get()
       exprt expr = converter_.get_expr(result);
 
       auto compute_scalar_result =
-        [&](double left, double right, double &out) -> bool {
+        [&](double left, double right, double &out) -> bool
+      {
         if (function == "add")
         {
           out = left + right;

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -22,8 +22,7 @@ static double round_ties_to_even_consteval(const double value)
 static double
 round_to_ndigits_ties_even_consteval(const double value, const int ndigits)
 {
-  auto round_ld_ties_even = [](const long double v) -> long double
-  {
+  auto round_ld_ties_even = [](const long double v) -> long double {
     const long double lower = std::floor(v);
     const long double diff = v - lower;
     constexpr long double tie_eps = 1e-15L;

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -2,6 +2,58 @@
 #include <algorithm>
 #include <cmath>
 
+static double round_ties_to_even_consteval(const double value)
+{
+  const double lower = std::floor(value);
+  const double diff = value - lower;
+  constexpr double tie_eps = 1e-12;
+
+  if (diff < 0.5 - tie_eps)
+    return lower;
+  if (diff > 0.5 + tie_eps)
+    return lower + 1.0;
+
+  const double parity = std::fmod(std::fabs(lower), 2.0);
+  const bool lower_is_even =
+    parity < tie_eps || std::fabs(parity - 2.0) < tie_eps;
+  return lower_is_even ? lower : lower + 1.0;
+}
+
+static double
+round_to_ndigits_ties_even_consteval(const double value, const int ndigits)
+{
+  auto round_ld_ties_even = [](const long double v) -> long double
+  {
+    const long double lower = std::floor(v);
+    const long double diff = v - lower;
+    constexpr long double tie_eps = 1e-15L;
+
+    if (diff < 0.5L - tie_eps)
+      return lower;
+    if (diff > 0.5L + tie_eps)
+      return lower + 1.0L;
+
+    const long double parity = std::fmod(std::fabs(lower), 2.0L);
+    const bool lower_is_even =
+      parity < tie_eps || std::fabs(parity - 2.0L) < tie_eps;
+    return lower_is_even ? lower : lower + 1.0L;
+  };
+
+  long double scale = 1.0L;
+  if (ndigits >= 0)
+  {
+    for (int i = 0; i < ndigits; ++i)
+      scale *= 10.0L;
+    return static_cast<double>(
+      round_ld_ties_even(static_cast<long double>(value) * scale) / scale);
+  }
+
+  for (int i = 0; i < -ndigits; ++i)
+    scale *= 10.0L;
+  return static_cast<double>(
+    round_ld_ties_even(static_cast<long double>(value) / scale) * scale);
+}
+
 bool PyConstValue::is_truthy() const
 {
   switch (kind)
@@ -868,6 +920,38 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
         return PyConstValue::make_int(
           arg->int_val < 0 ? -arg->int_val : arg->int_val);
       return std::nullopt;
+    }
+
+    // Built-in: round()
+    if (func_name == "round")
+    {
+      if (node["args"].size() < 1 || node["args"].size() > 2)
+        return std::nullopt;
+      auto arg = eval_expr(node["args"][0], env);
+      if (!arg)
+        return std::nullopt;
+
+      if (node["args"].size() == 1)
+      {
+        // round(x) -> int
+        if (arg->kind == PyConstValue::INT)
+          return PyConstValue::make_int(arg->int_val);
+        if (arg->kind == PyConstValue::FLOAT)
+          return PyConstValue::make_int(static_cast<long long>(
+            round_ties_to_even_consteval(arg->float_val)));
+        return std::nullopt;
+      }
+
+      // round(x, n) -> float (or int if n <= 0, but keep float for simplicity)
+      auto ndigits = eval_expr(node["args"][1], env);
+      if (!ndigits || ndigits->kind != PyConstValue::INT)
+        return std::nullopt;
+      int n = static_cast<int>(ndigits->int_val);
+      double val = (arg->kind == PyConstValue::INT)
+                     ? static_cast<double>(arg->int_val)
+                     : arg->float_val;
+      double rounded = round_to_ndigits_ties_even_consteval(val, n);
+      return PyConstValue::make_float(rounded);
     }
 
     // Built-in: min(), max() for two int arguments


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3638.

"[python-frontend] Add round() builtin support (#3638)

- Register 'round' in is_builtin_type() dispatch gate (type_utils.h)
- Add compile-time constant folding for round() (python_consteval.cpp)
- Implement handle_round() for literal and symbolic args
  - round(x): returns nearest int
  - round(x, n): returns float rounded to n decimals