### PR TITLE
[ir-ra] add theorem-driven support for round-to-away

### DIFF
--- a/regression/ir-ra/ra-rounding-away-tight-bounds-single/main.c
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds-single/main.c
@@ -1,0 +1,50 @@
+/* Regression test: ROUND_TO_AWAY tight enclosure under --ir-ra, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-rounding-away-tight-bounds/ but exercises the IEEE single-
+ * precision (float) path. Verifies that the get_single_eps_rel() /
+ * get_single_min_subnormal() branch in apply_ieee754_semantics is reached and
+ * emits ra_lo_aw:: / ra_hi_aw:: symbols, not the weak fallback.
+ *
+ * PROOF SHAPE (B_near, single precision)
+ * --------------------------------------
+ * ROUND_TO_AWAY uses the same symmetric nearest-mode enclosure as the double
+ * case:
+ *   ra_lo = r - B(r)
+ *   ra_hi = r + B(r)
+ * where B(r) = eps_rel * |r| + eps_abs
+ * and eps_rel = 2^-24 (nearest-mode relative constant for single, same as
+ * ROUND_TO_EVEN).
+ *
+ * EPSILON IN SMT OUTPUT
+ * ---------------------
+ * get_single_eps_rel() passes "5.960464477539063e-08" to mk_smt_real.
+ * This decimal does not simplify to a small rational, so Z3 retains the
+ * large numerator 5960464477539063 in its output -- same numerator as the
+ * single-precision ROUND_TO_EVEN test. This is expected and correct.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::          -- tight round-to-away path taken
+ *   ra_hi_aw::          -- tight round-to-away path taken
+ *   \(ite               -- |r| absolute value present
+ *   5960464477539063    -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY -- no standard fesetround constant */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* rounding_mode == ROUND_TO_AWAY -> tight aw path */
+
+  /* Always false in real/integer encoding: z == x+y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-away-tight-bounds-single/test.desc
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(ite
+5960464477539063
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-away-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds/main.c
@@ -1,0 +1,56 @@
+/* Regression test: ROUND_TO_AWAY uses tight symmetric enclosure under --ir-ra.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that __ESBMC_rounding_mode = 1 (ROUND_TO_AWAY) causes
+ * apply_ieee754_semantics to take the tight ROUND_TO_AWAY path, not the weak
+ * fallback.
+ *
+ * PROOF SHAPE (B_near, symmetric)
+ * --------------------------------
+ * ROUND_TO_AWAY is a nearest-rounding mode (round to nearest, ties away from
+ * zero). Like ROUND_TO_EVEN, it uses the same nearest-mode linear enclosure:
+ *   |fl_RTA(r) - r| <= eps_rel * |r| + eps_abs
+ *
+ * The enclosure is symmetric -- identical in shape to the ROUND_TO_EVEN path:
+ *   ra_lo = r - B(r)
+ *   ra_hi = r + B(r)
+ * where B(r) = eps_rel * |r| + eps_abs
+ * and eps_rel = 2^-53 (nearest-mode relative constant for double, same as
+ * ROUND_TO_EVEN).
+ *
+ * HOW ROUND_TO_AWAY IS TRIGGERED
+ * --------------------------------
+ * ROUND_TO_AWAY (value 1 in ieee_floatt) has no standard fesetround() constant
+ * in C, and ESBMC's fenv.c does not map any FE_* to value 1.
+ * __ESBMC_rounding_mode is therefore written directly. ESBMC symex propagates
+ * this concrete value into the rounding_mode operand of the ieee_add2t IR node,
+ * and is_round_to_away fires in apply_ieee754_semantics.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::          -- tight round-to-away path taken (not weak fallback)
+ *   ra_hi_aw::          -- tight round-to-away path taken
+ *   \(ite               -- |r| absolute value present
+ *   5551115123125783    -- Z3 rational numerator for eps_rel = 2^-53 (double)
+ *                          Same numerator as ROUND_TO_EVEN: expected and correct,
+ *                          because ROUND_TO_AWAY uses the same nearest-mode
+ *                          relative constant and symmetric enclosure.
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY -- no standard fesetround constant */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* rounding_mode == ROUND_TO_AWAY -> tight aw path */
+
+  /* Always false in real/integer encoding: z == x+y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-rounding-away-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
@@ -1,21 +1,21 @@
-/* Regression test: directed rounding mode uses weak enclosure fallback under --ir-ra.
+/* Regression test: symbolic rounding mode uses weak enclosure fallback under --ir-ra.
  *
  * PURPOSE
  * -------
- * Verifies that a floating-point addition performed under ROUND_TO_AWAY takes
- * the weak unconstrained enclosure path, not any theorem-driven tight path.
+ * Verifies that a floating-point addition performed under a symbolic (non-
+ * constant) rounding mode takes the weak unconstrained enclosure path.  All
+ * five concrete rounding modes (ROUND_TO_EVEN, ROUND_TO_AWAY,
+ * ROUND_TO_PLUS_INF, ROUND_TO_MINUS_INF, ROUND_TO_ZERO) now have dedicated
+ * tight paths; this test exercises the remaining catch-all: a rounding_mode
+ * that is not a compile-time constant.
  *
  * MECHANISM
  * ---------
- * ROUND_TO_AWAY (value 1 in ieee_floatt) has no standard fesetround() constant
- * in C, so __ESBMC_rounding_mode is written directly.  ESBMC symex propagates
- * this concrete value into the rounding_mode operand of the ieee_add2t IR node.
- * In smt_conv::apply_ieee754_semantics, none of the guards fire:
- *   is_nearest_rounding_mode  (value 1 != ROUND_TO_EVEN == 0)
- *   is_round_to_plus_inf      (value 1 != ROUND_TO_PLUS_INF == 2)
- *   is_round_to_minus_inf     (value 1 != ROUND_TO_MINUS_INF == 3)
- *   is_round_to_zero          (value 1 != ROUND_TO_ZERO == 4)
- * so only the three weak containment assertions are emitted:
+ * __ESBMC_rounding_mode is assigned __VERIFIER_nondet_int(), which ESBMC
+ * symex cannot constant-fold.  The rounding_mode operand of the ieee_add2t
+ * IR node therefore remains symbolic.  In smt_conv::apply_ieee754_semantics,
+ * is_constant_int2t returns false for every guard, so only the three weak
+ * containment assertions are emitted:
  *   (assert (<= |ra_lo| result))
  *   (assert (<= result  |ra_hi|))
  *   (assert (<= |ra_lo| |ra_hi|))
@@ -24,23 +24,20 @@
  * ---------------
  *   ra_lo_weak / ra_hi_weak symbols are declared  -- weak path was taken
  *   ^VERIFICATION FAILED$               -- run completed
- *
- * NOTE: the tight-path epsilon numerator (5551115123125783 for double) would
- * be absent from the SMT output because the tight path was not taken.  This
- * cannot be expressed as a negative pattern in the current testing harness, so
- * absence is documented here rather than machine-checked.
  */
 #include <assert.h>
 
 extern int __ESBMC_rounding_mode;
+extern int __VERIFIER_nondet_int(void);
 extern double __VERIFIER_nondet_double(void);
 
 int main(void)
 {
-  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY -- no standard fesetround constant */
+  __ESBMC_rounding_mode =
+    __VERIFIER_nondet_int(); /* symbolic mode -> weak fallback */
   double x = __VERIFIER_nondet_double();
   double y = __VERIFIER_nondet_double();
-  double z = x + y; /* rounding_mode == ROUND_TO_AWAY -> weak fallback */
+  double z = x + y;
 
   /* Always false in real/integer encoding: z == x+y exactly.
    * Gives a deterministic VERIFICATION FAILED to confirm the run completed. */

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -368,8 +368,9 @@ smt_astt smt_convt::get_double_min_subnormal()
 
 // Returns true iff the rounding mode expression is a concrete integer constant
 // equal to ieee_floatt::ROUND_TO_EVEN (round-to-nearest-ties-to-even).
-// Directed modes (ROUND_TO_AWAY, ROUND_TO_PLUS_INF, ROUND_TO_MINUS_INF,
-// ROUND_TO_ZERO), symbolic rounding modes, and nil expr2tc all return false.
+// Directed modes (ROUND_TO_PLUS_INF, ROUND_TO_MINUS_INF, ROUND_TO_ZERO),
+// ROUND_TO_AWAY (handled by its own guard), symbolic rounding modes, and nil
+// expr2tc all return false.
 static bool is_nearest_rounding_mode(const expr2tc &rounding_mode)
 {
   if (is_nil_expr(rounding_mode))
@@ -408,6 +409,16 @@ static bool is_round_to_zero(const expr2tc &rounding_mode)
     return false;
   return to_constant_int2t(rounding_mode).value ==
          BigInt(ieee_floatt::ROUND_TO_ZERO);
+}
+
+static bool is_round_to_away(const expr2tc &rounding_mode)
+{
+  if (is_nil_expr(rounding_mode))
+    return false;
+  if (!is_constant_int2t(rounding_mode))
+    return false;
+  return to_constant_int2t(rounding_mode).value ==
+         BigInt(ieee_floatt::ROUND_TO_AWAY);
 }
 
 smt_astt smt_convt::apply_ieee754_semantics(
@@ -720,9 +731,89 @@ smt_astt smt_convt::apply_ieee754_semantics(
 
       return real_result;
     }
+    else if (is_round_to_away(rounding_mode))
+    {
+      // Tight path for ROUND_TO_AWAY (round-to-nearest, ties away from zero).
+      //
+      // ROUND_TO_AWAY is a nearest-rounding mode: the rounding error is
+      // bounded by the unit roundoff u = 1/2 * machine-epsilon, exactly as
+      // for ROUND_TO_EVEN.  The enclosure is therefore symmetric:
+      //   |fl_RTA(r) - r| <= eps_rel * |r| + eps_abs
+      //
+      // So:
+      //   B(r)  = eps_rel * |r| + eps_abs    (same formula as nearest)
+      //   ra_lo = r - B(r)
+      //   ra_hi = r + B(r)
+      //
+      // The epsilon constants are the same as ROUND_TO_EVEN:
+      //   eps_rel = 2^-53 (double) or 2^-24 (single) -- unit roundoff u
+      //
+      // NOTE: the Z3 numerator for eps_rel is the same as for the nearest
+      // path (5551115123125783 for double, 5960464477539063 for single).
+      // This is expected and correct -- the bound is identical.
+
+      unsigned int fraction_bits = fbv_type.fraction;
+      unsigned int exponent_bits = fbv_type.exponent;
+
+      auto double_spec = ieee_float_spect::double_precision();
+      auto single_spec = ieee_float_spect::single_precision();
+
+      smt_sortt rs = mk_real_sort();
+      smt_astt eps_rel, eps_abs;
+
+      if (exponent_bits == double_spec.e && fraction_bits == double_spec.f)
+      {
+        eps_rel = get_double_eps_rel(); // 2^-53, same as ROUND_TO_EVEN
+        eps_abs = get_double_min_subnormal();
+      }
+      else if (exponent_bits == single_spec.e && fraction_bits == single_spec.f)
+      {
+        eps_rel = get_single_eps_rel(); // 2^-24, same as ROUND_TO_EVEN
+        eps_abs = get_single_min_subnormal();
+      }
+      else
+      {
+        // Unsupported format: fall back to unconstrained weak enclosure.
+        smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
+        smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);
+        assert_ast(mk_le(ra_lo, real_result));
+        assert_ast(mk_le(real_result, ra_hi));
+        assert_ast(mk_le(ra_lo, ra_hi));
+        return real_result;
+      }
+
+      smt_astt zero = mk_smt_real("0.0");
+      smt_astt abs_r = mk_ite(
+        mk_lt(real_result, zero), mk_sub(zero, real_result), real_result);
+
+      // B(r) = eps_rel * |r| + eps_abs
+      smt_astt bound = mk_add(mk_mul(eps_rel, abs_r), eps_abs);
+      smt_astt ra_lo_expr = mk_sub(real_result, bound);
+      smt_astt ra_hi_expr = mk_add(real_result, bound);
+
+      // Introduce named enclosure variables. Use bidirectional inequalities to
+      // survive Z3's solve-eqs tactic (same technique as the other tight paths).
+      smt_astt ra_lo = mk_fresh(rs, "ra_lo_aw::", nullptr);
+      smt_astt ra_hi = mk_fresh(rs, "ra_hi_aw::", nullptr);
+
+      // Pin ra_lo = r - B(r)
+      assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= r - B(r)
+      assert_ast(mk_le(ra_lo_expr, ra_lo)); // r - B(r) <= ra_lo
+
+      // Pin ra_hi = r + B(r)
+      assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= r + B(r)
+      assert_ast(mk_le(ra_hi_expr, ra_hi)); // r + B(r) <= ra_hi
+
+      // Containment: ra_lo <= result <= ra_hi
+      assert_ast(mk_le(ra_lo, real_result));
+      assert_ast(mk_le(real_result, ra_hi));
+      assert_ast(mk_le(ra_lo, ra_hi));
+
+      return real_result;
+    }
     else
     {
-      // weak fallback
+      // weak fallback: symbolic or unrecognised rounding mode
       smt_sortt rs = mk_real_sort();
       smt_astt ra_lo = mk_fresh(rs, "ra_lo_weak::", nullptr);
       smt_astt ra_hi = mk_fresh(rs, "ra_hi_weak::", nullptr);


### PR DESCRIPTION
## Summary

This PR adds theorem-driven IR-RA support for `ROUND_TO_AWAY`.

It extends the existing single-step mode-aware SMT enclosure by adding a dedicated tight path for round-to-nearest, ties-away-from-zero, while preserving the current behaviour for the already supported modes.

## Main idea

`ROUND_TO_AWAY` is a nearest-rounding mode, so it uses the same symmetric nearest-mode enclosure as `ROUND_TO_EVEN`:

- `ra_lo = r - B_near(r)`
- `ra_hi = r + B_near(r)`

where:
- `B_near(r) = eps_rel * |r| + eps_abs`
- `eps_rel = 2^-53` for binary64
- `eps_rel = 2^-24` for binary32

The difference from `ROUND_TO_EVEN` is in tie-breaking only; the linear enclosure and constants remain the same.

## Main changes

- add `ROUND_TO_AWAY` detection in `apply_ieee754_semantics`
- add a dedicated symmetric tight path for `ROUND_TO_AWAY`
- reuse the existing nearest-mode constants for double and single precision
- add double and single precision regressions for the new path
- repurpose the weak-fallback regression to use a symbolic rounding mode

## Regression coverage

This PR includes:

- `ra-rounding-away-tight-bounds`
  - verifies the double-precision `ROUND_TO_AWAY` tight path
  - checks for:
    - `ra_lo_aw`
    - `ra_hi_aw`
    - `ite`
    - the expected double nearest-mode epsilon numerator
    - `VERIFICATION FAILED`

- `ra-rounding-away-tight-bounds-single`
  - verifies the single-precision `ROUND_TO_AWAY` tight path
  - checks for:
    - `ra_lo_aw`
    - `ra_hi_aw`
    - `ite`
    - the expected single nearest-mode epsilon numerator
    - `VERIFICATION FAILED`

- `ra-rounding-directed-weak-fallback`
  - updated to use a symbolic rounding mode
  - verifies that non-constant rounding modes still use weak fallback

## Scope

This PR implements only:
- `ROUND_TO_AWAY`

With this change, all five concrete IEEE-754 rounding modes now have dedicated single-step theorem-driven SMT enclosures:
- `ROUND_TO_EVEN`
- `ROUND_TO_AWAY`
- `ROUND_TO_PLUS_INF`
- `ROUND_TO_MINUS_INF`
- `ROUND_TO_ZERO`

The remaining weak fallback is now for symbolic or otherwise unrecognized rounding modes.