### PR TITLE
 promote python/jpl to CORE with --no-unwinding-assertions

### DIFF
--- a/regression/python/jpl/test.desc
+++ b/regression/python/jpl/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---unwind 5
+--unwind 5 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
- The python/jpl test was marked as KNOWNBUG due to an unwinding assertion failure on the while true reactive loop.
- The frontend correctly handles all constructs in this test (classes, inheritance, lambda, random.randint as nondet). The failure was caused by missing --no-unwinding-assertions flag — standard practice for bounded verification of intentionally infinite loops.
