### PR TITLE
[python] cast any_type (void*) to integer for arithmetic and ordering ops

### DIFF
--- a/regression/python/github_3836/main.py
+++ b/regression/python/github_3836/main.py
@@ -1,0 +1,9 @@
+def f(a, k):
+    p = a[0]
+    b = [x for x in a if x > p]
+    n = len(a) - len(b)
+    if k >= n:
+        return f(b, k - n)
+    return p
+
+assert f([1,2,3], 1) == 2

--- a/regression/python/github_3836/test.desc
+++ b/regression/python/github_3836/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3836_2/main.py
+++ b/regression/python/github_3836_2/main.py
@@ -1,0 +1,7 @@
+# Unannotated int param in ordering comparison with subtraction (simpler case)
+def count_down(n):
+    if n <= 0:
+        return 0
+    return count_down(n - 1) + 1
+
+assert count_down(5) == 5

--- a/regression/python/github_3836_2/test.desc
+++ b/regression/python/github_3836_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3836_fail/main.py
+++ b/regression/python/github_3836_fail/main.py
@@ -1,0 +1,11 @@
+# A failing case: accessing first element of empty filtered list
+def f(a, k):
+    p = a[0]
+    b = [x for x in a if x > p]
+    n = len(a) - len(b)
+    if k >= n:
+        return f(b, k - n)
+    return p
+
+# f([3], 1) must fail: b is empty, k=1 >= n=1, then f([], 1) has a[0] OOB
+assert f([3], 1) == 3

--- a/regression/python/github_3836_fail/test.desc
+++ b/regression/python/github_3836_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --bitwuzla
+^VERIFICATION FAILED$

--- a/regression/quixbugs/kth/test.desc
+++ b/regression/quixbugs/kth/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---unwind 4 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
+--bitwuzla --unwind 4 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2052,15 +2052,31 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   if (!type_mismatch_result.is_nil())
     return type_mismatch_result;
 
-  // Handle Any-typed (void*) operands in comparisons: cast the concrete side
-  // to void* make sure like `y == False` work when y is Any-typed.
+  // Detect any_type (void*) operands — unannotated Python parameters.
+  auto is_any_ptr = [](const exprt &e) {
+    return e.type().is_pointer() && e.type().subtype().id() == "empty";
+  };
+  auto is_integer = [](const exprt &e) {
+    return e.type().is_signedbv() || e.type().is_unsignedbv();
+  };
+
+  // For arithmetic operations (Sub, Add, Mult, etc.) on an any_type (void*)
+  // operand combined with an integer operand, cast the void* to the integer type.
   if (
-    type_utils::is_relational_op(op) || op == "Is" || op == "IsNot" ||
-    op == "In" || op == "NotIn")
+    !type_utils::is_relational_op(op) && op != "Is" && op != "IsNot" &&
+    op != "In" && op != "NotIn")
   {
-    auto is_any_ptr = [](const exprt &e) {
-      return e.type().is_pointer() && e.type().subtype().id() == "empty";
-    };
+    if (is_any_ptr(lhs) && is_integer(rhs))
+      lhs = typecast_exprt(lhs, rhs.type());
+    else if (is_any_ptr(rhs) && is_integer(lhs))
+      rhs = typecast_exprt(rhs, lhs.type());
+  }
+
+  // Handle Any-typed (void*) operands in comparisons.
+  if (
+    type_utils::is_ordered_comparison(op) || op == "Eq" || op == "NotEq" ||
+    op == "Is" || op == "IsNot" || op == "In" || op == "NotIn")
+  {
     auto cast_to_void_ptr = [](exprt &e, const typet &ptr_type) {
       if (e.type().is_floatbv())
       {
@@ -2072,9 +2088,19 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
       e = typecast_exprt(e, ptr_type);
     };
     if (is_any_ptr(lhs) && !is_any_ptr(rhs) && !rhs.type().is_pointer())
-      cast_to_void_ptr(rhs, lhs.type());
+    {
+      if (type_utils::is_ordered_comparison(op) && is_integer(rhs))
+        lhs = typecast_exprt(lhs, rhs.type()); // cast void* to integer
+      else
+        cast_to_void_ptr(rhs, lhs.type()); // cast integer to void*
+    }
     else if (is_any_ptr(rhs) && !is_any_ptr(lhs) && !lhs.type().is_pointer())
-      cast_to_void_ptr(lhs, rhs.type());
+    {
+      if (type_utils::is_ordered_comparison(op) && is_integer(lhs))
+        rhs = typecast_exprt(rhs, lhs.type()); // cast void* to integer
+      else
+        cast_to_void_ptr(lhs, rhs.type()); // cast integer to void*
+    }
   }
 
   // Handle special mathematical operations


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3836.

In this PR, in `get_binary_operator_expr`, when one operand is `void*` and the other is an integer, cast the `void*` to the integer type for both arithmetic operations and ordering comparisons. Equality/identity operators retain the existing `void*` cast to preserve `y == False` and similar patterns. It also replaces the local `is_ordering_op` lambda with `type_utils::is_ordered_comparison` and tightens the comparison guard to exclude And/Or (which are `BoolOp`, not `BinOp`, but were admitted by the broader `is_relational_op` predicate).

This PR promotes `quixbugs/kth` from `KNOWNBUG` to `CORE`.