### PR TITLE
[python] fix super().method() crash with return type annotations (issue #3838)

### DIFF
--- a/regression/python/class-attributes_fail/test.desc
+++ b/regression/python/class-attributes_fail/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/python/github_3838_1/main.py
+++ b/regression/python/github_3838_1/main.py
@@ -1,0 +1,13 @@
+# Test: super().method() with return type annotation (the exact issue from #3838)
+class A:
+    def f(self) -> str:
+        return "A"
+
+class B(A):
+    def f(self) -> str:
+        x = super().f()
+        return x
+
+b = B()
+result = b.f()
+assert result == "A"

--- a/regression/python/github_3838_1/test.desc
+++ b/regression/python/github_3838_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3838_2/main.py
+++ b/regression/python/github_3838_2/main.py
@@ -1,0 +1,11 @@
+# Test: super().method() returning int with annotation
+class Base:
+    def get_value(self) -> int:
+        return 42
+
+class Derived(Base):
+    def get_value(self) -> int:
+        return super().get_value() + 1
+
+d = Derived()
+assert d.get_value() == 43

--- a/regression/python/github_3838_2/test.desc
+++ b/regression/python/github_3838_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3838_3/main.py
+++ b/regression/python/github_3838_3/main.py
@@ -1,0 +1,12 @@
+# Test: super().method() result used in arithmetic
+class Shape:
+    def area(self) -> int:
+        return 10
+
+class Square(Shape):
+    def area(self) -> int:
+        base_area: int = super().area()
+        return base_area * 2
+
+s = Square()
+assert s.area() == 20

--- a/regression/python/github_3838_3/test.desc
+++ b/regression/python/github_3838_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3838_4-nondet/main.py
+++ b/regression/python/github_3838_4-nondet/main.py
@@ -1,0 +1,15 @@
+# Test: super().method() with nondet input
+class Counter:
+    def increment(self, x: int) -> int:
+        return x + 1
+
+class DoubleCounter(Counter):
+    def increment(self, x: int) -> int:
+        base: int = super().increment(x)
+        return base + 1
+
+c = DoubleCounter()
+n: int = nondet_int()
+__ESBMC_assume(n >= 0 and n <= 100)
+result: int = c.increment(n)
+assert result == n + 2

--- a/regression/python/github_3838_4-nondet/test.desc
+++ b/regression/python/github_3838_4-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2458,6 +2458,47 @@ private:
                               ? call["func"]["attr"].template get<std::string>()
                               : "";
 
+    // Handle super().method() calls: look up the method in the parent class.
+    // Only handles simple base class names; dotted names (e.g. module.Base)
+    // and multiple-inheritance MRO traversal beyond the first base are not
+    // supported — they fall back to "Any".
+    if (obj == "super" && !attr_name.empty() && !current_class_name_.empty())
+    {
+      Json class_node = json_utils::find_class(ast_["body"], current_class_name_);
+      if (
+        !class_node.empty() && class_node.contains("bases") &&
+        !class_node["bases"].empty() &&
+        class_node["bases"][0].contains("id"))
+      {
+        const std::string base_name =
+          class_node["bases"][0]["id"].template get<std::string>();
+        Json base_class = json_utils::find_class(ast_["body"], base_name);
+        if (!base_class.empty())
+        {
+          for (const Json &member : base_class["body"])
+          {
+            if (member["_type"] != "FunctionDef" || member["name"] != attr_name)
+              continue;
+            if (member.contains("returns") && !member["returns"].is_null())
+            {
+              const Json &ret = member["returns"];
+              if (ret.contains("id"))
+                return ret["id"].template get<std::string>();
+              if (
+                ret.contains("_type") && ret["_type"] == "Subscript" &&
+                ret.contains("value") && ret["value"].contains("id"))
+                return ret["value"]["id"].template get<std::string>();
+            }
+            // attr_name == member["name"] by the loop invariant above
+            std::string inferred =
+              infer_from_return_statements(member["body"], attr_name);
+            return inferred.empty() ? "Any" : inferred;
+          }
+        }
+      }
+      return "Any";
+    }
+
     // Handle dict.keys() and dict.values()
     if (attr_name == "keys" || attr_name == "values")
     {

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2464,11 +2464,11 @@ private:
     // supported — they fall back to "Any".
     if (obj == "super" && !attr_name.empty() && !current_class_name_.empty())
     {
-      Json class_node = json_utils::find_class(ast_["body"], current_class_name_);
+      Json class_node =
+        json_utils::find_class(ast_["body"], current_class_name_);
       if (
         !class_node.empty() && class_node.contains("bases") &&
-        !class_node["bases"].empty() &&
-        class_node["bases"][0].contains("id"))
+        !class_node["bases"].empty() && class_node["bases"][0].contains("id"))
       {
         const std::string base_name =
           class_node["bases"][0]["id"].template get<std::string>();


### PR DESCRIPTION
Fixes #3838.

When `super().method()` was used inside a method with a return type annotation, `get_type_from_method()` in `python_annotation.h` tried to find a variable or class named "super" in the AST, found nothing, and threw "Object 'super' not found." before reaching the converter.

This PR adds a `super()` handler that uses `current_class_name_` to resolve the first base class and look up the method's return type there, matching Python 3 single-inheritance `super()` semantics.