### PR TITLE
[python] fix type annotation mismatch for method calls returning str (#3775)

### DIFF
--- a/regression/python/github_3775/main.py
+++ b/regression/python/github_3775/main.py
@@ -1,0 +1,13 @@
+class A:
+    pass
+
+class B(A):
+    def f(self) -> str:
+        return "Woof!"
+
+def test():
+    b = B()
+    x: int = b.f()
+    assert x == "Woof!"
+
+test()

--- a/regression/python/github_3775/test.desc
+++ b/regression/python/github_3775/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3775_2/main.py
+++ b/regression/python/github_3775_2/main.py
@@ -1,0 +1,10 @@
+class Dog:
+    def speak(self) -> str:
+        return "Woof!"
+
+def test():
+    d = Dog()
+    x: float = d.speak()
+    assert x == "Woof!"
+
+test()

--- a/regression/python/github_3775_2/test.desc
+++ b/regression/python/github_3775_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3775_3/main.py
+++ b/regression/python/github_3775_3/main.py
@@ -1,0 +1,16 @@
+class Base:
+    pass
+
+class Mid(Base):
+    pass
+
+class Child(Mid):
+    def label(self) -> str:
+        return "hello"
+
+def test():
+    c = Child()
+    y: int = c.label()
+    assert y == "hello"
+
+test()

--- a/regression/python/github_3775_3/test.desc
+++ b/regression/python/github_3775_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3775_4/main.py
+++ b/regression/python/github_3775_4/main.py
@@ -1,0 +1,8 @@
+def greet() -> str:
+    return "Hi"
+
+def test():
+    x: int = greet()
+    assert x == "Hi"
+
+test()

--- a/regression/python/github_3775_4/test.desc
+++ b/regression/python/github_3775_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3775_5/main.py
+++ b/regression/python/github_3775_5/main.py
@@ -1,0 +1,28 @@
+class Animal:
+    def __init__(self, name: str):
+        self.name = name
+        self.energy = 100
+    
+    def move(self) -> int:
+        self.energy -= 10
+        return self.energy
+
+class Dog(Animal):
+    def __init__(self, name: str, breed: str):
+        super().__init__(name)
+        self.breed = breed
+    
+    def bark(self) -> str:
+        self.energy -= 5
+        return "Woof!"
+
+def test_inheritance() -> None:
+    dog = Dog("Buddy", "Golden Retriever")
+    assert dog.energy == 100
+    energy_after_move:int = dog.move()
+    assert energy_after_move == 90
+    sound:int = dog.bark()
+    assert dog.energy == 85
+    assert sound == "Woof!"
+
+test_inheritance()

--- a/regression/python/github_3775_5/test.desc
+++ b/regression/python/github_3775_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/inheritance2/test.desc
+++ b/regression/python/inheritance2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5406,8 +5406,9 @@ std::string python_converter::infer_type_from_any_annotation(
   // For method calls (e.g., b.f()), the method symbol is stored under the
   // class scope (py:file@C@ClassName@F@method), not the top-level scope.
   // Look up the object's class and retry the symbol lookup.
-  if (!func_symbol && func_node["_type"] == "Attribute" &&
-      func_node["value"].contains("id"))
+  if (
+    !func_symbol && func_node["_type"] == "Attribute" &&
+    func_node["value"].contains("id"))
   {
     const std::string obj_name = func_node["value"]["id"].get<std::string>();
     symbol_id obj_sid = create_symbol_id();

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5403,6 +5403,32 @@ std::string python_converter::infer_type_from_any_annotation(
   symbol_id func_sid(current_python_file, "", func_name);
   symbolt *func_symbol = symbol_table_.find_symbol(func_sid.to_string());
 
+  // For method calls (e.g., b.f()), the method symbol is stored under the
+  // class scope (py:file@C@ClassName@F@method), not the top-level scope.
+  // Look up the object's class and retry the symbol lookup.
+  if (!func_symbol && func_node["_type"] == "Attribute" &&
+      func_node["value"].contains("id"))
+  {
+    const std::string obj_name = func_node["value"]["id"].get<std::string>();
+    symbol_id obj_sid = create_symbol_id();
+    obj_sid.set_object(obj_name);
+    const symbolt *obj_sym = symbol_table_.find_symbol(obj_sid.to_string());
+    if (obj_sym)
+    {
+      typet obj_type = ns.follow(obj_sym->type);
+      std::string class_name;
+      if (obj_type.is_struct())
+        class_name = to_struct_type(obj_type).tag().as_string();
+      if (class_name.rfind("tag-", 0) == 0)
+        class_name = class_name.substr(4);
+      if (!class_name.empty())
+      {
+        symbol_id method_sid(current_python_file, class_name, func_name);
+        func_symbol = symbol_table_.find_symbol(method_sid.to_string());
+      }
+    }
+  }
+
   if (func_symbol && func_symbol->type.is_code())
   {
     const code_typet &func_type = to_code_type(func_symbol->type);

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -8631,8 +8631,8 @@ void python_converter::get_return_statements(
   else
   {
     // If we're returning an array but the function expects a pointer,
-    // convert the array to a pointer (for string literals)
-    const typet &expected_return_type = current_element_type;
+    // convert the array to a pointer (for string literals).
+    const typet &expected_return_type = current_func_return_type_;
 
     if (expected_return_type.is_pointer() && return_value.type().is_array())
     {


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3775.

**Problem:** `infer_type_from_any_annotation` only looked up top-level function symbols (e.g., `f()`) but not method symbols (e.g., `b.f()`), which are stored under their class scope (`py:file@C@ClassName@F@method`). For `x: int = b.f()` where `b.f() -> str`, the method symbol lookup failed, leaving `x` typed as int. The function call then stored the `char*` return value in an `int` variable, truncating it to 0 and causing the assertion `x == "Woof!"` to fail with assertion 0.

**Fix:** when the top-level lookup fails for an attribute call (`obj.method()`), resolve obj's class via the symbol table and retry the lookup using the class-scoped symbol ID.