### PR TITLE
[symex] demote exception throw/catch logging from error/status to debug

### DIFF
--- a/regression/python/dict64/main.py
+++ b/regression/python/dict64/main.py
@@ -1,0 +1,5 @@
+d = {}
+
+d["attr"] = 42
+
+assert d["attr"] == 42

--- a/regression/python/dict64/test.desc
+++ b/regression/python/dict64/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 9 --no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/string-index-notfound_fail/test.desc
+++ b/regression/python/string-index-notfound_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Exception thrown of type ValueError at file .*string-index-notfound_fail/main.py line 3$
+^VERIFICATION FAILED$

--- a/regression/python/string-index-outofrange_fail/test.desc
+++ b/regression/python/string-index-outofrange_fail/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
 --incremental-bmc
-^ERROR: Exception thrown of type ValueError at file .*string-index-outofrange_fail/main.py line 3$
+^VERIFICATION FAILED$

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -105,8 +105,10 @@ bool goto_symext::symex_throw()
   // Save the throw
   last_throw = const_cast<goto_programt::instructiont *>(&instruction);
 
-  // Log
-  log_error(
+  // Log at debug level: the throw may be infeasible or caught; for uncaught
+  // exceptions, the error VCC is generated via claim(gen_false_expr()) below.
+  log_debug(
+    "symex",
     "Exception thrown of type {} at file {} line {}",
     exceptions_thrown.begin()->as_string(),
     instruction.location.file(),
@@ -260,8 +262,8 @@ bool goto_symext::symex_throw()
     return false;
   }
 
-  // Log
-  log_status(
+  log_debug(
+    "symex",
     "Caught by catch({}) at file {} line {}",
     catch_name,
     (*catch_insn)->location.file(),

--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -955,9 +955,6 @@ Generating GOTO Program
 GOTO program creation time: 1.433s
 GOTO program processing time: 0.029s
 Starting Bounded Model Checking
-ERROR: Exception thrown of type TypeError at file main.py line 13
-ERROR: Exception thrown of type TypeError at file main.py line 15
-ERROR: Exception thrown of type TypeError at file main.py line 17
 Symex completed in: 0.002s (10 assignments)
 Caching time: 0.000s (removed 2 assertions)
 Slicing time: 0.000s (removed 7 assignments)


### PR DESCRIPTION
This PR demotes both the throw and catch log calls to `log_debug` so they are visible only with `--verbosity` debug.