### PR TITLE
[k-induction] diagnose unresolved properties on VERIFICATION UNKNOWN

### DIFF
--- a/regression/loop-invariants/multi_property_unknown_diagnosis/main.c
+++ b/regression/loop-invariants/multi_property_unknown_diagnosis/main.c
@@ -1,0 +1,38 @@
+/* --multi-property --loop-invariant with an incomplete invariant that leaves
+ * the post-loop assertion unprovable by k-induction.
+ *
+ * The loop invariants cover the ranges of sum, bound2, and idx2, but omit
+ * the relational invariant (sum % bound2 == idx2 % bound2).  Without it the
+ * inductive step cannot discharge the post-loop assertion, so the result is
+ * VERIFICATION UNKNOWN.
+ *
+ * When UNKNOWN is reached, ESBMC should run a per-VCC diagnostic pass and
+ * identify the specific unresolved property by name.
+ *
+ * Regression test for GitHub issue #4022.
+ */
+
+int main()
+{
+  int bound2, idx2, sum;
+  idx2 = 0;
+  __ESBMC_assume(0 <= sum && sum < 256);
+  __ESBMC_assume(4 <= bound2 && bound2 < 256);
+  __ESBMC_assume(0 <= idx2 && idx2 <= bound2);
+  __ESBMC_assume(256 % bound2 == 0);
+  __ESBMC_assume((sum % bound2) == idx2 % bound2);
+
+  /* Range invariants only — relational invariant intentionally omitted */
+  __ESBMC_loop_invariant(0 <= sum && sum < 256);
+  __ESBMC_loop_invariant(4 <= bound2 && bound2 < 256);
+  __ESBMC_loop_invariant(0 <= idx2 && idx2 <= bound2);
+  __ESBMC_loop_invariant(256 % bound2 == 0);
+
+  while(idx2 < bound2)
+  {
+    sum = (sum + 1) % 256;
+    ++idx2;
+  }
+  __ESBMC_assert((sum % bound2) == (idx2 % bound2), "post loop modular equality");
+  return 0;
+}

--- a/regression/loop-invariants/multi_property_unknown_diagnosis/test.desc
+++ b/regression/loop-invariants/multi_property_unknown_diagnosis/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks --loop-invariant --multi-property --max-k-step 2
+^VERIFICATION UNKNOWN$
+\? UNKNOWN.*post loop modular equality

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1681,8 +1681,7 @@ smt_convt::resultt bmct::multi_property_check(
       {
         if (is)
           // Inductive step could not prove this claim - show in yellow
-          log_status(
-            "{}? UNKNOWN{}: '{}'", YELLOW, RESET, claim.claim_cstr);
+          log_status("{}? UNKNOWN{}: '{}'", YELLOW, RESET, claim.claim_cstr);
         else
           // Claim failed (counterexample found) - show in red
           log_status("{}✗ FAILED{}: '{}'", RED, RESET, claim.claim_cstr);

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -988,6 +988,10 @@ void bmct::report_result(smt_convt::resultt &res)
   // k-induction prints its own messages
   if (options.get_bool_option("k-induction-parallel"))
     return;
+  // Diagnostic pass: per-property results are already printed by
+  // multi_property_check; suppress any global verdict from this level.
+  if (options.get_bool_option("diagnose-unknown-properties"))
+    return;
 
   bool bs = options.get_bool_option("base-case");
   bool fc = options.get_bool_option("forward-condition");

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1369,7 +1369,8 @@ smt_convt::resultt bmct::run_thread(std::shared_ptr<symex_target_equationt> &eq)
 
     if (
       options.get_bool_option("multi-property") &&
-      options.get_bool_option("base-case"))
+      (options.get_bool_option("base-case") ||
+       options.get_bool_option("diagnose-unknown-properties")))
       return multi_property_check(
         *eq, solver_result.remaining_claims, *runtime_solver);
 
@@ -1465,11 +1466,6 @@ smt_convt::resultt bmct::multi_property_check(
   size_t remaining_claims,
   smt_convt &runtime_solver)
 {
-  // As of now, it only makes sense to do this for the base-case
-  assert(
-    options.get_bool_option("base-case") &&
-    "Multi-property only supports base-case");
-
   // Initial values
   smt_convt::resultt final_result = smt_convt::P_UNSATISFIABLE;
   std::mutex result_mutex;
@@ -1531,6 +1527,7 @@ smt_convt::resultt bmct::multi_property_check(
 
   // For color output
   bool is_color = options.get_bool_option("color");
+  const std::string YELLOW = is_color ? "\033[33m" : "";
 
   // TODO: This is the place to check a cache
   for (size_t i = 1; i <= remaining_claims; i++)
@@ -1573,6 +1570,7 @@ smt_convt::resultt bmct::multi_property_check(
                        &fc,
                        &is,
                        &is_color,
+                       &YELLOW,
                        &runtime_solver](const size_t &i) {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
@@ -1681,8 +1679,13 @@ smt_convt::resultt bmct::multi_property_check(
       }
       else if (solver_result == smt_convt::P_SATISFIABLE)
       {
-        // Claim failed - show in red
-        log_status("{}✗ FAILED{}: '{}'", RED, RESET, claim.claim_cstr);
+        if (is)
+          // Inductive step could not prove this claim - show in yellow
+          log_status(
+            "{}? UNKNOWN{}: '{}'", YELLOW, RESET, claim.claim_cstr);
+        else
+          // Claim failed (counterexample found) - show in red
+          log_status("{}✗ FAILED{}: '{}'", RED, RESET, claim.claim_cstr);
       }
     }
 
@@ -1698,13 +1701,27 @@ smt_convt::resultt bmct::multi_property_check(
       old_total_time_s, new_total_time_s));
 
     if (solver_result == smt_convt::P_SATISFIABLE)
-      summary.failed_properties++;
+    {
+      if (is)
+        summary.unknown_properties++;
+      else
+        summary.failed_properties++;
+    }
     else if (solver_result == smt_convt::P_UNSATISFIABLE)
       summary.passed_properties++;
 
     // If an assertion instance is verified to be violated
     if (solver_result == smt_convt::P_SATISFIABLE)
     {
+      // Inductive step SAT means unprovable (UNKNOWN), not a real
+      // counterexample — skip trace generation and return early.
+      if (is)
+      {
+        std::lock_guard lock(result_mutex);
+        final_result = solver_result;
+        return;
+      }
+
       bool is_compact_trace = true;
       if (
         options.get_bool_option("no-slice") &&
@@ -1858,6 +1875,13 @@ void bmct::report_simple_summary(const SimpleSummary &summary) const
   if (summary.failed_properties > 0)
     properties_oss << ", " << RED << "✗ " << summary.failed_properties
                    << " failed" << RESET;
+
+  if (summary.unknown_properties > 0)
+  {
+    const std::string YELLOW = is_color ? "\033[33m" : "";
+    properties_oss << ", " << YELLOW << "? " << summary.unknown_properties
+                   << " unknown" << RESET;
+  }
 
   // Build the timing summary string
   double avg_time = summary.total_properties > 0

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -127,6 +127,7 @@ private:
     std::atomic<size_t> skipped_properties = 0;
     std::atomic<size_t> simplified_properties = 0;
     std::atomic<size_t> failed_properties = 0;
+    std::atomic<size_t> unknown_properties = 0;
     std::atomic<double> total_time_s = 0.0;
     std::string solver_name;
     std::once_flag solver_name_flag;

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1457,6 +1457,9 @@ int esbmc_parseoptionst::do_bmc_strategy(
     }
   }
 
+  if (options.get_bool_option("multi-property") && options.get_bool_option("k-induction"))
+    diagnose_unknown_properties(options, goto_functions, max_k_step);
+
   log_status("Unable to prove or falsify the program, giving up.");
   log_fail("VERIFICATION UNKNOWN");
 
@@ -3069,4 +3072,32 @@ void esbmc_parseoptionst::help()
     else
       fmt::print(stderr, "{}\n", colorize_flag_refs(line));
   }
+}
+
+// When k-induction exhausts all k-steps without a definitive result, run one
+// final per-VCC inductive-step check at the last k to identify which specific
+// properties could not be resolved, without impacting the main k-induction loop.
+void esbmc_parseoptionst::diagnose_unknown_properties(
+  optionst &options,
+  goto_functionst &goto_functions,
+  const uint64_t k_step)
+{
+  if (options.get_bool_option("disable-inductive-step"))
+    return;
+
+  options.set_option("base-case", false);
+  options.set_option("forward-condition", false);
+  options.set_option("inductive-step", true);
+  options.set_option("no-unwinding-assertions", true);
+  options.set_option("partial-loops", true);
+  options.set_option("unwind", integer2string(k_step));
+  options.set_option("diagnose-unknown-properties", true);
+
+  bmct bmc(goto_functions, options, context);
+
+  log_progress(
+    "\nDiagnosing unresolved properties (inductive step, k = {:d}):", k_step);
+  do_bmc(bmc);
+
+  options.set_option("diagnose-unknown-properties", false);
 }

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1352,9 +1352,11 @@ int esbmc_parseoptionst::do_bmc_strategy(
   };
 
   // Trying all bounds from 1 to "max_k_step" in "k_step_inc"
+  uint64_t last_k_step = k_step_base;
   for (uint64_t k_step = k_step_base; k_step <= max_k_step;
        k_step += k_step_inc)
   {
+    last_k_step = k_step;
     // k-induction
     if (options.get_bool_option("k-induction"))
     {
@@ -1460,7 +1462,7 @@ int esbmc_parseoptionst::do_bmc_strategy(
   if (
     options.get_bool_option("multi-property") &&
     options.get_bool_option("k-induction"))
-    diagnose_unknown_properties(options, goto_functions, max_k_step);
+    diagnose_unknown_properties(options, goto_functions, last_k_step);
 
   log_status("Unable to prove or falsify the program, giving up.");
   log_fail("VERIFICATION UNKNOWN");
@@ -3087,6 +3089,21 @@ void esbmc_parseoptionst::diagnose_unknown_properties(
   if (options.get_bool_option("disable-inductive-step"))
     return;
 
+  // Mirror the guards used by is_inductive_step_violated in the main loop:
+  // inductive step is skipped for k==1 and capped by --max-inductive-step.
+  if (k_step <= 1)
+    return;
+  if (strtoul(cmdline.getval("max-inductive-step"), nullptr, 10) < k_step)
+    return;
+
+  const bool saved_base_case = options.get_bool_option("base-case");
+  const bool saved_forward_condition =
+    options.get_bool_option("forward-condition");
+  const bool saved_inductive_step = options.get_bool_option("inductive-step");
+  const bool saved_no_unwinding = options.get_bool_option("no-unwinding-assertions");
+  const bool saved_partial_loops = options.get_bool_option("partial-loops");
+  const std::string saved_unwind = options.get_option("unwind");
+
   options.set_option("base-case", false);
   options.set_option("forward-condition", false);
   options.set_option("inductive-step", true);
@@ -3101,5 +3118,11 @@ void esbmc_parseoptionst::diagnose_unknown_properties(
     "\nDiagnosing unresolved properties (inductive step, k = {:d}):", k_step);
   do_bmc(bmc);
 
+  options.set_option("base-case", saved_base_case);
+  options.set_option("forward-condition", saved_forward_condition);
+  options.set_option("inductive-step", saved_inductive_step);
+  options.set_option("no-unwinding-assertions", saved_no_unwinding);
+  options.set_option("partial-loops", saved_partial_loops);
+  options.set_option("unwind", saved_unwind);
   options.set_option("diagnose-unknown-properties", false);
 }

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1457,7 +1457,9 @@ int esbmc_parseoptionst::do_bmc_strategy(
     }
   }
 
-  if (options.get_bool_option("multi-property") && options.get_bool_option("k-induction"))
+  if (
+    options.get_bool_option("multi-property") &&
+    options.get_bool_option("k-induction"))
     diagnose_unknown_properties(options, goto_functions, max_k_step);
 
   log_status("Unable to prove or falsify the program, giving up.");

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -3100,7 +3100,8 @@ void esbmc_parseoptionst::diagnose_unknown_properties(
   const bool saved_forward_condition =
     options.get_bool_option("forward-condition");
   const bool saved_inductive_step = options.get_bool_option("inductive-step");
-  const bool saved_no_unwinding = options.get_bool_option("no-unwinding-assertions");
+  const bool saved_no_unwinding =
+    options.get_bool_option("no-unwinding-assertions");
   const bool saved_partial_loops = options.get_bool_option("partial-loops");
   const std::string saved_unwind = options.get_option("unwind");
 

--- a/src/esbmc/esbmc_parseoptions.h
+++ b/src/esbmc/esbmc_parseoptions.h
@@ -90,6 +90,11 @@ protected:
     goto_functionst &goto_functions,
     const uint64_t &k_step);
 
+  void diagnose_unknown_properties(
+    optionst &options,
+    goto_functionst &goto_functions,
+    uint64_t k_step);
+
   bool read_goto_binary(goto_functionst &goto_functions);
 
   bool set_claims(goto_functionst &goto_functions);


### PR DESCRIPTION
Fixes #4022.

## Summary

When `--multi-property --k-induction` exhausts all k-steps without a definitive result, ESBMC now runs a targeted diagnostic pass to identify which specific properties remain unresolved, instead of just reporting `VERIFICATION UNKNOWN`. Each property is individually reported as **PASSED** or **UNKNOWN**, so users can identify exactly which assertion or invariant is blocking the proof.

---

## Changes

### New diagnostic function
- Added `diagnose_unknown_properties()` in `esbmc_parseoptions.cpp` and its declaration in `esbmc_parseoptions.h`
- Runs a per-VCC inductive-step check at the final k-step when k-induction is inconclusive
- Triggered only at the `VERIFICATION UNKNOWN` exit point — the main k-induction loop is unchanged and SV-COMP performance is not affected

### Multi-property check improvements (`bmc.cpp` / `bmc.h`)
- Removed the `base-case`-only restriction in `multi_property_check()` so it can also run during the diagnostic inductive-step pass
- Distinguished between **failed** properties (real counterexample found, shown in red `✗`) and **unknown** properties (inductive step unprovable, shown in yellow `?`)
- Added `unknown_properties` counter to `SimpleSummary` and updated the summary output to display it

### Regression test
- Added `regression/loop-invariants/multi_property_unknown_diagnosis/` for #4022
- The test has intentionally incomplete loop invariants (relational invariant omitted), making the post-loop assertion unprovable in 2 k-steps
- Verifies that the output contains `VERIFICATION UNKNOWN` and `? UNKNOWN: 'post loop modular equality'`

---

## Testing

```
--no-standard-checks --loop-invariant --multi-property --max-k-step 2
```

Expected output:
```
VERIFICATION UNKNOWN
? UNKNOWN: 'post loop modular equality'
```