### PR TITLE
fix nested attribute chained method call typing

### DIFF
--- a/regression/python/nested-attr-7/test.desc
+++ b/regression/python/nested-attr-7/test.desc
@@ -1,5 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$
-

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4766,7 +4766,7 @@ exprt function_call_expr::handle_general_function_call()
 
           call.arguments().push_back(gen_address_of(symbol_expr(tmp)));
         }
-        else
+        else if (func_value["_type"] == "Call")
         {
           // Chained method call (e.g., B().g().f()): the receiver is the return
           // value of an inner method call. Create a temp to hold it and use
@@ -4800,6 +4800,13 @@ exprt function_call_expr::handle_general_function_call()
             exprt obj_expr = converter_.get_expr(func_value);
             call.arguments().push_back(gen_address_of(obj_expr));
           }
+        }
+        else
+        {
+          // Member/variable receiver (e.g., self.builder.build()): use the
+          // actual receiver expression instead of a nondet temporary.
+          exprt obj_expr = converter_.get_expr(func_value);
+          call.arguments().push_back(gen_address_of(obj_expr));
         }
       }
       else

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -986,8 +986,8 @@ std::string type_handler::get_operand_type(const nlohmann::json &operand) const
       attr_value.contains("_type") && attr_value["_type"] == "Name" &&
       attr_value.contains("id") && attr_value["id"] == "self")
     {
-      const auto self_class_node =
-        json_utils::find_class(converter_.ast()["body"], converter_.current_classname());
+      const auto self_class_node = json_utils::find_class(
+        converter_.ast()["body"], converter_.current_classname());
       std::string self_attr_type = find_annotated_attr_type(self_class_node);
       if (!self_attr_type.empty())
         return self_attr_type;
@@ -996,7 +996,8 @@ std::string type_handler::get_operand_type(const nlohmann::json &operand) const
     std::string obj_type = get_operand_type(attr_value);
     if (!obj_type.empty())
     {
-      const auto class_node = json_utils::find_class(converter_.ast()["body"], obj_type);
+      const auto class_node =
+        json_utils::find_class(converter_.ast()["body"], obj_type);
       std::string attr_type = find_annotated_attr_type(class_node);
       if (!attr_type.empty())
         return attr_type;

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -942,6 +942,66 @@ std::string type_handler::get_operand_type(const nlohmann::json &operand) const
     if (!rhs_type.empty())
       return rhs_type;
   }
+  else if (
+    operand["_type"] == "Attribute" && operand.contains("attr") &&
+    operand.contains("value"))
+  {
+    const std::string attr_name = operand["attr"].get<std::string>();
+
+    auto find_annotated_attr_type =
+      [&](const nlohmann::json &class_node) -> std::string {
+      if (class_node.empty() || !class_node.contains("body"))
+        return std::string();
+
+      for (const auto &member : class_node["body"])
+      {
+        if (
+          member["_type"] != "FunctionDef" || !member.contains("name") ||
+          member["name"] != "__init__" || !member.contains("body"))
+          continue;
+
+        for (const auto &stmt : member["body"])
+        {
+          if (
+            stmt["_type"] == "AnnAssign" && stmt.contains("target") &&
+            stmt["target"].contains("_type") &&
+            stmt["target"]["_type"] == "Attribute" &&
+            stmt["target"].contains("attr") &&
+            stmt["target"]["attr"] == attr_name &&
+            stmt["target"].contains("value") &&
+            stmt["target"]["value"].contains("_type") &&
+            stmt["target"]["value"]["_type"] == "Name" &&
+            stmt["target"]["value"].contains("id") &&
+            stmt["target"]["value"]["id"] == "self" &&
+            stmt.contains("annotation") && stmt["annotation"].contains("id"))
+            return stmt["annotation"]["id"].get<std::string>();
+        }
+      }
+
+      return std::string();
+    };
+
+    const auto &attr_value = operand["value"];
+    if (
+      attr_value.contains("_type") && attr_value["_type"] == "Name" &&
+      attr_value.contains("id") && attr_value["id"] == "self")
+    {
+      const auto self_class_node =
+        json_utils::find_class(converter_.ast()["body"], converter_.current_classname());
+      std::string self_attr_type = find_annotated_attr_type(self_class_node);
+      if (!self_attr_type.empty())
+        return self_attr_type;
+    }
+
+    std::string obj_type = get_operand_type(attr_value);
+    if (!obj_type.empty())
+    {
+      const auto class_node = json_utils::find_class(converter_.ast()["body"], obj_type);
+      std::string attr_type = find_annotated_attr_type(class_node);
+      if (!attr_type.empty())
+        return attr_type;
+    }
+  }
 
   // Handle call expressions: constructor calls like A() and method calls like B().g()
   else if (operand["_type"] == "Call" && operand.contains("func"))


### PR DESCRIPTION
- This PR fixes Python frontend handling of chained method calls on annotated nested attributes 
- It improves attribute type inference for self attributes declared in __init__ and avoids using nondet temporaries for non-call attribute receivers.
- It also promotes regression/python/nested-attr-7 from KNOWNBUG to CORE