### PR TITLE
[ir-ra] add theorem-driven RUP/RDN interval lifting for ieee_sub

### DIFF
--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_sub --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rdn-both-fresh but exercises the
+ * single-precision (float) path. Verifies that when both operands are fresh
+ * nondet variables, the point-interval fallback collapses to the single-step
+ * RDN formula with single-precision epsilon constants.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * ------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   ra_lo_dn = real_z - B_dir(real_z)   [eps_rel_dir = 2^-23]
+ *   ra_hi_dn = real_z          (exact upper: RDN never rounds above true value)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::       -- RDN tight path taken (single precision)
+ *   ra_hi_dn::       -- RDN tight path taken
+ *   (ite             -- |r| absolute value present in B_dir computation
+ *   8388608          -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y; /* RDN sub: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh/main.c
@@ -1,0 +1,42 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_sub --
+ * both operands fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that theorem-driven interval lifting fires for ieee_sub under
+ * ROUND_TO_MINUS_INF when both operands are fresh nondet variables.
+ * With no tracked operands both use the point-interval fallback {t, t},
+ * so the hull degenerates to the single-step RDN enclosure:
+ *   LR = UR = x - y
+ *   ra_lo_dn::0 = LR - B_dir(LR)
+ *   ra_hi_dn::0 = UR        (exact upper: RDN never rounds above true value)
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * EbRDN([LR, UR]) = [LR - B_dir(LR), UR]
+ * B_dir(r) = eps_rel_dir * |r| + eps_abs,  eps_rel_dir = 2^-52
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::[0-9]+  -- RDN interval lower bound declared
+ *   ra_hi_dn::[0-9]+  -- RDN interval upper bound declared
+ *   (ite               -- absolute value in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y; /* RDN sub: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked-single/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_sub --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rdn-both-tracked but exercises the
+ * single-precision (float) path. Verifies that the get_single_eps_dn() /
+ * get_single_min_subnormal() branch in apply_ieee754_rdn_enclosure is
+ * reached when both operands of a second RDN ieee_sub are tracked.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   ra_lo_dn::0 = real_z - B_dir(real_z)   [eps_rel_dir = 2^-23]
+ *   ra_hi_dn::0 = real_z          (exact upper bound)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second sub:  w = z - z  (both operands tracked -> full lift)
+ *   L_R2 = ra_lo_dn::0 - ra_hi_dn::0
+ *   U_R2 = ra_hi_dn::0 - ra_lo_dn::0
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)   [single eps: 2^-23]
+ *   ra_hi_dn::1 = U_R2          (exact upper: RDN never rounds above)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_dn::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_dn::0 ra_hi_dn::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RDN sub: both fresh -> point fallback; stored */
+  float w = z - z;   /* second RDN sub: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_sub --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RDN ieee_sub were themselves
+ * results of a prior tracked RDN ieee_sub, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RDN subtraction path is taken.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   L_R1 = x - y = real_z,   U_R1 = x - y = real_z
+ *   ra_lo_dn::0 = real_z - B_dir(real_z)
+ *   ra_hi_dn::0 = real_z          (exact: RDN never rounds above)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second sub:  w = z - z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}  (found in map, same entry twice)
+ *   L_R2 = ra_lo_dn::0 - ra_hi_dn::0
+ *   U_R2 = ra_hi_dn::0 - ra_lo_dn::0
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)
+ *   ra_hi_dn::1 = U_R2          (exact upper bound for second sub)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_dn::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_dn::0 ra_hi_dn::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RDN sub: both fresh -> point fallback; stored */
+  double w = z - z;   /* second RDN sub: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh-single/main.c
@@ -1,0 +1,50 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_sub --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rdn-one-fresh but exercises the
+ * single-precision (float) path. Verifies the mixed lookup path: when one
+ * operand of a second RDN ieee_sub is tracked and the other is a fresh
+ * nondet variable, the tracked operand uses its stored interval while the
+ * fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_dn::0 - x_smt
+ *   U_R2 = ra_hi_dn::0 - x_smt
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)   [single eps: 2^-23]
+ *   ra_hi_dn::1 = U_R2          (exact upper bound for RDN)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_dn::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_dn::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RDN sub: both fresh -> point fallback; stored */
+  float w = z - x;   /* second RDN sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_dn::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_sub --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RDN ieee_sub: when one operand of a
+ * second RDN ieee_sub is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_dn::0 - x_smt
+ *   U_R2 = ra_hi_dn::0 - x_smt
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)
+ *   ra_hi_dn::1 = U_R2          (exact upper bound for RDN)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_dn::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_dn::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RDN sub: both fresh -> point fallback; stored */
+  double w = z - x;   /* second RDN sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rdn-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_dn::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_sub --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rup-both-fresh but exercises the
+ * single-precision (float) path. Verifies that when both operands are fresh
+ * nondet variables, the point-interval fallback collapses to the single-step
+ * RUP formula with single-precision epsilon constants.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   ra_lo_up = real_z          (exact lower: RUP never rounds below true value)
+ *   ra_hi_up = real_z + B_dir(real_z)   [eps_rel_dir = 2^-23]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::       -- RUP tight path taken (single precision)
+ *   ra_hi_up::       -- RUP tight path taken
+ *   (ite             -- |r| absolute value present in B_dir computation
+ *   8388608          -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y; /* RUP sub: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh/main.c
@@ -1,0 +1,42 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_sub --
+ * both operands fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that theorem-driven interval lifting fires for ieee_sub under
+ * ROUND_TO_PLUS_INF when both operands are fresh nondet variables.
+ * With no tracked operands both use the point-interval fallback {t, t},
+ * so the hull degenerates to the single-step RUP enclosure:
+ *   LR = UR = x - y
+ *   ra_lo_up::0 = LR        (exact lower: RUP never rounds below true value)
+ *   ra_hi_up::0 = UR + B_dir(UR)
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * EbRUP([LR, UR]) = [LR, UR + B_dir(UR)]
+ * B_dir(r) = eps_rel_dir * |r| + eps_abs,  eps_rel_dir = 2^-52
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::[0-9]+  -- RUP interval lower bound declared
+ *   ra_hi_up::[0-9]+  -- RUP interval upper bound declared
+ *   (ite               -- absolute value in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y; /* RUP sub: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked-single/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_sub --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rup-both-tracked but exercises the
+ * single-precision (float) path. Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_rup_enclosure is
+ * reached when both operands of a second RUP ieee_sub are tracked.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   ra_lo_up::0 = real_z          (exact lower bound)
+ *   ra_hi_up::0 = real_z + B_dir(real_z)   [eps_rel_dir = 2^-23]
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second sub:  w = z - z  (both operands tracked -> full lift)
+ *   L_R2 = ra_lo_up::0 - ra_hi_up::0
+ *   U_R2 = ra_hi_up::0 - ra_lo_up::0
+ *   ra_lo_up::1 = L_R2          (exact lower: RUP never rounds below)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)   [single eps: 2^-23]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_up::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_up::0 ra_hi_up::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RUP sub: both fresh -> point fallback; stored */
+  float w = z - z;   /* second RUP sub: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_hi_up::0\|\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_sub --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RUP ieee_sub were themselves
+ * results of a prior tracked RUP ieee_sub, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RUP subtraction path is taken.
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   L_R1 = x - y = real_z,   U_R1 = x - y = real_z
+ *   ra_lo_up::0 = real_z          (exact: RUP never rounds below)
+ *   ra_hi_up::0 = real_z + B_dir(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second sub:  w = z - z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}  (found in map, same entry twice)
+ *   L_R2 = ra_lo_up::0 - ra_hi_up::0
+ *   U_R2 = ra_hi_up::0 - ra_lo_up::0
+ *   ra_lo_up::1 = L_R2          (exact lower bound for second sub)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_up::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_up::0 ra_hi_up::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RUP sub: both fresh -> point fallback; stored */
+  double w = z - z;   /* second RUP sub: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_hi_up::0\|\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh-single/main.c
@@ -1,0 +1,50 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_sub --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rup-one-fresh but exercises the
+ * single-precision (float) path. Verifies the mixed lookup path: when one
+ * operand of a second RUP ieee_sub is tracked and the other is a fresh
+ * nondet variable, the tracked operand uses its stored interval while the
+ * fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_up::0 - x_smt
+ *   U_R2 = ra_hi_up::0 - x_smt
+ *   ra_lo_up::1 = L_R2          (exact lower bound for RUP)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)   [single eps: 2^-23]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_up::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_up::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RUP sub: both fresh -> point fallback; stored */
+  float w = z - x;   /* second RUP sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_up::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_sub --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RUP ieee_sub: when one operand of a
+ * second RUP ieee_sub is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_up::0 - x_smt
+ *   U_R2 = ra_hi_up::0 - x_smt
+ *   ra_lo_up::1 = L_R2          (exact lower bound for RUP)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_up::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_up::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$  -- run completed
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RUP sub: both fresh -> point fallback; stored */
+  double w = z - x;   /* second RUP sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rup-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_up::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -554,6 +554,126 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rna_enclosure(
   return {ra_lo, ra_hi};
 }
 
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rup_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // EbRUP([LR, UR]) = [LR, UR + B_dir(UR)]
+  // fl_RUP(r) >= r for all r, so the lower bound is exact: ra_lo = lo_r.
+  // fl_RUP(r) <= r + B_dir(r) <= UR + B_dir(UR) for r in [LR, UR],
+  // so the upper bound is hi_r + B_dir(hi_r).
+  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
+  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel_dir, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel_dir = get_double_eps_up(); // 2^-52
+    eps_abs = get_double_min_subnormal();
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel_dir = get_single_eps_up(); // 2^-23
+    eps_abs = get_single_min_subnormal();
+  }
+  else
+  {
+    assert(!"apply_ieee754_rup_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_dir(hi_r) = eps_rel_dir * |hi_r| + eps_abs  (bound at upper endpoint)
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel_dir, abs_hi), eps_abs);
+  smt_astt ra_hi_expr = mk_add(hi_r, bound_hi); // UR + B_dir(UR)
+
+  // RUP-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_up::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_up::", nullptr);
+
+  // Pin ra_lo = lo_r  (exact lower bound: RUP never rounds below the true value)
+  assert_ast(mk_le(ra_lo, lo_r)); // ra_lo_up <= LR
+  assert_ast(mk_le(lo_r, ra_lo)); // LR <= ra_lo_up  =>  ra_lo_up == LR
+
+  // Pin ra_hi = hi_r + B_dir(hi_r)
+  assert_ast(mk_le(ra_hi, ra_hi_expr)); // ra_hi_up <= UR + B_dir(UR)
+  assert_ast(mk_le(ra_hi_expr, ra_hi)); // UR + B_dir(UR) <= ra_hi_up
+
+  // Containment: ra_lo_up <= real_result <= ra_hi_up  and  ra_lo_up <= ra_hi_up
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rdn_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // EbRDN([LR, UR]) = [LR - B_dir(LR), UR]
+  // fl_RDN(r) <= r for all r, so the upper bound is exact: ra_hi = hi_r.
+  // fl_RDN(r) >= r - B_dir(r) >= LR - B_dir(LR) for r in [LR, UR],
+  // so the lower bound is lo_r - B_dir(lo_r).
+  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
+  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel_dir, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel_dir = get_double_eps_up(); // 2^-52
+    eps_abs = get_double_min_subnormal();
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel_dir = get_single_eps_up(); // 2^-23
+    eps_abs = get_single_min_subnormal();
+  }
+  else
+  {
+    assert(!"apply_ieee754_rdn_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // B_dir(lo_r) = eps_rel_dir * |lo_r| + eps_abs  (bound at lower endpoint)
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel_dir, abs_lo), eps_abs);
+  smt_astt ra_lo_expr = mk_sub(lo_r, bound_lo); // LR - B_dir(LR)
+
+  // RDN-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_dn::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_dn::", nullptr);
+
+  // Pin ra_lo = lo_r - B_dir(lo_r)
+  assert_ast(mk_le(ra_lo, ra_lo_expr)); // ra_lo_dn <= LR - B_dir(LR)
+  assert_ast(mk_le(ra_lo_expr, ra_lo)); // LR - B_dir(LR) <= ra_lo_dn
+
+  // Pin ra_hi = hi_r  (exact upper bound: RDN never rounds above the true value)
+  assert_ast(mk_le(ra_hi, hi_r)); // ra_hi_dn <= UR
+  assert_ast(mk_le(hi_r, ra_hi)); // UR <= ra_hi_dn  =>  ra_hi_dn == UR
+
+  // Containment: ra_lo_dn <= real_result <= ra_hi_dn  and  ra_lo_dn <= ra_hi_dn
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
   const floatbv_type2t &fbv_type,
@@ -1455,21 +1575,27 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       const expr2tc &rounding_mode = to_ieee_sub2t(expr).rounding_mode;
 
-      // Interval-lifted nearest-mode enclosure for ieee_sub (--ir-ieee only).
-      // Covers both RNE (ROUND_TO_EVEN) and RNA (ROUND_TO_AWAY): both are
-      // nearest-rounding modes sharing the same B_near constants and the same
-      // subtraction interval hull:
+      // Interval-lifted enclosure for ieee_sub (--ir-ieee only).
+      // Covers RNE, RNA (nearest modes) and RUP, RDN (directed modes).
+      // All share the same subtraction interval hull:
       //   L_R = L_x - U_y,  U_R = U_x - L_y
-      //   ra_lo = L_R - B_near^-(L_R),  ra_hi = U_R + B_near^+(U_R)
-      // For RNE the result is named ra_lo:: / ra_hi::; for RNA ra_lo_aw:: /
-      // ra_hi_aw::, matching the single-step naming convention.
-      // Non-nearest modes, non-standard formats, and --ir-ieee disabled all
-      // fall through to apply_ieee754_semantics unchanged.
+      // Nearest (RNE/RNA): symmetric B_near at both endpoints
+      //   ra_lo = L_R - B_near(L_R),  ra_hi = U_R + B_near(U_R)
+      // RUP: exact lower bound, B_dir at upper endpoint
+      //   ra_lo = L_R (exact),  ra_hi = U_R + B_dir(U_R)
+      // RDN: B_dir at lower endpoint, exact upper bound
+      //   ra_lo = L_R - B_dir(L_R),  ra_hi = U_R (exact)
+      // For symbol names: ra_lo:: / ra_hi:: (RNE), ra_lo_aw:: / ra_hi_aw::
+      // (RNA), ra_lo_up:: / ra_hi_up:: (RUP), ra_lo_dn:: / ra_hi_dn:: (RDN).
+      // RTZ, non-standard formats, and --ir-ieee disabled fall through to
+      // apply_ieee754_semantics unchanged.
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
         (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode)))
+         is_round_to_away(rounding_mode) ||
+         is_round_to_plus_inf(rounding_mode) ||
+         is_round_to_minus_inf(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1493,9 +1619,15 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           if (is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else
+          else if (is_round_to_away(rounding_mode))
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else if (is_round_to_plus_inf(rounding_mode))
+            bounds =
+              apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else
+            bounds =
+              apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -1030,6 +1030,36 @@ private:
     smt_astt lo_r,
     smt_astt hi_r,
     const floatbv_type2t &fbv_type);
+
+  /** Interval-lifted RUP enclosure helper for ieee_sub (--ir-ieee only).
+   *  EbRUP([LR, UR]) = [LR, UR + B_dir(UR)]
+   *  fl_RUP(r) >= r always (directed mode rounds up), so the lower bound is
+   *  exact: ra_lo is pinned to lo_r with no B_dir adjustment.
+   *  The upper bound adds B_dir at the upper endpoint:
+   *    B_dir(r) = eps_rel_dir * |r| + eps_abs
+   *    eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+   *  Fresh symbols named ra_lo_up::N / ra_hi_up::N to match the single-step
+   *  RUP naming convention in apply_ieee754_semantics. */
+  std::pair<smt_astt, smt_astt> apply_ieee754_rup_enclosure(
+    smt_astt real_result,
+    smt_astt lo_r,
+    smt_astt hi_r,
+    const floatbv_type2t &fbv_type);
+
+  /** Interval-lifted RDN enclosure helper for ieee_sub (--ir-ieee only).
+   *  EbRDN([LR, UR]) = [LR - B_dir(LR), UR]
+   *  fl_RDN(r) <= r always (directed mode rounds down), so the upper bound is
+   *  exact: ra_hi is pinned to hi_r with no B_dir adjustment.
+   *  The lower bound subtracts B_dir at the lower endpoint:
+   *    B_dir(r) = eps_rel_dir * |r| + eps_abs
+   *    eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+   *  Fresh symbols named ra_lo_dn::N / ra_hi_dn::N to match the single-step
+   *  RDN naming convention in apply_ieee754_semantics. */
+  std::pair<smt_astt, smt_astt> apply_ieee754_rdn_enclosure(
+    smt_astt real_result,
+    smt_astt lo_r,
+    smt_astt hi_r,
+    const floatbv_type2t &fbv_type);
 };
 
 /** Given an array type, create a type2tc representing its domain. */


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RUP/RDN interval lifting for `ieee_sub`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- added theorem-driven RNE and RNA interval lifting for `ieee_add`
- added theorem-driven RNE and RNA interval lifting for `ieee_sub`
- propagated tracked interval metadata across assignments

This PR adds the next smallest sound step:

- theorem-driven interval lifting for `ieee_sub` under
  - `ROUND_TO_PLUS_INF` (RUP)
  - `ROUND_TO_MINUS_INF` (RDN)
- while keeping RTZ, `ieee_add` directed-mode lifting, and non-additive operations unchanged

## Main idea

For subtraction, let:

- `R = hull(X - Y) = [L_R, U_R]`

with:

- `L_R = L_x - U_y`
- `U_R = U_x - L_y`

For directed modes, use:

- `B_dir(r) = eps_rel_dir * |r| + eps_abs`

where:

- for double: `eps_rel_dir = 2^-52`
- for single: `eps_rel_dir = 2^-23`

So this PR implements the proof-aligned compositional shapes:

- `fl_RUP(x - y) ∈ [L_R, U_R + B_dir(U_R)]`
- `fl_RDN(x - y) ∈ [L_R - B_dir(L_R), U_R]`

For implementation, operand intervals are obtained as follows:

- if an operand already has a tracked lifted enclosure, reuse its stored interval from `ir_ra_interval_map`
- otherwise fall back to the point interval `{side, side}`

As with the existing sub lifting work, this preserves zero regression for fresh operands because the point-interval fallback collapses to the current single-step directed enclosure shape.

## Main changes

- extend the `ieee_sub` interval-lifted path under `--ir-ieee` to also cover:
  - `ROUND_TO_PLUS_INF`
  - `ROUND_TO_MINUS_INF`
- add two new helper functions:
  - `apply_ieee754_rup_enclosure`
  - `apply_ieee754_rdn_enclosure`
- reuse the existing subtraction hull:
  - `L_R = L_x - U_y`
  - `U_R = U_x - L_y`
- reuse the existing `ir_ra_interval_map`
- keep existing RNE/RNA lifting unchanged
- keep RTZ and non-sub operations unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-sub-rup-both-fresh`
- `ra-interval-lift-sub-rup-one-fresh`
- `ra-interval-lift-sub-rup-both-tracked`
- `ra-interval-lift-sub-rup-both-fresh-single`
- `ra-interval-lift-sub-rup-one-fresh-single`
- `ra-interval-lift-sub-rup-both-tracked-single`

- `ra-interval-lift-sub-rdn-both-fresh`
- `ra-interval-lift-sub-rdn-one-fresh`
- `ra-interval-lift-sub-rdn-both-tracked`
- `ra-interval-lift-sub-rdn-both-fresh-single`
- `ra-interval-lift-sub-rdn-one-fresh-single`
- `ra-interval-lift-sub-rdn-both-tracked-single`

This was also checked against the existing `ieee_sub` RNE/RNA interval-lifting regressions.

## Scope

This PR implements only:

- directed-mode interval lifting for `ieee_sub` under RUP/RDN

The following are deferred:

- RTZ interval lifting for `ieee_sub`
- directed-mode interval lifting for `ieee_add`
- `ieee_mul` interval lifting
- `ieee_div` interval lifting
- full IEEE corner-case handling for NaN / infinities / signed zero