### PR TITLE
[ir-ra] add theorem-driven RDN interval lifting for ieee_div

### DIFF
--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh-single/main.c
@@ -1,0 +1,39 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_div --
+ * both operands fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the single-precision RDN ieee_div path with point-interval
+ * fallback and the single-precision directed enclosure constant.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * -------------------------------------------
+ * Both x and y are fresh.
+ *   lo_r = hi_r = real_z
+ * EbRDN([R,R]):
+ *   ra_lo_dn::0 = real_z - B_dir(real_z)   (widened lower)
+ *   ra_hi_dn::0 = real_z                    (exact upper)
+ * with eps_rel_dir = 2^-23 (single precision).
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_dn::0   -- RDN tight path taken
+ *   ra_hi_dn::0   -- RDN tight path taken
+ *   8388608  -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x / y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x / y exactly. */
+  assert(z != x / y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh-single/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::0\| \(\) Real\)
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh/main.c
@@ -1,0 +1,42 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_div --
+ * both operands fresh (zero-regression sentinel), double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies that when both operands of a RDN ieee_div are fresh nondet
+ * variables, the point-interval fallback applies and the formula uses the
+ * RDN directed enclosure with double-precision directed constants.
+ * The upper endpoint is exact; only the lower is widened.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * Both x and y are fresh.
+ *   iv(x) = {x_smt, x_smt},  iv(y) = {y_smt, y_smt}  (point fallback)
+ *   All four endpoint quotients collapse to x_smt / y_smt = real_z.
+ *   lo_r = hi_r = real_z
+ * EbRDN([R,R]):
+ *   ra_lo_dn::0 = real_z - B_dir(real_z)   (widened lower)
+ *   ra_hi_dn::0 = real_z                    (exact upper)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_dn::0   -- RDN tight path taken
+ *   ra_hi_dn::0   -- RDN tight path taken
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x / y; /* both fresh -> point fallback */
+
+  /* Always false in real/integer encoding: z == x / y exactly. */
+  assert(z != x / y);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-fresh/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_hi_dn::0\| \(\) Real\)
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked-single/main.c
@@ -1,0 +1,44 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_div --
+ * both operands tracked, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies proof-aligned compositional interval lifting for single-precision
+ * RDN ieee_div when both operands are tracked. The admissibility-guarded
+ * four-endpoint hull uses tracked-over-tracked endpoint quotients.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * -------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second div:  w = z / z  (both operands tracked)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0} for numerator AND denominator
+ *   Full hull includes q2 = ra_lo_dn::0 / ra_hi_dn::0 (cross-product)
+ *   ra_lo_dn::1 = lo_r - B_dir(lo_r)   (widened lower, single-precision)
+ *   ra_hi_dn::1 = hi_r                  (exact upper)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_dn::0   -- first div's lower bound declared
+ *   ra_lo_dn::1   -- second div's lifted lower bound declared
+ *   (/ |smt_conv::ra_lo_dn::0| |smt_conv::ra_hi_dn::0|  -- q2 cross-product
+ *   8388608  -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x / y; /* first RDN div: both fresh -> point fallback; stored */
+  float w = z / z; /* second RDN div: both operands tracked */
+
+  /* Always false in real/integer encoding: w == z / z exactly. */
+  assert(w != z / z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked-single/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked/main.c
@@ -1,0 +1,53 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_div --
+ * both operands tracked, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies proof-aligned compositional interval lifting for RDN ieee_div
+ * when both the numerator and denominator are prior tracked results.
+ * The four-endpoint hull uses tracked-over-tracked endpoint quotients in
+ * the admissible branch. The upper endpoint is exact; the lower is widened.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second div:  w = z / z  (both operands tracked)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0} for numerator AND denominator
+ *   admissible = (ra_lo_dn::0 > 0 || ra_hi_dn::0 < 0)
+ *   If admissible: four-endpoint hull
+ *     q1 = ra_lo_dn::0 / ra_lo_dn::0
+ *     q2 = ra_lo_dn::0 / ra_hi_dn::0
+ *     q3 = ra_hi_dn::0 / ra_lo_dn::0
+ *     q4 = ra_hi_dn::0 / ra_hi_dn::0
+ *   lo_r = ite(admissible, min(q1..q4), lo_r_point)
+ *   hi_r = ite(admissible, max(q1..q4), hi_r_point)
+ *   ra_lo_dn::1 = lo_r - B_dir(lo_r)   (widened lower)
+ *   ra_hi_dn::1 = hi_r                  (exact upper)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_dn::0   -- first div's lower bound declared
+ *   ra_lo_dn::1   -- second div's lifted lower bound declared
+ *   (/ |smt_conv::ra_lo_dn::0| |smt_conv::ra_lo_dn::0|  -- q1
+ *   (/ |smt_conv::ra_lo_dn::0| |smt_conv::ra_hi_dn::0|  -- q2
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x / y; /* first RDN div: both fresh -> point fallback; stored */
+  double w = z / z; /* second RDN div: both operands tracked */
+
+  /* Always false in real/integer encoding: w == z / z exactly. */
+  assert(w != z / z);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-both-tracked/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_lo_dn::0\|
+\(\/ \|smt_conv::ra_lo_dn::0\| \|smt_conv::ra_hi_dn::0\|
+22204460492503131
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh-single/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh-single/main.c
@@ -1,0 +1,46 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_div --
+ * numerator tracked, denominator fresh, single precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for single-precision RDN ieee_div: when
+ * the numerator is tracked and the denominator is fresh, the tracked
+ * numerator endpoints appear in the hull quotients.
+ *
+ * PROOF SHAPE (B_dir, RDN, single precision)
+ * -------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second div:  w = z / x  (z tracked as numerator, x fresh as denominator)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   Hull quotients: ra_lo_dn::0 / x_smt, ra_hi_dn::0 / x_smt
+ *   ra_lo_dn::1 = lo_r - B_dir(lo_r)   (widened lower, single-precision)
+ *   ra_hi_dn::1 = hi_r                  (exact upper)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_dn::0   -- first div's lower bound declared
+ *   ra_lo_dn::1   -- second div's mixed-path lower bound declared
+ *   (/ |smt_conv::ra_lo_dn::0|  -- tracked endpoint in hull quotient
+ *   (ite           -- ITE for hull sort / admissibility guard
+ *   8388608  -- Z3 denominator for eps_rel_dir = 2^-23 (single)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  float x = __VERIFIER_nondet_float();
+  float y = __VERIFIER_nondet_float();
+  float z = x / y; /* first RDN div: both fresh -> point fallback; stored */
+  float w = z / x; /* second RDN div: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z / x exactly. */
+  assert(w != z / x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh-single/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh-single/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo_dn::0\|
+\(ite
+8388608
+^VERIFICATION FAILED$

--- a/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh/main.c
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh/main.c
@@ -1,0 +1,48 @@
+/* Regression test: RDN (ROUND_TO_MINUS_INF) interval lifting for ieee_div --
+ * numerator tracked, denominator fresh, double precision.
+ *
+ * PURPOSE
+ * -------
+ * Verifies the mixed lookup path for RDN ieee_div: when the numerator is
+ * tracked in ir_ra_interval_map and the denominator is fresh, the tracked
+ * numerator endpoints appear in the hull quotients.
+ *
+ * PROOF SHAPE (B_dir, RDN, double precision)
+ * ------------------------------------------
+ * First div:  z = x / y   (both fresh -> point fallback; z stored in map)
+ *   ir_ra_interval_map[z_smt] = {ra_lo_dn::0, ra_hi_dn::0}
+ *
+ * Second div:  w = z / x  (z tracked as numerator, x fresh as denominator)
+ *   iv(z) = {ra_lo_dn::0, ra_hi_dn::0}   (from map)
+ *   iv(x) = {x_smt, x_smt}               (point fallback)
+ *   denom_admissible = (x_smt > 0 || x_smt < 0)
+ *   Hull quotients: ra_lo_dn::0 / x_smt, ra_hi_dn::0 / x_smt
+ *   lo_r, hi_r via ITE
+ *   ra_lo_dn::1 = lo_r - B_dir(lo_r)   (widened lower)
+ *   ra_hi_dn::1 = hi_r                  (exact upper)
+ *
+ * PATTERNS CHECKED (see test.desc)
+ *   ra_lo_dn::0   -- first div's lower bound declared
+ *   ra_lo_dn::1   -- second div's mixed-path lower bound declared
+ *   (/ |smt_conv::ra_lo_dn::0|  -- tracked endpoint in hull quotient
+ *   (ite           -- ITE for hull sort / admissibility guard
+ *   22204460492503131  -- Z3 numerator for eps_rel_dir = 2^-52 (double)
+ *   ^VERIFICATION FAILED$
+ */
+#include <assert.h>
+
+extern int __ESBMC_rounding_mode;
+extern double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  __ESBMC_rounding_mode = 3; /* ROUND_TO_MINUS_INF */
+  double x = __VERIFIER_nondet_double();
+  double y = __VERIFIER_nondet_double();
+  double z = x / y; /* first RDN div: both fresh -> point fallback; stored */
+  double w = z / x; /* second RDN div: z tracked, x fresh -> mixed path */
+
+  /* Always false in real/integer encoding: w == z / x exactly. */
+  assert(w != z / x);
+  return 0;
+}

--- a/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh/test.desc
+++ b/regression/ir-ra/ra-interval-lift-div-rdn-one-fresh/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--ir-ieee --z3 --smt-formula-too
+\(declare-fun \|smt_conv::ra_lo_dn::0\| \(\) Real\)
+\(declare-fun \|smt_conv::ra_lo_dn::1\| \(\) Real\)
+\(\/ \|smt_conv::ra_lo_dn::0\|
+\(ite
+22204460492503131
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1986,11 +1986,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         std::pair<smt_astt, smt_astt> bounds =
           is_nearest_rounding_mode(rounding_mode)
             ? apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type)
-            : is_round_to_away(rounding_mode)
-                ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
-                : is_round_to_plus_inf(rounding_mode)
-                    ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
-                    : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
+          : is_round_to_away(rounding_mode)
+            ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
+          : is_round_to_plus_inf(rounding_mode)
+            ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
+            : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
         a = mk_ite(div_by_zero, inf_result, real_result);
         ir_ra_interval_map[a] = {bounds.first, bounds.second};
         interval_lifted = true;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1991,11 +1991,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
             ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
             : apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
 =======
-            : is_round_to_away(rounding_mode)
-                ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
-                : is_round_to_plus_inf(rounding_mode)
-                    ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
-                    : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
+          : is_round_to_away(rounding_mode)
+            ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
+          : is_round_to_plus_inf(rounding_mode)
+            ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
+            : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
 >>>>>>> Stashed changes
         a = mk_ite(div_by_zero, inf_result, real_result);
         ir_ra_interval_map[a] = {bounds.first, bounds.second};

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1916,7 +1916,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       smt_astt real_result = mk_div(side1, side2);
       const expr2tc &rounding_mode = to_ieee_div2t(expr).rounding_mode;
 
-      // RNE/RNA/RUP interval lifting for ieee_div.
+      // RNE/RNA/RUP/RDN interval lifting for ieee_div.
       // Proof-aligned compositional lifting:
       //   hull([L_x,U_x] / [L_y,U_y]) = [min(qi), max(qi)] for i in {1..4}
       //   where q1=L_x/L_y, q2=L_x/U_y, q3=U_x/L_y, q4=U_x/U_y.
@@ -1925,13 +1925,15 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       // iv2.hi < 0). When inadmissible, the numerator tracked interval is
       // preserved and the denominator is used as a point value (conservative
       // but sound). Both operands use point fallback when fresh.
-      // RNE and RNA share B_near; RUP uses B_dir with upper-only widening.
+      // RNE and RNA share B_near; RUP/RDN use B_dir (upper-only / lower-only
+      // widening respectively).
       bool interval_lifted = false;
       if (
         options.get_bool_option("ir-ieee") &&
         (is_nearest_rounding_mode(rounding_mode) ||
          is_round_to_away(rounding_mode) ||
-         is_round_to_plus_inf(rounding_mode)))
+         is_round_to_plus_inf(rounding_mode) ||
+         is_round_to_minus_inf(rounding_mode)))
       {
         auto get_iv = [this](smt_astt t) -> ra_interval_t {
           auto it = ir_ra_interval_map.find(t);
@@ -1984,9 +1986,17 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         std::pair<smt_astt, smt_astt> bounds =
           is_nearest_rounding_mode(rounding_mode)
             ? apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type)
+<<<<<<< Updated upstream
           : is_round_to_away(rounding_mode)
             ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
             : apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
+=======
+            : is_round_to_away(rounding_mode)
+                ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
+                : is_round_to_plus_inf(rounding_mode)
+                    ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
+                    : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
+>>>>>>> Stashed changes
         a = mk_ite(div_by_zero, inf_result, real_result);
         ir_ra_interval_map[a] = {bounds.first, bounds.second};
         interval_lifted = true;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1986,17 +1986,11 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         std::pair<smt_astt, smt_astt> bounds =
           is_nearest_rounding_mode(rounding_mode)
             ? apply_ieee754_rne_enclosure(real_result, lo_r, hi_r, fbv_type)
-<<<<<<< Updated upstream
-          : is_round_to_away(rounding_mode)
-            ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
-            : apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type);
-=======
-          : is_round_to_away(rounding_mode)
-            ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
-          : is_round_to_plus_inf(rounding_mode)
-            ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
-            : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
->>>>>>> Stashed changes
+            : is_round_to_away(rounding_mode)
+                ? apply_ieee754_rna_enclosure(real_result, lo_r, hi_r, fbv_type)
+                : is_round_to_plus_inf(rounding_mode)
+                    ? apply_ieee754_rup_enclosure(real_result, lo_r, hi_r, fbv_type)
+                    : apply_ieee754_rdn_enclosure(real_result, lo_r, hi_r, fbv_type);
         a = mk_ite(div_by_zero, inf_result, real_result);
         ir_ra_interval_map[a] = {bounds.first, bounds.second};
         interval_lifted = true;


### PR DESCRIPTION
## Summary

This PR adds theorem-driven RDN interval lifting for `ieee_div`.

The previously merged work already:

- added dedicated single-step theorem-driven SMT enclosures for all five concrete IEEE-754 rounding modes
- completed theorem-driven interval lifting for `ieee_add` across all five rounding modes
- completed theorem-driven interval lifting for `ieee_sub` across all five rounding modes
- completed theorem-driven interval lifting for `ieee_mul` across all five rounding modes
- added theorem-driven RNE interval lifting for `ieee_div`
- added theorem-driven RNA interval lifting for `ieee_div`
- added theorem-driven RUP interval lifting for `ieee_div`

This PR adds the next sound step:

- theorem-driven RDN interval lifting for `ieee_div`

## Main idea

For division, let:

- `R = hull(X / Y) = [L_R, U_R]`

For `ROUND_TO_MINUS_INF`, the proof uses the directed enclosure:

- `EbRDN(X / Y) = [L_R - B_dir^-(R), U_R]`

where:

- `B_dir^-(R) = eps_rel_dir * |L_R| + eps_abs`

with directed-mode constants:

- binary64: `eps_rel_dir = 2^-52`, `eps_abs = 2^-1074`
- binary32: `eps_rel_dir = 2^-23`, `eps_abs = 2^-149`

As in the earlier compositional lifting PRs, tracked operands use intervals from `ir_ra_interval_map`, while fresh operands fall back to point intervals `{side, side}`.

For the division hull, this PR reuses the existing proof-aligned `ieee_div` lifting structure. The full interval/interval quotient is only used when the denominator interval is admissible, i.e. when it does not contain zero:

- `L_y > 0 || U_y < 0`

In that case, the quotient hull is computed from the four endpoint quotients:

- `q1 = L_x / L_y`
- `q2 = L_x / U_y`
- `q3 = U_x / L_y`
- `q4 = U_x / U_y`

Then:

- `L_R = min(q1, q2, q3, q4)`
- `U_R = max(q1, q2, q3, q4)`

When the denominator interval is not admissible, the implementation keeps the same conservative fallback already used by the existing `ieee_div` lifting path.

So this PR keeps the existing division hull/admissibility logic unchanged and extends the lifted div path to RDN by dispatching to the RDN enclosure helper.

## Main changes

- extend the `ieee_div` interval-lifting path under `--ir-ieee` to cover `ROUND_TO_MINUS_INF`
- reuse tracked intervals from `ir_ra_interval_map` for both operands
- keep point fallback `{side, side}` for fresh operands
- keep the existing denominator admissibility guard unchanged
- keep the existing four-endpoint division hull construction unchanged
- keep the existing conservative fallback outside the admissible denominator case unchanged
- dispatch:
  - `RNE -> apply_ieee754_rne_enclosure(...)`
  - `RNA -> apply_ieee754_rna_enclosure(...)`
  - `RUP -> apply_ieee754_rup_enclosure(...)`
  - `RDN -> apply_ieee754_rdn_enclosure(...)`
- preserve existing division-by-zero saturation behavior
- leave `ieee_add`, `ieee_sub`, and `ieee_mul` paths unchanged
- leave other division rounding-mode paths unchanged

## Regression coverage

This PR adds:

- `ra-interval-lift-div-rdn-both-fresh`
- `ra-interval-lift-div-rdn-one-fresh`
- `ra-interval-lift-div-rdn-both-tracked`
- `ra-interval-lift-div-rdn-both-fresh-single`
- `ra-interval-lift-div-rdn-one-fresh-single`
- `ra-interval-lift-div-rdn-both-tracked-single`

These tests check:

- fresh operand fallback
- tracked/fresh mixed propagation
- tracked/tracked division hull construction
- RDN SMT symbols (`ra_lo_dn::`, `ra_hi_dn::`)
- directed-mode constants
- proof-aligned interval/interval quotient structure in the admissible branch
- widened lower endpoint and exact upper endpoint

This was also checked against the existing `ir-ra` interval-lifting regressions.

## Scope

This PR implements only:

- theorem-driven RDN interval lifting for `ieee_div`

The following remain out of scope:

- RTZ interval lifting for `ieee_div`
- full IEEE corner-case support such as NaN, infinities, signed zero, and comparison semantics
- full DAG-level compositional propagation beyond the current tracked interval flow