### PR TITLE
[symex] add interval-based assertion pruning (--interval-symex-assert)

### DIFF
--- a/regression/esbmc/interval_symex_assert_no_prune/main.c
+++ b/regression/esbmc/interval_symex_assert_no_prune/main.c
@@ -1,0 +1,9 @@
+// --interval-symex-assert: domain cannot prove x <= 60 from x in [0, 100];
+// SMT must still reach the genuine counterexample at x == 100.
+int main()
+{
+  int x;
+  __ESBMC_assume(x >= 0 && x <= 100);
+  __ESBMC_assert(x <= 60, "x must be at most 60");
+  return 0;
+}

--- a/regression/esbmc/interval_symex_assert_no_prune/test.desc
+++ b/regression/esbmc/interval_symex_assert_no_prune/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--interval-symex-assert
+^VERIFICATION FAILED$

--- a/regression/esbmc/interval_symex_assert_prune/main.c
+++ b/regression/esbmc/interval_symex_assert_prune/main.c
@@ -1,0 +1,9 @@
+// --interval-symex-assert: domain proves both claims from x in [5, 10].
+int main()
+{
+  int x;
+  __ESBMC_assume(x >= 5 && x <= 10);
+  __ESBMC_assert(x >= 0, "x must be non-negative");
+  __ESBMC_assert(x <= 100, "x must be at most 100");
+  return 0;
+}

--- a/regression/esbmc/interval_symex_assert_prune/test.desc
+++ b/regression/esbmc/interval_symex_assert_prune/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--interval-symex-assert --multi-property
+^VERIFICATION SUCCESSFUL$
+^Generated 2 VCC\(s\), 0 remaining after simplification
+PASSED \(interval\).*x must be non-negative
+PASSED \(interval\).*x must be at most 100

--- a/regression/esbmc/interval_symex_assert_silent/main.c
+++ b/regression/esbmc/interval_symex_assert_silent/main.c
@@ -1,0 +1,11 @@
+// --interval-symex-assert without --multi-property: both claims must be
+// pruned by the interval domain (0 VCCs remaining) yet no "PASSED (interval)"
+// per-claim log line should be emitted.
+int main()
+{
+  int x;
+  __ESBMC_assume(x >= -3 && x <= 3);
+  __ESBMC_assert(x >= -3, "x lower bound");
+  __ESBMC_assert(x <= 3, "x upper bound");
+  return 0;
+}

--- a/regression/esbmc/interval_symex_assert_silent/test.desc
+++ b/regression/esbmc/interval_symex_assert_silent/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--interval-symex-assert
+^VERIFICATION SUCCESSFUL$
+^Generated 2 VCC\(s\), 0 remaining after simplification

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -633,7 +633,11 @@ const struct group_opt_templ all_cmd_options[] = {
     {"interval-symex-guard",
      NULL,
      "Use interval-based guard pruning during symbolic execution to stop "
-     "loop unrolling when the guard becomes provably unsatisfiable"}}},
+     "loop unrolling when the guard becomes provably unsatisfiable"},
+    {"interval-symex-assert",
+     NULL,
+     "Use interval-based assertion pruning during symbolic execution to "
+     "skip assertions that are provably true under the tracked intervals"}}},
   {"Coverage options",
    {
      {"assertion-coverage", NULL, "Show the coverage of assertion statements"},

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -1560,7 +1560,8 @@ void interval_domaint::set_options(const optionst &options)
 {
   enable_interval_arithmetic =
     options.get_bool_option("interval-analysis-arithmetic") ||
-    options.get_bool_option("interval-symex-guard");
+    options.get_bool_option("interval-symex-guard") ||
+    options.get_bool_option("interval-symex-assert");
   enable_interval_bitwise_arithmetic =
     options.get_bool_option("interval-analysis-bitwise");
   enable_modular_intervals =

--- a/src/goto-programs/abstract-interpretation/interval_domain.h
+++ b/src/goto-programs/abstract-interpretation/interval_domain.h
@@ -175,7 +175,8 @@ public:
    * @brief Updates the interval state based on a single goto-program instruction.
    *
    * Handles ASSIGN, ASSUME, DECL, and DEAD without requiring an ai_baset reference.
-   * Intended for online use during symbolic execution (--interval-symex-guard).
+   * Intended for online use during symbolic execution
+   * (--interval-symex-guard, --interval-symex-assert).
    * @param from: iterator to the instruction to process
    */
   void process_instruction(goto_programt::const_targett from);

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -1130,7 +1130,8 @@ protected:
   std::map<unsigned, std::pair<std::string, unsigned>> loop_id_to_func_index;
   /** Global maximum number of unwinds. */
   BigInt max_unwind;
-  /** Optional local interval domain for --interval-symex-guard guard pruning. */
+  /** Online interval domain used by --interval-symex-guard to prune loop
+   *  guards and by --interval-symex-assert to discharge claims proven TRUE. */
   std::optional<interval_domaint> interval_domain_state;
   /** Whether constant propagation is to be enabled. */
   bool constant_propagation;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -139,7 +139,9 @@ goto_symext::goto_symext(
 
   art1 = nullptr;
 
-  if (options.get_bool_option("interval-symex-guard"))
+  if (
+    options.get_bool_option("interval-symex-guard") ||
+    options.get_bool_option("interval-symex-assert"))
   {
     interval_domaint::set_options(options);
     interval_domain_state.emplace();

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -51,7 +51,9 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
   }
 
   // Interval-based guard check (--interval-symex-guard)
-  if (!new_guard_false && !new_guard_true && interval_domain_state)
+  if (
+    !new_guard_false && !new_guard_true && interval_domain_state &&
+    options.get_bool_option("interval-symex-guard"))
   {
     tvt res = interval_domaint::eval_boolean_expression(
       old_guard, *interval_domain_state);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -93,6 +93,32 @@ void goto_symext::claim(const expr2tc &claim_expr, const std::string &msg)
     return;
   }
 
+  // Interval-based assertion pruning (--interval-symex-assert). Evaluate the
+  // pre-rename expression (the domain keys on original names). Skip when the
+  // domain is bottom — empty intervals vacuously don't contain 0, which would
+  // let every query succeed. Only prune on TRUE, never FALSE: the shared,
+  // non-forked domain may carry assume() residue from sibling branches, and
+  // pruning on a contaminated FALSE would silently drop real bugs.
+  if (
+    options.get_bool_option("interval-symex-assert") && interval_domain_state &&
+    !interval_domain_state->is_bottom() &&
+    interval_domaint::eval_boolean_expression(
+      claim_expr, *interval_domain_state)
+      .is_true())
+  {
+    if (options.get_bool_option("multi-property"))
+    {
+      log_success(
+        "✓ PASSED (interval): '{}' at {}",
+        msg,
+        cur_state->source.pc->location.as_string());
+      ++simplified_claims;
+    }
+
+    assume(claim_expr);
+    return;
+  }
+
   // Perform incremental SMT-based verification if enabled
   if (
     options.get_bool_option("smt-symex-assert") &&
@@ -448,7 +474,8 @@ void goto_symext::symex_step(reachability_treet &art)
     abort();
   }
 
-  // Update local interval domain for --interval-symex-guard
+  // Feed the instruction into the online interval domain shared by
+  // --interval-symex-guard and --interval-symex-assert.
   if (interval_domain_state)
     interval_domain_state->process_instruction(pre_step_pc);
 }


### PR DESCRIPTION
This PR introduces a new flag that reuses the online `interval_domaint` maintained during symbolic execution to discharge claims proven TRUE before they reach the SMT solver. 

For now, the option is independent from `--interval-symex-guard`; enabling either (or both) initializes the shared domain, but each flag gates only its own pruning step. 

The assertion check lives in `goto_symext::claim`, evaluates the pre-rename expression (the domain keys on original names), skips when the domain is bottom to avoid vacuous proofs, and only prunes on TRUE to stay sound.