### PR TITLE
Fix meaningless descriptions in branch-function-coverage probes  #3712

### DIFF
--- a/regression/python/github_3712/main.py
+++ b/regression/python/github_3712/main.py
@@ -1,0 +1,11 @@
+MAX_LEN: int = 31
+
+def validate_start_with_letter(category: str) -> bool:
+    assert category[0].isalpha(), "A categoria deve começar com uma letra."
+    return True
+
+def main() -> None:
+    category: str = input()
+    validate_start_with_letter(category)
+
+main()

--- a/regression/python/github_3712/main.py
+++ b/regression/python/github_3712/main.py
@@ -5,7 +5,10 @@ def validate_start_with_letter(category: str) -> bool:
     return True
 
 def main() -> None:
-    category: str = input()
+    try:
+        category: str = input()
+    except EOFError:
+        category = "A"
     validate_start_with_letter(category)
 
 main()

--- a/regression/python/github_3712/test.desc
+++ b/regression/python/github_3712/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.py
+--unwind 30 --branch-function-coverage
+^Function Entry Points & Branches : 3
+^Reached : 3
+^Branch Coverage: 100%
+^.*function entry:.*validate_start_with_letter.*$
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -127,7 +127,11 @@ void goto_coveraget::branch_function_coverage()
         {
           // add a false assert in the beginning
           // to check if the function is entered.
-          insert_assert(goto_program, it, gen_false_expr());
+          insert_assert(
+            goto_program,
+            it,
+            gen_false_expr(),
+            "function entry: " + id2string(f_it->first));
           flg = false;
         }
 

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -164,6 +164,18 @@ class NotImplementedError(RuntimeError):
         return self.message
 
 
+class EOFError(Exception):  # noqa: A001
+    """Raised when input() hits end-of-file without reading any data"""
+
+    message: str = ""
+
+    def __init__(self, message: str = "EOF when reading a line"):
+        self.message: str = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
 class ImportError(Exception):
     """Raised when an import statement fails to find the module"""
     message: str = ""

--- a/src/python-frontend/type_utils.h
+++ b/src/python-frontend/type_utils.h
@@ -127,7 +127,7 @@ public:
       name == "FileExistsError" || name == "PermissionError" ||
       name == "NotImplementedError" || name == "ImportError" ||
       name == "ModuleNotFoundError" || name == "RuntimeError" ||
-      name == "StopIteration");
+      name == "StopIteration" || name == "EOFError");
   }
 
   static bool is_c_model_func(const std::string &func_name)


### PR DESCRIPTION
Fixes #3712.

Fix meaningless descriptions in branch-function-coverage probes.

When using --branch-function-coverage, function-entry probes were assigned generic "0" descriptions instead of identifying the actual function names. This was caused by auto-generating the assertion description from, which simply returned the character representation of false.