### PR TITLE
[ir-ra] add theorem-driven support for round-to-zero

### DIFF
--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
@@ -2,20 +2,20 @@
  *
  * PURPOSE
  * -------
- * Verifies that a floating-point addition performed under a directed rounding
- * mode (FE_TOWARDZERO) takes the weak unconstrained enclosure path, not the
- * theorem-driven tight path that is valid only for round-to-nearest,
- * round-toward-+inf, or round-toward--inf.
+ * Verifies that a floating-point addition performed under ROUND_TO_AWAY takes
+ * the weak unconstrained enclosure path, not any theorem-driven tight path.
  *
  * MECHANISM
  * ---------
- * fesetround(FE_TOWARDZERO) writes 4 (ROUND_TO_ZERO) to __ESBMC_rounding_mode.
- * ESBMC symex propagates this concrete value into the rounding_mode operand of
- * the ieee_add2t IR node.  In smt_conv::apply_ieee754_semantics, none of the
- * is_nearest_rounding_mode, is_round_to_plus_inf, or is_round_to_minus_inf
- * guards fire (value 4 != ROUND_TO_EVEN == 0, value 4 != ROUND_TO_PLUS_INF == 2,
- * and value 4 != ROUND_TO_MINUS_INF == 3), so only the three weak containment
- * assertions are emitted:
+ * ROUND_TO_AWAY (value 1 in ieee_floatt) has no standard fesetround() constant
+ * in C, so __ESBMC_rounding_mode is written directly.  ESBMC symex propagates
+ * this concrete value into the rounding_mode operand of the ieee_add2t IR node.
+ * In smt_conv::apply_ieee754_semantics, none of the guards fire:
+ *   is_nearest_rounding_mode  (value 1 != ROUND_TO_EVEN == 0)
+ *   is_round_to_plus_inf      (value 1 != ROUND_TO_PLUS_INF == 2)
+ *   is_round_to_minus_inf     (value 1 != ROUND_TO_MINUS_INF == 3)
+ *   is_round_to_zero          (value 1 != ROUND_TO_ZERO == 4)
+ * so only the three weak containment assertions are emitted:
  *   (assert (<= |ra_lo| result))
  *   (assert (<= result  |ra_hi|))
  *   (assert (<= |ra_lo| |ra_hi|))
@@ -31,16 +31,16 @@
  * absence is documented here rather than machine-checked.
  */
 #include <assert.h>
-#include <fenv.h>
 
+extern int __ESBMC_rounding_mode;
 extern double __VERIFIER_nondet_double(void);
 
 int main(void)
 {
-  fesetround(FE_TOWARDZERO);
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY -- no standard fesetround constant */
   double x = __VERIFIER_nondet_double();
   double y = __VERIFIER_nondet_double();
-  double z = x + y; /* rounding_mode == ROUND_TO_ZERO -> weak fallback */
+  double z = x + y; /* rounding_mode == ROUND_TO_AWAY -> weak fallback */
 
   /* Always false in real/integer encoding: z == x+y exactly.
    * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds-single/main.c
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds-single/main.c
@@ -1,0 +1,49 @@
+/* Regression test: ROUND_TO_ZERO tight enclosure under --ir-ra, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-rounding-zero-tight-bounds/ but exercises the IEEE single-
+ * precision (float) path.  Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_semantics is reached and
+ * emits ra_lo_tz:: / ra_hi_tz:: symbols, not the weak fallback.
+ *
+ * PROOF SHAPE (B_dir, single precision)
+ * --------------------------------------
+ * Same sign-dependent enclosure as the double case:
+ *   r >= 0:  fl_RTZ(r) in [r - B_dir(r),  r]
+ *   r <  0:  fl_RTZ(r) in [r,  r + B_dir(r)]
+ * where eps_rel_dir = 2^-23 (full machine epsilon for single, FLT_EPSILON).
+ *
+ * EPSILON IN SMT OUTPUT
+ * ---------------------
+ * get_single_eps_up() passes "1.1920928955078125e-07" to mk_smt_real.
+ * This decimal is exactly 2^-23 = 1/8388608, so Z3 simplifies it to the
+ * rational (/ 1 8388608) rather than keeping a large numerator.  The pattern
+ * 8388608 (= 2^23) is matched in test.desc as the single-precision indicator,
+ * distinguishing this path from the double-precision path (numerator
+ * 22204460492503131).
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::      -- tight round-toward-zero path taken (not weak)
+ *   ra_hi_tz::      -- tight round-toward-zero path taken
+ *   \(ite           -- sign-conditional ITE present in formula
+ *   8388608         -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+#include <fenv.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  fesetround(FE_TOWARDZERO);
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* rounding_mode == ROUND_TO_ZERO -> tight tz path */
+
+  /* Always false in real/integer encoding: z == x+y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds-single/test.desc
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds/main.c
@@ -1,0 +1,56 @@
+/* Regression test: ROUND_TO_ZERO uses tight asymmetric enclosure under --ir-ra.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that fesetround(FE_TOWARDZERO) causes apply_ieee754_semantics to
+ * take the tight ROUND_TO_ZERO path, not the weak fallback.
+ *
+ * PROOF SHAPE (B_dir, sign-dependent)
+ * -------------------------------------
+ * ROUND_TO_ZERO truncates toward zero: it rounds down for r >= 0 and rounds
+ * up for r < 0.  The enclosure is therefore sign-dependent:
+ *
+ *   r >= 0:  fl_RTZ(r) in [r - B_dir(r),  r]   (truncate-down shape)
+ *   r <  0:  fl_RTZ(r) in [r,  r + B_dir(r)]   (truncate-up shape)
+ *
+ * Unified as:
+ *   ra_lo = ite(r >= 0,  r - B_dir(r),  r)
+ *   ra_hi = ite(r >= 0,  r,              r + B_dir(r))
+ *
+ * where B_dir(r) = eps_rel_dir * |r| + eps_abs
+ * and eps_rel_dir = 2^-52 (full machine epsilon for double, DBL_EPSILON).
+ * This is the same directed-mode constant used for ROUND_TO_PLUS_INF and
+ * ROUND_TO_MINUS_INF; only the bound shape differs (sign-conditional here).
+ *
+ * MECHANISM
+ * ---------
+ * fesetround(FE_TOWARDZERO) writes 4 (ROUND_TO_ZERO) to __ESBMC_rounding_mode.
+ * ESBMC symex propagates this concrete value into the rounding_mode operand of
+ * the ieee_add2t IR node.  In smt_conv::apply_ieee754_semantics, the guard
+ * is_round_to_zero fires and emits the ra_lo_tz:: / ra_hi_tz:: tight path.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::          -- tight round-toward-zero path taken (not weak)
+ *   ra_hi_tz::          -- tight round-toward-zero path taken
+ *   \(ite               -- sign-conditional ITE present in formula
+ *   22204460492503131   -- Z3 rational numerator for eps_rel_dir = 2^-52
+ *                          (same as ROUND_TO_PLUS_INF / ROUND_TO_MINUS_INF)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+#include <fenv.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  fesetround(FE_TOWARDZERO);
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* rounding_mode == ROUND_TO_ZERO -> tight tz path */
+
+  /* Always false in real/integer encoding: z == x+y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -372,6 +372,16 @@ static bool is_round_to_minus_inf(const expr2tc &rounding_mode)
          BigInt(ieee_floatt::ROUND_TO_MINUS_INF);
 }
 
+static bool is_round_to_zero(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_ZERO);
+}
+
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
   const floatbv_type2t &fbv_type,
@@ -593,6 +603,87 @@ smt_astt smt_convt::apply_ieee754_semantics(
       // Pin ra_hi = r  (exact upper bound for round-down)
       assert_ast(mk_le(ra_hi, real_result)); // ra_hi <= r
       assert_ast(mk_le(real_result, ra_hi)); // r <= ra_hi  =>  ra_hi == r
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
+    else if (is_round_to_zero(rounding_mode))
+    {
+      // Asymmetric tight enclosure for ROUND_TO_ZERO (truncation toward zero).
+      //
+      // RTZ is sign-dependent: it rounds down for r >= 0 and rounds up for r < 0.
+      //   r >= 0:  fl_RTZ(r) in [r - B_dir(r),  r]   (same shape as RDN)
+      //   r <  0:  fl_RTZ(r) in [r,  r + B_dir(r)]   (same shape as RUP)
+      //
+      // Unified via ITE on sign:
+      //   ra_lo = ite(r >= 0,  r - B_dir(r),  r)
+      //   ra_hi = ite(r >= 0,  r,              r + B_dir(r))
+      //
+      // where B_dir(r) = eps_rel_dir * |r| + eps_abs
+      //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_rel_dir, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_rel_dir = get_double_eps_up(); // 2^-52, same value as RUP/RDN
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_rel_dir = get_single_eps_up(); // 2^-23, same value as RUP/RDN
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B_dir(r) = eps_rel_dir * |r| + eps_abs
+      smt_astt b_dir = mk_add(mk_mul(eps_rel_dir, abs_r), eps_abs);
+
+      // Sign-dependent enclosure bounds via ITE:
+      //   r >= 0: lower is computed, upper is exact (truncate-down shape)
+      //   r <  0: lower is exact,    upper is computed (truncate-up shape)
+      smt_astt r_nonneg = mk_le(zero, real_result); // r >= 0
+      smt_astt ra_lo_expr =
+        mk_ite(r_nonneg, mk_sub(real_result, b_dir), real_result);
+      smt_astt ra_hi_expr =
+        mk_ite(r_nonneg, real_result, mk_add(real_result, b_dir));
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_tz::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_tz::", nullptr);
+
+      // Pin ra_lo = ite(r >= 0, r - B_dir(r), r)
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= ra_lo_expr
+      assert_ast(mk_le(ra_lo_expr, ra_lo)); // ra_lo_expr <= ra_lo
+
+      // Pin ra_hi = ite(r >= 0, r, r + B_dir(r))
+      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= ra_hi_expr
+      assert_ast(mk_le(ra_hi_expr, ra_hi)); // ra_hi_expr <= ra_hi
 
       // Containment: ra_lo <= result <= ra_hi
       assert_ast(mk_le(ra_lo, real_result));


### PR DESCRIPTION
## Summary

This PR adds theorem-driven IR-RA support for `ROUND_TO_ZERO` (`FE_TOWARDZERO`).

It implements the next smallest sound step after the existing nearest, round-to-plus-inf, and round-to-minus-inf work by adding a dedicated tight enclosure for truncation toward zero.

Unsupported directed rounding still falls back to the weak enclosure; in particular, `ROUND_TO_AWAY` remains deferred.

## Main idea

`ROUND_TO_ZERO` is sign-dependent:

- if `r >= 0`, truncation toward zero has the same shape as round-down:
  - `fl_RTZ(r) ∈ [r - B_dir(r), r]`

- if `r < 0`, truncation toward zero has the same shape as round-up:
  - `fl_RTZ(r) ∈ [r, r + B_dir(r)]`

where:
- `B_dir(r) = eps_rel_dir * |r| + eps_abs`
- `eps_rel_dir = 2^-52` for binary64
- `eps_rel_dir = 2^-23` for binary32

The sign split is encoded with SMT `ite` nodes.

## Main changes

- add `ROUND_TO_ZERO` detection in `apply_ieee754_semantics`
- add a sign-dependent tight path for `ROUND_TO_ZERO`
- keep `ROUND_TO_AWAY` on weak fallback
- update the directed weak-fallback regression to use `ROUND_TO_AWAY`
- add double and single precision regressions for the new `ROUND_TO_ZERO` path

## Regression coverage

This PR includes:

- `ra-rounding-zero-tight-bounds`
  - verifies the dedicated tight path for `FE_TOWARDZERO` in double precision
  - checks for:
    - `ra_lo_tz`
    - `ra_hi_tz`
    - `ite`
    - the expected double directed-mode epsilon numerator
    - `VERIFICATION FAILED`

- `ra-rounding-zero-tight-bounds-single`
  - verifies the single-precision `ROUND_TO_ZERO` path
  - checks for:
    - `ra_lo_tz`
    - `ra_hi_tz`
    - `ite`
    - the expected single-precision directed-mode epsilon denominator/pattern
    - `VERIFICATION FAILED`

- `ra-rounding-directed-weak-fallback`
  - updated to use `ROUND_TO_AWAY`
  - verifies that unsupported directed modes still use weak fallback

## Scope

This PR implements only:
- `ROUND_TO_ZERO`

The following mode remains on weak fallback and is deferred:
- `ROUND_TO_AWAY`