### PR TITLE
  [python] fix annotation crash for A().f() with explicit return type (#3683)

### DIFF
--- a/regression/python/github_3683/main.py
+++ b/regression/python/github_3683/main.py
@@ -1,0 +1,15 @@
+class A:
+    def f(self, d: dict[str, dict[str, dict[str, str]]]) -> dict[str, bool]:
+        r: dict[str, bool] = {}
+        for k, v in d["a"].items():
+            if v["x"] == "y":
+                r[k] = True
+        return r
+
+res = A().f({
+    "a": {
+        "p": {"x": "y"}
+    }
+})
+
+assert res["p"] == True

--- a/regression/python/github_3683/test.desc
+++ b/regression/python/github_3683/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3684/main.py
+++ b/regression/python/github_3684/main.py
@@ -1,0 +1,21 @@
+class Agents:
+    def use_inline_agent(self, outputSchema: dict) -> dict:
+        response = {}
+        if "properties" in outputSchema:
+            for prop, spec in outputSchema["properties"].items():
+                if spec["type"] == "boolean":
+                    response[prop] = True
+        return response
+
+agents = Agents()
+
+result = agents.use_inline_agent(
+    outputSchema={
+        "type": "object",
+        "properties": {
+            "has_price_text": {"type": "boolean"}
+        }
+    }
+)
+
+assert result["has_price_text"] == True

--- a/regression/python/github_3684/test.desc
+++ b/regression/python/github_3684/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 16 --bitwuzla --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -533,6 +533,19 @@ class Preprocessor(ast.NodeTransformer):
         target = node.target
         if isinstance(target, (ast.Tuple, ast.List)) and len(target.elts) == 2:
             k_var, v_var = target.elts[0], target.elts[1]
+            # If the key type is still unknown, check the loop body for
+            # some_dict[key_var] usage patterns: using a variable as a dict
+            # subscript key implies it is a str (the common dict key type).
+            if (isinstance(key_ann, ast.Name) and key_ann.id == 'Any' and
+                    isinstance(k_var, ast.Name) and
+                    self._key_used_as_subscript(k_var.id, node.body)):
+                key_ann = ast.Name(id='str', ctx=ast.Load())
+            # If the value type is still unknown, check the loop body for
+            # val["key"] usage patterns: string subscripts imply a dict value.
+            if (isinstance(val_ann, ast.Name) and val_ann.id == 'Any' and
+                    isinstance(v_var, ast.Name) and
+                    self._uses_string_subscript(v_var.id, node.body)):
+                val_ann = ast.Name(id='dict', ctx=ast.Load())
             if isinstance(k_var, ast.Name):
                 self.variable_annotations[k_var.id] = key_ann
             if isinstance(v_var, ast.Name):
@@ -1112,6 +1125,22 @@ class Preprocessor(ast.NodeTransformer):
             self.ensure_all_locations(dict_assign, node)
             setup_stmts.append(dict_assign)
 
+        # If key or val type is still unknown (Any), scan the loop body for
+        # usage patterns that reveal the type.
+        _tgt = node.target
+        if isinstance(_tgt, (ast.Tuple, ast.List)) and len(_tgt.elts) == 2:
+            _k_elt, _v_elt = _tgt.elts[0], _tgt.elts[1]
+            # some_dict[key_var] in the body => key is str (common dict key type)
+            if (isinstance(key_ann, ast.Name) and key_ann.id == 'Any' and
+                    isinstance(_k_elt, ast.Name) and
+                    self._key_used_as_subscript(_k_elt.id, node.body)):
+                key_ann = ast.Name(id='str', ctx=ast.Load())
+            # val["str_const"] in the body => value is a dict
+            if (isinstance(val_ann, ast.Name) and val_ann.id == 'Any' and
+                    isinstance(_v_elt, ast.Name) and
+                    self._uses_string_subscript(_v_elt.id, node.body)):
+                val_ann = ast.Name(id='dict', ctx=ast.Load())
+
         # Intermediate list variables: ESBMC_keys_N: list[base(K)] = d.keys()
         # The list slice uses the BASE type name only (e.g. 'dict' for dict[str,int])
         # so the C++ list subscript handler can call get_typet("dict") correctly.
@@ -1161,6 +1190,37 @@ class Preprocessor(ast.NodeTransformer):
     def _any_ann(self):
         """Return a fresh ast.Name(id='Any') annotation node."""
         return ast.Name(id='Any', ctx=ast.Load())
+
+    def _uses_string_subscript(self, var_name, body):
+        """Return True if var_name is subscripted with a string constant anywhere in body.
+
+        Used to infer that a loop variable annotated as Any is actually a dict,
+        because val["key"] access in Python is only valid on mappings.
+        """
+        module = ast.Module(body=list(body), type_ignores=[])
+        for node in ast.walk(module):
+            if (isinstance(node, ast.Subscript) and
+                    isinstance(node.value, ast.Name) and
+                    node.value.id == var_name and
+                    isinstance(node.slice, ast.Constant) and
+                    isinstance(node.slice.value, str)):
+                return True
+        return False
+
+    def _key_used_as_subscript(self, var_name, body):
+        """Return True if var_name appears as a subscript key anywhere in body.
+
+        Detects patterns like some_dict[var_name] or some_dict[var_name] = value.
+        When iterating a plain dict (key type = Any), this implies the key is str,
+        since it is being used to index another dict in the loop body.
+        """
+        module = ast.Module(body=list(body), type_ignores=[])
+        for node in ast.walk(module):
+            if (isinstance(node, ast.Subscript) and
+                    isinstance(node.slice, ast.Name) and
+                    node.slice.id == var_name):
+                return True
+        return False
 
     def _kv_types_from_annotation(self, annotation):
         """Extract (key_ann, val_ann) AST nodes from a dict[K, V] annotation node.

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2534,6 +2534,20 @@ private:
         {
           if (member["_type"] == "FunctionDef" && member["name"] == method_name)
           {
+            // Prefer the explicit return-type annotation when present.
+            if (
+              member.contains("returns") && !member["returns"].is_null())
+            {
+              const Json &ret = member["returns"];
+              // Simple type: -> str, -> int, -> MyClass
+              if (ret.contains("id"))
+                return ret["id"].template get<std::string>();
+              // Generic type: -> dict[str, bool], -> list[int], etc.
+              if (
+                ret.contains("_type") && ret["_type"] == "Subscript" &&
+                ret.contains("value") && ret["value"].contains("id"))
+                return ret["value"]["id"].template get<std::string>();
+            }
             std::string inferred_type =
               infer_from_return_statements(member["body"], method_name);
             if (!inferred_type.empty())

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2535,8 +2535,7 @@ private:
           if (member["_type"] == "FunctionDef" && member["name"] == method_name)
           {
             // Prefer the explicit return-type annotation when present.
-            if (
-              member.contains("returns") && !member["returns"].is_null())
+            if (member.contains("returns") && !member["returns"].is_null())
             {
               const Json &ret = member["returns"];
               // Simple type: -> str, -> int, -> MyClass


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3683.

Fixes https://github.com/esbmc/esbmc/issues/3434.

This PR checks the method's explicit `returns` annotation first: both simple types (-> str) and generic types (-> dict[K,V]) — before falling back to inference.
