### PR TITLE
python: cast integer operands before binary expressions

### DIFF
--- a/regression/python/int_subclass/main.py
+++ b/regression/python/int_subclass/main.py
@@ -1,0 +1,12 @@
+class uint256(int):
+    pass
+
+
+MOD = 123
+
+
+def foo(x: uint256):
+    return x % MOD
+
+
+assert foo(uint256(5)) == 5

--- a/regression/python/int_subclass/test.desc
+++ b/regression/python/int_subclass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2186,7 +2186,6 @@ exprt python_converter::build_binary_expression(
       return 1;
     return static_cast<const bv_typet &>(t).get_width();
   };
-
   // Adjust types for non-relational operations
   if (!type_utils::is_relational_op(op))
   {
@@ -2196,11 +2195,17 @@ exprt python_converter::build_binary_expression(
 
     // Check for bitvector width mismatch
     if (
-      (lhs_type.is_signedbv() || lhs_type.is_unsignedbv()) &&
-      (rhs_type.is_signedbv() || rhs_type.is_unsignedbv()) &&
-      lhs_type.width() != rhs_type.width())
+      is_bv_or_bool(lhs_type) && is_bv_or_bool(rhs_type) &&
+      (bit_width(lhs_type) != bit_width(rhs_type) ||
+       lhs_type.is_signedbv() != rhs_type.is_signedbv()))
     {
-      adjust_statement_types(lhs, rhs);
+      const typet &target_type =
+        bit_width(lhs_type) >= bit_width(rhs_type) ? lhs_type : rhs_type;
+
+      if (lhs.type() != target_type)
+        lhs = typecast_exprt(lhs, target_type);
+      if (rhs.type() != target_type)
+        rhs = typecast_exprt(rhs, target_type);
     }
   }
   else if (


### PR DESCRIPTION
This PR fixes a crash when converting binary expressions whose operands have different widths.

Example:
  ```python
  y = 123
  def f(x: uint256):
      return x % y

  assert f(uint256(5)) == 5
```

ESBMC was aborting during GOTO generation with:
```text
  arith_2ops::arith_2ops(...): Assertion `p1 || (is_bv_type(t) == is_bv_type(v2->type) && t->get_width() == v2->type->get_width())' failed
```
This change inserts casts to the larger type.
