### PR TITLE
[python] fix method calls on temporary instances: A().f(args) (#3678)

### DIFF
--- a/regression/python/github_3678/main.py
+++ b/regression/python/github_3678/main.py
@@ -1,0 +1,8 @@
+class A:
+    def f(self, d):
+        if "a" in d:
+            return {"x": 1}
+        return {}
+
+r = A().f({"a": 0})
+assert r["x"] == 1

--- a/regression/python/github_3678/test.desc
+++ b/regression/python/github_3678/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -167,6 +167,12 @@ void function_call_expr::get_function_type()
       }
     }
 
+    // Detect A().f(...): method call on a temporary instance from a constructor.
+    bool obj_is_temp_instance =
+      call_["func"]["value"]["_type"] == "Call" &&
+      call_["func"]["value"].contains("func") &&
+      call_["func"]["value"]["func"]["_type"] == "Name";
+
     // Handling a function call as a class method call when:
     // (1) The caller corresponds to a class name, for example: MyClass.foo().
     // (2) Calling methods of built-in types, such as int.from_bytes()
@@ -175,6 +181,7 @@ void function_call_expr::get_function_type()
     // If the caller is a class or a built-in type, the following condition detects a class method call.
     if (
       !is_nested_instance_attr &&
+      !obj_is_temp_instance &&
       (is_class(caller, converter_.ast()) ||
        type_utils::is_builtin_type(caller) ||
        type_utils::is_builtin_type(type_handler_.get_var_type(caller))))
@@ -3256,13 +3263,42 @@ exprt function_call_expr::handle_general_function_call()
     }
     else
     {
-      // Nested attribute: build expression dynamically
+      // Nested attribute or temporary instance: build expression dynamically
       if (
         call_["func"]["_type"] == "Attribute" &&
         call_["func"].contains("value"))
       {
-        exprt obj_expr = converter_.get_expr(call_["func"]["value"]);
-        call.arguments().push_back(gen_address_of(obj_expr));
+        const auto &func_value = call_["func"]["value"];
+        if (
+          func_value["_type"] == "Call" && func_value.contains("func") &&
+          func_value["func"]["_type"] == "Name")
+        {
+          // A().f(...): create a temporary A instance and use it as self.
+          const std::string &class_name =
+            func_value["func"]["id"].get<std::string>();
+          typet class_type = type_handler_.get_typet(class_name);
+
+          symbolt &tmp =
+            converter_.create_tmp_symbol(func_value, "$inst$", class_type, exprt());
+          converter_.symbol_table().add(tmp);
+          code_declt tmp_decl(symbol_expr(tmp));
+          tmp_decl.location() = location;
+          converter_.current_block->copy_to_operands(tmp_decl);
+
+          // Call the constructor if it is defined, using tmp as self.
+          exprt *saved_lhs = converter_.current_lhs;
+          exprt tmp_expr = symbol_expr(tmp);
+          converter_.current_lhs = &tmp_expr;
+          exprt ctor_result = converter_.get_expr(func_value);
+          converter_.current_lhs = saved_lhs;
+
+          call.arguments().push_back(gen_address_of(symbol_expr(tmp)));
+        }
+        else
+        {
+          exprt obj_expr = converter_.get_expr(func_value);
+          call.arguments().push_back(gen_address_of(obj_expr));
+        }
       }
       else
       {

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -180,8 +180,7 @@ void function_call_expr::get_function_type()
     // (3) Calling a instance method from a built-in type object, for example: x.bit_length() when x is an int
     // If the caller is a class or a built-in type, the following condition detects a class method call.
     if (
-      !is_nested_instance_attr &&
-      !obj_is_temp_instance &&
+      !is_nested_instance_attr && !obj_is_temp_instance &&
       (is_class(caller, converter_.ast()) ||
        type_utils::is_builtin_type(caller) ||
        type_utils::is_builtin_type(type_handler_.get_var_type(caller))))
@@ -3278,8 +3277,8 @@ exprt function_call_expr::handle_general_function_call()
             func_value["func"]["id"].get<std::string>();
           typet class_type = type_handler_.get_typet(class_name);
 
-          symbolt &tmp =
-            converter_.create_tmp_symbol(func_value, "$inst$", class_type, exprt());
+          symbolt &tmp = converter_.create_tmp_symbol(
+            func_value, "$inst$", class_type, exprt());
           converter_.symbol_table().add(tmp);
           code_declt tmp_decl(symbol_expr(tmp));
           tmp_decl.location() = location;

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -175,10 +175,89 @@ public:
     }
   }
 
+  // Preprocess method calls on temporary instances to infer parameter types.
+  // Handles patterns such as A().method(arg1, arg2) by annotating the method's
+  // parameters from the argument types at the call site.
+  void preprocess_method_calls(const Json &node)
+  {
+    if (node.is_object())
+    {
+      // Detect: A().method(args)
+      // func._type == "Attribute", func.value._type == "Call" (the A() part),
+      // func.value.func._type == "Name" (the class name A)
+      if (
+        node.contains("_type") && node["_type"] == "Call" &&
+        node.contains("func") &&
+        node["func"]["_type"] == "Attribute" &&
+        node["func"].contains("value") &&
+        node["func"]["value"]["_type"] == "Call" &&
+        node["func"]["value"].contains("func") &&
+        node["func"]["value"]["func"]["_type"] == "Name" &&
+        node["func"]["value"]["func"].contains("id") &&
+        node["func"].contains("attr"))
+      {
+        const std::string &class_name =
+          node["func"]["value"]["func"]["id"].template get<std::string>();
+        const std::string &method_name =
+          node["func"]["attr"].template get<std::string>();
+        const Json &call_args =
+          node.contains("args") ? node["args"] : Json::array();
+
+        for (Json &class_node : ast_["body"])
+        {
+          if (
+            class_node["_type"] == "ClassDef" &&
+            class_node["name"] == class_name)
+          {
+            for (Json &member : class_node["body"])
+            {
+              if (
+                member["_type"] == "FunctionDef" &&
+                member["name"] == method_name &&
+                member.contains("args") &&
+                member["args"].contains("args"))
+              {
+                Json &params = member["args"]["args"];
+                // Skip self (index 0); match remaining params to call args
+                for (
+                  size_t i = 1;
+                  i < params.size() && (i - 1) < call_args.size();
+                  ++i)
+                {
+                  Json &param = params[i];
+                  // Only annotate if the parameter is not yet annotated
+                  if (
+                    param.contains("annotation") &&
+                    !param["annotation"].is_null())
+                    continue;
+                  const Json &arg = call_args[i - 1];
+                  std::string arg_type = get_argument_type(arg);
+                  if (!arg_type.empty())
+                    add_parameter_annotation(param, arg_type);
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Recursively search all object fields
+      for (auto &kv : node.items())
+        preprocess_method_calls(kv.value());
+    }
+    else if (node.is_array())
+    {
+      for (const auto &element : node)
+        preprocess_method_calls(element);
+    }
+  }
+
   void add_type_annotation()
   {
     // First pass: preprocess all constructor calls to infer parameter types
     preprocess_constructor_calls(ast_);
+    // Also preprocess method calls on temporary instances: A().method(args)
+    preprocess_method_calls(ast_);
 
     // Second pass: add type annotations to global scope variables
     annotate_global_scope();
@@ -2064,6 +2143,16 @@ private:
     if (call["value"]["_type"] == "Constant")
       return get_type_from_constant(call["value"]);
 
+    // Handle method calls on temporary instances: A().method()
+    // A() is a Call node with no "id" field; return the class name so that
+    // get_type_from_method() can look up the method in the class definition.
+    if (
+      call["value"]["_type"] == "Call" &&
+      call["value"].contains("func") &&
+      call["value"]["func"]["_type"] == "Name" &&
+      call["value"]["func"].contains("id"))
+      return call["value"]["func"]["id"].template get<std::string>();
+
     // Handle normal Name values (variable references)
     if (!call["value"].contains("id"))
       return "";
@@ -2726,6 +2815,11 @@ private:
         // Method call on subscript (e.g., nested[i].pop()): let converter infer
         else if (
           func.contains("value") && func["value"]["_type"] == "Subscript")
+          return InferResult::UNKNOWN;
+        // Method call on temporary instance (e.g., A().f()): let converter infer
+        // if get_type_from_method couldn't resolve (class not in AST etc.)
+        else if (
+          func.contains("value") && func["value"]["_type"] == "Call")
           return InferResult::UNKNOWN;
       }
     }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -187,8 +187,7 @@ public:
       // func.value.func._type == "Name" (the class name A)
       if (
         node.contains("_type") && node["_type"] == "Call" &&
-        node.contains("func") &&
-        node["func"]["_type"] == "Attribute" &&
+        node.contains("func") && node["func"]["_type"] == "Attribute" &&
         node["func"].contains("value") &&
         node["func"]["value"]["_type"] == "Call" &&
         node["func"]["value"].contains("func") &&
@@ -213,16 +212,14 @@ public:
             {
               if (
                 member["_type"] == "FunctionDef" &&
-                member["name"] == method_name &&
-                member.contains("args") &&
+                member["name"] == method_name && member.contains("args") &&
                 member["args"].contains("args"))
               {
                 Json &params = member["args"]["args"];
                 // Skip self (index 0); match remaining params to call args
-                for (
-                  size_t i = 1;
-                  i < params.size() && (i - 1) < call_args.size();
-                  ++i)
+                for (size_t i = 1;
+                     i < params.size() && (i - 1) < call_args.size();
+                     ++i)
                 {
                   Json &param = params[i];
                   // Only annotate if the parameter is not yet annotated
@@ -2147,8 +2144,7 @@ private:
     // A() is a Call node with no "id" field; return the class name so that
     // get_type_from_method() can look up the method in the class definition.
     if (
-      call["value"]["_type"] == "Call" &&
-      call["value"].contains("func") &&
+      call["value"]["_type"] == "Call" && call["value"].contains("func") &&
       call["value"]["func"]["_type"] == "Name" &&
       call["value"]["func"].contains("id"))
       return call["value"]["func"]["id"].template get<std::string>();
@@ -2818,8 +2814,7 @@ private:
           return InferResult::UNKNOWN;
         // Method call on temporary instance (e.g., A().f()): let converter infer
         // if get_type_from_method couldn't resolve (class not in AST etc.)
-        else if (
-          func.contains("value") && func["value"]["_type"] == "Call")
+        else if (func.contains("value") && func["value"]["_type"] == "Call")
           return InferResult::UNKNOWN;
       }
     }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3678.

This PR implements a two-step process:

(1) **Annotation phase**: handle `A().f(args) in get_object_name()` and add `preprocess_method_calls()` to infer parameter types from call sites.

(2) **Conversion phase**: classify `A().f(args)` as InstanceMethod (not ClassMethod), and create a temporary A instance to pass as self.