### PR TITLE
python: Support int.to_bytes()

### DIFF
--- a/regression/python/int_to_bytes/main.py
+++ b/regression/python/int_to_bytes/main.py
@@ -1,0 +1,14 @@
+def foo(x: int):
+    return int.to_bytes(x, 2, "big")
+
+def bar(x: int):
+    return int.to_bytes(x, 2, "little")
+
+x = 255
+y = foo(x)
+assert y[0] == 0
+assert y[1] == 255
+
+z = bar(x)
+assert z[0] == 255
+assert z[1] == 0

--- a/regression/python/int_to_bytes/test.desc
+++ b/regression/python/int_to_bytes/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -719,6 +719,84 @@ exprt function_call_expr::handle_int_to_str(nlohmann::json &arg) const
     std::vector<uint8_t>(str_val.begin(), str_val.end()), t);
 }
 
+exprt function_call_expr::handle_int_to_bytes() const
+{
+  const auto &args = call_["args"];
+  // Python accepts both int.to_bytes(x, ...) and x.to_bytes(...).
+  const bool is_type_method_call = call_["func"]["_type"] == "Attribute" &&
+                                   call_["func"]["value"]["_type"] == "Name" &&
+                                   call_["func"]["value"]["id"] == "int";
+
+  // In the type-method form, the integer value is passed explicitly as the
+  // first argument. In the instance-method form, it comes from the receiver.
+  if (
+    args.size() < (is_type_method_call ? 3 : 2) ||
+    args.size() > (is_type_method_call ? 4 : 3))
+  {
+    throw std::runtime_error(
+      is_type_method_call ? "int.to_bytes() expects 3 or 4 positional "
+                            "arguments"
+                          : "int.to_bytes() expects 2 or 3 positional "
+                            "arguments");
+  }
+
+  exprt value = is_type_method_call
+                  ? converter_.get_expr(args[0])
+                  : converter_.get_expr(call_["func"]["value"]);
+  const nlohmann::json &length_arg = args[is_type_method_call ? 1 : 0];
+  const nlohmann::json &byteorder_arg = args[is_type_method_call ? 2 : 1];
+
+  if (
+    !length_arg.contains("value") || !length_arg["value"].is_number_unsigned())
+    throw std::runtime_error(
+      "int.to_bytes() currently expects a constant unsigned length");
+
+  const std::size_t length = length_arg["value"].get<std::size_t>();
+
+  bool big_endian = true;
+  if (byteorder_arg.contains("value"))
+  {
+    if (byteorder_arg["value"].is_boolean())
+      big_endian = byteorder_arg["value"].get<bool>();
+    else if (byteorder_arg["value"].is_string())
+      big_endian = byteorder_arg["value"].get<std::string>() == "big";
+  }
+
+  const typet bytes_type = type_handler_.get_typet("bytes", length);
+  exprt result = gen_zero(bytes_type);
+  const typet &elem_type = bytes_type.subtype();
+
+  if (!value.type().is_unsignedbv())
+  {
+    // Convert the source value to an unsigned integer type before extracting
+    // individual bytes with shifts and masks.
+    const unsigned width =
+      (value.type().is_signedbv() || value.type().is_unsignedbv())
+        ? std::max(1u, bv_width(value.type()))
+        : 64;
+    value = typecast_exprt(value, unsignedbv_typet(width));
+  }
+
+  // Fill the output array one byte at a time. For big-endian we start from the
+  // most significant byte; for little-endian we start from the least significant one.
+  for (std::size_t i = 0; i < length; ++i)
+  {
+    const std::size_t byte_index = big_endian ? (length - 1 - i) : i;
+
+    // Shift the selected byte down to the low 8 bits and mask everything else out.
+    const exprt shift_amount = from_integer(byte_index * 8, value.type());
+    exprt shifted("shr", value.type());
+    shifted.copy_to_operands(value, shift_amount);
+
+    exprt masked("bitand", value.type());
+    masked.copy_to_operands(shifted, from_integer(0xff, value.type()));
+
+    result.operands().at(i) = typecast_exprt(masked, elem_type);
+  }
+
+  return result;
+}
+
 exprt function_call_expr::handle_float_to_str(nlohmann::json &arg) const
 {
   std::string str_val = std::to_string(arg["value"].get<double>());
@@ -3448,6 +3526,21 @@ function_call_expr::get_dispatch_table()
     {[this]() { return is_any_call(); },
      [this]() { return handle_any(); },
      "any()"},
+
+    // int.to_bytes()
+    {[this]() {
+       if (call_["func"]["_type"] != "Attribute")
+         return false;
+       if (function_id_.get_function() != "to_bytes")
+         return false;
+
+       const auto &obj = call_["func"]["value"];
+       return (obj["_type"] == "Name" && obj["id"] == "int") ||
+              (obj["_type"] == "Name" &&
+               type_handler_.get_var_type(obj["id"]) == "int");
+     },
+     [this]() { return handle_int_to_bytes(); },
+     "int.to_bytes()"},
 
     // Min/Max functions
     {[this]() { return is_min_max_call(); },

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -143,6 +143,8 @@ private:
    */
   exprt handle_int_to_str(nlohmann::json &arg) const;
 
+  exprt handle_int_to_bytes() const;
+
   /*
    * Extracts a string representation from a symbol's constant value.
    * Handles both character arrays (e.g., ['6', '5']) and single-character

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -2268,6 +2268,8 @@ private:
         // Map specific class methods to their return types
         if (class_name == "int" && method_name == "from_bytes")
           return "int";
+        else if (class_name == "int" && method_name == "to_bytes")
+          return "bytes";
         else if (
           class_name == "str" &&
           (method_name == "join" || method_name == "format"))


### PR DESCRIPTION
This PR adds support for `int.to_bytes()`.

Example:
```python
def foo(x: int):
    return int.to_bytes(x, 2, "big")

y = foo(255)
assert y[0] == 0
assert y[1] == 255
```

This handles both `int.to_bytes(x, ...)` and `x.to_bytes(...)`, extracts each output byte according to the endianness parameter, and returns a bytes value. On master it was failing with:
```text
Unsupported comparison with unresolved operand type at /tmp/main.py:9
```
