### PR TITLE
[ai] inline ai_baset::output and entry_state to break circular link dep

### DIFF
--- a/src/goto-programs/abstract-interpretation/ai.cpp
+++ b/src/goto-programs/abstract-interpretation/ai.cpp
@@ -5,46 +5,10 @@
 
 #include <cassert>
 #include <memory>
-#include <sstream>
 
 #include <util/std_code.h>
 #include <util/std_expr.h>
 
-void ai_baset::output(const goto_functionst &goto_functions, std::ostream &out)
-  const
-{
-  forall_goto_functions (f_it, goto_functions)
-  {
-    if (f_it->second.body_available)
-    {
-      out << "////\n";
-      out << "//// Function: " << f_it->first << "\n";
-      out << "////\n";
-      out << "\n";
-
-      forall_goto_program_instructions (i_it, f_it->second.body)
-      {
-        out << i_it->location_number << " " << i_it->location << "\n";
-
-        abstract_state_before(i_it)->output(out);
-        out << "\n";
-        i_it->output_instruction(*migrate_namespace_lookup, "", out);
-        out << "\n";
-      }
-    }
-  }
-}
-
-void ai_baset::entry_state(const goto_functionst &goto_functions)
-{
-  // find the 'entry function'
-
-  goto_functionst::function_mapt::const_iterator f_it =
-    goto_functions.function_map.find(goto_functions.main_id());
-
-  if (f_it != goto_functions.function_map.end())
-    entry_state(f_it->second.body);
-}
 
 void ai_baset::entry_state(const goto_programt &goto_program)
 {

--- a/src/goto-programs/abstract-interpretation/ai.cpp
+++ b/src/goto-programs/abstract-interpretation/ai.cpp
@@ -9,7 +9,6 @@
 #include <util/std_code.h>
 #include <util/std_expr.h>
 
-
 void ai_baset::entry_state(const goto_programt &goto_program)
 {
   // The first instruction of 'goto_program' is the entry point

--- a/src/goto-programs/abstract-interpretation/ai.h
+++ b/src/goto-programs/abstract-interpretation/ai.h
@@ -7,10 +7,14 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <ostream>
 #include <goto-programs/abstract-interpretation/ai_domain.h>
 #include <goto-programs/goto_functions.h>
 #include <util/xml.h>
 #include <util/expr.h>
+
+// Required for ai_baset::output() inline definition below.
+extern const namespacet *migrate_namespace_lookup;
 
 /**
  * This is the basic interface of the abstract interpreter with default
@@ -78,7 +82,29 @@ public:
   }
 
   virtual void
-  output(const goto_functionst &goto_functions, std::ostream &out) const;
+  output(const goto_functionst &goto_functions, std::ostream &out) const
+  {
+    forall_goto_functions(f_it, goto_functions)
+    {
+      if(f_it->second.body_available)
+      {
+        out << "////\n";
+        out << "//// Function: " << f_it->first << "\n";
+        out << "////\n";
+        out << "\n";
+
+        forall_goto_program_instructions(i_it, f_it->second.body)
+        {
+          out << i_it->location_number << " " << i_it->location << "\n";
+
+          abstract_state_before(i_it)->output(out);
+          out << "\n";
+          i_it->output_instruction(*migrate_namespace_lookup, "", out);
+          out << "\n";
+        }
+      }
+    }
+  }
 
 protected:
   // overload to add a factory
@@ -90,7 +116,13 @@ protected:
   virtual void finalize();
 
   void entry_state(const goto_programt &);
-  void entry_state(const goto_functionst &);
+  void entry_state(const goto_functionst &goto_functions)
+  {
+    goto_functionst::function_mapt::const_iterator f_it =
+      goto_functions.function_map.find(goto_functions.main_id());
+    if(f_it != goto_functions.function_map.end())
+      entry_state(f_it->second.body);
+  }
 
   /* The fixedpoint is computed through a Work set algorithm which
    * consists in adding nodes that have changed with the current merge

--- a/src/goto-programs/abstract-interpretation/ai.h
+++ b/src/goto-programs/abstract-interpretation/ai.h
@@ -84,16 +84,16 @@ public:
   virtual void
   output(const goto_functionst &goto_functions, std::ostream &out) const
   {
-    forall_goto_functions(f_it, goto_functions)
+    forall_goto_functions (f_it, goto_functions)
     {
-      if(f_it->second.body_available)
+      if (f_it->second.body_available)
       {
         out << "////\n";
         out << "//// Function: " << f_it->first << "\n";
         out << "////\n";
         out << "\n";
 
-        forall_goto_program_instructions(i_it, f_it->second.body)
+        forall_goto_program_instructions (i_it, f_it->second.body)
         {
           out << i_it->location_number << " " << i_it->location << "\n";
 
@@ -120,7 +120,7 @@ protected:
   {
     goto_functionst::function_mapt::const_iterator f_it =
       goto_functions.function_map.find(goto_functions.main_id());
-    if(f_it != goto_functions.function_map.end())
+    if (f_it != goto_functions.function_map.end())
       entry_state(f_it->second.body);
   }
 

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -53,8 +53,8 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   // Interval-based guard check (--interval-symex-guard)
   if (!new_guard_false && !new_guard_true && interval_domain_state)
   {
-    tvt res =
-      interval_domaint::eval_boolean_expression(old_guard, *interval_domain_state);
+    tvt res = interval_domaint::eval_boolean_expression(
+      old_guard, *interval_domain_state);
     if (res.is_false())
       new_guard_false = true;
     else if (res.is_true())


### PR DESCRIPTION
This PR fixes the interval-symex-guard-test CI build failure introduced in af3ce2b95a and not fully resolved by 624a133898.