### PR TITLE
[ir-ra] add theorem-driven RUP/RDN interval lifting for ieee_add

### DIFF
--- a/regression/ir-ra/ra-interval-lift-rdn-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_add --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rdn-both-fresh but exercises the single-precision
+ * (float) path. Verifies that when both operands are fresh nondet variables,
+ * the point-interval fallback collapses to the single-step RDN formula with
+ * single-precision epsilon constants.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * ------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   ra_lo_dn = real_z - B_dir(real_z)   [eps_rel_dir = 2^-23]
+ *   ra_hi_dn = real_z          (exact upper: RDN never rounds above)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::       -- RDN tight path taken (single precision)
+ *   ra_hi_dn::       -- RDN tight path taken
+ *   (ite             -- |r| absolute value present in B_dir computation
+ *   8388608          -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* RDN add: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rdn-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-fresh/main.c
@@ -1,0 +1,42 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_add --
+ * both operands fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that theorem-driven interval lifting fires for ieee_add under
+ * ROUND_TO_MINUS_INF when both operands are fresh nondet variables.
+ * With no tracked operands both use the point-interval fallback {t, t},
+ * so the hull degenerates to the single-step RDN enclosure:
+ *   LR = UR = x + y
+ *   ra_lo_dn::0 = LR - B_dir(LR)
+ *   ra_hi_dn::0 = UR        (exact upper: RDN never rounds above true value)
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * EbRDN([LR, UR]) = [LR - B_dir(LR), UR]
+ * B_dir(r) = eps_rel_dir * |r| + eps_abs,  eps_rel_dir = 2^-52
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::[0-9]+  -- RDN interval lower bound declared
+ *   ra_hi_dn::[0-9]+  -- RDN interval upper bound declared
+ *   (ite               -- absolute value in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* RDN add: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rdn-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-tracked-single/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_add --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rdn-both-tracked but exercises the single-precision
+ * (float) path. Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_rdn_enclosure is reached
+ * when both operands of a second RDN ieee_add are tracked.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * ------------------------------------------
+ * Second add:  w = z + z  (both operands tracked -> full lift)
+ *   L_R2 = ra_lo_dn::0 + ra_lo_dn::0
+ *   U_R2 = ra_hi_dn::0 + ra_hi_dn::0
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)   [single eps: 2^-23]
+ *   ra_hi_dn::1 = U_R2          (exact upper: RDN never rounds above)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first addition's interval lower bound declared
+ *   ra_lo_dn::1   -- second addition's lifted lower bound declared
+ *   (+ ra_lo_dn::0 ra_lo_dn::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y;   /* first RDN add: both fresh -> point fallback; stored */
+  float w = z + z;   /* second RDN add: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rdn-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_lo_dn::0\|\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-tracked/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_add --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RDN ieee_add were themselves
+ * results of a prior tracked RDN ieee_add, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RDN path is taken.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * First add:  z = x + y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   L_R1 = x + y = real_z,   U_R1 = x + y = real_z
+ *   ra_lo_dn::0 = real_z - B_dir(real_z)
+ *   ra_hi_dn::0 = real_z          (exact upper)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second add:  w = z + z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}  (found in map, same entry twice)
+ *   L_R2 = ra_lo_dn::0 + ra_lo_dn::0
+ *   U_R2 = ra_hi_dn::0 + ra_hi_dn::0
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)
+ *   ra_hi_dn::1 = U_R2          (exact upper bound for second add)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first addition's interval lower bound declared
+ *   ra_lo_dn::1   -- second addition's lifted lower bound declared
+ *   (+ ra_lo_dn::0 ra_lo_dn::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RDN add: both fresh -> point fallback; stored */
+  double w = z + z;   /* second RDN add: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rdn-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_lo_dn::0\|\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rdn-one-fresh-single/main.c
@@ -1,0 +1,45 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_add --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rdn-one-fresh but exercises the single-precision
+ * (float) path. Verifies the mixed lookup path: when one operand of a second
+ * RDN ieee_add is tracked and the other is a fresh nondet variable, the
+ * tracked operand uses its stored interval while the fresh one falls back to
+ * the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * ------------------------------------------
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   L_R2 = ra_lo_dn::0 + x_smt
+ *   U_R2 = ra_hi_dn::0 + x_smt
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)   [single eps: 2^-23]
+ *   ra_hi_dn::1 = U_R2          (exact upper bound for RDN)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first addition's interval lower bound declared
+ *   ra_lo_dn::1   -- second addition's mixed-path lower bound declared
+ *   (+ ra_lo_dn::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y;   /* first RDN add: both fresh -> point fallback; stored */
+  float w = z + x;   /* second RDN add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_dn::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rdn-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rdn-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_add --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RDN ieee_add: when one operand of a
+ * second RDN ieee_add is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * First add:  z = x + y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_dn::0 + x_smt
+ *   U_R2 = ra_hi_dn::0 + x_smt
+ *   ra_lo_dn::1 = L_R2 - B_dir(L_R2)
+ *   ra_hi_dn::1 = U_R2          (exact upper bound for RDN)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_dn::0   -- first addition's interval lower bound declared
+ *   ra_lo_dn::1   -- second addition's mixed-path lower bound declared
+ *   (+ ra_lo_dn::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RDN add: both fresh -> point fallback; stored */
+  double w = z + x;   /* second RDN add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rdn-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_dn::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rup-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_add --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rup-both-fresh but exercises the single-precision
+ * (float) path. Verifies that when both operands are fresh nondet variables,
+ * the point-interval fallback collapses to the single-step RUP formula with
+ * single-precision epsilon constants.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   ra_lo_up = real_z          (exact lower: RUP never rounds below)
+ *   ra_hi_up = real_z + B_dir(real_z)   [eps_rel_dir = 2^-23]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::       -- RUP tight path taken (single precision)
+ *   ra_hi_up::       -- RUP tight path taken
+ *   (ite             -- |r| absolute value present in B_dir computation
+ *   8388608          -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* RUP add: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rup-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rup-both-fresh/main.c
@@ -1,0 +1,42 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_add --
+ * both operands fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that theorem-driven interval lifting fires for ieee_add under
+ * ROUND_TO_PLUS_INF when both operands are fresh nondet variables.
+ * With no tracked operands both use the point-interval fallback {t, t},
+ * so the hull degenerates to the single-step RUP enclosure:
+ *   LR = UR = x + y
+ *   ra_lo_up::0 = LR        (exact lower: RUP never rounds below true value)
+ *   ra_hi_up::0 = UR + B_dir(UR)
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * EbRUP([LR, UR]) = [LR, UR + B_dir(UR)]
+ * B_dir(r) = eps_rel_dir * |r| + eps_abs,  eps_rel_dir = 2^-52
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::[0-9]+  -- RUP interval lower bound declared
+ *   ra_hi_up::[0-9]+  -- RUP interval upper bound declared
+ *   (ite               -- absolute value in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* RUP add: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rup-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rup-both-tracked-single/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_add --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rup-both-tracked but exercises the single-precision
+ * (float) path. Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_rup_enclosure is reached
+ * when both operands of a second RUP ieee_add are tracked.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * Second add:  w = z + z  (both operands tracked -> full lift)
+ *   L_R2 = ra_lo_up::0 + ra_lo_up::0
+ *   U_R2 = ra_hi_up::0 + ra_hi_up::0
+ *   ra_lo_up::1 = L_R2          (exact lower: RUP never rounds below)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)   [single eps: 2^-23]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first addition's interval lower bound declared
+ *   ra_lo_up::1   -- second addition's lifted lower bound declared
+ *   (+ ra_lo_up::0 ra_lo_up::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y;   /* first RUP add: both fresh -> point fallback; stored */
+  float w = z + z;   /* second RUP add: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rup-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-rup-both-tracked/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_add --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RUP ieee_add were themselves
+ * results of a prior tracked RUP ieee_add, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RUP path is taken.
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * First add:  z = x + y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   L_R1 = x + y = real_z,   U_R1 = x + y = real_z
+ *   ra_lo_up::0 = real_z          (exact lower)
+ *   ra_hi_up::0 = real_z + B_dir(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second add:  w = z + z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}  (found in map, same entry twice)
+ *   L_R2 = ra_lo_up::0 + ra_lo_up::0
+ *   U_R2 = ra_hi_up::0 + ra_hi_up::0
+ *   ra_lo_up::1 = L_R2          (exact lower bound for second add)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first addition's interval lower bound declared
+ *   ra_lo_up::1   -- second addition's lifted lower bound declared
+ *   (+ ra_lo_up::0 ra_lo_up::0)  -- L_R2 subterm confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RUP add: both fresh -> point fallback; stored */
+  double w = z + z;   /* second RUP add: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rup-one-fresh-single/main.c
@@ -1,0 +1,45 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_add --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rup-one-fresh but exercises the single-precision
+ * (float) path. Verifies the mixed lookup path: when one operand of a second
+ * RUP ieee_add is tracked and the other is a fresh nondet variable, the
+ * tracked operand uses its stored interval while the fresh one falls back to
+ * the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   L_R2 = ra_lo_up::0 + x_smt
+ *   U_R2 = ra_hi_up::0 + x_smt
+ *   ra_lo_up::1 = L_R2          (exact lower bound for RUP)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)   [single eps: 2^-23]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first addition's interval lower bound declared
+ *   ra_lo_up::1   -- second addition's mixed-path lower bound declared
+ *   (+ ra_lo_up::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y;   /* first RUP add: both fresh -> point fallback; stored */
+  float w = z + x;   /* second RUP add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_up::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rup-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rup-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_add --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RUP ieee_add: when one operand of a
+ * second RUP ieee_add is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * First add:  z = x + y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   L_R2 = ra_lo_up::0 + x_smt
+ *   U_R2 = ra_hi_up::0 + x_smt
+ *   ra_lo_up::1 = L_R2          (exact lower bound for RUP)
+ *   ra_hi_up::1 = U_R2 + B_dir(U_R2)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_up::0   -- first addition's interval lower bound declared
+ *   ra_lo_up::1   -- second addition's mixed-path lower bound declared
+ *   (+ ra_lo_up::0 ...  -- L_R2 prefix confirming tracked lookup
+ *   (ite           -- absolute value present in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RUP add: both fresh -> point fallback; stored */
+  double w = z + x;   /* second RUP add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rup-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_up::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1604,21 +1604,27 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       const expr2tc &rounding_mode = to_ieee_add2t(expr).rounding_mode;
 
-      // Interval-lifted nearest-mode enclosure for ieee_add (--ir-ieee only).
-      // Covers both RNE (ROUND_TO_EVEN) and RNA (ROUND_TO_AWAY): both are
-      // nearest-rounding modes sharing the same B_near constants and the same
-      // symmetric interval-lifting formula:
-      //   L_R = lo1 + lo2,  U_R = hi1 + hi2
-      //   ra_lo = L_R - B_near^-(L_R),  ra_hi = U_R + B_near^+(U_R)
-      // For RNE the result is named ra_lo:: / ra_hi::; for RNA ra_lo_aw:: /
-      // ra_hi_aw::, matching the single-step naming convention.
-      // Non-nearest modes, non-standard formats, and --ir-ieee disabled all
-      // fall through to apply_ieee754_semantics unchanged.
+      // Interval-lifted enclosure for ieee_add (--ir-ieee only).
+      // Covers RNE, RNA (nearest modes) and RUP, RDN (directed modes).
+      // All share the same addition interval hull:
+      //   L_R = L_x + L_y,  U_R = U_x + U_y
+      // Nearest (RNE/RNA): symmetric B_near at both endpoints
+      //   ra_lo = L_R - B_near(L_R),  ra_hi = U_R + B_near(U_R)
+      // RUP: exact lower bound, B_dir at upper endpoint
+      //   ra_lo = L_R (exact),  ra_hi = U_R + B_dir(U_R)
+      // RDN: B_dir at lower endpoint, exact upper bound
+      //   ra_lo = L_R - B_dir(L_R),  ra_hi = U_R (exact)
+      // Symbol names: ra_lo:: / ra_hi:: (RNE), ra_lo_aw:: / ra_hi_aw::
+      // (RNA), ra_lo_up:: / ra_hi_up:: (RUP), ra_lo_dn:: / ra_hi_dn:: (RDN).
+      // RTZ, non-standard formats, and --ir-ieee disabled fall through to
+      // apply_ieee754_semantics unchanged.
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
         (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode)))
+         is_round_to_away(rounding_mode) ||
+         is_round_to_plus_inf(rounding_mode) ||
+         is_round_to_minus_inf(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1642,9 +1648,15 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           if (is_nearest_rounding_mode(rounding_mode))
             bounds =
               apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else
+          else if (is_round_to_away(rounding_mode))
             bounds =
               apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else if (is_round_to_plus_inf(rounding_mode))
+            bounds =
+              apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else
+            bounds =
+              apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RUP/RDN interval lifting for `ieee_add`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- added theorem-driven RNE and RNA interval lifting for `ieee_add`
- completed theorem-driven interval lifting for `ieee_sub` across RNE, RNA, RUP, RDN, and RTZ
- propagated tracked interval metadata across assignments

This PR adds the next smallest sound step:

- theorem-driven interval lifting for `ieee_add` under
  - `ROUND_TO_PLUS_INF` (RUP)
  - `ROUND_TO_MINUS_INF` (RDN)

## Main idea

For addition, let:

- `R = hull(X + Y) = [L_R, U_R]`

with:

- `L_R = L_x + L_y`
- `U_R = U_x + U_y`

For directed modes, use:

- `B_dir(r) = eps_rel_dir * |r| + eps_abs`

where:

- for double: `eps_rel_dir = 2^-52`
- for single: `eps_rel_dir = 2^-23`

So this PR implements the proof-aligned compositional shapes:

- `fl_RUP(x + y) ∈ [L_R, U_R + B_dir(U_R)]`
- `fl_RDN(x + y) ∈ [L_R - B_dir(L_R), U_R]`

The existing `apply_ieee754_rup_enclosure` and
`apply_ieee754_rdn_enclosure` helpers are operation-agnostic and are
reused directly with the additive hull.

For implementation, operand intervals are obtained as follows:

- if an operand already has a tracked lifted enclosure, reuse its stored interval from `ir_ra_interval_map`
- otherwise fall back to the point interval `{side, side}`

## Main changes

- extend the `ieee_add` interval-lifted path under `--ir-ieee` to cover:
  - `ROUND_TO_PLUS_INF`
  - `ROUND_TO_MINUS_INF`
- reuse the existing directed enclosure helpers:
  - `apply_ieee754_rup_enclosure`
  - `apply_ieee754_rdn_enclosure`
- reuse the existing `ir_ra_interval_map`
- keep existing nearest-mode lifting unchanged
- keep `ieee_sub`, `ieee_mul`, `ieee_div`, and RTZ-add unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-rup-both-fresh`
- `ra-interval-lift-rup-one-fresh`
- `ra-interval-lift-rup-both-tracked`
- `ra-interval-lift-rup-both-fresh-single`
- `ra-interval-lift-rup-one-fresh-single`
- `ra-interval-lift-rup-both-tracked-single`

- `ra-interval-lift-rdn-both-fresh`
- `ra-interval-lift-rdn-one-fresh`
- `ra-interval-lift-rdn-both-tracked`
- `ra-interval-lift-rdn-both-fresh-single`
- `ra-interval-lift-rdn-one-fresh-single`
- `ra-interval-lift-rdn-both-tracked-single`

This was also checked against the existing `ir-ra` regressions.

## Scope

This PR implements only:

- theorem-driven RUP/RDN interval lifting for `ieee_add`

The following remain out of scope:

- theorem-driven RTZ interval lifting for `ieee_add`
- `ieee_mul` interval lifting
- `ieee_div` interval lifting
- full IEEE corner-case handling for NaN / infinities / signed zero