### PR TITLE
[python] Fix false counterexample for math.sqrt() with constant arguments

### DIFF
--- a/regression/python/github_3637/main.py
+++ b/regression/python/github_3637/main.py
@@ -1,0 +1,9 @@
+import math
+
+def test_power_and_roots():
+    assert 2 ** 3 == 8
+    assert math.pow(2, 3) == 8.0
+    assert math.isclose(math.sqrt(16), 4.0)
+    assert math.isclose(27 ** (1/3), 3.0)
+
+test_power_and_roots()

--- a/regression/python/github_3637/test.desc
+++ b/regression/python/github_3637/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3637_1/main.py
+++ b/regression/python/github_3637_1/main.py
@@ -1,0 +1,8 @@
+import math
+
+def test_sqrt_float_literals():
+    assert math.sqrt(4.0) == 2.0
+    assert math.sqrt(9.0) == 3.0
+    assert math.sqrt(25.0) == 5.0
+
+test_sqrt_float_literals()

--- a/regression/python/github_3637_1/test.desc
+++ b/regression/python/github_3637_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3637_1_fail/main.py
+++ b/regression/python/github_3637_1_fail/main.py
@@ -1,0 +1,6 @@
+import math
+
+def test_sqrt_float_literals_fail():
+    assert math.sqrt(4.0) == 3.0  # wrong: sqrt(4.0) == 2.0, not 3.0
+
+test_sqrt_float_literals_fail()

--- a/regression/python/github_3637_1_fail/test.desc
+++ b/regression/python/github_3637_1_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3637_2/main.py
+++ b/regression/python/github_3637_2/main.py
@@ -1,0 +1,7 @@
+import math
+
+def test_fractional_power():
+    assert math.isclose(8 ** (1/3), 2.0)
+    assert math.isclose(27 ** (1/3), 3.0)
+
+test_fractional_power()

--- a/regression/python/github_3637_2/test.desc
+++ b/regression/python/github_3637_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3637_fail/main.py
+++ b/regression/python/github_3637_fail/main.py
@@ -1,0 +1,6 @@
+import math
+
+def test_power_and_roots_fail():
+    assert math.sqrt(16) == 5.0  # wrong: sqrt(16) == 4.0, not 5.0
+
+test_power_and_roots_fail()

--- a/regression/python/github_3637_fail/test.desc
+++ b/regression/python/github_3637_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -430,7 +430,10 @@ exprt python_math::handle_sqrt(exprt operand, const nlohmann::json &element)
     {
       BigInt int_val = binary2integer(
         resolved.value().as_string(), resolved.type().is_signedbv());
-      val = static_cast<double>(int_val.to_int64());
+      if (resolved.type().is_unsignedbv())
+        val = static_cast<double>(int_val.to_uint64());
+      else
+        val = static_cast<double>(int_val.to_int64());
       got_val = true;
     }
 

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -426,8 +426,7 @@ exprt python_math::handle_sqrt(exprt operand, const nlohmann::json &element)
       val = f.to_double();
       got_val = true;
     }
-    else if (
-      resolved.type().is_signedbv() || resolved.type().is_unsignedbv())
+    else if (resolved.type().is_signedbv() || resolved.type().is_unsignedbv())
     {
       BigInt int_val = binary2integer(
         resolved.value().as_string(), resolved.type().is_signedbv());

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -4,6 +4,7 @@
 #include <python-frontend/convert_float_literal.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/ieee_float.h>
 #include <util/std_code.h>
 #include <util/std_types.h>
 #include <util/message.h>
@@ -403,7 +404,42 @@ void python_math::promote_int_to_float(exprt &op, const typet &target_type)
 
 exprt python_math::handle_sqrt(exprt operand, const nlohmann::json &element)
 {
-  // Find the sqrt function symbol from C math library
+  // Constant folding: when operand is a compile-time constant, compute at compile time
+  exprt resolved = operand;
+  if (operand.is_symbol())
+  {
+    const symbolt *s = symbol_table.find_symbol(operand.identifier());
+    if (s && !s->value.value().empty())
+      resolved = s->value;
+  }
+
+  if (resolved.is_constant())
+  {
+    double val = 0.0;
+    bool got_val = false;
+
+    if (resolved.type().is_floatbv())
+    {
+      ieee_floatt f;
+      f.spec = to_floatbv_type(resolved.type());
+      f.unpack(binary2integer(resolved.value().as_string(), false));
+      val = f.to_double();
+      got_val = true;
+    }
+    else if (
+      resolved.type().is_signedbv() || resolved.type().is_unsignedbv())
+    {
+      BigInt int_val = binary2integer(
+        resolved.value().as_string(), resolved.type().is_signedbv());
+      val = static_cast<double>(int_val.to_int64());
+      got_val = true;
+    }
+
+    if (got_val && val >= 0.0)
+      return from_double(std::sqrt(val), double_type());
+  }
+
+  // Find the sqrt function symbol from C math library (for symbolic operands)
   symbolt *sqrt_symbol = symbol_table.find_symbol("c:@F@sqrt");
   if (!sqrt_symbol)
     throw std::runtime_error("sqrt function not found in symbol table");

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -437,7 +437,10 @@ exprt python_math::handle_sqrt(exprt operand, const nlohmann::json &element)
       got_val = true;
     }
 
-    if (got_val && val >= 0.0)
+    // Constant-fold when we have a concrete value that is either:
+    //  - non-negative finite, or
+    //  - NaN or +/-infinity (IEEE-754 defines std::sqrt for these)
+    if (got_val && (val >= 0.0 || std::isnan(val) || std::isinf(val)))
       return from_double(std::sqrt(val), double_type());
   }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where ESBMC produces a false counterexample when math.sqrt() is called with a constant argument (e.g., math.sqrt(16)).

## The Problem:
In floating-point mode, the sqrt() function lacks a concrete function body (as sqrt.c is often guarded by #ifdef __ESBMC_FIXEDBV). Consequently, the SMT solver treats the return value of math.sqrt() as unconstrained symbolic data. This leads to verification failures for assertions that are mathematically correct, such as assert math.sqrt(16) == 4.0.

## The Solution:
I have implemented constant folding for math.sqrt() in the Python frontend.

When the operand is a compile-time constant (either a float literal or an integer literal), the value is now pre-calculated using std::sqrt during the symbolic execution phase.

If the argument is a symbol or a non-constant expression, it falls back to the existing behavior (linking to the C math library's sqrt symbol).


## Impact
This improvement increases the precision of Python floating-point verification and prevents spurious counterexamples in models using constant mathematical parameters.