### PR TITLE
[ir-ra] add theorem-driven RNE interval lifting for ieee_add

### DIFF
--- a/regression/ir-ra/ra-interval-lift-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-both-fresh/main.c
@@ -1,0 +1,46 @@
+/* Regression test: RNE interval lifting with both operands fresh (zero-regression sentinel).
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of an ieee_add are fresh nondet variables
+ * (not in ir_ra_interval_map), the point-interval fallback is applied to
+ * both, and the resulting formula is structurally equivalent to the
+ * pre-lifting single-step RNE path.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step)
+ * ---------------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNE add).
+ *   iv(x) = {x_smt, x_smt}  (point fallback)
+ *   iv(y) = {y_smt, y_smt}  (point fallback)
+ *   L_R = x_smt + y_smt = real_z
+ *   U_R = x_smt + y_smt = real_z
+ * The helper receives lo_r == hi_r == real_z, producing:
+ *   ra_lo = real_z - B_near(real_z)
+ *   ra_hi = real_z + B_near(real_z)
+ * This is identical in structure to the pre-lifting single-step formula.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo::          -- tight RNE path taken (same as single-step)
+ *   ra_hi::          -- tight RNE path taken
+ *   (ite             -- |r| absolute value present
+ *   5551115123125783 -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ *
+ * These are the same patterns as ra-rounding-nearest-tight-bounds, confirming
+ * zero regression from the point-interval fallback on single additions.
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* both operands fresh -> point fallback -> single-step equivalent */
+
+  /* Always false in real/integer encoding: z == x + y exactly. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-both-tracked/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RNE interval lifting with both operands tracked.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second ieee_add were themselves
+ * the result of a prior tracked RNE ieee_add, ir_ra_interval_map lookup
+ * fires for both operands and the interval-lifted path is taken.
+ *
+ * PROOF SHAPE
+ * -----------
+ * First add:  z = x + y   (both x, y fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   L_R1 = x + y = real_z,   U_R1 = x + y = real_z
+ *   ra_lo::0 = real_z - B_near(real_z),   ra_hi::0 = real_z + B_near(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo::0, ra_hi::0}
+ *
+ * Second add:  w = z + z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo::0, ra_hi::0}   (found in map, same entry twice)
+ *   L_R2 = ra_lo::0 + ra_lo::0,   U_R2 = ra_hi::0 + ra_hi::0
+ *   ra_lo::1 = L_R2 - B_near(L_R2),   ra_hi::1 = U_R2 + B_near(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo::0        -- first addition's interval lower bound declared
+ *   ra_lo::1        -- second addition's lifted lower bound declared
+ *   (ite            -- absolute value present in both B_near computations
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RNE add: x,y fresh -> point fallback; stored */
+  double w = z + z;   /* second RNE add: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-both-tracked/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-one-fresh/main.c
@@ -1,0 +1,43 @@
+/* Regression test: RNE interval lifting with one tracked, one fresh operand.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that the mixed lookup path works: when one operand of a second
+ * ieee_add is tracked in ir_ra_interval_map and the other is a fresh nondet
+ * variable, the tracked operand uses its stored interval while the fresh one
+ * falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE
+ * -----------
+ * First add:  z = x + y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo::0, ra_hi::0}
+ *
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo::0, ra_hi::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}         (point fallback)
+ *   L_R2 = ra_lo::0 + x_smt,   U_R2 = ra_hi::0 + x_smt
+ *   ra_lo::1 = L_R2 - B_near(L_R2),   ra_hi::1 = U_R2 + B_near(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo::0        -- first addition's interval lower bound declared
+ *   ra_lo::1        -- second addition's mixed-path lower bound declared
+ *   (ite            -- absolute value present
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RNE add: both fresh -> point fallback; stored */
+  double w = z + x;   /* second RNE add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-one-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-unchanged/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-unchanged/main.c
@@ -1,0 +1,34 @@
+/* Regression test: RNA (ROUND_TO_AWAY) does NOT use the interval-lifted path.
+ *
+ * PURPOSE
+ * -------
+ * The interval-lifted ieee_add path is guarded by is_nearest_rounding_mode(),
+ * which checks for ROUND_TO_EVEN (value 0) only, not for ROUND_TO_AWAY
+ * (value 1).  This test verifies that chained additions under RNA continue
+ * to use the existing single-step apply_ieee754_semantics path, producing
+ * ra_lo_aw:: / ra_hi_aw:: symbols -- not ra_lo:: / ra_hi:: from the
+ * interval-lifting helper.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::   -- RNA single-step path taken (not interval path)
+ *   ra_hi_aw::   -- RNA single-step path taken
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY -- bypasses interval-lift guard */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* RNA add: must NOT enter interval-lifting path */
+  double w = z + x;   /* RNA add: both single-step, ra_lo_aw:: expected */
+
+  /* Always false in real/integer encoding. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-unchanged/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-unchanged/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--ir-ra --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -421,6 +421,60 @@ static bool is_round_to_away(const expr2tc &rounding_mode)
          BigInt(ieee_floatt::ROUND_TO_AWAY);
 }
 
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rne_interval_add(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // Caller guarantees fbv_type is double or single precision.
+  const auto double_spec = ieee_float_spect::double_precision();
+  smt_astt eps_rel, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel = get_double_eps_rel();       // 2^-53
+    eps_abs = get_double_min_subnormal(); // 2^-1074
+  }
+  else
+  {
+    // single precision (caller verified double-or-single)
+    eps_rel = get_single_eps_rel();       // 2^-24
+    eps_abs = get_single_min_subnormal(); // 2^-149
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_near^-(R) = eps_rel * |lo_r| + eps_abs  (bound using lower endpoint)
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel, abs_lo), eps_abs);
+
+  // B_near^+(R) = eps_rel * |hi_r| + eps_abs  (bound using upper endpoint)
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel, abs_hi), eps_abs);
+
+  // ra_lo = lo_r - B_near^-(R),  ra_hi = hi_r + B_near^+(R)
+  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo);
+  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi);
+
+  // Named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as the single-step path).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi::", nullptr);
+
+  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo <= lo_r - B_near^-(R)
+  assert_ast(mk_le(ra_lo_expr, ra_lo)); // lo_r - B_near^-(R) <= ra_lo
+  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi <= hi_r + B_near^+(R)
+  assert_ast(mk_le(ra_hi_expr, ra_hi)); // hi_r + B_near^+(R) <= ra_hi
+
+  // Containment: ra_lo <= real_result <= ra_hi  and  ra_lo <= ra_hi
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
   const floatbv_type2t &fbv_type,
@@ -1248,10 +1302,49 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt side1 = convert_ast(to_ieee_add2t(expr).side_1);
       smt_astt side2 = convert_ast(to_ieee_add2t(expr).side_2);
       smt_astt real_result = mk_add(side1, side2);
-
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
-      a = apply_ieee754_semantics(
-        real_result, fbv_type, nullptr, to_ieee_add2t(expr).rounding_mode);
+      const expr2tc &rounding_mode = to_ieee_add2t(expr).rounding_mode;
+
+      // Interval-lifted RNE enclosure for ieee_add (--ir-ra only).
+      // For RNE + known format (double/single): look up each operand's stored
+      // interval, falling back to a point interval {side, side} for fresh or
+      // untracked operands.  Compute L_R = lo1+lo2, U_R = hi1+hi2, call the
+      // interval helper, then store the resulting {ra_lo, ra_hi} pair.
+      // Non-RNE modes, non-standard formats, and --ir-ra disabled all fall
+      // through to apply_ieee754_semantics unchanged.
+      bool interval_lifted = false;
+      if (
+        options.get_bool_option("ir-ra") &&
+        is_nearest_rounding_mode(rounding_mode))
+      {
+        const auto double_spec = ieee_float_spect::double_precision();
+        const auto single_spec = ieee_float_spect::single_precision();
+        if (
+          (fbv_type.exponent == double_spec.e &&
+           fbv_type.fraction == double_spec.f) ||
+          (fbv_type.exponent == single_spec.e &&
+           fbv_type.fraction == single_spec.f))
+        {
+          // Lookup with unconditional point-interval fallback.
+          auto get_iv = [this](smt_astt t) -> ra_interval_t {
+            auto it = ir_ra_interval_map.find(t);
+            return it != ir_ra_interval_map.end() ? it->second
+                                                  : ra_interval_t{t, t};
+          };
+          ra_interval_t iv1 = get_iv(side1);
+          ra_interval_t iv2 = get_iv(side2);
+          smt_astt lo_r = mk_add(iv1.lo, iv2.lo); // L_R = L_x + L_y
+          smt_astt hi_r = mk_add(iv1.hi, iv2.hi); // U_R = U_x + U_y
+          auto [ra_lo, ra_hi] =
+            apply_ieee754_rne_interval_add(real_result, lo_r, hi_r, fbv_type);
+          ir_ra_interval_map[real_result] = {ra_lo, ra_hi};
+          a = real_result;
+          interval_lifted = true;
+        }
+      }
+      if (!interval_lifted)
+        a = apply_ieee754_semantics(
+          real_result, fbv_type, nullptr, rounding_mode);
     }
     else
     {

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -976,6 +976,46 @@ private:
   double convert_rational_to_double(
     const BigInt &numerator,
     const BigInt &denominator);
+
+  /** Interval metadata for the RNE ieee_add interval-lifting path (--ir-ra).
+   *  After each RNE ieee_add (double/single, int encoding), the {ra_lo, ra_hi}
+   *  SMT symbols are stored here, keyed on the exact real_result AST pointer
+   *  (pointer equality == SSA identity via smt_cache).  Subsequent RNE
+   *  ieee_add calls look up each operand; missing entries fall back to a point
+   *  interval {side, side} which reproduces the single-step formula exactly.
+   *
+   *  Map lifetime: safe in standard BMC (no push_ctx during formula build).
+   *  In runtime_encoded_equationt (incremental), pop_ctx() deletes ASTs for
+   *  the popped level; stale entries may linger but are never looked up in
+   *  practice because SSA renaming gives distinct pointers per step.
+   *  TODO: clear entries for the popped ctx_level in a follow-up PR. */
+  struct ra_interval_t
+  {
+    smt_astt lo;
+    smt_astt hi;
+  };
+  std::unordered_map<const smt_ast *, ra_interval_t> ir_ra_interval_map;
+
+  /** Interval-lifted RNE enclosure helper for ieee_add (--ir-ra only).
+   *  Called from ieee_add_id after verifying RNE mode + known format.
+   *  Inputs:
+   *    real_result  exact symbolic real for this addition (mk_add(side1,side2))
+   *    lo_r         lower endpoint of the result interval (iv1.lo + iv2.lo)
+   *    hi_r         upper endpoint of the result interval (iv1.hi + iv2.hi)
+   *    fbv_type     FP type; caller guarantees double or single precision
+   *  Behavior:
+   *    Creates fresh ra_lo::N / ra_hi::N Real symbols.
+   *    Pins ra_lo to lo_r - B_near^-(lo_r) via bidirectional inequalities.
+   *    Pins ra_hi to hi_r + B_near^+(hi_r) via bidirectional inequalities.
+   *    Asserts containment: ra_lo <= real_result <= ra_hi, ra_lo <= ra_hi.
+   *    Point-interval fallback (lo_r == hi_r == real_result) produces a
+   *    formula structurally equivalent to the single-step RNE path.
+   *  Returns: {ra_lo, ra_hi} for storage in ir_ra_interval_map. */
+  std::pair<smt_astt, smt_astt> apply_ieee754_rne_interval_add(
+    smt_astt real_result,
+    smt_astt lo_r,
+    smt_astt hi_r,
+    const floatbv_type2t &fbv_type);
 };
 
 /** Given an array type, create a type2tc representing its domain. */


### PR DESCRIPTION
## Summary

This PR adds the first theorem-driven compositional interval-lifting step for IR-RA.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- kept those integrations at the single-step enclosure level only
- did not yet lift the proof to interval/compositional reuse across operations

This PR adds the next smallest sound step:

- a dedicated RNE-only interval-lifted path for ieee_add
- while keeping all other operations and rounding modes on the existing single-step path

## Main idea

For round-to-nearest-even addition, let:

- `R = hull(X + Y) = [L_R, U_R]`

with:

- `L_R = L_x + L_y`
- `U_R = U_x + U_y`

and:

- `B_near^-(R) = eps_rel_near * |L_R| + eps_abs`
- `B_near^+(R) = eps_rel_near * |U_R| + eps_abs`

So this PR implements the proof-aligned compositional shape:

- `fl_RNE(x + y) ∈ [L_R - B_near^-(R), U_R + B_near^+(R)]`

For implementation, operand intervals are obtained as follows:

- if a prior tracked RNE `ieee_add` result exists, reuse its stored `{ra_lo, ra_hi}`
- otherwise fall back to the point interval `{side, side}`

This keeps the PR small and preserves zero regression for fresh operands, since the point-interval case collapses exactly to the current single-step RNE formula.

## Main changes

- add minimal interval metadata storage in `smt_convt` for tracked RNE `ieee_add` results
- add a dedicated private helper for the interval-lifted RNE `ieee_add` enclosure
- modify only the `ieee_add` path under `--ir-ra` and `ROUND_TO_EVEN`
- look up each operand interval independently, with point-interval fallback for untracked operands
- compute:
  - `L_R = lo_x + lo_y`
  - `U_R = hi_x + hi_y`
- construct the interval-lifted enclosure using the existing nearest-mode constants
- keep the existing symbol naming style:
  - `ra_lo::N`
  - `ra_hi::N`
- keep `ROUND_TO_AWAY`, directed modes, and non-add operations unchanged

## Regression coverage

This PR includes:

- `ra-interval-lift-both-tracked`
  - verifies the RNE `ieee_add` interval-lifted path when both operands come from prior tracked additions
  - checks that the second addition reuses the first addition's interval symbols

- `ra-interval-lift-one-fresh`
  - verifies the mixed path where one operand is tracked and one operand falls back to a point interval

- `ra-interval-lift-both-fresh`
  - verifies the zero-regression case where both operands are fresh
  - checks that point-interval fallback reproduces the existing single-step RNE structure

- `ra-interval-lift-rna-unchanged`
  - verifies that `ROUND_TO_AWAY` does not use the new interval-lifted path
  - checks that RNA remains on the existing single-step `ra_lo_aw` / `ra_hi_aw` path

- `ra-rounding-nearest-tight-bounds`
  - unchanged baseline nearest-mode single-step regression
  - confirms no regression for the existing RNE path

## Scope

This PR implements only:

- `ROUND_TO_EVEN` interval lifting
- `ieee_add` interval lifting

The following are deferred:

- `ROUND_TO_AWAY` interval lifting
- `ROUND_TO_PLUS_INF` interval lifting
- `ROUND_TO_MINUS_INF` interval lifting
- `ROUND_TO_ZERO` interval lifting
- `ieee_sub` interval lifting
- `ieee_mul` interval lifting
- `ieee_div` interval lifting
- `ieee_fma` interval lifting
- full DAG-level compositional propagation