### PR TITLE
[clang-cpp] fix spurious destructor warning for trivial implicit dtors (#3854)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_3854_1/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3854_1/main.cpp
@@ -1,0 +1,29 @@
+// Regression test for GitHub issue #3854:
+// Spurious "no body for function ~T#" warning for classes with
+// implicit trivial destructors when main() lacks an explicit return.
+class Num
+{
+private:
+  int val;
+
+public:
+  explicit constexpr Num(int num) : val(num) {}
+
+  Num() : val(nondet_int()) {}
+
+  Num inc() const { return Num(val + 1); }
+
+  bool operator==(const Num &rhs) { return this->val == rhs.val; }
+};
+
+int main()
+{
+  Num n0;
+  Num n1 = n0.inc();
+
+  // n0.val + 1 == n1.val, so n0 != n1: this assertion should always fail
+  __ESBMC_assert(!(n0 == n1), "n0 and n1 are not equal");
+
+  // No explicit return — triggers implicit destructor calls on scope exit.
+  // This must not produce a "no body for function ~Num#" warning.
+}

--- a/regression/esbmc-cpp/cpp/github_3854_1/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions
-^VERIFICATION SUCCESSFUL$
+\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\z

--- a/regression/esbmc-cpp/cpp/github_3854_1/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 1 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3854_1/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_1/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions
-\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\z
+\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\Z

--- a/regression/esbmc-cpp/cpp/github_3854_2/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3854_2/main.cpp
@@ -1,0 +1,33 @@
+// Regression test for GitHub issue #3854 (loop variant):
+// Spurious "no body for function ~T#" warning with loop control flow
+// even when main() has an explicit return 0.
+class Num
+{
+private:
+  int val;
+
+public:
+  explicit constexpr Num(int num) : val(num) {}
+
+  Num() : val(nondet_int()) {}
+
+  Num inc() const { return Num(val + 1); }
+
+  bool operator!=(const Num &rhs) { return this->val != rhs.val; }
+};
+
+int main()
+{
+  Num n0;
+  Num n1 = n0.inc();
+
+  for (int idx = 0; idx < 2; ++idx)
+  {
+    n0 = n1.inc();
+    n1 = n0.inc();
+  }
+
+  // After 2 iterations: n0.val = init+3, n1.val = init+4 — always differ
+  __ESBMC_assert(n0 != n1, "n0 and n1 are never equal after loop");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3854_2/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 3 --no-unwinding-assertions
-^VERIFICATION SUCCESSFUL$
+\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\z

--- a/regression/esbmc-cpp/cpp/github_3854_2/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 3 --no-unwinding-assertions
-\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\z
+\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\Z

--- a/regression/esbmc-cpp/cpp/github_3854_2/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 3 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3854_3/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3854_3/main.cpp
@@ -1,0 +1,30 @@
+// Regression test for GitHub issue #3854 (explicitly-defaulted destructor):
+// Verify no "no body for function ~T#" warning for an explicitly-defaulted
+// trivial destructor (~Num() = default), which Clang also doesn't synthesize
+// a body for until it is ODR-used.
+class Num
+{
+private:
+  int val;
+
+public:
+  explicit constexpr Num(int num) : val(num) {}
+
+  Num() : val(nondet_int()) {}
+
+  ~Num() = default;
+
+  Num inc() const { return Num(val + 1); }
+
+  bool operator!=(const Num &rhs) { return this->val != rhs.val; }
+};
+
+int main()
+{
+  Num n0;
+  Num n1 = n0.inc();
+
+  __ESBMC_assert(n0 != n1, "n0 and n1 always differ after inc");
+
+  // No explicit return — triggers implicit destructor calls on scope exit.
+}

--- a/regression/esbmc-cpp/cpp/github_3854_3/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions
-^VERIFICATION SUCCESSFUL$
+\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\z

--- a/regression/esbmc-cpp/cpp/github_3854_3/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 1 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3854_3/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions
-\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\z
+\A(?=[\s\S]*VERIFICATION SUCCESSFUL)(?![\s\S]*no body for function ~Num#)[\s\S]*\Z

--- a/regression/esbmc-cpp/cpp/github_3854_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3854_fail/main.cpp
@@ -1,0 +1,28 @@
+// Regression test for GitHub issue #3854 (expected failure):
+// Verify ESBMC correctly finds counterexamples (not masked by destructor
+// warning false negatives) for classes with implicit trivial destructors.
+class Num
+{
+private:
+  int val;
+
+public:
+  explicit constexpr Num(int num) : val(num) {}
+
+  Num() : val(nondet_int()) {}
+
+  Num inc() const { return Num(val + 1); }
+
+  bool operator==(const Num &rhs) { return this->val == rhs.val; }
+};
+
+int main()
+{
+  Num n0;
+  Num n1 = n0.inc();
+
+  // n0.val + 1 == n1.val, so n0 == n1 is always false: violation expected
+  __ESBMC_assert(n0 == n1, "n0 equals n1 after inc");
+
+  // No explicit return — tests implicit destructor call path
+}

--- a/regression/esbmc-cpp/cpp/github_3854_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3854_fail/main.cpp
@@ -1,6 +1,5 @@
 // Regression test for GitHub issue #3854 (expected failure):
-// Verify ESBMC correctly finds counterexamples (not masked by destructor
-// warning false negatives) for classes with implicit trivial destructors.
+// A class with an implicit trivial destructor where an assertion is violated.
 class Num
 {
 private:

--- a/regression/esbmc-cpp/cpp/github_3854_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions
-^VERIFICATION FAILED$
+\A(?=[\s\S]*VERIFICATION FAILED)(?![\s\S]*no body for function ~Num#)[\s\S]*\z

--- a/regression/esbmc-cpp/cpp/github_3854_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions
-\A(?=[\s\S]*VERIFICATION FAILED)(?![\s\S]*no body for function ~Num#)[\s\S]*\z
+\A(?=[\s\S]*VERIFICATION FAILED)(?![\s\S]*no body for function ~Num#)[\s\S]*\Z

--- a/regression/esbmc-cpp/cpp/github_3854_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3854_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 1 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -716,12 +716,12 @@ bool clang_c_convertert::get_function(
   added_symbol.type = type;
   new_expr.type() = type;
 
-  // We need: a type, a name, and an optional body
-  if (fd.hasBody())
-  {
-    if (get_function_body(fd, added_symbol.value, type))
-      return true;
-  }
+  // We need: a type, a name, and an optional body.
+  // Always call get_function_body so overrides (e.g. the C++ frontend) can
+  // synthesise a body for bodyless declarations such as trivial destructors.
+  // The base implementation returns immediately when fd.hasBody() is false.
+  if (get_function_body(fd, added_symbol.value, type))
+    return true;
 
   // Restore old functionDecl
   current_functionDecl = old_functionDecl;
@@ -734,7 +734,8 @@ bool clang_c_convertert::get_function_body(
   exprt &new_expr,
   const code_typet &)
 {
-  assert(fd.hasBody());
+  if (!fd.hasBody())
+    return false;
 
   exprt body_exprt;
   if (get_expr(*fd.getBody(), body_exprt))

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -360,6 +360,21 @@ bool clang_cpp_convertert::get_method(
   if (clang_c_convertert::get_function(md, new_expr))
     return true;
 
+  // For implicit or explicitly-defaulted trivial destructors, Clang does not
+  // synthesize a body (hasBody() returns false), leaving symbol.value as nil.
+  // This causes a "no body for function ~T#" warning when destructor calls are
+  // emitted at scope exit. A trivial destructor is a no-op: generate an empty body.
+  if (
+    llvm::isa<clang::CXXDestructorDecl>(md) && !md.hasBody() &&
+    (md.isImplicit() || md.isExplicitlyDefaulted()))
+  {
+    std::string id, unused_name;
+    get_decl_name(md, unused_name, id);
+    symbolt *s = context.find_symbol(id);
+    if (s && s->value.is_nil())
+      s->value = code_blockt();
+  }
+
   if (annotate_class_method(md, new_expr))
     return true;
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -360,21 +360,6 @@ bool clang_cpp_convertert::get_method(
   if (clang_c_convertert::get_function(md, new_expr))
     return true;
 
-  // For implicit or explicitly-defaulted trivial destructors, Clang does not
-  // synthesize a body (hasBody() returns false), leaving symbol.value as nil.
-  // This causes a "no body for function ~T#" warning when destructor calls are
-  // emitted at scope exit. A trivial destructor is a no-op: generate an empty body.
-  if (
-    llvm::isa<clang::CXXDestructorDecl>(md) && !md.hasBody() &&
-    (md.isImplicit() || md.isExplicitlyDefaulted()))
-  {
-    std::string id, unused_name;
-    get_decl_name(md, unused_name, id);
-    symbolt *s = context.find_symbol(id);
-    if (s && s->value.is_nil())
-      s->value = code_blockt();
-  }
-
   if (annotate_class_method(md, new_expr))
     return true;
 
@@ -1347,6 +1332,19 @@ bool clang_cpp_convertert::get_function_body(
   exprt &new_expr,
   const code_typet &ftype)
 {
+  // For trivial implicit or explicitly-defaulted destructors, Clang does not
+  // synthesise a body (hasBody() returns false), leaving symbol.value as nil.
+  // This causes a "no body for function ~T#" warning when destructor calls are
+  // emitted at scope exit. A trivial destructor is a no-op: generate an empty body.
+  if (const auto *dd = llvm::dyn_cast<clang::CXXDestructorDecl>(&fd))
+  {
+    if (!fd.hasBody() && (dd->isImplicit() || dd->isExplicitlyDefaulted()))
+    {
+      new_expr = code_blockt();
+      return false;
+    }
+  }
+
   // do nothing if function body doesn't exist
   if (!fd.hasBody())
     return false;


### PR DESCRIPTION
Fixes #3854.