### PR TITLE
[ir-ra] strengthen tracked-sub interval regression expectations

### DIFF
--- a/regression/ir-ra/ra-interval-lift-sub-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-both-tracked-single/test.desc
@@ -3,6 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|\)
 \(ite
 5960464477539063
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-both-tracked/test.desc
@@ -3,6 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|\)
 \(ite
 5551115123125783
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-one-fresh-single/test.desc
@@ -3,6 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo::0\|
 \(ite
 5960464477539063
 ^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-one-fresh/test.desc
@@ -3,6 +3,7 @@ main.c
 --ir-ieee --z3 --smt-formula-too
 \(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
 \(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo::0\|
 \(ite
 5551115123125783
 ^VERIFICATION FAILED$


### PR DESCRIPTION
## Summary

Re-strengthen the tracked-sub regression expectations now that both ieee_sub interval lifting (#3950) and interval propagation across assignments (#3967) are in master.

These expectations were temporarily removed in #3950 because they depended on the propagation fix (#3967), which had not yet landed at the time.

## Changes

Adds the stronger tracked-sub SMT pattern checks back to:

- `ra-interval-lift-sub-both-tracked` — asserts `(- ra_lo::0 ra_hi::0)`
- `ra-interval-lift-sub-both-tracked-single` — same, single-precision
- `ra-interval-lift-sub-one-fresh` — asserts `(- ra_lo::0` prefix (open match)
- `ra-interval-lift-sub-one-fresh-single` — same, single-precision

No source code changes.

## Validation

Ran all 4 regressions locally against the current master build — all pass.