### PR TITLE
[c++] wrap unbraced range-for body in block before prepending loop var

### DIFF
--- a/regression/esbmc-cpp11/cpp/github_3977/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3977/main.cpp
@@ -1,0 +1,9 @@
+#include <cassert>
+int main()
+{
+  int sum = 0;
+  int init[] = {0, 1, 2, 3, 4};
+  for (int val : init)
+    sum += val;
+  assert(sum == 10);
+}

--- a/regression/esbmc-cpp11/cpp/github_3977/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3977/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/cpp/github_3977_2/main.cpp
+++ b/regression/esbmc-cpp11/cpp/github_3977_2/main.cpp
@@ -1,0 +1,10 @@
+#include <cassert>
+int main()
+{
+  int init[] = {1, -2, 3, -4, 5};
+  int positives = 0;
+  for (int val : init)
+    if (val > 0)
+      positives++;
+  assert(positives == 3);
+}

--- a/regression/esbmc-cpp11/cpp/github_3977_2/test.desc
+++ b/regression/esbmc-cpp11/cpp/github_3977_2/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --std c++11
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1155,9 +1155,23 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       if (get_expr(*loop_var, loop))
         return true;
 
-    codet::operandst &ops = body.operands();
-    ops.insert(ops.begin(), loop);
-    convert_expression_to_code(body);
+    // When body is not a block (single-statement without braces), it is a raw
+    // expression or non-block code node. Inserting the loop variable declaration
+    // directly into its operands would corrupt the expression structure. Wrap in
+    // a block first so that the prepend targets a statement list.
+    if (body.get_statement() != "block")
+    {
+      convert_expression_to_code(body);
+      code_blockt new_body;
+      new_body.location() = body.location();
+      new_body.operands().push_back(body);
+      body = new_body;
+    }
+    if (loop_var)
+    {
+      codet::operandst &ops = body.operands();
+      ops.insert(ops.begin(), loop);
+    }
 
     code_fort code_for;
     code_for.init() = decls;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/discussions/3977.

When a C++ range-based for loop had a single-statement body without braces, the `CXXForRangeStmtClass` handler inserted the loop variable declaration into the body expression's sub-expression operands, corrupting it (e.g., "assign+" gaining a third operand). `goto_convert` then crashed with "assign+ takes two arguments".

This PR ensures body is a `code_blockt` before the prepend: if not a block, convert to code and wrap it in a new block (copying the body's location for correct destructor scoping. It also adds regression tests for a compound-assignment body and an if-statement body (github_3977, _2).