### PR TITLE
[ir-ra] add theorem-driven RNA interval lifting for ieee_mul

### DIFF
--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh-single/main.c
@@ -1,0 +1,38 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_mul --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rna-mul-both-fresh but exercises the
+ * single-precision (float) path. Verifies point-interval fallback for fresh
+ * operands under RNA.
+ *
+ * PROOF SHAPE (point-interval fallback, single precision RNA)
+ * -----------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNA mul).
+ *   lo_r = hi_r = x_smt * y_smt = real_z
+ * The helper receives lo_r == hi_r, producing tight RNA enclosure.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_aw::   -- RNA tight path taken
+ *   ra_hi_aw::   -- RNA tight path taken
+ *   (ite          -- |r| absolute value present
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single, same as RNE)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x * y exactly. */
+  assert(z != x * y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh/main.c
@@ -1,0 +1,45 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_mul --
+ * both operands fresh (zero-regression sentinel).
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of an RNA ieee_mul are fresh nondet
+ * variables (not in ir_ra_interval_map), the point-interval fallback
+ * applies to both, and the resulting formula uses the RNA enclosure over the
+ * degenerate hull lo_r = hi_r = real_z.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step RNA)
+ * -------------------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNA mul).
+ *   iv(x) = {x_smt, x_smt}  (point fallback)
+ *   iv(y) = {y_smt, y_smt}  (point fallback)
+ *   p1=p2=p3=p4 = x_smt * y_smt = real_z
+ *   lo_r = hi_r = real_z
+ * The helper receives lo_r == hi_r, producing:
+ *   ra_lo_aw = real_z - B_near(real_z)
+ *   ra_hi_aw = real_z + B_near(real_z)
+ * This is structurally equivalent to the pre-lifting single-step RNA formula.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_aw::   -- RNA tight path taken
+ *   ra_hi_aw::   -- RNA tight path taken
+ *   (ite          -- |r| absolute value present
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double, same as RNE)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* both fresh -> point fallback -> single-step equivalent */
+
+  /* Always false in real/integer encoding: z == x * y exactly. */
+  assert(z != x * y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_aw::[0-9]+\| \(\) Real\)
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked-single/main.c
@@ -1,0 +1,46 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_mul --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rna-mul-both-tracked but exercises the
+ * single-precision (float) path. Verifies that both-tracked lookup fires
+ * and the mul hull is computed from four endpoint products under RNA.
+ *
+ * PROOF SHAPE (B_near, RNA, single precision)
+ * -------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point-interval fallback; stored)
+ *   ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second mul:  w = z * z  (both operands tracked -> full lift)
+ *   p1 = ra_lo_aw::0 * ra_lo_aw::0
+ *   p2 = ra_lo_aw::0 * ra_hi_aw::0  (= p3)
+ *   p4 = ra_hi_aw::0 * ra_hi_aw::0
+ *   lo_r = min(p1,p2,p3,p4),  hi_r = max(p1,p2,p3,p4)
+ *   ra_lo_aw::1, ra_hi_aw::1 pinned with B_near (single eps, same as RNE)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_aw::0   -- first mul's interval lower bound declared
+ *   ra_lo_aw::1   -- second mul's lifted lower bound declared
+ *   (* |smt_conv::ra_lo_aw::0|  -- endpoint product in hull computation
+ *   (ite           -- nested ITE present
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single, same as RNE)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* first RNA mul: both fresh -> point fallback; stored */
+  float w = z * z; /* second RNA mul: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z * z exactly. */
+  assert(w != z * z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_lo_aw::0\|
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked/main.c
@@ -1,0 +1,54 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_mul --
+ * both operands tracked.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RNA ieee_mul were themselves
+ * results of a prior tracked RNA ieee_mul, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RNA multiplication path is taken.
+ *
+ * PROOF SHAPE (B_near, RNA, double precision)
+ * -------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   p1=p2=p3=p4 = x * y = real_z
+ *   ra_lo_aw::0 = real_z - B_near(real_z)
+ *   ra_hi_aw::0 = real_z + B_near(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second mul:  w = z * z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_aw::0, ra_hi_aw::0}  (found in map, same entry twice)
+ *   p1 = ra_lo_aw::0 * ra_lo_aw::0
+ *   p2 = ra_lo_aw::0 * ra_hi_aw::0
+ *   p3 = ra_hi_aw::0 * ra_lo_aw::0
+ *   p4 = ra_hi_aw::0 * ra_hi_aw::0
+ *   lo_r = min(p1,p2,p3,p4) via nested ITE
+ *   hi_r = max(p1,p2,p3,p4) via nested ITE
+ *   ra_lo_aw::1 = lo_r - B_near(lo_r)
+ *   ra_hi_aw::1 = hi_r + B_near(hi_r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_aw::0   -- first mul's interval lower bound declared
+ *   ra_lo_aw::1   -- second mul's lifted lower bound declared
+ *   (* |smt_conv::ra_lo_aw::0|  -- endpoint product in hull computation
+ *   (ite           -- nested ITE for min/max hull and absolute value
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double, same as RNE)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* first RNA mul: both fresh -> point fallback; stored */
+  double w = z * z; /* second RNA mul: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z * z exactly. */
+  assert(w != z * z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-both-tracked/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_aw::0\| \|smt_conv::ra_lo_aw::0\|
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh-single/main.c
@@ -1,0 +1,41 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_mul --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-rna-mul-one-fresh but exercises the
+ * single-precision (float) path. Verifies the mixed lookup path: when one
+ * operand of a second RNA ieee_mul is tracked and the other is fresh.
+ *
+ * PROOF SHAPE (B_near, RNA, single precision)
+ * -------------------------------------------
+ * Second mul:  w = z * x  (z tracked, x fresh -> mixed path)
+ *   lo_r = min(ra_lo_aw::0 * x_smt, ra_hi_aw::0 * x_smt)
+ *   hi_r = max(ra_lo_aw::0 * x_smt, ra_hi_aw::0 * x_smt)
+ *   ra_lo_aw::1, ra_hi_aw::1 pinned with B_near (single eps, same as RNE)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_aw::0   -- first mul's interval lower bound declared
+ *   ra_lo_aw::1   -- second mul's mixed-path lower bound declared
+ *   (* |smt_conv::ra_lo_aw::0|  -- tracked endpoint in hull product
+ *   (ite           -- nested ITE present
+ *   5960464477539063  -- Z3 numerator for eps_rel = 2^-24 (single, same as RNE)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* first RNA mul: both fresh -> point fallback; stored */
+  float w = z * x; /* second RNA mul: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z * x exactly. */
+  assert(w != z * x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_aw::0\|
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh/main.c
@@ -1,0 +1,51 @@
+/* Regression test: RNA (ROUND_TO_AWAY) interval lifting for ieee_mul --
+ * one tracked, one fresh.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RNA ieee_mul: when one operand of a
+ * second RNA ieee_mul is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_near, RNA, double precision)
+ * -------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_aw::0, ra_hi_aw::0}
+ *
+ * Second mul:  w = z * x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_aw::0, ra_hi_aw::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   p1 = ra_lo_aw::0 * x_smt
+ *   p2 = ra_lo_aw::0 * x_smt  (= p1, iv(x) is a point)
+ *   p3 = ra_hi_aw::0 * x_smt
+ *   p4 = ra_hi_aw::0 * x_smt  (= p3)
+ *   lo_r = min(p1,p3),  hi_r = max(p1,p3)  via ITE on sign of x
+ *   ra_lo_aw::1 = lo_r - B_near(lo_r)
+ *   ra_hi_aw::1 = hi_r + B_near(hi_r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_aw::0   -- first mul's interval lower bound declared
+ *   ra_lo_aw::1   -- second mul's mixed-path lower bound declared
+ *   (* |smt_conv::ra_lo_aw::0|  -- tracked endpoint in hull product
+ *   (ite           -- nested ITE for min/max hull and absolute value
+ *   5551115123125783  -- Z3 numerator for eps_rel = 2^-53 (double, same as RNE)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 1; /* ROUND_TO_AWAY */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* first RNA mul: both fresh -> point fallback; stored */
+  double w = z * x; /* second RNA mul: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z * x exactly. */
+  assert(w != z * x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-rna-mul-one-fresh/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_aw::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_aw::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_aw::0\|
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1793,13 +1793,14 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       const expr2tc &rounding_mode = to_ieee_mul2t(expr).rounding_mode;
 
-      // RNE interval lifting for ieee_mul.
+      // RNE/RNA interval lifting for ieee_mul.
       // Hull: lo_r = min(p1,p2,p3,p4), hi_r = max(p1,p2,p3,p4)
       // where p1=L_x*L_y, p2=L_x*U_y, p3=U_x*L_y, p4=U_x*U_y.
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
-        is_nearest_rounding_mode(rounding_mode))
+        (is_nearest_rounding_mode(rounding_mode) ||
+         is_round_to_away(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1843,7 +1844,9 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
               mk_ite(mk_le(p4, p2), p2, p4),
               mk_ite(mk_le(p4, p3), p3, p4)));
           std::pair<smt_astt, smt_astt> bounds =
-            apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
+            is_nearest_rounding_mode(rounding_mode)
+              ? apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type)
+              : apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RNA interval lifting for `ieee_mul`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- added theorem-driven RNE and RNA interval lifting for `ieee_add`
- added theorem-driven RNE and RNA interval lifting for `ieee_sub`
- added theorem-driven RNE interval lifting for `ieee_mul`

This PR adds the next smallest sound step:

- theorem-driven RNA interval lifting for `ieee_mul`

## Main idea

For multiplication, let:

- `R = hull(X * Y) = [L_R, U_R]`

As in the existing `ieee_mul` interval-lifted path, the multiplication hull is computed in real arithmetic from the four endpoint products:

- `p1 = L_x * L_y`
- `p2 = L_x * U_y`
- `p3 = U_x * L_y`
- `p4 = U_x * U_y`

Then:

- `L_R = min(p1, p2, p3, p4)`
- `U_R = max(p1, p2, p3, p4)`

For nearest modes, the proof uses the same interval form for RNE and RNA. So for round-to-away:

- `EbRNA(X * Y) = [L_R - B_near^-(R), U_R + B_near^+(R)]`

where:

- `B_near^-(R) = eps_rel_near * |L_R| + eps_abs`
- `B_near^+(R) = eps_rel_near * |U_R| + eps_abs`

So this PR reuses the existing 4-corner multiplication hull unchanged, and only switches the final nearest-mode enclosure from the RNE helper to the RNA helper when the rounding mode is `ROUND_TO_AWAY`.

## Main changes

- extend the `ieee_mul` path under `--ir-ieee` to cover `ROUND_TO_AWAY` in addition to the existing RNE path
- keep the existing multiplication hull computation unchanged:
  - `L_R = min(p1, p2, p3, p4)`
  - `U_R = max(p1, p2, p3, p4)`
- dispatch to `apply_ieee754_rna_enclosure` for `ROUND_TO_AWAY`
- reuse the existing `ir_ra_interval_map`
- keep the existing tracked/fresh operand handling unchanged
- keep directed modes on the existing path
- keep `ieee_add`, `ieee_sub`, and `ieee_div` unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-rna-mul-both-fresh`
- `ra-interval-lift-rna-mul-one-fresh`
- `ra-interval-lift-rna-mul-both-tracked`
- `ra-interval-lift-rna-mul-both-fresh-single`
- `ra-interval-lift-rna-mul-one-fresh-single`
- `ra-interval-lift-rna-mul-both-tracked-single`

This was also checked against the existing `ir-ra` regressions.

## Scope

This PR implements only:

- theorem-driven RNA interval lifting for `ieee_mul`

The following remain out of scope:

- directed-mode interval lifting for `ieee_mul`
- RTZ interval lifting for `ieee_mul`
- `ieee_div` interval lifting
- full IEEE corner-case support (NaN, infinities, signed zero, comparison semantics)
- full DAG-level compositional propagation beyond the current tracked interval flow