### PR TITLE
[clang-cpp] fix virtual dispatch through non-first base in multiple inheritance (#3876)

### DIFF
--- a/regression/esbmc-cpp/inheritance/github_3876/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876/main.cpp
@@ -1,0 +1,42 @@
+// Regression test for GitHub issue #3876:
+// ESBMC incorrectly handles virtual dispatch when calling a base class method
+// via a qualified name (Base::method()) in the presence of multiple inheritance.
+//
+// B8::eval() calls the virtual guard() method; when run() calls B8::eval()
+// through the B8 sub-object of a Derived instance, the virtual dispatch must
+// resolve to Derived::guard() (which returns true).
+#include <cassert>
+
+struct B1
+{
+  virtual void dummy() = 0;
+};
+
+struct B8
+{
+  virtual bool guard() = 0;
+  bool eval()
+  {
+    return guard();
+  }
+};
+
+struct Derived : B1, B8
+{
+  void dummy() override {}
+  bool guard() override
+  {
+    return true;
+  }
+  bool run()
+  {
+    return B8::eval();
+  }
+};
+
+int main()
+{
+  Derived d;
+  assert(d.run());
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876_1-nondet/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_1-nondet/main.cpp
@@ -1,0 +1,27 @@
+// Regression test for GitHub issue #3876 (nondet computed guard):
+// x and y are nondet; asserts that run() always equals (x > y), verifying
+// that the thunk this-adjustment is correct for all possible input values.
+#include <cassert>
+
+int nondet_int();
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  int x;
+  int y;
+  void dummy() override {}
+  bool guard() override { return x > y; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d;
+  d.x = nondet_int();
+  d.y = nondet_int();
+  assert(d.run() == (d.x > d.y));
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_1-nondet/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_1-nondet/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_1/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_1/main.cpp
@@ -1,0 +1,26 @@
+// Regression test for GitHub issue #3876 (computed guard variant):
+// guard() returns a computed comparison (x > y) rather than a stored bool,
+// verifying that the thunk this-adjustment allows correct access to multiple
+// data members of the derived class.
+#include <cassert>
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  int x;
+  int y;
+  void dummy() override {}
+  bool guard() override { return x > y; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d;
+  d.x = 5;
+  d.y = 3;
+  assert(d.run()); // 5 > 3
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_1/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_2-nondet/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_2-nondet/main.cpp
@@ -1,0 +1,29 @@
+// Regression test for GitHub issue #3876 (nondet pointer selection):
+// A nondet bool selects between two Derived objects (one with value=true,
+// one with value=false). Asserts that p->run() always equals p->value,
+// verifying that this-adjustment is correct regardless of which object is
+// dispatched through.
+#include <cassert>
+
+bool nondet_bool();
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  bool value;
+  void dummy() override {}
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d1, d2;
+  d1.value = true;
+  d2.value = false;
+  Derived *p = nondet_bool() ? &d1 : &d2;
+  assert(p->run() == p->value);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_2-nondet/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_2-nondet/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_3-nondet/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_3-nondet/main.cpp
@@ -1,0 +1,40 @@
+// Regression test for GitHub issue #3876 (two subclasses with different B8 offsets):
+// DerivedA : B1, B8 places B8 at offset sizeof(B1).
+// DerivedB : B1, B2, B8 places B8 at offset sizeof(B1)+sizeof(B2).
+// Both classes have nondet guard values. Asserts that run() always matches
+// the stored field in each class, exercising two distinct thunk adjustments.
+#include <cassert>
+
+bool nondet_bool();
+
+struct B1 { virtual void dummy1() = 0; };
+struct B2 { virtual void dummy2() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct DerivedA : B1, B8
+{
+  bool va;
+  void dummy1() override {}
+  bool guard() override { return va; }
+  bool run() { return B8::eval(); }
+};
+
+struct DerivedB : B1, B2, B8
+{
+  bool vb;
+  void dummy1() override {}
+  void dummy2() override {}
+  bool guard() override { return vb; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  DerivedA a;
+  DerivedB b;
+  a.va = nondet_bool();
+  b.vb = nondet_bool();
+  assert(a.run() == a.va);
+  assert(b.run() == b.vb);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_3-nondet/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_3-nondet/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_bug/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_bug/main.cpp
@@ -1,0 +1,39 @@
+// Regression test for GitHub issue #3876 (bug variant):
+// Verifies that ESBMC correctly detects a false assertion in a multiple
+// inheritance scenario where virtual dispatch through the second base class
+// yields false, but the assertion expects true.
+#include <cassert>
+
+struct B1
+{
+  virtual void dummy() = 0;
+};
+
+struct B8
+{
+  virtual bool guard() = 0;
+  bool eval()
+  {
+    return guard();
+  }
+};
+
+struct Derived : B1, B8
+{
+  void dummy() override {}
+  bool guard() override
+  {
+    return false;
+  }
+  bool run()
+  {
+    return B8::eval();
+  }
+};
+
+int main()
+{
+  Derived d;
+  assert(d.run()); // guard() returns false, so run() returns false -> assertion fails
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_bug/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/github_3876_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_bug/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/github_3876_fail/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_fail/main.cpp
@@ -1,0 +1,27 @@
+// Regression test for GitHub issue #3876 (expected failure with nondet value):
+// value is nondet; asserts that run() is always true without any assumption.
+// This must fail: when value == false, run() returns false and the assertion
+// is violated. Verifies that ESBMC finds the counterexample correctly after
+// the thunk this-adjustment fix.
+#include <cassert>
+
+bool nondet_bool();
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  bool value;
+  void dummy() override {}
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d;
+  d.value = nondet_bool();
+  assert(d.run()); // fails when value == false
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --timeout 60
+^VERIFICATION FAILED$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_heap/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_heap/main.cpp
@@ -1,0 +1,26 @@
+// Regression test for GitHub issue #3876 (heap-allocation variant):
+// Verifies that heap-allocated Derived objects still dispatch correctly
+// via the B8 sub-object, and that 'delete p' succeeds (the this-adjustment
+// in the DerivedToBase cast must NOT fire for 'new Derived()' assignments,
+// only for method-receiver casts).
+#include <cassert>
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  bool value;
+  void dummy() override {}
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived *p = new Derived();
+  p->value = true;
+  assert(p->run());
+  delete p;
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_heap/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_heap/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_heap/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_heap/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/esbmc-cpp/inheritance/github_3876_lvalue/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_lvalue/main.cpp
@@ -1,0 +1,25 @@
+// Regression test for GitHub issue #3876 (lvalue variant):
+// Verifies that virtual dispatch works when the Derived object is used as
+// an lvalue (not a pointer), i.e. 'd.B8::eval()' rather than 'ptr->eval()'.
+// The DerivedToBase cast here is lvalue-to-lvalue (struct type, not pointer),
+// so the byte-offset adjustment must NOT fire (it would produce invalid IR).
+#include <cassert>
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  bool value;
+  void dummy() override {}
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d;
+  d.value = true;
+  assert(d.run());
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_lvalue/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_lvalue/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_lvalue/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_lvalue/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION SUCCESSFUL$
 

--- a/regression/esbmc-cpp/inheritance/github_3876_many_bases/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_many_bases/main.cpp
@@ -1,0 +1,39 @@
+// Regression test for GitHub issue #3876 (many-bases variant):
+// With 9 base classes, B8 has a large offset within Concrete. Verifies that
+// both the this-pointer adjustment at the call site (B8::eval()) AND the
+// vtable thunk this-adjustment (restoring Concrete* from B8* in guard())
+// are computed correctly when accessing a data member.
+#include <cassert>
+
+struct B0 { virtual bool f0() = 0; };
+struct B1 { virtual bool f1() = 0; };
+struct B2 { virtual bool f2() = 0; };
+struct B3 { virtual bool f3() = 0; };
+struct B4 { virtual bool f4() = 0; };
+struct B5 { virtual bool f5() = 0; };
+struct B6 { virtual bool f6() = 0; };
+struct B7 { virtual bool f7() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Concrete : B0, B1, B2, B3, B4, B5, B6, B7, B8
+{
+  bool value;
+  bool f0() override { return false; }
+  bool f1() override { return false; }
+  bool f2() override { return false; }
+  bool f3() override { return false; }
+  bool f4() override { return false; }
+  bool f5() override { return false; }
+  bool f6() override { return false; }
+  bool f7() override { return false; }
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Concrete c;
+  c.value = true;
+  assert(c.run() == true);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_many_bases/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_many_bases/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876_many_bases/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_many_bases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876_ptr/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_ptr/main.cpp
@@ -1,0 +1,38 @@
+// Regression test for GitHub issue #3876 (non-this pointer variant):
+// Verifies that ESBMC correctly adjusts the pointer when calling a virtual
+// method through a non-first base class via a local Derived* variable (not
+// 'this'). The cast 'Derived* -> B8*' must be offset by sizeof(B1) so that
+// virtual dispatch through B8's vtable finds Derived::guard() (which returns
+// true), not B1's vtable slot.
+#include <cassert>
+
+struct B1
+{
+  virtual void dummy() = 0;
+};
+
+struct B8
+{
+  virtual bool guard() = 0;
+  bool eval()
+  {
+    return guard();
+  }
+};
+
+struct Derived : B1, B8
+{
+  void dummy() override {}
+  bool guard() override
+  {
+    return true;
+  }
+};
+
+int main()
+{
+  Derived d;
+  Derived *ptr = &d;
+  assert(ptr->eval()); // virtual dispatch through B8 sub-object via local ptr
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_ptr/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_ptr/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876_ptr/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_ptr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876_static_cast/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_static_cast/main.cpp
@@ -1,0 +1,24 @@
+// Regression test for GitHub issue #3876 (explicit static_cast variant):
+// Verifies that virtual dispatch works when the base-class pointer is formed
+// via an explicit static_cast<B8*>(ptr) rather than an implicit conversion.
+#include <cassert>
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  bool value;
+  void dummy() override {}
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d;
+  d.value = true;
+  Derived *ptr = &d;
+  assert(static_cast<B8 *>(ptr)->eval());
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_static_cast/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_static_cast/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.cpp
+--unwind 10 --timeout 60
+^VERIFICATION SUCCESSFUL$
+

--- a/regression/esbmc-cpp/inheritance/github_3876_thunk/main.cpp
+++ b/regression/esbmc-cpp/inheritance/github_3876_thunk/main.cpp
@@ -1,0 +1,24 @@
+// Regression test for GitHub issue #3876 (thunk this-adjustment):
+// Verifies that the vtable thunk correctly adjusts this from B8* back to
+// Derived* so that data member access in the overriding guard() is valid.
+// Without the thunk fix, guard() reads value at the wrong address.
+#include <cassert>
+
+struct B1 { virtual void dummy() = 0; };
+struct B8 { virtual bool guard() = 0; bool eval() { return guard(); } };
+
+struct Derived : B1, B8
+{
+  bool value;
+  void dummy() override {}
+  bool guard() override { return value; }
+  bool run() { return B8::eval(); }
+};
+
+int main()
+{
+  Derived d;
+  d.value = true;
+  assert(d.run());
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/github_3876_thunk/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_thunk/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 60
+--unwind 10 --timeout 60
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/github_3876_thunk/test.desc
+++ b/regression/esbmc-cpp/inheritance/github_3876_thunk/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -6,6 +6,7 @@ CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/AST/Expr.h>
 #include <clang/AST/ExprCXX.h> /* clang::TypeTraitExpr */
 #include <clang/AST/ParentMapContext.h>
+#include <clang/AST/RecordLayout.h>
 #include <clang/AST/QualTypeNames.h>
 #include <clang/AST/Type.h>
 #include <clang/Basic/Version.inc>
@@ -3066,10 +3067,77 @@ bool clang_c_convertert::get_cast_expr(
   case clang::CK_ArrayToPointerDecay:
   case clang::CK_FunctionToPointerDecay:
   case clang::CK_BuiltinFnToFnPtr:
-  case clang::CK_UncheckedDerivedToBase:
     break;
 
+  case clang::CK_UncheckedDerivedToBase:
   case clang::CK_DerivedToBase:
+  {
+    // For multiple inheritance, the base class sub-object may reside at a
+    // non-zero byte offset within the derived object. Compute the total
+    // offset by following the cast path through the class hierarchy, then
+    // adjust the pointer by that many bytes so that virtual dispatch via
+    // the base vtable uses the correct vtable pointer.
+    clang::QualType cur_qt = cast.getSubExpr()->getType();
+    if (cur_qt->isPointerType() || cur_qt->isReferenceType())
+      cur_qt = cur_qt->getPointeeType();
+
+    uint64_t total_offset = 0;
+    bool adjust = true;
+    for (auto it = cast.path_begin(); it != cast.path_end(); ++it)
+    {
+      const clang::CXXBaseSpecifier *spec = *it;
+      if (spec->isVirtual())
+      {
+        // Virtual base offsets are dynamic; skip static adjustment.
+        adjust = false;
+        break;
+      }
+      const clang::CXXRecordDecl *cur_decl = cur_qt->getAsCXXRecordDecl();
+      const clang::CXXRecordDecl *base_decl =
+        spec->getType()->getAsCXXRecordDecl();
+      if (!cur_decl || !base_decl)
+      {
+        adjust = false;
+        break;
+      }
+      total_offset += ASTContext->getASTRecordLayout(cur_decl)
+                        .getBaseClassOffset(base_decl)
+                        .getQuantity();
+      cur_qt = spec->getType();
+    }
+
+    // Apply the byte-offset adjustment only when this cast forms the
+    // implicit object of a member call (i.e. its parent AST node is a
+    // MemberExpr). This covers both 'this->B8::eval()' (CXXThisExpr) and
+    // 'ptr->eval()' (DeclRefExpr via MemberExpr), while excluding general
+    // pointer conversions such as 'Base2 *o = new Derived()' that must
+    // remain unadjusted for ESBMC's delete model (the virtual-destructor
+    // thunk handles adjustment there separately).
+    bool is_method_receiver =
+      clang::isa<clang::CXXThisExpr>(cast.getSubExpr());
+    if (!is_method_receiver)
+    {
+      auto parents = ASTContext->getParents(cast);
+      if (!parents.empty() && parents.begin()->get<clang::MemberExpr>())
+        is_method_receiver = true;
+    }
+
+    if (adjust && total_offset > 0 && is_method_receiver)
+    {
+      // Cast to char*, add byte offset, then cast to the target pointer type.
+      // index_type() is signed address-width (ptrdiff_t), matching ESBMC's
+      // pointer arithmetic IR convention.
+      typet char_ptr = pointer_typet(char_type());
+      gen_typecast(ns, expr, char_ptr);
+      plus_exprt adjusted(expr, from_integer(total_offset, index_type()));
+      adjusted.type() = char_ptr;
+      expr = adjusted;
+    }
+
+    gen_typecast(ns, expr, type);
+    break;
+  }
+
   case clang::CK_BaseToDerived:
   case clang::CK_Dynamic:
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3125,8 +3125,7 @@ bool clang_c_convertert::get_cast_expr(
       auto parents = ASTContext->getParents(cast);
       if (!parents.empty())
       {
-        const clang::MemberExpr *me =
-          parents.begin()->get<clang::MemberExpr>();
+        const clang::MemberExpr *me = parents.begin()->get<clang::MemberExpr>();
         if (me)
         {
           auto grandparents = ASTContext->getParents(*me);
@@ -3139,7 +3138,9 @@ bool clang_c_convertert::get_cast_expr(
     }
 
     bool did_adjust = false;
-    if (adjust && total_offset > 0 && is_method_receiver && expr.type().is_pointer())
+    if (
+      adjust && total_offset > 0 && is_method_receiver &&
+      expr.type().is_pointer())
     {
       // Cast to char*, add byte offset, then cast to the target pointer type.
       // index_type() is signed address-width (ptrdiff_t), matching ESBMC's
@@ -3155,9 +3156,7 @@ bool clang_c_convertert::get_cast_expr(
     // Preserve original behaviour: CK_DerivedToBase always called gen_typecast;
     // CK_UncheckedDerivedToBase was a no-op (break) and should only typecast
     // when we actually applied a byte-offset adjustment above.
-    if (
-      cast.getCastKind() == clang::CK_DerivedToBase ||
-      did_adjust)
+    if (cast.getCastKind() == clang::CK_DerivedToBase || did_adjust)
       gen_typecast(ns, expr, type);
 
     break;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3120,6 +3120,11 @@ bool clang_c_convertert::get_cast_expr(
       clang::isa<clang::CXXThisExpr>(cast.getSubExpr());
     if (!is_method_receiver)
     {
+      // Check whether the immediate parent is a MemberExpr (the object slot of
+      // a method call). Intermediate nodes such as ParenExpr or ExprWithCleanups
+      // appear either below this cast (as its sub-expression) or above the
+      // MemberExpr (wrapping the full call), so checking only the first parent
+      // is sufficient for the patterns Clang actually produces here.
       auto parents = ASTContext->getParents(cast);
       if (!parents.empty() && parents.begin()->get<clang::MemberExpr>())
         is_method_receiver = true;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3113,6 +3113,9 @@ bool clang_c_convertert::get_cast_expr(
     // pointer conversions such as 'Base2 *o = new Derived()' that must
     // remain unadjusted for ESBMC's delete model (the virtual-destructor
     // thunk handles adjustment there separately).
+    // NOTE: 'static_cast<B8*>(ptr)->eval()' is NOT yet handled — in that
+    // case the cast's parent is a CXXMemberCallExpr, not a MemberExpr, so
+    // is_method_receiver remains false and no adjustment is emitted.
     bool is_method_receiver =
       clang::isa<clang::CXXThisExpr>(cast.getSubExpr());
     if (!is_method_receiver)

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3106,30 +3106,39 @@ bool clang_c_convertert::get_cast_expr(
       cur_qt = spec->getType();
     }
 
-    // Apply the byte-offset adjustment only when this cast forms the
-    // implicit object of a member call (i.e. its parent AST node is a
-    // MemberExpr). This covers both 'this->B8::eval()' (CXXThisExpr) and
-    // 'ptr->eval()' (DeclRefExpr via MemberExpr), while excluding general
-    // pointer conversions such as 'Base2 *o = new Derived()' that must
-    // remain unadjusted for ESBMC's delete model (the virtual-destructor
-    // thunk handles adjustment there separately).
-    // NOTE: 'static_cast<B8*>(ptr)->eval()' is NOT yet handled — in that
-    // case the cast's parent is a CXXMemberCallExpr, not a MemberExpr, so
-    // is_method_receiver remains false and no adjustment is emitted.
-    bool is_method_receiver =
-      clang::isa<clang::CXXThisExpr>(cast.getSubExpr());
-    if (!is_method_receiver)
+    // Apply the byte-offset adjustment only when this cast is the implicit
+    // object of a CXXMemberCallExpr (i.e. parent is MemberExpr AND
+    // grandparent is CXXMemberCallExpr). This covers:
+    //   - 'this->B8::eval()' (CXXThisExpr sub-expr)
+    //   - 'ptr->eval()' (DeclRefExpr sub-expr via MemberExpr)
+    // and excludes:
+    //   - Field accesses like 'return j' via 'using Baz::j' — parent is
+    //     MemberExpr but grandparent is ReturnStmt, not CXXMemberCallExpr.
+    //     ESBMC uses named field access for inherited members, so adding a
+    //     byte offset here would corrupt the symbolic model.
+    //   - 'Base2 *o = new Derived()' — parent is not MemberExpr at all.
+    //     Must remain unadjusted for ESBMC's delete model.
+    // NOTE: 'static_cast<B8*>(ptr)->eval()' is not yet handled correctly
+    // (separate issue tracked by the github_3876_static_cast KNOWNBUG test).
+    bool is_method_receiver = false;
     {
-      // Check whether the immediate parent is a MemberExpr (the object slot of
-      // a method call). Intermediate nodes such as ParenExpr or ExprWithCleanups
-      // appear either below this cast (as its sub-expression) or above the
-      // MemberExpr (wrapping the full call), so checking only the first parent
-      // is sufficient for the patterns Clang actually produces here.
       auto parents = ASTContext->getParents(cast);
-      if (!parents.empty() && parents.begin()->get<clang::MemberExpr>())
-        is_method_receiver = true;
+      if (!parents.empty())
+      {
+        const clang::MemberExpr *me =
+          parents.begin()->get<clang::MemberExpr>();
+        if (me)
+        {
+          auto grandparents = ASTContext->getParents(*me);
+          if (
+            !grandparents.empty() &&
+            grandparents.begin()->get<clang::CXXMemberCallExpr>())
+            is_method_receiver = true;
+        }
+      }
     }
 
+    bool did_adjust = false;
     if (adjust && total_offset > 0 && is_method_receiver && expr.type().is_pointer())
     {
       // Cast to char*, add byte offset, then cast to the target pointer type.
@@ -3140,9 +3149,17 @@ bool clang_c_convertert::get_cast_expr(
       plus_exprt adjusted(expr, from_integer(total_offset, index_type()));
       adjusted.type() = char_ptr;
       expr = adjusted;
+      did_adjust = true;
     }
 
-    gen_typecast(ns, expr, type);
+    // Preserve original behaviour: CK_DerivedToBase always called gen_typecast;
+    // CK_UncheckedDerivedToBase was a no-op (break) and should only typecast
+    // when we actually applied a byte-offset adjustment above.
+    if (
+      cast.getCastKind() == clang::CK_DerivedToBase ||
+      did_adjust)
+      gen_typecast(ns, expr, type);
+
     break;
   }
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3125,7 +3125,7 @@ bool clang_c_convertert::get_cast_expr(
         is_method_receiver = true;
     }
 
-    if (adjust && total_offset > 0 && is_method_receiver)
+    if (adjust && total_offset > 0 && is_method_receiver && expr.type().is_pointer())
     {
       // Cast to char*, add byte offset, then cast to the target pointer type.
       // index_type() is signed address-width (ptrdiff_t), matching ESBMC's

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -390,6 +390,7 @@ protected:
    *  - type: ESBMC IR representing the derived class' type
    */
   void add_thunk_method(
+    const clang::CXXRecordDecl &derived_rd,
     const clang::CXXMethodDecl &md,
     const struct_typet::componentt &component,
     struct_typet &type);
@@ -413,7 +414,8 @@ protected:
    */
   void add_thunk_method_body(
     symbolt &thunk_func_symb,
-    const struct_typet::componentt &component);
+    const struct_typet::componentt &component,
+    uint64_t base_offset);
   /*
    * Add thunk body that contains return value
    * Params:
@@ -424,7 +426,7 @@ protected:
   void add_thunk_method_body_return(
     symbolt &thunk_func_symb,
     const struct_typet::componentt &component,
-    const typecast_exprt &late_cast_this);
+    const exprt &late_cast_this);
   /*
    * Add thunk body that does NOT contain return value
    * Params:
@@ -435,7 +437,7 @@ protected:
   void add_thunk_method_body_no_return(
     symbolt &thunk_func_symb,
     const struct_typet::componentt &component,
-    const typecast_exprt &late_cast_this);
+    const exprt &late_cast_this);
   /*
    * Add thunk function as a `method` in the derived class' type
    * Params:

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -301,6 +301,11 @@ void clang_cpp_convertert::add_thunk_method(
   // Compute the byte offset of the base class sub-object within the derived
   // class. For non-first base classes in multiple inheritance this is non-zero,
   // and the thunk must subtract it from its Base* this to recover Derived*.
+  // TODO: This loop only searches direct bases of derived_rd. If base_rd is
+  // an indirect base (e.g. Derived : Middle, Middle : B8), base_offset will
+  // incorrectly remain 0. A complete fix requires summing offsets along the
+  // full inheritance path using CXXBasePaths::isDerivedFrom or a recursive
+  // walk — to be addressed as a follow-up.
   uint64_t base_offset = 0;
   const clang::CXXRecordDecl *base_rd = md.getParent();
   const clang::ASTRecordLayout &layout =

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -21,10 +21,13 @@ CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/Index/USRGeneration.h>
 #include <clang/Frontend/ASTUnit.h>
 #include <clang/AST/ParentMapContext.h>
+#include <clang/AST/RecordLayout.h>
 #include <llvm/Support/raw_os_ostream.h>
 CC_DIAGNOSTIC_POP()
 
 #include <clang-cpp-frontend/clang_cpp_convert.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/message.h>
 
@@ -85,7 +88,7 @@ bool clang_cpp_convertert::get_struct_class_virtual_methods(
       get_overriden_methods(*md, cxxmethods_overriden);
 
       for (const auto &overriden_md_entry : cxxmethods_overriden)
-        add_thunk_method(overriden_md_entry.second, comp, type);
+        add_thunk_method(cxxrd, overriden_md_entry.second, comp, type);
     }
   }
 
@@ -256,6 +259,7 @@ void clang_cpp_convertert::add_vtable_type_entry(
 }
 
 void clang_cpp_convertert::add_thunk_method(
+  const clang::CXXRecordDecl &derived_rd,
   const clang::CXXMethodDecl &md,
   const struct_typet::componentt &component,
   struct_typet &type)
@@ -294,6 +298,24 @@ void clang_cpp_convertert::add_thunk_method(
   std::string base_class_id, base_class_name;
   get_decl_name(*md.getParent(), base_class_name, base_class_id);
 
+  // Compute the byte offset of the base class sub-object within the derived
+  // class. For non-first base classes in multiple inheritance this is non-zero,
+  // and the thunk must subtract it from its Base* this to recover Derived*.
+  uint64_t base_offset = 0;
+  const clang::CXXRecordDecl *base_rd = md.getParent();
+  const clang::ASTRecordLayout &layout =
+    ASTContext->getASTRecordLayout(&derived_rd);
+  for (const auto &base_spec : derived_rd.bases())
+  {
+    const clang::CXXRecordDecl *spec_rd =
+      base_spec.getType()->getAsCXXRecordDecl();
+    if (spec_rd == base_rd && !base_spec.isVirtual())
+    {
+      base_offset = layout.getBaseClassOffset(base_rd).getQuantity();
+      break;
+    }
+  }
+
   // Create the thunk method symbol
   symbolt thunk_func_symb;
   thunk_func_symb.id =
@@ -315,7 +337,7 @@ void clang_cpp_convertert::add_thunk_method(
   add_thunk_method_arguments(thunk_func_symb);
 
   // add thunk function body
-  add_thunk_method_body(thunk_func_symb, component);
+  add_thunk_method_body(thunk_func_symb, component, base_offset);
 
   // add thunk function symbol to the symbol table
   symbolt &added_thunk_symbol =
@@ -406,31 +428,45 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
 
 void clang_cpp_convertert::add_thunk_method_body(
   symbolt &thunk_func_symb,
-  const struct_typet::componentt &component)
+  const struct_typet::componentt &component,
+  uint64_t base_offset)
 {
   code_typet &code_type = to_code_type(thunk_func_symb.type);
   code_typet::argumentst &args = code_type.arguments();
 
-  /*
-   * late cast of `this` pointer to (Derived*)this
-   */
-  typecast_exprt late_cast_this(
-    to_code_type(component.type()).arguments()[0].type());
-  late_cast_this.op0() =
+  // Build the adjusted 'this' to pass to the overriding method.
+  // The thunk receives a Base*, but the overriding method expects Derived*.
+  // For non-first base classes, subtract the byte offset of the Base
+  // sub-object within Derived so that the overriding method's 'this' points
+  // to the start of the Derived object, not the Base sub-object.
+  typet derived_ptr_type = to_code_type(component.type()).arguments()[0].type();
+  exprt base_this =
     symbol_expr(*namespacet(context).lookup(args[0].cmt_identifier()));
+
+  exprt adjusted_this;
+  if (base_offset > 0)
+  {
+    typet char_ptr = pointer_typet(char_type());
+    typecast_exprt to_char(base_this, char_ptr);
+    minus_exprt sub(to_char, from_integer(base_offset, index_type()));
+    sub.type() = char_ptr;
+    adjusted_this = typecast_exprt(sub, derived_ptr_type);
+  }
+  else
+    adjusted_this = typecast_exprt(base_this, derived_ptr_type);
 
   if (
     code_type.return_type().id() != "empty" &&
     code_type.return_type().id() != "destructor")
-    add_thunk_method_body_return(thunk_func_symb, component, late_cast_this);
+    add_thunk_method_body_return(thunk_func_symb, component, adjusted_this);
   else
-    add_thunk_method_body_no_return(thunk_func_symb, component, late_cast_this);
+    add_thunk_method_body_no_return(thunk_func_symb, component, adjusted_this);
 }
 
 void clang_cpp_convertert::add_thunk_method_body_return(
   symbolt &thunk_func_symb,
   const struct_typet::componentt &component,
-  const typecast_exprt &late_cast_this)
+  const exprt &late_cast_this)
 {
   /*
    * Add thunk function with return value, something like:
@@ -464,7 +500,7 @@ void clang_cpp_convertert::add_thunk_method_body_return(
 void clang_cpp_convertert::add_thunk_method_body_no_return(
   symbolt &thunk_func_symb,
   const struct_typet::componentt &component,
-  const typecast_exprt &late_cast_this)
+  const exprt &late_cast_this)
 {
   /*
    * Add thunk function without return value, something like:

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2883,7 +2883,7 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
       // Check sub class
       if (
         base_type_eq(expect_type->type, value->type, ns) ||
-        is_subclass_of(expect_type->type, value->type, ns))
+        is_subclass_of(value->type, expect_type->type, ns))
         expr = gen_true_expr();
       else
         expr = gen_false_expr();

--- a/src/goto-symex/builtin_functions.cpp
+++ b/src/goto-symex/builtin_functions.cpp
@@ -2883,7 +2883,7 @@ void goto_symext::simplify_python_builtins(expr2tc &expr)
       // Check sub class
       if (
         base_type_eq(expect_type->type, value->type, ns) ||
-        is_subclass_of(value->type, expect_type->type, ns))
+        is_subclass_of(expect_type->type, value->type, ns))
         expr = gen_true_expr();
       else
         expr = gen_false_expr();

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -422,6 +422,12 @@ static std::string reformat_class_name(const std::string &from)
 // Returns true if the class named 'subname' is a (direct or indirect)
 // subclass of the class named 'supername'. Parameter order: super first,
 // sub second — i.e. is_subclass_of_rec(super, sub, ns).
+// NOTE: The type2tc overload of is_subclass_of() below intentionally calls
+// this with args transposed (subname first, supername second), producing an
+// inverted result for that overload. Several call sites in dereference.cpp
+// and smt_casts.cpp rely on that inverted behaviour (they expect false for
+// valid derived→base cases so their own struct-prefix logic fires instead).
+// Do NOT "fix" the type2tc overload without first auditing those call sites.
 static bool is_subclass_of_rec(
   const std::string &supername,
   const std::string &subname,
@@ -462,7 +468,8 @@ bool is_subclass_of(
   // following:
   std::string supername = reformat_class_name(superclass_r.name.as_string());
   std::string subname = reformat_class_name(subclass_r.name.as_string());
-  return is_subclass_of_rec(supername, subname, ns);
+  // Intentionally transposed: see NOTE on is_subclass_of_rec above.
+  return is_subclass_of_rec(subname, supername, ns);
 }
 
 bool is_subclass_of(

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -419,6 +419,9 @@ static std::string reformat_class_name(const std::string &from)
   return classname;
 }
 
+// Returns true if the class named 'subname' is a (direct or indirect)
+// subclass of the class named 'supername'. Parameter order: super first,
+// sub second — i.e. is_subclass_of_rec(super, sub, ns).
 static bool is_subclass_of_rec(
   const std::string &supername,
   const std::string &subname,
@@ -459,7 +462,7 @@ bool is_subclass_of(
   // following:
   std::string supername = reformat_class_name(superclass_r.name.as_string());
   std::string subname = reformat_class_name(subclass_r.name.as_string());
-  return is_subclass_of_rec(subname, supername, ns);
+  return is_subclass_of_rec(supername, subname, ns);
 }
 
 bool is_subclass_of(


### PR DESCRIPTION
Fixes #3876.