### PR TITLE
[python] fix crash on chained method calls: B().g().f()

### DIFF
--- a/regression/python/github_3778/main.py
+++ b/regression/python/github_3778/main.py
@@ -1,0 +1,10 @@
+class A:
+    def f(self) -> int:
+        return 1
+
+class B:
+    def g(self) -> A:
+        return A()
+
+x = B().g().f()
+assert x == 1

--- a/regression/python/github_3778/test.desc
+++ b/regression/python/github_3778/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3778_2/main.py
+++ b/regression/python/github_3778_2/main.py
@@ -1,0 +1,14 @@
+class C:
+    def h(self) -> int:
+        return 42
+
+class A:
+    def f(self) -> C:
+        return C()
+
+class B:
+    def g(self) -> A:
+        return A()
+
+x = B().g().f().h()
+assert x == 42

--- a/regression/python/github_3778_2/test.desc
+++ b/regression/python/github_3778_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3778_3/main.py
+++ b/regression/python/github_3778_3/main.py
@@ -1,0 +1,10 @@
+class A:
+    def f(self, n: int) -> int:
+        return n + 1
+
+class B:
+    def g(self) -> A:
+        return A()
+
+x = B().g().f(5)
+assert x == 6

--- a/regression/python/github_3778_3/test.desc
+++ b/regression/python/github_3778_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3778_fail/main.py
+++ b/regression/python/github_3778_fail/main.py
@@ -1,0 +1,10 @@
+class A:
+    def f(self) -> int:
+        return 1
+
+class B:
+    def g(self) -> A:
+        return A()
+
+x = B().g().f()
+assert x == 2  # Should fail: f() returns 1, not 2

--- a/regression/python/github_3778_fail/test.desc
+++ b/regression/python/github_3778_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -239,11 +239,16 @@ void function_call_expr::get_function_type()
       }
     }
 
-    // Detect A().f(...): method call on a temporary instance from a constructor.
+    // Detect A().f(...): method call on a temporary instance.
+    // This covers both direct construction (A().f()) and chained method calls
+    // (B().g().f()) — any Call node in the value position means the receiver
+    // is a temporary, so we must treat it as an InstanceMethod regardless of
+    // whether the inferred receiver class name matches a class in the AST.
     bool obj_is_temp_instance =
       call_["func"]["value"]["_type"] == "Call" &&
       call_["func"]["value"].contains("func") &&
-      call_["func"]["value"]["func"]["_type"] == "Name";
+      (call_["func"]["value"]["func"]["_type"] == "Name" ||
+       call_["func"]["value"]["func"]["_type"] == "Attribute");
 
     // Handling a function call as a class method call when:
     // (1) The caller corresponds to a class name, for example: MyClass.foo().
@@ -4562,8 +4567,38 @@ exprt function_call_expr::handle_general_function_call()
         }
         else
         {
-          exprt obj_expr = converter_.get_expr(func_value);
-          call.arguments().push_back(gen_address_of(obj_expr));
+          // Chained method call (e.g., B().g().f()): the receiver is the return
+          // value of an inner method call. Create a temp to hold it and use
+          // &temp as self so that self is addressable in the GOTO IR.
+          std::string receiver_type =
+            type_handler_.get_operand_type(func_value);
+          if (!receiver_type.empty())
+          {
+            typet class_type = type_handler_.get_typet(receiver_type);
+            symbolt &tmp = converter_.create_tmp_symbol(
+              func_value, "$inst$", class_type, exprt());
+            converter_.symbol_table().add(tmp);
+            code_declt tmp_decl(symbol_expr(tmp));
+            tmp_decl.location() = location;
+            converter_.current_block->copy_to_operands(tmp_decl);
+
+            // Process the inner call; set its LHS to tmp so the return value
+            // is stored there (emits: FUNCTION_CALL: tmp = inner_call(...)).
+            exprt inner_call = converter_.get_expr(func_value);
+            if (inner_call.is_code() &&
+                inner_call.statement() == "function_call")
+            {
+              inner_call.op0() = symbol_expr(tmp);
+              inner_call.location() = location;
+              converter_.add_instruction(inner_call);
+            }
+            call.arguments().push_back(gen_address_of(symbol_expr(tmp)));
+          }
+          else
+          {
+            exprt obj_expr = converter_.get_expr(func_value);
+            call.arguments().push_back(gen_address_of(obj_expr));
+          }
         }
       }
       else

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4585,8 +4585,8 @@ exprt function_call_expr::handle_general_function_call()
             // Process the inner call; set its LHS to tmp so the return value
             // is stored there (emits: FUNCTION_CALL: tmp = inner_call(...)).
             exprt inner_call = converter_.get_expr(func_value);
-            if (inner_call.is_code() &&
-                inner_call.statement() == "function_call")
+            if (
+              inner_call.is_code() && inner_call.statement() == "function_call")
             {
               inner_call.op0() = symbol_expr(tmp);
               inner_call.location() = location;

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2252,6 +2252,14 @@ private:
       call["value"]["func"].contains("id"))
       return call["value"]["func"]["id"].template get<std::string>();
 
+    // Handle chained method calls: B().g().f() where B().g() is itself a method
+    // call returning an object. Recursively resolve the return type of B().g()
+    // so that the outer call .f() can look up the method in the right class.
+    if (
+      call["value"]["_type"] == "Call" && call["value"].contains("func") &&
+      call["value"]["func"]["_type"] == "Attribute")
+      return get_type_from_method(call["value"]);
+
     // Handle normal Name values (variable references)
     if (!call["value"].contains("id"))
       return "";

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -896,6 +896,39 @@ std::string type_handler::get_operand_type(const nlohmann::json &operand) const
       return rhs_type;
   }
 
+  // Handle call expressions: constructor calls like A() and method calls like B().g()
+  else if (operand["_type"] == "Call" && operand.contains("func"))
+  {
+    const auto &func = operand["func"];
+    // Direct constructor call: A() — return the class name as the type
+    if (func["_type"] == "Name" && func.contains("id"))
+      return func["id"].get<std::string>();
+    // Method call: obj.method() — infer the return type from the class definition
+    if (
+      func["_type"] == "Attribute" && func.contains("attr") &&
+      func.contains("value"))
+    {
+      std::string obj_type = get_operand_type(func["value"]);
+      if (!obj_type.empty())
+      {
+        std::string method_name = func["attr"].get<std::string>();
+        const auto &ast = converter_.ast();
+        nlohmann::json class_node =
+          json_utils::find_class(ast["body"], obj_type);
+        if (class_node.empty() || !class_node.contains("body"))
+          return std::string();
+        for (const auto &member : class_node["body"])
+        {
+          if (
+            member["_type"] == "FunctionDef" && member["name"] == method_name &&
+            member.contains("returns") && !member["returns"].is_null() &&
+            member["returns"].contains("id"))
+            return member["returns"]["id"].get<std::string>();
+        }
+      }
+    }
+  }
+
   // Handle list subscript (e.g., `mylist[0]`)
   else if (
     operand["_type"] == "Subscript" && operand.contains("value") &&


### PR DESCRIPTION
Fixes #3778.

Three-part fix for "ERROR: Object "" not found" when chaining method calls on returned objects:

**1. python_annotation.h**: `get_object_name()` now recursively resolves the return type of inner method calls (e.g., `B().g() -> A`) instead of returning "" for `Call` nodes with `Attribute` func.

**2. type_handler.cpp**: `get_operand_type()` extended to handle `Call` nodes, enabling `build_function_id()` to determine the correct receiver class.

**3. function_call_expr.cpp**: `obj_is_temp_instance` now covers chained calls (`Attribute` func), thus preventing misclassification as `ClassMethod`; `InstanceMethod` else branch creates a temp symbol, stores the inner call result into it, and passes &temp as self.