### PR TITLE
[smt] fix int-to-ptr fallback for byte-updated pointer patterns

### DIFF
--- a/regression/esbmc/github_2153/test.desc
+++ b/regression/esbmc/github_2153/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_2153_2/main.c
+++ b/regression/esbmc/github_2153_2/main.c
@@ -1,0 +1,18 @@
+// Variant of github_2153: byte-manipulation via struct-field pointer cast
+// at a non-zero byte offset.  After ptr[1] = nondet_char(), bug.bar can
+// represent any pointer value, so the assertion must fail.
+
+struct
+{
+  void *bar;
+} bug;
+
+int some_var;
+
+int main()
+{
+  char *ptr = (char *)&bug.bar;
+  ptr[1] = nondet_char();
+
+  __ESBMC_assert(bug.bar != &some_var, "");
+}

--- a/regression/esbmc/github_2153_2/test.desc
+++ b/regression/esbmc/github_2153_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_2153_2/test.desc
+++ b/regression/esbmc/github_2153_2/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_2153_3/main.c
+++ b/regression/esbmc/github_2153_3/main.c
@@ -1,0 +1,19 @@
+// Variant of github_2153: byte-manipulation through a char* cast to the whole
+// struct (not to a specific field).  The goto-symex produces a struct-level
+// byte_update, so bug.bar is extracted from byte_update<struct>(...).
+// After ptr[0] = nondet_char(), bug.bar can represent any pointer value.
+
+struct
+{
+  void *bar;
+} bug;
+
+int some_var;
+
+int main()
+{
+  char *ptr = (char *)&bug; /* points to the struct, not to bug.bar directly */
+  ptr[0] = nondet_char();
+
+  __ESBMC_assert(bug.bar != &some_var, "");
+}

--- a/regression/esbmc/github_2153_3/test.desc
+++ b/regression/esbmc/github_2153_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_2153_3/test.desc
+++ b/regression/esbmc/github_2153_3/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
-
+--incremental-bmc
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_2153_4/main.c
+++ b/regression/esbmc/github_2153_4/main.c
@@ -1,0 +1,21 @@
+int some_var;
+
+typedef struct local_s
+{
+    void *ptr;
+} local_t;
+
+void init(void* base, unsigned int size) {
+    for (int i = 0; i < size; i++) {
+        *((char*)base + i) = __VERIFIER_nondet_uchar();
+    }
+}
+
+local_t local_data;
+
+int main()
+{
+    init(&local_data, sizeof(local_t));
+
+    assert(local_data.ptr != &some_var);
+}

--- a/regression/esbmc/github_2153_4/test.desc
+++ b/regression/esbmc/github_2153_4/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_2153_5/main.c
+++ b/regression/esbmc/github_2153_5/main.c
@@ -1,0 +1,21 @@
+char nondet_char();
+
+void init_loop(void *base, unsigned int size) {
+  for (int i = 0; i < size; i++) {
+    *((char *)base + i) = nondet_char();
+  }
+}
+
+typedef struct my_obj {
+  int foo;
+  void *bar;
+} obj;
+
+int some_var;
+
+int main() {
+  obj bug;
+  init_loop(&bug, sizeof(bug));
+  __ESBMC_assume(bug.bar == &some_var);
+  __ESBMC_assert(0, "this should be reachable");
+}

--- a/regression/esbmc/github_2153_5/test.desc
+++ b/regression/esbmc/github_2153_5/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -513,8 +513,7 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
   // integer rather than pinning the fallback to the invalid object.
   const bool from_byte_update =
     is_byte_update2t(cast.from) ||
-    (is_extract2t(cast.from) &&
-     is_byte_update2t(to_extract2t(cast.from).from));
+    (is_extract2t(cast.from) && is_byte_update2t(to_extract2t(cast.from).from));
 
   if (from_byte_update)
   {
@@ -524,11 +523,12 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
       addr_space_type,
       symbol2tc(addr_space_arr_type, get_cur_addrspace_ident()),
       obj_num);
-    expr2tc from_start = member2tc(as.members[0], from_addr, as.member_names[0]);
-    expr2tc ptr_offs = pointer_offset2tc(
-      get_int_type(config.ansi_c.address_width), output_sym);
-    expr2tc address =
-      add2tc(ptraddr_type2(), from_start, typecast2tc(ptraddr_type2(), ptr_offs));
+    expr2tc from_start =
+      member2tc(as.members[0], from_addr, as.member_names[0]);
+    expr2tc ptr_offs =
+      pointer_offset2tc(get_int_type(config.ansi_c.address_width), output_sym);
+    expr2tc address = add2tc(
+      ptraddr_type2(), from_start, typecast2tc(ptraddr_type2(), ptr_offs));
     smt_astt addr = convert_ast(address);
     assert_ast(mk_implies(not_matched, addr->eq(this, target)));
     return output;

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -453,8 +453,9 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
   // Technically C doesn't allow for any variable to hold an invalid pointer,
   // except through initialization.
 
-  smt_sortt s = convert_sort(cast.type);
-  smt_astt output = mk_fresh(s, "smt_convt::int_to_ptr");
+  std::string newname = mk_fresh_name("smt_convt::int_to_ptr");
+  expr2tc output_sym = symbol2tc(cast.type, newname);
+  smt_astt output = convert_ast(output_sym);
   smt_astt output_obj = output->project(this, 0);
   smt_astt output_offs = output->project(this, 1);
   if (config.ansi_c.cheri)
@@ -505,44 +506,39 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
   smt_astt inv_obj = id;
   smt_astt inv_offs = offs;
 
-  if (is_byte_update2t(cast.from))
+  // Cast from a byte-updated pointer: either the direct BV-mode update
+  // byte_update<uint>(bitcast<uint>(ptr), ...) or a struct-field extraction
+  // extract<W>(byte_update<uint>(bitcast<uint>(struct), ...)).
+  // In both cases, constrain the output pointer's address to equal the target
+  // integer rather than pinning the fallback to the invalid object.
+  const bool from_byte_update =
+    is_byte_update2t(cast.from) ||
+    (is_extract2t(cast.from) &&
+     is_byte_update2t(to_extract2t(cast.from).from));
+
+  if (from_byte_update)
   {
-    // Handle byte_update(nondet_sym, offset, update) case
-    // The nondet pointer cannot match any address.
-    // Assign the object of int_to_ptr to the nondet pointer's object.
-    byte_update2t bu = to_byte_update2t(cast.from);
-    bitcast2t bc = to_bitcast2t(bu.source_value);
-    smt_astt sym = convert_ast(bc.from);
-
-    // Convert symbolic representation and project the object
-    smt_astt obj = sym->project(this, 0);
-    inv_obj = obj;
-
-    // Derive the numeric representation of the pointer object
-    // Access the current address space using obj_num as an index
-    expr2tc obj_num = pointer_object2tc(ptraddr_type2(), bc.from);
+    const struct_type2t &as = to_struct_type(addr_space_type);
+    expr2tc obj_num = pointer_object2tc(ptraddr_type2(), output_sym);
     expr2tc from_addr = index2tc(
       addr_space_type,
       symbol2tc(addr_space_arr_type, get_cur_addrspace_ident()),
       obj_num);
-
-    // Compute the offset between target and the start address
-    const struct_type2t &addr_space = to_struct_type(addr_space_type);
-    expr2tc from_start =
-      member2tc(addr_space.members[0], from_addr, addr_space.member_names[0]);
-
-    smt_astt addr_start = convert_ast(from_start);
-    inv_offs =
-      int_encoding ? mk_sub(target, addr_start) : mk_bvsub(target, addr_start);
+    expr2tc from_start = member2tc(as.members[0], from_addr, as.member_names[0]);
+    expr2tc ptr_offs = pointer_offset2tc(
+      get_int_type(config.ansi_c.address_width), output_sym);
+    expr2tc address =
+      add2tc(ptraddr_type2(), from_start, typecast2tc(ptraddr_type2(), ptr_offs));
+    smt_astt addr = convert_ast(address);
+    assert_ast(mk_implies(not_matched, addr->eq(this, target)));
+    return output;
   }
 
   smt_astt obj_eq = inv_obj->eq(this, output_obj);
   smt_astt offs_eq = inv_offs->eq(this, output_offs);
   smt_astt is_inv = mk_and(obj_eq, offs_eq);
 
-  smt_astt imp = mk_implies(not_matched, is_inv);
-  assert_ast(imp);
-
+  assert_ast(mk_implies(not_matched, is_inv));
   return output;
 }
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2153.

When a pointer is nondeterministically byte-manipulated through a char* cast (void*, struct field, or whole-struct cast), converting the result back to a pointer via `convert_typecast_to_ptr` should not pin the fallback to the INVALID object.  Pinning to INVALID (a constant) conflicted with the negated assertion, preventing the solver from finding the counterexample.

This PR replaces the fallback with `not_matched → addr_space[output.obj].start + output.offset = target`, which gives the solver freedom to pick any object whose address equals the target integer.  It also extends pattern detection to include struct-field extraction (via extract2t, wrapping byte_update2t).  Lastly, it adds regression tests github_2153_2 and github_2153_3.