### PR TITLE
[clang-cpp] support CXXNoexceptExpr conversion

### DIFF
--- a/regression/esbmc-cpp/cpp/noexcept_expr/main.cpp
+++ b/regression/esbmc-cpp/cpp/noexcept_expr/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+
+void f() noexcept
+{
+}
+void g()
+{
+}
+
+int main()
+{
+  bool b1 = noexcept(f()); // true: f is noexcept
+  bool b2 = noexcept(g()); // false: g may throw
+  assert(b1 == true);
+  assert(b2 == false);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/noexcept_expr/test.desc
+++ b/regression/esbmc-cpp/cpp/noexcept_expr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/noexcept_expr_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/noexcept_expr_fail/main.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+
+void f() noexcept
+{
+}
+
+int main()
+{
+  bool b = noexcept(f()); // true: f is noexcept
+  assert(b == false);     // should fail: b is true
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/noexcept_expr_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/noexcept_expr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1231,6 +1231,31 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  case clang::Stmt::CXXNoexceptExprClass:
+  {
+    const clang::CXXNoexceptExpr &noexcept_expr =
+      static_cast<const clang::CXXNoexceptExpr &>(stmt);
+
+    if (noexcept_expr.isValueDependent())
+    {
+      std::ostringstream oss;
+      llvm::raw_os_ostream ross(oss);
+      ross << "Conversion of unsupported value-dependent noexcept expr: \"";
+      ross << stmt.getStmtClassName() << "\" to expression"
+           << "\n";
+      stmt.dump(ross, *ASTContext);
+      ross.flush();
+      log_error("{}", oss.str());
+      return true;
+    }
+
+    if (noexcept_expr.getValue())
+      new_expr = true_exprt();
+    else
+      new_expr = false_exprt();
+    break;
+  }
+
   default:
     if (clang_c_convertert::get_expr(stmt, new_expr))
       return true;


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2319.

This PR adds handling for `CXXNoexceptExprClass` in `clang_cpp_convertert::get_expr()`.

`noexcept(expr)` is a compile-time constant bool; Clang pre-computes its value in `CXXNoexceptExpr::getValue()`, so we map it directly to `true_exprt()` or `false_exprt()`; the same pattern used for `CXXBoolLiteralExpr`.