### PR TITLE
[C++ verification] support UserDefinedLiteral node

### DIFF
--- a/regression/esbmc-cpp/cpp/udl_operator/main.cpp
+++ b/regression/esbmc-cpp/cpp/udl_operator/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+constexpr long double operator""_deg(long double d)
+{
+  return d * 3.14159265358979L / 180.0L;
+}
+
+int main()
+{
+  constexpr long double pi = 3.14159265358979L;
+  long double r = 180.0_deg;
+  assert(r == pi);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/udl_operator/test.desc
+++ b/regression/esbmc-cpp/cpp/udl_operator/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/udl_operator_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/udl_operator_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+constexpr long double operator""_deg(long double d)
+{
+  return d * 3.14159265358979L / 180.0L;
+}
+
+int main()
+{
+  long double r = 90.0_deg;
+  // 90 degrees in radians is ~1.5707..., not 90.0
+  assert(r == 90.0L);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/udl_operator_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/udl_operator_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1091,7 +1091,7 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     sym.move_to_operands(list);
     sym.move_to_operands(size);
 
-    // Implicit construction of a std::initializer_list<T> object
+    // Implicit construction of a std::initializer_list<T> objectcal
     // from an array temporary within list-initialization
     // Therefore the AST does not call the constructor
     new_expr = sym;
@@ -1253,6 +1253,36 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       new_expr = true_exprt();
     else
       new_expr = false_exprt();
+    break;
+  }
+
+  case clang::Stmt::UserDefinedLiteralClass:
+  {
+    const clang::UserDefinedLiteral &udl =
+      static_cast<const clang::UserDefinedLiteral &>(stmt);
+
+    exprt callee_expr;
+    if (get_expr(*udl.getCallee(), callee_expr))
+      return true;
+
+    typet type;
+    if (get_type(udl.getCallReturnType(*ASTContext), type))
+      return true;
+
+    side_effect_expr_function_callt call;
+    call.function() = callee_expr;
+    call.type() = type;
+
+    for (const clang::Expr *arg : udl.arguments())
+    {
+      exprt single_arg;
+      if (get_expr(*arg, single_arg))
+        return true;
+
+      call.arguments().push_back(single_arg);
+    }
+
+    new_expr = call;
     break;
   }
 


### PR DESCRIPTION
Fixes #4087 

code:
```c
constexpr long double operator""_deg(long double d)
{
  return d * 3.14159265358979L / 180.0L;
}
long double r = 90.0_deg;
```

```c
        DECL long double return_value$_operator""_deg$1;

        FUNCTION_CALL:  return_value$_operator""_deg$1=operator""_deg(90.000000l)

        ASSIGN r=return_value$_operator""_deg$1;
```