### PR TITLE
[ir-ra] add theorem-driven RNA interval lifting for ieee_sub

### DIFF
--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_sub --
+ * both operands fresh, single precision (zero-regression sentinel).
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rna-sub-both-fresh but exercises the
+ * single-precision (float) path. Verifies that when both operands are fresh
+ * nondet variables, the point-interval fallback collapses to the single-step
+ * RNA formula with single-precision epsilon constants.
+ *
+ * PROOF SHAPE (point-interval fallback, single precision)
+ * -------------------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   ra_lo_aw = real_z - B_near(real_z)   [eps_rel = 2^-24]
+ *   ra_hi_aw = real_z + B_near(real_z)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::       -- RNA tight path taken
+ *   ra_hi_aw::       -- RNA tight path taken
+ *   (ite             -- |r| absolute value present
+ *   5960464477539063 -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* both operands fresh -> point fallback -> single-step equivalent */
+
+  /* Always false in real/integer encoding: z == x - y exactly. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(ite
+5960464477539063
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh/main.c
@@ -1,0 +1,46 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_sub --
+ * both operands fresh (zero-regression sentinel).
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of an RNA ieee_sub are fresh nondet
+ * variables (not in ir_ra_interval_map), the point-interval fallback
+ * applies to both, and the resulting formula is structurally equivalent to
+ * the pre-lifting single-step RNA path.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step RNA)
+ * -------------------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNA sub).
+ *   iv(x) = {x_smt, x_smt}  (point fallback)
+ *   iv(y) = {y_smt, y_smt}  (point fallback)
+ *   L_R = x_smt - y_smt = real_z
+ *   U_R = x_smt - y_smt = real_z
+ * The helper receives lo_r == hi_r == real_z, producing:
+ *   ra_lo_aw = real_z - B_near(real_z)
+ *   ra_hi_aw = real_z + B_near(real_z)
+ * This is identical in structure to the pre-lifting single-step RNA formula.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::   -- RNA tight path taken (same naming as single-step RNA)
+ *   ra_hi_aw::   -- RNA tight path taken
+ *   (ite          -- |r| absolute value present
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double, same as RNE)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* both operands fresh -> point fallback -> single-step equivalent */
+
+  /* Always false in real/integer encoding: z == x - y exactly. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked-single/main.c
@@ -1,0 +1,48 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_sub --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rna-sub-both-tracked but exercises the
+ * single-precision (float) path. Verifies that the get_single_eps_rel() /
+ * get_single_min_subnormal() branch in apply_ieee754_rna_enclosure is
+ * reached when both operands of a second RNA ieee_sub are tracked.
+ *
+ * PROOF SHAPE (B_near, RNA, single precision)
+ * -------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   ra_lo_aw::0 = real_z - B_near(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second sub:  w = z - z  (both operands tracked -> full lift)
+ *   L_R2 = ra_lo_aw::0 - ra_hi_aw::0
+ *   U_R2 = ra_hi_aw::0 - ra_lo_aw::0
+ *   ra_lo_aw::1 = L_R2 - B_near(L_R2)   [single eps: 2^-24]
+ *   ra_hi_aw::1 = U_R2 + B_near(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_aw::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_aw::0 ra_hi_aw::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_near computations
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RNA sub: both fresh -> point fallback; stored */
+  float w = z - z;   /* second RNA sub: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_hi_aw::0\|\)
+\(ite
+5960464477539063
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_sub --
+ * both operands tracked.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RNA ieee_sub were themselves
+ * results of a prior tracked RNA ieee_sub, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RNA subtraction path is taken.
+ *
+ * PROOF SHAPE (B_near, RNA, double precision)
+ * -------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   L_R1 = x - y = real_z,   U_R1 = x - y = real_z
+ *   ra_lo_aw::0 = real_z - B_near(real_z)
+ *   ra_hi_aw::0 = real_z + B_near(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second sub:  w = z - z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_aw::0, ra_hi_aw::0}  (found in map, same entry twice)
+ *   L_R2 = ra_lo_aw::0 - ra_hi_aw::0
+ *   U_R2 = ra_hi_aw::0 - ra_lo_aw::0
+ *   ra_lo_aw::1 = L_R2 - B_near(L_R2)
+ *   ra_hi_aw::1 = U_R2 + B_near(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_aw::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_aw::0 ra_hi_aw::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_near computations
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double, same as RNE)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RNA sub: both fresh -> point fallback; stored */
+  double w = z - z;   /* second RNA sub: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_hi_aw::0\|\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh-single/main.c
@@ -1,0 +1,50 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_sub --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rna-sub-one-fresh but exercises the
+ * single-precision (float) path. Verifies the mixed lookup path: when one
+ * operand of a second RNA ieee_sub is tracked and the other is a fresh
+ * nondet variable, the tracked operand uses its stored interval while the
+ * fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_near, RNA, single precision)
+ * -------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_aw::0, ra_hi_aw::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_aw::0 - x_smt
+ *   U_R2 = ra_hi_aw::0 - x_smt
+ *   ra_lo_aw::1 = L_R2 - B_near(L_R2)   [single eps: 2^-24]
+ *   ra_hi_aw::1 = U_R2 + B_near(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_aw::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_aw::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RNA sub: both fresh -> point fallback; stored */
+  float w = z - x;   /* second RNA sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_aw::0\|
+\(ite
+5960464477539063
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_sub --
+ * one tracked, one fresh.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RNA ieee_sub: when one operand of a
+ * second RNA ieee_sub is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_near, RNA, double precision)
+ * -------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_aw::0, ra_hi_aw::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_aw::0 - x_smt
+ *   U_R2 = ra_hi_aw::0 - x_smt
+ *   ra_lo_aw::1 = L_R2 - B_near(L_R2)
+ *   ra_hi_aw::1 = U_R2 + B_near(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_aw::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_aw::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_aw::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RNA sub: both fresh -> point fallback; stored */
+  double w = z - x;   /* second RNA sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-sub-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_aw::0\|
+\(ite
+5551115123125783
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1422,7 +1422,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           if (is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_away(rounding_mode))
+          else
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
@@ -1493,7 +1493,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           if (is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else if (is_round_to_away(rounding_mode))
+          else
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1455,16 +1455,21 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       const expr2tc &rounding_mode = to_ieee_sub2t(expr).rounding_mode;
 
-      // Interval-lifted RNE enclosure for ieee_sub (--ir-ieee only).
-      // Subtraction interval hull:
+      // Interval-lifted nearest-mode enclosure for ieee_sub (--ir-ieee only).
+      // Covers both RNE (ROUND_TO_EVEN) and RNA (ROUND_TO_AWAY): both are
+      // nearest-rounding modes sharing the same B_near constants and the same
+      // subtraction interval hull:
       //   L_R = L_x - U_y,  U_R = U_x - L_y
       //   ra_lo = L_R - B_near^-(L_R),  ra_hi = U_R + B_near^+(U_R)
-      // Non-RNE modes, non-standard formats, and --ir-ieee disabled all
+      // For RNE the result is named ra_lo:: / ra_hi::; for RNA ra_lo_aw:: /
+      // ra_hi_aw::, matching the single-step naming convention.
+      // Non-nearest modes, non-standard formats, and --ir-ieee disabled all
       // fall through to apply_ieee754_semantics unchanged.
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
-        is_nearest_rounding_mode(rounding_mode))
+        (is_nearest_rounding_mode(rounding_mode) ||
+         is_round_to_away(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1484,8 +1489,13 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           ra_interval_t iv2 = get_iv(side2);
           smt_astt lo_r = mk_sub(iv1.lo, iv2.hi); // L_R = L_x - U_y
           smt_astt hi_r = mk_sub(iv1.hi, iv2.lo); // U_R = U_x - L_y
-          auto bounds =
-            apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
+          std::pair<smt_astt, smt_astt> bounds;
+          if (is_nearest_rounding_mode(rounding_mode))
+            bounds =
+              apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else if (is_round_to_away(rounding_mode))
+            bounds =
+              apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RNA interval lifting for `ieee_sub`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- added theorem-driven RNE and RNA interval lifting for `ieee_add`
- added theorem-driven RNE interval lifting for `ieee_sub`
- kept interval lifting for other operations out of scope

This PR adds the next smallest sound step:

- a dedicated RNA-only interval-lifted path for `ieee_sub`
- while keeping all other operations and rounding modes on the existing paths

## Main idea

For round-to-away subtraction, let:

- `R = hull(X - Y) = [L_R, U_R]`

with:

- `L_R = L_x - U_y`
- `U_R = U_x - L_y`

and:

- `B_near^-(R) = eps_rel_near * |L_R| + eps_abs`
- `B_near^+(R) = eps_rel_near * |U_R| + eps_abs`

So this PR implements the proof-aligned compositional shape:

- `fl_RNA(x - y) ∈ [L_R - B_near^-(R), U_R + B_near^+(R)]`

For implementation, operand intervals are obtained as follows:

- if an operand already has a tracked lifted enclosure, reuse its stored `{ra_lo, ra_hi}` / `{ra_lo_aw, ra_hi_aw}` as appropriate
- otherwise fall back to the point interval `{side, side}`

This preserves zero regression for fresh operands, because the point-interval fallback collapses exactly to the current single-step RNA enclosure.

## Main changes

- extend the `ieee_sub` path under `--ir-ieee` and `ROUND_TO_AWAY` with interval lifting
- compute the subtraction hull as:
  - `L_R = L_x - U_y`
  - `U_R = U_x - L_y`
- reuse the existing `ir_ra_interval_map`
- reuse the existing `apply_ieee754_rna_enclosure` helper, since it is operation-agnostic and only depends on `(real_result, lo_r, hi_r)`
- keep the existing RNA symbol naming style:
  - `ra_lo_aw::N`
  - `ra_hi_aw::N`
- keep `ieee_add` lifting unchanged
- keep directed modes and non-sub operations unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-rna-sub-both-tracked`
  - double-precision both-tracked case

- `ra-interval-lift-rna-sub-one-fresh`
  - double-precision mixed tracked/fresh case

- `ra-interval-lift-rna-sub-both-fresh`
  - double-precision zero-regression / point-fallback case

- `ra-interval-lift-rna-sub-both-tracked-single`
  - single-precision both-tracked case

- `ra-interval-lift-rna-sub-one-fresh-single`
  - single-precision mixed tracked/fresh case

- `ra-interval-lift-rna-sub-both-fresh-single`
  - single-precision zero-regression / point-fallback case

This PR was also checked against these existing regressions:

- `ra-interval-lift-sub-both-tracked`
- `ra-interval-lift-sub-one-fresh`
- `ra-interval-lift-sub-both-fresh`
- `ra-interval-lift-rna-both-tracked`
- `ra-interval-lift-rna-one-fresh`

## Scope

This PR implements only:

- `ROUND_TO_AWAY` interval lifting
- `ieee_sub` interval lifting

The following are deferred:

- directed-mode interval lifting for `ieee_sub`
- `ieee_mul` interval lifting
- `ieee_div` interval lifting
- `ieee_fma` interval lifting
- full IEEE corner-case support (`NaN`, infinities, signed zero, comparison semantics)
- full DAG-level compositional propagation beyond the current tracked interval flow