### PR TITLE
[ir-ra] rename --ir-ra option to --ir-ieee

### DIFF
--- a/regression/esbmc/github_2572/test.desc
+++ b/regression/esbmc/github_2572/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---z3 --ir-ra
+--z3 --ir-ieee
 ^VERIFICATION SUCCESSFUL$

--- a/regression/ir-ra/fp-to-int-signed/main.c
+++ b/regression/ir-ra/fp-to-int-signed/main.c
@@ -2,7 +2,7 @@
 
 extern double __VERIFIER_nondet_double(void);
 
-/* Under --ir-ra, a nondet double cast to signed int can be <= 0,
+/* Under --ir-ieee, a nondet double cast to signed int can be <= 0,
  * so the assertion must fail. */
 int main(void)
 {

--- a/regression/ir-ra/fp-to-int-signed/test.desc
+++ b/regression/ir-ra/fp-to-int-signed/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/fp-to-int-unsigned/main.c
+++ b/regression/ir-ra/fp-to-int-unsigned/main.c
@@ -2,7 +2,7 @@
 
 extern double __VERIFIER_nondet_double(void);
 
-/* Under --ir-ra, a negative double cast to unsigned int is clamped to 0,
+/* Under --ir-ieee, a negative double cast to unsigned int is clamped to 0,
  * so the assertion must fail when x < 0. */
 int main(void)
 {

--- a/regression/ir-ra/fp-to-int-unsigned/test.desc
+++ b/regression/ir-ra/fp-to-int-unsigned/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/int-to-fp/main.c
+++ b/regression/ir-ra/int-to-fp/main.c
@@ -2,7 +2,7 @@
 
 extern int __VERIFIER_nondet_int(void);
 
-/* Under --ir-ra, a nondet int lifted to double can be <= 0.0,
+/* Under --ir-ieee, a nondet int lifted to double can be <= 0.0,
  * so the assertion must fail. */
 int main(void)
 {

--- a/regression/ir-ra/int-to-fp/test.desc
+++ b/regression/ir-ra/int-to-fp/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-bounds-add/main.c
+++ b/regression/ir-ra/ra-enclosure-bounds-add/main.c
@@ -1,4 +1,4 @@
-/* Regression: --ir-ra should process a double-precision addition through the
+/* Regression: --ir-ieee should process a double-precision addition through the
  * enclosure path. The assertion is intentionally false so ESBMC produces a
  * counterexample and exercises the encoding. */
 #include <assert.h>

--- a/regression/ir-ra/ra-enclosure-bounds-add/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-add/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-bounds-chain/main.c
+++ b/regression/ir-ra/ra-enclosure-bounds-chain/main.c
@@ -1,4 +1,4 @@
-/* Regression: --ir-ra should process a small chain of double-precision
+/* Regression: --ir-ieee should process a small chain of double-precision
  * operations through the enclosure path. The assertion is intentionally false
  * so ESBMC produces a counterexample and exercises multiple enclosure sites. */
 #include <assert.h>

--- a/regression/ir-ra/ra-enclosure-bounds-chain/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-chain/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-bounds-mul/main.c
+++ b/regression/ir-ra/ra-enclosure-bounds-mul/main.c
@@ -1,4 +1,4 @@
-/* Regression: --ir-ra should process a double-precision multiplication through
+/* Regression: --ir-ieee should process a double-precision multiplication through
  * the enclosure path. The assertion is intentionally false so ESBMC produces a
  * counterexample and exercises the encoding. */
 #include <assert.h>

--- a/regression/ir-ra/ra-enclosure-bounds-mul/test.desc
+++ b/regression/ir-ra/ra-enclosure-bounds-mul/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-generation/test.desc
+++ b/regression/ir-ra/ra-enclosure-generation/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-multiple-ops/test.desc
+++ b/regression/ir-ra/ra-enclosure-multiple-ops/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.c
---ir-ra --z3
+--ir-ieee --z3
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-enclosure-tight-bounds-float/main.c
+++ b/regression/ir-ra/ra-enclosure-tight-bounds-float/main.c
@@ -1,10 +1,10 @@
-/* Regression test: theorem-driven tight enclosure under --ir-ra, single precision.
+/* Regression test: theorem-driven tight enclosure under --ir-ieee, single precision.
  *
  * PURPOSE
  * -------
  * Mirrors ra-enclosure-tight-bounds/ but exercises the IEEE single-precision
  * (float) path instead of double.  Verifies that the SMT formula emitted by
- * --ir-ra for a float addition contains the structural hallmarks of the NEW
+ * --ir-ieee for a float addition contains the structural hallmarks of the NEW
  * theorem-driven encoding, not just the old containment-only (weak) encoding.
  *
  * OLD weak encoding:

--- a/regression/ir-ra/ra-enclosure-tight-bounds-float/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds-float/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-enclosure-tight-bounds/main.c
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/main.c
@@ -1,8 +1,8 @@
-/* Regression test: theorem-driven tight enclosure under --ir-ra.
+/* Regression test: theorem-driven tight enclosure under --ir-ieee.
  *
  * PURPOSE
  * -------
- * Verifies that the SMT formula emitted by --ir-ra for a double-precision
+ * Verifies that the SMT formula emitted by --ir-ieee for a double-precision
  * addition contains the structural hallmarks of the NEW theorem-driven
  * encoding, NOT just the old containment-only (weak) encoding.
  *

--- a/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-enclosure-tight-bounds/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-enclosure-weak-bounds-long-double/main.c
+++ b/regression/ir-ra/ra-enclosure-weak-bounds-long-double/main.c
@@ -1,4 +1,4 @@
-/* Regression test: weak (unconstrained) enclosure for long double under --ir-ra.
+/* Regression test: weak (unconstrained) enclosure for long double under --ir-ieee.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-enclosure-weak-bounds-long-double/test.desc
+++ b/regression/ir-ra/ra-enclosure-weak-bounds-long-double/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_weak::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_weak::[0-9]+\| \(\) Real\)
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-both-fresh/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-interval-lift-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-both-tracked/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-interval-lift-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-one-fresh/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-interval-lift-rna-unchanged/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-unchanged/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-away-tight-bounds-single/main.c
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds-single/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_AWAY tight enclosure under --ir-ra, single precision.
+/* Regression test: ROUND_TO_AWAY tight enclosure under --ir-ieee, single precision.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-away-tight-bounds-single/test.desc
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds-single/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-away-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_AWAY uses tight symmetric enclosure under --ir-ra.
+/* Regression test: ROUND_TO_AWAY uses tight symmetric enclosure under --ir-ieee.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-away-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-away-tight-bounds/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/main.c
@@ -1,4 +1,4 @@
-/* Regression test: symbolic rounding mode uses weak enclosure fallback under --ir-ra.
+/* Regression test: symbolic rounding mode uses weak enclosure fallback under --ir-ieee.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-directed-weak-fallback/test.desc
+++ b/regression/ir-ra/ra-rounding-directed-weak-fallback/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_weak::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_weak::[0-9]+\| \(\) Real\)
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/main.c
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_MINUS_INF tight enclosure under --ir-ra, single precision.
+/* Regression test: ROUND_TO_MINUS_INF tight enclosure under --ir-ieee, single precision.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/test.desc
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds-single/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_MINUS_INF uses tight asymmetric enclosure under --ir-ra.
+/* Regression test: ROUND_TO_MINUS_INF uses tight asymmetric enclosure under --ir-ieee.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-minus-inf-tight-bounds/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-nearest-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-nearest-tight-bounds/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-plus-inf-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-plus-inf-tight-bounds/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_PLUS_INF uses tight asymmetric enclosure under --ir-ra.
+/* Regression test: ROUND_TO_PLUS_INF uses tight asymmetric enclosure under --ir-ieee.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-plus-inf-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-plus-inf-tight-bounds/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds-single/main.c
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds-single/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_ZERO tight enclosure under --ir-ra, single precision.
+/* Regression test: ROUND_TO_ZERO tight enclosure under --ir-ieee, single precision.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds-single/test.desc
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds-single/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
 \(ite

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds/main.c
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds/main.c
@@ -1,4 +1,4 @@
-/* Regression test: ROUND_TO_ZERO uses tight asymmetric enclosure under --ir-ra.
+/* Regression test: ROUND_TO_ZERO uses tight asymmetric enclosure under --ir-ieee.
  *
  * PURPOSE
  * -------

--- a/regression/ir-ra/ra-rounding-zero-tight-bounds/test.desc
+++ b/regression/ir-ra/ra-rounding-zero-tight-bounds/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ir-ra --z3 --smt-formula-too
+--ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
 \(ite

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -322,10 +322,10 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
   if (cmdline.isset("ir"))
     options.set_option("int-encoding", true);
 
-  if (cmdline.isset("ir-ra"))
+  if (cmdline.isset("ir-ieee"))
   {
     options.set_option("int-encoding", true);
-    options.set_option("ir-ra", true);
+    options.set_option("ir-ieee", true);
   }
   if (cmdline.isset("fixedbv"))
     options.set_option("fixedbv", true);

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -369,7 +369,7 @@ const struct group_opt_templ all_cmd_options[] = {
      "use solver with integer/real arithmetic. Integer/real have an unbounded "
      "range, overapproximating normal integers/reals while significantly "
      "boosting performance"},
-    {"ir-ra",
+    {"ir-ieee",
      NULL,
      "use integer/real arithmetic with real-arithmetic enclosure constraints "
      "for floating-point operations"},

--- a/src/solvers/README.txt
+++ b/src/solvers/README.txt
@@ -49,9 +49,9 @@ Finally, there's some boilerplate in solvers/solve.cpp for creating
 solvers. The idea is to implement the factory pattern for solver
 creation, avoiding general-esbmc code having to touch solver-specific stuff.
 
-Interval/Real-Arithmetic (--ir-ra) mode
-----------------------------------------
-When the --ir-ra flag is enabled, floating-point operations are encoded
+Interval/Real-Arithmetic (--ir-ieee) mode
+------------------------------------------
+When the --ir-ieee flag is enabled, floating-point operations are encoded
 in real arithmetic rather than bit-precise FP. The key entry point is
 smt_convt::apply_ieee754_semantics (smt_conv.cpp), which wraps each
 real-valued FP result in a sound symmetric error enclosure.

--- a/src/solvers/smt/smt_bitcast.cpp
+++ b/src/solvers/smt/smt_bitcast.cpp
@@ -158,8 +158,8 @@ smt_astt smt_convt::convert_bitcast(const expr2tc &expr)
   }
   else if (is_bv_type(to_type))
   {
-    // Under --ir-ra, float values are real-encoded; bit-pattern reinterpretation
-    // Under integer encoding (--ir/--ir-ra), fixed- and floating-point values are
+    // Under --ir-ieee, float values are real-encoded; bit-pattern reinterpretation
+    // Under integer encoding (--ir/--ir-ieee), fixed- and floating-point values are
     // real-encoded; fall back to value-based typecast.
     if (int_encoding && (is_fixedbv_type(from) || is_floatbv_type(from)))
       return convert_ast(typecast2tc(to_type, from));

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -682,7 +682,7 @@ smt_astt smt_convt::convert_typecast(const expr2tc &expr)
 {
   const typecast2t &cast = to_typecast2t(expr);
 
-  // Under integer encoding (--ir/--ir-ra), fp values are represented as reals.
+  // Under integer encoding (--ir/--ir-ieee), fp values are represented as reals.
   // The following three cases handle fp<->int casts explicitly because the
   // generic bitvector-based path is incorrect when operands are real-encoded.
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -481,7 +481,7 @@ smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt operand_zero_check,
   const expr2tc &rounding_mode)
 {
-  if (this->options.get_bool_option("ir-ra"))
+  if (this->options.get_bool_option("ir-ieee"))
   {
     if (is_nearest_rounding_mode(rounding_mode))
     {
@@ -1305,16 +1305,16 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       const expr2tc &rounding_mode = to_ieee_add2t(expr).rounding_mode;
 
-      // Interval-lifted RNE enclosure for ieee_add (--ir-ra only).
+      // Interval-lifted RNE enclosure for ieee_add (--ir-ieee only).
       // For RNE + known format (double/single): look up each operand's stored
       // interval, falling back to a point interval {side, side} for fresh or
       // untracked operands.  Compute L_R = lo1+lo2, U_R = hi1+hi2, call the
       // interval helper, then store the resulting {ra_lo, ra_hi} pair.
-      // Non-RNE modes, non-standard formats, and --ir-ra disabled all fall
+      // Non-RNE modes, non-standard formats, and --ir-ieee disabled all fall
       // through to apply_ieee754_semantics unchanged.
       bool interval_lifted = false;
       if (
-        options.get_bool_option("ir-ra") &&
+        options.get_bool_option("ir-ieee") &&
         is_nearest_rounding_mode(rounding_mode))
       {
         const auto double_spec = ieee_float_spect::double_precision();

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -572,7 +572,7 @@ public:
    *  subnormal range [4.941e-324, 2.225e-308). For single precision: overflow
    *  to ±3.403e+38, underflow below 1.401e-45, subnormal range [1.401e-45, 1.175e-38).
    *  Other formats return the original result unchanged.
-   *  Under --ir-ra, when rounding_mode is a concrete round-to-nearest constant
+   *  Under --ir-ieee, when rounding_mode is a concrete round-to-nearest constant
    *  (ROUND_TO_EVEN == 0), a tight symmetric epsilon enclosure is asserted.
    *  For symbolic or directed rounding modes the function falls back to a weak
    *  unconstrained enclosure (sound but imprecise); tight directed bounds are
@@ -977,7 +977,7 @@ private:
     const BigInt &numerator,
     const BigInt &denominator);
 
-  /** Interval metadata for the RNE ieee_add interval-lifting path (--ir-ra).
+  /** Interval metadata for the RNE ieee_add interval-lifting path (--ir-ieee).
    *  After each RNE ieee_add (double/single, int encoding), the {ra_lo, ra_hi}
    *  SMT symbols are stored here, keyed on the exact real_result AST pointer
    *  (pointer equality == SSA identity via smt_cache).  Subsequent RNE
@@ -996,7 +996,7 @@ private:
   };
   std::unordered_map<const smt_ast *, ra_interval_t> ir_ra_interval_map;
 
-  /** Interval-lifted RNE enclosure helper for ieee_add (--ir-ra only).
+  /** Interval-lifted RNE enclosure helper for ieee_add (--ir-ieee only).
    *  Called from ieee_add_id after verifying RNE mode + known format.
    *  Inputs:
    *    real_result  exact symbolic real for this addition (mk_add(side1,side2))


### PR DESCRIPTION
## Summary

This PR renames the user-facing option `--ir-ra` to `--ir-ieee`.

The change is limited to:
- option registration/parsing
- solver call sites using the option
- regression `.desc` files invoking the flag
- user-facing documentation/comments that mention the CLI flag by name

No directory names or internal identifiers are changed.

## Validation

I checked the rename end-to-end with:
- an existing regression that still produces `VERIFICATION SUCCESSFUL` under `--ir-ieee`
- a nearest-mode theorem-driven regression that still reaches the expected SMT enclosure path under `--ir-ieee`