### PR TITLE
python: handle TypeVar aliases from typing

### DIFF
--- a/regression/python/typing_typevar/main.py
+++ b/regression/python/typing_typevar/main.py
@@ -1,0 +1,10 @@
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def identity(x: T) -> T:
+    return x
+
+
+assert identity(1) == 1

--- a/regression/python/typing_typevar/test.desc
+++ b/regression/python/typing_typevar/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/typing_typevar_fail/main.py
+++ b/regression/python/typing_typevar_fail/main.py
@@ -1,0 +1,10 @@
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def identity(x: T) -> T:
+    return x
+
+
+assert identity(1) == 2

--- a/regression/python/typing_typevar_fail/test.desc
+++ b/regression/python/typing_typevar_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -1,3 +1,7 @@
+def TypeVar(name, *args, **kwargs) -> type:
+    return object
+
+
 class List:
     pass
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3367,6 +3367,13 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     return set_handler.get_empty_set();
   }
 
+  // TypeVar(...) is only used to build typing aliases and has no runtime
+  // effect in the frontend, so model it as an opaque placeholder value.
+  if (element["func"]["_type"] == "Name" && element["func"]["id"] == "TypeVar")
+  {
+    return gen_zero(any_type());
+  }
+
   const std::string function = config.options.get_option("function");
   // To verify a specific function, it is necessary to load the definitions of functions it calls.
   if (!function.empty() && !is_loading_models)

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -537,6 +537,19 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (!is_defined)
     is_defined = converter_.is_imported_module(ast_type);
 
+  if (!is_defined)
+  {
+    const nlohmann::json &decl =
+      json_utils::find_var_decl(ast_type, "", converter_.ast());
+    if (
+      !decl.empty() && decl.contains("value") && decl["value"].is_object() &&
+      decl["value"].contains("_type") && decl["value"]["_type"] == "Call" &&
+      decl["value"].contains("func") && decl["value"]["func"].is_object() &&
+      decl["value"]["func"].contains("id") &&
+      decl["value"]["func"]["id"] == "TypeVar")
+      return any_type();
+  }
+
   // If still not found, it's a NameError
   if (!is_defined)
   {


### PR DESCRIPTION
This PR adds basic support for `typing.TypeVar` in the Python frontend.

  Example:
  ```python
  from typing import TypeVar

  T = TypeVar("T")

  def identity(x: T) -> T:
      return x

  assert identity(1) == 1
```

ESBMC was failing when handling TypeVar aliases in annotations:
```text
ERROR: NameError: name 'TypeVar' is not defined
```

This change adds the minimal typing stubs needed, treats TypeVar(...) as an annotation-only construct, and resolves aliases such as T = TypeVar("T") when they appear in type annotations.