### PR TITLE
[bug fix] --no-standard-checks not suppressing VLA size check

### DIFF
--- a/regression/esbmc/no_standard_checks_vla/main.c
+++ b/regression/esbmc/no_standard_checks_vla/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int SIZE = 16;
+  int vec[SIZE];
+  int x = vec[0];
+  __ESBMC_assert(SIZE == 16, "size is 16");
+  return 0;
+}

--- a/regression/esbmc/no_standard_checks_vla/main.c
+++ b/regression/esbmc/no_standard_checks_vla/main.c
@@ -1,8 +1,26 @@
 int main()
 {
   int SIZE = 16;
-  int vec[SIZE];
-  int x = vec[0];
-  __ESBMC_assert(SIZE == 16, "size is 16");
+  int vec[ SIZE ];
+  int max = vec[0];
+  int idx_v0;
+  int idx;
+  //------------------------------------------------------------
+  for ( idx = 1; idx < SIZE; ++idx )
+  { if ( vec[idx] >= max )
+      max = vec[ idx ];
+  }
+  //------------------------------------------------------------
+  __ESBMC_assert(
+    __ESBMC_forall(
+      &idx_v0,
+      !( 0 <= idx_v0 ) ||
+      !( idx_v0 < SIZE ) ||
+      ( vec[ idx_v0 ] <= max )
+    ),
+    "end of loop assertion"
+  );
+  //------------------------------------------------------------
   return 0;
+  //------------------------------------------------------------
 }

--- a/regression/esbmc/no_standard_checks_vla/test.desc
+++ b/regression/esbmc/no_standard_checks_vla/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/no_standard_checks_vla/test.desc
+++ b/regression/esbmc/no_standard_checks_vla/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
---no-standard-checks
-^VERIFICATION SUCCESSFUL$
+--show-claims --no-standard-checks
+^Claim 1:
+end of loop assertion

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1896,6 +1896,21 @@ bool esbmc_parseoptionst::parse_goto_program(
         exit(0);
     }
 
+    // Expand --no-standard-checks into individual options before goto_convert,
+    // because VLA size checks are generated during goto conversion.
+    if (
+      cmdline.isset("no-standard-checks") ||
+      options.get_bool_option("no-standard-checks"))
+    {
+      options.set_option("no-pointer-check", true);
+      options.set_option("no-div-by-zero-check", true);
+      options.set_option("no-pointer-relation-check", true);
+      options.set_option("no-unlimited-scanf-check", true);
+      options.set_option("no-vla-size-check", true);
+      options.set_option("no-align-check", true);
+      options.set_option("no-bounds-check", true);
+    }
+
     log_progress("Generating GOTO Program");
     goto_convert(context, options, goto_functions);
   }
@@ -1961,7 +1976,9 @@ bool esbmc_parseoptionst::process_goto_program(
       for (size_t i = 1; i < cmdline.args.size(); i++)
         config.ansi_c.include_files.push_back(cmdline.args[i]);
 
-    // this should be before goto_check()
+    // Expand --no-standard-checks before goto_check (also expanded before
+    // goto_convert in parse_goto_program; re-expanding here is idempotent
+    // and covers the read_goto_binary path).
     if (
       cmdline.isset("no-standard-checks") ||
       options.get_bool_option("no-standard-checks"))
@@ -1973,9 +1990,6 @@ bool esbmc_parseoptionst::process_goto_program(
       options.set_option("no-vla-size-check", true);
       options.set_option("no-align-check", true);
       options.set_option("no-bounds-check", true);
-      //?
-      // options.set_option("no-abnormal-memory-leak", true);
-      // options.set_option("no-reachable-memory-leak", true);
     }
 
     // Start by removing all no-op instructions and unreachable code


### PR DESCRIPTION
  `--no-standard-checks` was not suppressing the "VLA array size in bytes overflows address space size" assertion. The root cause is a
  timing issue: `--no-standard-checks` was expanded into individual `no-*` options only in `process_goto_program()`, which runs **after**
  `goto_convert()`. However, VLA size check assertions are generated during `goto_convert()` by `generate_dynamic_size_vla()`, which reads
  the `no-vla-size-check` option — an option that wasn't set yet at that point.

  Using `--no-vla-size-check` directly always worked, because it is parsed from the command line before `goto_convert()`.

  **Reproducer** (from bug report):
  ```c
  int main()
  {
    int SIZE = 16;
    int vec[ SIZE ];
    int max = vec[0];
    int idx_v0;
    int idx;
    for ( idx = 1; idx < SIZE; ++idx )
    { if ( vec[idx] >= max )
        max = vec[ idx ];
    }
    __ESBMC_assert(
      __ESBMC_forall(
        &idx_v0,
        !( 0 <= idx_v0 ) ||
        !( idx_v0 < SIZE ) ||
        ( vec[ idx_v0 ] <= max )
      ),
      "end of loop assertion"
    );
    return 0;
  }
```
  esbmc --show-claims --no-standard-checks max-1.c incorrectly showed:
  Claim 1: VLA array size in bytes overflows address space size
  Claim 2: end of loop assertion

  After fix, only the user assertion remains:
  Claim 1: end of loop assertion

  Fix

  - Expand --no-standard-checks into individual options before goto_convert() in parse_goto_program()
  - Keep the expansion in process_goto_program() (idempotent) to cover the read_goto_binary path before goto_check()

  Test plan

  - Added regression test regression/esbmc/no_standard_checks_vla/ using original bug report program
  - Verified --show-claims --no-standard-checks shows only user assertion (no VLA claim)
  - Verified VLA claim still appears without --no-standard-checks

  Assisted-by: Claude Opus 4.6

<img width="2123" height="550" alt="图片" src="https://github.com/user-attachments/assets/936f531c-9601-4895-b460-7c5b6f92fa60" />
