### PR TITLE
[python] support nested attribute chain resolution for non-self base objects

### DIFF
--- a/regression/python/github_3824/main.py
+++ b/regression/python/github_3824/main.py
@@ -1,0 +1,15 @@
+class C:
+    def f(self):
+        return 1
+
+class B:
+    def __init__(self):
+        self.c = C()
+
+class A:
+    def __init__(self):
+        self.b = B()
+
+a = A()
+x = a.b.c.f()
+assert x == 1

--- a/regression/python/github_3824/test.desc
+++ b/regression/python/github_3824/test.desc
@@ -2,4 +2,3 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-

--- a/regression/python/github_3824_2/main.py
+++ b/regression/python/github_3824_2/main.py
@@ -1,0 +1,16 @@
+# Test with explicit type annotations on intermediate attributes
+class C:
+    def get_value(self) -> int:
+        return 42
+
+class B:
+    def __init__(self):
+        self.c: C = C()
+
+class A:
+    def __init__(self):
+        self.b: B = B()
+
+a = A()
+result = a.b.c.get_value()
+assert result == 42

--- a/regression/python/github_3824_2/test.desc
+++ b/regression/python/github_3824_2/test.desc
@@ -2,4 +2,3 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-

--- a/regression/python/github_3824_3/main.py
+++ b/regression/python/github_3824_3/main.py
@@ -1,0 +1,18 @@
+# Test self.b.c.f() pattern (nested attribute on self)
+class C:
+    def get_value(self) -> int:
+        return 7
+
+class B:
+    def __init__(self):
+        self.c = C()
+
+class A:
+    def __init__(self):
+        self.b = B()
+
+    def run(self) -> int:
+        return self.b.c.get_value()
+
+a = A()
+assert a.run() == 7

--- a/regression/python/github_3824_3/test.desc
+++ b/regression/python/github_3824_3/test.desc
@@ -2,4 +2,3 @@ CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-

--- a/regression/python/nested-attr-15/test.desc
+++ b/regression/python/nested-attr-15/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2708,7 +2708,8 @@ private:
               json_utils::find_class(ast_["body"], current_type);
             if (!final_class.empty())
             {
-              const std::string &method_name = call["func"]["attr"];
+              const std::string method_name =
+                call["func"]["attr"].template get<std::string>();
               for (const Json &method : final_class["body"])
               {
                 if (

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2608,8 +2608,7 @@ private:
               var_node["annotation"]["id"].template get<std::string>();
           // Assign: a = A()
           else if (
-            var_node.contains("value") &&
-            var_node["value"].contains("_type") &&
+            var_node.contains("value") && var_node["value"].contains("_type") &&
             var_node["value"]["_type"] == "Call" &&
             var_node["value"].contains("func") &&
             var_node["value"]["func"].contains("_type") &&
@@ -2650,8 +2649,7 @@ private:
           for (const Json &member : current_class["body"])
           {
             if (
-              member["_type"] != "FunctionDef" ||
-              member["name"] != "__init__")
+              member["_type"] != "FunctionDef" || member["name"] != "__init__")
               continue;
             for (const Json &stmt : member["body"])
             {
@@ -2662,8 +2660,7 @@ private:
                 stmt["target"]["value"].contains("id") &&
                 stmt["target"]["value"]["id"] == "self" &&
                 stmt["target"]["attr"] == chain_attr &&
-                stmt.contains("annotation") &&
-                !stmt["annotation"].is_null() &&
+                stmt.contains("annotation") && !stmt["annotation"].is_null() &&
                 stmt["annotation"].contains("id") &&
                 !stmt["annotation"]["id"].is_null())
               {
@@ -2674,15 +2671,14 @@ private:
               }
               // Assign: self.attr = SomeClass()
               if (
-                stmt["_type"] == "Assign" &&
-                stmt.contains("targets") && !stmt["targets"].empty() &&
+                stmt["_type"] == "Assign" && stmt.contains("targets") &&
+                !stmt["targets"].empty() &&
                 stmt["targets"][0].contains("_type") &&
                 stmt["targets"][0]["_type"] == "Attribute" &&
                 stmt["targets"][0]["value"].contains("id") &&
                 stmt["targets"][0]["value"]["id"] == "self" &&
                 stmt["targets"][0]["attr"] == chain_attr &&
-                stmt.contains("value") &&
-                stmt["value"].contains("_type") &&
+                stmt.contains("value") && stmt["value"].contains("_type") &&
                 stmt["value"]["_type"] == "Call" &&
                 stmt["value"].contains("func") &&
                 stmt["value"]["func"].contains("_type") &&
@@ -2717,17 +2713,14 @@ private:
                   method["name"] == method_name)
                 {
                   if (
-                    method.contains("returns") &&
-                    !method["returns"].is_null())
+                    method.contains("returns") && !method["returns"].is_null())
                   {
                     const auto &ret = method["returns"];
                     if (ret.contains("id"))
                       return ret["id"].template get<std::string>();
                     if (
-                      ret.contains("_type") &&
-                      ret["_type"] == "Subscript" &&
-                      ret.contains("value") &&
-                      ret["value"].contains("id"))
+                      ret.contains("_type") && ret["_type"] == "Subscript" &&
+                      ret.contains("value") && ret["value"].contains("id"))
                       return ret["value"]["id"].template get<std::string>();
                   }
                   // Infer return type from return statements when no annotation

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2718,8 +2718,18 @@ private:
                 {
                   if (
                     method.contains("returns") &&
-                    method["returns"].contains("id"))
-                    return method["returns"]["id"].template get<std::string>();
+                    !method["returns"].is_null())
+                  {
+                    const auto &ret = method["returns"];
+                    if (ret.contains("id"))
+                      return ret["id"].template get<std::string>();
+                    if (
+                      ret.contains("_type") &&
+                      ret["_type"] == "Subscript" &&
+                      ret.contains("value") &&
+                      ret["value"].contains("id"))
+                      return ret["value"]["id"].template get<std::string>();
+                  }
                   // Infer return type from return statements when no annotation
                   std::string inferred =
                     infer_from_return_statements(method["body"], method_name);

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2568,11 +2568,12 @@ private:
       // For self.b.a, we get [a, b] but need [b, a] to process left to right
       std::reverse(attr_chain.begin(), attr_chain.end());
 
-      // If base object is "self" and we have at least one attribute, resolve the chain
-      if (base_obj == "self" && !attr_chain.empty() && current_func != nullptr)
+      // Determine the initial class type of the base object.
+      // Handles both "self" (look up current class) and arbitrary variables
+      // (look up variable type from annotation or constructor call).
+      std::string initial_type;
+      if (base_obj == "self" && current_func != nullptr)
       {
-        // Get the class name from current_func's context
-        std::string class_name = "";
         for (const Json &elem : ast_["body"])
         {
           if (elem["_type"] == "ClassDef" && elem.contains("body"))
@@ -2583,66 +2584,124 @@ private:
                 member["_type"] == "FunctionDef" &&
                 member["name"] == (*current_func)["name"])
               {
-                class_name = elem["name"].template get<std::string>();
+                initial_type = elem["name"].template get<std::string>();
                 break;
               }
             }
-            if (!class_name.empty())
+            if (!initial_type.empty())
               break;
           }
         }
+      }
+      else if (!base_obj.empty())
+      {
+        Json var_node =
+          json_utils::find_var_decl(base_obj, get_current_func_name(), ast_);
+        if (!var_node.empty())
+        {
+          // AnnAssign: a: A = ...
+          if (
+            var_node.contains("annotation") &&
+            !var_node["annotation"].is_null() &&
+            var_node["annotation"].contains("id"))
+            initial_type =
+              var_node["annotation"]["id"].template get<std::string>();
+          // Assign: a = A()
+          else if (
+            var_node.contains("value") &&
+            var_node["value"].contains("_type") &&
+            var_node["value"]["_type"] == "Call" &&
+            var_node["value"].contains("func") &&
+            var_node["value"]["func"].contains("_type") &&
+            var_node["value"]["func"]["_type"] == "Name" &&
+            var_node["value"]["func"].contains("id"))
+            initial_type =
+              var_node["value"]["func"]["id"].template get<std::string>();
+        }
+        // Also check function parameters
+        if (
+          initial_type.empty() && current_func != nullptr &&
+          (*current_func).contains("args") &&
+          (*current_func)["args"].contains("args"))
+        {
+          Json param =
+            find_annotated_assign(base_obj, (*current_func)["args"]["args"]);
+          if (
+            !param.empty() && param.contains("annotation") &&
+            !param["annotation"].is_null() &&
+            param["annotation"].contains("id"))
+            initial_type =
+              param["annotation"]["id"].template get<std::string>();
+        }
+      }
 
-        // Recursively resolve the attribute chain
-        std::string current_type = class_name;
+      if (!initial_type.empty() && !attr_chain.empty())
+      {
+        std::string current_type = initial_type;
         for (size_t i = 0; i < attr_chain.size(); ++i)
         {
-          const std::string &attr_name = attr_chain[i];
-
-          // Find the current class
+          const std::string &chain_attr = attr_chain[i];
           Json current_class =
             json_utils::find_class(ast_["body"], current_type);
           if (current_class.empty())
             break;
 
-          // Look for the attribute in __init__ method
           bool found = false;
           for (const Json &member : current_class["body"])
           {
             if (
-              member["_type"] == "FunctionDef" && member["name"] == "__init__")
+              member["_type"] != "FunctionDef" ||
+              member["name"] != "__init__")
+              continue;
+            for (const Json &stmt : member["body"])
             {
-              for (const Json &stmt : member["body"])
+              // AnnAssign: self.attr: Type = value
+              if (
+                stmt["_type"] == "AnnAssign" &&
+                stmt["target"]["_type"] == "Attribute" &&
+                stmt["target"]["value"].contains("id") &&
+                stmt["target"]["value"]["id"] == "self" &&
+                stmt["target"]["attr"] == chain_attr &&
+                stmt.contains("annotation") &&
+                !stmt["annotation"].is_null() &&
+                stmt["annotation"].contains("id") &&
+                !stmt["annotation"]["id"].is_null())
               {
-                // Check for AnnAssign: self.attr: Type = value
-                if (
-                  stmt["_type"] == "AnnAssign" &&
-                  stmt["target"]["_type"] == "Attribute" &&
-                  stmt["target"]["value"]["id"] == "self" &&
-                  stmt["target"]["attr"] == attr_name)
-                {
-                  // Found the attribute, get its type
-                  if (
-                    stmt.contains("annotation") &&
-                    !stmt["annotation"].is_null() &&
-                    stmt["annotation"].contains("id") &&
-                    !stmt["annotation"]["id"].is_null())
-                  {
-                    current_type =
-                      stmt["annotation"]["id"].template get<std::string>();
-                    found = true;
-                    break;
-                  }
-                }
-              }
-              if (found)
+                current_type =
+                  stmt["annotation"]["id"].template get<std::string>();
+                found = true;
                 break;
+              }
+              // Assign: self.attr = SomeClass()
+              if (
+                stmt["_type"] == "Assign" &&
+                stmt.contains("targets") && !stmt["targets"].empty() &&
+                stmt["targets"][0].contains("_type") &&
+                stmt["targets"][0]["_type"] == "Attribute" &&
+                stmt["targets"][0]["value"].contains("id") &&
+                stmt["targets"][0]["value"]["id"] == "self" &&
+                stmt["targets"][0]["attr"] == chain_attr &&
+                stmt.contains("value") &&
+                stmt["value"].contains("_type") &&
+                stmt["value"]["_type"] == "Call" &&
+                stmt["value"].contains("func") &&
+                stmt["value"]["func"].contains("_type") &&
+                stmt["value"]["func"]["_type"] == "Name" &&
+                stmt["value"]["func"].contains("id"))
+              {
+                current_type =
+                  stmt["value"]["func"]["id"].template get<std::string>();
+                found = true;
+                break;
+              }
             }
+            if (found)
+              break;
           }
 
           if (!found)
             break;
 
-          // If this is the last attribute in the chain, find the method return type
           if (i == attr_chain.size() - 1)
           {
             Json final_class =
@@ -2659,15 +2718,21 @@ private:
                   if (
                     method.contains("returns") &&
                     method["returns"].contains("id"))
-                  {
                     return method["returns"]["id"].template get<std::string>();
-                  }
+                  // Infer return type from return statements when no annotation
+                  std::string inferred =
+                    infer_from_return_statements(method["body"], method_name);
+                  return inferred.empty() ? "Any" : inferred;
                 }
               }
             }
+            // Chain resolved but method not in final class
+            return "";
           }
         }
       }
+      // Could not resolve chain - return empty rather than throwing
+      return "";
     }
 
     if (obj_node.empty())
@@ -3006,6 +3071,11 @@ private:
         // Method call on temporary instance (e.g., A().f()): let converter infer
         // if get_type_from_method couldn't resolve (class not in AST etc.)
         else if (func.contains("value") && func["value"]["_type"] == "Call")
+          return InferResult::UNKNOWN;
+        // Method call on nested attribute chain (e.g., a.b.c.f()): could not
+        // resolve type - let converter infer
+        else if (
+          func.contains("value") && func["value"]["_type"] == "Attribute")
           return InferResult::UNKNOWN;
       }
     }


### PR DESCRIPTION
Fixes #3824.

`get_type_from_method()` built a dotted string `"a.b.c"` for chains such as `a.b.c.f()` and tried to look it up as a variable name (always failing). The existing chain resolver handled only `self.x.y.f()` and matched only annotated `AnnAssign` nodes, missing plain `self.c = C()` assignments.

This PR extends the resolver to handle arbitrary base variables by looking up their type from the variable declaration (annotation or constructor call). It also handles plain `Assign` nodes alongside `AnnAssign` when walking the chain. Lastly, this PR adds return "" at block end to prevent spurious throw for unresolvable chains; adds `InferResult::UNKNOWN` fallback in the caller. 

Promote `nested-attr-14` and `nested-attr-15` from `KNOWNBUG` to `CORE` as they now pass.