### PR TITLE
[ir-ra] add theorem-driven RNE interval lifting for ieee_mul

### DIFF
--- a/regression/ir-ra/ra-interval-lift-mul-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-both-fresh-single/main.c
@@ -1,0 +1,37 @@
+/* Regression test: RNE interval lifting for ieee_mul -- both operands fresh,
+ * single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-mul-both-fresh but exercises the single-precision
+ * (float) path. Verifies point-interval fallback for fresh operands.
+ *
+ * PROOF SHAPE (point-interval fallback, single precision)
+ * -------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNE mul).
+ *   iv(x) = {x_smt, x_smt}  (point fallback)
+ *   iv(y) = {y_smt, y_smt}  (point fallback)
+ *   lo_r = hi_r = x_smt * y_smt = real_z
+ * The helper receives lo_r == hi_r, producing tight RNE enclosure.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::          -- tight RNE path taken
+ *   ra_hi::          -- tight RNE path taken
+ *   (ite             -- |r| absolute value present
+ *   5960464477539063 -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x * y exactly. */
+  assert(z != x * y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-both-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-both-fresh/main.c
@@ -1,0 +1,43 @@
+/* Regression test: RNE interval lifting for ieee_mul -- both operands fresh
+ * (zero-regression sentinel).
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of an ieee_mul are fresh nondet variables
+ * (not in ir_ra_interval_map), the point-interval fallback is applied to
+ * both, and the resulting formula uses the RNE enclosure over the
+ * degenerate hull lo_r = hi_r = real_z.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step)
+ * ---------------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNE mul).
+ *   iv(x) = {x_smt, x_smt}  (point fallback)
+ *   iv(y) = {y_smt, y_smt}  (point fallback)
+ *   p1=p2=p3=p4 = x_smt * y_smt = real_z
+ *   lo_r = hi_r = real_z
+ * The helper receives lo_r == hi_r, producing:
+ *   ra_lo = real_z - B_near(real_z)
+ *   ra_hi = real_z + B_near(real_z)
+ * This is structurally equivalent to the pre-lifting single-step formula.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::          -- tight RNE path taken
+ *   ra_hi::          -- tight RNE path taken
+ *   (ite             -- |r| absolute value present
+ *   5551115123125783 -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* both fresh -> point fallback -> single-step equivalent */
+
+  /* Always false in real/integer encoding: z == x * y exactly. */
+  assert(z != x * y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-both-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::[0-9]+\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-both-tracked-single/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RNE interval lifting for ieee_mul -- both operands tracked,
+ * single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-mul-both-tracked but exercises the single-precision
+ * (float) path. Verifies that both-tracked lookup fires and the mul hull is
+ * computed from four endpoint products.
+ *
+ * PROOF SHAPE (B_near, RNE, single precision)
+ * -------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point-interval fallback; stored)
+ *   ir_ra_interval_map[real_z] = {ra_lo::0, ra_hi::0}
+ *
+ * Second mul:  w = z * z  (both operands tracked -> full lift)
+ *   p1 = ra_lo::0 * ra_lo::0
+ *   p2 = ra_lo::0 * ra_hi::0  (= p3)
+ *   p4 = ra_hi::0 * ra_hi::0
+ *   lo_r = min(p1,p2,p3,p4),  hi_r = max(p1,p2,p3,p4)
+ *   ra_lo::1, ra_hi::1 pinned with B_near (single eps)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first mul's interval lower bound declared
+ *   ra_lo::1   -- second mul's lifted lower bound declared
+ *   (* |smt_conv::ra_lo::0|  -- endpoint product in hull computation
+ *   (ite        -- nested ITE present
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* first RNE mul: both fresh -> point fallback; stored */
+  float w = z * z; /* second RNE mul: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z * z exactly. */
+  assert(w != z * z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-both-tracked-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-both-tracked/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RNE interval lifting for ieee_mul -- both operands tracked.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RNE ieee_mul were themselves
+ * results of a prior tracked RNE ieee_mul, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted multiplication path is taken.
+ *
+ * PROOF SHAPE (B_near, RNE, double precision)
+ * -------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   p1=p2=p3=p4 = x * y = real_z
+ *   ra_lo::0 = real_z - B_near(real_z)
+ *   ra_hi::0 = real_z + B_near(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo::0, ra_hi::0}
+ *
+ * Second mul:  w = z * z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo::0, ra_hi::0}  (found in map, same entry twice)
+ *   p1 = ra_lo::0 * ra_lo::0
+ *   p2 = ra_lo::0 * ra_hi::0
+ *   p3 = ra_hi::0 * ra_lo::0
+ *   p4 = ra_hi::0 * ra_hi::0
+ *   lo_r = min(p1,p2,p3,p4) via nested ITE
+ *   hi_r = max(p1,p2,p3,p4) via nested ITE
+ *   ra_lo::1 = lo_r - B_near(lo_r)
+ *   ra_hi::1 = hi_r + B_near(hi_r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first multiplication's interval lower bound declared
+ *   ra_lo::1   -- second multiplication's lifted lower bound declared
+ *   (* |smt_conv::ra_lo::0|  -- endpoint product in hull computation
+ *   (ite        -- nested ITE for min/max hull and absolute value
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* first RNE mul: both fresh -> point fallback; stored */
+  double w = z * z; /* second RNE mul: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z * z exactly. */
+  assert(w != z * z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-both-tracked/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-one-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RNE interval lifting for ieee_mul -- one tracked, one fresh,
+ * single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-mul-one-fresh but exercises the single-precision
+ * (float) path. Verifies the mixed lookup path: when one operand of a second
+ * RNE ieee_mul is tracked and the other is a fresh nondet variable.
+ *
+ * PROOF SHAPE (B_near, RNE, single precision)
+ * -------------------------------------------
+ * Second mul:  w = z * x  (z tracked, x fresh -> mixed path)
+ *   lo_r = min(ra_lo::0 * x_smt, ra_hi::0 * x_smt)
+ *   hi_r = max(ra_lo::0 * x_smt, ra_hi::0 * x_smt)
+ *   RTZ three-way ITE on sign not present (RNE uses symmetric B_near)
+ *   ra_lo::1 and ra_hi::1 pinned accordingly
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first mul's interval lower bound declared
+ *   ra_lo::1   -- second mul's mixed-path lower bound declared
+ *   (* |smt_conv::ra_lo::0|  -- tracked endpoint in hull product
+ *   (ite        -- nested ITE present
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* first RNE mul: both fresh -> point fallback; stored */
+  float w = z * x; /* second RNE mul: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z * x exactly. */
+  assert(w != z * x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-one-fresh-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo::0\|
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RNE interval lifting for ieee_mul -- one tracked, one fresh.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for ieee_mul: when one operand of a second
+ * RNE ieee_mul is tracked in ir_ra_interval_map and the other is a fresh
+ * nondet variable, the tracked operand uses its stored interval while the
+ * fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_near, RNE, double precision)
+ * -------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo::0, ra_hi::0}
+ *
+ * Second mul:  w = z * x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo::0, ra_hi::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}         (point fallback)
+ *   p1 = ra_lo::0 * x_smt
+ *   p2 = ra_lo::0 * x_smt  (= p1, since iv(x) is a point)
+ *   p3 = ra_hi::0 * x_smt
+ *   p4 = ra_hi::0 * x_smt  (= p3)
+ *   lo_r = min(p1,p3) = ITE(ra_lo::0 * x_smt <= ra_hi::0 * x_smt, ...)
+ *   hi_r = max(p1,p3)
+ *   ra_lo::1 = lo_r - B_near(lo_r)
+ *   ra_hi::1 = hi_r + B_near(hi_r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first mul's interval lower bound declared
+ *   ra_lo::1   -- second mul's mixed-path lower bound declared
+ *   (* |smt_conv::ra_lo::0|  -- tracked endpoint in hull product
+ *   (ite        -- nested ITE for min/max hull and absolute value
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* first RNE mul: both fresh -> point fallback; stored */
+  double w = z * x; /* second RNE mul: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z * x exactly. */
+  assert(w != z * x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-one-fresh/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo::0\|
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1791,11 +1791,67 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt operand_is_zero = mk_or(mk_eq(side1, zero), mk_eq(side2, zero));
 
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
-      a = apply_ieee754_semantics(
-        real_result,
-        fbv_type,
-        operand_is_zero,
-        to_ieee_mul2t(expr).rounding_mode);
+      const expr2tc &rounding_mode = to_ieee_mul2t(expr).rounding_mode;
+
+      // RNE interval lifting for ieee_mul.
+      // Hull: lo_r = min(p1,p2,p3,p4), hi_r = max(p1,p2,p3,p4)
+      // where p1=L_x*L_y, p2=L_x*U_y, p3=U_x*L_y, p4=U_x*U_y.
+      bool interval_lifted = false;
+      if (
+        options.get_bool_option("ir-ieee") &&
+        is_nearest_rounding_mode(rounding_mode))
+      {
+        const auto double_spec = ieee_float_spect::double_precision();
+        const auto single_spec = ieee_float_spect::single_precision();
+        if (
+          (fbv_type.exponent == double_spec.e &&
+           fbv_type.fraction == double_spec.f) ||
+          (fbv_type.exponent == single_spec.e &&
+           fbv_type.fraction == single_spec.f))
+        {
+          auto get_iv = [this](smt_astt t) -> ra_interval_t {
+            auto it = ir_ra_interval_map.find(t);
+            return it != ir_ra_interval_map.end() ? it->second
+                                                  : ra_interval_t{t, t};
+          };
+          ra_interval_t iv1 = get_iv(side1);
+          ra_interval_t iv2 = get_iv(side2);
+          // Four endpoint products
+          smt_astt p1 = mk_mul(iv1.lo, iv2.lo);
+          smt_astt p2 = mk_mul(iv1.lo, iv2.hi);
+          smt_astt p3 = mk_mul(iv1.hi, iv2.lo);
+          smt_astt p4 = mk_mul(iv1.hi, iv2.hi);
+          // min/max via nested ITE
+          smt_astt lo_r = mk_ite(
+            mk_le(p1, p2),
+            mk_ite(
+              mk_le(p1, p3),
+              mk_ite(mk_le(p1, p4), p1, p4),
+              mk_ite(mk_le(p3, p4), p3, p4)),
+            mk_ite(
+              mk_le(p2, p3),
+              mk_ite(mk_le(p2, p4), p2, p4),
+              mk_ite(mk_le(p3, p4), p3, p4)));
+          smt_astt hi_r = mk_ite(
+            mk_le(p2, p1),
+            mk_ite(
+              mk_le(p3, p1),
+              mk_ite(mk_le(p4, p1), p1, p4),
+              mk_ite(mk_le(p4, p3), p3, p4)),
+            mk_ite(
+              mk_le(p3, p2),
+              mk_ite(mk_le(p4, p2), p2, p4),
+              mk_ite(mk_le(p4, p3), p3, p4)));
+          std::pair<smt_astt, smt_astt> bounds =
+            apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
+          ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
+          a = real_result;
+          interval_lifted = true;
+        }
+      }
+      if (!interval_lifted)
+        a = apply_ieee754_semantics(
+          real_result, fbv_type, operand_is_zero, rounding_mode);
     }
     else
     {


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RNE interval lifting for `ieee_mul`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- completed theorem-driven interval lifting for `ieee_add` across all five rounding modes
- completed theorem-driven interval lifting for `ieee_sub` across all five rounding modes

This PR adds the next smallest sound step:

- theorem-driven RNE interval lifting for `ieee_mul`

## Main idea

For multiplication, let:

- `R = hull(X * Y) = [L_R, U_R]`

Unlike `ieee_add` and `ieee_sub`, the multiplication hull is not monotone in a single left/right endpoint pairing, so it must be computed from the four endpoint products:

- `p1 = L_x * L_y`
- `p2 = L_x * U_y`
- `p3 = U_x * L_y`
- `p4 = U_x * U_y`

Then:

- `L_R = min(p1, p2, p3, p4)`
- `U_R = max(p1, p2, p3, p4)`

For round-to-nearest-even:

- `EbRNE(X * Y) = [L_R - B_near(L_R), U_R + B_near(U_R)]`

where:

- `B_near(r) = eps_rel_near * |r| + eps_abs`

## Main changes

- extend the `ieee_mul` path under `--ir-ieee` and `ROUND_TO_EVEN` with interval lifting
- compute the multiplication hull from the four endpoint products
- reuse the existing `apply_ieee754_rne_enclosure` helper
- reuse `ir_ra_interval_map`
- keep non-RNE modes on the existing path
- keep `ieee_add`, `ieee_sub`, and `ieee_div` unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-mul-both-fresh`
- `ra-interval-lift-mul-one-fresh`
- `ra-interval-lift-mul-both-tracked`
- `ra-interval-lift-mul-both-fresh-single`
- `ra-interval-lift-mul-one-fresh-single`
- `ra-interval-lift-mul-both-tracked-single`

This was also checked against the existing `ir-ra` regressions.

## Scope

This PR implements only:

- theorem-driven RNE interval lifting for `ieee_mul`

The following remain out of scope:

- theorem-driven RNA interval lifting for `ieee_mul`
- directed-mode interval lifting for `ieee_mul`
- RTZ interval lifting for `ieee_mul`
- `ieee_div` interval lifting