### PR TITLE
Fix polymorphic call-site specialization in polymorphism02

### DIFF
--- a/regression/python/polymorphism02/test.desc
+++ b/regression/python/polymorphism02/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -281,7 +281,6 @@ public:
     }
 
     apply_pending_specializations();
-
   }
 
   void add_type_annotation(const std::string &func_name)
@@ -542,8 +541,7 @@ private:
             bool already_pending = false;
             for (const auto &spec : pending_specializations_)
             {
-              if (
-                spec.function_name == func_name && spec.param_index == i)
+              if (spec.function_name == func_name && spec.param_index == i)
               {
                 already_pending = true;
                 break;
@@ -723,26 +721,27 @@ private:
     return base_name + "__esbmc_poly_" + class_name;
   }
 
-  std::string resolve_name_assigned_class(const std::string &name, const Json &node)
+  std::string
+  resolve_name_assigned_class(const std::string &name, const Json &node)
   {
     if (name.empty())
       return "";
 
     if (node.is_object())
     {
-      if (node.contains("_type") && node["_type"] == "Assign" &&
-          node.contains("targets") && node["targets"].is_array() &&
-          !node["targets"].empty() && node["targets"][0].is_object() &&
-          node["targets"][0].contains("_type") &&
-          node["targets"][0]["_type"] == "Name" &&
-          node["targets"][0].contains("id") &&
-          node["targets"][0]["id"] == name && node.contains("value") &&
-          node["value"].is_object() && node["value"].contains("_type") &&
-          node["value"]["_type"] == "Call" && node["value"].contains("func") &&
-          node["value"]["func"].is_object() &&
-          node["value"]["func"].contains("_type") &&
-          node["value"]["func"]["_type"] == "Name" &&
-          node["value"]["func"].contains("id"))
+      if (
+        node.contains("_type") && node["_type"] == "Assign" &&
+        node.contains("targets") && node["targets"].is_array() &&
+        !node["targets"].empty() && node["targets"][0].is_object() &&
+        node["targets"][0].contains("_type") &&
+        node["targets"][0]["_type"] == "Name" &&
+        node["targets"][0].contains("id") && node["targets"][0]["id"] == name &&
+        node.contains("value") && node["value"].is_object() &&
+        node["value"].contains("_type") && node["value"]["_type"] == "Call" &&
+        node["value"].contains("func") && node["value"]["func"].is_object() &&
+        node["value"]["func"].contains("_type") &&
+        node["value"]["func"]["_type"] == "Name" &&
+        node["value"]["func"].contains("id"))
       {
         std::string class_name =
           node["value"]["func"]["id"].template get<std::string>();
@@ -778,12 +777,13 @@ private:
   {
     if (node.is_object())
     {
-      if (node.contains("_type") && node["_type"] == "Call" &&
-          node.contains("func") && node["func"].is_object() &&
-          node["func"].contains("_type") && node["func"]["_type"] == "Name" &&
-          node["func"].contains("id") && node["func"]["id"] == original_name &&
-          node.contains("args") && node["args"].is_array() &&
-          param_index < node["args"].size())
+      if (
+        node.contains("_type") && node["_type"] == "Call" &&
+        node.contains("func") && node["func"].is_object() &&
+        node["func"].contains("_type") && node["func"]["_type"] == "Name" &&
+        node["func"].contains("id") && node["func"]["id"] == original_name &&
+        node.contains("args") && node["args"].is_array() &&
+        param_index < node["args"].size())
       {
         std::string arg_type = get_argument_type(node["args"][param_index]);
         if (
@@ -826,8 +826,9 @@ private:
       size_t idx = 0;
       for (const auto &node : ast_["body"])
       {
-        if (node.contains("_type") && node["_type"] == "FunctionDef" &&
-            node.contains("name") && node["name"] == func_name)
+        if (
+          node.contains("_type") && node["_type"] == "FunctionDef" &&
+          node.contains("name") && node["name"] == func_name)
         {
           original_function = node;
           found = true;
@@ -867,10 +868,11 @@ private:
           build_specialized_function_name(func_name, class_name);
         specialized["name"] = specialized_name;
 
-        if (specialized.contains("args") && specialized["args"].is_object() &&
-            specialized["args"].contains("args") &&
-            specialized["args"]["args"].is_array() &&
-            param_index < specialized["args"]["args"].size())
+        if (
+          specialized.contains("args") && specialized["args"].is_object() &&
+          specialized["args"].contains("args") &&
+          specialized["args"]["args"].is_array() &&
+          param_index < specialized["args"]["args"].size())
         {
           Json &param = specialized["args"]["args"][param_index];
           add_parameter_annotation(param, class_name);
@@ -880,11 +882,13 @@ private:
         specialized_nodes.push_back(std::move(specialized));
       }
 
-      auto insert_it = ast_["body"].begin() + static_cast<ptrdiff_t>(original_index + 1);
+      auto insert_it =
+        ast_["body"].begin() + static_cast<ptrdiff_t>(original_index + 1);
       ast_["body"].insert(
         insert_it, specialized_nodes.begin(), specialized_nodes.end());
 
-      rewrite_specialized_calls(func_name, param_index, specialized_names, ast_);
+      rewrite_specialized_calls(
+        func_name, param_index, specialized_names, ast_);
     }
 
     pending_specializations_.clear();

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -8,6 +8,7 @@
 #include <util/message.h>
 
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 
 enum class InferResult
@@ -278,6 +279,9 @@ public:
       else if (element["_type"] == "ClassDef")
         annotate_class(element);
     }
+
+    apply_pending_specializations();
+
   }
 
   void add_type_annotation(const std::string &func_name)
@@ -528,6 +532,33 @@ private:
         // Try to infer type from function calls if available
         if (needs_inference && !function_calls.empty())
         {
+          std::vector<std::string> call_types =
+            collect_parameter_types_from_calls(i, function_calls);
+
+          if (
+            parent_func == nullptr && call_types.size() > 1 &&
+            are_all_user_classes(call_types))
+          {
+            bool already_pending = false;
+            for (const auto &spec : pending_specializations_)
+            {
+              if (
+                spec.function_name == func_name && spec.param_index == i)
+              {
+                already_pending = true;
+                break;
+              }
+            }
+
+            if (!already_pending)
+            {
+              pending_specializations_.push_back(
+                {func_name, i, std::move(call_types)});
+            }
+
+            continue;
+          }
+
           std::string saved_ctx = current_func_name_context_;
           current_func_name_context_ = call_site_context;
           inferred_type = infer_parameter_type_from_calls(i, function_calls);
@@ -646,6 +677,217 @@ private:
       for (const auto &element : node)
         find_function_calls_recursive(func_name, element, calls);
     }
+  }
+
+  std::vector<std::string> collect_parameter_types_from_calls(
+    size_t param_index,
+    const std::vector<Json> &function_calls)
+  {
+    std::vector<std::string> types;
+    std::unordered_set<std::string> seen;
+
+    for (const Json &call : function_calls)
+    {
+      if (!call.contains("args") || param_index >= call["args"].size())
+        continue;
+
+      std::string arg_type = get_argument_type(call["args"][param_index]);
+      if (arg_type.empty())
+        continue;
+
+      if (seen.insert(arg_type).second)
+        types.push_back(arg_type);
+    }
+
+    return types;
+  }
+
+  bool are_all_user_classes(const std::vector<std::string> &types) const
+  {
+    if (types.empty())
+      return false;
+
+    for (const auto &type_name : types)
+    {
+      if (type_name.empty() || !json_utils::is_class(type_name, ast_))
+        return false;
+    }
+
+    return true;
+  }
+
+  std::string build_specialized_function_name(
+    const std::string &base_name,
+    const std::string &class_name) const
+  {
+    return base_name + "__esbmc_poly_" + class_name;
+  }
+
+  std::string resolve_name_assigned_class(const std::string &name, const Json &node)
+  {
+    if (name.empty())
+      return "";
+
+    if (node.is_object())
+    {
+      if (node.contains("_type") && node["_type"] == "Assign" &&
+          node.contains("targets") && node["targets"].is_array() &&
+          !node["targets"].empty() && node["targets"][0].is_object() &&
+          node["targets"][0].contains("_type") &&
+          node["targets"][0]["_type"] == "Name" &&
+          node["targets"][0].contains("id") &&
+          node["targets"][0]["id"] == name && node.contains("value") &&
+          node["value"].is_object() && node["value"].contains("_type") &&
+          node["value"]["_type"] == "Call" && node["value"].contains("func") &&
+          node["value"]["func"].is_object() &&
+          node["value"]["func"].contains("_type") &&
+          node["value"]["func"]["_type"] == "Name" &&
+          node["value"]["func"].contains("id"))
+      {
+        std::string class_name =
+          node["value"]["func"]["id"].template get<std::string>();
+        if (json_utils::is_class(class_name, ast_))
+          return class_name;
+      }
+
+      for (auto it = node.begin(); it != node.end(); ++it)
+      {
+        std::string found = resolve_name_assigned_class(name, it.value());
+        if (!found.empty())
+          return found;
+      }
+    }
+    else if (node.is_array())
+    {
+      for (const auto &element : node)
+      {
+        std::string found = resolve_name_assigned_class(name, element);
+        if (!found.empty())
+          return found;
+      }
+    }
+
+    return "";
+  }
+
+  void rewrite_specialized_calls(
+    const std::string &original_name,
+    size_t param_index,
+    const std::unordered_map<std::string, std::string> &specialized_names,
+    Json &node)
+  {
+    if (node.is_object())
+    {
+      if (node.contains("_type") && node["_type"] == "Call" &&
+          node.contains("func") && node["func"].is_object() &&
+          node["func"].contains("_type") && node["func"]["_type"] == "Name" &&
+          node["func"].contains("id") && node["func"]["id"] == original_name &&
+          node.contains("args") && node["args"].is_array() &&
+          param_index < node["args"].size())
+      {
+        std::string arg_type = get_argument_type(node["args"][param_index]);
+        if (
+          arg_type.empty() && node["args"][param_index].contains("_type") &&
+          node["args"][param_index]["_type"] == "Name" &&
+          node["args"][param_index].contains("id"))
+        {
+          const std::string arg_name =
+            node["args"][param_index]["id"].template get<std::string>();
+          arg_type = resolve_name_assigned_class(arg_name, ast_["body"]);
+        }
+
+        auto it = specialized_names.find(arg_type);
+        if (it != specialized_names.end())
+          node["func"]["id"] = it->second;
+      }
+
+      for (auto it = node.begin(); it != node.end(); ++it)
+        rewrite_specialized_calls(
+          original_name, param_index, specialized_names, it.value());
+    }
+    else if (node.is_array())
+    {
+      for (auto &element : node)
+        rewrite_specialized_calls(
+          original_name, param_index, specialized_names, element);
+    }
+  }
+
+  void apply_pending_specializations()
+  {
+    for (const auto &spec : pending_specializations_)
+    {
+      const std::string &func_name = spec.function_name;
+      size_t param_index = spec.param_index;
+
+      Json original_function;
+      bool found = false;
+      size_t original_index = 0;
+      size_t idx = 0;
+      for (const auto &node : ast_["body"])
+      {
+        if (node.contains("_type") && node["_type"] == "FunctionDef" &&
+            node.contains("name") && node["name"] == func_name)
+        {
+          original_function = node;
+          found = true;
+          original_index = idx;
+          break;
+        }
+        ++idx;
+      }
+
+      if (!found)
+        continue;
+
+      if (!spec.class_types.empty())
+      {
+        for (auto &node : ast_["body"])
+        {
+          if (
+            node.contains("_type") && node["_type"] == "FunctionDef" &&
+            node.contains("name") && node["name"] == func_name &&
+            node.contains("args") && node["args"].is_object() &&
+            node["args"].contains("args") && node["args"]["args"].is_array() &&
+            param_index < node["args"]["args"].size())
+          {
+            Json &param = node["args"]["args"][param_index];
+            add_parameter_annotation(param, spec.class_types.front());
+            break;
+          }
+        }
+      }
+
+      std::unordered_map<std::string, std::string> specialized_names;
+      Json specialized_nodes = Json::array();
+      for (const auto &class_name : spec.class_types)
+      {
+        Json specialized = original_function;
+        const std::string specialized_name =
+          build_specialized_function_name(func_name, class_name);
+        specialized["name"] = specialized_name;
+
+        if (specialized.contains("args") && specialized["args"].is_object() &&
+            specialized["args"].contains("args") &&
+            specialized["args"]["args"].is_array() &&
+            param_index < specialized["args"]["args"].size())
+        {
+          Json &param = specialized["args"]["args"][param_index];
+          add_parameter_annotation(param, class_name);
+        }
+
+        specialized_names[class_name] = specialized_name;
+        specialized_nodes.push_back(std::move(specialized));
+      }
+
+      auto insert_it = ast_["body"].begin() + static_cast<ptrdiff_t>(original_index + 1);
+      ast_["body"].insert(
+        insert_it, specialized_nodes.begin(), specialized_nodes.end());
+
+      rewrite_specialized_calls(func_name, param_index, specialized_names, ast_);
+    }
+
+    pending_specializations_.clear();
   }
 
   // Returns the ancestors of a class (including itself) in BFS order via
@@ -3782,4 +4024,11 @@ private:
   std::set<std::string> resolving_rhs_vars_;
   std::string current_func_name_context_;
   std::string current_class_name_;
+  struct pending_specializationt
+  {
+    std::string function_name;
+    size_t param_index;
+    std::vector<std::string> class_types;
+  };
+  std::vector<pending_specializationt> pending_specializations_;
 };


### PR DESCRIPTION
- Promotes regression/python/polymorphism02/test.desc from KNOWNBUG to CORE.
- Fixes Python frontend type inference/annotation for polymorphic calls with multiple concrete classes at the same call site.
- Generates specialized versions of the target function per concrete type and rewrites calls to those specialized variants.