### PR TITLE
[python] fix annotation type mismatch when function returns str (#3772)

### DIFF
--- a/regression/python/github_3772/main.py
+++ b/regression/python/github_3772/main.py
@@ -1,0 +1,10 @@
+def f() -> str:
+    return "x"
+
+
+def test() -> None:
+    y: int = f()
+    assert y == "x"
+
+
+test()

--- a/regression/python/github_3772/test.desc
+++ b/regression/python/github_3772/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3772_2/main.py
+++ b/regression/python/github_3772_2/main.py
@@ -1,0 +1,11 @@
+# Annotation says float but function returns int - Python allows this
+def get_value() -> int:
+    return 42
+
+
+def test() -> None:
+    x: float = get_value()
+    assert x == 42
+
+
+test()

--- a/regression/python/github_3772_2/test.desc
+++ b/regression/python/github_3772_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3772_3/main.py
+++ b/regression/python/github_3772_3/main.py
@@ -1,0 +1,11 @@
+# Annotation says str but function returns int - Python allows this
+def get_num() -> int:
+    return 10
+
+
+def test() -> None:
+    s: str = get_num()
+    assert s == 10
+
+
+test()

--- a/regression/python/github_3772_3/test.desc
+++ b/regression/python/github_3772_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5421,10 +5421,9 @@ std::string python_converter::infer_type_from_any_annotation(
     // use the actual return type so comparisons like y == "x" work correctly.
     bool ret_is_charptr =
       ret_type.is_pointer() && ret_type.subtype() == char_type();
-    bool lhs_is_scalar = !current_element_type.is_pointer() &&
-                         !current_element_type.is_array() &&
-                         !current_element_type.is_struct() &&
-                         !current_element_type.id().empty();
+    bool lhs_is_scalar =
+      !current_element_type.is_pointer() && !current_element_type.is_array() &&
+      !current_element_type.is_struct() && !current_element_type.id().empty();
     if (ret_is_charptr && lhs_is_scalar)
     {
       current_element_type = ret_type;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5386,9 +5386,6 @@ std::string python_converter::infer_type_from_any_annotation(
   const nlohmann::json &ast_node,
   const std::string &lhs_type)
 {
-  if (lhs_type != "Any")
-    return lhs_type;
-
   if (ast_node["value"].is_null() || ast_node["value"]["_type"] != "Call")
     return lhs_type;
 
@@ -5409,8 +5406,30 @@ std::string python_converter::infer_type_from_any_annotation(
   if (func_symbol && func_symbol->type.is_code())
   {
     const code_typet &func_type = to_code_type(func_symbol->type);
-    current_element_type = func_type.return_type();
-    return ""; // Clear to avoid further "Any" processing
+    const typet &ret_type = func_type.return_type();
+
+    if (lhs_type == "Any")
+    {
+      // For Any-annotated variables, always use the function's return type.
+      current_element_type = ret_type;
+      return ""; // Clear to avoid further "Any" processing
+    }
+
+    // Python type annotations are hints only and do not enforce runtime types.
+    // When a function explicitly returns str (char*) but the variable is
+    // annotated with a scalar type (e.g. y: int = f() where f() -> str),
+    // use the actual return type so comparisons like y == "x" work correctly.
+    bool ret_is_charptr =
+      ret_type.is_pointer() && ret_type.subtype() == char_type();
+    bool lhs_is_scalar = !current_element_type.is_pointer() &&
+                         !current_element_type.is_array() &&
+                         !current_element_type.is_struct() &&
+                         !current_element_type.id().empty();
+    if (ret_is_charptr && lhs_is_scalar)
+    {
+      current_element_type = ret_type;
+      return "";
+    }
   }
 
   return lhs_type;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3772.

This PR extends the override logic beyond `Any` to also apply when the called function returns `char*` (`str`) and the annotation is a scalar type.