### PR TITLE
[python] fix dict.popitem() crash on tuple unpacking (issue #3783)

### DIFF
--- a/regression/python/github_3783_1/main.py
+++ b/regression/python/github_3783_1/main.py
@@ -1,0 +1,7 @@
+# Basic dict.popitem() with string keys and int values
+d: dict[str, int] = {"a": 1, "b": 2, "c": 3}
+key, value = d.popitem()
+# LIFO: last inserted is "c": 3
+assert key == "c"
+assert value == 3
+assert len(d) == 2

--- a/regression/python/github_3783_1/test.desc
+++ b/regression/python/github_3783_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_10-nondet_fail/main.py
+++ b/regression/python/github_3783_10-nondet_fail/main.py
@@ -1,0 +1,7 @@
+# popitem() on a possibly-empty nondet dict raises KeyError
+def test_nondet_dict_popitem_empty_keyerror() -> None:
+    x = nondet_dict(2, key_type=nondet_int(), value_type=nondet_int())
+    # No assumption on len(x): empty dict is reachable -> KeyError
+    k, v = x.popitem()
+
+test_nondet_dict_popitem_empty_keyerror()

--- a/regression/python/github_3783_10-nondet_fail/test.desc
+++ b/regression/python/github_3783_10-nondet_fail/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION FAILED$

--- a/regression/python/github_3783_2/main.py
+++ b/regression/python/github_3783_2/main.py
@@ -1,0 +1,8 @@
+# dict.popitem() reduces dict size and can empty it
+d: dict[str, int] = {"x": 10, "y": 20}
+k1, v1 = d.popitem()
+assert k1 == "y"
+assert v1 == 20
+k2, v2 = d.popitem()
+assert k2 == "x"
+assert v2 == 10

--- a/regression/python/github_3783_2/test.desc
+++ b/regression/python/github_3783_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_3/main.py
+++ b/regression/python/github_3783_3/main.py
@@ -1,0 +1,8 @@
+# dict.popitem() with int values: verify sequential removal
+d: dict[str, int] = {"a": 1, "b": 2, "c": 3}
+k, v = d.popitem()
+assert k == "c"
+assert v == 3
+k2, v2 = d.popitem()
+assert k2 == "b"
+assert v2 == 2

--- a/regression/python/github_3783_3/test.desc
+++ b/regression/python/github_3783_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_4-nondet/main.py
+++ b/regression/python/github_3783_4-nondet/main.py
@@ -1,0 +1,6 @@
+# popitem() returns the nondet value that was inserted last
+v: int = nondet_int()
+d: dict[str, int] = {"a": 1, "b": v}
+key, value = d.popitem()
+assert key == "b"
+assert value == v

--- a/regression/python/github_3783_4-nondet/test.desc
+++ b/regression/python/github_3783_4-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_5-nondet/main.py
+++ b/regression/python/github_3783_5-nondet/main.py
@@ -1,0 +1,13 @@
+# nondet_bool controls whether a second entry is added;
+# popitem() always removes whichever was last inserted
+b: bool = nondet_bool()
+d: dict[str, int] = {"x": 10}
+if b:
+    d["y"] = 20
+    key, val = d.popitem()
+    assert key == "y"
+    assert val == 20
+else:
+    key, val = d.popitem()
+    assert key == "x"
+    assert val == 10

--- a/regression/python/github_3783_5-nondet/test.desc
+++ b/regression/python/github_3783_5-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_6-nondet/main.py
+++ b/regression/python/github_3783_6-nondet/main.py
@@ -1,0 +1,7 @@
+# popitem() on a dict whose value is a nondet_bool preserves the value
+# and the dict is empty afterwards
+flag: bool = nondet_bool()
+d: dict[str, bool] = {"active": flag}
+key, value = d.popitem()
+assert key == "active"
+assert value == flag

--- a/regression/python/github_3783_6-nondet/test.desc
+++ b/regression/python/github_3783_6-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_7-nondet_fail/main.py
+++ b/regression/python/github_3783_7-nondet_fail/main.py
@@ -1,0 +1,6 @@
+# popitem() returns the inserted value; asserting otherwise must fail
+v: int = nondet_int()
+__ESBMC_assume(v > 0)
+d: dict[str, int] = {"a": v}
+key, value = d.popitem()
+assert value != v  # always false — VERIFICATION FAILED expected

--- a/regression/python/github_3783_7-nondet_fail/test.desc
+++ b/regression/python/github_3783_7-nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3783_8-nondet/main.py
+++ b/regression/python/github_3783_8-nondet/main.py
@@ -1,0 +1,9 @@
+# popitem() removes exactly one entry: dict size decreases by 1
+def test_nondet_dict_popitem_key_removed() -> None:
+    x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+    __ESBMC_assume(len(x) > 0)
+    original_size = len(x)
+    k, v = x.popitem()
+    assert len(x) == original_size - 1
+
+test_nondet_dict_popitem_key_removed()

--- a/regression/python/github_3783_8-nondet/test.desc
+++ b/regression/python/github_3783_8-nondet/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_9-nondet/main.py
+++ b/regression/python/github_3783_9-nondet/main.py
@@ -1,0 +1,8 @@
+# popitem() on a single-entry dict leaves it empty
+def test_nondet_dict_popitem_empties_dict() -> None:
+    x = nondet_dict(3, key_type=nondet_int(), value_type=nondet_int())
+    __ESBMC_assume(len(x) == 1)
+    k, v = x.popitem()
+    assert len(x) == 0
+
+test_nondet_dict_popitem_empties_dict()

--- a/regression/python/github_3783_9-nondet/test.desc
+++ b/regression/python/github_3783_9-nondet/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.py
+--unwind 9 --no-bounds-check --no-pointer-check --no-div-by-zero-check --no-align-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3783_fail/main.py
+++ b/regression/python/github_3783_fail/main.py
@@ -1,0 +1,3 @@
+# dict.popitem() on empty dict raises KeyError
+d: dict[str, int] = {}
+key, value = d.popitem()

--- a/regression/python/github_3783_fail/test.desc
+++ b/regression/python/github_3783_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -224,6 +224,8 @@ Below is an overview of ESBMC-Python's key capabilities:
     - **update()**: Merges another dictionary into the current one (e.g., `d.update({"x": 9})`).
     - **get()**: Returns the value for a key, or a default if the key is absent (e.g., `d.get("a", 0)`).
     - **setdefault()**: Returns the value for a key if present; otherwise inserts the key with the given default and returns it (e.g., `d.setdefault("d", 4)`). Supports `int`, `float`, `bool`, and `str` value types.
+    - **pop()**: Removes a key and returns its value (e.g., `d.pop("a")`); raises `KeyError` if the key is absent and no default is provided.
+    - **popitem()**: Removes and returns the last inserted `(key, value)` pair as a tuple (e.g., `key, value = d.popitem()`); raises `KeyError` if the dictionary is empty.
     - **Nested dictionaries**: Supports dicts whose values are themselves dicts (e.g., `dict[int, dict[int, int]]`).
 - **Bytes and Integers**: Supports byte and integer operations, such as conversions and bit length.
 
@@ -408,7 +410,7 @@ The current version of ESBMC-Python has the following limitations:
 - Only `for` loops using the `range()` function are supported.
 - List and String support are partial and limited in functionality. Currently supported list methods include `append()`, `extend()`, `insert()`, `clear()`, `pop()`, `remove()`, and `copy()`.
 - String slicing does not support step values (e.g., string[::2] for every second character is not supported).
-- Dictionary support is partial: the supported operations are literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, and `setdefault()`. Other methods (e.g., `pop()`, `copy()`, `popitem()`) are not yet implemented.
+- Dictionary support is partial: the supported operations are literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, `setdefault()`, `pop()`, and `popitem()`. Other methods (e.g., `copy()`) are not yet implemented.
 - `min()` and `max()` currently support only two arguments and do not handle iterables or the key/default parameters.
 - `any()` currently supports only list literals as arguments and does not support other iterable types.
 - `input()` is modeled as a nondeterministic string with a maximum length of 256 characters (under-approximation).

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2714,6 +2714,7 @@ bool function_call_expr::is_dict_method_call() const
     return sym == nullptr || sym->type != list_type;
   }
 
+  // "popitem" is dict-only (lists have no popitem), no disambiguation needed.
   return true;
 }
 
@@ -2745,6 +2746,10 @@ exprt function_call_expr::handle_dict_method() const
 
   if (method_name == "pop")
     return converter_.get_dict_handler()->handle_dict_pop(
+      symbol_expr(*dict_symbol), call_);
+
+  if (method_name == "popitem")
+    return converter_.get_dict_handler()->handle_dict_popitem(
       symbol_expr(*dict_symbol), call_);
 
   throw std::runtime_error("Unsupported dict method: " + method_name);

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2714,7 +2714,6 @@ bool function_call_expr::is_dict_method_call() const
     return sym == nullptr || sym->type != list_type;
   }
 
-  // "popitem" is dict-only (lists have no popitem), no disambiguation needed.
   return true;
 }
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5573,10 +5573,19 @@ symbolt *python_converter::create_symbol_for_unannotated_assign(
     if (is_dict_method)
     {
       // obj_sym != nullptr is guaranteed by the is_dict_method check above
-      inferred_type = dict_handler_->resolve_expected_type_for_dict_subscript(
-        symbol_expr(*obj_sym));
-      if (inferred_type.is_nil() || inferred_type.is_empty())
-        inferred_type = long_int_type();
+      if (method == "popitem")
+      {
+        // popitem() returns (key, value) tuple — infer the full tuple type
+        inferred_type =
+          dict_handler_->get_popitem_tuple_type(symbol_expr(*obj_sym));
+      }
+      else
+      {
+        inferred_type = dict_handler_->resolve_expected_type_for_dict_subscript(
+          symbol_expr(*obj_sym));
+        if (inferred_type.is_nil() || inferred_type.is_empty())
+          inferred_type = long_int_type();
+      }
     }
     else
     {

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1978,10 +1978,6 @@ typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
               get_dict_key_type_from_annotation(func_def["returns"]);
           }
         }
-        else
-        {
-          key_type = get_dict_key_type_from_annotation(var_decl["annotation"]);
-        }
       }
     }
   }
@@ -1992,8 +1988,7 @@ typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
 
   // Get value type from annotation (default: long int)
   typet val_type = resolve_expected_type_for_dict_subscript(dict_expr);
-  if (val_type.is_nil() || val_type.is_empty())
-    val_type = long_int_type();
+  assert(!val_type.is_empty());
   if (val_type.is_array() && val_type.subtype() == char_type())
     val_type = gen_pointer_type(char_type());
 
@@ -2095,7 +2090,7 @@ exprt python_dict_handler::handle_dict_popitem(
     empty_block.copy_to_operands(raise_code);
   }
 
-  // Non-empty → get last (key, value), remove, build tuple
+  // Non-empty: get last (key, value), remove, build tuple
   code_blockt nonempty_block;
   {
     // last_idx = size - 1
@@ -2129,8 +2124,7 @@ exprt python_dict_handler::handle_dict_popitem(
     key_at_call.location() = location;
     nonempty_block.copy_to_operands(key_at_call);
 
-    // Assign key into tuple BEFORE removing from list (avoid use-after-free
-    // if __ESBMC_list_remove_at frees the PyListObj storage).
+    // Assign key into tuple before removing from list
     member_exprt key_obj_value(
       dereference_exprt(
         symbol_expr(key_obj_var), type_handler_.get_list_element_type()),
@@ -2157,7 +2151,7 @@ exprt python_dict_handler::handle_dict_popitem(
     val_at_call.location() = location;
     nonempty_block.copy_to_operands(val_at_call);
 
-    // Assign value into tuple BEFORE removing from list.
+    // Assign value into tuple before removing from list.
     member_exprt val_obj_value(
       dereference_exprt(
         symbol_expr(val_obj_var), type_handler_.get_list_element_type()),

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1698,9 +1698,8 @@ bool python_dict_handler::is_value_returning_method(
 
 // Retrieve a typed value from a PyObj's void* value field.
 // Used by both handle_dict_pop and handle_dict_popitem.
-static exprt retrieve_list_value(
-  const exprt &obj_value,
-  const typet &result_type)
+static exprt
+retrieve_list_value(const exprt &obj_value, const typet &result_type)
 {
   if (result_type.is_pointer() && result_type.subtype() == char_type())
     return typecast_exprt(obj_value, gen_pointer_type(char_type()));
@@ -1962,8 +1961,7 @@ typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
         if (
           var_decl["annotation"]["_type"] == "Name" &&
           var_decl["annotation"]["id"] == "dict" &&
-          var_decl.contains("value") &&
-          var_decl["value"]["_type"] == "Call" &&
+          var_decl.contains("value") && var_decl["value"]["_type"] == "Call" &&
           var_decl["value"]["func"]["_type"] == "Name")
         {
           std::string func_name =
@@ -1974,8 +1972,7 @@ typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
             !func_def.empty() && func_def.contains("returns") &&
             !func_def["returns"].is_null())
           {
-            key_type =
-              get_dict_key_type_from_annotation(func_def["returns"]);
+            key_type = get_dict_key_type_from_annotation(func_def["returns"]);
           }
         }
       }
@@ -2053,8 +2050,7 @@ exprt python_dict_handler::handle_dict_popitem(
   converter_.add_instruction(size_call);
 
   // Empty dict → raise KeyError
-  exprt is_empty =
-    equality_exprt(symbol_expr(size_var), gen_zero(size_type()));
+  exprt is_empty = equality_exprt(symbol_expr(size_var), gen_zero(size_type()));
 
   code_blockt empty_block;
   {
@@ -2132,7 +2128,8 @@ exprt python_dict_handler::handle_dict_popitem(
       "value",
       pointer_typet(empty_typet()));
     member_exprt key_field(symbol_expr(result_var), "element_0", key_type);
-    code_assignt key_assign(key_field, retrieve_list_value(key_obj_value, key_type));
+    code_assignt key_assign(
+      key_field, retrieve_list_value(key_obj_value, key_type));
     key_assign.location() = location;
     nonempty_block.copy_to_operands(key_assign);
 
@@ -2159,7 +2156,8 @@ exprt python_dict_handler::handle_dict_popitem(
       "value",
       pointer_typet(empty_typet()));
     member_exprt val_field(symbol_expr(result_var), "element_1", val_type);
-    code_assignt val_assign(val_field, retrieve_list_value(val_obj_value, val_type));
+    code_assignt val_assign(
+      val_field, retrieve_list_value(val_obj_value, val_type));
     val_assign.location() = location;
     nonempty_block.copy_to_operands(val_assign);
 

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1988,7 +1988,8 @@ typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
 
   // Get value type from annotation (default: long int)
   typet val_type = resolve_expected_type_for_dict_subscript(dict_expr);
-  assert(!val_type.is_empty());
+  if (val_type.is_nil() || val_type.is_empty())
+    val_type = long_int_type();
   if (val_type.is_array() && val_type.subtype() == char_type())
     val_type = gen_pointer_type(char_type());
 

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -3,6 +3,7 @@
 #include <python-frontend/python_converter.h>
 #include <python-frontend/python_list.h>
 #include <python-frontend/string_builder.h>
+#include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_handler.h>
 #include <util/arith_tools.h>
 #include <util/c_types.h>
@@ -1692,7 +1693,27 @@ bool python_dict_handler::is_value_returning_method(
   const std::string &method_name)
 {
   return method_name == "pop" || method_name == "get" ||
-         method_name == "setdefault";
+         method_name == "setdefault" || method_name == "popitem";
+}
+
+// Retrieve a typed value from a PyObj's void* value field.
+// Used by both handle_dict_pop and handle_dict_popitem.
+static exprt retrieve_list_value(
+  const exprt &obj_value,
+  const typet &result_type)
+{
+  if (result_type.is_pointer() && result_type.subtype() == char_type())
+    return typecast_exprt(obj_value, gen_pointer_type(char_type()));
+  if (result_type.is_floatbv())
+    return dereference_exprt(
+      typecast_exprt(obj_value, pointer_typet(result_type)), result_type);
+  if (result_type.is_signedbv() || result_type.is_unsignedbv())
+    return dereference_exprt(
+      typecast_exprt(obj_value, pointer_typet(result_type)), result_type);
+  if (result_type.is_bool())
+    return dereference_exprt(
+      typecast_exprt(obj_value, pointer_typet(bool_type())), bool_type());
+  return typecast_exprt(obj_value, result_type);
 }
 
 exprt python_dict_handler::handle_dict_pop(
@@ -1819,32 +1840,7 @@ exprt python_dict_handler::handle_dict_pop(
     "value",
     pointer_typet(empty_typet()));
 
-  exprt retrieved_value;
-  if (result_type.is_floatbv())
-  {
-    typecast_exprt value_as_float_ptr(obj_value, pointer_typet(result_type));
-    retrieved_value = dereference_exprt(value_as_float_ptr, result_type);
-  }
-  else if (result_type.is_signedbv() || result_type.is_unsignedbv())
-  {
-    typecast_exprt value_as_int_ptr(obj_value, pointer_typet(result_type));
-    retrieved_value = dereference_exprt(value_as_int_ptr, result_type);
-  }
-  else if (result_type.is_bool())
-  {
-    typecast_exprt value_as_bool_ptr(obj_value, pointer_typet(bool_type()));
-    retrieved_value = dereference_exprt(value_as_bool_ptr, bool_type());
-  }
-  else if (is_string_result)
-  {
-    typecast_exprt value_as_string(obj_value, gen_pointer_type(char_type()));
-    retrieved_value = value_as_string;
-  }
-  else
-  {
-    typecast_exprt value_as_typed(obj_value, result_type);
-    retrieved_value = value_as_typed;
-  }
+  exprt retrieved_value = retrieve_list_value(obj_value, result_type);
 
   code_assignt value_assign(symbol_expr(result_var), retrieved_value);
   value_assign.location() = location;
@@ -1920,6 +1916,280 @@ exprt python_dict_handler::handle_dict_pop(
   if_stmt.cond() = key_found;
   if_stmt.then_case() = then_block;
   if_stmt.else_case() = else_block;
+  if_stmt.location() = location;
+  converter_.add_instruction(if_stmt);
+
+  return symbol_expr(result_var);
+}
+
+typet python_dict_handler::get_dict_key_type_from_annotation(
+  const nlohmann::json &annotation_node)
+{
+  if (!annotation_node.contains("slice"))
+    return empty_typet();
+
+  const auto &slice = annotation_node["slice"];
+  if (
+    slice.contains("_type") && slice["_type"] == "Tuple" &&
+    slice.contains("elts") && slice["elts"].size() >= 2)
+  {
+    return converter_.get_type_from_annotation(
+      slice["elts"][0], annotation_node);
+  }
+
+  return empty_typet();
+}
+
+typet python_dict_handler::get_popitem_tuple_type(const exprt &dict_expr)
+{
+  // Get key type from annotation (default: char* / str).
+  // Mirrors the value-type lookup in resolve_expected_type_for_dict_subscript.
+  typet key_type = empty_typet();
+  if (dict_expr.is_symbol())
+  {
+    const symbolt *sym = symbol_table_.find_symbol(dict_expr.identifier());
+    if (sym)
+    {
+      std::string var_name = sym->name.as_string();
+      nlohmann::json var_decl = json_utils::find_var_decl(
+        var_name,
+        converter_.get_current_func_name(),
+        converter_.get_ast_json());
+      if (!var_decl.empty() && var_decl.contains("annotation"))
+      {
+        // If annotation is a bare "dict" with a function-call initializer,
+        // look up the key type from the function's return annotation.
+        if (
+          var_decl["annotation"]["_type"] == "Name" &&
+          var_decl["annotation"]["id"] == "dict" &&
+          var_decl.contains("value") &&
+          var_decl["value"]["_type"] == "Call" &&
+          var_decl["value"]["func"]["_type"] == "Name")
+        {
+          std::string func_name =
+            var_decl["value"]["func"]["id"].get<std::string>();
+          nlohmann::json func_def = json_utils::find_function(
+            converter_.get_ast_json()["body"], func_name);
+          if (
+            !func_def.empty() && func_def.contains("returns") &&
+            !func_def["returns"].is_null())
+          {
+            key_type =
+              get_dict_key_type_from_annotation(func_def["returns"]);
+          }
+        }
+        else
+        {
+          key_type = get_dict_key_type_from_annotation(var_decl["annotation"]);
+        }
+      }
+    }
+  }
+  if (key_type.is_nil() || key_type.is_empty())
+    key_type = gen_pointer_type(char_type());
+  if (key_type.is_array() && key_type.subtype() == char_type())
+    key_type = gen_pointer_type(char_type());
+
+  // Get value type from annotation (default: long int)
+  typet val_type = resolve_expected_type_for_dict_subscript(dict_expr);
+  if (val_type.is_nil() || val_type.is_empty())
+    val_type = long_int_type();
+  if (val_type.is_array() && val_type.subtype() == char_type())
+    val_type = gen_pointer_type(char_type());
+
+  return converter_.get_tuple_handler().create_tuple_struct_type(
+    {key_type, val_type});
+}
+
+exprt python_dict_handler::handle_dict_popitem(
+  const exprt &dict_expr,
+  const nlohmann::json &call_node)
+{
+  if (!call_node["args"].empty())
+    throw std::runtime_error("popitem() takes no arguments");
+
+  locationt location = converter_.get_location_from_decl(call_node);
+  typet list_type = type_handler_.get_list_type();
+
+  member_exprt keys_member(dict_expr, "keys", list_type);
+  member_exprt values_member(dict_expr, "values", list_type);
+
+  typet tuple_type = get_popitem_tuple_type(dict_expr);
+  const struct_typet &tuple_struct = to_struct_type(tuple_type);
+  typet key_type = tuple_struct.components()[0].type();
+  typet val_type = tuple_struct.components()[1].type();
+
+  const symbolt *size_func =
+    symbol_table_.find_symbol("c:@F@__ESBMC_list_size");
+  if (!size_func)
+    throw std::runtime_error("__ESBMC_list_size not found");
+
+  const symbolt *at_func = symbol_table_.find_symbol("c:@F@__ESBMC_list_at");
+  if (!at_func)
+    throw std::runtime_error("__ESBMC_list_at not found");
+
+  const symbolt *remove_func =
+    symbol_table_.find_symbol("c:@F@__ESBMC_list_remove_at");
+  if (!remove_func)
+    throw std::runtime_error("__ESBMC_list_remove_at not found");
+
+  // Create result variable (tuple)
+  symbolt &result_var = converter_.create_tmp_symbol(
+    call_node, "$dict_popitem_result$", tuple_type, exprt());
+  code_declt result_decl(symbol_expr(result_var));
+  result_decl.location() = location;
+  converter_.add_instruction(result_decl);
+
+  // Get size of the keys list
+  symbolt &size_var = converter_.create_tmp_symbol(
+    call_node, "$dict_popitem_size$", size_type(), exprt());
+  code_declt size_decl(symbol_expr(size_var));
+  size_decl.location() = location;
+  converter_.add_instruction(size_decl);
+
+  code_function_callt size_call;
+  size_call.function() = symbol_expr(*size_func);
+  size_call.lhs() = symbol_expr(size_var);
+  // list_type is already a pointer (PyListObject*), pass directly
+  size_call.arguments().push_back(keys_member);
+  size_call.type() = size_type();
+  size_call.location() = location;
+  converter_.add_instruction(size_call);
+
+  // Empty dict → raise KeyError
+  exprt is_empty =
+    equality_exprt(symbol_expr(size_var), gen_zero(size_type()));
+
+  code_blockt empty_block;
+  {
+    std::string error_msg = "popitem(): dictionary is empty";
+    exprt msg_size_expr = constant_exprt(
+      integer2binary(error_msg.size() + 1, bv_width(size_type())),
+      integer2string(error_msg.size() + 1),
+      size_type());
+    typet str_type = array_typet(char_type(), msg_size_expr);
+
+    symbolt &err_var = converter_.create_tmp_symbol(
+      call_node, "$popitem_err$", str_type, exprt());
+    code_declt err_decl(symbol_expr(err_var));
+    err_decl.location() = location;
+    empty_block.copy_to_operands(err_decl);
+
+    exprt err_str =
+      converter_.get_string_builder().build_string_literal(error_msg);
+    code_assignt err_assign(symbol_expr(err_var), err_str);
+    err_assign.location() = location;
+    empty_block.copy_to_operands(err_assign);
+
+    std::string keyerror_type_str = "KeyError";
+    typet keyerror_type = type_handler_.get_typet(keyerror_type_str);
+    exprt exc_struct("struct", keyerror_type);
+    exc_struct.copy_to_operands(address_of_exprt(symbol_expr(err_var)));
+
+    exprt raise = side_effect_exprt("cpp-throw", keyerror_type);
+    raise.move_to_operands(exc_struct);
+    raise.location() = location;
+
+    code_expressiont raise_code(raise);
+    raise_code.location() = location;
+    empty_block.copy_to_operands(raise_code);
+  }
+
+  // Non-empty → get last (key, value), remove, build tuple
+  code_blockt nonempty_block;
+  {
+    // last_idx = size - 1
+    symbolt &last_idx_var = converter_.create_tmp_symbol(
+      call_node, "$dict_popitem_last_idx$", size_type(), exprt());
+    code_declt last_idx_decl(symbol_expr(last_idx_var));
+    last_idx_decl.location() = location;
+    nonempty_block.copy_to_operands(last_idx_decl);
+
+    exprt last_idx_expr("-", size_type());
+    last_idx_expr.copy_to_operands(symbol_expr(size_var), gen_one(size_type()));
+    code_assignt last_idx_assign(symbol_expr(last_idx_var), last_idx_expr);
+    last_idx_assign.location() = location;
+    nonempty_block.copy_to_operands(last_idx_assign);
+
+    typet obj_ptr_type = pointer_typet(type_handler_.get_list_element_type());
+
+    // Retrieve key
+    symbolt &key_obj_var = converter_.create_tmp_symbol(
+      call_node, "$dict_popitem_key_obj$", obj_ptr_type, exprt());
+    code_declt key_obj_decl(symbol_expr(key_obj_var));
+    key_obj_decl.location() = location;
+    nonempty_block.copy_to_operands(key_obj_decl);
+
+    code_function_callt key_at_call;
+    key_at_call.function() = symbol_expr(*at_func);
+    key_at_call.lhs() = symbol_expr(key_obj_var);
+    key_at_call.arguments().push_back(keys_member);
+    key_at_call.arguments().push_back(symbol_expr(last_idx_var));
+    key_at_call.type() = obj_ptr_type;
+    key_at_call.location() = location;
+    nonempty_block.copy_to_operands(key_at_call);
+
+    // Assign key into tuple BEFORE removing from list (avoid use-after-free
+    // if __ESBMC_list_remove_at frees the PyListObj storage).
+    member_exprt key_obj_value(
+      dereference_exprt(
+        symbol_expr(key_obj_var), type_handler_.get_list_element_type()),
+      "value",
+      pointer_typet(empty_typet()));
+    member_exprt key_field(symbol_expr(result_var), "element_0", key_type);
+    code_assignt key_assign(key_field, retrieve_list_value(key_obj_value, key_type));
+    key_assign.location() = location;
+    nonempty_block.copy_to_operands(key_assign);
+
+    // Retrieve value
+    symbolt &val_obj_var = converter_.create_tmp_symbol(
+      call_node, "$dict_popitem_val_obj$", obj_ptr_type, exprt());
+    code_declt val_obj_decl(symbol_expr(val_obj_var));
+    val_obj_decl.location() = location;
+    nonempty_block.copy_to_operands(val_obj_decl);
+
+    code_function_callt val_at_call;
+    val_at_call.function() = symbol_expr(*at_func);
+    val_at_call.lhs() = symbol_expr(val_obj_var);
+    val_at_call.arguments().push_back(values_member);
+    val_at_call.arguments().push_back(symbol_expr(last_idx_var));
+    val_at_call.type() = obj_ptr_type;
+    val_at_call.location() = location;
+    nonempty_block.copy_to_operands(val_at_call);
+
+    // Assign value into tuple BEFORE removing from list.
+    member_exprt val_obj_value(
+      dereference_exprt(
+        symbol_expr(val_obj_var), type_handler_.get_list_element_type()),
+      "value",
+      pointer_typet(empty_typet()));
+    member_exprt val_field(symbol_expr(result_var), "element_1", val_type);
+    code_assignt val_assign(val_field, retrieve_list_value(val_obj_value, val_type));
+    val_assign.location() = location;
+    nonempty_block.copy_to_operands(val_assign);
+
+    // Now safe to remove: tuple fields are already populated.
+    code_function_callt remove_key;
+    remove_key.function() = symbol_expr(*remove_func);
+    remove_key.arguments().push_back(keys_member);
+    remove_key.arguments().push_back(symbol_expr(last_idx_var));
+    remove_key.type() = bool_type();
+    remove_key.location() = location;
+    nonempty_block.copy_to_operands(remove_key);
+
+    code_function_callt remove_val;
+    remove_val.function() = symbol_expr(*remove_func);
+    remove_val.arguments().push_back(values_member);
+    remove_val.arguments().push_back(symbol_expr(last_idx_var));
+    remove_val.type() = bool_type();
+    remove_val.location() = location;
+    nonempty_block.copy_to_operands(remove_val);
+  }
+
+  code_ifthenelset if_stmt;
+  if_stmt.cond() = is_empty;
+  if_stmt.then_case() = empty_block;
+  if_stmt.else_case() = nonempty_block;
   if_stmt.location() = location;
   converter_.add_instruction(if_stmt);
 

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -321,6 +321,25 @@ public:
   get_dict_value_type_from_annotation(const nlohmann::json &annotation_node);
 
   /**
+   * @brief Returns the tuple type (key_type, value_type) for dict.popitem().
+   * @param dict_expr The dictionary expression (must be a symbol)
+   * @return struct_typet with element_0=key_type, element_1=value_type
+   */
+  typet get_popitem_tuple_type(const exprt &dict_expr);
+
+  /**
+   * @brief Handles dict.popitem() method calls.
+   * Implements Python's dict.popitem() semantics:
+   * - Raises KeyError if the dictionary is empty.
+   * - Otherwise removes and returns the last (key, value) pair as a tuple.
+   * @param dict_expr The dictionary expression
+   * @param call_node The function call AST node
+   * @return Expression representing the (key, value) tuple
+   */
+  exprt
+  handle_dict_popitem(const exprt &dict_expr, const nlohmann::json &call_node);
+
+  /**
    * @brief Resolve expected type for dict subscript using variable annotation
    *
    * Looks up the dict variable's annotation to determine what type
@@ -481,6 +500,15 @@ private:
 
   /// Counter for generating unique dictionary variable names
   static int dict_counter_;
+
+  /**
+   * @brief Extract key type from dict type annotation.
+   * For annotations like `dict[K, V]`, extracts the key type K.
+   * @param annotation_node The annotation AST node (Subscript with slice)
+   * @return The key type, or empty_typet if cannot be determined
+   */
+  typet
+  get_dict_key_type_from_annotation(const nlohmann::json &annotation_node);
 
   /**
    * @brief Extracts the key expression from a subscript slice node.

--- a/src/python-frontend/tuple_handler.h
+++ b/src/python-frontend/tuple_handler.h
@@ -94,14 +94,6 @@ public:
   exprt handle_tuple_membership(const exprt &lhs, const exprt &rhs, bool invert)
     const;
 
-private:
-  /**
-   * @brief Build a unique tag name for a tuple based on element types
-   * @param element_types Vector of types for tuple elements
-   * @return std::string The tag name (e.g., "tag-tuple_int_str")
-   */
-  std::string build_tuple_tag(const std::vector<typet> &element_types) const;
-
   /**
    * @brief Create a tuple struct type from element types
    * @param element_types Vector of types for tuple elements
@@ -109,6 +101,14 @@ private:
    */
   struct_typet
   create_tuple_struct_type(const std::vector<typet> &element_types) const;
+
+private:
+  /**
+   * @brief Build a unique tag name for a tuple based on element types
+   * @param element_types Vector of types for tuple elements
+   * @return std::string The tag name (e.g., "tag-tuple_int_str")
+   */
+  std::string build_tuple_tag(const std::vector<typet> &element_types) const;
 
   python_converter &converter_;
   type_handler &type_handler_;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3783.

Implement dict.popitem() in the Python frontend. Previously, calling popitem() fell through to the undefined-function stub (assert(false)), returning an empty expression; the tuple-unpacking handler then crashed with "Cannot unpack empty - only tuples and arrays can be unpacked".

The fix implements handle_dict_popitem() following the same GOTO IR pattern as handle_dict_pop(): retrieve the last key and value via __ESBMC_list_size/__ESBMC_list_at, build a (key, value) tuple struct, remove the last element from both lists, and raise KeyError on an empty dict. create_symbol_for_unannotated_assign() is updated to infer the tuple return type for popitem() without double-evaluating the call.