### PR TITLE
[contracts] fix find_function_symbol for C++ functions

### DIFF
--- a/regression/function_contract/cpp_assigns_fail/main.cpp
+++ b/regression/function_contract/cpp_assigns_fail/main.cpp
@@ -1,0 +1,18 @@
+/* cpp_assigns_fail:
+ * --enforce-contract with assigns clause on a C++ free function.
+ * foo modifies 'y' which is NOT listed in __ESBMC_assigns(x), so
+ * assigns compliance must report a violation.
+ *
+ * Expected: VERIFICATION FAILED
+ */
+
+int x = 0;
+int y = 0;
+
+void foo(void)
+{
+  __ESBMC_assigns(x);
+  __ESBMC_ensures(x == 1);
+  x = 1;
+  y = 2; /* y is not in assigns — compliance fails */
+}

--- a/regression/function_contract/cpp_assigns_fail/test.desc
+++ b/regression/function_contract/cpp_assigns_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract foo --function foo
+^VERIFICATION FAILED$

--- a/regression/function_contract/cpp_assigns_pass/main.cpp
+++ b/regression/function_contract/cpp_assigns_pass/main.cpp
@@ -1,0 +1,18 @@
+/* cpp_assigns_pass:
+ * --enforce-contract with assigns clause on a C++ free function.
+ * foo only modifies 'x' which is listed in __ESBMC_assigns, so
+ * assigns compliance must pass.
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+
+int x = 0;
+int y = 0;
+
+void foo(void)
+{
+  __ESBMC_assigns(x);
+  __ESBMC_ensures(x == 1);
+  x = 1;
+  /* y is not modified — compliance passes */
+}

--- a/regression/function_contract/cpp_assigns_pass/test.desc
+++ b/regression/function_contract/cpp_assigns_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract foo --function foo
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/cpp_enforce_fail/main.cpp
+++ b/regression/function_contract/cpp_enforce_fail/main.cpp
@@ -1,0 +1,20 @@
+/* cpp_enforce_fail:
+ * --enforce-contract on a C++ free function.
+ * The ensures says counter == old(counter) + 2 but the body only does +1,
+ * so contract enforcement must report a violation.
+ *
+ * Regression for: find_function_symbol not trying the C++ USR suffix '#',
+ * which caused "Function X not found" and vacuous VERIFICATION SUCCESSFUL
+ * even when the ensures clause was clearly wrong.
+ *
+ * Expected: VERIFICATION FAILED
+ */
+
+int counter = 0;
+
+void increment(void)
+{
+  __ESBMC_requires(counter >= 0);
+  __ESBMC_ensures(counter == __ESBMC_old(counter) + 2);
+  counter++;
+}

--- a/regression/function_contract/cpp_enforce_fail/test.desc
+++ b/regression/function_contract/cpp_enforce_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract increment --function increment
+^VERIFICATION FAILED$

--- a/regression/function_contract/cpp_enforce_pass/main.cpp
+++ b/regression/function_contract/cpp_enforce_pass/main.cpp
@@ -1,0 +1,19 @@
+/* cpp_enforce_pass:
+ * --enforce-contract on a C++ free function.
+ * The ensures says counter == old(counter) + 1 and the body does exactly
+ * that, so contract enforcement must succeed.
+ *
+ * Regression for: find_function_symbol not trying the C++ USR suffix '#',
+ * which caused "Function X not found" and vacuous VERIFICATION SUCCESSFUL.
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+
+int counter = 0;
+
+void increment(void)
+{
+  __ESBMC_requires(counter >= 0);
+  __ESBMC_ensures(counter == __ESBMC_old(counter) + 1);
+  counter++;
+}

--- a/regression/function_contract/cpp_enforce_pass/test.desc
+++ b/regression/function_contract/cpp_enforce_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--enforce-contract increment --function increment
+^VERIFICATION SUCCESSFUL$

--- a/regression/function_contract/cpp_replace_fail/main.cpp
+++ b/regression/function_contract/cpp_replace_fail/main.cpp
@@ -1,0 +1,29 @@
+/* cpp_replace_fail:
+ * --replace-call-with-contract on a C++ free function.
+ * The contract says counter == old(counter) + 5 but the caller asserts
+ * counter == 1, which contradicts the assumed ensures clause.
+ *
+ * Regression for: matches_replace_pattern not stripping the trailing '#'
+ * from C++ USR symbol names and is_compiler_generated falsely treating
+ * C++ free functions as compiler-generated.  Both bugs prevented the call
+ * from being replaced, so the inline __ESBMC_ensures ASSUME silenced the
+ * assert and the result was wrongly VERIFICATION SUCCESSFUL.
+ *
+ * Expected: VERIFICATION FAILED
+ */
+
+int counter = 0;
+
+void increment(void)
+{
+  __ESBMC_requires(counter >= 0);
+  __ESBMC_ensures(counter == __ESBMC_old(counter) + 5);
+  counter++;
+}
+
+int main()
+{
+  increment();
+  __ESBMC_assert(counter == 1, "counter should be 1 (body ran)");
+  return 0;
+}

--- a/regression/function_contract/cpp_replace_fail/test.desc
+++ b/regression/function_contract/cpp_replace_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--replace-call-with-contract increment
+^VERIFICATION FAILED$

--- a/regression/function_contract/cpp_replace_pass/main.cpp
+++ b/regression/function_contract/cpp_replace_pass/main.cpp
@@ -1,0 +1,27 @@
+/* cpp_replace_pass:
+ * --replace-call-with-contract on a C++ free function.
+ * The contract correctly describes the body (counter += 1), so the caller's
+ * assertion counter == 1 must hold after replacement.
+ *
+ * Regression for: matches_replace_pattern not stripping the trailing '#'
+ * from C++ USR symbol names, causing zero replacements, and
+ * is_compiler_generated falsely skipping the call site due to '#' in name.
+ *
+ * Expected: VERIFICATION SUCCESSFUL
+ */
+
+int counter = 0;
+
+void increment(void)
+{
+  __ESBMC_requires(counter >= 0);
+  __ESBMC_ensures(counter == __ESBMC_old(counter) + 1);
+  counter++;
+}
+
+int main()
+{
+  increment();
+  __ESBMC_assert(counter == 1, "counter should be 1");
+  return 0;
+}

--- a/regression/function_contract/cpp_replace_pass/test.desc
+++ b/regression/function_contract/cpp_replace_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--replace-call-with-contract increment
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -97,8 +97,16 @@ bool code_contractst::is_compiler_generated(
   if (!function_name.empty() && function_name[0] == '~')
     return true;
 
-  // Skip functions with # in name (compiler-generated, e.g., exception destructors)
-  if (function_name.find('#') != std::string::npos)
+  // C++ free functions and methods are stored with a trailing '#' in the Clang
+  // USR encoding (e.g. "c:@F@foo#", "c:@S@MyClass@F@bar#").  Strip exactly
+  // one trailing '#' before the compiler-generated check so that user-defined
+  // C++ functions are not accidentally skipped.
+  std::string name = function_name;
+  if (!name.empty() && name.back() == '#')
+    name.pop_back();
+
+  // Skip functions with # remaining in name (compiler-generated, e.g., exception destructors)
+  if (name.find('#') != std::string::npos)
     return true;
 
   // Skip functions starting with __ESBMC_contracts_original_ (already processed)
@@ -3098,10 +3106,17 @@ static bool matches_replace_pattern(
     if (func_name == pattern)
       return true;
     // Match unqualified name: extract the part after the last '@'
-    // e.g. "c:@F@foo" → "foo"
+    // e.g. "c:@F@foo" → "foo", "c:@F@foo#" (C++ free func) → "foo"
     auto pos = func_name.rfind('@');
-    if (pos != std::string::npos && func_name.substr(pos + 1) == pattern)
-      return true;
+    if (pos != std::string::npos)
+    {
+      std::string tail = func_name.substr(pos + 1);
+      // Strip trailing '#' used by C++ free function symbols
+      if (!tail.empty() && tail.back() == '#')
+        tail.pop_back();
+      if (tail == pattern)
+        return true;
+    }
   }
   return false;
 }

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -118,8 +118,13 @@ symbolt *code_contractst::find_function_symbol(const std::string &function_name)
   symbolt *sym = context.find_symbol(function_name);
   if (sym != nullptr)
     return sym;
+  // C convention: c:@F@funcname
   std::string func_id = "c:@F@" + function_name;
-  return context.find_symbol(func_id);
+  sym = context.find_symbol(func_id);
+  if (sym != nullptr)
+    return sym;
+  // C++ convention: c:@F@funcname# (free function, no namespace/class)
+  return context.find_symbol(func_id + "#");
 }
 
 void code_contractst::rename_function(


### PR DESCRIPTION
This pull request adds regression tests and fixes several issues related to function contracts for C++ free functions, particularly around symbol name handling and contract enforcement. The changes ensure that C++ free functions are correctly recognized and processed when enforcing, replacing, or checking assigns clauses in contracts. Several new regression tests are introduced to verify both successful and failing cases for contract enforcement and replacement.

**Function contract bug fixes and improvements:**

* Updated `is_compiler_generated` to correctly handle C++ free function symbol names by stripping a single trailing `#` before checking for compiler-generated symbols, preventing user-defined functions from being skipped.
* Improved `find_function_symbol` to try both C and C++ USR naming conventions (including the trailing `#` for C++ free functions) when searching for function symbols, ensuring correct symbol resolution.
* Enhanced `matches_replace_pattern` to strip a trailing `#` from C++ free function symbols when matching against replacement patterns, fixing missed matches for user-defined functions.

**Regression tests for function contracts:**

* Added regression tests for `--enforce-contract` with `assigns` clauses, covering both passing and failing scenarios for C++ free functions (`cpp_assigns_pass` and `cpp_assigns_fail`). [[1]](diffhunk://#diff-47c4594d1527058b6c2b96e752bec23f8bf6ed848550e539660d539425853112R1-R18) [[2]](diffhunk://#diff-f11baa75947eeb3c7b19730461b8791e7826aac9d64ccd5cdf0cf2b78c5f20c6R1-R4) [[3]](diffhunk://#diff-356b841db665a12f6605a214de3663f4039dc853ac48f45ac2345b104edaf6d4R1-R18) [[4]](diffhunk://#diff-ddd551ee58feffd3a52960591313384f82879623558b59dcfe4f937b8ed046a8R1-R4)
* Added regression tests for contract enforcement and replacement, including cases where the ensures clause is correct or incorrect, and where call replacement should succeed or fail (`cpp_enforce_pass`, `cpp_enforce_fail`, `cpp_replace_pass`, `cpp_replace_fail`). [[1]](diffhunk://#diff-3c2f190e2cdb86e598dba4ffe211e318d08058763c8798fc87d54f1fefe2d6abR1-R19) [[2]](diffhunk://#diff-66e6dfa5caa696b57b1a5c28402767880ce298ec76a5ccf578a217eedb1f1be3R1-R4) [[3]](diffhunk://#diff-2cb0166758eec9ca5f89364efe136813bee15364e037579e387badab4d8b9b2dR1-R20) [[4]](diffhunk://#diff-9423022a85dd75306d0da02d0af124bcf2ac8a83ad866d3a668b2b96a7922626R1-R4) [[5]](diffhunk://#diff-4f7aa6a6e01cd5629b12567faf5db412a287d0ed2c4ad189364304ff3dbd829dR1-R27) [[6]](diffhunk://#diff-31dbdf0bc2a4775ac67ea863093ab182219842531467051273b17257da636a0aR1-R4) [[7]](diffhunk://#diff-b248ec49a74211d315d18357d73babbb905aabae9ef14951fe8d65012e5e4973R1-R29) [[8]](diffhunk://#diff-e74493238ecf74ba197334ec85b3bb78fe155641607e99019ec7fed67c4ea48dR1-R4)

These changes collectively improve the reliability of function contract handling for C++ free functions, especially in scenarios involving contract enforcement and call replacement.