### PR TITLE
[C verification] allow unsupported extensions as the return value

### DIFF
--- a/regression/esbmc-unix/unsupported_extensions/main.c
+++ b/regression/esbmc-unix/unsupported_extensions/main.c
@@ -1,0 +1,5 @@
+#include <mmintrin.h>
+
+int main()
+{
+}

--- a/regression/esbmc-unix/unsupported_extensions/test.desc
+++ b/regression/esbmc-unix/unsupported_extensions/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--function _mm_adds_pi8
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1471,6 +1471,11 @@ bool clang_c_convertert::get_builtin_type(
     break;
 #endif
 
+  case clang::BuiltinType::BoundMember:
+    new_type = ptrmem_typet();
+    c_type = "_ptrmem";
+    break;
+
   // Unsupported extensions (optional don't care)
   case clang::BuiltinType::BFloat16:
     if (config.options.get_bool_option("dont-care-about-missing-extensions"))
@@ -1480,11 +1485,6 @@ bool clang_c_convertert::get_builtin_type(
       break;
     }
     // fallthrough
-
-  case clang::BuiltinType::BoundMember:
-    new_type = ptrmem_typet();
-    c_type = "_ptrmem";
-    break;
 
   default:
   {

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1576,9 +1576,14 @@ void goto_convertt::convert_return(
   {
     if (!new_code.has_return_value())
     {
-      code.dump();
-      log_error("function must return value");
-      abort();
+      log_warning(
+        "The return of the function {} is missing",
+        id2string(code.location().function()));
+      // This might be because the remove_sideeffect removed the undefined function
+      // We replaced it with nondet
+      exprt ret = exprt("sideeffect", code.op0().type());
+      ret.statement("nondet");
+      new_code.return_value() = ret;
     }
 
     // Now add a return node to set the return value.


### PR DESCRIPTION
Fixes #3640.

ESBMC will crash when the return value is an unknown function call.

Although we have `--dont-care-about-missing-extensions,` its coverage is not comprehensive. Perhaps we should follow the `add_return` method and treat the return values of these unknown functions as nondet.

