### PR TITLE
[regression] add tests for alignment check via intermediate pointer (#1220)

### DIFF
--- a/regression/esbmc/github_1220-fail/main.c
+++ b/regression/esbmc/github_1220-fail/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+int arr[16];
+
+void f(unsigned k, unsigned v)
+{
+	k %= 16;
+	arr[k] = v;
+	void *p = arr;
+	int *q = (int *)(void *)((short *)p + (k * 1));
+	int w = *q;
+	assert(w == v);
+}

--- a/regression/esbmc/github_1220-fail/test.desc
+++ b/regression/esbmc/github_1220-fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
---func f
+--func f --multi-property
 ^VERIFICATION FAILED$
 \bdereference failure: Incorrect alignment when accessing data object\b

--- a/regression/esbmc/github_1220-fail/test.desc
+++ b/regression/esbmc/github_1220-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--func f
+^VERIFICATION FAILED$
+\bdereference failure: Incorrect alignment when accessing data object\b

--- a/regression/esbmc/github_1220-success/main.c
+++ b/regression/esbmc/github_1220-success/main.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+int arr[16];
+
+void f(unsigned k, unsigned v)
+{
+	k %= 8;
+	arr[k] = v;
+	void *p = arr;
+	int *q = (int *)(void *)((short *)p + (k * 2));
+	int w = *q;
+	assert(w == v);
+}

--- a/regression/esbmc/github_1220-success/test.desc
+++ b/regression/esbmc/github_1220-success/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--func f
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/1220.

Issue #1220 reported that ESBMC missed the alignment check when a misaligned pointer was stored in an intermediate symbol before dereference. The fix (PR #2684, check_pointer_alignment) already handles this; add two regression tests to prevent regressions.

The fail case stores `(int*)((short*)p + k*1)` in `q`, then dereferences *q -- misaligned when `k` is odd. The success case uses `k*2` short-steps (= `k*4` bytes) so the `int*` access is correctly aligned and `w==v` holds.