### PR TITLE
[python] fix crash on dict.items() with subscript base (e.g. d["k"].items())

### DIFF
--- a/regression/python/dict_items1/test.desc
+++ b/regression/python/dict_items1/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.py
---unwind 9
+--smt-during-symex --smt-symex-guard --z3
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_items2/test.desc
+++ b/regression/python/dict_items2/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.py
 --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_items2/test.desc
+++ b/regression/python/dict_items2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --unwind 9
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3650/main.py
+++ b/regression/python/github_3650/main.py
@@ -1,0 +1,4 @@
+d = {"properties": {"x": 1}}
+for k, v in d["properties"].items():
+    assert k == "x"
+    assert v == 1

--- a/regression/python/github_3650/test.desc
+++ b/regression/python/github_3650/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 12
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3650_2/main.py
+++ b/regression/python/github_3650_2/main.py
@@ -1,0 +1,2 @@
+d = {"properties": {"x": 1}}
+d["properties"].items()

--- a/regression/python/github_3650_2/test.desc
+++ b/regression/python/github_3650_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1543,12 +1543,12 @@ std::string function_call_expr::get_object_name() const
   else if (subelement["_type"] == "Subscript")
   {
     // Method call on a subscript result, e.g. d["key"].method().
-    // Extract the base variable name from the subscript value node.
-    // For-loop uses of dict.items() are already rewritten by the preprocessor.
-    if (subelement.contains("value") && subelement["value"].contains("id"))
-      obj_name = subelement["value"]["id"].template get<std::string>();
-    // If the base is itself complex (nested subscript, attribute, etc.) leave
-    // obj_name empty so the caller falls back to AttributeError reporting.
+    // We intentionally leave obj_name empty: the subscript result is a
+    // temporary value, not a named symbol, so resolving obj_name to the base
+    // variable (e.g. 'd' from d["k"]) would cause method handlers to operate
+    // on the wrong object.  For-loop uses of dict.items() are rewritten by the
+    // preprocessor into a named temp before reaching here; other methods on
+    // subscript results are not yet supported.
   }
   else
   {

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2458,10 +2458,12 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         typet list_type = type_handler_.get_list_type();
         if (method_name == "items")
         {
-          // items() returns (key, value) pairs. For-loop uses are handled by
-          // the preprocessor (which transforms dict.items() into separate
-          // keys()/values() accesses). For standalone calls on a dict object,
-          // return the keys member so the call is well-typed and non-crashing.
+          // For-loop uses of items() are rewritten by the preprocessor into
+          // separate keys()/values() accesses and never reach here.
+          // For standalone/discarded calls (e.g. bare `d.items()` statement),
+          // return the keys member as a harmless placeholder — the result is
+          // not consumed so soundness is unaffected.
+          // Storing and consuming d.items() outside a for-loop is not supported.
           member_exprt member(obj_expr, "keys", list_type);
           return member;
         }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2448,7 +2448,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
   {
     const std::string &method_name = element["func"]["attr"].get<std::string>();
 
-    if (method_name == "keys" || method_name == "values" || method_name == "items")
+    if (
+      method_name == "keys" || method_name == "values" ||
+      method_name == "items")
     {
       exprt obj_expr = get_expr(element["func"]["value"]);
 


### PR DESCRIPTION
 Fixes #3650.

This PR handles `Subscript` nodes in `get_object_name()` and adds `items()` to the dict method handler in `get_function_call()` to avoid a JSON type_error. It also adds `_get_kv_types_from_subscript()` in the preprocessor so that `for k, v in d["key"].items()` infers concrete K/V types from the outer dict's annotation instead of falling back to `Any`/`empty_type`.

