### PR TITLE
[ir-ra] add theorem-driven RTZ interval lifting for ieee_add

### DIFF
--- a/regression/ir-ra/ra-interval-lift-rtz-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_add --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rtz-both-fresh but exercises the single-precision
+ * (float) path. Verifies that when both operands are fresh nondet variables,
+ * the point-interval fallback collapses to the single-step RTZ sign-conditional
+ * formula with single-precision epsilon constants.
+ *
+ * PROOF SHAPE (B_dir, RTZ, single precision)
+ * ------------------------------------------
+ * Both x and y are fresh; lo_r == hi_r == real_z, producing:
+ *   r >= 0: ra_lo_tz = r - B_dir(r),  ra_hi_tz = r   [eps_rel_dir = 2^-23]
+ *   r <  0: ra_lo_tz = r,             ra_hi_tz = r + B_dir(r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::       -- RTZ tight path taken (single precision)
+ *   ra_hi_tz::       -- RTZ tight path taken
+ *   (ite             -- sign-conditional ITE in enclosure formula
+ *   8388608          -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y; /* RTZ add: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rtz-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-fresh/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_add --
+ * both operands fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that theorem-driven interval lifting fires for ieee_add under
+ * ROUND_TO_ZERO when both operands are fresh nondet variables.
+ * With no tracked operands both use the point-interval fallback {t, t},
+ * so the hull degenerates to lo_r = hi_r = real_result (single point).
+ * The RTZ enclosure collapses to the single-step sign-dependent shape:
+ *
+ *   r >= 0: ra_lo_tz = r - B_dir(r),  ra_hi_tz = r  (truncate down)
+ *   r <  0: ra_lo_tz = r,             ra_hi_tz = r + B_dir(r)  (truncate up)
+ *
+ * encoded as nested ITE on the sign of r.
+ *
+ * PROOF SHAPE (B_dir, RTZ, double precision)
+ * ------------------------------------------
+ * B_dir(r) = eps_rel_dir * |r| + eps_abs,  eps_rel_dir = 2^-52
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::[0-9]+  -- RTZ interval lower bound declared
+ *   ra_hi_tz::[0-9]+  -- RTZ interval upper bound declared
+ *   (ite               -- sign-conditional ITE in enclosure formula
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y; /* RTZ add: both fresh -> point fallback */
+
+  /* Always false in real/integer encoding. */
+  assert(z != x + y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rtz-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_tz::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-tracked-single/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_add --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rtz-both-tracked but exercises the single-precision
+ * (float) path. Verifies that the get_single_eps_up() /
+ * get_single_min_subnormal() branch in apply_ieee754_rtz_enclosure is reached
+ * when both operands of a second RTZ ieee_add are tracked.
+ *
+ * PROOF SHAPE (B_dir, RTZ, single precision)
+ * ------------------------------------------
+ * Second add:  w = z + z  (both operands tracked)
+ *   lo_r = ra_lo_tz::0 + ra_lo_tz::0
+ *   hi_r = ra_hi_tz::0 + ra_hi_tz::0
+ *   RTZ three-way ITE on sign of [lo_r, hi_r]  [eps_rel_dir = 2^-23]
+ *   ra_lo_tz::1 and ra_hi_tz::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first addition's interval lower bound declared
+ *   ra_lo_tz::1   -- second addition's lifted lower bound declared
+ *   (+ ra_lo_tz::0 ra_lo_tz::0)  -- lo_r subterm confirming tracked lookup
+ *   (ite           -- sign-conditional/max ITEs present
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y;   /* first RTZ add: both fresh -> point fallback; stored */
+  float w = z + z;   /* second RTZ add: both operands tracked */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rtz-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|\)
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-tracked/main.c
@@ -1,0 +1,56 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_add --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RTZ ieee_add were themselves
+ * results of a prior tracked RTZ ieee_add, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RTZ path is taken.
+ *
+ * This test also exercises the crossing-zero conservative fallback.
+ * For the second add w = z + z:
+ *   iv(z) = {ra_lo_tz::0, ra_hi_tz::0}
+ *   lo_r = ra_lo_tz::0 + ra_lo_tz::0  (= 2 * ra_lo_tz::0)
+ *   hi_r = ra_hi_tz::0 + ra_hi_tz::0  (= 2 * ra_hi_tz::0)
+ * Since ra_lo_tz::0 <= ra_hi_tz::0 and both can be negative or positive
+ * depending on the value of z, the hull can cross zero.
+ *
+ * PROOF SHAPE (B_dir, RTZ, double precision)
+ * ------------------------------------------
+ * First add:  z = x + y   (both fresh -> point-interval fallback)
+ *   lo_r1 = hi_r1 = real_z (point hull)
+ *   RTZ sign-ITE on real_z:  ra_lo_tz::0, ra_hi_tz::0
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_tz::0, ra_hi_tz::0}
+ *
+ * Second add:  w = z + z  (both operands are z -> both tracked)
+ *   lo_r = ra_lo_tz::0 + ra_lo_tz::0
+ *   hi_r = ra_hi_tz::0 + ra_hi_tz::0
+ *   RTZ three-way ITE on sign of [lo_r, hi_r]:
+ *   ra_lo_tz::1 and ra_hi_tz::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first addition's interval lower bound declared
+ *   ra_lo_tz::1   -- second addition's lifted lower bound declared
+ *   (+ ra_lo_tz::0 ra_lo_tz::0)  -- lo_r subterm confirming tracked lookup
+ *   (ite           -- sign-conditional/max ITEs present
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RTZ add: both fresh -> point fallback; stored */
+  double w = z + z;   /* second RTZ add: both operands tracked */
+
+  /* Always false in real/integer encoding: w == z + z exactly. */
+  assert(w != z + z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rtz-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_tz::0\| \|smt_conv::ra_lo_tz::0\|\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rtz-one-fresh-single/main.c
@@ -1,0 +1,45 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_add --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rtz-one-fresh but exercises the single-precision
+ * (float) path. Verifies the mixed lookup path: when one operand of a second
+ * RTZ ieee_add is tracked and the other is a fresh nondet variable, the
+ * tracked operand uses its stored interval while the fresh one falls back to
+ * the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RTZ, single precision)
+ * ------------------------------------------
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   lo_r = ra_lo_tz::0 + x_smt
+ *   hi_r = ra_hi_tz::0 + x_smt
+ *   RTZ three-way ITE on sign of [lo_r, hi_r]  [eps_rel_dir = 2^-23]
+ *   ra_lo_tz::1 and ra_hi_tz::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first addition's interval lower bound declared
+ *   ra_lo_tz::1   -- second addition's mixed-path lower bound declared
+ *   (+ ra_lo_tz::0 ...  -- lo_r prefix confirming tracked lookup
+ *   (ite           -- sign-conditional ITEs present
+ *   8388608        -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x + y;   /* first RTZ add: both fresh -> point fallback; stored */
+  float w = z + x;   /* second RTZ add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rtz-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_tz::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-rtz-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rtz-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RTZ (ROUND_TO_ZERO) interval lifting for ieee_add --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RTZ ieee_add: when one operand of a
+ * second RTZ ieee_add is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RTZ, double precision)
+ * ------------------------------------------
+ * First add:  z = x + y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_tz::0, ra_hi_tz::0}
+ *
+ * Second add:  w = z + x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_tz::0, ra_hi_tz::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   lo_r = ra_lo_tz::0 + x_smt
+ *   hi_r = ra_hi_tz::0 + x_smt
+ *   RTZ three-way ITE on sign of [lo_r, hi_r]:
+ *   ra_lo_tz::1 and ra_hi_tz::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ * ---------------------------------
+ *   ra_lo_tz::0   -- first addition's interval lower bound declared
+ *   ra_lo_tz::1   -- second addition's mixed-path lower bound declared
+ *   (+ ra_lo_tz::0 ...  -- lo_r prefix confirming tracked lookup
+ *   (ite           -- sign-conditional ITEs present
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 4; /* ROUND_TO_ZERO */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x + y;   /* first RTZ add: both fresh -> point fallback; stored */
+  double w = z + x;   /* second RTZ add: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z + x exactly. */
+  assert(w != z + x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rtz-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rtz-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_tz::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_tz::1\| \(\) Real\)
+\(\+ \|smt_conv::ra_lo_tz::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1605,7 +1605,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const expr2tc &rounding_mode = to_ieee_add2t(expr).rounding_mode;
 
       // Interval-lifted enclosure for ieee_add (--ir-ieee only).
-      // Covers RNE, RNA (nearest modes) and RUP, RDN (directed modes).
+      // Covers RNE, RNA (nearest modes) and RUP, RDN, RTZ (directed modes).
       // All share the same addition interval hull:
       //   L_R = L_x + L_y,  U_R = U_x + U_y
       // Nearest (RNE/RNA): symmetric B_near at both endpoints
@@ -1614,9 +1614,15 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       //   ra_lo = L_R (exact),  ra_hi = U_R + B_dir(U_R)
       // RDN: B_dir at lower endpoint, exact upper bound
       //   ra_lo = L_R - B_dir(L_R),  ra_hi = U_R (exact)
+      // RTZ: sign-dependent three-way case on hull sign:
+      //   LR >= 0: ra_lo = LR - B_dir(LR), ra_hi = UR (exact upper)
+      //   UR <= 0: ra_lo = LR (exact lower), ra_hi = UR + B_dir(UR)
+      //   else:   ra_lo = LR - B_dir_max, ra_hi = UR + B_dir_max
+      //           where B_dir_max = eps_rel_dir * max(|LR|, |UR|) + eps_abs
       // Symbol names: ra_lo:: / ra_hi:: (RNE), ra_lo_aw:: / ra_hi_aw::
-      // (RNA), ra_lo_up:: / ra_hi_up:: (RUP), ra_lo_dn:: / ra_hi_dn:: (RDN).
-      // RTZ, non-standard formats, and --ir-ieee disabled fall through to
+      // (RNA), ra_lo_up:: / ra_hi_up:: (RUP), ra_lo_dn:: / ra_hi_dn:: (RDN),
+      // ra_lo_tz:: / ra_hi_tz:: (RTZ).
+      // Non-standard formats and --ir-ieee disabled fall through to
       // apply_ieee754_semantics unchanged.
       bool interval_lifted = false;
       if (
@@ -1624,7 +1630,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         (is_nearest_rounding_mode(rounding_mode) ||
          is_round_to_away(rounding_mode) ||
          is_round_to_plus_inf(rounding_mode) ||
-         is_round_to_minus_inf(rounding_mode)))
+         is_round_to_minus_inf(rounding_mode) ||
+         is_round_to_zero(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1654,9 +1661,12 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
           else if (is_round_to_plus_inf(rounding_mode))
             bounds =
               apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
-          else
+          else if (is_round_to_minus_inf(rounding_mode))
             bounds =
               apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else
+            bounds =
+              apply_ieee754_rtz_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RTZ interval lifting for `ieee_add`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- added theorem-driven RNE and RNA interval lifting for `ieee_add`
- added theorem-driven RUP and RDN interval lifting for `ieee_add`
- completed theorem-driven interval lifting for `ieee_sub` across all five rounding modes

This PR adds the next smallest sound step:

- theorem-driven RTZ interval lifting for `ieee_add`

## Main idea

For addition, let:

- `R = hull(X + Y) = [L_R, U_R]`

with:

- `L_R = L_x + L_y`
- `U_R = U_x + U_y`

For `ROUND_TO_ZERO`, the enclosure is sign-dependent:

- if `L_R >= 0`:
  - `EbRTZ = [L_R - B_dir(L_R), U_R]`
- if `U_R <= 0`:
  - `EbRTZ = [L_R, U_R + B_dir(U_R)]`
- if the hull crosses zero:
  - `EbRTZ = [L_R - B_dir_max, U_R + B_dir_max]`

where:

- `B_dir(r) = eps_rel_dir * |r| + eps_abs`
- `B_dir_max = eps_rel_dir * max(|L_R|, |U_R|) + eps_abs`

## Main changes

- extend the `ieee_add` interval-lifting gate under `--ir-ieee` to cover `ROUND_TO_ZERO`
- reuse the existing `apply_ieee754_rtz_enclosure` helper directly
- preserve the existing addition hull:
  - `L_R = L_x + L_y`
  - `U_R = U_x + U_y`
- reuse `ir_ra_interval_map`
- keep existing RNE/RNA/RUP/RDN lifting unchanged
- keep `ieee_sub`, `ieee_mul`, and `ieee_div` unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-rtz-both-fresh`
- `ra-interval-lift-rtz-one-fresh`
- `ra-interval-lift-rtz-both-tracked`
- `ra-interval-lift-rtz-both-fresh-single`
- `ra-interval-lift-rtz-one-fresh-single`
- `ra-interval-lift-rtz-both-tracked-single`

This was also checked against the existing `ir-ra` regressions.

## Scope

This PR implements only:

- theorem-driven RTZ interval lifting for `ieee_add`

The following remain out of scope:

- `ieee_mul` interval lifting
- `ieee_div` interval lifting
- full IEEE corner-case handling for NaN / infinities / signed zero