### PR TITLE
[witness] add special treatment for branching waypoints

### DIFF
--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -108,6 +108,7 @@ void goto_convertt::optimize_guarded_gotos(goto_programt &dest)
     {
       it->set_target(it_goto_y->get_target());
       make_not(it->guard);
+      it->flipped_guard = true;
       it_goto_y->make_skip();
     }
   }

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -148,6 +148,11 @@ public:
 
     bool inductive_assertion;
 
+    // Set by optimize_guarded_gotos when "IF !cond GOTO skip; GOTO target" is
+    // folded into "IF cond GOTO target". The guard is then the positive source
+    // condition, so GOTO-taken means the branch body (original target) IS reached.
+    bool flipped_guard;
+
     //! is this node a branch target?
     inline bool is_target() const
     {
@@ -165,6 +170,7 @@ public:
       loop_assigns_targets.clear();
       inductive_step_instruction = false;
       inductive_assertion = false;
+      flipped_guard = false;
     }
 
     inline void make_goto()
@@ -353,6 +359,7 @@ public:
         type(NO_INSTRUCTION_TYPE),
         inductive_step_instruction(false),
         inductive_assertion(false),
+        flipped_guard(false),
         location_number(0),
         loop_number(unsigned(0)),
         pragma_unroll_count(0),
@@ -366,6 +373,7 @@ public:
         type(_type),
         inductive_step_instruction(false),
         inductive_assertion(false),
+        flipped_guard(false),
         location_number(0),
         loop_number(unsigned(0)),
         pragma_unroll_count(0),
@@ -384,6 +392,7 @@ public:
         labels(other.labels),
         inductive_step_instruction(other.inductive_step_instruction),
         inductive_assertion(other.inductive_assertion),
+        flipped_guard(other.flipped_guard),
         location_number(other.location_number),
         loop_number(other.loop_number),
         pragma_unroll_count(other.pragma_unroll_count),
@@ -410,6 +419,7 @@ public:
         labels(std::move(other.labels)),
         inductive_step_instruction(other.inductive_step_instruction),
         inductive_assertion(other.inductive_assertion),
+        flipped_guard(other.flipped_guard),
         location_number(other.location_number),
         loop_number(other.loop_number),
         pragma_unroll_count(other.pragma_unroll_count),
@@ -442,6 +452,7 @@ public:
       std::swap(
         inductive_step_instruction, instruction.inductive_step_instruction);
       std::swap(inductive_assertion, instruction.inductive_assertion);
+      std::swap(flipped_guard, instruction.flipped_guard);
       std::swap(instruction.loop_number, loop_number);
       std::swap(instruction.pragma_unroll_count, pragma_unroll_count);
       std::swap(target_number, instruction.target_number);

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -83,9 +83,17 @@ void goto_symext::symex_goto(const expr2tc &old_guard)
     !is_constant(old_guard) &&
     !(is_not2t(old_guard) && is_constant(to_not2t(old_guard).value)))
   {
+    // Normalize the branching condition so that cond=true always means
+    // "the branch body was reached". For standard GOTOs (IF !cond GOTO skip)
+    // new_guard already has this form. For flipped GOTOs produced by
+    // optimize_guarded_gotos (IF cond GOTO target), the guard sense is
+    // inverted, so we apply make_not to restore the canonical direction.
+    expr2tc branching_cond = new_guard;
+    if (instruction.flipped_guard)
+      make_not(branching_cond);
     target->branching(
       cur_state->guard.as_expr(),
-      new_guard,
+      branching_cond,
       cur_state->source,
       cur_state->top().hidden,
       first_loop);


### PR DESCRIPTION
This PR has fixed the following branching waypoints:

```c
  do
  {
    if (some_var)
      break;
  } while (0);
```

GOTO:

```
  if (!guard) goto 1;
    goto 2;
 1: 
```
It will be simplified to:
```
  if (guard) goto 2;
```

Therefore, we need to handle it in the opposite way here.

 