### PR TITLE
[python] Avoid copying list payloads in pop()

### DIFF
--- a/regression/python/list_pop_perf/main.py
+++ b/regression/python/list_pop_perf/main.py
@@ -1,0 +1,7 @@
+xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+total = 0
+while xs:
+    total += xs.pop()
+
+assert total == 45

--- a/regression/python/list_pop_perf/test.desc
+++ b/regression/python/list_pop_perf/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 15
+^VERIFICATION SUCCESSFUL$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -505,14 +505,9 @@ PyObject *__ESBMC_list_pop(PyListObject *l, int64_t index)
   // Make a copy of the element to return before shifting
   PyObject *popped = __ESBMC_alloca(sizeof(PyObject));
 
-  // Copy the element's data
-  popped->value = __ESBMC_alloca(l->items[actual_index].size);
-  memcpy(
-    (void *)popped->value,
-    l->items[actual_index].value,
-    l->items[actual_index].size);
-  popped->type_id = l->items[actual_index].type_id;
-  popped->size = l->items[actual_index].size;
+  // Return the removed object as-is. The payload already has stable storage
+  // and shifting the remaining slots only moves PyObject descriptors.
+  *popped = l->items[actual_index];
 
   // Now shift elements to fill the gap
   size_t i = actual_index;


### PR DESCRIPTION
This PR improves the performance of `list.pop()` in the operational model.

`__ESBMC_list_pop()` copied the removed element payload before shifting the remaining list slots. This was expensive due to `memcpy` calls.

This change returns the removed `PyObject` as-is and only shifts the remaining `PyObject` entries in the list.

A regression test was added:
```python
  xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]

  total = 0
  while xs:
      total += xs.pop()

  assert total == 45
```
With --unwind 15 we got:

**Before**
  Symex completed in: 12.667s (7331 assignments)
  Generated 8005 VCC(s), 4374 remaining after simplification (5444 assignments)
  BMC program time: 14.077s

**After**
Symex completed in: 0.327s (1151 assignments)
Generated 1015 VCC(s), 344 remaining after simplification (505 assignments)
BMC program time: 0.443s