### PR TITLE
python: resolve subscript via __getitem__/__setitem__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ src/CMakeCache.txt
 src/CMakeFiles/
 src/CPackConfig.cmake
 src/CPackSourceConfig.cmake
+/.mypy_cache/

--- a/regression/python/dunder-getsetitem-fail/main.py
+++ b/regression/python/dunder-getsetitem-fail/main.py
@@ -1,0 +1,12 @@
+class MyClass:
+    def __init__(self) -> None:
+        self.value = 0
+
+    def __setitem__(self, key: int, value: int) -> None:
+        assert key == 3     #key == 2
+        assert value == 12  #value == 11
+        self.value = value
+
+
+obj = MyClass()
+obj[2] = 11

--- a/regression/python/dunder-getsetitem-fail/test.desc
+++ b/regression/python/dunder-getsetitem-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/dunder-getsetitem/main.py
+++ b/regression/python/dunder-getsetitem/main.py
@@ -1,0 +1,18 @@
+class MyClass:
+    def __init__(self) -> None:
+        self.value = 0
+
+    def __getitem__(self, key: int) -> int:
+        assert key == 2
+        return self.value
+
+    def __setitem__(self, key: int, value: int) -> None:
+        assert key == 2
+        assert value == 11
+        self.value = value
+
+
+obj = MyClass()
+obj[2] = 11
+v:int = obj[2]
+assert v == 11

--- a/regression/python/dunder-getsetitem/test.desc
+++ b/regression/python/dunder-getsetitem/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3636,6 +3636,18 @@ symbolt *python_converter::find_dunder_method(
   return find_symbol(sid.to_string());
 }
 
+bool python_converter::has_dunder_method(
+  const nlohmann::json &value_node,
+  const std::string &dunder_name)
+{
+  const std::string class_name =
+    type_handler_.get_var_classname(value_node);
+  if (class_name.empty())
+    return false;
+
+  return find_dunder_method(class_name, dunder_name) != nullptr;
+}
+
 exprt python_converter::dispatch_dunder_operator(
   const std::string &op,
   exprt &lhs,
@@ -4412,16 +4424,17 @@ exprt python_converter::get_expr(const nlohmann::json &element)
   {
     exprt array = get_expr(element["value"]);
     const nlohmann::json &slice = element["slice"];
+    typet array_type = ns.follow(array.type());
 
     // Handle tuple subscripting - tuples are structs, not arrays
-    if (tuple_handler_->is_tuple_type(array.type()))
+    if (tuple_handler_->is_tuple_type(array_type))
     {
       expr = tuple_handler_->handle_tuple_subscript(array, slice, element);
       break;
     }
 
     // Handle dictionary subscript with type inference from annotations
-    if (array.type().is_struct() && dict_handler_->is_dict_type(array.type()))
+    if (array_type.is_struct() && dict_handler_->is_dict_type(array_type))
     {
       // Try to resolve the expected return type from the dict's type annotation
       typet expected_type =
@@ -4430,6 +4443,32 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       // Pass the expected type to the dict handler
       // If empty, the handler will use its default heuristics
       expr = dict_handler_->handle_dict_subscript(array, slice, expected_type);
+      break;
+    }
+
+    // Handle object subscripting through __getitem__:
+    //   obj[key] -> obj.__getitem__(key)
+    if (has_dunder_method(element["value"], "__getitem__"))
+    {
+      nlohmann::json call_node;
+      call_node["_type"] = "Call";
+      call_node["func"] = {
+        {"_type", "Attribute"},
+        {"value", element["value"]},
+        {"attr", "__getitem__"}};
+      call_node["args"] = nlohmann::json::array();
+      call_node["args"].push_back(slice);
+      call_node["keywords"] = nlohmann::json::array();
+      if (element.contains("lineno"))
+        call_node["lineno"] = element["lineno"];
+      if (element.contains("col_offset"))
+        call_node["col_offset"] = element["col_offset"];
+      if (element.contains("end_lineno"))
+        call_node["end_lineno"] = element["end_lineno"];
+      if (element.contains("end_col_offset"))
+        call_node["end_col_offset"] = element["end_col_offset"];
+
+      expr = get_function_call(call_node);
       break;
     }
 
@@ -5541,6 +5580,40 @@ void python_converter::get_var_assign(
     }
   }
 
+  // Handle object subscript assignment via __setitem__:
+  //   obj[key] = value  ->  obj.__setitem__(key, value)
+  if (
+    target.contains("_type") && target["_type"] == "Subscript" &&
+    target.contains("value") && target.contains("slice") &&
+    ast_node.contains("value") && !ast_node["value"].is_null())
+  {
+    if (has_dunder_method(target["value"], "__setitem__"))
+    {
+      nlohmann::json call_node;
+      call_node["_type"] = "Call";
+      call_node["func"] = {
+        {"_type", "Attribute"},
+        {"value", target["value"]},
+        {"attr", "__setitem__"}};
+      call_node["args"] = nlohmann::json::array();
+      call_node["args"].push_back(target["slice"]);
+      call_node["args"].push_back(ast_node["value"]);
+      call_node["keywords"] = nlohmann::json::array();
+      if (ast_node.contains("lineno"))
+        call_node["lineno"] = ast_node["lineno"];
+      if (ast_node.contains("col_offset"))
+        call_node["col_offset"] = ast_node["col_offset"];
+      if (ast_node.contains("end_lineno"))
+        call_node["end_lineno"] = ast_node["end_lineno"];
+      if (ast_node.contains("end_col_offset"))
+        call_node["end_col_offset"] = ast_node["end_col_offset"];
+
+      exprt setitem_call = get_function_call(call_node);
+      target_block.copy_to_operands(convert_expression_to_code(setitem_call));
+      return;
+    }
+  }
+
   if (ast_node["_type"] == "AnnAssign")
   {
     // Extract name and set in symbol ID
@@ -6451,7 +6524,12 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
   // bool(z) == (z.real != 0.0 or z.imag != 0.0).
   if (is_complex_type(cond.type()))
   {
-    cond = complex_to_bool_expr(cond);
+    exprt real = member_exprt(cond, "real", double_type());
+    exprt imag = member_exprt(cond, "imag", double_type());
+    exprt zero = from_double(0.0, double_type());
+    cond = or_exprt(
+      not_exprt(equality_exprt(real, zero)),
+      not_exprt(equality_exprt(imag, zero)));
     cond.location() = get_location_from_decl(ast_node["test"]);
   }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5564,11 +5564,12 @@ void python_converter::get_var_assign(
         *this, ast_node, target, target_block))
     return;
 
-  // Tuple subscript assignment: tuples are immutable, raise TypeError
-  if (target["_type"] == "Subscript")
+  if (target.contains("_type") && target["_type"] == "Subscript")
   {
     exprt container_expr = get_expr(target["value"]);
     typet container_type = container_expr.type();
+
+    // Tuple subscript assignment: tuples are immutable, raise TypeError
     if (tuple_handler_->is_tuple_type(container_type))
     {
       exprt raise = get_exception_handler().gen_exception_raise(
@@ -5578,16 +5579,12 @@ void python_converter::get_var_assign(
       target_block.copy_to_operands(throw_code);
       return;
     }
-  }
 
-  // Handle object subscript assignment via __setitem__:
-  //   obj[key] = value  ->  obj.__setitem__(key, value)
-  if (
-    target.contains("_type") && target["_type"] == "Subscript" &&
-    target.contains("value") && target.contains("slice") &&
-    ast_node.contains("value") && !ast_node["value"].is_null())
-  {
-    if (has_dunder_method(target["value"], "__setitem__"))
+    // Handle object subscript assignment via __setitem__:
+    //   obj[key] = value  ->  obj.__setitem__(key, value)
+    if (target.contains("value") && target.contains("slice") &&
+        ast_node.contains("value") && !ast_node["value"].is_null() &&
+        has_dunder_method(target["value"], "__setitem__"))
     {
       nlohmann::json call_node;
       call_node["_type"] = "Call";

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -825,6 +825,9 @@ private:
   symbolt *find_dunder_method(
     const std::string &class_name,
     const std::string &dunder_name);
+  bool has_dunder_method(
+    const nlohmann::json &value_node,
+    const std::string &dunder_name);
   exprt dispatch_dunder_operator(
     const std::string &op,
     exprt &lhs,

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/json_utils.h>
 #include <python-frontend/type_utils.h>
 #include <python-frontend/python_converter.h>
+#include <python-frontend/python_typechecking.h>
 #include <python-frontend/symbol_id.h>
 #include <util/arith_tools.h>
 #include <util/context.h>
@@ -178,6 +179,49 @@ std::string type_handler::get_var_type(const std::string &var_name) const
   }
 
   return std::string();
+}
+
+std::string type_handler::get_var_classname(const nlohmann::json &value_node) const
+{
+  if (!value_node.contains("_type") || value_node["_type"] != "Name")
+    return "";
+
+  const std::string var_name = value_node["id"].get<std::string>();
+  auto get_class_name = [this](const std::string &name) -> std::string {
+    if (name.empty())
+      return "";
+
+    const std::string class_name =
+      (name.rfind("tag-", 0) == 0) ? name.substr(4) : name;
+    const std::string class_tag = "tag-" + class_name;
+    return converter_.symbol_table().find_symbol(class_tag) ? class_name : "";
+  };
+
+  symbol_id var_sid(
+    converter_.python_file(),
+    converter_.current_classname(),
+    converter_.current_function_name());
+  var_sid.set_object(var_name);
+
+  symbolt *var_symbol = converter_.find_symbol(var_sid.to_string());
+  if (!var_symbol)
+    var_symbol = converter_.find_symbol(var_sid.global_to_string());
+
+  if (var_symbol)
+  {
+    const auto annotation_types =
+      converter_.get_typechecker().get_annotation_types(var_symbol->id.as_string());
+    if (!annotation_types.empty())
+    {
+      typet ann_type = annotation_types.front();
+      if (ann_type.is_pointer())
+        ann_type = ann_type.subtype();
+      if (ann_type.is_struct())
+        return get_class_name(to_struct_type(ann_type).tag().as_string());
+    }
+  }
+
+  return get_class_name(get_var_type(var_name));
 }
 
 /// Check if two types are compatible for list homogeneity

--- a/src/python-frontend/type_handler.h
+++ b/src/python-frontend/type_handler.h
@@ -85,6 +85,7 @@ public:
    * @return A string representing the variable's type.
    */
   std::string get_var_type(const std::string &var_name) const;
+  std::string get_var_classname(const nlohmann::json &value_node) const;
 
   /*
    * Creates an array_typet.


### PR DESCRIPTION
This PR adds proper indexing resolution through [\_\_getitem\_\_ ](https://docs.python.org/3/reference/datamodel.html#object.__getitem__)and [\_\_setitem\_\_ ](https://docs.python.org/3/reference/datamodel.html#object.__setitem__) when those methods are defined on the object type, matching expected Python behavior for user-defined classes.