### PR TITLE
[ir-ra] add theorem-driven support for round-to-minus-inf

### DIFF
--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
@@ -3,18 +3,19 @@
  * PURPOSE
  * -------
  * Verifies that a floating-point addition performed under a directed rounding
- * mode (FE_DOWNWARD) takes the weak unconstrained enclosure path, not the
- * theorem-driven tight path that is valid only for round-to-nearest or
- * round-toward-+inf.
+ * mode (FE_TOWARDZERO) takes the weak unconstrained enclosure path, not the
+ * theorem-driven tight path that is valid only for round-to-nearest,
+ * round-toward-+inf, or round-toward--inf.
  *
  * MECHANISM
  * ---------
- * fesetround(FE_DOWNWARD) writes 3 (ROUND_TO_MINUS_INF) to __ESBMC_rounding_mode.
+ * fesetround(FE_TOWARDZERO) writes 4 (ROUND_TO_ZERO) to __ESBMC_rounding_mode.
  * ESBMC symex propagates this concrete value into the rounding_mode operand of
- * the ieee_add2t IR node.  In smt_conv::apply_ieee754_semantics, neither the
- * is_nearest_rounding_mode nor the is_round_to_plus_inf guard fires
- * (value 3 != ROUND_TO_EVEN == 0 and value 3 != ROUND_TO_PLUS_INF == 2), so
- * only the three weak containment assertions are emitted:
+ * the ieee_add2t IR node.  In smt_conv::apply_ieee754_semantics, none of the
+ * is_nearest_rounding_mode, is_round_to_plus_inf, or is_round_to_minus_inf
+ * guards fire (value 4 != ROUND_TO_EVEN == 0, value 4 != ROUND_TO_PLUS_INF == 2,
+ * and value 4 != ROUND_TO_MINUS_INF == 3), so only the three weak containment
+ * assertions are emitted:
  *   (assert (<= |ra_lo| result))
  *   (assert (<= result  |ra_hi|))
  *   (assert (<= |ra_lo| |ra_hi|))
@@ -36,10 +37,10 @@ extern double __VERIFIER_nondet_double(void);
 
 int main(void)
 {
-  fesetround(FE_DOWNWARD);
+  fesetround(FE_TOWARDZERO);
   double x = __VERIFIER_nondet_double();
   double y = __VERIFIER_nondet_double();
-  double z = x + y; /* rounding_mode == ROUND_TO_MINUS_INF -> weak fallback */
+  double z = x + y; /* rounding_mode == ROUND_TO_ZERO -> weak fallback */
 
   /* Always false in real/integer encoding: z == x+y exactly.
    * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/main.c
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/main.c
@@ -1,0 +1,49 @@
+/* Regression test: ROUND_TO_MINUS_INF tight enclosure under --ir-ra, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-rounding-minus-inf-tight-bounds/ but exercises the IEEE single-
+ * precision (float) path.  Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_semantics is reached and
+ * emits ra_lo_dn:: / ra_hi_dn:: symbols, not the weak fallback.
+ *
+ * PROOF SHAPE (B_dir, single precision)
+ * --------------------------------------
+ * For round-toward-minus-inf, fl_RDN(r) <= r always. The enclosure is asymmetric:
+ *   fl_RDN(r) in [r - B_dir(r),  r]
+ * where B_dir(r) = eps_rel_dir * |r| + eps_abs
+ * and eps_rel_dir = 2^-23 (full machine epsilon for single, FLT_EPSILON).
+ *
+ * EPSILON IN SMT OUTPUT
+ * ---------------------
+ * get_single_eps_up() passes "1.1920928955078125e-07" to mk_smt_real.
+ * This decimal is exactly 2^-23 = 1/8388608, so Z3 simplifies it to the
+ * rational (/ 1 8388608) rather than keeping a large numerator.  The pattern
+ * 8388608 (= 2^23) is matched in test.desc as the single-precision indicator,
+ * distinguishing this path from the double-precision path (which shows the
+ * large numerator 22204460492503131).
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::  -- tight round-down path taken (not weak fallback)
+ *   ra_hi_dn::  -- tight round-down path taken
+ *   \(ite       -- |r| absolute value present
+ *   8388608     -- Z3 denominator for eps_rel_dir = 2^-23 (single precision)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+#include <fenv.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  fesetround(FE_DOWNWARD);
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* rounding_mode == ROUND_TO_MINUS_INF -> tight down path */
+
+  /* Always false in real/integer encoding: z == x+y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/test.desc
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/main.c
@@ -7,7 +7,7 @@
  *
  * PROOF SHAPE (B_dir)
  * -------------------
- * For round-toward--inf, fl_RDN(r) <= r always. The enclosure is asymmetric:
+ * For round-toward-minus-inf, fl_RDN(r) <= r always. The enclosure is asymmetric:
  *   fl_RDN(r) in [r - B_dir(r),  r]
  * where B_dir(r) = eps_rel_dir * |r| + eps_abs
  * and eps_rel_dir = 2^-52 (full machine epsilon for double, DBL_EPSILON).

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/main.c
@@ -1,0 +1,41 @@
+/* Regression test: ROUND_TO_MINUS_INF uses tight asymmetric enclosure under --ir-ra.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that fesetround(FE_DOWNWARD) causes apply_ieee754_semantics to take
+ * the tight ROUND_TO_MINUS_INF path, not the weak fallback.
+ *
+ * PROOF SHAPE (B_dir)
+ * -------------------
+ * For round-toward--inf, fl_RDN(r) <= r always. The enclosure is asymmetric:
+ *   fl_RDN(r) in [r - B_dir(r),  r]
+ * where B_dir(r) = eps_rel_dir * |r| + eps_abs
+ * and eps_rel_dir = 2^-52 (full machine epsilon for double, DBL_EPSILON).
+ * This is the same directed-mode constant used for ROUND_TO_PLUS_INF; only
+ * the bound shape is mirrored (ra_hi is now the exact side, ra_lo the loose side).
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::  -- tight round-down path taken (not weak fallback)
+ *   ra_hi_dn::  -- tight round-down path taken
+ *   \(ite       -- |r| absolute value present (lower bound B_dir needs it)
+ *   22204460492503131  -- Z3 rational numerator for eps_rel_dir = 2^-52
+ *                         (same as ROUND_TO_PLUS_INF; this is expected and correct)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+#include <fenv.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  fesetround(FE_DOWNWARD);
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* rounding_mode == ROUND_TO_MINUS_INF -> tight down path */
+
+  /* Always false in real/integer encoding: z == x+y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -362,6 +362,16 @@ static bool is_round_to_plus_inf(const expr2tc &rounding_mode)
          BigInt(ieee_floatt::ROUND_TO_PLUS_INF);
 }
 
+static bool is_round_to_minus_inf(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_MINUS_INF);
+}
+
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
   const floatbv_type2t &fbv_type,
@@ -515,6 +525,74 @@ smt_astt smt_convt::apply_ieee754_semantics(
       // Pin ra_hi = r + B_dir(r)
       assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B_dir(r)
       assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B_dir(r) <= ra_hi
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else if (is_round_to_minus_inf(rounding_mode))
+    {
+      // Asymmetric tight enclosure for ROUND_TO_MINUS_INF:
+      //   fl_RDN(r) <= r  (exact upper bound; round-down never overshoots)
+      //   fl_RDN(r) >= r - B_dir(r)
+      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
+      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single)
+      //   This is the directed-mode error constant, the same value used for
+      //   ROUND_TO_PLUS_INF; the bound shape is the mirror image.
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_dn, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_dn = get_double_eps_up(); // eps_rel_dir = 2^-52, same as RUP
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_dn = get_single_eps_up(); // eps_rel_dir = 2^-23, same as RUP
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B_dir(r) = eps_rel_dir * |r| + eps_abs
+      smt_astt b_dir = mk_add(mk_mul(eps_dn, abs_r), eps_abs);
+      smt_astt ra_lo_expr = mk_sub(real_result, b_dir); // r - B_dir(r)
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_dn::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_dn::", nullptr);
+
+      // Pin ra_lo = r - B_dir(r)  (the computed lower bound)
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B_dir(r)
+      assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B_dir(r) <= ra_lo
+
+      // Pin ra_hi = r  (exact upper bound for round-down)
+      assert_ast(mk_le(ra_hi, real_result)); // ra_hi <= r
+      assert_ast(mk_le(real_result, ra_hi)); // r <= ra_hi  =>  ra_hi == r
 
       // Containment: ra_lo <= result <= ra_hi
       assert_ast(mk_le(ra_lo, real_result));

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -550,16 +550,16 @@ smt_astt smt_convt::apply_ieee754_semantics(
       auto single_spec = ieee_float_spect::single_precision();
 
       smt_sortt rs = mk_real_sort();
-      smt_astt eps_dn, eps_abs;
+      smt_astt eps_rel_dir, eps_abs;
 
       if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
       {
-        eps_dn = get_double_eps_up(); // eps_rel_dir = 2^-52, same as RUP
+        eps_rel_dir = get_double_eps_up(); // 2^-52, same value as RUP
         eps_abs = get_double_min_subnormal();
       }
       else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
       {
-        eps_dn = get_single_eps_up(); // eps_rel_dir = 2^-23, same as RUP
+        eps_rel_dir = get_single_eps_up(); // 2^-23, same value as RUP
         eps_abs = get_single_min_subnormal();
       }
       else
@@ -578,7 +578,7 @@ smt_astt smt_convt::apply_ieee754_semantics(
         mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
 
       // B_dir(r) = eps_rel_dir * |r| + eps_abs
-      smt_astt b_dir = mk_add(mk_mul(eps_dn, abs_r), eps_abs);
+      smt_astt b_dir = mk_add(mk_mul(eps_rel_dir, abs_r), eps_abs);
       smt_astt ra_lo_expr = mk_sub(real_result, b_dir); // r - B_dir(r)
 
       // Introduce named enclosure variables. Use bidirectional inequalities to


### PR DESCRIPTION
## Summary

This PR adds theorem-driven IR-RA support for `ROUND_TO_MINUS_INF` (`FE_DOWNWARD`).

The previously merged work already:
- kept round-to-nearest on the current tight symmetric path
- added a dedicated asymmetric tight path for `ROUND_TO_PLUS_INF`
- kept the remaining directed modes on weak fallback

This PR adds the next smallest sound step:
- a dedicated asymmetric tight enclosure for `ROUND_TO_MINUS_INF`
- while keeping `ROUND_TO_ZERO` and `ROUND_TO_AWAY` on the weak fallback path

## Main idea

For round-to-minus-inf, the exact one-step enclosure is modelled as:

- `ra_lo = r - B_dir(r)`
- `ra_hi = r`

where:
- `B_dir(r) = eps_rel_dir * |r| + eps_abs`
- `eps_rel_dir = 2^-52` for binary64
- `eps_rel_dir = 2^-23` for binary32

So this PR implements the proof-aligned single-step shape:

- `fl_RDN(r) ∈ [r - B_dir(r), r]`

## Main changes

- add `ROUND_TO_MINUS_INF` detection in `apply_ieee754_semantics`
- keep the nearest path unchanged
- keep the existing `ROUND_TO_PLUS_INF` path unchanged
- add a new asymmetric tight path for `ROUND_TO_MINUS_INF`
- keep `ROUND_TO_ZERO` and `ROUND_TO_AWAY` on weak fallback
- add a new regression for the minus-inf tight path
- update the directed weak-fallback regression to use `FE_TOWARDZERO`

## Regression coverage

This PR includes:

- `ra-rounding-nearest-tight-bounds`
  - unchanged nearest-mode tight path

- `ra-rounding-plus-inf-tight-bounds`
  - unchanged plus-inf tight path

- `ra-rounding-minus-inf-tight-bounds`
  - verifies the dedicated tight path for `FE_DOWNWARD`
  - checks for:
    - `ra_lo_dn`
    - `ra_hi_dn`
    - `ite`
    - the expected double directed-mode epsilon numerator
    - `VERIFICATION FAILED`

- `ra-rounding-directed-weak-fallback`
  - updated to use `FE_TOWARDZERO`
  - verifies that unsupported directed modes still use weak fallback

## Scope

This PR implements only:
- `ROUND_TO_MINUS_INF`

The following modes remain on weak fallback and are deferred:
- `ROUND_TO_ZERO`
- `ROUND_TO_AWAY`