### PR TITLE
[ir-ra] add theorem-driven enclosure bounds and regressions

### DIFF
--- a/regression/ir-ra/ra-enclosure-bounds-add/main.c
+++ b/regression/ir-ra/ra-enclosure-bounds-add/main.c
@@ -1,0 +1,17 @@
+/* Regression: --ir-ra should process a double-precision addition through the
+ * enclosure path. The assertion is intentionally false so ESBMC produces a
+ * counterexample and exercises the encoding. */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;
+
+  /* This is always falsifiable: x=1, y=0 gives z=1 which is not > 2. */
+  assert(z > x + y + 1.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-enclosure-bounds-add/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-add/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--ir-ra --z3
+^VERIFICATION FAILED$
+
+

--- a/regression/ir-ra/ra-enclosure-bounds-add/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-add/test.desc
@@ -2,5 +2,3 @@ CORE
 main.c
 --ir-ra --z3
 ^VERIFICATION FAILED$
-
-

--- a/regression/ir-ra/ra-enclosure-bounds-chain/main.c
+++ b/regression/ir-ra/ra-enclosure-bounds-chain/main.c
@@ -1,0 +1,20 @@
+/* Regression: --ir-ra should process a small chain of double-precision
+ * operations through the enclosure path. The assertion is intentionally false
+ * so ESBMC produces a counterexample and exercises multiple enclosure sites. */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double a = __VERIFIER_nondet_double();
+  double b = __VERIFIER_nondet_double();
+  double c = __VERIFIER_nondet_double();
+
+  double t = a * b; /* first enclosure pair generated here */
+  double s = t + c; /* second enclosure pair generated here */
+
+  /* Falsifiable: a=1, b=1, c=0 gives s=1, which is not > 100. */
+  assert(s > 100.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-enclosure-bounds-chain/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-chain/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--ir-ra --z3
+^VERIFICATION FAILED$
+
+

--- a/regression/ir-ra/ra-enclosure-bounds-chain/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-chain/test.desc
@@ -2,5 +2,3 @@ CORE
 main.c
 --ir-ra --z3
 ^VERIFICATION FAILED$
-
-

--- a/regression/ir-ra/ra-enclosure-bounds-mul/main.c
+++ b/regression/ir-ra/ra-enclosure-bounds-mul/main.c
@@ -1,0 +1,17 @@
+/* Regression: --ir-ra should process a double-precision multiplication through
+ * the enclosure path. The assertion is intentionally false so ESBMC produces a
+ * counterexample and exercises the encoding. */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double a = __VERIFIER_nondet_double();
+  double b = __VERIFIER_nondet_double();
+  double p = a * b;
+
+  /* Falsifiable: a=0, b=anything gives p=0 which is not > a+b in general. */
+  assert(p > a + b + 1.0);
+  return 0;
+}

--- a/regression/ir-ra/ra-enclosure-bounds-mul/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-mul/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--ir-ra --z3
+^VERIFICATION FAILED$
+
+

--- a/regression/ir-ra/ra-enclosure-bounds-mul/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-mul/test.desc
@@ -2,5 +2,3 @@ CORE
 main.c
 --ir-ra --z3
 ^VERIFICATION FAILED$
-
-

--- a/regression/ir-ra/ra-enclosure-generation/test.desc
+++ b/regression/ir-ra/ra-enclosure-generation/test.desc
@@ -2,4 +2,3 @@ CORE
 main.c
 --ir-ra --z3
 ^VERIFICATION FAILED$
-

--- a/regression/ir-ra/ra-enclosure-multiple-ops/test.desc
+++ b/regression/ir-ra/ra-enclosure-multiple-ops/test.desc
@@ -2,4 +2,3 @@ CORE
 main.c
 --ir-ra --z3
 ^VERIFICATION FAILED$
-

--- a/regression/ir-ra/ra-enclosure-tight-bounds-float/main.c
+++ b/regression/ir-ra/ra-enclosure-tight-bounds-float/main.c
@@ -48,7 +48,7 @@
  *
  * The first four patterns are absent in the old weak encoding.  The eps_rel
  * numerator 5960464477539063 is also distinct from the double-precision
- * numerator 2220446049250313, so the test specifically targets the
+ * numerator 5551115123125783, so the test specifically targets the
  * single-precision path in apply_ieee754_semantics.
  */
 #include <assert.h>

--- a/regression/ir-ra/ra-enclosure-tight-bounds-float/main.c
+++ b/regression/ir-ra/ra-enclosure-tight-bounds-float/main.c
@@ -1,0 +1,68 @@
+/* Regression test: theorem-driven tight enclosure under --ir-ra, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-enclosure-tight-bounds/ but exercises the IEEE single-precision
+ * (float) path instead of double.  Verifies that the SMT formula emitted by
+ * --ir-ra for a float addition contains the structural hallmarks of the NEW
+ * theorem-driven encoding, not just the old containment-only (weak) encoding.
+ *
+ * OLD weak encoding:
+ *   (declare-fun |smt_conv::ra_lo::N| () Real)
+ *   (declare-fun |smt_conv::ra_hi::N| () Real)
+ *   (assert (<= |ra_lo| result))
+ *   (assert (<= result  |ra_hi|))
+ *   (assert (<= |ra_lo| |ra_hi|))
+ *   No ITE.  No epsilon constants.
+ *
+ * NEW theorem-driven encoding also emits:
+ *   B(r)  = eps_rel * |r| + eps_abs
+ *   ra_lo = r - B(r),   ra_hi = r + B(r)
+ * where for single precision (IEEE 754 binary32):
+ *   eps_rel = 2^-24 ~= 5.960464477539063e-08
+ *           = (/ 5960464477539063.0 100000000000000000000000.0)  in SMT-LIB
+ *   eps_abs = 2^-149 (minimum positive subnormal)
+ * and |r| is encoded as:
+ *   (ite (< r 0.0) (- 0.0 r) r)
+ *
+ * WHY THE VERDICT ALONE IS NOT ENOUGH
+ * ------------------------------------
+ * In integer/real encoding the C variable z is the exact real sum x+y.
+ * ra_lo and ra_hi are SMT-internal auxiliary symbols that do not constrain z.
+ * Both encodings produce the same verdict for any C-level assertion; only the
+ * formula content differs.
+ *
+ * ASSERTION CHOICE
+ * ----------------
+ * "z != x + y" is always false in real arithmetic (z was assigned x+y), so
+ * VERIFICATION FAILED is deterministic and independent of encoding strength.
+ * It serves as a run-completion guard, not an encoding-sensitive signal.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)  -- symbol declared
+ *   \(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)  -- symbol declared
+ *   \(ite                                              -- |r| absolute value
+ *   5960464477539063                                   -- eps_rel numerator (2^-24)
+ *   ^VERIFICATION FAILED$                             -- run completed
+ *
+ * The first four patterns are absent in the old weak encoding.  The eps_rel
+ * numerator 5960464477539063 is also distinct from the double-precision
+ * numerator 2220446049250313, so the test specifically targets the
+ * single-precision path in apply_ieee754_semantics.
+ */
+#include <assert.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* triggers apply_ieee754_semantics -> ra_lo::0, ra_hi::0 */
+
+  /* Always false in real/integer encoding: z == x+y exactly.
+   * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-enclosure-tight-bounds-float/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds-float/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
+\(ite
+5960464477539063
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-tight-bounds-float/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds-float/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --ir-ra --z3 --smt-formula-too
-\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
-\(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
 \(ite
 5960464477539063
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-tight-bounds/main.c
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/main.c
@@ -21,7 +21,7 @@
  *     ra_lo = r - B(r),   ra_hi = r + B(r)
  *   encoded as:
  *     (ite (< r 0.0) (- 0.0 r) r)               <- |r| via ITE
- *     (* (/ 2220446049250313.0 ...) |r|)         <- eps_rel = 2^-53
+ *     (* (/ 5551115123125783.0 ...) |r|)         <- eps_rel = 2^-53
  *
  * WHY THE VERDICT ALONE IS NOT ENOUGH
  * ------------------------------------
@@ -42,7 +42,7 @@
  *   \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)  -- symbol declared
  *   \(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)  -- symbol declared
  *   \(ite                                              -- |r| absolute value
- *   2220446049250313                                   -- eps_rel numerator
+ *   5551115123125783                                   -- eps_rel numerator
  *   ^VERIFICATION FAILED$                             -- run completed
  *
  * The first four patterns are absent in the old weak encoding; the last is

--- a/regression/ir-ra/ra-enclosure-tight-bounds/main.c
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/main.c
@@ -1,0 +1,65 @@
+/* Regression test: theorem-driven tight enclosure under --ir-ra.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that the SMT formula emitted by --ir-ra for a double-precision
+ * addition contains the structural hallmarks of the NEW theorem-driven
+ * encoding, NOT just the old containment-only (weak) encoding.
+ *
+ * OLD weak encoding (commit b83680d40e):
+ *   (declare-fun |smt_conv::ra_lo::N| () Real)
+ *   (declare-fun |smt_conv::ra_hi::N| () Real)
+ *   (assert (<= |ra_lo| result))        <- containment only
+ *   (assert (<= result  |ra_hi|))
+ *   (assert (<= |ra_lo| |ra_hi|))
+ *   No ITE.  No epsilon constants.
+ *
+ * NEW theorem-driven encoding:
+ *   Same declarations, PLUS four pinning constraints that tie ra_lo/ra_hi
+ *   to the sound symmetric error enclosure:
+ *     B(r)  = eps_rel * |r| + eps_abs
+ *     ra_lo = r - B(r),   ra_hi = r + B(r)
+ *   encoded as:
+ *     (ite (< r 0.0) (- 0.0 r) r)               <- |r| via ITE
+ *     (* (/ 2220446049250313.0 ...) |r|)         <- eps_rel = 2^-53
+ *
+ * WHY THE VERDICT ALONE IS NOT ENOUGH
+ * ------------------------------------
+ * In integer/real encoding the C variable z is assigned the *exact* real sum
+ * x+y.  ra_lo and ra_hi are SMT-internal auxiliary symbols that do not feed
+ * back into z.  Both encodings therefore produce the same verification
+ * verdict for any C-level assertion.  Only the formula content differs.
+ *
+ * ASSERTION CHOICE
+ * ----------------
+ * "z != x + y" is always false in real arithmetic (z was just assigned x+y),
+ * so the verdict is deterministically VERIFICATION FAILED regardless of
+ * solver search.  This makes the verdict check a stable sanity-of-run guard
+ * rather than an encoding-sensitive signal.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)  -- symbol declared
+ *   \(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)  -- symbol declared
+ *   \(ite                                              -- |r| absolute value
+ *   2220446049250313                                   -- eps_rel numerator
+ *   ^VERIFICATION FAILED$                             -- run completed
+ *
+ * The first four patterns are absent in the old weak encoding; the last is
+ * present in both.  A revert to the weak encoding breaks the first four.
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* triggers apply_ieee754_semantics -> ra_lo::0, ra_hi::0 */
+
+  /* Always false in real/integer encoding: z == x+y exactly.
+   * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --ir-ra --z3 --smt-formula-too
-\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
-\(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
 \(ite
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
@@ -4,5 +4,5 @@ main.c
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
 \(ite
-2220446049250313
+5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
+\(ite
+2220446049250313
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-weak-bounds-long-double/main.c
+++ b/regression/ir-ra/ra-enclosure-weak-bounds-long-double/main.c
@@ -1,0 +1,57 @@
+/* Regression test: weak (unconstrained) enclosure for long double under --ir-ra.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that the fallback path in apply_ieee754_semantics fires correctly
+ * for non-standard FP formats.  long double is 128-bit (fraction=112,
+ * exponent=15) on LP64 systems and 96-bit (fraction=80, exponent=15) on
+ * ILP32 systems; neither matches the IEEE double (f=52, e=11) or single
+ * (f=23, e=8) specs, so it exercises the else-branch:
+ *
+ *   else {
+ *     // theorem-driven bounds not yet implemented for non-standard formats
+ *     ra_lo = mk_fresh(Real);
+ *     ra_hi = mk_fresh(Real);
+ *     assert ra_lo <= result <= ra_hi  and  ra_lo <= ra_hi;
+ *   }
+ *
+ * WHAT IS CHECKED
+ * ---------------
+ * The test checks that:
+ *   (a) ra_lo and ra_hi are still declared (the weak enclosure fires, not a crash)
+ *   (b) the run completes with VERIFICATION FAILED
+ *
+ * Notably, no ITE (absolute-value term) and no eps_rel numerator appear in the
+ * formula -- those are hallmarks of the tight-bound path and must be absent
+ * here.  The test framework does not support negative assertions, so their
+ * absence is not checked directly; the tight-bound regression tests
+ * (ra-enclosure-tight-bounds/ and ra-enclosure-tight-bounds-float/) serve as
+ * the counterpart positive checks.
+ *
+ * ASSERTION CHOICE
+ * ----------------
+ * "z != x + y" is always false in real arithmetic (z was assigned x+y exactly),
+ * so the verdict is deterministically VERIFICATION FAILED regardless of how
+ * tight the enclosure is.  This makes the verdict a stable run-completion guard.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)  -- weak enclosure declared
+ *   \(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)  -- weak enclosure declared
+ *   ^VERIFICATION FAILED$                             -- run completed
+ */
+#include <assert.h>
+
+extern long double __VERIFIER_nondet_long_double(void);
+
+int main(void)
+{
+  long double x = __VERIFIER_nondet_long_double();
+  long double y = __VERIFIER_nondet_long_double();
+  long double z = x + y; /* triggers apply_ieee754_semantics -> ra_lo::0, ra_hi::0 */
+
+  /* Always false in real/integer encoding: z == x+y exactly.
+   * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-enclosure-weak-bounds-long-double/test.desc
+++ b/regression/ir-ra/ra-enclosure-weak-bounds-long-double/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -3813,14 +3813,16 @@ void python_list::handle_list_var_unpacking(
     const std::string &var_name = ast_node["value"]["id"].get<std::string>();
     nlohmann::json decl = json_utils::find_var_decl(
       var_name, converter_.current_function_name(), converter_.ast());
-    elem_type = get_elem_type_from_annotation(decl, converter_.get_type_handler());
+    elem_type =
+      get_elem_type_from_annotation(decl, converter_.get_type_handler());
   }
   if (elem_type == typet())
     throw std::runtime_error(
       "Cannot determine element type for list variable unpacking");
 
   // Helper: find or create a variable symbol and assign an expression to it
-  auto assign_to_target = [&](const nlohmann::json &tgt_node, const exprt &val) {
+  auto assign_to_target = [&](
+                            const nlohmann::json &tgt_node, const exprt &val) {
     if (tgt_node["_type"] != "Name")
       throw std::runtime_error(
         "List unpacking only supports simple names, not " +
@@ -3904,7 +3906,8 @@ void python_list::handle_list_var_unpacking(
     // Loop: for loop_idx = before_star; loop_idx < upper; loop_idx++
     symbolt &loop_idx = converter_.create_tmp_symbol(
       list_value_, "$i$", size_type(), gen_zero(size_type()));
-    code_assignt idx_init(symbol_expr(loop_idx), from_integer(before_star, size_type()));
+    code_assignt idx_init(
+      symbol_expr(loop_idx), from_integer(before_star, size_type()));
     target_block.copy_to_operands(idx_init);
 
     exprt loop_cond("<", bool_type());

--- a/src/solvers/README.txt
+++ b/src/solvers/README.txt
@@ -49,6 +49,39 @@ Finally, there's some boilerplate in solvers/solve.cpp for creating
 solvers. The idea is to implement the factory pattern for solver
 creation, avoiding general-esbmc code having to touch solver-specific stuff.
 
+Interval/Real-Arithmetic (--ir-ra) mode
+----------------------------------------
+When the --ir-ra flag is enabled, floating-point operations are encoded
+in real arithmetic rather than bit-precise FP. The key entry point is
+smt_convt::apply_ieee754_semantics (smt_conv.cpp), which wraps each
+real-valued FP result in a sound symmetric error enclosure.
+
+For each FP operation whose exact real value is r, the round-to-nearest
+rounding error satisfies the standard model:
+
+  |fl(r) - r| <= eps_rel * |r| + eps_abs
+
+where eps_rel is half the machine epsilon (2^-53 for double, 2^-24 for
+single) and eps_abs is the minimum positive subnormal (2^-1074 for
+double, 2^-149 for single), covering the underflow region. The enclosure
+is therefore:
+
+  ra_lo = r - (eps_rel * |r| + eps_abs)
+  ra_hi = r + (eps_rel * |r| + eps_abs)
+
+and the assertions ra_lo <= result <= ra_hi and ra_lo <= ra_hi are
+added to the formula. The enclosure bounds are pinned via bidirectional
+inequalities (rather than equalities) to survive Z3's solve-eqs tactic.
+
+The epsilon constants are provided by four helpers in smt_conv.cpp:
+get_double_eps_rel, get_single_eps_rel, get_double_min_subnormal, and
+get_single_min_subnormal. Each decimal literal is rounded upward at the
+last digit to guarantee the SMT solver parses it as a value >= the true
+power-of-two, preserving soundness of the enclosure.
+
+Non-standard FP formats fall back to an unconstrained (weak) enclosure
+until theorem-driven bounds are implemented for them.
+
 [0] It's variardic; I thought that'd be useful then; see
 boolector_convt::mk_sort for an implementation. In reality, it could have
 been more useful.

--- a/src/solvers/cvc4/cvc_conv.h
+++ b/src/solvers/cvc4/cvc_conv.h
@@ -152,7 +152,7 @@ public:
 
   void assert_ast(smt_astt a) override;
 
-  void dump_smt() override;
+  std::string dump_smt() override;
 
   unsigned int to_bv_counter;
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -334,7 +334,8 @@ smt_astt smt_convt::get_double_min_normal()
 smt_astt smt_convt::get_double_min_subnormal()
 {
   // IEEE 754 double precision minimum positive subnormal value (2^-1074)
-  return mk_smt_real("4.9406564584124654e-324");
+  // Rounded UP at the last digit to ensure the enclosure is conservative.
+  return mk_smt_real("4.9406564584124655e-324");
 }
 
 smt_astt smt_convt::apply_ieee754_semantics(
@@ -549,8 +550,9 @@ smt_astt smt_convt::get_single_max_normal()
 smt_astt smt_convt::get_double_eps_rel()
 {
   // Relative error bound for IEEE 754 double under round-to-nearest:
-  // half machine epsilon = 2^-53
-  return mk_smt_real("1.1102230246251565e-16");
+  // half machine epsilon = 2^-53; rounded UP at the last digit to ensure
+  // the enclosure is conservative.
+  return mk_smt_real("1.1102230246251566e-16");
 }
 
 smt_astt smt_convt::get_single_eps_rel()

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -344,16 +344,88 @@ smt_astt smt_convt::apply_ieee754_semantics(
 {
   if (this->options.get_bool_option("ir-ra"))
   {
-    smt_astt final_result = real_result;
+    // First step: attach a sound symmetric enclosure around the real semantic
+    // term `r` for nearest rounding mode.
+    //
+    // For an FP operation whose exact real value is r, the round-to-nearest
+    // error satisfies:
+    //   |fl(r) - r| <= eps_rel * |r| + eps_abs
+    //
+    // So we define:
+    //   B(r)  = eps_rel * |r| + eps_abs
+    //   ra_lo = r - B(r)
+    //   ra_hi = r + B(r)
+    //
+    // and assert  ra_lo <= result <= ra_hi  and  ra_lo <= ra_hi.
+    //
+    // TODO: add directed-rounding modes (up/down/zero) once the rounding mode
+    //       is threaded through apply_ieee754_semantics.
+    // TODO: extend to non-standard FP formats beyond single and double.
+
+    unsigned int fraction_bits = fbv_type.fraction;
+    unsigned int exponent_bits = fbv_type.exponent;
+
+    auto double_spec = ieee_float_spect::double_precision();
+    auto single_spec = ieee_float_spect::single_precision();
+
+    smt_astt eps_rel, eps_abs;
+
+    if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+    {
+      eps_rel = get_double_eps_rel();       // 2^-53
+      eps_abs = get_double_min_subnormal(); // 2^-1074 (covers underflow region)
+    }
+    else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+    {
+      eps_rel = get_single_eps_rel();       // 2^-24
+      eps_abs = get_single_min_subnormal(); // 2^-149
+    }
+    else
+    {
+      // TODO: theorem-driven bounds for non-standard formats are not yet
+      // implemented; fall back to unconstrained enclosure (sound but weak).
+      smt_sortt rs = mk_real_sort();
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+      return real_result;
+    }
+
     smt_sortt rs = mk_real_sort();
+    smt_astt zero = mk_smt_real("0.0");
+
+    // |r| = r >= 0 ? r : -r
+    smt_astt abs_r =
+      mk_ite(mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+    // B(r) = eps_rel * |r| + eps_abs
+    smt_astt bound = mk_add(mk_mul(eps_rel, abs_r), eps_abs);
+
+    // ra_lo = r - B(r),  ra_hi = r + B(r)
+    smt_astt ra_lo_expr = mk_sub(real_result, bound);
+    smt_astt ra_hi_expr = mk_add(real_result, bound);
+
+    // Introduce named enclosure variables and pin them to the bound expressions
+    // via bidirectional inequalities.  A plain mk_eq(ra_lo, ra_lo_expr) is
+    // correct but the Z3 tactic pipeline (solve-eqs) eliminates definitional
+    // equalities from the visible assertion set, making them invisible in the
+    // SMT output.  Two mk_le assertions are logically equivalent and are not
+    // targeted by solve-eqs, so they survive in the final formula.
     smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
     smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+    assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
+    assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo  =>  ra_lo == r - B(r)
+    assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
+    assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi  =>  ra_hi == r + B(r)
 
-    assert_ast(mk_le(ra_lo, final_result));
-    assert_ast(mk_le(final_result, ra_hi));
+    // Containment: ra_lo <= result <= ra_hi
+    assert_ast(mk_le(ra_lo, real_result));
+    assert_ast(mk_le(real_result, ra_hi));
     assert_ast(mk_le(ra_lo, ra_hi));
 
-    return final_result;
+    return real_result;
   }
   else
   {
@@ -470,6 +542,20 @@ smt_astt smt_convt::get_single_max_normal()
 {
   // IEEE 754 single precision maximum normal positive value (~(2-2^-23)*2^127)
   return mk_smt_real("3.4028234663852886e+38");
+}
+
+smt_astt smt_convt::get_double_eps_rel()
+{
+  // Relative error bound for IEEE 754 double under round-to-nearest:
+  // half machine epsilon = 2^-53
+  return mk_smt_real("1.1102230246251565e-16");
+}
+
+smt_astt smt_convt::get_single_eps_rel()
+{
+  // Relative error bound for IEEE 754 single under round-to-nearest:
+  // half machine epsilon = 2^-24
+  return mk_smt_real("5.960464477539063e-08");
 }
 
 smt_astt smt_convt::convert_ast(const expr2tc &expr)

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -416,9 +416,11 @@ smt_astt smt_convt::apply_ieee754_semantics(
     smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
     smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
     assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
-    assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo  =>  ra_lo == r - B(r)
+    assert_ast(
+      mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo  =>  ra_lo == r - B(r)
     assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
-    assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi  =>  ra_hi == r + B(r)
+    assert_ast(
+      mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi  =>  ra_hi == r + B(r)
 
     // Containment: ra_lo <= result <= ra_hi
     assert_ast(mk_le(ra_lo, real_result));

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -436,6 +436,12 @@ public:
   smt_astt get_single_min_subnormal();
   // Returns SMT AST representing single precision maximum normal value (~3.4028234663852886e+38)
   smt_astt get_single_max_normal();
+  // Returns SMT AST for the double precision relative error bound under
+  // round-to-nearest: half machine epsilon = 2^-53 ~ 1.11e-16
+  smt_astt get_double_eps_rel();
+  // Returns SMT AST for the single precision relative error bound under
+  // round-to-nearest: half machine epsilon = 2^-24 ~ 5.96e-08
+  smt_astt get_single_eps_rel();
 
   /** Create a bitvector.
    *  @param theint Integer representation of the bitvector. Any excess bits
@@ -574,7 +580,6 @@ public:
   /** Method to dump the SMT formula */
   virtual std::string dump_smt();
 
-  //virtual void smt
 
   /** Method to print the SMT model */
   virtual void print_model();

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -580,7 +580,6 @@ public:
   /** Method to dump the SMT formula */
   virtual std::string dump_smt();
 
-
   /** Method to print the SMT model */
   virtual void print_model();
 


### PR DESCRIPTION
## Summary

This PR is the next step after the initial `--ir-ra` infrastructure.

Previously, `--ir-ra` introduced fresh symbolic enclosure variables
`ra_lo` / `ra_hi` together with weak containment constraints only:

- `ra_lo <= result`
- `result <= ra_hi`
- `ra_lo <= ra_hi`

That was useful as infrastructure, but the bounds were unconstrained and did
not yet carry mathematical information.

This PR replaces that weak enclosure with a theorem-driven symmetric real
enclosure for IEEE single- and double-precision floating-point operations
under the current nearest-rounding interpretation:

- `B(r) = eps_rel * |r| + eps_abs`
- `ra_lo = r - B(r)`
- `ra_hi = r + B(r)`

where:
- for double: `eps_rel = 2^-53`, `eps_abs = 2^-1074`
- for float:  `eps_rel = 2^-24`, `eps_abs = 2^-149`

The original IR real-semantic result is still returned unchanged; the
enclosure variables are attached as side constraints.

## Main changes

### SMT encoding
In `smt_convt::apply_ieee754_semantics(...)`, when `--ir-ra` is enabled:

- detect whether the format is IEEE single or double precision
- build `|r|` using an SMT `ite`
- build the enclosure bound `B(r) = eps_rel * |r| + eps_abs`
- define:
  - `ra_lo = r - B(r)`
  - `ra_hi = r + B(r)`
- encode these definitions via bidirectional inequalities so the named symbols
  remain visible in SMT output
- keep the containment constraints:
  - `ra_lo <= result`
  - `result <= ra_hi`
  - `ra_lo <= ra_hi`

For unsupported floating-point formats, the implementation falls back to the
previous weak unconstrained enclosure.

### Helper constants
Added:
- `get_double_eps_rel()`
- `get_single_eps_rel()`

### Division handling
For `ieee_div`, the non-single/non-double path now falls back to generic
`apply_ieee754_semantics(...)` instead of using single/double-specific
saturation logic.

## Regression coverage

This PR adds/updates regression coverage for `ir-ra` and registers it in
`regression/CMakeLists.txt`.

### Smoke regressions
These are intentionally falsifiable and are expected to end with
`VERIFICATION FAILED`:

- `fp-to-int-signed`
- `fp-to-int-unsigned`
- `int-to-fp`
- `ra-enclosure-bounds-add`
- `ra-enclosure-bounds-mul`
- `ra-enclosure-bounds-chain`

### SMT-structure regressions
These check for structure that distinguishes the new theorem-driven encoding
from the previous weak containment-only encoding.

#### Double precision
`ra-enclosure-tight-bounds`
checks for:
- declaration of `ra_lo::0`
- declaration of `ra_hi::0`
- presence of `ite`
- presence of the double epsilon rational fragment
- `VERIFICATION FAILED`

#### Single precision
`ra-enclosure-tight-bounds-float`
checks for:
- declaration of `ra_lo::0`
- declaration of `ra_hi::0`
- presence of `ite`
- presence of the float epsilon rational fragment
- `VERIFICATION FAILED`

## Notes / scope

- This PR is still a first theorem-driven step for `--ir-ra`
- The current implementation is aligned with the nearest-rounding model used
  for this enclosure
- Directed rounding modes are left for follow-up work
- Non-standard formats still use the previous weak fallback path