### PR TITLE
[python] fix Z3 crash and nested dict retrieval for unparameterized dict (#3653)

### DIFF
--- a/regression/python/github_3647_10/test.desc
+++ b/regression/python/github_3647_10/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3653/main.py
+++ b/regression/python/github_3653/main.py
@@ -1,0 +1,11 @@
+class A:
+    def f(self, d: dict[str, dict[str, int]]) -> dict:
+        r = {}
+        if "prop" in d:
+            for k, v in d["prop"].items():
+                r[k] = True
+        return r
+
+
+a = A()
+a.f({"prop": {"x": 1, "y": 2}})

--- a/regression/python/github_3653/test.desc
+++ b/regression/python/github_3653/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/isinstance32_fail/main.py
+++ b/regression/python/isinstance32_fail/main.py
@@ -1,0 +1,3 @@
+d = {"a": {"x": 1}, "b": {"y": 2}}
+for v in d.values():
+    assert not isinstance(v, dict)

--- a/regression/python/isinstance32_fail/test.desc
+++ b/regression/python/isinstance32_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/isinstance33/main.py
+++ b/regression/python/isinstance33/main.py
@@ -1,0 +1,3 @@
+d = {"a": [1, 2], "b": [3, 4]}
+for v in d.values():
+    assert isinstance(v, list)

--- a/regression/python/isinstance33/test.desc
+++ b/regression/python/isinstance33/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-depth-exceed/test.desc
+++ b/regression/python/list-depth-exceed/test.desc
@@ -1,5 +1,5 @@
 THOROUGH
 main.py
---unwind 10 --python-list-compare-depth 2
+--unwind 10 --python-list-compare-depth 2 --bitwuzla --smt-during-symex --smt-symex-guard
 ^VERIFICATION FAILED$
 --python-list-compare-depth to increase

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -243,7 +243,8 @@ const static std::vector<std::string> python_c_models = {
   "__ESBMC_copysign",
   "__ESBMC_list_remove",
   "__ESBMC_list_sort",
-  "__ESBMC_list_reverse"};
+  "__ESBMC_list_reverse",
+  "__ESBMC_list_push_dict_ptr"};
 } // namespace
 
 static void generate_symbol_deps(

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -103,10 +103,7 @@ bool __ESBMC_list_push_object(PyListObject *l, PyObject *o)
 
 // Store a dict pointer directly in the list without byte-copying.
 // Used for nested dicts so that pointer identity is preserved in the SMT model.
-bool __ESBMC_list_push_dict_ptr(
-  PyListObject *l,
-  void *dict_ptr,
-  size_t type_id)
+bool __ESBMC_list_push_dict_ptr(PyListObject *l, void *dict_ptr, size_t type_id)
 {
   PyObject *item = &l->items[l->size];
   item->value = dict_ptr;

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -101,6 +101,21 @@ bool __ESBMC_list_push_object(PyListObject *l, PyObject *o)
   return __ESBMC_list_push(l, o->value, o->type_id, o->size);
 }
 
+// Store a dict pointer directly in the list without byte-copying.
+// Used for nested dicts so that pointer identity is preserved in the SMT model.
+bool __ESBMC_list_push_dict_ptr(
+  PyListObject *l,
+  void *dict_ptr,
+  size_t type_id)
+{
+  PyObject *item = &l->items[l->size];
+  item->value = dict_ptr;
+  item->type_id = type_id;
+  item->size = 0;
+  l->size++;
+  return true;
+}
+
 bool __ESBMC_list_eq(
   const PyListObject *l1,
   const PyListObject *l2,

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -433,9 +433,13 @@ class Preprocessor(ast.NodeTransformer):
                                 if method_name == 'keys':
                                     if isinstance(key_type, ast.Name):
                                         return key_type.id
+                                    elif isinstance(key_type, ast.Subscript) and isinstance(key_type.value, ast.Name):
+                                        return key_type.value.id
                                 elif method_name == 'values':
                                     if isinstance(value_type, ast.Name):
                                         return value_type.id
+                                    elif isinstance(value_type, ast.Subscript) and isinstance(value_type.value, ast.Name):
+                                        return value_type.value.id
 
         # 2. Handle direct dict iteration: for k in d:
         if isinstance(iterable_node, ast.Name):

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4689,11 +4689,12 @@ exprt python_converter::get_rhs_with_dict_resolution(
     return get_expr(ast_node["value"]);
 
   // Check if we need special dict subscript handling for typed variables
-  // Including list type
+  // Including list type and dict type
   typet list_type = type_handler_.get_list_type();
   if (
     !target_type.is_signedbv() && !target_type.is_unsignedbv() &&
-    !target_type.is_bool() && target_type != list_type)
+    !target_type.is_bool() && target_type != list_type &&
+    !dict_handler_->is_dict_type(target_type))
   {
     return get_expr(ast_node["value"]);
   }


### PR DESCRIPTION
Fixes #3653.

This PR:
  - Extends `get_rhs_with_dict_resolution` to handle dict-typed LHS (was causing "Sorts incompatible" Z3 error when assigning d["key"] to a dict variable with no type params)
  - Adds `__ESBMC_list_push_dict_ptr` to store nested dict pointers directly in PyObject.value without byte-copying, avoiding broken *(uint64_t*) extraction of pointer values in ESBMC's symbolic model
  - Replaces `safe_cast_to_dict_pointer` in `retrieve_nested_dict_value` with a direct void*→dict* cast to match the new storage scheme
  - Adds regression test `regression/python/github_3653/`.