### PR TITLE
[python] fix list repetition crash for variable list operands (#3679)

### DIFF
--- a/regression/python/github_3679-nondet/main.py
+++ b/regression/python/github_3679-nondet/main.py
@@ -1,0 +1,7 @@
+c = nondet_int()
+lst2 = [c]
+repeated = lst2 * 3
+assert len(repeated) == 3
+assert repeated[0] == c
+assert repeated[1] == c
+assert repeated[2] == c

--- a/regression/python/github_3679-nondet/test.desc
+++ b/regression/python/github_3679-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3679/main.py
+++ b/regression/python/github_3679/main.py
@@ -1,0 +1,7 @@
+c = 2
+lst2 = [c]
+repeated = lst2 * 3
+assert len(repeated) == 3
+assert repeated[0] == c
+assert repeated[1] == c
+assert repeated[2] == c

--- a/regression/python/github_3679/test.desc
+++ b/regression/python/github_3679/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2239,6 +2239,8 @@ exprt python_list::list_repetition(
   BigInt list_size;
   exprt list_elem;
   symbolt *list_symbol = nullptr;
+  // True when the list operand is a variable (not a literal).
+  bool is_variable_list = false;
 
   auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool {
     if (
@@ -2252,7 +2254,16 @@ exprt python_list::list_repetition(
     return true;
   };
 
-  // Get list size from lhs (e.g.: 3 * [1])
+  // Get element expression from list_type_map for a variable list.
+  auto elem_from_type_map = [&](const std::string &src_id) -> exprt {
+    const std::string &elem_id = get_list_element_id(src_id, 0);
+    assert(!elem_id.empty());
+    symbolt *elem_sym = converter_.find_symbol(elem_id);
+    assert(elem_sym);
+    return symbol_expr(*elem_sym);
+  };
+
+  // Get list size from lhs (e.g.: 3 * [1] or 3 * lst)
   if (lhs.type() != list_type)
   {
     if (lhs.is_symbol())
@@ -2270,17 +2281,31 @@ exprt python_list::list_repetition(
     else if (lhs.is_constant())
       list_size = binary2integer(lhs.value().c_str(), true);
 
-    // List element is the rhs
-    list_elem = converter_.get_expr(right_node["elts"][0]);
+    // List element comes from the rhs operand
+    if (right_node.contains("elts"))
+      list_elem = converter_.get_expr(right_node["elts"][0]);
+    else
+    {
+      // rhs is a variable list — get element from list_type_map
+      list_elem = elem_from_type_map(rhs.identifier().as_string());
+      is_variable_list = true;
+    }
   }
 
-  // Get list size from rhs (e.g.: [1] * 3)
+  // Get list size from rhs (e.g.: [1] * 3 or lst * 3)
   if (rhs.type() != list_type)
   {
-    // List element is the rhs
-    list_elem = converter_.get_expr(left_node["elts"][0]);
+    // List element comes from the lhs operand
+    if (left_node.contains("elts"))
+      list_elem = converter_.get_expr(left_node["elts"][0]);
+    else
+    {
+      // lhs is a variable list — get element from list_type_map
+      list_elem = elem_from_type_map(lhs.identifier().as_string());
+      is_variable_list = true;
+    }
 
-    if (rhs.is_symbol()) // (e.g.: [1] * n)
+    if (rhs.is_symbol()) // (e.g.: [1] * n or lst * n)
     {
       symbolt *size_var = converter_.find_symbol(
         to_symbol_expr(rhs).get_identifier().as_string());
@@ -2296,7 +2321,14 @@ exprt python_list::list_repetition(
       list_size = binary2integer(rhs.value().c_str(), true);
   }
 
-  if (!list_symbol)
+  // For variable lists, allocate a fresh result list so the source is not
+  // mutated.  For literal lists the temp symbol created by get() is reused.
+  if (is_variable_list)
+  {
+    symbolt &result = create_list();
+    list_symbol = &result;
+  }
+  else if (!list_symbol)
   {
     if (lhs.type() == list_type && lhs.is_symbol())
       list_symbol = converter_.find_symbol(lhs.identifier().as_string());
@@ -2311,7 +2343,12 @@ exprt python_list::list_repetition(
   else
     list_id = list_symbol->id.as_string();
 
-  for (int64_t i = 0; i < list_size.to_int64() - 1; ++i)
+  // Literal lists already contain their first element; variable-list results
+  // start empty.  Adjust the loop bounds accordingly.
+  const int64_t push_count =
+    is_variable_list ? list_size.to_int64() : list_size.to_int64() - 1;
+
+  for (int64_t i = 0; i < push_count; ++i)
   {
     converter_.add_instruction(
       build_push_list_call(*list_symbol, list_value_, list_elem));


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3679.

This PR guards access to "elts" and falls back to `list_type_map` for variable lists. Also, create a fresh result list in the variable case to avoid mutating the source.

Before this PR, `list_repetition()` unconditionally accessed `left_node["elts"][0]`,   which is only valid for list literals. When the `lhs` is a variable, the JSON node has no "elts" key, causing an assertion failure in `json.hpp`. 