### PR TITLE
[c++] fix infinite unwinding of ~list when main() lacks return 0

### DIFF
--- a/regression/esbmc-cpp/cpp/github_3978/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3978/main.cpp
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/esbmc/esbmc/discussions/3978
+// ~list should not cause infinite unwinding when main() lacks return 0
+#include <list>
+
+int main()
+{
+  std::list<int> lst;
+  lst.push_front(2);
+}

--- a/regression/esbmc-cpp/cpp/github_3978/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3978/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --multi-property
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -1165,10 +1165,6 @@ public:
 
   ~list()
   {
-    for (int i = 0; i < this->_size; i++)
-    {
-      this->_list[i] = T();
-    }
     this->_size = 0;
   }
 


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/discussions/3978.

Without an explicit `return 0;`, `goto_convert` emits the ~list destructor into the GOTO program. The original loop `for (i=0; i<_size; i++)` has a "symbolic" bound, causing the symex engine to unwind indefinitely when "max_unwind=0".

Note that the loop body only zero-initializes stack-allocated elements that are about to go out of scope, which is a semantically no-op in our operational model. 

This PR drops it and just resets `_size` to 0, consistent with how the vector model treats its destructor.