### PR TITLE
Extract complex utilities into complex_handler_utils

### DIFF
--- a/regression/python/complex_keyword_args/main.py
+++ b/regression/python/complex_keyword_args/main.py
@@ -1,0 +1,68 @@
+# Tests for complex() constructor keyword argument handling.
+# Validates that keyword arguments are correctly parsed and
+# error conditions are properly detected.
+
+# Named keyword: real only
+z1 = complex(real=3.5)
+assert z1.real == 3.5
+assert z1.imag == 0.0
+
+# Named keyword: imag only
+z2 = complex(imag=4.0)
+assert z2.real == 0.0
+assert z2.imag == 4.0
+
+# Named keywords: both
+z3 = complex(real=1.0, imag=2.0)
+assert z3.real == 1.0
+assert z3.imag == 2.0
+
+# Named keywords: reversed order
+z4 = complex(imag=2.0, real=1.0)
+assert z4.real == 1.0
+assert z4.imag == 2.0
+
+# Named keyword with complex value
+c1 = complex(1.0, 2.0)
+z5 = complex(real=c1, imag=3.0)
+assert z5.real == 1.0
+assert z5.imag == 5.0
+
+# Named keyword: string in real (one-arg form equivalent)
+z6 = complex(real="5+6j")
+assert z6.real == 5.0
+assert z6.imag == 6.0
+
+# Unexpected keyword -> TypeError
+raised_type = False
+try:
+    complex(foo=1)
+except TypeError:
+    raised_type = True
+assert raised_type
+
+# Positional + duplicate keyword 'real' -> TypeError
+raised_type = False
+try:
+    complex(1, real=2)
+except TypeError:
+    raised_type = True
+assert raised_type
+
+# Positional + duplicate keyword 'imag' -> TypeError
+raised_type = False
+try:
+    complex(1, 2, imag=3)
+except TypeError:
+    raised_type = True
+assert raised_type
+
+# Integer keyword value for real
+z7 = complex(real=0)
+assert z7.real == 0.0
+assert z7.imag == 0.0
+
+# Bool keyword value for imag
+z8 = complex(imag=True)
+assert z8.real == 0.0
+assert z8.imag == 1.0

--- a/regression/python/complex_keyword_args/test.desc
+++ b/regression/python/complex_keyword_args/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/complex_string_parsing/main.py
+++ b/regression/python/complex_string_parsing/main.py
@@ -1,0 +1,110 @@
+# Tests for complex() string parsing via parse_complex_string utility.
+# Validates all CPython-accepted string formats are correctly handled.
+
+# Pure real strings
+z1 = complex("0")
+assert z1.real == 0.0 and z1.imag == 0.0
+
+z2 = complex("42")
+assert z2.real == 42.0 and z2.imag == 0.0
+
+z3 = complex("-3.5")
+assert z3.real == -3.5 and z3.imag == 0.0
+
+z4 = complex("1e2")
+assert z4.real == 100.0 and z4.imag == 0.0
+
+# Pure imaginary strings
+z5 = complex("j")
+assert z5.real == 0.0 and z5.imag == 1.0
+
+z6 = complex("+j")
+assert z6.real == 0.0 and z6.imag == 1.0
+
+z7 = complex("-j")
+assert z7.real == 0.0 and z7.imag == -1.0
+
+z8 = complex("2j")
+assert z8.real == 0.0 and z8.imag == 2.0
+
+z9 = complex("-3.5j")
+assert z9.real == 0.0 and z9.imag == -3.5
+
+# Combined real+imag strings
+z10 = complex("1+2j")
+assert z10.real == 1.0 and z10.imag == 2.0
+
+z11 = complex("1-2j")
+assert z11.real == 1.0 and z11.imag == -2.0
+
+z12 = complex("-1+2j")
+assert z12.real == -1.0 and z12.imag == 2.0
+
+z13 = complex("-1-2j")
+assert z13.real == -1.0 and z13.imag == -2.0
+
+# Unit imaginary with real part
+z14 = complex("3+j")
+assert z14.real == 3.0 and z14.imag == 1.0
+
+z15 = complex("3-j")
+assert z15.real == 3.0 and z15.imag == -1.0
+
+# Scientific notation
+z16 = complex("1e3+2e-1j")
+assert z16.real == 1000.0 and z16.imag == 0.2
+
+z17 = complex("1.5E2-3.0E1j")
+assert z17.real == 150.0 and z17.imag == -30.0
+
+# Parenthesized form
+z18 = complex("(3+4j)")
+assert z18.real == 3.0 and z18.imag == 4.0
+
+# Whitespace-trimmed
+z19 = complex("  5  ")
+assert z19.real == 5.0 and z19.imag == 0.0
+
+z20 = complex(" (3+4j) ")
+assert z20.real == 3.0 and z20.imag == 4.0
+
+# Malformed strings -> ValueError
+raised = False
+try:
+    complex("x")
+except ValueError:
+    raised = True
+assert raised
+
+raised = False
+try:
+    complex("1 + 2j")
+except ValueError:
+    raised = True
+assert raised
+
+raised = False
+try:
+    complex("++1j")
+except ValueError:
+    raised = True
+assert raised
+
+raised = False
+try:
+    complex("")
+except ValueError:
+    raised = True
+assert raised
+
+# Zero imaginary explicit
+z21 = complex("0j")
+assert z21.real == 0.0 and z21.imag == 0.0
+
+# Decimal without integer part
+z22 = complex(".5j")
+assert z22.real == 0.0 and z22.imag == 0.5
+
+# Negative zero IEEE
+z24 = complex("-0.0")
+assert z24.imag == 0.0

--- a/regression/python/complex_string_parsing/test.desc
+++ b/regression/python/complex_string_parsing/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/CMakeLists.txt
+++ b/src/python-frontend/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(pythonfrontend STATIC
             symbol_id.cpp
             type_handler.cpp
             cmath_lowering_policy.cpp
+            complex_handler_utils.cpp
             function_call_expr.cpp
             numpy_call_expr.cpp
             function_call_builder.cpp

--- a/src/python-frontend/complex_handler_utils.cpp
+++ b/src/python-frontend/complex_handler_utils.cpp
@@ -8,10 +8,8 @@
 
 namespace complex_utils
 {
-
 namespace
 {
-
 std::string trim(const std::string &s)
 {
   size_t b = 0;

--- a/src/python-frontend/complex_handler_utils.cpp
+++ b/src/python-frontend/complex_handler_utils.cpp
@@ -12,7 +12,7 @@ namespace complex_utils
 namespace
 {
 
-std::string trim(std::string s)
+std::string trim(const std::string &s)
 {
   size_t b = 0;
   while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b])))

--- a/src/python-frontend/complex_handler_utils.cpp
+++ b/src/python-frontend/complex_handler_utils.cpp
@@ -1,0 +1,124 @@
+#include <python-frontend/complex_handler_utils.h>
+#include <python-frontend/python_converter.h>
+#include <python-frontend/python_exception_handler.h>
+
+#include <cctype>
+#include <cstdlib>
+#include <string>
+
+namespace complex_utils
+{
+
+namespace
+{
+
+std::string trim(std::string s)
+{
+  size_t b = 0;
+  while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b])))
+    ++b;
+  size_t e = s.size();
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])))
+    --e;
+  return s.substr(b, e - b);
+}
+
+bool parse_double_strict(const std::string &s, double &out)
+{
+  if (s.empty())
+    return false;
+  char *end = nullptr;
+  out = std::strtod(s.c_str(), &end);
+  return end == s.c_str() + s.size();
+}
+
+} // anonymous namespace
+
+bool parse_complex_string(
+  const std::string &raw,
+  double &real_out,
+  double &imag_out)
+{
+  std::string s = trim(raw);
+  if (s.empty())
+    return false;
+
+  // Accept optional wrapping parentheses (possibly repeated).
+  while (s.size() > 2 && s.front() == '(' && s.back() == ')')
+    s = trim(s.substr(1, s.size() - 2));
+
+  auto lower_last = [](char c) {
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  };
+
+  // No imaginary suffix: parse as real number.
+  if (lower_last(s.back()) != 'j')
+  {
+    double r = 0.0;
+    if (!parse_double_strict(s, r))
+      return false;
+    real_out = r;
+    imag_out = 0.0;
+    return true;
+  }
+
+  std::string body = trim(s.substr(0, s.size() - 1));
+  if (body.empty() || body == "+" || body == "-")
+  {
+    real_out = 0.0;
+    imag_out = (body == "-") ? -1.0 : 1.0;
+    return true;
+  }
+
+  size_t split = std::string::npos;
+  for (size_t i = 1; i < body.size(); ++i)
+  {
+    const char c = body[i];
+    if (c == '+' || c == '-')
+    {
+      const char prev = body[i - 1];
+      if (prev != 'e' && prev != 'E')
+        split = i;
+    }
+  }
+
+  if (split == std::string::npos)
+  {
+    double imag = 0.0;
+    if (!parse_double_strict(body, imag))
+      return false;
+    real_out = 0.0;
+    imag_out = imag;
+    return true;
+  }
+
+  const std::string real_part = trim(body.substr(0, split));
+  const std::string imag_part = trim(body.substr(split));
+  double real = 0.0;
+  if (!parse_double_strict(real_part, real))
+    return false;
+
+  double imag = 0.0;
+  if (imag_part == "+" || imag_part == "-")
+    imag = (imag_part == "-") ? -1.0 : 1.0;
+  else if (!parse_double_strict(imag_part, imag))
+    return false;
+
+  real_out = real;
+  imag_out = imag;
+  return true;
+}
+
+exprt raise_math_real_type_error_expr(python_converter &converter)
+{
+  return converter.get_exception_handler().gen_exception_raise(
+    "TypeError", "must be real number, not complex");
+}
+
+exprt raise_math_int_type_error_expr(python_converter &converter)
+{
+  return converter.get_exception_handler().gen_exception_raise(
+    "TypeError", "'complex' object cannot be interpreted as an integer");
+}
+
+} // namespace complex_utils

--- a/src/python-frontend/complex_handler_utils.h
+++ b/src/python-frontend/complex_handler_utils.h
@@ -8,7 +8,6 @@ class python_converter;
 
 namespace complex_utils
 {
-
 /**
  * Parses a Python complex literal string into (real, imag) components.
  * Handles all CPython-accepted formats: "1+2j", "(3-4.5j)", "2j", "1.5",

--- a/src/python-frontend/complex_handler_utils.h
+++ b/src/python-frontend/complex_handler_utils.h
@@ -1,0 +1,41 @@
+#ifndef PYTHON_FRONTEND_COMPLEX_HANDLER_UTILS_H
+#define PYTHON_FRONTEND_COMPLEX_HANDLER_UTILS_H
+
+#include <string>
+#include <util/expr.h>
+
+class python_converter;
+
+namespace complex_utils
+{
+
+/**
+ * Parses a Python complex literal string into (real, imag) components.
+ * Handles all CPython-accepted formats: "1+2j", "(3-4.5j)", "2j", "1.5",
+ * "+j", "-j", scientific notation like "1e3+2e-1j", etc.
+ *
+ * @param raw   Input string (may include whitespace and wrapping parentheses).
+ * @param real_out  Output real part.
+ * @param imag_out  Output imaginary part.
+ * @return true on success, false if the string is malformed.
+ */
+bool parse_complex_string(
+  const std::string &raw,
+  double &real_out,
+  double &imag_out);
+
+/**
+ * Generates a TypeError expression for math functions that reject
+ * complex arguments: "must be real number, not complex".
+ */
+exprt raise_math_real_type_error_expr(python_converter &converter);
+
+/**
+ * Generates a TypeError expression for functions that require an integer
+ * but received a complex: "'complex' object cannot be interpreted as an integer".
+ */
+exprt raise_math_int_type_error_expr(python_converter &converter);
+
+} // namespace complex_utils
+
+#endif

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -64,18 +64,6 @@ bool is_cpp_throw_expr(const exprt &e)
   return e.statement() == "cpp-throw";
 }
 
-exprt raise_math_real_type_error_expr(python_converter &converter)
-{
-  return converter.get_exception_handler().gen_exception_raise(
-    "TypeError", "must be real number, not complex");
-}
-
-exprt raise_math_int_type_error_expr(python_converter &converter)
-{
-  return converter.get_exception_handler().gen_exception_raise(
-    "TypeError", "'complex' object cannot be interpreted as an integer");
-}
-
 double round_ties_to_even(const double value)
 {
   const double lower = std::floor(value);
@@ -3417,7 +3405,7 @@ function_call_expr::get_dispatch_table()
          if (is_cpp_throw_expr(arg_expr))
            return arg_expr;
          if (is_complex_type(arg_expr.type()))
-           return raise_math_real_type_error_expr(converter_);
+           return complex_utils::raise_math_real_type_error_expr(converter_);
          exprt isnan_expr("isnan", bool_typet());
          isnan_expr.copy_to_operands(arg_expr);
          return isnan_expr;
@@ -3431,7 +3419,7 @@ function_call_expr::get_dispatch_table()
          if (is_cpp_throw_expr(arg_expr))
            return arg_expr;
          if (is_complex_type(arg_expr.type()))
-           return raise_math_real_type_error_expr(converter_);
+           return complex_utils::raise_math_real_type_error_expr(converter_);
          exprt isinf_expr("isinf", bool_typet());
          isinf_expr.copy_to_operands(arg_expr);
          return isinf_expr;
@@ -3735,12 +3723,10 @@ function_call_expr::get_dispatch_table()
                                        ? raw_func_name.substr(8)
                                        : raw_func_name;
        const auto &args = call_["args"];
-       auto raise_math_real_type_error = [this]() -> exprt {
-         return raise_math_real_type_error_expr(converter_);
-       };
-       auto raise_math_int_type_error = [this]() -> exprt {
-         return raise_math_int_type_error_expr(converter_);
-       };
+       auto raise_math_real_type_error = [this]() -> exprt
+       { return complex_utils::raise_math_real_type_error_expr(converter_); };
+       auto raise_math_int_type_error = [this]() -> exprt
+       { return complex_utils::raise_math_int_type_error_expr(converter_); };
        auto has_complex_arg = [](const exprt &arg_expr) -> bool {
          return is_complex_type(arg_expr.type());
        };

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1,8 +1,10 @@
 #include <python-frontend/function_call_expr.h>
 #include <python-frontend/cmath_lowering_policy.h>
+#include <python-frontend/complex_handler_utils.h>
 #include <python-frontend/exception_utils.h>
 #include <python-frontend/json_utils.h>
 #include <python-frontend/math_guard_utils.h>
+#include <python-frontend/string_handler_utils.h>
 #include <python-frontend/python_exception_handler.h>
 #include <python-frontend/python_list.h>
 #include <python-frontend/string_builder.h>
@@ -1579,25 +1581,8 @@ exprt function_call_expr::handle_complex() const
 
     return value;
   };
-  auto is_cpp_throw = [](const exprt &e) -> bool {
-    return e.statement() == "cpp-throw";
-  };
-  auto trim = [](std::string s) -> std::string {
-    size_t b = 0;
-    while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b])))
-      ++b;
-    size_t e = s.size();
-    while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1])))
-      --e;
-    return s.substr(b, e - b);
-  };
-  auto parse_double_strict = [](const std::string &s, double &out) -> bool {
-    if (s.empty())
-      return false;
-    char *end = nullptr;
-    out = std::strtod(s.c_str(), &end);
-    return end == s.c_str() + s.size();
-  };
+  auto is_cpp_throw = [](const exprt &e) -> bool
+  { return e.statement() == "cpp-throw"; };
   auto extract_constant_string =
     [&](const nlohmann::json &arg, std::string &out) -> bool {
     if (!arg.contains("value"))
@@ -1703,83 +1688,13 @@ exprt function_call_expr::handle_complex() const
 
     return std::nullopt;
   };
-  auto is_unsigned_byte_array = [](const typet &type) -> bool {
+  auto is_unsigned_byte_array = [](const typet &type) -> bool
+  {
     if (!type.is_array())
       return false;
     const typet &subtype = type.subtype();
     return subtype.is_unsignedbv() &&
            to_unsignedbv_type(subtype).get_width() == 8;
-  };
-  auto parse_complex_string =
-    [&](const std::string &raw, double &real_out, double &imag_out) -> bool {
-    std::string s = trim(raw);
-    if (s.empty())
-      return false;
-
-    // Accept optional wrapping parentheses (possibly repeated).
-    while (s.size() > 2 && s.front() == '(' && s.back() == ')')
-      s = trim(s.substr(1, s.size() - 2));
-
-    auto lower_last = [](char c) {
-      return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-    };
-
-    // No imaginary suffix: parse as real number.
-    if (lower_last(s.back()) != 'j')
-    {
-      double r = 0.0;
-      if (!parse_double_strict(s, r))
-        return false;
-      real_out = r;
-      imag_out = 0.0;
-      return true;
-    }
-
-    std::string body = trim(s.substr(0, s.size() - 1));
-    if (body.empty() || body == "+" || body == "-")
-    {
-      real_out = 0.0;
-      imag_out = (body == "-") ? -1.0 : 1.0;
-      return true;
-    }
-
-    size_t split = std::string::npos;
-    for (size_t i = 1; i < body.size(); ++i)
-    {
-      const char c = body[i];
-      if (c == '+' || c == '-')
-      {
-        const char prev = body[i - 1];
-        if (prev != 'e' && prev != 'E')
-          split = i;
-      }
-    }
-
-    if (split == std::string::npos)
-    {
-      double imag = 0.0;
-      if (!parse_double_strict(body, imag))
-        return false;
-      real_out = 0.0;
-      imag_out = imag;
-      return true;
-    }
-
-    const std::string real_part = trim(body.substr(0, split));
-    const std::string imag_part = trim(body.substr(split));
-    double real = 0.0;
-    if (!parse_double_strict(real_part, real))
-      return false;
-
-    double imag = 0.0;
-    if (imag_part == "+" || imag_part == "-")
-      imag = (imag_part == "-") ? -1.0 : 1.0;
-    else if (!parse_double_strict(imag_part, imag))
-      return false;
-
-    real_out = real;
-    imag_out = imag;
-    return true;
   };
 
   if (arguments.size() > 2)
@@ -1847,7 +1762,7 @@ exprt function_call_expr::handle_complex() const
     if (extract_constant_string(*real_json, text))
     {
       double real = 0.0, imag = 0.0;
-      if (!parse_complex_string(text, real, imag))
+      if (!complex_utils::parse_complex_string(text, real, imag))
         return raise_value_error("complex() arg is a malformed string");
       return make_complex(
         from_double(real, double_type()), from_double(imag, double_type()));
@@ -1895,7 +1810,7 @@ exprt function_call_expr::handle_complex() const
           if (value_opt)
           {
             double real = 0.0, imag = 0.0;
-            if (!parse_complex_string(*value_opt, real, imag))
+            if (!complex_utils::parse_complex_string(*value_opt, real, imag))
               return raise_value_error("complex() arg is a malformed string");
             return make_complex(
               from_double(real, double_type()),

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1696,33 +1696,35 @@ exprt function_call_expr::handle_complex() const
   if (arguments.size() >= 2)
     imag_json = &arguments[1];
 
-  if (keywords.is_array())
+  if (keywords.is_array() && !keywords.empty())
   {
-    for (const auto &kw : keywords)
+    try
     {
-      if (!kw.contains("arg") || kw["arg"].is_null() || !kw.contains("value"))
-        return raise_type_error("complex() does not support **kwargs");
+      auto kw_vals =
+        string_call_utils::collect_keyword_values("complex", keywords);
+      string_call_utils::ensure_allowed_keywords(
+        "complex", kw_vals, {"real", "imag"});
 
-      const std::string name = kw["arg"].get<std::string>();
-      if (name == "real")
+      if (
+        auto *real_kw = string_call_utils::find_keyword_value(kw_vals, "real"))
       {
         if (real_json != nullptr)
           return raise_type_error(
             "complex() got multiple values for argument 'real'");
-        real_json = &kw["value"];
+        real_json = real_kw;
       }
-      else if (name == "imag")
+      if (
+        auto *imag_kw = string_call_utils::find_keyword_value(kw_vals, "imag"))
       {
         if (imag_json != nullptr)
           return raise_type_error(
             "complex() got multiple values for argument 'imag'");
-        imag_json = &kw["value"];
+        imag_json = imag_kw;
       }
-      else
-      {
-        return raise_type_error(
-          "complex() got an unexpected keyword argument '" + name + "'");
-      }
+    }
+    catch (const std::runtime_error &e)
+    {
+      return raise_type_error(e.what());
     }
   }
 

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -1569,8 +1569,9 @@ exprt function_call_expr::handle_complex() const
 
     return value;
   };
-  auto is_cpp_throw = [](const exprt &e) -> bool
-  { return e.statement() == "cpp-throw"; };
+  auto is_cpp_throw = [](const exprt &e) -> bool {
+    return e.statement() == "cpp-throw";
+  };
   auto extract_constant_string =
     [&](const nlohmann::json &arg, std::string &out) -> bool {
     if (!arg.contains("value"))
@@ -1676,8 +1677,7 @@ exprt function_call_expr::handle_complex() const
 
     return std::nullopt;
   };
-  auto is_unsigned_byte_array = [](const typet &type) -> bool
-  {
+  auto is_unsigned_byte_array = [](const typet &type) -> bool {
     if (!type.is_array())
       return false;
     const typet &subtype = type.subtype();
@@ -3725,10 +3725,12 @@ function_call_expr::get_dispatch_table()
                                        ? raw_func_name.substr(8)
                                        : raw_func_name;
        const auto &args = call_["args"];
-       auto raise_math_real_type_error = [this]() -> exprt
-       { return complex_utils::raise_math_real_type_error_expr(converter_); };
-       auto raise_math_int_type_error = [this]() -> exprt
-       { return complex_utils::raise_math_int_type_error_expr(converter_); };
+       auto raise_math_real_type_error = [this]() -> exprt {
+         return complex_utils::raise_math_real_type_error_expr(converter_);
+       };
+       auto raise_math_int_type_error = [this]() -> exprt {
+         return complex_utils::raise_math_int_type_error_expr(converter_);
+       };
        auto has_complex_arg = [](const exprt &arg_expr) -> bool {
          return is_complex_type(arg_expr.type());
        };


### PR DESCRIPTION
This PR creates complex_handler_utils as a dedicated utility module for complex number handling, following the same pattern as string_handler_utils.

The main changes are:

- Extract parse_complex_string from a local lambda into a standalone free function, removing the helper lambda trim, parse_double_strict that only existed to support it.
- Move raise_math_real_type_error_expr and raise_math_int_type_error_expr into the complex_utils namespace so they can be reused outside function_call_expr.cpp.
- Replace the hand-written keyword loop in handle_complex() with the existing collect_keyword_values utilities from the string handler.
