### PR TITLE
Improved pointer pointer offset simplifications

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -159,7 +159,7 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
       while (is_with2t(current))
       {
         const with2t &w = to_with2t(current);
-        if (!is_constant_expr(w.update_value))
+        if (!constant_propagation(w.update_value))
         {
           all_constant_updates = false;
           break;

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -749,8 +749,7 @@ inline void expand_symbol_types(expr2tc &expr, const namespacet *ns)
 
   result->type = expand_type(result->type, ns);
 
-  result->Foreach_operand(
-    [&ns](expr2tc &op) { expand_symbol_types(op, ns); });
+  result->Foreach_operand([&ns](expr2tc &op) { expand_symbol_types(op, ns); });
 
   expr = result;
 }

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -6,6 +6,7 @@
 #include <irep2/irep2_expr.h>
 #include <util/migrate.h>
 #include <util/message.h>
+#include <util/namespace.h>
 
 std::string indent_str_irep2(unsigned int indent);
 
@@ -710,6 +711,48 @@ inline void get_symbols(
 
   expr->foreach_operand(
     [&symbols](const expr2tc &e) -> void { get_symbols(e, symbols); });
+}
+
+// Expand all symbol_type2t occurrences in a type to their concrete definitions.
+// Stops at struct/union boundaries to avoid infinite recursion on recursive
+// types (e.g. struct S { S *next; }) ==>  pointer(symbol("S")) in a member would
+// loop back to struct S indefinitely.
+inline type2tc expand_type(const type2tc &t, const namespacet *ns)
+{
+  if (is_nil_type(t))
+    return t;
+
+  // ns.follow handles chains of typedefs: symbol("A") -> symbol("B") -> struct
+  if (is_symbol_type(t))
+    return expand_type(ns->follow(t), ns);
+
+  // Struct/union are terminal: they ARE the concrete definition.
+  if (is_struct_type(t) || is_union_type(t))
+    return t;
+
+  // For pointer, array, vector, etc.: clone and expand each sub-type.
+  // Foreach_subtype visits all type2tc fields registered in the type's traits
+  // (e.g. pointer_data::subtype, array_data::subtype).
+  type2tc result = t->clone();
+  result->Foreach_subtype([&ns](type2tc &sub) { sub = expand_type(sub, ns); });
+  return result;
+}
+
+// Recursively replace every symbol_type2t in an expression tree with its
+// concrete type, both in each node's own type and in all sub-expressions.
+inline void expand_symbol_types(expr2tc &expr, const namespacet *ns)
+{
+  if (is_nil_expr(expr))
+    return;
+
+  expr2tc result = expr->clone();
+
+  result->type = expand_type(result->type, ns);
+
+  result->Foreach_operand(
+    [&ns](expr2tc &op) { expand_symbol_types(op, ns); });
+
+  expr = result;
 }
 
 #endif /* UTIL_IREP2_UTILS_H_ */

--- a/src/irep2/irep2_utils.h
+++ b/src/irep2/irep2_utils.h
@@ -742,7 +742,7 @@ inline type2tc expand_type(const type2tc &t, const namespacet *ns)
 // concrete type, both in each node's own type and in all sub-expressions.
 inline void expand_symbol_types(expr2tc &expr, const namespacet *ns)
 {
-  if (is_nil_expr(expr))
+  if (is_nil_expr(expr) || ns == nullptr)
     return;
 
   expr2tc result = expr->clone();

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -598,10 +598,12 @@ void value_sett::get_value_set_rec(
 
     if (sym.rlevel == symbol2t::renaming_level::level1_global)
       assert(sym.level1_num == 0);
-    /* These assertions do not hold during value_sett::assign():
-     * - level2 (non-global): the RHS can be an L2 symbol (e.g. pthread_create)
-     * - level2_global: global variables renamed during symbolic execution appear
-     *   as L2_global symbols; their value set is looked up via the base name.
+
+    /* This assertion does not hold: during value_sett::assign() the RHS is the
+     * L2 symbol c:pthread_lib.c@5466@F@pthread_create@startdata in e.g.
+     * - regression/esbmc-unix/02_account_symbolic_06
+     * - regression/esbmc/10_bicycle_01
+     * - regression/nonz3/10_bicycle_02
     // assert(sym.rlevel != symbol2t::renaming_level::level2);
     // assert(sym.rlevel != symbol2t::renaming_level::level2_global);
      */

--- a/src/util/expr_simplifier.cpp
+++ b/src/util/expr_simplifier.cpp
@@ -1207,7 +1207,7 @@ expr2tc pointer_offset2t::do_simplify() const
       expand_symbol_types(ptr_op, migrate_namespace_lookup);
 
     assert(!is_symbol_type(to_pointer_type(ptr_op->type).subtype));
-    
+
     // Turn the pointer one into pointer_offset.
     expr2tc new_ptr_op = pointer_offset2tc(type, ptr_op);
     // And multiply the non pointer one by the type size.

--- a/src/util/expr_simplifier.cpp
+++ b/src/util/expr_simplifier.cpp
@@ -1202,12 +1202,12 @@ expr2tc pointer_offset2t::do_simplify() const
     expr2tc non_ptr_op =
       (is_pointer_type(add.side_1)) ? add.side_2 : add.side_1;
 
-    // Can't do any kind of simplification if the ptr op has a symbolic type.
-    // Let the SMT layer handle this. In the future, can we pass around a
-    // namespace?
+    // Use namespace to expand symbolic types
     if (is_symbol_type(to_pointer_type(ptr_op->type).subtype))
-      return expr2tc();
+      expand_symbol_types(ptr_op, migrate_namespace_lookup);
 
+    assert(!is_symbol_type(to_pointer_type(ptr_op->type).subtype));
+    
     // Turn the pointer one into pointer_offset.
     expr2tc new_ptr_op = pointer_offset2tc(type, ptr_op);
     // And multiply the non pointer one by the type size.


### PR DESCRIPTION
This PR optimises the cases generated from pointer offsets of symbolic types. For example:

```c
typedef struct
{
  unsigned Flags;
} Aux;
typedef struct
{
  Aux Aux;
  unsigned Wc;
  unsigned V;
} RegEntry;
typedef struct
{
  RegEntry *Map;
} table;
void write(table *tbl, unsigned EntryIndex);

#define N 100
int main()
{
  RegEntry e[N];
  table M;
  M.Map = e;
  for (int i = 0; i < N; i++)
    write(&M, i);
  return 0;
}
void write(table *tbl, unsigned EntryIndex)
{
  (tbl->Map[EntryIndex]).Aux.Flags &= 1;
}

```

Results in a massive chain because:

1. ` (tbl->Map[EntryIndex])` results in a symbolic type into RegEntry.
2. Constant propagation of struct with had a bug.

Before:
```
ASSIGNMENT ()
e?1!0&0#301 == ((((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 64 || ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 >= 96) && (((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 32 || ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 >= 64) && ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 32 && ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 32 && ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 == 0 ? (e?1!0&0#300 WITH [(unsigned long int)(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) / 96):=e?1!0&0#300[(unsigned long int)(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) / 96)] WITH [Aux:=e?1!0&0#300[(unsigned long int)(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) / 96)].Aux WITH [Flags:=(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 >= 64 && ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 96 ? ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 == 64 ? e?1!0&0#300[(unsigned long int)(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) / 96)].V : symex::invalid_object799&0#0 : ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 >= 32 && ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 64 ? ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 == 32 ? e?1!0&0#300[(unsigned long int)(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) / 96)].Wc : symex::invalid_object798&0#0 : ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 32 ? ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 < 32 ? ((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) % 96 == 0 ? e?1!0&0#300[(unsigned long int)(((unsigned _ExtInt(67))(POINTER_OFFSET(M?1!0&0#2.Map + 99)) * 8) / 96)].Aux.Flags : symex::invalid_object797&0#0 : symex::invalid_object796&0#0 : symex::invalid_object796&0#0) & 1]]]) : e?1!0&0#300)
...
BMC program time: 3.778s
```

After:

```
Thread 0 file test.c line 35 column 3 function write
ASSIGNMENT ()
e?1!0&0#301 == (e?1!0&0#300 WITH [99:=e?1!0&0#300[99] WITH [Aux:=e?1!0&0#300[99].Aux WITH [Flags:=e?1!0&0#300[99].Aux.Flags & 1]]])
...
BMC program time: 2.568s
```