### PR TITLE
python: resolve tuple subscripts via __getitem__/__setitem__

### DIFF
--- a/regression/python/dunder-getsetitem-tuple-fail/main.py
+++ b/regression/python/dunder-getsetitem-tuple-fail/main.py
@@ -1,0 +1,16 @@
+from typing import Tuple
+
+class MyClass:
+    def __init__(self) -> None:
+        self.value = 0
+
+    def __setitem__(self, key:Tuple[int,int], value: int) -> None:
+        i,j = key
+        assert i == 4
+        assert j == 5
+        assert value == 12
+        self.value = value
+
+
+obj = MyClass()
+obj[2, 3] = 11

--- a/regression/python/dunder-getsetitem-tuple-fail/test.desc
+++ b/regression/python/dunder-getsetitem-tuple-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/dunder-getsetitem-tuple/main.py
+++ b/regression/python/dunder-getsetitem-tuple/main.py
@@ -1,0 +1,24 @@
+from typing import Tuple
+
+class MyClass:
+    def __init__(self) -> None:
+        self.value = 0
+
+    def __getitem__(self, key:Tuple[int, int]) -> int:
+        i, j = key
+        assert i == 2
+        assert j == 3
+        return self.value
+
+    def __setitem__(self, key:Tuple[int, int], value: int) -> None:
+        i, j = key
+        assert i == 2
+        assert j == 3
+        assert value == 11
+        self.value = value
+
+
+obj = MyClass()
+obj[2, 3] = 11
+v:int = obj[2, 3]
+assert v == 11

--- a/regression/python/dunder-getsetitem-tuple/test.desc
+++ b/regression/python/dunder-getsetitem-tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5622,7 +5622,9 @@ bool python_converter::handle_unpacking_assignment(
   else if (rhs.type().is_pointer())
   {
     typet pointed_type = ns.follow(rhs.type().subtype());
-    if (pointed_type.id() == "struct" && tuple_handler_->is_tuple_type(pointed_type))
+    if (
+      pointed_type.id() == "struct" &&
+      tuple_handler_->is_tuple_type(pointed_type))
     {
       exprt tuple_value = dereference_exprt(rhs, pointed_type);
       tuple_value.location() = rhs.location();

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5621,6 +5621,16 @@ bool python_converter::handle_unpacking_assignment(
   }
   else if (rhs.type().is_pointer())
   {
+    typet pointed_type = ns.follow(rhs.type().subtype());
+    if (pointed_type.id() == "struct" && tuple_handler_->is_tuple_type(pointed_type))
+    {
+      exprt tuple_value = dereference_exprt(rhs, pointed_type);
+      tuple_value.location() = rhs.location();
+      tuple_handler_->handle_tuple_unpacking(
+        ast_node, target, tuple_value, target_block);
+      return true;
+    }
+
     const auto &value_node = ast_node["value"];
     if (value_node["_type"] == "List")
     {
@@ -7248,6 +7258,9 @@ typet python_converter::get_type_from_annotation(
 
     if (value_id == "dict" || value_id == "Dict")
       return dict_handler_->get_dict_struct_type();
+
+    if (value_id == "tuple" || value_id == "Tuple")
+      return tuple_handler_->get_tuple_type_from_annotation(annotation_node);
 
     // Handle Literal[T]: extract the type from the literal value
     if (value_id == "Literal")


### PR DESCRIPTION
This PR adds support for handling tuple subscripts with `__getitem__()` and `__setitem__()`.

Example:
 ```python
  class MyClass:
    def __init__(self) -> None:
        self.value = 0

    def __setitem__(self, key:Tuple[int,int], value: int) -> None:
        i, j = key
        assert i == 2
        assert j == 3
        assert value == 11
        self.value = value


  obj = MyClass()
  obj[2, 3] = 11
  v = obj[2, 3]
  assert v == 11
```

This allows objects that implement these dunder methods to work with tuple subscripts in the same way they already work with list subscripts. Before this change, cases like this would fail with:
```text
ERROR: Cannot unpack pointer - only tuples and arrays can be unpacked
```

Needed by #3813 