### PR TITLE
[ir-ra] guard theorem-driven enclosure to round-to-nearest

### DIFF
--- a/regression/ir-ra/ra-enclosure-weak-bounds-long-double/main.c
+++ b/regression/ir-ra/ra-enclosure-weak-bounds-long-double/main.c
@@ -10,15 +10,15 @@
  *
  *   else {
  *     // theorem-driven bounds not yet implemented for non-standard formats
- *     ra_lo = mk_fresh(Real);
- *     ra_hi = mk_fresh(Real);
+ *     ra_lo_weak = mk_fresh(Real);
+ *     ra_hi_weak = mk_fresh(Real);
  *     assert ra_lo <= result <= ra_hi  and  ra_lo <= ra_hi;
  *   }
  *
  * WHAT IS CHECKED
  * ---------------
  * The test checks that:
- *   (a) ra_lo and ra_hi are still declared (the weak enclosure fires, not a crash)
+ *   (a) ra_lo_weak and ra_hi_weak are still declared (the weak enclosure fires, not a crash)
  *   (b) the run completes with VERIFICATION FAILED
  *
  * Notably, no ITE (absolute-value term) and no eps_rel numerator appear in the
@@ -36,8 +36,8 @@
  *
  * PATTERNS CHECKED (see test.desc)
  * ---------------------------------
- *   \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)  -- weak enclosure declared
- *   \(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)  -- weak enclosure declared
+ *   \(declare-fun \|smt_conv::ra_lo_weak::0\| \(\) Real\)  -- weak enclosure declared
+ *   \(declare-fun \|smt_conv::ra_hi_weak::0\| \(\) Real\)  -- weak enclosure declared
  *   ^VERIFICATION FAILED$                             -- run completed
  */
 #include <assert.h>
@@ -48,7 +48,7 @@ int main(void)
 {
   long double x = __VERIFIER_nondet_long_double();
   long double y = __VERIFIER_nondet_long_double();
-  long double z = x + y; /* triggers apply_ieee754_semantics -> ra_lo::0, ra_hi::0 */
+  long double z = x + y; /* triggers apply_ieee754_semantics -> ra_lo_weak::0, ra_hi_weak::0 */
 
   /* Always false in real/integer encoding: z == x+y exactly.
    * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */

--- a/regression/ir-ra/ra-enclosure-weak-bounds-long-double/test.desc
+++ b/regression/ir-ra/ra-enclosure-weak-bounds-long-double/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
 --ir-ra --z3 --smt-formula-too
-\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
-\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_weak::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_weak::[0-9]+\| \(\) Real\)
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
@@ -1,0 +1,49 @@
+/* Regression test: directed rounding mode uses weak enclosure fallback under --ir-ra.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that a floating-point addition performed under a directed rounding
+ * mode (FE_UPWARD) takes the weak unconstrained enclosure path, not the
+ * theorem-driven tight path that is valid only for round-to-nearest.
+ *
+ * MECHANISM
+ * ---------
+ * fesetround(FE_UPWARD) writes 2 (ROUND_TO_PLUS_INF) to __ESBMC_rounding_mode.
+ * ESBMC symex propagates this concrete value into the rounding_mode operand of
+ * the ieee_add2t IR node.  In smt_conv::apply_ieee754_semantics, the guard:
+ *
+ *   if (!is_nearest_rounding_mode(rounding_mode))
+ *
+ * fires (value 2 != ROUND_TO_EVEN == 0), so only the three weak containment
+ * assertions are emitted:
+ *   (assert (<= |ra_lo| result))
+ *   (assert (<= result  |ra_hi|))
+ *   (assert (<= |ra_lo| |ra_hi|))
+ *
+ * WHAT IS CHECKED
+ * ---------------
+ *   ra_lo / ra_hi symbols are declared  -- weak path was taken
+ *   ^VERIFICATION FAILED$               -- run completed
+ *
+ * NOTE: the tight-path epsilon numerator (5551115123125783 for double) would
+ * be absent from the SMT output because the tight path was not taken.  This
+ * cannot be expressed as a negative pattern in the current testing harness, so
+ * absence is documented here rather than machine-checked.
+ */
+#include <assert.h>
+#include <fenv.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  fesetround(FE_UPWARD);
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* rounding_mode == ROUND_TO_PLUS_INF -> weak fallback */
+
+  /* Always false in real/integer encoding: z == x+y exactly.
+   * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
@@ -22,7 +22,7 @@
  *
  * WHAT IS CHECKED
  * ---------------
- *   ra_lo / ra_hi symbols are declared  -- weak path was taken
+ *   ra_lo_weak / ra_hi_weak symbols are declared  -- weak path was taken
  *   ^VERIFICATION FAILED$               -- run completed
  *
  * NOTE: the tight-path epsilon numerator (5551115123125783 for double) would

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/test.desc
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/test.desc
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
 --ir-ra --z3 --smt-formula-too
-\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
-\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_weak::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_weak::[0-9]+\| \(\) Real\)
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-nearest-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-nearest-tight-bounds/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+extern double __VERIFIER_nondet_double(void);
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-nearest-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-nearest-tight-bounds/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -365,7 +365,7 @@ smt_astt smt_convt::apply_ieee754_semantics(
     // a future PR.
 
     // Guard: if the rounding mode is not concrete round-to-nearest, emit only
-    // the weak containment enclosure (sound but unprecise) and return.
+    // the weak containment enclosure (sound but imprecise) and return.
     if (!is_nearest_rounding_mode(rounding_mode))
     {
       smt_sortt rs = mk_real_sort();

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -369,8 +369,8 @@ smt_astt smt_convt::apply_ieee754_semantics(
     if (!is_nearest_rounding_mode(rounding_mode))
     {
       smt_sortt rs = mk_real_sort();
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
       assert_ast(mk_le(ra_lo, real_result));
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));
@@ -417,8 +417,8 @@ smt_astt smt_convt::apply_ieee754_semantics(
       // TODO: theorem-driven bounds for non-standard formats are not yet
       // implemented; fall back to unconstrained enclosure (sound but weak).
       smt_sortt rs = mk_real_sort();
-      smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
-      smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
       assert_ast(mk_le(ra_lo, real_result));
       assert_ast(mk_le(real_result, ra_hi));
       assert_ast(mk_le(ra_lo, ra_hi));

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -338,14 +338,47 @@ smt_astt smt_convt::get_double_min_subnormal()
   return mk_smt_real("4.9406564584124655e-324");
 }
 
+// Returns true iff the rounding mode expression is a concrete integer constant
+// equal to ieee_floatt::ROUND_TO_EVEN (round-to-nearest-ties-to-even).
+// Directed modes (ROUND_TO_AWAY, ROUND_TO_PLUS_INF, ROUND_TO_MINUS_INF,
+// ROUND_TO_ZERO), symbolic rounding modes, and nil expr2tc all return false.
+static bool is_nearest_rounding_mode(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_EVEN);
+}
+
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
   const floatbv_type2t &fbv_type,
-  smt_astt operand_zero_check)
+  smt_astt operand_zero_check,
+  const expr2tc &rounding_mode)
 {
   if (this->options.get_bool_option("ir-ra"))
   {
-    // First step: attach a sound symmetric enclosure around the real semantic
+    // NOTE: directed rounding modes (FE_UPWARD, FE_DOWNWARD, FE_TOWARDZERO)
+    // fall back to the weak unconstrained enclosure below and are deferred to
+    // a future PR.
+
+    // Guard: if the rounding mode is not concrete round-to-nearest, emit only
+    // the weak containment enclosure (sound but unprecise) and return.
+    if (!is_nearest_rounding_mode(rounding_mode))
+    {
+      smt_sortt rs = mk_real_sort();
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+      return real_result;
+    }
+
+    // Tight path: rounding mode is concrete round-to-nearest.
+    // Attach a sound symmetric enclosure around the real semantic
     // term `r` for nearest rounding mode.
     //
     // For an FP operation whose exact real value is r, the round-to-nearest
@@ -359,8 +392,6 @@ smt_astt smt_convt::apply_ieee754_semantics(
     //
     // and assert  ra_lo <= result <= ra_hi  and  ra_lo <= ra_hi.
     //
-    // TODO: add directed-rounding modes (up/down/zero) once the rounding mode
-    //       is threaded through apply_ieee754_semantics.
     // TODO: extend to non-standard FP formats beyond single and double.
 
     unsigned int fraction_bits = fbv_type.fraction;
@@ -841,7 +872,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt real_result = mk_add(side1, side2);
 
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
-      a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
+      a = apply_ieee754_semantics(
+        real_result, fbv_type, nullptr, to_ieee_add2t(expr).rounding_mode);
     }
     else
     {
@@ -862,7 +894,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt real_result = mk_sub(side1, side2);
 
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
-      a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
+      a = apply_ieee754_semantics(
+        real_result, fbv_type, nullptr, to_ieee_sub2t(expr).rounding_mode);
     }
     else
     {
@@ -886,7 +919,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt operand_is_zero = mk_or(mk_eq(side1, zero), mk_eq(side2, zero));
 
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
-      a = apply_ieee754_semantics(real_result, fbv_type, operand_is_zero);
+      a = apply_ieee754_semantics(
+        real_result,
+        fbv_type,
+        operand_is_zero,
+        to_ieee_mul2t(expr).rounding_mode);
     }
     else
     {
@@ -921,7 +958,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       if (!is_single && !is_double)
       {
         smt_astt real_result = mk_div(side1, side2);
-        a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
+        a = apply_ieee754_semantics(
+          real_result, fbv_type, nullptr, to_ieee_div2t(expr).rounding_mode);
         break;
       }
 
@@ -930,8 +968,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt inf_result =
         mk_ite(mk_lt(side1, zero), mk_sub(zero, max_val), max_val);
       smt_astt real_result = mk_div(side1, side2);
-      smt_astt ieee_result =
-        apply_ieee754_semantics(real_result, fbv_type, nullptr);
+      smt_astt ieee_result = apply_ieee754_semantics(
+        real_result, fbv_type, nullptr, to_ieee_div2t(expr).rounding_mode);
       a = mk_ite(div_by_zero, inf_result, ieee_result);
     }
     else
@@ -958,7 +996,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt real_result = mk_add(intermediate, val3);
 
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
-      a = apply_ieee754_semantics(real_result, fbv_type, nullptr);
+      a = apply_ieee754_semantics(
+        real_result, fbv_type, nullptr, to_ieee_fma2t(expr).rounding_mode);
     }
     else
     {

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -566,16 +566,24 @@ public:
    *  subnormal range [4.941e-324, 2.225e-308). For single precision: overflow
    *  to ±3.403e+38, underflow below 1.401e-45, subnormal range [1.401e-45, 1.175e-38).
    *  Other formats return the original result unchanged.
+   *  Under --ir-ra, when rounding_mode is a concrete round-to-nearest constant
+   *  (ROUND_TO_EVEN == 0), a tight symmetric epsilon enclosure is asserted.
+   *  For symbolic or directed rounding modes the function falls back to a weak
+   *  unconstrained enclosure (sound but imprecise); tight directed bounds are
+   *  deferred to a future PR.
    *  @param real_result The result of exact real arithmetic operation
    *  @param fbv_type The floating-point type information (exponent/fraction bits)
    *  @param operand_zero_check Optional boolean AST for special zero handling
    *         (e.g., multiplication where either operand is zero should yield zero
    *         regardless of the other operand, even if it would cause underflow)
+   *  @param rounding_mode The rounding mode expr2tc from the IR operation node;
+   *         typically a constant_int2t or the __ESBMC_rounding_mode symbol.
    *  @return SMT AST representing the result with IEEE 754 semantics applied */
   virtual smt_astt apply_ieee754_semantics(
     smt_astt real_result,
     const floatbv_type2t &fbv_type,
-    smt_astt operand_zero_check = nullptr);
+    smt_astt operand_zero_check = nullptr,
+    const expr2tc &rounding_mode = expr2tc());
 
   /** Method to dump the SMT formula */
   virtual std::string dump_smt();


### PR DESCRIPTION
## Summary

This PR makes the current rounding-mode assumption in the IR-RA theorem-driven enclosure path explicit and sound.

The existing tight symmetric enclosure is valid for round-to-nearest only. This PR adds an explicit guard so that:

- round-to-nearest operations continue to use the theorem-driven tight bounds
- non-nearest or symbolic rounding modes fall back to the existing weak enclosure

No directed-rounding bounds are introduced here; this PR only makes the current nearest-only assumption explicit and safe.

## Main changes

- add explicit nearest-rounding detection in the IR-RA theorem-driven path
- keep the tight theorem-driven enclosure only for round-to-nearest
- use weak fallback for directed or symbolic rounding modes
- leave unsupported-format fallback behaviour unchanged

## Regression coverage

This PR adds two regression tests:

- `ra-rounding-nearest-tight-bounds`
  - verifies that default nearest rounding still takes the tight path
  - checks for `ra_lo`, `ra_hi`, `ite`, and the expected double epsilon numerator
  - expected result: `VERIFICATION FAILED`

- `ra-rounding-directed-weak-fallback`
  - uses `fesetround(FE_UPWARD)` to exercise a non-nearest rounding mode
  - verifies the weak enclosure fallback path
  - expected result: `VERIFICATION FAILED`

## Notes

- this PR does not implement directed-rounding enclosure theory
- directed modes currently fall back to the weak enclosure intentionally
- asymmetric bounds for directed rounding are deferred to a future PR