### PR TITLE
[python] add initial support for dict.setdefault() (#3658)

### DIFF
--- a/regression/python/github_3658/main.py
+++ b/regression/python/github_3658/main.py
@@ -1,0 +1,4 @@
+d: dict[str, int] = {"a": 1, "b": 2}
+result: int = d.setdefault("d", 4)
+assert result == 4
+assert d["d"] == 4

--- a/regression/python/github_3658/test.desc
+++ b/regression/python/github_3658/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3658_2/main.py
+++ b/regression/python/github_3658_2/main.py
@@ -1,0 +1,6 @@
+d: dict[str, int] = {"a": 1, "b": 2}
+result: int = d.setdefault("a", 99)
+# key "a" already exists with value 1 — must return 1, not 99
+assert result == 1
+# dict must remain unchanged
+assert d["a"] == 1

--- a/regression/python/github_3658_2/test.desc
+++ b/regression/python/github_3658_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3658_2_fail/main.py
+++ b/regression/python/github_3658_2_fail/main.py
@@ -1,0 +1,4 @@
+d: dict[str, int] = {"a": 1, "b": 2}
+result: int = d.setdefault("a", 99)
+# wrong: expects setdefault to overwrite existing key — it should not
+assert result == 99

--- a/regression/python/github_3658_2_fail/test.desc
+++ b/regression/python/github_3658_2_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/python/github_3658_3/main.py
+++ b/regression/python/github_3658_3/main.py
@@ -1,0 +1,9 @@
+d: dict[str, int] = {"x": 10}
+# key "x" already present — returns 10, no mutation
+r1: int = d.setdefault("x", 0)
+assert r1 == 10
+assert d["x"] == 10
+# key "y" missing — inserts and returns 20
+r2: int = d.setdefault("y", 20)
+assert r2 == 20
+assert d["y"] == 20

--- a/regression/python/github_3658_3/test.desc
+++ b/regression/python/github_3658_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3658_3_fail/main.py
+++ b/regression/python/github_3658_3_fail/main.py
@@ -1,0 +1,4 @@
+d: dict[str, int] = {"x": 10}
+r1: int = d.setdefault("x", 0)
+# wrong: "x" was already present so result must be 10, not 0
+assert r1 == 0

--- a/regression/python/github_3658_3_fail/test.desc
+++ b/regression/python/github_3658_3_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/python/github_3658_4/main.py
+++ b/regression/python/github_3658_4/main.py
@@ -1,0 +1,8 @@
+d: dict[str, str] = {"lang": "python"}
+# key "lang" present — returns existing value
+r1: str = d.setdefault("lang", "java")
+assert r1 == "python"
+# key "version" missing — inserts and returns default
+r2: str = d.setdefault("version", "3.11")
+assert r2 == "3.11"
+assert d["version"] == "3.11"

--- a/regression/python/github_3658_4/test.desc
+++ b/regression/python/github_3658_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3658_4_fail/main.py
+++ b/regression/python/github_3658_4_fail/main.py
@@ -1,0 +1,4 @@
+d: dict[str, str] = {"lang": "python"}
+# key "version" is missing — inserts "3.11" and returns "3.11"
+r: str = d.setdefault("version", "3.11")
+assert r == "2.7"  # wrong: the default was "3.11", not "2.7"

--- a/regression/python/github_3658_4_fail/test.desc
+++ b/regression/python/github_3658_4_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/python/github_3658_5/main.py
+++ b/regression/python/github_3658_5/main.py
@@ -1,0 +1,4 @@
+d: dict[str, int] = {}
+r: int = d.setdefault("k")
+# key must have been inserted even when no default is given
+assert "k" in d

--- a/regression/python/github_3658_5/test.desc
+++ b/regression/python/github_3658_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3658_5_fail/main.py
+++ b/regression/python/github_3658_5_fail/main.py
@@ -1,0 +1,4 @@
+d: dict[str, int] = {}
+r: int = d.setdefault("k")
+# wrong: asserts key is NOT in d after setdefault — must fail
+assert "k" not in d

--- a/regression/python/github_3658_5_fail/test.desc
+++ b/regression/python/github_3658_5_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$

--- a/regression/python/github_3658_6/main.py
+++ b/regression/python/github_3658_6/main.py
@@ -1,0 +1,7 @@
+from typing import Optional
+
+d: dict[str, Optional[int]] = {}
+r: Optional[int] = d.setdefault("k")
+
+# key must have been inserted even when no default is given
+assert "k" in d

--- a/regression/python/github_3658_6/test.desc
+++ b/regression/python/github_3658_6/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3658_7/main.py
+++ b/regression/python/github_3658_7/main.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+d: dict[str, Optional[int]] = {}
+r: Optional[int] = d.setdefault("k")
+
+# returned value must match the stored value
+assert d["k"] == r
+
+d2: dict[str, Optional[int]] = {}
+r2: Optional[int] = d2.setdefault("k", None)
+
+# key must have been inserted when an explicit None default is given
+assert "k" in d2
+
+# explicit-None defaults must be stored and returned consistently
+assert d2["k"] == r2
+

--- a/regression/python/github_3658_7/test.desc
+++ b/regression/python/github_3658_7/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/python/github_3658_fail/main.py
+++ b/regression/python/github_3658_fail/main.py
@@ -1,0 +1,3 @@
+d: dict[str, int] = {"a": 1, "b": 2}
+result: int = d.setdefault("d", 4)
+assert result == 99  # wrong: setdefault returns the default (4), not 99

--- a/regression/python/github_3658_fail/test.desc
+++ b/regression/python/github_3658_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION FAILED$

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -213,6 +213,18 @@ Below is an overview of ESBMC-Python's key capabilities:
     - **Tuple Equality**: Supports equality comparisons between tuples (e.g., `t1 == (1, 2, 3)`).
     - **len() Function**: The built-in `len()` function works with tuples to return the number of elements.
     - **isinstance() Type Checking**: Supports runtime type checking with `isinstance(obj, tuple)`.
+  - **Dictionary Operations**: Supports Python's built-in `dict` type with the following operations:
+    - **Literals**: Creates dictionaries from literal syntax (e.g., `d = {"a": 1, "b": 2}`).
+    - **Subscript access**: Retrieves values by key (e.g., `d["a"]`); raises `KeyError` if the key is absent.
+    - **Subscript assignment**: Inserts or updates a key-value pair (e.g., `d["c"] = 3`).
+    - **Membership testing (`in` / `not in`)**: Checks whether a key exists (e.g., `"a" in d`).
+    - **Key deletion (`del`)**: Removes a key-value pair (e.g., `del d["a"]`); raises `KeyError` if absent.
+    - **Equality comparison**: Compares two dictionaries for equal content regardless of insertion order (e.g., `d1 == d2`).
+    - **Iteration**: Supports `for` loops over `d.keys()`, `d.values()`, and `d.items()`.
+    - **update()**: Merges another dictionary into the current one (e.g., `d.update({"x": 9})`).
+    - **get()**: Returns the value for a key, or a default if the key is absent (e.g., `d.get("a", 0)`).
+    - **setdefault()**: Returns the value for a key if present; otherwise inserts the key with the given default and returns it (e.g., `d.setdefault("d", 4)`). Supports `int`, `float`, `bool`, and `str` value types.
+    - **Nested dictionaries**: Supports dicts whose values are themselves dicts (e.g., `dict[int, dict[int, int]]`).
 - **Bytes and Integers**: Supports byte and integer operations, such as conversions and bit length.
 
 ### Error Handling and Assertions
@@ -396,7 +408,7 @@ The current version of ESBMC-Python has the following limitations:
 - Only `for` loops using the `range()` function are supported.
 - List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, `remove()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
-- Dictionaries are not supported at all.
+- Dictionary support is partial: the supported operations are literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, and `setdefault()`. Other methods (e.g., `pop()`, `copy()`, `popitem()`) are not yet implemented.
 - `min()` and `max()` currently support only two arguments and do not handle iterables or the key/default parameters.
 - `any()` currently supports only list literals as arguments and does not support other iterable types.
 - `input()` is modeled as a nondeterministic string with a maximum length of 256 characters (under-approximation).

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1797,30 +1797,31 @@ bool function_call_expr::is_dict_method_call() const
   const std::string &method_name = function_id_.get_function();
 
   // Check if this is a known dict method
-  return method_name == "get";
+  return method_name == "get" || method_name == "setdefault";
 }
 
 exprt function_call_expr::handle_dict_method() const
 {
   const std::string &method_name = function_id_.get_function();
 
+  // Get the dict object (shared by all dict methods)
+  std::string dict_name = get_object_name();
+
+  symbol_id dict_symbol_id = converter_.create_symbol_id();
+  dict_symbol_id.set_object(dict_name);
+  const symbolt *dict_symbol =
+    converter_.find_symbol(dict_symbol_id.to_string());
+
+  if (!dict_symbol)
+    throw std::runtime_error("Dictionary variable not found: " + dict_name);
+
   if (method_name == "get")
-  {
-    // Get the dict object
-    std::string dict_name = get_object_name();
-
-    symbol_id dict_symbol_id = converter_.create_symbol_id();
-    dict_symbol_id.set_object(dict_name);
-    const symbolt *dict_symbol =
-      converter_.find_symbol(dict_symbol_id.to_string());
-
-    if (!dict_symbol)
-      throw std::runtime_error("Dictionary variable not found: " + dict_name);
-
-    // Delegate to dict handler
     return converter_.get_dict_handler()->handle_dict_get(
       symbol_expr(*dict_symbol), call_);
-  }
+
+  if (method_name == "setdefault")
+    return converter_.get_dict_handler()->handle_dict_setdefault(
+      symbol_expr(*dict_symbol), call_);
 
   throw std::runtime_error("Unsupported dict method: " + method_name);
 }

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1821,6 +1821,8 @@ exprt function_call_expr::handle_dict_method() const
 
   if (method_name == "setdefault")
     return converter_.get_dict_handler()->handle_dict_setdefault(
+      symbol_expr(*dict_symbol), call_);
+
   if (method_name == "update")
     return converter_.get_dict_handler()->handle_dict_update(
       symbol_expr(*dict_symbol), call_);

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1797,7 +1797,8 @@ bool function_call_expr::is_dict_method_call() const
   const std::string &method_name = function_id_.get_function();
 
   // Check if this is a known dict method
-  return method_name == "get" || method_name == "setdefault" || method_name == "update";
+  return method_name == "get" || method_name == "setdefault" ||
+         method_name == "update";
 }
 
 exprt function_call_expr::handle_dict_method() const

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1310,6 +1310,253 @@ exprt python_dict_handler::handle_dict_get(
   return symbol_expr(result_var);
 }
 
+exprt python_dict_handler::handle_dict_setdefault(
+  const exprt &dict_expr,
+  const nlohmann::json &call_node)
+{
+  locationt location = converter_.get_location_from_decl(call_node);
+  typet list_type = type_handler_.get_list_type();
+
+  const auto &args = call_node["args"];
+
+  if (args.empty())
+    throw std::runtime_error("setdefault() missing required argument: 'key'");
+
+  exprt key_expr = converter_.get_expr(args[0]);
+
+  // Determine the default value
+  bool has_explicit_default = args.size() >= 2;
+  exprt default_value;
+  if (has_explicit_default)
+    default_value = converter_.get_expr(args[1]);
+  else
+    default_value = gen_zero(none_type());
+
+  // Infer result type
+  typet result_type = resolve_expected_type_for_dict_subscript(dict_expr);
+
+  // If we can't infer from dict annotation, use sensible defaults
+  if (result_type.is_nil() || result_type.is_empty())
+  {
+    if (has_explicit_default && default_value.type() != none_type())
+      result_type = default_value.type();
+    else
+      result_type = long_int_type();
+  }
+
+  // Strings are stored in the dict values list as char arrays, but list_at
+  // returns a void* that points to the first character.  Normalise any
+  // non-primitive, non-dict, non-list type to char* so that retrieval is
+  // done the same way as in handle_dict_subscript.
+  bool is_string_result = !result_type.is_floatbv() &&
+                          !result_type.is_signedbv() &&
+                          !result_type.is_unsignedbv() &&
+                          !result_type.is_bool() &&
+                          result_type != none_type() &&
+                          !is_dict_type(result_type) &&
+                          result_type != list_type;
+  if (is_string_result)
+    result_type = gen_pointer_type(char_type());
+
+  // Get dict members
+  member_exprt keys_member(dict_expr, "keys", list_type);
+  member_exprt values_member(dict_expr, "values", list_type);
+
+  const symbolt *try_find_func =
+    symbol_table_.find_symbol("c:@F@__ESBMC_list_try_find_index");
+  if (!try_find_func)
+    throw std::runtime_error("__ESBMC_list_try_find_index not found");
+
+  // Create temp for index result
+  symbolt &index_var = converter_.create_tmp_symbol(
+    call_node, "$dict_setdefault_idx$", size_type(), exprt());
+  code_declt index_decl(symbol_expr(index_var));
+  index_decl.location() = location;
+  converter_.add_instruction(index_decl);
+
+  // Get element info for the key
+  python_list list_handler(converter_, call_node);
+  list_elem_info key_info =
+    list_handler.get_list_element_info(call_node, key_expr);
+
+  // Build key arg
+  exprt key_arg;
+  if (
+    key_info.elem_symbol->type.is_pointer() &&
+    key_info.elem_symbol->type.subtype() == char_type())
+    key_arg = symbol_expr(*key_info.elem_symbol);
+  else
+    key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));
+
+  // Call try_find_index (returns SIZE_MAX if not found)
+  code_function_callt try_find_call;
+  try_find_call.function() = symbol_expr(*try_find_func);
+  try_find_call.lhs() = symbol_expr(index_var);
+  try_find_call.arguments().push_back(keys_member);
+  try_find_call.arguments().push_back(key_arg);
+  try_find_call.arguments().push_back(symbol_expr(*key_info.elem_type_sym));
+  try_find_call.arguments().push_back(key_info.elem_size);
+  try_find_call.type() = size_type();
+  try_find_call.location() = location;
+  converter_.add_instruction(try_find_call);
+
+  // Check if key was found (index != SIZE_MAX)
+  constant_exprt size_max(
+    integer2binary(SIZE_MAX, bv_width(size_type())),
+    integer2string(SIZE_MAX),
+    size_type());
+  exprt key_found = not_exprt(equality_exprt(symbol_expr(index_var), size_max));
+
+  // Create result variable
+  symbolt &result_var = converter_.create_tmp_symbol(
+    call_node, "$dict_setdefault_result$", result_type, exprt());
+  code_declt result_decl(symbol_expr(result_var));
+  result_decl.location() = location;
+  converter_.add_instruction(result_decl);
+
+  // Then branch: key found, retrieve value (no dict mutation)
+  code_blockt then_block;
+
+  const symbolt *at_func = symbol_table_.find_symbol("c:@F@__ESBMC_list_at");
+  if (!at_func)
+    throw std::runtime_error("__ESBMC_list_at not found");
+
+  typet obj_ptr_type = pointer_typet(type_handler_.get_list_element_type());
+  symbolt &obj_var = converter_.create_tmp_symbol(
+    call_node, "$dict_setdefault_obj$", obj_ptr_type, exprt());
+  code_declt obj_decl(symbol_expr(obj_var));
+  obj_decl.location() = location;
+  then_block.copy_to_operands(obj_decl);
+
+  code_function_callt at_call;
+  at_call.function() = symbol_expr(*at_func);
+  at_call.lhs() = symbol_expr(obj_var);
+  at_call.arguments().push_back(values_member);
+  at_call.arguments().push_back(symbol_expr(index_var));
+  at_call.type() = obj_ptr_type;
+  at_call.location() = location;
+  then_block.copy_to_operands(at_call);
+
+  member_exprt obj_value(
+    dereference_exprt(
+      symbol_expr(obj_var), type_handler_.get_list_element_type()),
+    "value",
+    pointer_typet(empty_typet()));
+
+  // Cast and assign the retrieved value to result_type
+  exprt retrieved_value;
+  if (result_type.is_floatbv())
+  {
+    typecast_exprt value_as_float_ptr(obj_value, pointer_typet(result_type));
+    retrieved_value = dereference_exprt(value_as_float_ptr, result_type);
+  }
+  else if (result_type.is_signedbv() || result_type.is_unsignedbv())
+  {
+    typecast_exprt value_as_int_ptr(obj_value, pointer_typet(result_type));
+    retrieved_value = dereference_exprt(value_as_int_ptr, result_type);
+  }
+  else if (result_type.is_bool())
+  {
+    typecast_exprt value_as_bool_ptr(obj_value, pointer_typet(bool_type()));
+    retrieved_value = dereference_exprt(value_as_bool_ptr, bool_type());
+  }
+  else if (result_type == none_type())
+  {
+    typecast_exprt value_as_none(obj_value, result_type);
+    retrieved_value = value_as_none;
+  }
+  else
+  {
+    typecast_exprt value_as_typed(obj_value, result_type);
+    retrieved_value = value_as_typed;
+  }
+
+  code_assignt value_assign(symbol_expr(result_var), retrieved_value);
+  value_assign.location() = location;
+  then_block.copy_to_operands(value_assign);
+
+  // Else branch: key not found — insert (key, default) and return default
+  code_blockt else_block;
+
+  // value_arg is the proper char* / typed pointer to the default value.
+  exprt value_arg;
+
+  if (has_explicit_default && default_value.type() != none_type())
+  {
+    const symbolt *push_func =
+      symbol_table_.find_symbol("c:@F@__ESBMC_list_push");
+    if (!push_func)
+      throw std::runtime_error("__ESBMC_list_push not found");
+
+    // Get element info for the default value
+    list_elem_info value_info =
+      list_handler.get_list_element_info(call_node, default_value);
+
+    if (
+      value_info.elem_symbol->type.is_pointer() &&
+      value_info.elem_symbol->type.subtype() == char_type())
+      value_arg = symbol_expr(*value_info.elem_symbol);
+    else
+      value_arg = address_of_exprt(symbol_expr(*value_info.elem_symbol));
+
+    // Push key into keys list
+    code_function_callt push_key_call;
+    push_key_call.function() = symbol_expr(*push_func);
+    push_key_call.arguments().push_back(keys_member);
+    push_key_call.arguments().push_back(key_arg);
+    push_key_call.arguments().push_back(symbol_expr(*key_info.elem_type_sym));
+    push_key_call.arguments().push_back(key_info.elem_size);
+    push_key_call.type() = bool_type();
+    push_key_call.location() = location;
+    else_block.copy_to_operands(push_key_call);
+
+    // Push default value into values list
+    code_function_callt push_value_call;
+    push_value_call.function() = symbol_expr(*push_func);
+    push_value_call.arguments().push_back(values_member);
+    push_value_call.arguments().push_back(value_arg);
+    push_value_call.arguments().push_back(
+      symbol_expr(*value_info.elem_type_sym));
+    push_value_call.arguments().push_back(value_info.elem_size);
+    push_value_call.type() = bool_type();
+    push_value_call.location() = location;
+    else_block.copy_to_operands(push_value_call);
+  }
+
+  // Assign default to result
+  if (default_value.type() == none_type() && result_type != none_type())
+  {
+    typecast_exprt casted_default(default_value, result_type);
+    code_assignt default_assign(symbol_expr(result_var), casted_default);
+    default_assign.location() = location;
+    else_block.copy_to_operands(default_assign);
+  }
+  else if (is_string_result)
+  {
+    // value_arg was set above when has_explicit_default is true; when the
+    // default is None the none_type() branch above is taken instead.
+    code_assignt default_assign(symbol_expr(result_var), value_arg);
+    default_assign.location() = location;
+    else_block.copy_to_operands(default_assign);
+  }
+  else
+  {
+    code_assignt default_assign(symbol_expr(result_var), default_value);
+    default_assign.location() = location;
+    else_block.copy_to_operands(default_assign);
+  }
+
+  // Create if-then-else
+  code_ifthenelset if_stmt;
+  if_stmt.cond() = key_found;
+  if_stmt.then_case() = then_block;
+  if_stmt.else_case() = else_block;
+  if_stmt.location() = location;
+  converter_.add_instruction(if_stmt);
+
+  return symbol_expr(result_var);
+}
+
 exprt python_dict_handler::compare(
   const exprt &lhs,
   const exprt &rhs,

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1344,15 +1344,10 @@ exprt python_dict_handler::handle_dict_setdefault(
       result_type = long_int_type();
   }
 
-  // Strings are stored in the dict values list as char arrays, but list_at
-  // returns a void* that points to the first character.  Normalise any
-  // non-primitive, non-dict, non-list type to char* so that retrieval is
-  // done the same way as in handle_dict_subscript.
+  // Strings are stored as char arrays; list_at returns a void* to the first character.
   bool is_string_result =
-    !result_type.is_floatbv() && !result_type.is_signedbv() &&
-    !result_type.is_unsignedbv() && !result_type.is_bool() &&
-    result_type != none_type() && !is_dict_type(result_type) &&
-    result_type != list_type;
+    (result_type.is_pointer() && result_type.subtype() == char_type()) ||
+    (result_type.is_array() && result_type.subtype() == char_type());
   if (is_string_result)
     result_type = gen_pointer_type(char_type());
 

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1560,92 +1560,89 @@ exprt python_dict_handler::handle_dict_setdefault(
   converter_.add_instruction(if_stmt);
 
   return symbol_expr(result_var);
-exprt python_dict_handler::handle_dict_update(
-  const exprt &dict_expr,
-  const nlohmann::json &call_node)
-{
-  const auto &args = call_node["args"];
-
-  if (args.size() != 1)
-    throw std::runtime_error("update() takes exactly one argument");
-
-  const nlohmann::json &arg = args[0];
-
-  if (!is_dict_literal(arg))
-    throw std::runtime_error(
-      "update() argument must be a dict literal in ESBMC model");
-
-  const auto &keys = arg["keys"];
-  const auto &values = arg["values"];
-
-  // For each key-value pair in the argument dict, update the target dict.
-  // handle_dict_subscript_assign implements:
-  //   if key exists → update value; else → insert new key-value pair.
-  for (size_t i = 0; i < keys.size(); ++i)
+  exprt python_dict_handler::handle_dict_update(
+    const exprt &dict_expr, const nlohmann::json &call_node)
   {
-    exprt value_expr = converter_.get_expr(values[i]);
-    code_blockt pair_block;
-    handle_dict_subscript_assign(dict_expr, keys[i], value_expr, pair_block);
-    converter_.add_instruction(pair_block);
+    const auto &args = call_node["args"];
+
+    if (args.size() != 1)
+      throw std::runtime_error("update() takes exactly one argument");
+
+    const nlohmann::json &arg = args[0];
+
+    if (!is_dict_literal(arg))
+      throw std::runtime_error(
+        "update() argument must be a dict literal in ESBMC model");
+
+    const auto &keys = arg["keys"];
+    const auto &values = arg["values"];
+
+    // For each key-value pair in the argument dict, update the target dict.
+    // handle_dict_subscript_assign implements:
+    //   if key exists → update value; else → insert new key-value pair.
+    for (size_t i = 0; i < keys.size(); ++i)
+    {
+      exprt value_expr = converter_.get_expr(values[i]);
+      code_blockt pair_block;
+      handle_dict_subscript_assign(dict_expr, keys[i], value_expr, pair_block);
+      converter_.add_instruction(pair_block);
+    }
+
+    return nil_exprt();
   }
 
-  return nil_exprt();
-}
-
-exprt python_dict_handler::compare(
-  const exprt &lhs,
-  const exprt &rhs,
-  const std::string &op)
-{
-  locationt location = lhs.location();
-  if (location.is_nil())
-    location = rhs.location();
-
-  typet list_type = type_handler_.get_list_type();
-
-  // Get keys and values from both dicts
-  member_exprt lhs_keys(lhs, "keys", list_type);
-  member_exprt lhs_values(lhs, "values", list_type);
-  member_exprt rhs_keys(rhs, "keys", list_type);
-  member_exprt rhs_values(rhs, "values", list_type);
-
-  // Find __ESBMC_dict_eq function
-  const symbolt *dict_eq_func =
-    symbol_table_.find_symbol("c:@F@__ESBMC_dict_eq");
-
-  if (!dict_eq_func)
-    throw std::runtime_error("__ESBMC_dict_eq not found in symbol table");
-
-  // Create temp for result
-  symbolt &result_var = converter_.create_tmp_symbol(
-    nlohmann::json(), "$dict_eq_result$", bool_type(), exprt());
-  code_declt result_decl(symbol_expr(result_var));
-  result_decl.location() = location;
-  converter_.add_instruction(result_decl);
-
-  // Call __ESBMC_dict_eq(lhs_keys, lhs_values, rhs_keys, rhs_values)
-  code_function_callt dict_eq_call;
-  dict_eq_call.function() = symbol_expr(*dict_eq_func);
-  dict_eq_call.lhs() = symbol_expr(result_var);
-  dict_eq_call.arguments().push_back(lhs_keys);
-  dict_eq_call.arguments().push_back(lhs_values);
-  dict_eq_call.arguments().push_back(rhs_keys);
-  dict_eq_call.arguments().push_back(rhs_values);
-  dict_eq_call.type() = bool_type();
-  dict_eq_call.location() = location;
-  converter_.add_instruction(dict_eq_call);
-
-  // Return result
-  exprt result = symbol_expr(result_var);
-  result.location() = location;
-
-  if (op == "NotEq")
+  exprt python_dict_handler::compare(
+    const exprt &lhs, const exprt &rhs, const std::string &op)
   {
-    exprt negated("not", bool_type());
-    negated.move_to_operands(result);
-    negated.location() = location;
-    return negated;
-  }
+    locationt location = lhs.location();
+    if (location.is_nil())
+      location = rhs.location();
 
-  return result;
-}
+    typet list_type = type_handler_.get_list_type();
+
+    // Get keys and values from both dicts
+    member_exprt lhs_keys(lhs, "keys", list_type);
+    member_exprt lhs_values(lhs, "values", list_type);
+    member_exprt rhs_keys(rhs, "keys", list_type);
+    member_exprt rhs_values(rhs, "values", list_type);
+
+    // Find __ESBMC_dict_eq function
+    const symbolt *dict_eq_func =
+      symbol_table_.find_symbol("c:@F@__ESBMC_dict_eq");
+
+    if (!dict_eq_func)
+      throw std::runtime_error("__ESBMC_dict_eq not found in symbol table");
+
+    // Create temp for result
+    symbolt &result_var = converter_.create_tmp_symbol(
+      nlohmann::json(), "$dict_eq_result$", bool_type(), exprt());
+    code_declt result_decl(symbol_expr(result_var));
+    result_decl.location() = location;
+    converter_.add_instruction(result_decl);
+
+    // Call __ESBMC_dict_eq(lhs_keys, lhs_values, rhs_keys, rhs_values)
+    code_function_callt dict_eq_call;
+    dict_eq_call.function() = symbol_expr(*dict_eq_func);
+    dict_eq_call.lhs() = symbol_expr(result_var);
+    dict_eq_call.arguments().push_back(lhs_keys);
+    dict_eq_call.arguments().push_back(lhs_values);
+    dict_eq_call.arguments().push_back(rhs_keys);
+    dict_eq_call.arguments().push_back(rhs_values);
+    dict_eq_call.type() = bool_type();
+    dict_eq_call.location() = location;
+    converter_.add_instruction(dict_eq_call);
+
+    // Return result
+    exprt result = symbol_expr(result_var);
+    result.location() = location;
+
+    if (op == "NotEq")
+    {
+      exprt negated("not", bool_type());
+      negated.move_to_operands(result);
+      negated.location() = location;
+      return negated;
+    }
+
+    return result;
+  }

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1574,88 +1574,91 @@ exprt python_dict_handler::handle_dict_setdefault(
 }
 
 exprt python_dict_handler::handle_dict_update(
-    const exprt &dict_expr, const nlohmann::json &call_node)
+  const exprt &dict_expr,
+  const nlohmann::json &call_node)
+{
+  const auto &args = call_node["args"];
+
+  if (args.size() != 1)
+    throw std::runtime_error("update() takes exactly one argument");
+
+  const nlohmann::json &arg = args[0];
+
+  if (!is_dict_literal(arg))
+    throw std::runtime_error(
+      "update() argument must be a dict literal in ESBMC model");
+
+  const auto &keys = arg["keys"];
+  const auto &values = arg["values"];
+
+  // For each key-value pair in the argument dict, update the target dict.
+  // handle_dict_subscript_assign implements:
+  //   if key exists → update value; else → insert new key-value pair.
+  for (size_t i = 0; i < keys.size(); ++i)
   {
-    const auto &args = call_node["args"];
-
-    if (args.size() != 1)
-      throw std::runtime_error("update() takes exactly one argument");
-
-    const nlohmann::json &arg = args[0];
-
-    if (!is_dict_literal(arg))
-      throw std::runtime_error(
-        "update() argument must be a dict literal in ESBMC model");
-
-    const auto &keys = arg["keys"];
-    const auto &values = arg["values"];
-
-    // For each key-value pair in the argument dict, update the target dict.
-    // handle_dict_subscript_assign implements:
-    //   if key exists → update value; else → insert new key-value pair.
-    for (size_t i = 0; i < keys.size(); ++i)
-    {
-      exprt value_expr = converter_.get_expr(values[i]);
-      code_blockt pair_block;
-      handle_dict_subscript_assign(dict_expr, keys[i], value_expr, pair_block);
-      converter_.add_instruction(pair_block);
-    }
-
-    return nil_exprt();
+    exprt value_expr = converter_.get_expr(values[i]);
+    code_blockt pair_block;
+    handle_dict_subscript_assign(dict_expr, keys[i], value_expr, pair_block);
+    converter_.add_instruction(pair_block);
   }
 
-  exprt python_dict_handler::compare(
-    const exprt &lhs, const exprt &rhs, const std::string &op)
+  return nil_exprt();
+}
+
+exprt python_dict_handler::compare(
+  const exprt &lhs,
+  const exprt &rhs,
+  const std::string &op)
+{
+  locationt location = lhs.location();
+  if (location.is_nil())
+    location = rhs.location();
+
+  typet list_type = type_handler_.get_list_type();
+
+  // Get keys and values from both dicts
+  member_exprt lhs_keys(lhs, "keys", list_type);
+  member_exprt lhs_values(lhs, "values", list_type);
+  member_exprt rhs_keys(rhs, "keys", list_type);
+  member_exprt rhs_values(rhs, "values", list_type);
+
+  // Find __ESBMC_dict_eq function
+  const symbolt *dict_eq_func =
+    symbol_table_.find_symbol("c:@F@__ESBMC_dict_eq");
+
+  if (!dict_eq_func)
+    throw std::runtime_error("__ESBMC_dict_eq not found in symbol table");
+
+  // Create temp for result
+  symbolt &result_var = converter_.create_tmp_symbol(
+    nlohmann::json(), "$dict_eq_result$", bool_type(), exprt());
+  code_declt result_decl(symbol_expr(result_var));
+  result_decl.location() = location;
+  converter_.add_instruction(result_decl);
+
+  // Call __ESBMC_dict_eq(lhs_keys, lhs_values, rhs_keys, rhs_values)
+  code_function_callt dict_eq_call;
+  dict_eq_call.function() = symbol_expr(*dict_eq_func);
+  dict_eq_call.lhs() = symbol_expr(result_var);
+  dict_eq_call.arguments().push_back(lhs_keys);
+  dict_eq_call.arguments().push_back(lhs_values);
+  dict_eq_call.arguments().push_back(rhs_keys);
+  dict_eq_call.arguments().push_back(rhs_values);
+  dict_eq_call.type() = bool_type();
+  dict_eq_call.location() = location;
+  converter_.add_instruction(dict_eq_call);
+
+  // Return result
+  exprt result = symbol_expr(result_var);
+  result.location() = location;
+
+  if (op == "NotEq")
   {
-    locationt location = lhs.location();
-    if (location.is_nil())
-      location = rhs.location();
-
-    typet list_type = type_handler_.get_list_type();
-
-    // Get keys and values from both dicts
-    member_exprt lhs_keys(lhs, "keys", list_type);
-    member_exprt lhs_values(lhs, "values", list_type);
-    member_exprt rhs_keys(rhs, "keys", list_type);
-    member_exprt rhs_values(rhs, "values", list_type);
-
-    // Find __ESBMC_dict_eq function
-    const symbolt *dict_eq_func =
-      symbol_table_.find_symbol("c:@F@__ESBMC_dict_eq");
-
-    if (!dict_eq_func)
-      throw std::runtime_error("__ESBMC_dict_eq not found in symbol table");
-
-    // Create temp for result
-    symbolt &result_var = converter_.create_tmp_symbol(
-      nlohmann::json(), "$dict_eq_result$", bool_type(), exprt());
-    code_declt result_decl(symbol_expr(result_var));
-    result_decl.location() = location;
-    converter_.add_instruction(result_decl);
-
-    // Call __ESBMC_dict_eq(lhs_keys, lhs_values, rhs_keys, rhs_values)
-    code_function_callt dict_eq_call;
-    dict_eq_call.function() = symbol_expr(*dict_eq_func);
-    dict_eq_call.lhs() = symbol_expr(result_var);
-    dict_eq_call.arguments().push_back(lhs_keys);
-    dict_eq_call.arguments().push_back(lhs_values);
-    dict_eq_call.arguments().push_back(rhs_keys);
-    dict_eq_call.arguments().push_back(rhs_values);
-    dict_eq_call.type() = bool_type();
-    dict_eq_call.location() = location;
-    converter_.add_instruction(dict_eq_call);
-
-    // Return result
-    exprt result = symbol_expr(result_var);
-    result.location() = location;
-
-    if (op == "NotEq")
-    {
-      exprt negated("not", bool_type());
-      negated.move_to_operands(result);
-      negated.location() = location;
-      return negated;
-    }
-
-    return result;
+    exprt negated("not", bool_type());
+    negated.move_to_operands(result);
+    negated.location() = location;
+    return negated;
   }
+
+  return result;
+}

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1476,26 +1476,27 @@ exprt python_dict_handler::handle_dict_setdefault(
   // Else branch: key not found — insert (key, default) and return default
   code_blockt else_block;
 
+  // Compute a single effective default used for both insertion and return.
+  // When the caller omits the default or passes None, approximate None as
+  // zero of the result type so that both the stored value and the returned
+  // value are identical.
+  exprt effective_default =
+    (has_explicit_default && default_value.type() != none_type())
+      ? default_value
+      : gen_zero(result_type);
+
   // value_arg is the proper char* / typed pointer to the value to insert.
   // Hoisted so the default assignment below can reuse it for string results.
   exprt value_arg;
 
   {
-    // Always insert (key, value) when the key is absent — Python semantics:
-    // d.setdefault("k") inserts ("k", None) and must make "k" in d true.
-    // When no explicit default is given, approximate None as a zero integer.
-    exprt value_to_push =
-      (has_explicit_default && default_value.type() != none_type())
-        ? default_value
-        : gen_zero(long_int_type());
-
     const symbolt *push_func =
       symbol_table_.find_symbol("c:@F@__ESBMC_list_push");
     if (!push_func)
       throw std::runtime_error("__ESBMC_list_push not found");
 
     list_elem_info value_info =
-      list_handler.get_list_element_info(call_node, value_to_push);
+      list_handler.get_list_element_info(call_node, effective_default);
 
     if (
       value_info.elem_symbol->type.is_pointer() &&
@@ -1528,25 +1529,13 @@ exprt python_dict_handler::handle_dict_setdefault(
     else_block.copy_to_operands(push_value_call);
   }
 
-  // Assign default to result
-  if (default_value.type() == none_type() && result_type != none_type())
+  // Assign effective_default to result.
+  // For strings use value_arg (the char* pointer already staged for insertion)
+  // so that the returned pointer is identical to what was pushed into the list.
+  // For all other types, effective_default already has the correct type.
   {
-    typecast_exprt casted_default(default_value, result_type);
-    code_assignt default_assign(symbol_expr(result_var), casted_default);
-    default_assign.location() = location;
-    else_block.copy_to_operands(default_assign);
-  }
-  else if (is_string_result)
-  {
-    // value_arg was set above when has_explicit_default is true; when the
-    // default is None the none_type() branch above is taken instead.
-    code_assignt default_assign(symbol_expr(result_var), value_arg);
-    default_assign.location() = location;
-    else_block.copy_to_operands(default_assign);
-  }
-  else
-  {
-    code_assignt default_assign(symbol_expr(result_var), default_value);
+    exprt result_expr = is_string_result ? value_arg : effective_default;
+    code_assignt default_assign(symbol_expr(result_var), result_expr);
     default_assign.location() = location;
     else_block.copy_to_operands(default_assign);
   }

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1356,6 +1356,10 @@ exprt python_dict_handler::handle_dict_setdefault(
   if (is_string_result)
     result_type = gen_pointer_type(char_type());
 
+  if (is_dict_type(result_type) || result_type == list_type)
+    throw std::runtime_error(
+      "setdefault(): dict and list value types are not supported");
+
   // Get dict members
   member_exprt keys_member(dict_expr, "keys", list_type);
   member_exprt values_member(dict_expr, "values", list_type);

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -593,6 +593,20 @@ exprt python_dict_handler::handle_dict_subscript(
     return result;
   }
 
+  // Handle non-char pointer types (e.g., Optional[T] stored as T*).
+  // The value was stored by-reference (value_arg = address_of(T* var)), so
+  // item->value points to a buffer holding the T* bytes.
+  // Dereference as T** to recover the stored T* value.
+  if (
+    resolved_type.is_pointer() && resolved_type.subtype() != char_type() &&
+    !resolved_type.is_nil())
+  {
+    typecast_exprt value_as_ptr_ptr(obj_value, pointer_typet(resolved_type));
+    dereference_exprt result(value_as_ptr_ptr, resolved_type);
+    result.type() = resolved_type;
+    return result;
+  }
+
   // Default: cast void* to char* for string values
   typecast_exprt value_as_string(obj_value, gen_pointer_type(char_type()));
   return value_as_string;
@@ -1456,6 +1470,15 @@ exprt python_dict_handler::handle_dict_setdefault(
   {
     typecast_exprt value_as_bool_ptr(obj_value, pointer_typet(bool_type()));
     retrieved_value = dereference_exprt(value_as_bool_ptr, bool_type());
+  }
+  else if (
+    result_type.is_pointer() && result_type.subtype() != char_type() &&
+    !result_type.is_nil())
+  {
+    // Non-char pointer (e.g., Optional[T] stored as T*): stored by-reference,
+    // so dereference as T** to recover the stored T* value.
+    typecast_exprt value_as_ptr_ptr(obj_value, pointer_typet(result_type));
+    retrieved_value = dereference_exprt(value_as_ptr_ptr, result_type);
   }
   else if (result_type == none_type())
   {

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1348,13 +1348,11 @@ exprt python_dict_handler::handle_dict_setdefault(
   // returns a void* that points to the first character.  Normalise any
   // non-primitive, non-dict, non-list type to char* so that retrieval is
   // done the same way as in handle_dict_subscript.
-  bool is_string_result = !result_type.is_floatbv() &&
-                          !result_type.is_signedbv() &&
-                          !result_type.is_unsignedbv() &&
-                          !result_type.is_bool() &&
-                          result_type != none_type() &&
-                          !is_dict_type(result_type) &&
-                          result_type != list_type;
+  bool is_string_result =
+    !result_type.is_floatbv() && !result_type.is_signedbv() &&
+    !result_type.is_unsignedbv() && !result_type.is_bool() &&
+    result_type != none_type() && !is_dict_type(result_type) &&
+    result_type != list_type;
   if (is_string_result)
     result_type = gen_pointer_type(char_type());
 

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1560,7 +1560,9 @@ exprt python_dict_handler::handle_dict_setdefault(
   converter_.add_instruction(if_stmt);
 
   return symbol_expr(result_var);
-  exprt python_dict_handler::handle_dict_update(
+}
+
+exprt python_dict_handler::handle_dict_update(
     const exprt &dict_expr, const nlohmann::json &call_node)
   {
     const auto &args = call_node["args"];

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1478,19 +1478,26 @@ exprt python_dict_handler::handle_dict_setdefault(
   // Else branch: key not found — insert (key, default) and return default
   code_blockt else_block;
 
-  // value_arg is the proper char* / typed pointer to the default value.
+  // value_arg is the proper char* / typed pointer to the value to insert.
+  // Hoisted so the default assignment below can reuse it for string results.
   exprt value_arg;
 
-  if (has_explicit_default && default_value.type() != none_type())
   {
+    // Always insert (key, value) when the key is absent — Python semantics:
+    // d.setdefault("k") inserts ("k", None) and must make "k" in d true.
+    // When no explicit default is given, approximate None as a zero integer.
+    exprt value_to_push =
+      (has_explicit_default && default_value.type() != none_type())
+        ? default_value
+        : gen_zero(long_int_type());
+
     const symbolt *push_func =
       symbol_table_.find_symbol("c:@F@__ESBMC_list_push");
     if (!push_func)
       throw std::runtime_error("__ESBMC_list_push not found");
 
-    // Get element info for the default value
     list_elem_info value_info =
-      list_handler.get_list_element_info(call_node, default_value);
+      list_handler.get_list_element_info(call_node, value_to_push);
 
     if (
       value_info.elem_symbol->type.is_pointer() &&
@@ -1510,7 +1517,7 @@ exprt python_dict_handler::handle_dict_setdefault(
     push_key_call.location() = location;
     else_block.copy_to_operands(push_key_call);
 
-    // Push default value into values list
+    // Push value into values list
     code_function_callt push_value_call;
     push_value_call.function() = symbol_expr(*push_func);
     push_value_call.arguments().push_back(values_member);

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -405,19 +405,17 @@ public:
     const exprt &dict_expr,
     const nlohmann::json &call_node);
 
-  *@brief Handles dict.update()
-        method calls **Implements Python's dict.update(other) semantics: *
-      -For each key
-    - value pair in other : if key exists,
-    update value;
-  *otherwise insert the new key -
-    value pair.*
-      -Returns nil(update() is a void operation)
-         .**@param dict_expr The dictionary
-       expression to update *@param call_node The function call AST node
-       containing the argument dict *@ return nil_exprt(void operation) *
-      /
-      exprt handle_dict_update(
+  /**
+   * @brief Handles dict.update() method calls.
+   * Implements Python's dict.update(other) semantics:
+   * - For each key-value pair in other: if key exists, update value;
+   *   otherwise insert the new key-value pair.
+   * - Returns nil_exprt (update() is a void operation).
+   * @param dict_expr The dictionary expression to update
+   * @param call_node The function call AST node containing the argument dict
+   * @return nil_exprt (void operation)
+   */
+  exprt handle_dict_update(
         const exprt &dict_expr,
         const nlohmann::json &call_node);
 

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -377,17 +377,33 @@ public:
 
   /**
    * @brief Handles dict.get() method calls
-   * 
+   *
    * Implements Python's dict.get(key, default=None) semantics:
    * - Returns value if key exists
    * - Returns default (or None) if key doesn't exist
-   * 
+   *
    * @param dict_expr The dictionary expression
    * @param call_node The function call AST node containing arguments
    * @return Expression representing the result (value or default)
    */
   exprt
   handle_dict_get(const exprt &dict_expr, const nlohmann::json &call_node);
+
+  /**
+   * @brief Handles dict.setdefault() method calls
+   *
+   * Implements Python's dict.setdefault(key, default=None) semantics:
+   * - If key exists in the dictionary: returns its current value (no mutation)
+   * - If key does not exist: inserts (key, default) into the dictionary
+   *   and returns default
+   *
+   * @param dict_expr The dictionary expression
+   * @param call_node The function call AST node containing arguments
+   * @return Expression representing the result (existing value or default)
+   */
+  exprt handle_dict_setdefault(
+    const exprt &dict_expr,
+    const nlohmann::json &call_node);
 
   /**
    * @brief Compares two dictionaries for equality or inequality

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -415,9 +415,8 @@ public:
    * @param call_node The function call AST node containing the argument dict
    * @return nil_exprt (void operation)
    */
-  exprt handle_dict_update(
-        const exprt &dict_expr,
-        const nlohmann::json &call_node);
+  exprt
+  handle_dict_update(const exprt &dict_expr, const nlohmann::json &call_node);
 
   /**
    * @brief Compares two dictionaries for equality or inequality

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -405,19 +405,21 @@ public:
     const exprt &dict_expr,
     const nlohmann::json &call_node);
 
-   * @brief Handles dict.update() method calls
-   *
-   * Implements Python's dict.update(other) semantics:
-   * - For each key-value pair in other: if key exists, update value;
-   *   otherwise insert the new key-value pair.
-   * - Returns nil (update() is a void operation).
-   *
-   * @param dict_expr The dictionary expression to update
-   * @param call_node The function call AST node containing the argument dict
-   * @return nil_exprt (void operation)
-   */
-  exprt
-  handle_dict_update(const exprt &dict_expr, const nlohmann::json &call_node);
+  *@brief Handles dict.update()
+        method calls **Implements Python's dict.update(other) semantics: *
+      -For each key
+    - value pair in other : if key exists,
+    update value;
+  *otherwise insert the new key -
+    value pair.*
+      -Returns nil(update() is a void operation)
+         .**@param dict_expr The dictionary
+       expression to update *@param call_node The function call AST node
+       containing the argument dict *@ return nil_exprt(void operation) *
+      /
+      exprt handle_dict_update(
+        const exprt &dict_expr,
+        const nlohmann::json &call_node);
 
   /**
    * @brief Compares two dictionaries for equality or inequality

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -179,6 +179,17 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 
     elem_size = from_integer(BigInt(total_size), size_type());
   }
+  // For non-char, non-bool pointer types (e.g., Optional[T] stored as T*):
+  // pointer_typet has no width() attribute, so we must use pointer_width here
+  // rather than falling to the generic else branch which calls width().
+  else if (
+    elem_symbol.type.is_pointer() &&
+    elem_symbol.type.subtype() != char_type() &&
+    elem_symbol.type.subtype() != bool_type())
+  {
+    const size_t pointer_size_bytes = config.ansi_c.pointer_width() / 8;
+    elem_size = from_integer(BigInt(pointer_size_bytes), size_type());
+  }
   // For string pointers (char*), calculate length at runtime using strlen
   else if (
     elem_symbol.type.is_pointer() && elem_symbol.type.subtype() == char_type())


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3658.

This PR  adds initial support for `dict.setdefault(key, default=None)`. When the key is present, the existing value is returned without modifying the dictionary; when absent, the key is inserted with the given default value, and that value is returned.