### PR TITLE
[python] implement dict.update() semantics (#3657)

### DIFF
--- a/regression/python/dict_update1/main.py
+++ b/regression/python/dict_update1/main.py
@@ -1,0 +1,6 @@
+# dict.update() inserts new key-value pairs
+d: dict = {"x": 10}
+d.update({"y": 20, "z": 30})
+assert d["x"] == 10
+assert d["y"] == 20
+assert d["z"] == 30

--- a/regression/python/dict_update1/test.desc
+++ b/regression/python/dict_update1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_update1_fail/main.py
+++ b/regression/python/dict_update1_fail/main.py
@@ -1,0 +1,4 @@
+# dict.update() with new keys; assert on wrong value must fail
+d: dict = {"x": 10}
+d.update({"y": 20})
+assert d["y"] == 99  # wrong: y was set to 20

--- a/regression/python/dict_update1_fail/test.desc
+++ b/regression/python/dict_update1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/dict_update2/main.py
+++ b/regression/python/dict_update2/main.py
@@ -1,0 +1,5 @@
+# dict.update() overwrites values for existing keys
+d: dict = {"a": 1, "b": 2}
+d.update({"a": 100, "b": 200})
+assert d["a"] == 100
+assert d["b"] == 200

--- a/regression/python/dict_update2/test.desc
+++ b/regression/python/dict_update2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_update3/main.py
+++ b/regression/python/dict_update3/main.py
@@ -1,0 +1,7 @@
+# dict.update() with mix of new and existing keys
+d: dict = {"a": 1, "b": 2, "c": 3}
+d.update({"b": 20, "d": 40})
+assert d["a"] == 1    # unchanged
+assert d["b"] == 20   # updated
+assert d["c"] == 3    # unchanged
+assert d["d"] == 40   # inserted

--- a/regression/python/dict_update3/test.desc
+++ b/regression/python/dict_update3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3657/main.py
+++ b/regression/python/github_3657/main.py
@@ -1,0 +1,5 @@
+# Test case from issue #3657: dict.update() basic usage
+d = {"a": 1, "b": 2}
+d.update({"e": 5, "f": 6})
+assert d["e"] == 5
+assert d["f"] == 6

--- a/regression/python/github_3657/test.desc
+++ b/regression/python/github_3657/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3657_fail/main.py
+++ b/regression/python/github_3657_fail/main.py
@@ -1,0 +1,4 @@
+# dict.update() should overwrite existing values; this assert must fail
+d = {"a": 1, "b": 2}
+d.update({"a": 99})
+assert d["a"] == 1  # wrong: update should have changed it to 99

--- a/regression/python/github_3657_fail/test.desc
+++ b/regression/python/github_3657_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1797,30 +1797,30 @@ bool function_call_expr::is_dict_method_call() const
   const std::string &method_name = function_id_.get_function();
 
   // Check if this is a known dict method
-  return method_name == "get";
+  return method_name == "get" || method_name == "update";
 }
 
 exprt function_call_expr::handle_dict_method() const
 {
   const std::string &method_name = function_id_.get_function();
 
+  // Resolve the dict symbol for all dict methods
+  std::string dict_name = get_object_name();
+  symbol_id dict_symbol_id = converter_.create_symbol_id();
+  dict_symbol_id.set_object(dict_name);
+  const symbolt *dict_symbol =
+    converter_.find_symbol(dict_symbol_id.to_string());
+
+  if (!dict_symbol)
+    throw std::runtime_error("Dictionary variable not found: " + dict_name);
+
   if (method_name == "get")
-  {
-    // Get the dict object
-    std::string dict_name = get_object_name();
-
-    symbol_id dict_symbol_id = converter_.create_symbol_id();
-    dict_symbol_id.set_object(dict_name);
-    const symbolt *dict_symbol =
-      converter_.find_symbol(dict_symbol_id.to_string());
-
-    if (!dict_symbol)
-      throw std::runtime_error("Dictionary variable not found: " + dict_name);
-
-    // Delegate to dict handler
     return converter_.get_dict_handler()->handle_dict_get(
       symbol_expr(*dict_symbol), call_);
-  }
+
+  if (method_name == "update")
+    return converter_.get_dict_handler()->handle_dict_update(
+      symbol_expr(*dict_symbol), call_);
 
   throw std::runtime_error("Unsupported dict method: " + method_name);
 }

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1310,6 +1310,38 @@ exprt python_dict_handler::handle_dict_get(
   return symbol_expr(result_var);
 }
 
+exprt python_dict_handler::handle_dict_update(
+  const exprt &dict_expr,
+  const nlohmann::json &call_node)
+{
+  const auto &args = call_node["args"];
+
+  if (args.size() != 1)
+    throw std::runtime_error("update() takes exactly one argument");
+
+  const nlohmann::json &arg = args[0];
+
+  if (!is_dict_literal(arg))
+    throw std::runtime_error(
+      "update() argument must be a dict literal in ESBMC model");
+
+  const auto &keys = arg["keys"];
+  const auto &values = arg["values"];
+
+  // For each key-value pair in the argument dict, update the target dict.
+  // handle_dict_subscript_assign implements:
+  //   if key exists → update value; else → insert new key-value pair.
+  for (size_t i = 0; i < keys.size(); ++i)
+  {
+    exprt value_expr = converter_.get_expr(values[i]);
+    code_blockt pair_block;
+    handle_dict_subscript_assign(dict_expr, keys[i], value_expr, pair_block);
+    converter_.add_instruction(pair_block);
+  }
+
+  return nil_exprt();
+}
+
 exprt python_dict_handler::compare(
   const exprt &lhs,
   const exprt &rhs,

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -377,17 +377,33 @@ public:
 
   /**
    * @brief Handles dict.get() method calls
-   * 
+   *
    * Implements Python's dict.get(key, default=None) semantics:
    * - Returns value if key exists
    * - Returns default (or None) if key doesn't exist
-   * 
+   *
    * @param dict_expr The dictionary expression
    * @param call_node The function call AST node containing arguments
    * @return Expression representing the result (value or default)
    */
   exprt
   handle_dict_get(const exprt &dict_expr, const nlohmann::json &call_node);
+
+  /**
+   * @brief Handles dict.update() method calls
+   *
+   * Implements Python's dict.update(other) semantics:
+   * - For each key-value pair in other: if key exists, update value;
+   *   otherwise insert the new key-value pair.
+   * - Returns nil (update() is a void operation).
+   *
+   * @param dict_expr The dictionary expression to update
+   * @param call_node The function call AST node containing the argument dict
+   * @return nil_exprt (void operation)
+   */
+  exprt handle_dict_update(
+    const exprt &dict_expr,
+    const nlohmann::json &call_node);
 
   /**
    * @brief Compares two dictionaries for equality or inequality

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -401,9 +401,8 @@ public:
    * @param call_node The function call AST node containing the argument dict
    * @return nil_exprt (void operation)
    */
-  exprt handle_dict_update(
-    const exprt &dict_expr,
-    const nlohmann::json &call_node);
+  exprt
+  handle_dict_update(const exprt &dict_expr, const nlohmann::json &call_node);
 
   /**
    * @brief Compares two dictionaries for equality or inequality


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3657.

This PR adds support for `dict.update(other)` by iterating over each key-value pair in the argument dict literal and calling the existing subscript-assign logic (update value if key exists, insert otherwise). It also adds regression tests covering new-key insertion, existing-key overwrite, and mixed updates.