### PR TITLE
[python] fix crash on nested attribute method call returning string (#3767)

### DIFF
--- a/regression/python/nested-attr-13/test.desc
+++ b/regression/python/nested-attr-13/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-

--- a/regression/python/nested-attr-8/test.desc
+++ b/regression/python/nested-attr-8/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/nested-attr-9/test.desc
+++ b/regression/python/nested-attr-9/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -587,17 +587,23 @@ void value_sett::get_value_set_rec(
 
     // Look up this symbol, with the given suffix to distinguish any arrays or
     // members we've picked out of it at a higher level.
-    valuest::const_iterator v_it = values.find(sym.get_symbol_name() + suffix);
+    // For level2_global symbols (global variables renamed during symbolic
+    // execution), use the base name for lookup since the value set is indexed
+    // by the level0/level1_global name, not the level2 name.
+    std::string lookup_name =
+      (sym.rlevel == symbol2t::renaming_level::level2_global)
+        ? sym.thename.as_string() + suffix
+        : sym.get_symbol_name() + suffix;
+    valuest::const_iterator v_it = values.find(lookup_name);
 
     if (sym.rlevel == symbol2t::renaming_level::level1_global)
       assert(sym.level1_num == 0);
-    assert(sym.rlevel != symbol2t::renaming_level::level2_global);
-    /* This assertion does not hold: during value_sett::assign() the RHS is the
-     * L2 symbol c:pthread_lib.c@5466@F@pthread_create@startdata in e.g.
-     * - regression/esbmc-unix/02_account_symbolic_06
-     * - regression/esbmc/10_bicycle_01
-     * - regression/nonz3/10_bicycle_02
+    /* These assertions do not hold during value_sett::assign():
+     * - level2 (non-global): the RHS can be an L2 symbol (e.g. pthread_create)
+     * - level2_global: global variables renamed during symbolic execution appear
+     *   as L2_global symbols; their value set is looked up via the base name.
     // assert(sym.rlevel != symbol2t::renaming_level::level2);
+    // assert(sym.rlevel != symbol2t::renaming_level::level2_global);
      */
 
     // If it points at things, put those things into the destination object map.

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -207,17 +207,18 @@ void function_call_expr::get_function_type()
 
     // Check for nested instance attribute (e.g., self.b.a.method())
     // Exclude module.Class.method() pattern
+    // Walk the full attribute chain to find the root Name node, regardless of depth.
     bool is_nested_instance_attr = false;
     if (call_["func"]["value"]["_type"] == "Attribute")
     {
-      if (call_["func"]["value"]["value"]["_type"] == "Name")
+      const nlohmann::json *cur = &call_["func"]["value"];
+      while ((*cur)["_type"] == "Attribute")
+        cur = &(*cur)["value"];
+      if ((*cur)["_type"] == "Name")
       {
-        std::string root_name =
-          call_["func"]["value"]["value"]["id"].get<std::string>();
+        std::string root_name = (*cur)["id"].get<std::string>();
         if (!converter_.is_imported_module(root_name))
-        {
           is_nested_instance_attr = true;
-        }
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3767.

Two bugs caused ESBMC to crash on `self.b.a.f(s)` patterns:

1. **Incorrect method classification (function_call_expr.cpp)**: `is_nested_instance_attr` only checked one level of attributes, so calls such as `self.b.a.f()` were incorrectly treated as ClassMethod instead of InstanceMethod. As a result, self was not passed, leading to an invalid symbol reaching `value_set.cpp`. Fixed by traversing the full attribute chain to the root Name.

2. **level2_global assertion (value_set.cpp)**: `get_value_set_rec()` assumed `level2_global` symbols never occur. However, they appear when string methods are called on global objects during symbolic execution. Fixed by resolving `level2_global` symbols using their base name, consistent with the earlier removal of the similar level2 assertion.