### PR TITLE
[solver] implement quantifier support in Bitwuzla backend

### DIFF
--- a/regression/bitwuzla/quantifiers-exists/main.c
+++ b/regression/bitwuzla/quantifiers-exists/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int value;
+  __ESBMC_assert(__ESBMC_exists(&value, value == 42), "exists 42");
+  __ESBMC_assert(
+    !__ESBMC_exists(&value, value == 0 && value == 1), "contradiction");
+  return 0;
+}

--- a/regression/bitwuzla/quantifiers-exists/test.desc
+++ b/regression/bitwuzla/quantifiers-exists/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/quantifiers-hello-false/main.c
+++ b/regression/bitwuzla/quantifiers-hello-false/main.c
@@ -1,0 +1,9 @@
+
+int main()
+{
+  int non_zero_array[10];
+  int sym;
+  __ESBMC_assert(
+    __ESBMC_forall(&sym, !(sym >= 0 && sym < 10) || non_zero_array[sym] == 0),
+    "array is zero initialized");
+}

--- a/regression/bitwuzla/quantifiers-hello-false/test.desc
+++ b/regression/bitwuzla/quantifiers-hello-false/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--bitwuzla
+^VERIFICATION FAILED$

--- a/regression/bitwuzla/quantifiers-hello/main.c
+++ b/regression/bitwuzla/quantifiers-hello/main.c
@@ -1,0 +1,26 @@
+int zero_array[10];
+
+int main()
+{
+  int sym;
+  __ESBMC_assert(
+    __ESBMC_forall(&sym, !(sym >= 0 && sym < 10) || zero_array[sym] == 0),
+    "array is zero initialized");
+
+  const unsigned N = 10;
+  unsigned i = 0;
+  char c[N];
+
+  for (i = 0; i < N; ++i)
+    c[i] = i;
+
+  unsigned j;
+  __ESBMC_assert(
+    __ESBMC_forall(&j, j > 9 || c[j] == j), "array is initialized correctly");
+
+  int value;
+  __ESBMC_assert(__ESBMC_exists(&value, value == 0), "can be anything");
+  __ESBMC_assert(__ESBMC_exists(&value, value == 1), "can be anything 2");
+  __ESBMC_assert(
+    !__ESBMC_exists(&value, value == 0 && value == 1), "contradiction");
+}

--- a/regression/bitwuzla/quantifiers-hello/test.desc
+++ b/regression/bitwuzla/quantifiers-hello/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/regression/bitwuzla/quantifiers-nested/main.c
+++ b/regression/bitwuzla/quantifiers-nested/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int a, b;
+  /* forall a b: (a == b) || (b == 17) — false when a=0, b=0 */
+  __ESBMC_assert(
+    __ESBMC_forall(&a, __ESBMC_forall(&b, (a == b) || (b == 17))) == 0,
+    "nested forall should be false");
+  return 0;
+}

--- a/regression/bitwuzla/quantifiers-nested/test.desc
+++ b/regression/bitwuzla/quantifiers-nested/test.desc
@@ -1,0 +1,4 @@
+THOROUGH
+main.c
+--bitwuzla
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -975,11 +975,42 @@ smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 }
 
 smt_astt bitwuzla_convt::mk_quantifier(
-  [[maybe_unused]] bool is_forall,
-  [[maybe_unused]] std::vector<smt_astt> lhs,
-  [[maybe_unused]] smt_astt rhs)
+  bool is_forall,
+  std::vector<smt_astt> lhs,
+  smt_astt rhs)
 {
-  log_error("Bitwuzla does not support quantifiers");
-  abort();
-  return nullptr;
+  std::vector<BitwuzlaTerm> original_terms;
+  std::vector<BitwuzlaTerm> bound_vars;
+  original_terms.reserve(lhs.size());
+  bound_vars.reserve(lhs.size());
+
+  for (size_t i = 0; i < lhs.size(); i++)
+  {
+    BitwuzlaTerm orig = to_solver_smt_ast<bitw_smt_ast>(lhs[i])->a;
+    original_terms.push_back(orig);
+    std::string name =
+      "qvar_" + std::to_string(quantifier_counter) + "_" + std::to_string(i);
+    bound_vars.push_back(bitwuzla_mk_var(
+      bitw_term_manager, bitwuzla_term_get_sort(orig), name.c_str()));
+  }
+
+  // Substitute SSA terms with bound vars in the body.
+  // Args to bitwuzla_mk_term: [var0, ..., varN-1, body] — no VARIABLE_LIST
+  // wrapper needed (unlike CVC5).
+  BitwuzlaTerm body = bitwuzla_substitute_term(
+    to_solver_smt_ast<bitw_smt_ast>(rhs)->a,
+    original_terms.size(),
+    original_terms.data(),
+    bound_vars.data());
+
+  std::vector<BitwuzlaTerm> args(bound_vars);
+  args.push_back(body);
+
+  return new_ast(
+    bitwuzla_mk_term(
+      bitw_term_manager,
+      is_forall ? BITWUZLA_KIND_FORALL : BITWUZLA_KIND_EXISTS,
+      static_cast<uint32_t>(args.size()),
+      args.data()),
+    rhs->sort);
 }


### PR DESCRIPTION
Replace the abort()-stub in bitwuzla_convt::mk_quantifier with a real implementation using the Bitwuzla C API: create fresh bound variables with bitwuzla_mk_var, substitute the SSA terms in the body with bitwuzla_substitute_term, then build the FORALL/EXISTS term directly with bitwuzla_mk_term (no VARIABLE_LIST wrapper, unlike CVC5).

Add four regression tests covering forall, exists, a counterexample case, and nested quantifiers.