### PR TITLE
[c++] migrate esbmc-cpp/inheritance tests to supported test.desc format

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -52,7 +52,7 @@ function(add_esbmc_regression_test folder modes test)
       PROPERTIES SKIP_RETURN_CODE 10
       TIMEOUT ${ESBMC_REGRESS_TIMEOUT}
       ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}"
-      LABELS "regression;${folder}")
+      LABELS "regression;${folder}/")
 endfunction()
 
 function(add_esbmc_regression folder modes)
@@ -116,6 +116,7 @@ set(REGRESSIONS_CPP03 esbmc-cpp/cpp
                       esbmc-cpp/destructors
                       esbmc-cpp/polymorphism_bringup
                       esbmc-cpp/polymorphism_bringup_overload
+                      esbmc-cpp/inheritance
                       esbmc-cpp/inheritance_bringup
                       esbmc-cpp/bug_fixes
                       esbmc-cpp/OM_sanity_checks
@@ -193,8 +194,10 @@ if(APPLE)
                     ${REGRESSIONS_MATHSAT}
                     ${REGRESSIONS_Z3}
                     incremental-smt
-                    esbmc-cpp11/cpp
-                    esbmc-cpp11/cbmc-constructors
+                    ${REGRESSIONS_CPP03}
+                    ${REGRESSIONS_CPP11}
+                    ${REGRESSIONS_CPP14}
+                    ${REGRESSIONS_CPP17}
                     extensions
                     ${REGRESSIONS_CHERI}
                     ${REGRESSIONS_PYTHON}

--- a/regression/esbmc-cpp/inheritance/ch13_25/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch13_25/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp Employee.cpp HourlyEmployee.cpp SalariedEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+BasePlusCommissionEmployee.cpp CommissionEmployee.cpp Employee.cpp HourlyEmployee.cpp SalariedEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/ch22_1/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch22_1/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/ch22_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch22_2/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/ch22_4/test.desc
+++ b/regression/esbmc-cpp/inheritance/ch22_4/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>derived.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+derived.cpp --unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast1/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast1/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast1/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast2_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast2_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast4/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast4/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast4_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast4_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast5/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast5/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast5/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast5/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast5_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast5_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast6/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast6/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple2/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple2/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple2_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple2_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple3_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple3_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple_bug/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_simple_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_simple_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_void/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_void/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_void/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_void/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/inheritance-cbmc/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance-cbmc/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance01/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance01/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance02/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance02/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/inheritance04/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance04/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance05/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance05/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance06/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance06/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+BasePlusCommissionEmployee.cpp CommissionEmployee.cpp --unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance07/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance07/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance08/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance08/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/inheritance09/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance09/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance10/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance10/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/inheritance11/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance11/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance12/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance12/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance12/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance12/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance13/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance13/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance14/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance14/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/inheritance15/test.desc
+++ b/regression/esbmc-cpp/inheritance/inheritance15/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance-wrong/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_multiple_inheritance/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 2 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance-wrong/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/llbmc_virtual_inheritance/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 2 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 2 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/multiple_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/multiple_inheritance/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/multiple_inheritance_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/multiple_inheritance_2/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/multiple_inheritance_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/multiple_inheritance_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/paper_inheritance_example/test.desc
+++ b/regression/esbmc-cpp/inheritance/paper_inheritance_example/test.desc
@@ -1,13 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/paper_inheritance_example_fail/test.desc
+++ b/regression/esbmc-cpp/inheritance/paper_inheritance_example_fail/test.desc
@@ -1,13 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-  <item_10_mode>KNOWNBUG</item_10_mode>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/polymorphism_abstract_base_class/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_abstract_base_class/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_1/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_1/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_1/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_2/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_2/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_2/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_3/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_4/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_common_error_4/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_common_error_4/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^CONVERSION ERROR$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^CONVERSION ERROR$

--- a/regression/esbmc-cpp/inheritance/polymorphism_dynamic_allocation/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_dynamic_allocation/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/polymorphism_pointer_to_base_class/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_pointer_to_base_class/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/polymorphism_virtual_members/test.desc
+++ b/regression/esbmc-cpp/inheritance/polymorphism_virtual_members/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/single_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/single_inheritance/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/single_inheritance_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/single_inheritance_bug/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 10 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION FAILED$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 900
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.cpp
 --unwind 5 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 3 --no-standard-checks --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 5 --no-unwinding-assertions --timeout 900
+--unwind 5 --no-standard-checks --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
@@ -1,12 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
-<test-case>
-  <item_01_test_case_version>Versão 1.0</item_01_test_case_version>
-  <item_02_id>esbmc-inheritance</item_02_id>
-  <item_03_summary>Aims to analyze the main function from module: esbmc-inheritance</item_03_summary>
-  <item_04_file_C_to_test>main.cpp </item_04_file_C_to_test>
-  <item_05_option_to_run_esbmc>--unwind 5 --no-unwinding-assertions --timeout 900</item_05_option_to_run_esbmc>
-  <item_06_expected_result>^VERIFICATION SUCCESSFUL$</item_06_expected_result>
-  <item_07_test_importance>High</item_07_test_importance>
-  <item_08_execution_type>Automated</item_08_execution_type>
-  <item_09_author>Ceteli/UFAM</item_09_author>
-</test-case>
+CORE
+main.cpp
+--unwind 5 --no-unwinding-assertions --timeout 900
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
+++ b/regression/esbmc-cpp/inheritance/z_inheritance/test.desc
@@ -1,4 +1,4 @@
 KNOWNBUG
 main.cpp
---unwind 5 --no-standard-checks --no-unwinding-assertions --timeout 900
+--unwind 3 --no-standard-checks --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Convert 53 test.desc files from the obsolete XML format to the plain-text format expected by testing_tool.py. Register esbmc-cpp/inheritance in REGRESSIONS_CPP03 (Linux/macOS), expand the macOS APPLE branch from two hardcoded entries to the full REGRESSIONS_CPP03/11/14/17 variable sets, and append a trailing slash to test labels so ctest -L regex matching is precise (e.g. esbmc-cpp/inheritance/ no longer matches esbmc-cpp/inheritance_bringup/).