### PR TITLE
[smt] fix crash in tuple-sym-flattener with non-constant array size

### DIFF
--- a/regression/esbmc/github_2639/main.c
+++ b/regression/esbmc/github_2639/main.c
@@ -1,0 +1,5 @@
+int main(int argc, char *argv[])
+{
+  if(argc > 1)
+    ;
+}

--- a/regression/esbmc/github_2639/test.desc
+++ b/regression/esbmc/github_2639/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--tuple-sym-flattener --smt-symex-guard --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_2639_1/main.c
+++ b/regression/esbmc/github_2639_1/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main(int argc, char *argv[])
+{
+  if(argc > 1)
+    ;
+  assert(argc <= 0);
+}

--- a/regression/esbmc/github_2639_1/test.desc
+++ b/regression/esbmc/github_2639_1/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--tuple-sym-flattener --smt-symex-guard --z3
+^VERIFICATION FAILED$

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -107,10 +107,7 @@ smt_astt smt_tuple_node_flattener::tuple_array_create(
     return newsym;
   }
   if (!is_constant_int2t(arr_type.array_size))
-  {
-    log_error("Non-constant sized array of type constant_array_of2t");
-    abort();
-  }
+    return newsym;
 
   const constant_int2t &thesize = to_constant_int2t(arr_type.array_size);
   unsigned int sz = thesize.value.to_uint64();

--- a/src/solvers/smt/tuple/smt_tuple_sym.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_sym.cpp
@@ -85,10 +85,7 @@ smt_astt smt_tuple_sym_flattener::tuple_array_create(
     return newsym;
   }
   if (!is_constant_int2t(arr_type.array_size))
-  {
-    log_error("Non-constant sized array of type constant_array_of2t");
-    abort();
-  }
+    return newsym;
 
   const constant_int2t &thesize = to_constant_int2t(arr_type.array_size);
   unsigned int sz = thesize.value.to_uint64();


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/2639.

`smt_tuple_sym_flattener::tuple_array_create` aborted when the array size was non-constant (e.g., `argv` typed as `char*[argc+1]`), which triggered a crash with `--tuple-sym-flattener --smt-symex-guard`. 

This PR returns the unconstrained fresh symbol instead, matching the existing handling for infinite-sized arrays. It also applies the same defensive fix to `smt_tuple_node_flattener` for the `const_array=false` path.