### PR TITLE
[python] add support for global variable lookup from class methods (issue #3851)

### DIFF
--- a/regression/python/github_3851/main.py
+++ b/regression/python/github_3851/main.py
@@ -1,0 +1,9 @@
+class A:
+    def pre(self) -> bool:
+        return counter > 0
+
+
+counter: int = 1
+
+a = A()
+assert a.pre()

--- a/regression/python/github_3851/test.desc
+++ b/regression/python/github_3851/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3851_1-nondet/main.py
+++ b/regression/python/github_3851_1-nondet/main.py
@@ -1,0 +1,14 @@
+# Global declared after class; method branches on a nondet int global.
+# If counter >= 0, pre() returns True; otherwise False.
+# The assertion must hold under all nondet values satisfying the assumption.
+
+class A:
+    def pre(self) -> bool:
+        return counter >= 0
+
+
+counter: int = nondet_int()
+__ESBMC_assume(counter >= 0)
+
+a = A()
+assert a.pre()

--- a/regression/python/github_3851_1-nondet/test.desc
+++ b/regression/python/github_3851_1-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3851_2-nondet/main.py
+++ b/regression/python/github_3851_2-nondet/main.py
@@ -1,0 +1,15 @@
+# Bool global declared after class; method returns it and caller branches.
+# Verifies that both True and False paths through the method are reachable.
+
+class Guard:
+    def is_enabled(self) -> bool:
+        return enabled
+
+
+enabled: bool = nondet_bool()
+
+g = Guard()
+if g.is_enabled():
+    assert enabled
+else:
+    assert not enabled

--- a/regression/python/github_3851_2-nondet/test.desc
+++ b/regression/python/github_3851_2-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3851_2/main.py
+++ b/regression/python/github_3851_2/main.py
@@ -1,0 +1,15 @@
+# Multiple class methods referencing globals declared after the class
+class Checker:
+    def check_positive(self) -> bool:
+        return threshold > 0
+
+    def check_max(self) -> bool:
+        return threshold <= max_val
+
+
+threshold: int = 5
+max_val: int = 100
+
+c = Checker()
+assert c.check_positive()
+assert c.check_max()

--- a/regression/python/github_3851_2/test.desc
+++ b/regression/python/github_3851_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3851_3-nondet/main.py
+++ b/regression/python/github_3851_3-nondet/main.py
@@ -1,0 +1,20 @@
+# Two nondet int globals declared after a class with two methods.
+# Verifies both globals are visible inside the methods under all nondet values.
+
+class Range:
+    def in_range(self, x: int) -> bool:
+        return lo <= x <= hi
+
+    def width(self) -> int:
+        return hi - lo
+
+
+lo: int = nondet_int()
+hi: int = nondet_int()
+__ESBMC_assume(lo >= 0)
+__ESBMC_assume(hi >= lo)
+
+r = Range()
+assert r.width() >= 0
+assert r.in_range(lo)
+assert r.in_range(hi)

--- a/regression/python/github_3851_3-nondet/test.desc
+++ b/regression/python/github_3851_3-nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_3851_4-nondet_fail/main.py
+++ b/regression/python/github_3851_4-nondet_fail/main.py
@@ -1,0 +1,12 @@
+# Nondet int global with no assumption — method can return False,
+# so the assertion is reachable and must fail.
+
+class A:
+    def pre(self) -> bool:
+        return counter > 0
+
+
+counter: int = nondet_int()
+
+a = A()
+assert a.pre()

--- a/regression/python/github_3851_4-nondet_fail/test.desc
+++ b/regression/python/github_3851_4-nondet_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_3851_fail/main.py
+++ b/regression/python/github_3851_fail/main.py
@@ -1,0 +1,10 @@
+# Global variable accessed from method - assertion should fail
+class A:
+    def pre(self) -> bool:
+        return counter > 0
+
+
+counter: int = 0
+
+a = A()
+assert a.pre()

--- a/regression/python/github_3851_fail/test.desc
+++ b/regression/python/github_3851_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -171,12 +171,24 @@ symbol_id function_call_builder::build_function_id() const
        * symbol table, until we reach the final object whose class we need.
        */
 
+      // Tracks the dotted module path being built during type resolution.
+      // Set as a side-effect in the Name base case and extended in Attribute
+      // nodes when type resolution fails, so that pkg.mod4.MyClass() can be
+      // recognised as module "pkg.mod4" without a separate traversal pass.
+      std::string module_path_candidate;
+
       std::function<typet(const nlohmann::json &)> resolve_attr_type =
         [&](const nlohmann::json &node) -> typet {
         if (node["_type"] == "Name")
         {
           // Base case: resolve variable to its type
-          std::string name = node["id"].get<std::string>();
+          std::string name = node.value("id", "");
+          if (name.empty())
+            return typet();
+
+          // Track the name for dotted-path reconstruction (used when type
+          // resolution fails and we need to check for a module path).
+          module_path_candidate = name;
 
           // Skip module names - let the module handling logic deal with them
           if (converter_.is_imported_module(name))
@@ -192,8 +204,18 @@ symbol_id function_call_builder::build_function_id() const
         {
           // Recursive case: resolve base, then look up member
           typet base_type = resolve_attr_type(node["value"]);
-          if (base_type.id().empty())
+          std::string attr = node.value("attr", "");
+          if (attr.empty())
             return typet();
+          if (base_type.id().empty())
+          {
+            // Type resolution failed for the base — extend the dotted path
+            // candidate so the caller can check is_imported_module on the
+            // full path (e.g., "pkg" + "mod4" -> "pkg.mod4").
+            if (!module_path_candidate.empty())
+              module_path_candidate += "." + attr;
+            return typet();
+          }
 
           // Normalize type (dereference pointers, follow symbol types)
           if (base_type.is_pointer())
@@ -205,7 +227,6 @@ symbol_id function_call_builder::build_function_id() const
           if (base_type.is_struct())
           {
             const struct_typet &struct_type = to_struct_type(base_type);
-            std::string attr = node["attr"].get<std::string>();
             if (struct_type.has_component(attr))
               return struct_type.get_component(attr).type();
             // Not an instance member — check for class-level symbol
@@ -255,24 +276,22 @@ symbol_id function_call_builder::build_function_id() const
       }
       else
       {
-        // Fallback: try to reconstruct the full dotted module path.
-        // For pkg.mod4.MyClass(), func_json["value"] is the "pkg.mod4" Attribute
-        // node, and we need obj_name = "pkg.mod4" (not just "mod4") so that
-        // is_imported_module() can find the module registered under its full name.
-        std::function<std::string(const nlohmann::json &)> build_module_path =
-          [&](const nlohmann::json &n) -> std::string {
-          if (n["_type"] == "Name")
-            return n["id"].get<std::string>();
-          if (n["_type"] == "Attribute")
-            return build_module_path(n["value"]) + "." +
-                   n["attr"].get<std::string>();
-          return "";
-        };
-        std::string full_module = build_module_path(func_json["value"]);
-        if (!full_module.empty() && converter_.is_imported_module(full_module))
-          obj_name = full_module;
+        // Type resolution failed. module_path_candidate was built as a
+        // side-effect of resolve_attr_type; check whether it names a module
+        // that is directly registered (e.g., "pkg.mod4" for pkg.mod4.MyClass()).
+        // We require get_imported_module_path() to be non-empty rather than
+        // just is_imported_module(), because is_imported_module() can return
+        // true based solely on a JSON file existing (is_module fallback), even
+        // for submodules like "os.path" that are registered under their stem
+        // ("path") rather than their dotted name. If the dotted name has no
+        // direct path mapping, fall back to the last attribute component
+        // (e.g., "path" for os.path.exists()) which IS in imported_modules.
+        if (
+          !module_path_candidate.empty() &&
+          !converter_.get_imported_module_path(module_path_candidate).empty())
+          obj_name = module_path_candidate;
         else
-          obj_name = func_json["value"]["attr"].get<std::string>();
+          obj_name = func_json["value"].value("attr", "");
       }
     }
     else if (

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -255,9 +255,24 @@ symbol_id function_call_builder::build_function_id() const
       }
       else
       {
-        // Fallback: use the direct attribute name
-        // For module.Class.method(), we want "Class" as the object name
-        obj_name = func_json["value"]["attr"].get<std::string>();
+        // Fallback: try to reconstruct the full dotted module path.
+        // For pkg.mod4.MyClass(), func_json["value"] is the "pkg.mod4" Attribute
+        // node, and we need obj_name = "pkg.mod4" (not just "mod4") so that
+        // is_imported_module() can find the module registered under its full name.
+        std::function<std::string(const nlohmann::json &)> build_module_path =
+          [&](const nlohmann::json &n) -> std::string {
+          if (n["_type"] == "Name")
+            return n["id"].get<std::string>();
+          if (n["_type"] == "Attribute")
+            return build_module_path(n["value"]) + "." +
+                   n["attr"].get<std::string>();
+          return "";
+        };
+        std::string full_module = build_module_path(func_json["value"]);
+        if (!full_module.empty() && converter_.is_imported_module(full_module))
+          obj_name = full_module;
+        else
+          obj_name = func_json["value"]["attr"].get<std::string>();
       }
     }
     else if (

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4847,6 +4847,10 @@ exprt function_call_expr::handle_general_function_call()
       // is a struct (class instance), take its address and cast to the pointer type
       // so that the attribute access handler can safely cast back and dereference.
       // Follow symbol types because class symbols use symbol_typet, not struct_typet.
+      // NOTE: python_converter.cpp has a complementary post-processing pass that
+      // handles the general pointer-to-struct coercion case. This earlier pass is
+      // specific to the char[0]* union representation and materialises non-symbol
+      // struct temporaries before taking their address.
       typet arg_followed_type = converter_.ns.follow(arg.type());
       if (
         param_type.is_pointer() &&

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4853,8 +4853,7 @@ exprt function_call_expr::handle_general_function_call()
       // struct temporaries before taking their address.
       typet arg_followed_type = converter_.ns.follow(arg.type());
       if (
-        param_type.is_pointer() &&
-        param_type.subtype().is_array() &&
+        param_type.is_pointer() && param_type.subtype().is_array() &&
         param_type.subtype().subtype() == char_type() &&
         arg_followed_type.is_struct())
       {

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4841,6 +4841,34 @@ exprt function_call_expr::handle_general_function_call()
           arg = converter_.wrap_in_optional(arg, param_type);
         }
       }
+
+      // Handle struct argument passed to a union-typed parameter (e.g. str | T).
+      // Union parameters are stored as pointer(char[0]). When the actual argument
+      // is a struct (class instance), take its address and cast to the pointer type
+      // so that the attribute access handler can safely cast back and dereference.
+      // Follow symbol types because class symbols use symbol_typet, not struct_typet.
+      typet arg_followed_type = converter_.ns.follow(arg.type());
+      if (
+        param_type.is_pointer() &&
+        param_type.subtype().is_array() &&
+        param_type.subtype().subtype() == char_type() &&
+        arg_followed_type.is_struct())
+      {
+        if (!arg.is_symbol())
+        {
+          // Materialize the struct in a temp variable first
+          symbolt &tmp = converter_.create_tmp_symbol(
+            call_, "$union_arg$", arg.type(), gen_zero(arg.type()));
+          code_declt tmp_decl(symbol_expr(tmp));
+          tmp_decl.location() = location;
+          converter_.current_block->copy_to_operands(tmp_decl);
+          code_assignt tmp_assign(symbol_expr(tmp), arg);
+          tmp_assign.location() = location;
+          converter_.current_block->copy_to_operands(tmp_assign);
+          arg = symbol_expr(tmp);
+        }
+        arg = typecast_exprt(address_of_exprt(arg), param_type);
+      }
     }
 
     // Handle string literal constants

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -11,6 +11,15 @@
 
 namespace json_utils
 {
+/// Convert a dotted Python module name to a filesystem path segment.
+/// Example: "pkg.mod4" -> "pkg/mod4", "l.ks.foo" -> "l/ks/foo"
+inline std::string dotted_to_path(const std::string &module_name)
+{
+  std::string result = module_name;
+  std::replace(result.begin(), result.end(), '.', '/');
+  return result;
+}
+
 template <typename JsonType>
 bool search_function_in_ast(const JsonType &node, const std::string &func_name)
 {
@@ -81,10 +90,7 @@ bool is_class(const std::string &name, const JsonType &ast_json)
   // Use continue after a negative result
   // so that all Import&ImportFrom nodes are scanned
   auto load_and_check = [&](const std::string &module_name) -> bool {
-    // Convert dotted module name to directory path (e.g., "l.ks.foo" -> "l/ks/foo")
-    std::string module_path_str = module_name;
-    std::replace(module_path_str.begin(), module_path_str.end(), '.', '/');
-    const std::string path = output_dir + "/" + module_path_str + ".json";
+    const std::string path = output_dir + "/" + dotted_to_path(module_name) + ".json";
     auto it = module_cache.find(path);
     if (it == module_cache.end())
     {
@@ -126,11 +132,8 @@ bool is_module(const std::string &module_name, const JsonType &ast)
   if (!ast.contains("ast_output_dir"))
     return false;
 
-  // Convert dotted module name to directory path (e.g., "pkg.mod4" -> "pkg/mod4")
-  std::string module_path_str = module_name;
-  std::replace(module_path_str.begin(), module_path_str.end(), '.', '/');
   const std::string path = ast["ast_output_dir"].template get<std::string>() +
-                           "/" + module_path_str + ".json";
+                           "/" + dotted_to_path(module_name) + ".json";
 
   auto it = is_module_cache.find(path);
   if (it != is_module_cache.end())

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -81,7 +81,10 @@ bool is_class(const std::string &name, const JsonType &ast_json)
   // Use continue after a negative result
   // so that all Import&ImportFrom nodes are scanned
   auto load_and_check = [&](const std::string &module_name) -> bool {
-    const std::string path = output_dir + "/" + module_name + ".json";
+    // Convert dotted module name to directory path (e.g., "l.ks.foo" -> "l/ks/foo")
+    std::string module_path_str = module_name;
+    std::replace(module_path_str.begin(), module_path_str.end(), '.', '/');
+    const std::string path = output_dir + "/" + module_path_str + ".json";
     auto it = module_cache.find(path);
     if (it == module_cache.end())
     {
@@ -123,8 +126,11 @@ bool is_module(const std::string &module_name, const JsonType &ast)
   if (!ast.contains("ast_output_dir"))
     return false;
 
+  // Convert dotted module name to directory path (e.g., "pkg.mod4" -> "pkg/mod4")
+  std::string module_path_str = module_name;
+  std::replace(module_path_str.begin(), module_path_str.end(), '.', '/');
   const std::string path = ast["ast_output_dir"].template get<std::string>() +
-                           "/" + module_name + ".json";
+                           "/" + module_path_str + ".json";
 
   auto it = is_module_cache.find(path);
   if (it != is_module_cache.end())

--- a/src/python-frontend/json_utils.h
+++ b/src/python-frontend/json_utils.h
@@ -90,7 +90,8 @@ bool is_class(const std::string &name, const JsonType &ast_json)
   // Use continue after a negative result
   // so that all Import&ImportFrom nodes are scanned
   auto load_and_check = [&](const std::string &module_name) -> bool {
-    const std::string path = output_dir + "/" + dotted_to_path(module_name) + ".json";
+    const std::string path =
+      output_dir + "/" + dotted_to_path(module_name) + ".json";
     auto it = module_cache.find(path);
     if (it == module_cache.end())
     {

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1536,6 +1536,10 @@ private:
               functions_in_analysis_.erase(func_name);
               if (returns.contains("value") && returns["value"].is_null())
                 return "NoneType";
+              else if (
+                returns.contains("value") && returns["value"].is_string())
+                // Forward reference annotation: -> "float", -> "MyClass", etc.
+                return returns["value"].template get<std::string>();
               else if (returns.contains("value"))
                 return "Any"; // Other constant types
             }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1538,8 +1538,25 @@ private:
                 return "NoneType";
               else if (
                 returns.contains("value") && returns["value"].is_string())
+              {
                 // Forward reference annotation: -> "float", -> "MyClass", etc.
-                return returns["value"].template get<std::string>();
+                // Validate that the string looks like a Python identifier (or
+                // dotted name) before returning it, to guard against arbitrary
+                // string constants used as non-type annotations.
+                std::string type_name =
+                  returns["value"].template get<std::string>();
+                bool valid = !type_name.empty() &&
+                             (std::isalpha((unsigned char)type_name[0]) ||
+                              type_name[0] == '_');
+                for (size_t i = 1; valid && i < type_name.size(); ++i)
+                  valid =
+                    std::isalnum((unsigned char)type_name[i]) ||
+                    type_name[i] == '_' || type_name[i] == '.';
+                if (valid)
+                  return type_name;
+                // Not a valid identifier — treat as opaque
+                return "Any";
+              }
               else if (returns.contains("value"))
                 return "Any"; // Other constant types
             }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -3508,12 +3508,6 @@ private:
 
   void update_assignment_node(Json &element, const std::string &inferred_type)
   {
-    // Update type field
-    element["_type"] = "AnnAssign";
-    // Mark as inferred to distinguish from explicit
-    // annotations like `x: Any = ...` during assignment type handling.
-    element["_inferred_annotation"] = true;
-
     auto target = element["targets"][0];
     std::string id;
 
@@ -3527,7 +3521,13 @@ private:
            target["attr"].template get<std::string>();
     }
     else if (target.contains("slice"))
-      return; // No need to annotate assignments to array elements.
+      return; // No need to annotate subscript assignments (e.g. d["k"] = v).
+
+    // Update type field only after confirming this is an annotatable target.
+    element["_type"] = "AnnAssign";
+    // Mark as inferred to distinguish from explicit
+    // annotations like `x: Any = ...` during assignment type handling.
+    element["_inferred_annotation"] = true;
 
     assert(!id.empty());
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1549,9 +1549,8 @@ private:
                              (std::isalpha((unsigned char)type_name[0]) ||
                               type_name[0] == '_');
                 for (size_t i = 1; valid && i < type_name.size(); ++i)
-                  valid =
-                    std::isalnum((unsigned char)type_name[i]) ||
-                    type_name[i] == '_' || type_name[i] == '.';
+                  valid = std::isalnum((unsigned char)type_name[i]) ||
+                          type_name[i] == '_' || type_name[i] == '.';
                 if (valid)
                   return type_name;
                 // Not a valid identifier — treat as opaque

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6021,6 +6021,49 @@ python_converter::extract_target_name(const nlohmann::json &target) const
     "Unsupported assignment target type: " + target_type.get<std::string>());
 }
 
+void python_converter::preregister_global_variables(
+  const nlohmann::json &ast_body)
+{
+  // Pre-register module-level annotated variable symbols so that class methods
+  // can reference globals declared later in the source (Python LEGB rule).
+  // Only annotated assignments (AnnAssign) carry enough type information for
+  // symbol registration; plain Assign without annotation is skipped via the
+  // nil-type guard below.
+  for (const auto &element : ast_body)
+  {
+    if (element.value("_type", "") != "AnnAssign")
+      continue;
+
+    const auto &target = element["target"];
+    if (!target.contains("id"))
+      continue;
+
+    const std::string var_name = target["id"].get<std::string>();
+
+    symbol_id sid(current_python_file, "", "");
+    sid.set_object(var_name);
+
+    if (symbol_table_.find_symbol(sid.to_string()))
+      continue;
+
+    typet var_type = extract_type_info(element).second;
+    if (var_type.is_nil() || var_type.is_empty())
+      continue;
+
+    locationt location = get_location_from_decl(element);
+    std::string module_name =
+      current_python_file.substr(0, current_python_file.find_last_of("."));
+
+    symbolt symbol =
+      create_symbol(module_name, var_name, sid.to_string(), location, var_type);
+    symbol.lvalue = true;
+    symbol.file_local = true;
+    symbol.is_extern = false;
+
+    symbol_table_.move_symbol_to_context(symbol);
+  }
+}
+
 void python_converter::get_var_assign(
   const nlohmann::json &ast_node,
   codet &target_block)
@@ -9827,6 +9870,10 @@ void python_converter::convert()
   // Create a block to hold intrinsic assignments and load C intrinsics
   code_blockt intrinsic_block;
   load_c_intrisics(intrinsic_block);
+
+  // Pre-register module-level variable symbols so class methods can reference
+  // globals declared later in the file (Python LEGB rule).
+  preregister_global_variables((*ast_json)["body"]);
 
   // Variables to hold user code and initialization code
   codet user_code;

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3747,7 +3747,14 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
                 arg_actual_type = ns.follow(arg_actual_type);
             }
           }
-          // Handle union types: if param is pointer and arg is struct (or symbol to struct), take address
+          // Handle union types: if param is pointer and arg is struct (or symbol
+          // to struct), take address. This is the post-processing pass for
+          // general pointer-to-struct coercion.
+          // NOTE: function_call_expr.cpp also has an earlier coercion pass that
+          // specifically handles char[0]* union parameters (str | T pattern).
+          // These two mechanisms are complementary: the pass here handles the
+          // general case; the earlier pass handles the specific char[0]* union
+          // representation and also materialises non-symbol struct temporaries.
           if (
             param_type.is_pointer() && arg_actual_type.is_struct() &&
             !arg.is_address_of() && !arg_actual_type.is_pointer())
@@ -6071,11 +6078,15 @@ void python_converter::preregister_global_variables(
     {
       var_type = extract_type_info(element).second;
     }
-    catch (const std::exception &)
+    catch (const std::exception &e)
     {
       // Type not yet resolvable (e.g., from an unprocessed import). Skip for
       // now; the variable will be registered when the assignment is processed
       // after imports are loaded.
+      log_warning(
+        "preregister_global_variables: skipping '{}' ({})",
+        element["target"].value("id", "<unknown>"),
+        e.what());
       continue;
     }
     if (var_type.is_nil() || var_type.is_empty())

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6034,6 +6034,23 @@ void python_converter::preregister_global_variables(
     if (element.value("_type", "") != "AnnAssign")
       continue;
 
+    // Skip implicitly inferred annotations (plain Assign converted by the
+    // annotator). Only preregister variables that the user explicitly annotated
+    // (e.g., `x: SomeClass = ...`). Inferred globals like `l = [1, 2, 3]`
+    // should not be visible inside functions that don't declare `global l`.
+    if (element.value("_inferred_annotation", false))
+      continue;
+
+    // Skip union-type forward declarations (e.g., `x: str | datetime`).
+    // These are bare declarations with no value and the union type cannot be
+    // reliably resolved at this stage. The variable will be registered when
+    // the actual assignment is processed (after imports are loaded).
+    if (
+      element.contains("annotation") && !element["annotation"].is_null() &&
+      element["annotation"].value("_type", "") == "BinOp" &&
+      element.contains("value") && element["value"].is_null())
+      continue;
+
     if (!element.contains("target"))
       continue;
 
@@ -6049,7 +6066,18 @@ void python_converter::preregister_global_variables(
     if (symbol_table_.find_symbol(sid.to_string()))
       continue;
 
-    typet var_type = extract_type_info(element).second;
+    typet var_type;
+    try
+    {
+      var_type = extract_type_info(element).second;
+    }
+    catch (const std::exception &)
+    {
+      // Type not yet resolvable (e.g., from an unprocessed import). Skip for
+      // now; the variable will be registered when the assignment is processed
+      // after imports are loaded.
+      continue;
+    }
     if (var_type.is_nil() || var_type.is_empty())
       continue;
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6034,6 +6034,9 @@ void python_converter::preregister_global_variables(
     if (element.value("_type", "") != "AnnAssign")
       continue;
 
+    if (!element.contains("target"))
+      continue;
+
     const auto &target = element["target"];
     if (!target.contains("id"))
       continue;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -258,6 +258,8 @@ private:
 
   void get_var_assign(const nlohmann::json &ast_node, codet &target_block);
 
+  void preregister_global_variables(const nlohmann::json &ast_body);
+
   typet
   resolve_variable_type(const std::string &var_name, const locationt &loc);
 


### PR DESCRIPTION
Fixes #3851.

Class methods can now reference module-level variables declared after the class definition, in accordance with Python's LEGB name resolution rule.

Root cause: `get_block` processes statements in source order, so when a `ClassDef` is processed first, symbols for later-declared globals are not yet in the symbol table, causing a 'Variable not defined' abort.

This PR adds `preregister_global_variables()` to pre-register all annotated module-level variable symbols before any class or function bodies are converted, so forward references from methods resolve correctly.