### PR TITLE
Fix builtin time import for sleep regression

### DIFF
--- a/regression/python/sleep/test.desc
+++ b/regression/python/sleep/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/time.py
+++ b/src/python-frontend/models/time.py
@@ -1,0 +1,12 @@
+_esbmc_time_now: float = 0.0
+
+
+def time() -> float:
+    global _esbmc_time_now
+    current: float = _esbmc_time_now
+    _esbmc_time_now = _esbmc_time_now + 1.0
+    return current
+
+
+def sleep(seconds: float) -> None:
+    assert seconds >= 0.0

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -39,7 +39,16 @@ def check_usage():
         sys.exit(2)
 
 def is_imported_model(module_name):
-    models = ["math", "os", "numpy", "esbmc", "decimal", "collections", "typing"]
+    models = [
+        "math",
+        "os",
+        "numpy",
+        "esbmc",
+        "decimal",
+        "collections",
+        "typing",
+        "time",
+    ]
     return module_name in models
 
 def is_unsupported_module(module_name):


### PR DESCRIPTION
- Promote regression/python/sleep/test.desc from KNOWNBUG to CORE and fix Python frontend support for import time.
- Add "time" to imported models in parser.py
- Add models/time.py with minimal time.time() and time.sleep() stubs
