### PR TITLE
[ir-ra] add theorem-driven RNE interval lifting for ieee_div

### DIFF
--- a/regression/ir-ra/ra-interval-lift-div-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-both-fresh-single/main.c
@@ -1,0 +1,40 @@
+/* Regression test: RNE (ROUND_TO_EVEN) interval lifting for ieee_div --
+ * both operands fresh (zero-regression sentinel), single precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the single-precision path for RNE ieee_div: when both operands
+ * are fresh nondet variables, the point-interval fallback applies and the
+ * formula uses the single-precision RNE enclosure constants.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step RNE)
+ * -------------------------------------------------------------------
+ * Both x and y are fresh.
+ *   iv(x) = {x_smt, x_smt}  (point fallback)
+ *   denominator = y_smt      (point)
+ *   d_lo = d_hi = x_smt / y_smt = real_z
+ *   lo_r = hi_r = real_z
+ * Eb_near([R,R]) applies with eps_rel_near = 2^-24 (single precision).
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0     -- RNE tight path taken
+ *   ra_hi::0     -- RNE tight path taken
+ *   5960464477539063  -- Z3 numerator for eps_rel_near = 2^-24 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x / y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x / y exactly. */
+  assert(z != x / y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-both-fresh-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-div-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-both-fresh/main.c
@@ -1,0 +1,42 @@
+/* Regression test: RNE (ROUND_TO_EVEN) interval lifting for ieee_div --
+ * both operands fresh (zero-regression sentinel), double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a RNE ieee_div are fresh nondet
+ * variables (not in ir_ra_interval_map), the point-interval fallback applies
+ * to the numerator, the denominator is used directly, and the resulting
+ * formula uses the RNE enclosure over the degenerate hull lo_r = hi_r = real_z.
+ *
+ * PROOF SHAPE (point-interval fallback, collapses to single-step RNE)
+ * -------------------------------------------------------------------
+ * Both x and y are fresh (no prior tracked RNE div).
+ *   iv(x) = {x_smt, x_smt}  (point fallback for numerator)
+ *   denominator = y_smt      (point, always)
+ *   d_lo = d_hi = x_smt / y_smt = real_z
+ *   lo_r = hi_r = real_z
+ * Eb_near([R,R]) applies the symmetric RNE enclosure.
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0     -- RNE tight path taken
+ *   ra_hi::0     -- RNE tight path taken
+ *   5960464477539063  -- unused (double uses 5551115123125783)
+ *   5551115123125783  -- Z3 numerator for eps_rel_near = 2^-53 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x / y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x / y exactly. */
+  assert(z != x / y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-both-fresh/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi::0\| \(\) Real\)
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-div-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-both-tracked-single/main.c
@@ -1,0 +1,50 @@
+/* Regression test: RNE (ROUND_TO_EVEN) interval lifting for ieee_div --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies proof-aligned compositional interval lifting for single-precision
+ * RNE ieee_div when both operands are tracked. The four-endpoint hull formula
+ * divides tracked-over-tracked endpoint pairs in the admissible branch.
+ *
+ * PROOF SHAPE (B_near, RNE, single precision)
+ * --------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo::0, ra_hi::0}
+ *
+ * Second div:  w = z / z  (both operands tracked)
+ *   iv(z) = {ra_lo::0, ra_hi::0} for numerator AND denominator
+ *   admissible = (ra_lo::0 > 0 || ra_hi::0 < 0)
+ *   If admissible: four-endpoint hull
+ *     q1 = ra_lo::0 / ra_lo::0
+ *     q2 = ra_lo::0 / ra_hi::0
+ *     q3 = ra_hi::0 / ra_lo::0
+ *     q4 = ra_hi::0 / ra_hi::0
+ *   lo_r = ite(admissible, min(q1..q4), lo_r_point)
+ *   hi_r = ite(admissible, max(q1..q4), hi_r_point)
+ *   ra_lo::1, ra_hi::1 pinned via single-precision RNE enclosure
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first div's lower bound declared
+ *   ra_lo::1   -- second div's lifted lower bound declared
+ *   (/ |smt_conv::ra_lo::0| |smt_conv::ra_hi::0|  -- q2: tracked/tracked
+ *   5960464477539063  -- Z3 numerator for eps_rel_near = 2^-24 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x / y; /* first RNE div: both fresh -> point fallback; stored */
+  float w = z / z; /* second RNE div: both operands tracked */
+
+  /* Always false in real/integer encoding: w == z / z exactly. */
+  assert(w != z / z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-both-tracked-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-div-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-both-tracked/main.c
@@ -1,0 +1,54 @@
+/* Regression test: RNE (ROUND_TO_EVEN) interval lifting for ieee_div --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies proof-aligned compositional interval lifting for RNE ieee_div
+ * when both the numerator and denominator were themselves results of a prior
+ * tracked RNE ieee_div. The implementation uses the full four-endpoint hull
+ * formula when the denominator interval is admissible (does not contain zero),
+ * and falls back to point denominator otherwise.
+ *
+ * PROOF SHAPE (B_near, RNE, double precision)
+ * -------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo::0, ra_hi::0}
+ *
+ * Second div:  w = z / z  (both operands tracked)
+ *   iv(z) = {ra_lo::0, ra_hi::0} for numerator AND denominator
+ *   admissible = (ra_lo::0 > 0 || ra_hi::0 < 0)
+ *   If admissible: four-endpoint hull
+ *     q1 = ra_lo::0 / ra_lo::0
+ *     q2 = ra_lo::0 / ra_hi::0
+ *     q3 = ra_hi::0 / ra_lo::0
+ *     q4 = ra_hi::0 / ra_hi::0
+ *   If inadmissible (zero in denominator interval): fallback to point denom
+ *   lo_r = ite(admissible, min(q1..q4), lo_r_point)
+ *   hi_r = ite(admissible, max(q1..q4), hi_r_point)
+ *   ra_lo::1, ra_hi::1 pinned via RNE enclosure
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first div's lower bound declared
+ *   ra_lo::1   -- second div's lifted lower bound declared
+ *   (/ |smt_conv::ra_lo::0| |smt_conv::ra_lo::0|  -- q1: tracked/tracked
+ *   (/ |smt_conv::ra_lo::0| |smt_conv::ra_hi::0|  -- q2: tracked/tracked
+ *   5551115123125783  -- Z3 numerator for eps_rel_near = 2^-53 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x / y; /* first RNE div: both fresh -> point fallback; stored */
+  double w = z / z; /* second RNE div: both operands tracked */
+
+  /* Always false in real/integer encoding: w == z / z exactly. */
+  assert(w != z / z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-both-tracked/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo::0\| \|smt_conv::ra_lo::0\|
+\(\/ \|smt_conv::ra_lo::0\| \|smt_conv::ra_hi::0\|
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-div-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-one-fresh-single/main.c
@@ -1,0 +1,47 @@
+/* Regression test: RNE (ROUND_TO_EVEN) interval lifting for ieee_div --
+ * numerator tracked, denominator fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the single-precision mixed lookup path for RNE ieee_div: when the
+ * numerator is tracked and the denominator is fresh, the tracked interval
+ * endpoints appear in the hull quotients and the single-precision RNE
+ * enclosure constants are used.
+ *
+ * PROOF SHAPE (B_near, RNE, single precision)
+ * --------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo::0, ra_hi::0}
+ *
+ * Second div:  w = z / x  (z tracked as numerator, x fresh as denominator)
+ *   iv(z) = {ra_lo::0, ra_hi::0}   (from map)
+ *   d_lo = ra_lo::0 / x_smt
+ *   d_hi = ra_hi::0 / x_smt
+ *   lo_r, hi_r via ITE
+ *   ra_lo::1, ra_hi::1 pinned via single-precision RNE enclosure
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first div's lower bound declared
+ *   ra_lo::1   -- second div's mixed-path lower bound declared
+ *   (/ |smt_conv::ra_lo::0|  -- tracked endpoint in hull quotient
+ *   (ite           -- ITE for hull min/max
+ *   5960464477539063  -- Z3 numerator for eps_rel_near = 2^-24 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x / y; /* first RNE div: both fresh -> point fallback; stored */
+  float w = z / x; /* second RNE div: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z / x exactly. */
+  assert(w != z / x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-one-fresh-single/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo::0\|
+\(ite
+5960464477539063
+^VERIFICATION FAILED$
+

--- a/regression/ir-ra/ra-interval-lift-div-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-one-fresh/main.c
@@ -1,0 +1,50 @@
+/* Regression test: RNE (ROUND_TO_EVEN) interval lifting for ieee_div --
+ * numerator tracked, denominator fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RNE ieee_div: when the numerator of a
+ * second RNE ieee_div is tracked in ir_ra_interval_map and the denominator
+ * is a fresh nondet variable, the tracked numerator uses its stored interval
+ * while the denominator is used as a point value (conservative design to
+ * avoid zero-crossing unsoundness in the division hull).
+ *
+ * PROOF SHAPE (B_near, RNE, double precision)
+ * -------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo::0, ra_hi::0}
+ *
+ * Second div:  w = z / x  (z tracked as numerator, x fresh as denominator)
+ *   iv(z) = {ra_lo::0, ra_hi::0}   (from map)
+ *   denominator = x_smt             (point -- never lifted)
+ *   d_lo = ra_lo::0 / x_smt
+ *   d_hi = ra_hi::0 / x_smt
+ *   lo_r = min(d_lo, d_hi) via ITE on sign of x
+ *   hi_r = max(d_lo, d_hi) via ITE on sign of x
+ *   ra_lo::1, ra_hi::1 pinned via RNE enclosure
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo::0   -- first div's lower bound declared
+ *   ra_lo::1   -- second div's mixed-path lower bound declared
+ *   (/ |smt_conv::ra_lo::0|  -- tracked endpoint in hull quotient
+ *   (ite           -- ITE for hull min/max
+ *   5551115123125783  -- Z3 numerator for eps_rel_near = 2^-53 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 0; /* ROUND_TO_EVEN */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x / y; /* first RNE div: both fresh -> point fallback; stored */
+  double w = z / x; /* second RNE div: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z / x exactly. */
+  assert(w != z / x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-one-fresh/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo::0\|
+\(ite
+5551115123125783
+^VERIFICATION FAILED$
+

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1914,9 +1914,70 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt inf_result =
         mk_ite(mk_lt(side1, zero), mk_sub(zero, max_val), max_val);
       smt_astt real_result = mk_div(side1, side2);
-      smt_astt ieee_result = apply_ieee754_semantics(
-        real_result, fbv_type, nullptr, to_ieee_div2t(expr).rounding_mode);
-      a = mk_ite(div_by_zero, inf_result, ieee_result);
+      const expr2tc &rounding_mode = to_ieee_div2t(expr).rounding_mode;
+
+      // RNE interval lifting for ieee_div.
+      // Proof-aligned compositional lifting:
+      //   hull([L_x,U_x] / [L_y,U_y]) = [min(qi), max(qi)] for i in {1..4}
+      //   where q1=L_x/L_y, q2=L_x/U_y, q3=U_x/L_y, q4=U_x/U_y.
+      // Admissibility guard: the four-endpoint formula is only sound when
+      // the denominator interval does not contain zero (iv2.lo > 0 or
+      // iv2.hi < 0). When inadmissible, the numerator tracked interval is
+      // preserved and the denominator is used as a point value (conservative
+      // but sound). Both operands use point fallback when fresh.
+      bool interval_lifted = false;
+      if (
+        options.get_bool_option("ir-ieee") &&
+        is_nearest_rounding_mode(rounding_mode))
+      {
+        auto get_iv = [this](smt_astt t) -> ra_interval_t {
+          auto it = ir_ra_interval_map.find(t);
+          return it != ir_ra_interval_map.end() ? it->second
+                                                : ra_interval_t{t, t};
+        };
+        ra_interval_t iv1 = get_iv(side1);
+        ra_interval_t iv2 = get_iv(side2);
+
+        // Admissibility: denominator interval does not contain zero.
+        smt_astt denom_admissible =
+          mk_or(mk_lt(zero, iv2.lo), mk_lt(iv2.hi, zero));
+
+        // Full four-endpoint hull (sound when denominator is admissible).
+        smt_astt q1 = mk_div(iv1.lo, iv2.lo);
+        smt_astt q2 = mk_div(iv1.lo, iv2.hi);
+        smt_astt q3 = mk_div(iv1.hi, iv2.lo);
+        smt_astt q4 = mk_div(iv1.hi, iv2.hi);
+        smt_astt lo_r_full = mk_ite(
+          mk_le(q1, q2),
+          mk_ite(mk_le(q1, q3), mk_ite(mk_le(q1, q4), q1, q4), mk_ite(mk_le(q3, q4), q3, q4)),
+          mk_ite(mk_le(q2, q3), mk_ite(mk_le(q2, q4), q2, q4), mk_ite(mk_le(q3, q4), q3, q4)));
+        smt_astt hi_r_full = mk_ite(
+          mk_le(q2, q1),
+          mk_ite(mk_le(q3, q1), mk_ite(mk_le(q4, q1), q1, q4), mk_ite(mk_le(q4, q3), q3, q4)),
+          mk_ite(mk_le(q3, q2), mk_ite(mk_le(q4, q2), q2, q4), mk_ite(mk_le(q4, q3), q3, q4)));
+
+        // Fallback hull: point denominator, numerator tracked interval kept.
+        smt_astt d_lo = mk_div(iv1.lo, side2);
+        smt_astt d_hi = mk_div(iv1.hi, side2);
+        smt_astt lo_r_point = mk_ite(mk_le(d_lo, d_hi), d_lo, d_hi);
+        smt_astt hi_r_point = mk_ite(mk_le(d_hi, d_lo), d_lo, d_hi);
+
+        // Guard: use full hull when denominator interval is admissible.
+        smt_astt lo_r = mk_ite(denom_admissible, lo_r_full, lo_r_point);
+        smt_astt hi_r = mk_ite(denom_admissible, hi_r_full, hi_r_point);
+
+        std::pair<smt_astt, smt_astt> bounds =
+          apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type);
+        a = mk_ite(div_by_zero, inf_result, real_result);
+        ir_ra_interval_map[a] = {bounds.first, bounds.second};
+        interval_lifted = true;
+      }
+      if (!interval_lifted)
+      {
+        smt_astt ieee_result =
+          apply_ieee754_semantics(real_result, fbv_type, nullptr, rounding_mode);
+        a = mk_ite(div_by_zero, inf_result, ieee_result);
+      }
     }
     else
     {

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1949,12 +1949,24 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         smt_astt q4 = mk_div(iv1.hi, iv2.hi);
         smt_astt lo_r_full = mk_ite(
           mk_le(q1, q2),
-          mk_ite(mk_le(q1, q3), mk_ite(mk_le(q1, q4), q1, q4), mk_ite(mk_le(q3, q4), q3, q4)),
-          mk_ite(mk_le(q2, q3), mk_ite(mk_le(q2, q4), q2, q4), mk_ite(mk_le(q3, q4), q3, q4)));
+          mk_ite(
+            mk_le(q1, q3),
+            mk_ite(mk_le(q1, q4), q1, q4),
+            mk_ite(mk_le(q3, q4), q3, q4)),
+          mk_ite(
+            mk_le(q2, q3),
+            mk_ite(mk_le(q2, q4), q2, q4),
+            mk_ite(mk_le(q3, q4), q3, q4)));
         smt_astt hi_r_full = mk_ite(
           mk_le(q2, q1),
-          mk_ite(mk_le(q3, q1), mk_ite(mk_le(q4, q1), q1, q4), mk_ite(mk_le(q4, q3), q3, q4)),
-          mk_ite(mk_le(q3, q2), mk_ite(mk_le(q4, q2), q2, q4), mk_ite(mk_le(q4, q3), q3, q4)));
+          mk_ite(
+            mk_le(q3, q1),
+            mk_ite(mk_le(q4, q1), q1, q4),
+            mk_ite(mk_le(q4, q3), q3, q4)),
+          mk_ite(
+            mk_le(q3, q2),
+            mk_ite(mk_le(q4, q2), q2, q4),
+            mk_ite(mk_le(q4, q3), q3, q4)));
 
         // Fallback hull: point denominator, numerator tracked interval kept.
         smt_astt d_lo = mk_div(iv1.lo, side2);
@@ -1974,8 +1986,8 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       }
       if (!interval_lifted)
       {
-        smt_astt ieee_result =
-          apply_ieee754_semantics(real_result, fbv_type, nullptr, rounding_mode);
+        smt_astt ieee_result = apply_ieee754_semantics(
+          real_result, fbv_type, nullptr, rounding_mode);
         a = mk_ite(div_by_zero, inf_result, ieee_result);
       }
     }


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RNE interval lifting for `ieee_div`.

The previously merged work already:

* added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
* completed theorem-driven interval lifting for `ieee_add` across all five rounding modes
* completed theorem-driven interval lifting for `ieee_sub` across all five rounding modes
* completed theorem-driven interval lifting for `ieee_mul` across all five rounding modes

This PR adds the next sound step:

* theorem-driven RNE interval lifting for `ieee_div`

## Main idea

For division, let:

* `R = hull(X / Y) = [L_R, U_R]`

For nearest-even, the proof uses the nearest-mode enclosure:

* `EbRNE(X / Y) = [L_R - B_near^-(R), U_R + B_near^+(R)]`

where:

* `B_near^-(R) = eps_rel_near * |L_R| + eps_abs`
* `B_near^+(R) = eps_rel_near * |U_R| + eps_abs`

with nearest-mode constants:

* binary64: `eps_rel_near = 2^-53`, `eps_abs = 2^-1074`
* binary32: `eps_rel_near = 2^-24`, `eps_abs = 2^-149`

As in the earlier compositional lifting PRs, tracked operands use intervals from `ir_ra_interval_map`, while fresh operands fall back to point intervals `{side, side}`.

For the division hull, this PR uses an admissible interval/interval quotient when the denominator interval does not contain zero. In that case, the quotient hull is computed from the four endpoint quotients:

* `q1 = L_x / L_y`
* `q2 = L_x / U_y`
* `q3 = U_x / L_y`
* `q4 = U_x / U_y`

Then:

* `L_R = min(q1, q2, q3, q4)`
* `U_R = max(q1, q2, q3, q4)`

This interval quotient is only used when the denominator interval is admissible, i.e. when it does not cross zero:

* `L_y > 0 || U_y < 0`

When that guard holds, the implementation uses the full interval/interval division hull and then applies the proof-aligned nearest-mode enclosure.

When it does not hold, the implementation falls back conservatively to a weaker division hull construction rather than applying the full interval quotient across a zero-crossing denominator interval.

So this PR is proof-aligned at the nearest-mode enclosure level, while using a guarded conservative implementation strategy for division-hull construction outside the admissible denominator case. :contentReference[oaicite:0]{index=0} :contentReference[oaicite:1]{index=1}

## Main changes

* extend the `ieee_div` interval-lifting path under `--ir-ieee` to cover `ROUND_TO_EVEN`
* reuse tracked intervals from `ir_ra_interval_map` for both operands
* keep point fallback `{side, side}` for fresh operands
* add an explicit admissibility guard for denominator intervals so the full interval quotient is only used when the denominator interval does not contain zero
* when admissible, compute the division hull from the four endpoint quotients
* when inadmissible, fall back conservatively to a weaker hull construction
* apply the existing `apply_ieee754_rne_enclosure(...)` helper to the resulting hull
* preserve existing division-by-zero saturation behavior
* leave all non-RNE division modes unchanged
* leave `ieee_add`, `ieee_sub`, and `ieee_mul` paths unchanged

## Regression coverage

This PR adds:

* `ra-interval-lift-div-both-fresh`
* `ra-interval-lift-div-one-fresh`
* `ra-interval-lift-div-both-tracked`
* `ra-interval-lift-div-both-fresh-single`
* `ra-interval-lift-div-one-fresh-single`
* `ra-interval-lift-div-both-tracked-single`

These tests check:

* fresh operand fallback
* tracked/fresh mixed propagation
* tracked/tracked division hull construction
* nearest-mode SMT symbols and constants
* proof-aligned interval/interval quotient structure in the admissible branch

This was also checked against the existing `ir-ra` interval-lifting regressions.

## Scope

This PR implements only:

* theorem-driven RNE interval lifting for `ieee_div`

The following remain out of scope:

* RNA interval lifting for `ieee_div`
* RUP interval lifting for `ieee_div`
* RDN interval lifting for `ieee_div`
* RTZ interval lifting for `ieee_div`
* full IEEE corner-case support such as NaN, infinities, signed zero, and comparison semantics
* full DAG-level compositional propagation beyond the current tracked interval flow