### PR TITLE
[pointer-analysis] fix big-endian byte access into struct via dyn offset

### DIFF
--- a/regression/esbmc/endianness_03/main.c
+++ b/regression/esbmc/endianness_03/main.c
@@ -1,0 +1,18 @@
+#include <string.h>
+#include <assert.h>
+
+struct chars
+{
+  char fst;
+  char snd;
+};
+
+int main()
+{
+  struct chars c = {0x01, 0x02};
+  short s;
+  memcpy(&s, &c, 2);
+  /* big-endian: fst is MSB, snd is LSB */
+  assert(s == 0x0102);
+  return 0;
+}

--- a/regression/esbmc/endianness_03/test.desc
+++ b/regression/esbmc/endianness_03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--big-endian
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/endianness_04/main.c
+++ b/regression/esbmc/endianness_04/main.c
@@ -1,0 +1,18 @@
+#include <string.h>
+#include <assert.h>
+
+struct chars
+{
+  char fst;
+  char snd;
+};
+
+int main()
+{
+  struct chars c = {0x01, 0x02};
+  short s;
+  memcpy(&s, &c, 2);
+  /* little-endian: fst is LSB, snd is MSB */
+  assert(s == 0x0201);
+  return 0;
+}

--- a/regression/esbmc/endianness_04/test.desc
+++ b/regression/esbmc/endianness_04/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--little-endian
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/endianness_05/main.c
+++ b/regression/esbmc/endianness_05/main.c
@@ -1,0 +1,18 @@
+#include <string.h>
+#include <assert.h>
+
+struct chars
+{
+  char fst;
+  char snd;
+};
+
+int main()
+{
+  struct chars c = {0x01, 0x02};
+  short s;
+  memcpy(&s, &c, 2);
+  /* expect s == 0x0102 under --big-endian; negate to force counterexample */
+  assert(s != 0x0102);
+  return 0;
+}

--- a/regression/esbmc/endianness_05/test.desc
+++ b/regression/esbmc/endianness_05/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--big-endian
+^VERIFICATION FAILED$

--- a/regression/esbmc/endianness_06/main.c
+++ b/regression/esbmc/endianness_06/main.c
@@ -1,0 +1,20 @@
+#include <string.h>
+#include <assert.h>
+
+struct quad
+{
+  char b0;
+  char b1;
+  char b2;
+  char b3;
+};
+
+int main()
+{
+  struct quad q = {0x01, 0x02, 0x03, 0x04};
+  unsigned int x;
+  memcpy(&x, &q, 4);
+  /* big-endian: b0 is MSB, b3 is LSB */
+  assert(x == 0x01020304u);
+  return 0;
+}

--- a/regression/esbmc/endianness_06/test.desc
+++ b/regression/esbmc/endianness_06/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--big-endian
+^VERIFICATION SUCCESSFUL$

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -1441,9 +1441,18 @@ void dereferencet::construct_from_dyn_struct_offset(
   // construct_from_dyn_offset
   if (access_sz == config.ansi_c.char_width)
   {
-    value = bitcast2tc(
-      get_uint_type(type_byte_size_bits(value->type, &ns).to_uint64()), value);
-    return construct_from_dyn_offset(value, offset, type);
+    uint64_t struct_bits = type_byte_size_bits(value->type, &ns).to_uint64();
+    value = bitcast2tc(get_uint_type(struct_bits), value);
+    // flatten_to_bitvector places the first struct member in the low bits
+    // regardless of target endianness, so under big-endian we must mirror
+    // the bit offset before delegating to the scalar byte extractor.
+    expr2tc adjusted_offset = offset;
+    if (is_big_endian)
+      adjusted_offset = sub2tc(
+        offset->type,
+        gen_long(offset->type, struct_bits - config.ansi_c.char_width),
+        offset);
+    return construct_from_dyn_offset(value, adjusted_offset, type);
   }
 
   // For each element of the struct, look at the alignment, and produce an


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/1454.

`construct_from_dyn_struct_offset` flattens the struct to a `uint` via `flatten_to_bitvector`, which always places the first member in the low bits. 

Under `--big-endian`, the downstream `byte_extract` then reads from the opposite end, returning the wrong byte for each dynamic-offset access (e.g., the per-byte loop in `memcpy`). 

This PR mirrors the bit offset when the target is big-endian, so memory byte N maps to the matching slice of the flattened `uint`.