### PR TITLE
python: handle dict instance attributes

### DIFF
--- a/regression/python/dict-attr-int-int-fail/main.py
+++ b/regression/python/dict-attr-int-int-fail/main.py
@@ -1,0 +1,17 @@
+class Counter:
+    def __init__(self) -> None:
+        self.data: dict[int, int]
+        self.data = {}
+
+    def __getitem__(self, key: int) -> int:
+        try:
+            return self.data[key]
+        except KeyError:
+            return 0
+
+    def __setitem__(self, key: int, value: int) -> None:
+        self.data[key] = value
+
+
+c = Counter()
+assert c[2] == 1

--- a/regression/python/dict-attr-int-int-fail/test.desc
+++ b/regression/python/dict-attr-int-int-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/dict-attr-int-int/main.py
+++ b/regression/python/dict-attr-int-int/main.py
@@ -1,0 +1,19 @@
+class Counter:
+    def __init__(self) -> None:
+        self.data: dict[int, int]
+        self.data = {}
+
+    def __getitem__(self, key: int) -> int:
+        try:
+            return self.data[key]
+        except KeyError:
+            return 0
+
+    def __setitem__(self, key: int, value: int) -> None:
+        self.data[key] = value
+
+
+c = Counter()
+assert c[2] == 0
+c[1] = 7
+assert c[1] == 7

--- a/regression/python/dict-attr-int-int/test.desc
+++ b/regression/python/dict-attr-int-int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2740,8 +2740,12 @@ private:
             {
               // AnnAssign: self.attr: Type = value
               if (
-                stmt["_type"] == "AnnAssign" &&
+                stmt.contains("_type") && stmt["_type"] == "AnnAssign" &&
+                stmt.contains("target") && stmt["target"].is_object() &&
+                stmt["target"].contains("_type") &&
                 stmt["target"]["_type"] == "Attribute" &&
+                stmt["target"].contains("value") &&
+                stmt["target"]["value"].is_object() &&
                 stmt["target"]["value"].contains("id") &&
                 stmt["target"]["value"]["id"] == "self" &&
                 stmt["target"]["attr"] == chain_attr &&
@@ -2756,10 +2760,13 @@ private:
               }
               // Assign: self.attr = SomeClass()
               if (
-                stmt["_type"] == "Assign" && stmt.contains("targets") &&
-                !stmt["targets"].empty() &&
+                stmt.contains("_type") && stmt["_type"] == "Assign" &&
+                stmt.contains("targets") && stmt["targets"].is_array() &&
+                !stmt["targets"].empty() && stmt["targets"][0].is_object() &&
                 stmt["targets"][0].contains("_type") &&
                 stmt["targets"][0]["_type"] == "Attribute" &&
+                stmt["targets"][0].contains("value") &&
+                stmt["targets"][0]["value"].is_object() &&
                 stmt["targets"][0]["value"].contains("id") &&
                 stmt["targets"][0]["value"]["id"] == "self" &&
                 stmt["targets"][0]["attr"] == chain_attr &&

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -8562,7 +8562,12 @@ void python_converter::get_attributes_from_self(
   for (const auto &stmt : method_body)
   {
     if (
-      stmt["_type"] == "AnnAssign" && stmt["target"]["_type"] == "Attribute" &&
+      stmt.contains("_type") && stmt["_type"] == "AnnAssign" &&
+      stmt.contains("target") && stmt["target"].is_object() &&
+      stmt["target"].contains("_type") &&
+      stmt["target"]["_type"] == "Attribute" &&
+      stmt["target"].contains("value") && stmt["target"]["value"].is_object() &&
+      stmt["target"]["value"].contains("id") &&
       stmt["target"]["value"]["id"] == "self")
     {
       const std::string &attr_name = stmt["target"]["attr"];
@@ -8670,7 +8675,14 @@ void python_converter::get_attributes_from_self(
         class_components.push_back(comp);
     }
     else if (
-      stmt["_type"] == "Assign" && stmt["targets"][0]["_type"] == "Attribute" &&
+      stmt.contains("_type") && stmt["_type"] == "Assign" &&
+      stmt.contains("targets") && stmt["targets"].is_array() &&
+      !stmt["targets"].empty() && stmt["targets"][0].is_object() &&
+      stmt["targets"][0].contains("_type") &&
+      stmt["targets"][0]["_type"] == "Attribute" &&
+      stmt["targets"][0].contains("value") &&
+      stmt["targets"][0]["value"].is_object() &&
+      stmt["targets"][0]["value"].contains("id") &&
       stmt["targets"][0]["value"]["id"] == "self")
     {
       // A member is initialized with something that might be not annotated

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -1067,6 +1067,62 @@ typet python_dict_handler::get_dict_value_type_from_annotation(
 typet python_dict_handler::resolve_expected_type_for_dict_subscript(
   const exprt &dict_expr)
 {
+  if (dict_expr.id() == "member")
+  {
+    const auto &member = to_member_expr(dict_expr);
+    typet class_type = member.struct_op().type();
+    namespacet ns(symbol_table_);
+
+    if (class_type.is_pointer())
+      class_type = ns.follow(class_type.subtype());
+    else
+      class_type = ns.follow(class_type);
+
+    assert(class_type.is_struct());
+
+    // For self.data[key], look up the dict value type from the class
+    // annotation before falling back to the usual symbol-based path.
+    const std::string class_name = converter_.extract_class_name_from_tag(
+      to_struct_type(class_type).tag().as_string());
+    const nlohmann::json class_node =
+      json_utils::find_class(converter_.get_ast_json()["body"], class_name);
+
+    if (!class_node.empty() && class_node.contains("body"))
+    {
+      for (const auto &class_elem : class_node["body"])
+      {
+        if (
+          class_elem.contains("_type") &&
+          class_elem["_type"] == "FunctionDef" && class_elem.contains("name") &&
+          class_elem["name"] == "__init__" && class_elem.contains("body"))
+        {
+          for (const auto &stmt : class_elem["body"])
+          {
+            if (
+              stmt.contains("_type") && stmt["_type"] == "AnnAssign" &&
+              stmt.contains("target") && stmt["target"].is_object() &&
+              stmt["target"].contains("_type") &&
+              stmt["target"]["_type"] == "Attribute" &&
+              stmt["target"].contains("value") &&
+              stmt["target"]["value"].is_object() &&
+              stmt["target"]["value"].contains("id") &&
+              stmt["target"]["value"]["id"] == "self" &&
+              stmt["target"].contains("attr") &&
+              stmt["target"]["attr"].get<std::string>() ==
+                member.get_component_name().as_string() &&
+              stmt.contains("annotation"))
+            {
+              typet result =
+                get_dict_value_type_from_annotation(stmt["annotation"]);
+              if (!result.is_nil() && !result.is_empty())
+                return result;
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Only works if dict_expr is a symbol (variable reference)
   if (!dict_expr.is_symbol())
     return empty_typet();


### PR DESCRIPTION
This PR fixes dict instance attributes used through subscripts.

  Example:
  ```python
  class Counter:
      def __init__(self) -> None:
          self.data: dict[int, int]
          self.data = {}

      def __getitem__(self, key: int) -> int:
          try:
              return self.data[key]
          except KeyError:
              return 0

      def __setitem__(self, key: int, value: int) -> None:
          self.data[key] = value
```
This change recovers the value type from the attribute annotation in `__init__` when handling `self.data[key]`.

Needed by #3813 