### PR TITLE
[smt] prevent INVALID from being spuriously chosen

### DIFF
--- a/regression/esbmc/github_3928/main.c
+++ b/regression/esbmc/github_3928/main.c
@@ -1,0 +1,33 @@
+// Regression test for issue #3928: chained byte-update loop over a struct
+// containing a void* field.  After init_loop overwrites all bytes of local_data
+// (including the pointer field), __ESBMC_assume constrains the reconstructed
+// pointer to equal &some_var.  The assert(0) must be reachable, so the correct
+// verdict is VERIFICATION FAILED.
+//
+// Before the fix (bidirectional int-to-ptr implications), the byte-update chain
+// forced intermediate int-to-ptr casts to resolve to the INVALID object because
+// the fallback constraint was underconstrained.  This made the assume impossible
+// to satisfy and produced a wrong VERIFICATION PASSED result.
+
+char nondet_char();
+
+void init_loop(void *base, unsigned int size)
+{
+  for (int i = 0; i < size; i++)
+    *((char *)base + i) = nondet_char();
+}
+
+typedef struct
+{
+  void *ptr;
+} local_t;
+
+int some_var;
+local_t local_data;
+
+int main()
+{
+  init_loop(&local_data, sizeof(local_t));
+  __ESBMC_assume(local_data.ptr == &some_var);
+  __ESBMC_assert(0, "reachable");
+}

--- a/regression/esbmc/github_3928/test.desc
+++ b/regression/esbmc/github_3928/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -531,6 +531,11 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
       ptraddr_type2(), from_start, typecast2tc(ptraddr_type2(), ptr_offs));
     smt_astt addr = convert_ast(address);
     assert_ast(mk_implies(not_matched, addr->eq(this, target)));
+    // Prevent INVALID from being spuriously chosen as the fallback: INVALID has
+    // start_1 = 1, so "1 + offs = target" is trivially satisfiable for any
+    // target.  Excluding INVALID forces the solver to pick a real object via the
+    // unconstrained addr_space array entries when one matches target.
+    assert_ast(mk_implies(not_matched, mk_not(id->eq(this, output_obj))));
     return output;
   }
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/3928.

CBMC output:

```
Counterexample:

State 15 file main.c function main line 30 thread 0
----------------------------------------------------
  base=(const void *)&local_data.ptr (00000010 00000000 00000000 00000000 00000000 00000000 00000000 00000000)

State 16 file main.c function main line 30 thread 0
----------------------------------------------------
  size=8u (00000000 00000000 00000000 00001000)

State 18 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=0 (00000000 00000000 00000000 00000000)

State 21 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 22 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 0l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[0l + 7l, 0l] (?)

State 23 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=1 (00000000 00000000 00000000 00000001)

State 27 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 28 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 1l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[8l + 7l, 8l] (?)

State 29 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=2 (00000000 00000000 00000000 00000010)

State 33 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 34 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 2l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[16l + 7l, 16l] (?)

State 35 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=3 (00000000 00000000 00000000 00000011)

State 39 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 40 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 3l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[24l + 7l, 24l] (?)

State 41 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=4 (00000000 00000000 00000000 00000100)

State 45 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 46 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 4l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[32l + 7l, 32l] (?)

State 47 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=5 (00000000 00000000 00000000 00000101)

State 51 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 52 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 5l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[40l + 7l, 40l] (?)

State 53 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=6 (00000000 00000000 00000000 00000110)

State 57 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=0 (00000000)

State 58 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 6l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))NULL[48l + 7l, 48l] (?)

State 59 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=7 (00000000 00000000 00000000 00000111)

State 63 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  return_value_nondet_char=3 (00000011)

State 64 file main.c function init_loop line 17 thread 0
----------------------------------------------------
  byte_extract_little_endian(local_data.ptr, 7l, char)=(irep("(\"bv\" \"width\" (\"64\"))"))(const void *)&some_var[56l + 7l, 56l] (?)

State 65 file main.c function init_loop line 16 thread 0
----------------------------------------------------
  i=8 (00000000 00000000 00000000 00001000)

Assumption:
  file main.c line 31 function main
  local_data.ptr == (void *)&some_var

Violated property:
  file main.c function main line 32 thread 0
  reachable
  0 != 0


VERIFICATION FAILED
```

ESBMC output:

```
[Counterexample]


State 1 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr = 0 }), 0, 3))

State 2 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 1, 4))

State 3 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 2, 112))

State 4 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 3, 167))

State 5 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 4, 100))

State 6 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 5, 199))

State 7 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 6, 48))

State 8 file main.c line 17 column 27 function init_loop thread 0
----------------------------------------------------
  (signed char *)base[i] = ( struct __anon_typedef_local_t_at_main_c__20_9 { void * ptr; })(byte_update_little_endian((unsigned long int)({ .ptr=local_data.ptr }), 7, 0))

State 10 file main.c line 32 column 3 function main thread 0
----------------------------------------------------
Violated property:
  file main.c line 32 column 3 function main
  reachable
  0


VERIFICATION FAILED
```