### PR TITLE
[Solidity] reclassify constructor_4 regression from THOROUGH to CORE

### DIFF
--- a/regression/esbmc-solidity/constructor_4/test.desc
+++ b/regression/esbmc-solidity/constructor_4/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 contract.solast
 --contract DD --sol contract.sol --k-induction --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/1723.

The test runs in ~0.5s on current hardware, well below the 2s CORE threshold used in PR #2863 for the THOROUGH cutoff. The original THOROUGH label came from one-shot CI timing data in that reflow PR; subsequent frontend/solver improvements have brought it firmly back into CORE range.

Test results (esbmc-solidity, constructor_4 only):
  1 total, 1 passed, 0 failed, 0 timeout (0.49s)

Assisted-by: Claude-Opus4.7