### PR TITLE
remove the extern definition

### DIFF
--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -502,7 +502,8 @@ void add_cprover_library(contextt &context, const languaget *language)
   context.Foreach_operand([&context](symbolt &s) {
     if (s.is_extern && !s.type.is_code())
     {
-      log_warning(
+      log_debug(
+        "c2goto",
         "extern variable with id {} not found, initializing value to "
         "nondet! "
         "This code would not compile with an actual compiler.",

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -534,7 +534,7 @@ void __ESBMC_unroll(int);
  * Active contract enforcement only kicks in with --enforce-contract etc. */
 void __ESBMC_requires(_Bool);
 void __ESBMC_ensures(_Bool);
-extern int __ESBMC_return_value;
+int __ESBMC_return_value;
 void* __ESBMC_old_raw(void*);
 #define __ESBMC_old(x) (*(__typeof__(x)*)__ESBMC_old_raw((void*)(&(x))))
 #define __ESBMC_and(a, b) ((a) & (b))


### PR DESCRIPTION
This pull request makes a minor change to the declaration of `__ESBMC_return_value` in `clang_c_language.cpp` to improve linkage and visibility.

* Changed the declaration of `__ESBMC_return_value` from `extern int` to `int`, making it a definition rather than just a declaration.