### PR TITLE
[ir-ra] add theorem-driven RUP interval lifting for ieee_mul

### DIFF
--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh-single/main.c
@@ -1,0 +1,35 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_mul --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-mul-rup-both-fresh but exercises the
+ * single-precision (float) path.
+ *
+ * PROOF SHAPE (point-interval fallback, single precision RUP)
+ * -----------------------------------------------------------
+ * EbRUP([R,R]) = [R, R + B_dir(R)], B_dir uses eps_rel_dir = 2^-23 (single).
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_up::   -- RUP tight path taken
+ *   ra_hi_up::   -- RUP tight path taken
+ *   (ite          -- |r| absolute value in B_dir computation
+ *   8388608       -- Z3 numerator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x * y exactly. */
+  assert(z != x * y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(ite
+8388608
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh/main.c
@@ -1,0 +1,43 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_mul --
+ * both operands fresh (zero-regression sentinel).
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a RUP ieee_mul are fresh nondet
+ * variables (not in ir_ra_interval_map), the point-interval fallback applies
+ * to both, and the resulting formula uses the RUP enclosure over the
+ * degenerate hull lo_r = hi_r = real_z.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step RUP)
+ * -------------------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RUP mul).
+ *   iv(x) = {x_smt, x_smt},  iv(y) = {y_smt, y_smt}  (point fallback)
+ *   p1=p2=p3=p4 = x_smt * y_smt = real_z
+ *   lo_r = hi_r = real_z
+ * EbRUP([R,R]) = [R, R + B_dir(R)]:
+ *   ra_lo_up = real_z          (exact lower: RUP never rounds below)
+ *   ra_hi_up = real_z + B_dir(real_z)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_up::   -- RUP tight path taken
+ *   ra_hi_up::   -- RUP tight path taken
+ *   (ite          -- |r| absolute value in B_dir computation
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x * y exactly. */
+  assert(z != x * y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::[0-9]+\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_up::[0-9]+\| \(\) Real\)
+\(ite
+22204460492503131
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked-single/main.c
@@ -1,0 +1,39 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_mul --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-mul-rup-both-tracked but exercises the
+ * single-precision (float) path.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * Second mul:  w = z * z  (both tracked)
+ *   lo_r = min(p1,p2,p3,p4), hi_r = max(p1,p2,p3,p4)
+ *   ra_lo_up::1 = lo_r,  ra_hi_up::1 = hi_r + B_dir(hi_r)  [single eps]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_up::0   -- first mul's lower bound declared
+ *   ra_lo_up::1   -- second mul's lifted lower bound declared
+ *   (* |smt_conv::ra_lo_up::0|  -- endpoint product in hull
+ *   (ite           -- nested ITE present
+ *   8388608        -- Z3 numerator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* first RUP mul: both fresh -> point fallback; stored */
+  float w = z * z; /* second RUP mul: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z * z exactly. */
+  assert(w != z * z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked/main.c
@@ -1,0 +1,54 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_mul --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a second RUP ieee_mul were themselves
+ * results of a prior tracked RUP ieee_mul, ir_ra_interval_map lookup fires
+ * for both operands and the interval-lifted RUP multiplication path is taken.
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point-interval fallback)
+ *   iv(x) = {x, x},  iv(y) = {y, y}
+ *   p1=p2=p3=p4 = x * y = real_z
+ *   ra_lo_up::0 = real_z          (exact lower)
+ *   ra_hi_up::0 = real_z + B_dir(real_z)
+ *   stored: ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second mul:  w = z * z  (both operands are z -> both tracked)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}  (found in map, same entry twice)
+ *   p1 = ra_lo_up::0 * ra_lo_up::0
+ *   p2 = ra_lo_up::0 * ra_hi_up::0
+ *   p3 = ra_hi_up::0 * ra_lo_up::0
+ *   p4 = ra_hi_up::0 * ra_hi_up::0
+ *   lo_r = min(p1,p2,p3,p4) via nested ITE
+ *   hi_r = max(p1,p2,p3,p4) via nested ITE
+ *   ra_lo_up::1 = lo_r          (exact lower)
+ *   ra_hi_up::1 = hi_r + B_dir(hi_r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_up::0   -- first mul's interval lower bound declared
+ *   ra_lo_up::1   -- second mul's lifted lower bound declared
+ *   (* |smt_conv::ra_lo_up::0|  -- endpoint product in hull computation
+ *   (ite           -- nested ITE for min/max hull and |r| in B_dir
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* first RUP mul: both fresh -> point fallback; stored */
+  double w = z * z; /* second RUP mul: both operands tracked -> full lift */
+
+  /* Always false in real/integer encoding: w == z * z exactly. */
+  assert(w != z * z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-both-tracked/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_up::0\| \|smt_conv::ra_lo_up::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_mul --
+ * one tracked, one fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Mirrors ra-interval-lift-mul-rup-one-fresh but exercises the
+ * single-precision (float) path.
+ *
+ * PROOF SHAPE (B_dir, RUP, single precision)
+ * ------------------------------------------
+ * Second mul:  w = z * x  (z tracked, x fresh -> mixed path)
+ *   lo_r = min(ra_lo_up::0 * x_smt, ra_hi_up::0 * x_smt)
+ *   hi_r = max(ra_lo_up::0 * x_smt, ra_hi_up::0 * x_smt)
+ *   ra_lo_up::1 = lo_r,  ra_hi_up::1 = hi_r + B_dir(hi_r)  [single eps]
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_up::0   -- first mul's lower bound declared
+ *   ra_lo_up::1   -- second mul's mixed-path lower bound declared
+ *   (* |smt_conv::ra_lo_up::0|  -- tracked endpoint in hull product
+ *   (ite           -- nested ITE present
+ *   8388608        -- Z3 numerator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x * y; /* first RUP mul: both fresh -> point fallback; stored */
+  float w = z * x; /* second RUP mul: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z * x exactly. */
+  assert(w != z * x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_up::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh/main.c
@@ -1,0 +1,49 @@
+/* Regression test: RUP (ROUND_TO_PLUS_INF) interval lifting for ieee_mul --
+ * one tracked, one fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RUP ieee_mul: when one operand of a
+ * second RUP ieee_mul is tracked in ir_ra_interval_map and the other is a
+ * fresh nondet variable, the tracked operand uses its stored interval while
+ * the fresh one falls back to the point interval {side, side}.
+ *
+ * PROOF SHAPE (B_dir, RUP, double precision)
+ * ------------------------------------------
+ * First mul:  z = x * y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[real_z] = {ra_lo_up::0, ra_hi_up::0}
+ *
+ * Second mul:  w = z * x  (z tracked, x fresh -> mixed path)
+ *   iv(z) = {ra_lo_up::0, ra_hi_up::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   p1 = ra_lo_up::0 * x_smt
+ *   p3 = ra_hi_up::0 * x_smt
+ *   lo_r = min(p1,p3),  hi_r = max(p1,p3)
+ *   ra_lo_up::1 = lo_r          (exact lower)
+ *   ra_hi_up::1 = hi_r + B_dir(hi_r)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_up::0   -- first mul's interval lower bound declared
+ *   ra_lo_up::1   -- second mul's mixed-path lower bound declared
+ *   (* |smt_conv::ra_lo_up::0|  -- tracked endpoint in hull product
+ *   (ite           -- nested ITE for min/max hull and |r| in B_dir
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 2; /* ROUND_TO_PLUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x * y; /* first RUP mul: both fresh -> point fallback; stored */
+  double w = z * x; /* second RUP mul: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z * x exactly. */
+  assert(w != z * x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-mul-rup-one-fresh/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_up::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_up::1\| \(\) Real\)
+\(\* \|smt_conv::ra_lo_up::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$
+

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1793,14 +1793,15 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       const floatbv_type2t &fbv_type = to_floatbv_type(expr->type);
       const expr2tc &rounding_mode = to_ieee_mul2t(expr).rounding_mode;
 
-      // RNE/RNA interval lifting for ieee_mul.
+      // RNE/RNA/RUP interval lifting for ieee_mul.
       // Hull: lo_r = min(p1,p2,p3,p4), hi_r = max(p1,p2,p3,p4)
       // where p1=L_x*L_y, p2=L_x*U_y, p3=U_x*L_y, p4=U_x*U_y.
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
         (is_nearest_rounding_mode(rounding_mode) ||
-         is_round_to_away(rounding_mode)))
+         is_round_to_away(rounding_mode) ||
+         is_round_to_plus_inf(rounding_mode)))
       {
         const auto double_spec = ieee_float_spect::double_precision();
         const auto single_spec = ieee_float_spect::single_precision();
@@ -1843,10 +1844,16 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
               mk_le(p3, p2),
               mk_ite(mk_le(p4, p2), p2, p4),
               mk_ite(mk_le(p4, p3), p3, p4)));
-          std::pair<smt_astt, smt_astt> bounds =
-            is_nearest_rounding_mode(rounding_mode)
-              ? apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type)
-              : apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
+          std::pair<smt_astt, smt_astt> bounds;
+          if (is_nearest_rounding_mode(rounding_mode))
+            bounds =
+              apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else if (is_round_to_away(rounding_mode))
+            bounds =
+              apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type);
+          else
+            bounds =
+              apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
           ir_ra_interval_map[real_result] = {bounds.first, bounds.second};
           a = real_result;
           interval_lifted = true;


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RUP interval lifting for `ieee_mul`.

The previously merged work already:

* added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
* completed theorem-driven interval lifting for `ieee_add` across all five rounding modes
* completed theorem-driven interval lifting for `ieee_sub` across all five rounding modes
* added theorem-driven RNE and RNA interval lifting for `ieee_mul`

This PR adds the next smallest sound step:

* theorem-driven RUP interval lifting for `ieee_mul`

## Main idea

For multiplication, let:

* `R = hull(X * Y) = [L_R, U_R]`

As in the existing `ieee_mul` interval-lifted path, the multiplication hull is computed in real arithmetic from the four endpoint products:

* `p1 = L_x * L_y`
* `p2 = L_x * U_y`
* `p3 = U_x * L_y`
* `p4 = U_x * U_y`

Then:

* `L_R = min(p1, p2, p3, p4)`
* `U_R = max(p1, p2, p3, p4)`

For `ROUND_TO_PLUS_INF`:

* `EbRUP(X * Y) = [L_R, U_R + B_dir^+(R)]`

where:

* `B_dir^+(R) = eps_rel_dir * |U_R| + eps_abs`

with directed-mode constants:

* binary64: `eps_rel_dir = 2^-52`, `eps_abs = 2^-1074`
* binary32: `eps_rel_dir = 2^-23`, `eps_abs = 2^-149`

So this PR reuses the existing 4-corner multiplication hull unchanged, and applies the proof-aligned one-sided directed enclosure for `ROUND_TO_PLUS_INF`:

* the lower endpoint stays exact at `L_R`
* only the upper endpoint is widened

## Main changes

* extend the `ieee_mul` interval-lifting path under `--ir-ieee` to cover `ROUND_TO_PLUS_INF`
* keep the existing multiplication hull computation unchanged:

  * `L_R = min(p1, p2, p3, p4)`
  * `U_R = max(p1, p2, p3, p4)`

* apply the RUP-specific directed enclosure so that only the upper endpoint is expanded
* reuse `ir_ra_interval_map`
* keep the existing tracked/fresh operand handling unchanged
* leave all other operations and rounding-mode paths unchanged

## Regression coverage

This PR adds:

* `ra-interval-lift-mul-rup-both-fresh`
* `ra-interval-lift-mul-rup-one-fresh`
* `ra-interval-lift-mul-rup-both-tracked`
* `ra-interval-lift-mul-rup-both-fresh-single`
* `ra-interval-lift-mul-rup-one-fresh-single`
* `ra-interval-lift-mul-rup-both-tracked-single`

This was also checked against the existing `ir-ra` regressions.

## Scope

This PR implements only:

* theorem-driven RUP interval lifting for `ieee_mul`

The following remain out of scope:

* theorem-driven RDN interval lifting for `ieee_mul`
* RTZ interval lifting for `ieee_mul`
* `ieee_div` interval lifting
* full IEEE corner-case support such as NaN, infinities, signed zero, and comparison semantics
* full DAG-level compositional propagation beyond the current tracked interval flow