### PR TITLE
[python] Add support for tuple.index()

### DIFF
--- a/regression/python/tuple_index_fail/main.py
+++ b/regression/python/tuple_index_fail/main.py
@@ -1,0 +1,6 @@
+def f() -> int:
+    planets = ("Mercury", "Venus", "Earth")
+    return planets.index("Venus")
+
+
+assert f() == 2

--- a/regression/python/tuple_index_fail/test.desc
+++ b/regression/python/tuple_index_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/tuple_index_method/main.py
+++ b/regression/python/tuple_index_method/main.py
@@ -1,0 +1,6 @@
+def f() -> int:
+    planets = ("Mercury", "Venus", "Earth")
+    return planets.index("Earth")
+
+
+assert f() == 2

--- a/regression/python/tuple_index_method/test.desc
+++ b/regression/python/tuple_index_method/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -67,6 +67,38 @@ bool PyConstValue::is_truthy() const
     return float_val != 0.0;
   case STRING:
     return !string_val.empty();
+  case TUPLE:
+    return !tuple_val.empty();
+  }
+  return false;
+}
+
+static bool pyconst_equal(const PyConstValue &lhs, const PyConstValue &rhs)
+{
+  if (lhs.kind != rhs.kind)
+    return false;
+
+  switch (lhs.kind)
+  {
+  case PyConstValue::NONE:
+    return true;
+  case PyConstValue::BOOL:
+    return lhs.bool_val == rhs.bool_val;
+  case PyConstValue::INT:
+    return lhs.int_val == rhs.int_val;
+  case PyConstValue::FLOAT:
+    return lhs.float_val == rhs.float_val;
+  case PyConstValue::STRING:
+    return lhs.string_val == rhs.string_val;
+  case PyConstValue::TUPLE:
+    if (lhs.tuple_val.size() != rhs.tuple_val.size())
+      return false;
+    for (size_t i = 0; i < lhs.tuple_val.size(); ++i)
+    {
+      if (!pyconst_equal(lhs.tuple_val[i], rhs.tuple_val[i]))
+        return false;
+    }
+    return true;
   }
   return false;
 }
@@ -480,10 +512,24 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
     if (val.is_number_integer())
       return PyConstValue::make_int(val.get<long long>());
     if (val.is_number_float())
-      return PyConstValue{PyConstValue::FLOAT, false, 0, val.get<double>(), ""};
+      return PyConstValue{
+        PyConstValue::FLOAT, false, 0, val.get<double>(), "", {}};
     if (val.is_string())
       return PyConstValue::make_string(val.get<std::string>());
     return std::nullopt;
+  }
+
+  if (type == "Tuple")
+  {
+    std::vector<PyConstValue> values;
+    for (const auto &elt : node["elts"])
+    {
+      auto value = eval_expr(elt, env);
+      if (!value)
+        return std::nullopt;
+      values.push_back(*value);
+    }
+    return PyConstValue::make_tuple(values);
   }
 
   // Variable lookup
@@ -523,7 +569,7 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
         return PyConstValue::make_int(-operand->int_val);
       if (operand->kind == PyConstValue::FLOAT)
         return PyConstValue{
-          PyConstValue::FLOAT, false, 0, -operand->float_val, ""};
+          PyConstValue::FLOAT, false, 0, -operand->float_val, "", {}};
       return std::nullopt;
     }
 
@@ -846,7 +892,28 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
     if (!node.contains("func"))
       return std::nullopt;
 
-    // Only support simple function calls (Name), not methods
+    if (
+      node["func"]["_type"] == "Attribute" &&
+      node["func"].contains("attr") && node["func"]["attr"] == "index" &&
+      node["func"].contains("value"))
+    {
+      auto recv = eval_expr(node["func"]["value"], env);
+      if (!recv || recv->kind != PyConstValue::TUPLE || node["args"].size() != 1)
+        return std::nullopt;
+
+      auto needle = eval_expr(node["args"][0], env);
+      if (!needle)
+        return std::nullopt;
+
+      for (size_t i = 0; i < recv->tuple_val.size(); ++i)
+      {
+        if (pyconst_equal(recv->tuple_val[i], *needle))
+          return PyConstValue::make_int(static_cast<long long>(i));
+      }
+      return std::nullopt;
+    }
+
+    // Only support simple function calls (Name), not other methods
     if (node["func"]["_type"] != "Name")
       return std::nullopt;
 

--- a/src/python-frontend/python_consteval.cpp
+++ b/src/python-frontend/python_consteval.cpp
@@ -893,12 +893,12 @@ python_consteval::eval_expr(const nlohmann::json &node, const Env &env)
       return std::nullopt;
 
     if (
-      node["func"]["_type"] == "Attribute" &&
-      node["func"].contains("attr") && node["func"]["attr"] == "index" &&
-      node["func"].contains("value"))
+      node["func"]["_type"] == "Attribute" && node["func"].contains("attr") &&
+      node["func"]["attr"] == "index" && node["func"].contains("value"))
     {
       auto recv = eval_expr(node["func"]["value"], env);
-      if (!recv || recv->kind != PyConstValue::TUPLE || node["args"].size() != 1)
+      if (
+        !recv || recv->kind != PyConstValue::TUPLE || node["args"].size() != 1)
         return std::nullopt;
 
       auto needle = eval_expr(node["args"][0], env);

--- a/src/python-frontend/python_consteval.h
+++ b/src/python-frontend/python_consteval.h
@@ -15,7 +15,8 @@ struct PyConstValue
     BOOL,
     INT,
     FLOAT,
-    STRING
+    STRING,
+    TUPLE
   };
 
   Kind kind = NONE;
@@ -23,26 +24,31 @@ struct PyConstValue
   long long int_val = 0;
   double float_val = 0.0;
   std::string string_val;
+  std::vector<PyConstValue> tuple_val;
 
   static PyConstValue make_none()
   {
-    return {NONE, false, 0, 0.0, ""};
+    return {NONE, false, 0, 0.0, "", {}};
   }
   static PyConstValue make_bool(bool v)
   {
-    return {BOOL, v, 0, 0.0, ""};
+    return {BOOL, v, 0, 0.0, "", {}};
   }
   static PyConstValue make_int(long long v)
   {
-    return {INT, false, v, 0.0, ""};
+    return {INT, false, v, 0.0, "", {}};
   }
   static PyConstValue make_float(double v)
   {
-    return {FLOAT, false, 0, v, ""};
+    return {FLOAT, false, 0, v, "", {}};
   }
   static PyConstValue make_string(const std::string &s)
   {
-    return {STRING, false, 0, 0.0, s};
+    return {STRING, false, 0, 0.0, s, {}};
+  }
+  static PyConstValue make_tuple(const std::vector<PyConstValue> &values)
+  {
+    return {TUPLE, false, 0, 0.0, "", values};
   }
 
   bool is_truthy() const;


### PR DESCRIPTION
This PR adds support for `tuple.index()`.

  Example:
  ```python
  def f() -> int:
      planets = ("Mercury", "Venus", "Earth")
      return planets.index("Earth")

  assert f() == 2
```

We were raising a ValueError instead of resolving the constant tuple index:
```text
  [Counterexample]

  State 22 file regression/python/tuple_index_method/main.py line 3 column 11 function f thread 0
  ----------------------------------------------------
  Violated property:
    file regression/python/tuple_index_method/main.py line 3 column 11 function f
    Throwing an exception of type ValueError but there is not catch for it.

  VERIFICATION FAILED
```
