### PR TITLE
fix - use pre-computed symbolic length for len(input()) #3713

### DIFF
--- a/regression/python/github_3713/main.py
+++ b/regression/python/github_3713/main.py
@@ -1,0 +1,8 @@
+MAX_PRICE_LEN: int = 6
+
+def main() -> None:
+    price: str = input()
+    length_price: int = len(price)
+    assert 1 <= length_price <= 5
+
+main()

--- a/regression/python/github_3713/test.desc
+++ b/regression/python/github_3713/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 30
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -69,6 +69,8 @@ ignored_dirs=(
   "input3"
   "input5"
   "input6"
+  "github_3712"
+  "github_3713"
   "insertion_fail"
   "insertion3_fail"
   "jpl"

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -841,6 +841,22 @@ exprt function_call_builder::build() const
       }
     }
 
+    // If this is a symbol for an input() string, use the pre-computed
+    // $input_len$ companion instead of falling back to strlen() unrolling.
+    if (arg_expr.is_symbol())
+    {
+      const std::string sym_id =
+        to_symbol_expr(arg_expr).get_identifier().as_string();
+      const auto& len_map = converter_.input_str_to_len_sym_;
+      auto it = len_map.find(sym_id);
+      if (it != len_map.end())
+      {
+        const symbolt* len_sym = converter_.find_symbol(it->second);
+        if (len_sym)
+          return typecast_exprt(symbol_expr(*len_sym), size_type());
+      }
+    }
+
     // If this is a fixed-size char array, compute length at compile time
     // to avoid strlen unwinding.
     typet actual_type = arg_expr.type();

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -847,11 +847,11 @@ exprt function_call_builder::build() const
     {
       const std::string sym_id =
         to_symbol_expr(arg_expr).get_identifier().as_string();
-      const auto& len_map = converter_.input_str_to_len_sym_;
+      const auto &len_map = converter_.input_str_to_len_sym_;
       auto it = len_map.find(sym_id);
       if (it != len_map.end())
       {
-        const symbolt* len_sym = converter_.find_symbol(it->second);
+        const symbolt *len_sym = converter_.find_symbol(it->second);
         if (len_sym)
           return typecast_exprt(symbol_expr(*len_sym), size_type());
       }

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -330,6 +330,12 @@ exprt function_call_expr::handle_input() const
   term_assign.location() = converter_.get_location_from_decl(call_);
   converter_.add_instruction(term_assign);
 
+  // Record the companion $input_len$ symbol so len() on this string (or any
+  // variable aliasing it) can return the symbolic length directly instead of
+  // falling back to strlen() loop-unrolling.
+  converter_.input_str_to_len_sym_[input_sym.id.as_string()] =
+    len_sym.id.as_string();
+
   return symbol_expr(input_sym);
 }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5629,6 +5629,17 @@ void python_converter::get_var_assign(
     handle_assignment_type_adjustments(
       lhs_symbol, lhs, rhs, lhs_type, ast_node, is_ctor_call);
 
+    // Propagate $input_str$ → $input_len$ companion mapping so that len()
+    // on any alias of an input() string can use the symbolic length directly.
+    // Must run before type-branching which may take early returns.
+    if (lhs.is_symbol() && rhs.is_symbol())
+    {
+      const std::string rhs_id = rhs.identifier().as_string();
+      auto it = input_str_to_len_sym_.find(rhs_id);
+      if (it != input_str_to_len_sym_.end())
+        input_str_to_len_sym_[lhs.identifier().as_string()] = it->second;
+    }
+
     // Function call handling
     if (rhs.is_function_call())
     {

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -875,6 +875,8 @@ private:
   std::map<std::string, std::set<std::string>> instance_attr_map;
   /// Map imported modules to their corresponding paths
   std::unordered_map<std::string, std::string> imported_modules;
+  /// Maps $input_str$N symbol ID → $input_len$N symbol ID for input() strings
+  std::unordered_map<std::string, std::string> input_str_to_len_sym_;
 
   std::vector<std::string> global_declarations;
   std::vector<std::string> local_loads;


### PR DESCRIPTION
Fixes #3713

When `len()` is called on a string returned by `input()`, the Python frontend was falling through to C `strlen()`, which gets loop-unrolled during symbolic execution. This generated O(N) verification conditions per `len()` call and caused Z3 to timeout on programs with multiple `len()` invocations and large unwind bounds.

The `handle_input()` function already creates a bounded symbolic `$input_len$` variable alongside the `$input_str$` array, but this companion symbol was never reused when `len()` was later called on the string.

This PR tracks the `$input_str$ → $input_len$` mapping in `python_converter` and propagates it through variable assignments, so that `len()` on any alias of an `input()` string returns the symbolic length directly, skipping `strlen()` entirely.
