### PR TITLE
python: handle list conditions in conditional expressions

### DIFF
--- a/regression/python/list-condition-ifexp-fail/main.py
+++ b/regression/python/list-condition-ifexp-fail/main.py
@@ -1,0 +1,3 @@
+xs = []
+value = 1 if xs else 0
+assert value == 1

--- a/regression/python/list-condition-ifexp-fail/test.desc
+++ b/regression/python/list-condition-ifexp-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION FAILED$

--- a/regression/python/list-condition-ifexp/main.py
+++ b/regression/python/list-condition-ifexp/main.py
@@ -1,0 +1,7 @@
+xs = []
+value = 1 if xs else 0
+assert value == 0
+
+ys = [1]
+value2 = 1 if ys else 0
+assert value2 == 1

--- a/regression/python/list-condition-ifexp/test.desc
+++ b/regression/python/list-condition-ifexp/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --no-standard-checks --smt-during-symex --smt-symex-guard
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -6993,6 +6993,43 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
         }
       }
     }
+
+    typet list_type = type_handler_.get_list_type();
+    // Python treats lists in conditions by their size, for example:
+    // `1 if xs else 0`.
+    if (
+      current_block &&
+      (cond.type() == list_type ||
+       (cond.type().is_pointer() && cond.type().subtype() == list_type)))
+    {
+      const symbolt *size_func =
+        symbol_table_.find_symbol("c:@F@__ESBMC_list_size");
+      if (!size_func)
+        throw std::runtime_error(
+          "__ESBMC_list_size not found for list condition check");
+
+      symbolt &size_result = create_tmp_symbol(
+        ast_node["test"], "$list_size$", size_type(), gen_zero(size_type()));
+      code_declt size_decl(symbol_expr(size_result));
+      size_decl.location() = location;
+      current_block->copy_to_operands(size_decl);
+
+      // Use `__ESBMC_list_size(cond) != 0` to evaluate the list condition.
+      code_function_callt size_call;
+      size_call.function() = symbol_expr(*size_func);
+      size_call.lhs() = symbol_expr(size_result);
+      if (cond.type().is_pointer())
+        size_call.arguments().push_back(cond);
+      else
+        size_call.arguments().push_back(address_of_exprt(cond));
+      size_call.type() = size_type();
+      size_call.location() = location;
+      current_block->copy_to_operands(size_call);
+
+      cond = exprt("notequal", bool_type());
+      cond.copy_to_operands(symbol_expr(size_result), gen_zero(size_type()));
+      cond.location() = location;
+    }
   }
 
   // Python truthiness for complex in conditional contexts:


### PR DESCRIPTION
This PR handles lists used as conditions.

  Example:
  ```python
  xs = []
  value = 1 if xs else 0
  assert value == 0
```

This makes list conditions follow Python semantics by evaluating them through their size.
Before this change ESBMC was failing with:
```text
Violated property:
  file main.py line 3 column 0
  assertion value == 0
  value == 0
```

Needed by #3386