### PR TITLE
python: return one-character strings from string indexing

### DIFF
--- a/regression/python/string-index-concat-char/main.py
+++ b/regression/python/string-index-concat-char/main.py
@@ -1,0 +1,6 @@
+def f(a):
+    if not a:
+        return ''
+    return a[0] + f(a[1:])
+
+assert f("ab") == "ab"

--- a/regression/python/string-index-concat-char/test.desc
+++ b/regression/python/string-index-concat-char/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 2 --no-unwinding-assertions --no-standard-checks --smt-during-symex --smt-symex-guard --bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-index-return-char/main.py
+++ b/regression/python/string-index-return-char/main.py
@@ -1,0 +1,6 @@
+def f(a):
+    if not a:
+        return ''
+    return a[0]
+
+assert f("ab") == "a"

--- a/regression/python/string-index-return-char/test.desc
+++ b/regression/python/string-index-return-char/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2064,6 +2064,26 @@ exprt python_list::handle_index_access(
     return extract_pyobject_value(list_at_call, elem_type);
   }
 
+  auto char_to_python_str = [&](exprt char_expr, const locationt &location) {
+    if (char_expr.type() != unsigned_char_type())
+      char_expr = typecast_exprt(char_expr, unsigned_char_type());
+    if (char_expr.type() != int_type())
+      char_expr = typecast_exprt(char_expr, int_type());
+
+    symbolt *chr_symbol =
+      converter_.symbol_table().find_symbol("c:@F@__python_chr");
+    if (!chr_symbol)
+      throw std::runtime_error(
+        "__python_chr function not found in symbol table");
+
+    side_effect_expr_function_callt chr_call;
+    chr_call.function() = symbol_expr(*chr_symbol);
+    chr_call.arguments().push_back(char_expr);
+    chr_call.location() = location;
+    chr_call.type() = pointer_typet(char_type());
+    return static_cast<exprt>(chr_call);
+  };
+
   // Handle static string indexing with IndexError on out-of-bounds
   if (array.type().is_array() && array.type().subtype() == char_type())
   {
@@ -2093,8 +2113,14 @@ exprt python_list::handle_index_access(
     guard.then_case() = throw_code;
     converter_.add_instruction(guard);
 
-    return index_exprt(array, idx, char_type());
+    return char_to_python_str(
+      index_exprt(array, idx, char_type()), guard.location());
   }
+
+  if (array.type().is_pointer() && array.type().subtype() == char_type())
+    return char_to_python_str(
+      index_exprt(array, pos_expr, char_type()),
+      converter_.get_location_from_decl(list_value_));
 
   // Handle static arrays
   return index_exprt(array, pos_expr, array.type().subtype());


### PR DESCRIPTION
This PR fixes string indexing in `python_list`.

Example:
```python
def f(a: str) -> str:
    if not a:
        return ''
    return a[0]

assert f("ab") == "a"
```

When indexing a string, the frontend now returns a one-character Python string instead of a scalar character value.
Before this change ESBMC the example above was failing with:
```text
[Counterexample]


State 2 file /tmp/main.py line 6 column 0 thread 0
----------------------------------------------------
Violated property:
  file /tmp/main.py line 6 column 0
  assertion tmp$3
  tmp$3


VERIFICATION FAILED
```
And regression/python/string-index-concat-char/main.py (added in this PR) was failing with: 

```text
Unwinding recursion f iteration 1 (1 max)
esbmc: /home/bruno/esbmc/src/pointer-analysis/dereference.cpp:443: virtual expr2tc dereferencet::dereference_expr_nonscalar(expr2tc&, guardt&, dereferencet::modet, const expr2tc&): Assertion `!has_dereference(expr)' failed.
[2]    583413 IOT instruction (core dumped)  esbmc /tmp/main.py --incremental-bmc
```

Needed by #3237 