### PR TITLE
feat: update to bitwuzla 0.9.0

### DIFF
--- a/regression/quixbugs/hanoi/test.desc
+++ b/regression/quixbugs/hanoi/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 12 --no-standard-checks --bitwuzla
+--unwind 9 --no-standard-checks --bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -248,6 +248,7 @@ collect_ubuntu_packages() {
     libboost-iostreams-dev
     libboost-system-dev
     libboost-filesystem-dev
+    libmpfr-dev
     ninja-build
     python3-setuptools
     libncurses-dev
@@ -285,6 +286,7 @@ collect_macos_formulae() {
     cmake
     z3
     gmp
+    mpfr
     csmith
     boost
     ninja

--- a/scripts/cmake/StaticSymbolRenaming.cmake
+++ b/scripts/cmake/StaticSymbolRenaming.cmake
@@ -1,0 +1,78 @@
+include_guard(GLOBAL)
+
+# Rename symbols matching MATCH_REGEXES in a static library, prefixing them with PREFIX.
+# Sets OUTPUT_PATH (variable name) to the renamed copy if any symbols matched,
+# or to the original library path if nothing needed renaming.
+function(esbmc_rename_static_symbols)
+  cmake_parse_arguments(ARG "" "STATIC_LIBRARY;OUTPUT_PATH;PREFIX" "MATCH_REGEXES" ${ARGN})
+
+  # Prefer the LLVM toolchain already found by find_package(LLVM), fall back to PATH.
+  # Also try versioned names (e.g. llvm-objcopy-17) common on Debian/Ubuntu.
+  set(_llvm_tool_hints)
+  if(DEFINED LLVM_TOOLS_BINARY_DIR)
+    list(APPEND _llvm_tool_hints "${LLVM_TOOLS_BINARY_DIR}")
+  endif()
+
+  set(_llvm_version_suffix)
+  if(DEFINED LLVM_VERSION_MAJOR)
+    set(_llvm_version_suffix "-${LLVM_VERSION_MAJOR}")
+  endif()
+
+  find_program(_llvm_nm NAMES "llvm-nm${_llvm_version_suffix}" llvm-nm HINTS ${_llvm_tool_hints} REQUIRED)
+  find_program(_llvm_objcopy NAMES "llvm-objcopy${_llvm_version_suffix}" llvm-objcopy HINTS ${_llvm_tool_hints} REQUIRED)
+  find_program(_llvm_ranlib NAMES "llvm-ranlib${_llvm_version_suffix}" llvm-ranlib HINTS ${_llvm_tool_hints} REQUIRED)
+
+  get_filename_component(_basename "${ARG_STATIC_LIBRARY}" NAME)
+  set(_dir "${CMAKE_CURRENT_BINARY_DIR}/renamed")
+  file(MAKE_DIRECTORY "${_dir}")
+  set(_renamed "${_dir}/${_basename}")
+  set(_syms "${_dir}/${_basename}.syms")
+
+  execute_process(
+    COMMAND "${_llvm_nm}" --defined-only -g -j "${ARG_STATIC_LIBRARY}"
+    OUTPUT_VARIABLE _nm_output
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _nm_result)
+
+  if(NOT _nm_result EQUAL 0 OR _nm_output STREQUAL "")
+    set(${ARG_OUTPUT_PATH} "${ARG_STATIC_LIBRARY}" PARENT_SCOPE)
+    return()
+  endif()
+
+  string(REPLACE "\n" ";" _symbols "${_nm_output}")
+  set(_map_content "")
+  foreach(_sym IN LISTS _symbols)
+    string(STRIP "${_sym}" _sym)
+    foreach(_regex IN LISTS ARG_MATCH_REGEXES)
+      if(_sym MATCHES "${_regex}")
+        string(APPEND _map_content "${_sym} ${ARG_PREFIX}${_sym}\n")
+        break()
+      endif()
+    endforeach()
+  endforeach()
+
+  if(_map_content STREQUAL "")
+    set(${ARG_OUTPUT_PATH} "${ARG_STATIC_LIBRARY}" PARENT_SCOPE)
+    return()
+  endif()
+
+  file(WRITE "${_syms}" "${_map_content}")
+
+  execute_process(
+    COMMAND "${_llvm_objcopy}" "--redefine-syms=${_syms}"
+      "${ARG_STATIC_LIBRARY}" "${_renamed}"
+    RESULT_VARIABLE _objcopy_result)
+
+  execute_process(
+    COMMAND "${_llvm_ranlib}" "${_renamed}"
+    RESULT_VARIABLE _ranlib_result)
+
+  if(NOT _objcopy_result EQUAL 0 OR NOT _ranlib_result EQUAL 0)
+    message(FATAL_ERROR "Failed to rename symbols in '${ARG_STATIC_LIBRARY}'")
+  endif()
+
+  file(STRINGS "${_syms}" _syms_lines)
+  list(LENGTH _syms_lines _count)
+  message(STATUS "Renamed ${_count} symbols in ${_basename}")
+  set(${ARG_OUTPUT_PATH} "${_renamed}" PARENT_SCOPE)
+endfunction()

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -10,14 +10,14 @@ else()
             NAME bitwuzla
             DOWNLOAD_ONLY YES
             GITHUB_REPOSITORY bitwuzla/bitwuzla
-            GIT_TAG 0.8.2)
-	  
+            GIT_TAG 0.9.0)
+
 	  message("[bitwuzla] Source-dir: ${bitwuzla_SOURCE_DIR} ")
         message("[bitwuzla] Configuring project:  ./configure.py --prefix ${bitwuzla_BINARY_DIR}")
         execute_process(COMMAND python3 ./configure.py --prefix ${bitwuzla_BINARY_DIR}
           WORKING_DIRECTORY "${bitwuzla_SOURCE_DIR}")
 
-	
+
         message("[bitwuzla] Building...")
         execute_process(COMMAND meson install
           WORKING_DIRECTORY ${bitwuzla_SOURCE_DIR}/build
@@ -33,7 +33,7 @@ if(EXISTS $ENV{HOME}/bitwuzla)
 endif()
 
 if(ENABLE_BITWUZLA)
-  
+
   if(Bitwuzla_DIR)
     # We need to tell cmake where to look for the .pc file exported by bitwuzla
     list(APPEND CMAKE_PREFIX_PATH "${Bitwuzla_DIR}")

--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -42,6 +42,29 @@ if(ENABLE_BITWUZLA)
   include(FindPkgConfig)
   pkg_check_modules(Bitwuzla REQUIRED IMPORTED_TARGET bitwuzla)
 
+  # Bitwuzla 0.9.0 statically links CaDiCaL which can clash
+  # with cvc5 (also statically links CaDiCaL). Rename the symbols in the static library to avoid this.
+  if(ENABLE_CVC5 AND Bitwuzla_VERSION VERSION_GREATER_EQUAL "0.9.0")
+    message(STATUS "Renaming CaDiCaL symbols in Bitwuzla library to avoid clashes with cvc5")
+    include(StaticSymbolRenaming)
+
+    get_target_property(_bzla_libs PkgConfig::Bitwuzla INTERFACE_LINK_LIBRARIES)
+    set(_updated_libs)
+    foreach(_lib IN LISTS _bzla_libs)
+      if(_lib MATCHES "\\.(a|lib)$" AND EXISTS "${_lib}")
+        esbmc_rename_static_symbols(
+          STATIC_LIBRARY "${_lib}"
+          OUTPUT_PATH _lib
+          PREFIX "esbmc_bzla__"
+          MATCH_REGEXES "CaDiCaL" "^ccadical_" "^ipasir_")
+      else()
+        list(APPEND _updated_libs "${_lib}")
+      endif()
+      list(APPEND _updated_libs "${_lib}")
+    endforeach()
+    set_property(TARGET PkgConfig::Bitwuzla PROPERTY INTERFACE_LINK_LIBRARIES ${_updated_libs})
+  endif()
+
   if(NOT Bitwuzla_FOUND)
     message(ERROR "Could not find Bitwuzla in '${Bitwuzla_DIR}'")
   endif()

--- a/website/content/docs/development/building.md
+++ b/website/content/docs/development/building.md
@@ -98,7 +98,7 @@ Before starting, note that ESBMC is mainly distributed under the terms of the [A
 | MathSAT   | no       | 5.5.4           |
 | Yices     | no       | 2.6.4           |
 | Z3        | no       | 4.13.3          |
-| Bitwuzla  | no       | 0.8.2           |
+| Bitwuzla  | no       | 0.9.0           |
 
 The version requirements are stable but can change between releases.
 
@@ -347,11 +347,21 @@ cp -rp $(brew info z3 | egrep "/usr[/a-zA-Z\.0-9]+ " -o) z3
 
 ### Setting Up Bitwuzla
 
+Bitwuzla 0.9.0 requires MPFR >= 4.2.1. Install it before building:
+
+```
+Linux:
+sudo apt-get install libmpfr-dev
+
+macOS:
+brew install mpfr
+```
+
 We have wrapped the entire build and setup of Bitwuzla in the following command:
 
 ```
 Linux/macOS:
-git clone --depth=1 --branch=0.8.2 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
+git clone --depth=1 --branch=0.9.0 https://github.com/bitwuzla/bitwuzla.git && cd bitwuzla && ./configure.py --prefix $PWD/../bitwuzla-release && cd build && meson install
 ```
 
 For more details on Bitwuzla, please refer to [its Github](https://github.com/bitwuzla/bitwuzla).


### PR DESCRIPTION
EDIT: This has been cleaned up now and is ready.
The current implementation was Codex-generated and is honestly **not good**, but I didn't have time to clean it up yet.
So focus on the general idea, not the concrete implementation.

## Problem
Basically, what was the problem with updating to bitwuzla 0.9.0:
1. Bitwuzla started to statically link to cadical.
2. CVC5 already links statically to cadical.
3. Esbmc links to bitwuzla and CVC5 which fails as there are duplicate symbols for cadical.

## Explored solutions
1. Disable cadical - not really a solution :P
2. Let ESBMC build a specific cadical version and then make cvc5 and bitwuzla link against that => no more duplicate symbols, but then we have to figure out a version that is accepted by both cvc5 and bitwuzla which is a bit annoying.
3. ~~Convert *global* symbols to *local* symbols: we convert all the (global) cadical symbols in bitwuzla and cvc5 to local symbols. When we then link esbmc to bitwuzla and cvc5, there are no duplicate symbols for cadical as duplicate local symbols are fine => cvc5 and bitwuzla can continue to link against whatever version of cadical they want.~~
4. Rename cadical symbols inside bitwuzla, this way they won't clash with the cadical symbols in cvc5.

~~To me, solution 3 felt like the cleanest solution and that's why I implemented it.~~

EDIT: While solution 3 worked locally, it apparently didn't work in CI.
I cleaned up the code and switched to renaming the symbols.