### PR TITLE
ci: restore Codecov integration with dedicated coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ jobs:
   coverage:
     name: Build and upload coverage to Codecov
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
     env:
       CC: gcc
       CXX: g++
@@ -17,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies and build with coverage
-        run: ./scripts/build.sh -b Debug -k ON deps build
+        run: ./scripts/build.sh -b Debug -k ON
 
       - name: Run tests
         run: cd build/ && ctest -j4 --output-on-failure --progress .

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,49 @@
+name: Coverage
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  coverage:
+    name: Build and upload coverage to Codecov
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      CC: gcc
+      CXX: g++
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies and build with coverage
+        run: ./scripts/build.sh -b Debug -k ON deps build
+
+      - name: Run tests
+        run: cd build/ && ctest -j4 --output-on-failure --progress .
+
+      - name: Collect coverage data
+        run: |
+          lcov --capture \
+               --directory build/ \
+               --output-file coverage.info \
+               --ignore-errors mismatch
+
+      # Paths mirrored in codecov.yml for server-side filtering as a safety net
+      - name: Filter out uninteresting paths
+        run: |
+          lcov --remove coverage.info \
+               '/usr/*' \
+               '*/build/_deps/*' \
+               '*/unit/*' \
+               '*/src/ansi-c/cpp/*' \
+               '*/src/clang-c-frontend/headers/*' \
+               '*/src/c2goto/library/libm/musl/*' \
+               --output-file coverage.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.info
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+# Mirrors the lcov --remove filters in .github/workflows/coverage.yml
+ignore:
+  - "src/ansi-c/cpp/**"
+  - "src/clang-c-frontend/headers/**"
+  - "src/c2goto/library/libm/musl/**"
+  - "build/**"
+  - "**/unit/**"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,6 +45,7 @@ SOLVER_FLAGS=(
 COMPILER_ENV=()
 
 STATIC=""
+COVERAGE=OFF
 CLANG_VERSION=16
 MIN_MACOS_CLANG_VERSION=17
 
@@ -260,6 +261,10 @@ collect_ubuntu_packages() {
     UBUNTU_PACKAGES+=(g++-multilib)
   else
     log "Skipping g++-multilib on aarch64"
+  fi
+
+  if [[ "$COVERAGE" == "ON" ]]; then
+    UBUNTU_PACKAGES+=(lcov)
   fi
 
   if [[ "$STATIC" == "OFF" ]]; then
@@ -541,6 +546,7 @@ Options [defaults]:
   -C         build an SV-COMP version [disabled]
   -B ON|OFF  enable/disable esbmc bundled libc [ON]
   -x ON|OFF  enable/disable esbmc cheri [OFF]
+  -k ON|OFF  enable/disable coverage instrumentation (GCC/Clang --coverage) [OFF]
 
 Commands:
   fetch-deps         fetch dependency metadata and source archives [internal]
@@ -558,7 +564,7 @@ USAGE
 }
 
 # Setup build flags (release, debug, sanitizer, ...)
-while getopts "hb:s:e:r:dS:c:CB:x:" flag; do
+while getopts "hb:s:e:r:dS:c:CB:x:k:" flag; do
   case "$flag" in
     h)
       usage
@@ -606,6 +612,11 @@ while getopts "hb:s:e:r:dS:c:CB:x:" flag; do
     B)
       require_on_off "-B" "$OPTARG"
       BASE_ARGS+=("-DESBMC_BUNDLE_LIBC=$OPTARG")
+      ;;
+    k)
+      require_on_off "-k" "$OPTARG"
+      COVERAGE="$OPTARG"
+      BASE_ARGS+=("-DENABLE_COVERAGE=${OPTARG}")
       ;;
     x)
       require_on_off "-x" "$OPTARG"

--- a/scripts/cmake/Coverage.cmake
+++ b/scripts/cmake/Coverage.cmake
@@ -1,24 +1,18 @@
 if(ENABLE_COVERAGE)
-    if(CMAKE_COMPILER_IS_GNUCXX)        
-        if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(WARNING "Code coverage requires GCC or Clang — coverage flags not applied.")
+    else()
+        if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
             message(WARNING "Code coverage results with an optimized (non-Debug) build may be misleading")
         endif()
 
-        find_program(LCOV_PATH lcov REQUIRED)
+        find_program(LCOV_PATH lcov)
         if(NOT LCOV_PATH)
-            message(FATAL_ERROR "lcov not found! Aborting...")
+            message(WARNING "lcov not found — coverage reports will not be generated")
         endif()
 
-        find_program(GENHTML_PATH genhtml)
-        if(NOT GENHTML_PATH)
-            message(FATAL_ERROR "genhtml not found! Aborting...")
-        endif()
-
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
-
-        
-    else()
-        message(FATAL_ERROR "Code coverage requires GCC. Aborting.")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
     endif()
 endif()


### PR DESCRIPTION
Add coverage.yml workflow that builds ESBMC with GCC coverage instrumentation, runs ctest, filters lcov data, and uploads to Codecov on every push to master. Add -k ON|OFF flag to build.sh to enable ENABLE_COVERAGE and install lcov. Fix Coverage.cmake to accept GCC and Clang (not GCC-only), simplify to --coverage (dropping the redundant -fprofile-arcs -ftest-coverage), and add a codecov.yml for server-side path filtering.