### PR TITLE
[ir-ra] add theorem-driven RTZ interval lifting for ieee_sub

### DIFF
--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_sub --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rtz-both-fresh but exercises the
+ * single-precision (float) path. Verifies that when both operands are fresh
+ * nondet variables, the point-interval fallback collapses to the single-step
+ * RTZ sign-conditional formula with single-precision epsilon constants.
+ *
+ * PROOF SHAPE (B_dir, RTZ, single precision)
+ * ------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   r >= 0: ra_lo_tz = r - B_dir(r),  ra_hi_tz = r   [eps_rel_dir = 2^-23]
+ *   r <  0: ra_lo_tz = r,             ra_hi_tz = r + B_dir(r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::       -- RTZ tight path taken (single precision)
+ *   ra_hi_tz::       -- RTZ tight path taken
+ *   (ite             -- sign-conditional ITE in enclosure formula
+ *   8388608          -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y; /* RTZ sub: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_sub --
+ * both operands fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that theorem-driven interval lifting fires for ieee_sub under
+ * ROUND_TO_ZERO when both operands are fresh nondet variables.
+ * With no tracked operands both use the point-interval fallback {t, t},
+ * so the hull degenerates to lo_r = hi_r = real_result (single point).
+ * The RTZ enclosure collapses to the single-step sign-dependent shape:
+ *
+ *   r >= 0: ra_lo_tz = r - B_dir(r),  ra_hi_tz = r  (truncate down)
+ *   r <  0: ra_lo_tz = r,             ra_hi_tz = r + B_dir(r)  (truncate up)
+ *
+ * encoded as nested ITE on the sign of r.
+ *
+ * PROOF SHAPE (B_dir, RTZ, double precision)
+ * ------------------------------------------
+ * B_dir(r) = eps_rel_dir * |r| + eps_abs,  eps_rel_dir = 2^-52
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::[0-9]+  -- RTZ interval lower bound declared
+ *   ra_hi_tz::[0-9]+  -- RTZ interval upper bound declared
+ *   (ite               -- sign-conditional ITE in enclosure formula
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y; /* RTZ sub: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x - y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked-single/main.c
@@ -1,0 +1,45 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_sub --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rtz-both-tracked but exercises the
+ * single-precision (float) path. Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_rtz_enclosure is
+ * reached when both operands of a second RTZ ieee_sub are tracked.
+ * Also exercises the crossing-zero conservative fallback (see both-tracked
+ * double variant for the proof shape).
+ *
+ * PROOF SHAPE (B_dir, RTZ, single precision)
+ * ------------------------------------------
+ * Second sub: w = z - z (both tracked, hull crosses zero)
+ *   B_dir_max = eps_rel_dir * max(|lo_r|, |hi_r|) + eps_abs  [eps = 2^-23]
+ *   ra_lo_tz::1 = lo_r - B_dir_max
+ *   ra_hi_tz::1 = hi_r + B_dir_max
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_tz::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_tz::0 ra_hi_tz::0)  -- lo_r subterm confirming tracked lookup
+ *   (ite           -- sign-conditional/max ITEs present
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RTZ sub: both fresh -> point fallback; stored */
+  float w = z - z;   /* second RTZ sub: both operands tracked -> crossing-zero */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_hi_tz::0\|\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked/main.c
@@ -1,0 +1,56 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_sub --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RTZ ieee_sub were themselves
+ * results of a prior tracked RTZ ieee_sub, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RTZ subtraction path is taken.
+ *
+ * This test also exercises the crossing-zero conservative fallback.
+ * For the second sub w = z - z:
+ *   iv(z) = {ra_lo_tz::0, ra_hi_tz::0}
+ *   lo_r = ra_lo_tz::0 - ra_hi_tz::0  (<= 0, since ra_lo <= ra_hi)
+ *   hi_r = ra_hi_tz::0 - ra_lo_tz::0  (>= 0, since ra_lo <= ra_hi)
+ * So the hull crosses zero -> conservative B_dir_max bound fires.
+ *
+ * PROOF SHAPE (B_dir, RTZ, double precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point-interval fallback)
+ *   lo_r1 = hi_r1 = real_z (point hull)
+ *   RTZ sign-ITE on real_z:  ra_lo_tz::0, ra_hi_tz::0
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_tz::0, ra_hi_tz::0}
+ *
+ * Second sub:  w = z - z  (both operands are z -> both tracked)
+ *   lo_r = ra_lo_tz::0 - ra_hi_tz::0  (crosses zero)
+ *   hi_r = ra_hi_tz::0 - ra_lo_tz::0  (crosses zero)
+ *   B_dir_max = eps_rel_dir * max(|lo_r|, |hi_r|) + eps_abs
+ *   ra_lo_tz::1 = lo_r - B_dir_max
+ *   ra_hi_tz::1 = hi_r + B_dir_max
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_tz::1   -- second subtraction's lifted lower bound declared
+ *   (- ra_lo_tz::0 ra_hi_tz::0)  -- lo_r subterm confirming tracked lookup
+ *   (ite           -- sign-conditional/max ITEs present
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RTZ sub: both fresh -> point fallback; stored */
+  double w = z - z;   /* second RTZ sub: both operands tracked -> crossing-zero */
+
+  /* Always false in real/integer encoding: w == z - z exactly. */
+  assert(w != z - z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_hi_tz::0\|\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh-single/main.c
@@ -1,0 +1,48 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_sub --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-sub-rtz-one-fresh but exercises the
+ * single-precision (float) path. Verifies the mixed lookup path: when one
+ * operand of a second RTZ ieee_sub is tracked and the other is a fresh
+ * nondet variable, the tracked operand uses its stored interval while the
+ * fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RTZ, single precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_tz::0, ra_hi_tz::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   lo_r = ra_lo_tz::0 - x_smt
+ *   hi_r = ra_hi_tz::0 - x_smt
+ *   RTZ three-way ITE on sign of [lo_r, hi_r]:  [eps_rel_dir = 2^-23]
+ *   ra_lo_tz::1 and ra_hi_tz::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_tz::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_tz::0 ...  -- lo_r prefix confirming tracked lookup
+ *   (ite           -- sign-conditional ITEs present
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x - y;   /* first RTZ sub: both fresh -> point fallback; stored */
+  float w = z - x;   /* second RTZ sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_tz::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_sub --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RTZ ieee_sub: when one operand of a
+ * second RTZ ieee_sub is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RTZ, double precision)
+ * ------------------------------------------
+ * First sub:  z = x - y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_tz::0, ra_hi_tz::0}
+ *
+ * Second sub:  w = z - x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_tz::0, ra_hi_tz::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   lo_r = ra_lo_tz::0 - x_smt
+ *   hi_r = ra_hi_tz::0 - x_smt
+ *   RTZ three-way ITE on sign of [lo_r, hi_r]:
+ *   ra_lo_tz::1 and ra_hi_tz::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first subtraction's interval lower bound declared
+ *   ra_lo_tz::1   -- second subtraction's mixed-path lower bound declared
+ *   (- ra_lo_tz::0 ...  -- lo_r prefix confirming tracked lookup
+ *   (ite           -- sign-conditional ITEs present
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x - y;   /* first RTZ sub: both fresh -> point fallback; stored */
+  double w = z - x;   /* second RTZ sub: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z - x exactly. */
+  assert(w != z - x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-sub-rtz-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(- \|smt_conv::ra_lo_tz::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -674,6 +674,106 @@ std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rdn_enclosure(
   return {ra_lo, ra_hi};
 }
 
+std::pair<smt_astt, smt_astt> smt_convt::apply_ieee754_rtz_enclosure(
+  smt_astt real_result,
+  smt_astt lo_r,
+  smt_astt hi_r,
+  const floatbv_type2t &fbv_type)
+{
+  // RTZ (truncation toward zero) is sign-dependent.
+  // For an interval hull [LR, UR] = [lo_r, hi_r]:
+  //
+  //   Case 1 -- LR >= 0 (all non-negative): fl_RTZ acts like RDN
+  //     EbRTZ([LR,UR]) = [LR - B_dir(LR), UR]   (exact upper bound)
+  //
+  //   Case 2 -- UR <= 0 (all non-positive): fl_RTZ acts like RUP
+  //     EbRTZ([LR,UR]) = [LR, UR + B_dir(UR)]   (exact lower bound)
+  //
+  //   Case 3 -- LR < 0 < UR (hull crosses zero): sign of actual result
+  //     is unknown at encode time; use conservative symmetric bound:
+  //     B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs
+  //     EbRTZ([LR,UR]) = [LR - B_dir_max, UR + B_dir_max]
+  //
+  // The three cases are encoded as nested ITE on lo_nonneg / hi_nonpos.
+  // B_dir(r) = eps_rel_dir * |r| + eps_abs,
+  //   eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+  const auto double_spec = ieee_float_spect::double_precision();
+  const auto single_spec = ieee_float_spect::single_precision();
+  smt_astt eps_rel_dir, eps_abs;
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+  {
+    eps_rel_dir = get_double_eps_up(); // 2^-52
+    eps_abs = get_double_min_subnormal();
+  }
+  else if (
+    fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+  {
+    eps_rel_dir = get_single_eps_up(); // 2^-23
+    eps_abs = get_single_min_subnormal();
+  }
+  else
+  {
+    assert(!"apply_ieee754_rtz_enclosure: unsupported FP format");
+  }
+
+  smt_sortt rs = mk_real_sort();
+  smt_astt zero = mk_smt_real("0.0");
+
+  // |LR| and |UR|
+  smt_astt abs_lo = mk_ite(mk_lt(lo_r, zero), mk_sub(zero, lo_r), lo_r);
+  smt_astt abs_hi = mk_ite(mk_lt(hi_r, zero), mk_sub(zero, hi_r), hi_r);
+
+  // B_dir at each endpoint
+  smt_astt bound_lo = mk_add(mk_mul(eps_rel_dir, abs_lo), eps_abs); // B_dir(LR)
+  smt_astt bound_hi = mk_add(mk_mul(eps_rel_dir, abs_hi), eps_abs); // B_dir(UR)
+
+  // B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs  (crossing-zero case)
+  smt_astt abs_max = mk_ite(mk_le(abs_lo, abs_hi), abs_hi, abs_lo);
+  smt_astt bound_max = mk_add(mk_mul(eps_rel_dir, abs_max), eps_abs);
+
+  // Case selectors
+  smt_astt lo_nonneg = mk_le(zero, lo_r); // LR >= 0
+  smt_astt hi_nonpos = mk_le(hi_r, zero); // UR <= 0
+
+  // ra_lo_expr:
+  //   LR >= 0 -> LR - B_dir(LR)    (truncate-down: lower gets error)
+  //   UR <= 0 -> LR                 (truncate-up: lower is exact)
+  //   else    -> LR - B_dir_max    (crossing zero: conservative)
+  smt_astt ra_lo_expr = mk_ite(
+    lo_nonneg,
+    mk_sub(lo_r, bound_lo),
+    mk_ite(hi_nonpos, lo_r, mk_sub(lo_r, bound_max)));
+
+  // ra_hi_expr:
+  //   LR >= 0 -> UR                 (truncate-down: upper is exact)
+  //   UR <= 0 -> UR + B_dir(UR)    (truncate-up: upper gets error)
+  //   else    -> UR + B_dir_max    (crossing zero: conservative)
+  smt_astt ra_hi_expr = mk_ite(
+    lo_nonneg,
+    hi_r,
+    mk_ite(hi_nonpos, mk_add(hi_r, bound_hi), mk_add(hi_r, bound_max)));
+
+  // RTZ-named enclosure variables, pinned via bidirectional inequalities to
+  // survive Z3's solve-eqs tactic (same technique as all other tight paths).
+  smt_astt ra_lo = mk_fresh(rs, "ra_lo_tz::", nullptr);
+  smt_astt ra_hi = mk_fresh(rs, "ra_hi_tz::", nullptr);
+
+  // Pin ra_lo = ra_lo_expr
+  assert_ast(mk_le(ra_lo, ra_lo_expr));
+  assert_ast(mk_le(ra_lo_expr, ra_lo));
+
+  // Pin ra_hi = ra_hi_expr
+  assert_ast(mk_le(ra_hi, ra_hi_expr));
+  assert_ast(mk_le(ra_hi_expr, ra_hi));
+
+  // Containment: ra_lo_tz <= real_result <= ra_hi_tz  and  ra_lo_tz <= ra_hi_tz
+  assert_ast(mk_le(ra_lo, real_result));
+  assert_ast(mk_le(real_result, ra_hi));
+  assert_ast(mk_le(ra_lo, ra_hi));
+
+  return {ra_lo, ra_hi};
+}
+
 smt_astt smt_convt::apply_ieee754_semantics(
   smt_astt real_result,
   const floatbv_type2t &fbv_type,
@@ -1576,7 +1676,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const expr2tc &rounding_mode = to_ieee_sub2t(expr).rounding_mode;
 
       // Interval-lifted enclosure for ieee_sub (--ir-ieee only).
-      // Covers RNE, RNA (nearest modes) and RUP, RDN (directed modes).
+      // Covers RNE, RNA (nearest modes), RUP, RDN, and RTZ (directed modes).
       // All share the same subtraction interval hull:
       //   L_R = L_x - U_y,  U_R = U_x - L_y
       // Nearest (RNE/RNA): symmetric B_near at both endpoints
@@ -1585,9 +1685,15 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       //   ra_lo = L_R (exact),  ra_hi = U_R + B_dir(U_R)
       // RDN: B_dir at lower endpoint, exact upper bound
       //   ra_lo = L_R - B_dir(L_R),  ra_hi = U_R (exact)
-      // For symbol names: ra_lo:: / ra_hi:: (RNE), ra_lo_aw:: / ra_hi_aw::
-      // (RNA), ra_lo_up:: / ra_hi_up:: (RUP), ra_lo_dn:: / ra_hi_dn:: (RDN).
-      // RTZ, non-standard formats, and --ir-ieee disabled fall through to
+      // RTZ: sign-dependent three-way case on hull sign:
+      //   LR >= 0: ra_lo = LR - B_dir(LR), ra_hi = UR (exact upper)
+      //   UR <= 0: ra_lo = LR (exact lower), ra_hi = UR + B_dir(UR)
+      //   else:   ra_lo = LR - B_dir_max, ra_hi = UR + B_dir_max
+      //           where B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs
+      // Symbol names: ra_lo:: / ra_hi:: (RNE), ra_lo_aw:: / ra_hi_aw::
+      // (RNA), ra_lo_up:: / ra_hi_up:: (RUP), ra_lo_dn:: / ra_hi_dn:: (RDN),
+      // ra_lo_tz:: / ra_hi_tz:: (RTZ).
+      // Non-standard formats and --ir-ieee disabled fall through to
       // apply_ieee754_semantics unchanged.
       bool interval_lifted = false;
       if (
@@ -1595,7 +1701,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         (is_nearest_rounding_mode(rounding_mode) ||
          is_round_to_away(rounding_mode) ||
          is_round_to_plus_inf(rounding_mode) ||
-         is_round_to_minus_inf(rounding_mode)))
+         is_round_to_minus_inf(rounding_mode) ||
+         is_round_to_zero(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1625,9 +1732,12 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           else if (is_round_to_plus_inf(rounding_mode))
             bounds =
               apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else
+          else if (is_round_to_minus_inf(rounding_mode))
             bounds =
               apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else
+            bounds =
+              apply_ieee754_rtz_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -1060,6 +1060,32 @@ private:
     smt_astt lo_r,
     smt_astt hi_r,
     const floatbv_type2t &fbv_type);
+
+  /** Interval-lifted RTZ enclosure helper for ieee_sub (--ir-ieee only).
+   *  RTZ (truncation toward zero) is sign-dependent: it rounds down for
+   *  non-negative inputs and rounds up for non-positive inputs.
+   *  The enclosure has three cases based on the sign of [LR, UR]:
+   *
+   *  1. LR >= 0 (hull entirely non-negative): fl_RTZ acts like RDN
+   *     EbRTZ = [LR - B_dir(LR), UR]    (exact upper bound)
+   *
+   *  2. UR <= 0 (hull entirely non-positive): fl_RTZ acts like RUP
+   *     EbRTZ = [LR, UR + B_dir(UR)]    (exact lower bound)
+   *
+   *  3. LR < 0 < UR (hull crosses zero): sign of actual result is unknown,
+   *     conservative symmetric bound:
+   *     B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs
+   *     EbRTZ = [LR - B_dir_max, UR + B_dir_max]
+   *
+   *  B_dir(r) = eps_rel_dir * |r| + eps_abs
+   *    eps_rel_dir = 2^-52 (double) or 2^-23 (single) -- full machine epsilon.
+   *  Fresh symbols named ra_lo_tz::N / ra_hi_tz::N to match the single-step
+   *  RTZ naming convention in apply_ieee754_semantics. */
+  std::pair<smt_astt, smt_astt> apply_ieee754_rtz_enclosure(
+    smt_astt real_result,
+    smt_astt lo_r,
+    smt_astt hi_r,
+    const floatbv_type2t &fbv_type);
 };
 
 /** Given an array type, create a type2tc representing its domain. */


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RTZ interval lifting for `ieee_sub`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- added theorem-driven RNE and RNA interval lifting for `ieee_sub`
- added theorem-driven RUP and RDN interval lifting for `ieee_sub`
- propagated tracked interval metadata across assignments

This PR adds the next smallest sound step:

- a dedicated RTZ interval-lifted path for `ieee_sub`
- while keeping other operations unchanged

## Main idea

For subtraction, let:

- `R = hull(X - Y) = [L_R, U_R]`

with:

- `L_R = L_x - U_y`
- `U_R = U_x - L_y`

For `ROUND_TO_ZERO`, the proof-aligned enclosure is sign-dependent:

- if `L_R >= 0`, use:
  - `EbRTZ = [L_R - B_dir^-(R), U_R]`
- if `U_R <= 0`, use:
  - `EbRTZ = [L_R, U_R + B_dir^+(R)]`
- if the interval crosses zero, use the conservative fallback:
  - `EbRTZ = [L_R - B_dir_max(R), U_R + B_dir_max(R)]`

where:

- `B_dir(r) = eps_rel_dir * |r| + eps_abs`
- `B_dir_max(R) = eps_rel_dir * max(|L_R|, |U_R|) + eps_abs`

This matches the proof-level RTZ interval transformer while staying linear and solver-friendly.

## Main changes

- extend the `ieee_sub` interval-lifted path under `--ir-ieee` to cover `ROUND_TO_ZERO`
- add a dedicated RTZ enclosure helper in `smt_conv`
- preserve the existing subtraction hull:
  - `L_R = L_x - U_y`
  - `U_R = U_x - L_y`
- reuse `ir_ra_interval_map`
- keep existing RNE/RNA/RUP/RDN lifting unchanged
- keep `ieee_add`, `ieee_mul`, and `ieee_div` unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-sub-rtz-both-fresh`
- `ra-interval-lift-sub-rtz-one-fresh`
- `ra-interval-lift-sub-rtz-both-tracked`
- `ra-interval-lift-sub-rtz-both-fresh-single`
- `ra-interval-lift-sub-rtz-one-fresh-single`
- `ra-interval-lift-sub-rtz-both-tracked-single`

This was also checked against the existing `ieee_sub` interval-lifting regressions for:

- RNE
- RNA
- RUP
- RDN

## Scope

This PR implements only:

- theorem-driven RTZ interval lifting for `ieee_sub`

The following remain out of scope:

- directed-mode interval lifting for `ieee_add`
- `ieee_mul` interval lifting
- `ieee_div` interval lifting
- full IEEE corner-case handling for NaN / infinities / signed zero