### PR TITLE
[Python] support inline literals and smarter return-type inference

### DIFF
--- a/regression/python/dict_basics/main.py
+++ b/regression/python/dict_basics/main.py
@@ -1,0 +1,47 @@
+def test_dict_get() -> None:
+    assert {"wah": 2}.get("aap", 3) == 3
+
+
+def test_dict_del() -> None:
+    d = {1: 4, 2: 5}
+    del d[1]
+    assert d == {2: 5}
+
+
+def test_mixed_numeric_keys() -> None:
+    a = {}
+    a[1.0] = 1
+    assert a[1.0] == 1
+
+    b = {}
+    b[1] = 1.0
+    assert b[1] == 1.0
+
+    c = {}
+    c[4] = 1.0
+    assert c[4] == 1.0
+    assert 4 in c
+
+
+def test_negative_keys() -> None:
+    d = {-1: 2}
+    assert d[-1] == 2
+
+
+def test_pop() -> None:
+    d = {-1: 2, 12: 24}
+    assert d.pop(-1) == 2
+    assert d.pop(7, 8) == 8
+    assert d.pop(12, 9) == 24
+    assert len(d) == 0
+
+
+def test_all() -> None:
+    test_dict_get()
+    test_dict_del()
+    test_mixed_numeric_keys()
+    test_negative_keys()
+    test_pop()
+
+
+test_all()

--- a/regression/python/dict_basics/test.desc
+++ b/regression/python/dict_basics/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_basics_fail/main.py
+++ b/regression/python/dict_basics_fail/main.py
@@ -1,0 +1,7 @@
+def test() -> None:
+    # pop with default on missing key returns the default value.
+    d = {-1: 2}
+    assert d.pop(7, 8) == 7
+
+
+test()

--- a/regression/python/dict_basics_fail/test.desc
+++ b/regression/python/dict_basics_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/dict_method_inline/main.py
+++ b/regression/python/dict_method_inline/main.py
@@ -1,0 +1,11 @@
+def test() -> None:
+    x = {"a": 1}.get("missing", 3)
+    assert x == 3
+
+    y = {"a": 1}.get("a", 99)
+    assert y == 1
+
+    z = list({}.items())
+    assert len(z) == 0
+
+test()

--- a/regression/python/dict_method_inline/main.py
+++ b/regression/python/dict_method_inline/main.py
@@ -1,9 +1,22 @@
 def test() -> None:
+    # Existing: inline dict.get with int defaults.
     x = {"a": 1}.get("missing", 3)
     assert x == 3
 
     y = {"a": 1}.get("a", 99)
     assert y == 1
+
+    # Inline dict.get with scalar defaults of other builtin types: the
+    # frontend must narrow the return type to the concrete builtin
+    # instead of falling back to Any.
+    assert {"a": 1}.get("missing", 3.14) > 3.0
+    assert {"a": 1}.get("missing", "x") == "x"
+    assert {"a": 1}.get("missing", True) == True
+
+    # Untyped dict variable: same inference applies through the
+    # converter's unannotated-assign path.
+    d = {}
+    assert d.get("k", 7) == 7
 
     z = list({}.items())
     assert len(z) == 0

--- a/regression/python/dict_method_inline/test.desc
+++ b/regression/python/dict_method_inline/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dict_method_inline_fail/main.py
+++ b/regression/python/dict_method_inline_fail/main.py
@@ -1,0 +1,5 @@
+def test() -> None:
+    x = {"a": 1}.get("missing", 3)
+    assert x == 99
+
+test()

--- a/regression/python/dict_method_inline_fail/test.desc
+++ b/regression/python/dict_method_inline_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2984,35 +2984,47 @@ exprt function_call_expr::handle_dict_method() const
 {
   const std::string &method_name = function_id_.get_function();
 
-  // Resolve the dict symbol for all dict methods
+  // Resolve the dict to a symbol.
+  // Named receivers look up by name;
+  // inline literals (e.g. `{"a":1}.get(...)`) have none,
+  // so spill into a tmp first.
+  exprt dict_expr;
   std::string dict_name = get_object_name();
-  symbol_id dict_symbol_id = converter_.create_symbol_id();
-  dict_symbol_id.set_object(dict_name);
-  const symbolt *dict_symbol =
-    converter_.find_symbol(dict_symbol_id.to_string());
-
-  if (!dict_symbol)
-    throw std::runtime_error("Dictionary variable not found: " + dict_name);
+  if (!dict_name.empty())
+  {
+    symbol_id dict_symbol_id = converter_.create_symbol_id();
+    dict_symbol_id.set_object(dict_name);
+    const symbolt *dict_symbol =
+      converter_.find_symbol(dict_symbol_id.to_string());
+    if (!dict_symbol)
+      throw std::runtime_error("Dictionary variable not found: " + dict_name);
+    dict_expr = symbol_expr(*dict_symbol);
+  }
+  else
+  {
+    exprt literal = converter_.get_expr(call_["func"]["value"]);
+    symbolt &tmp = converter_.create_tmp_symbol(
+      call_, "$dict_lit$", literal.type(), exprt());
+    converter_.add_instruction(code_declt(symbol_expr(tmp)));
+    converter_.add_instruction(code_assignt(symbol_expr(tmp), literal));
+    dict_expr = symbol_expr(tmp);
+  }
 
   if (method_name == "get")
-    return converter_.get_dict_handler()->handle_dict_get(
-      symbol_expr(*dict_symbol), call_);
+    return converter_.get_dict_handler()->handle_dict_get(dict_expr, call_);
 
   if (method_name == "setdefault")
     return converter_.get_dict_handler()->handle_dict_setdefault(
-      symbol_expr(*dict_symbol), call_);
+      dict_expr, call_);
 
   if (method_name == "update")
-    return converter_.get_dict_handler()->handle_dict_update(
-      symbol_expr(*dict_symbol), call_);
+    return converter_.get_dict_handler()->handle_dict_update(dict_expr, call_);
 
   if (method_name == "pop")
-    return converter_.get_dict_handler()->handle_dict_pop(
-      symbol_expr(*dict_symbol), call_);
+    return converter_.get_dict_handler()->handle_dict_pop(dict_expr, call_);
 
   if (method_name == "popitem")
-    return converter_.get_dict_handler()->handle_dict_popitem(
-      symbol_expr(*dict_symbol), call_);
+    return converter_.get_dict_handler()->handle_dict_popitem(dict_expr, call_);
 
   throw std::runtime_error("Unsupported dict method: " + method_name);
 }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -304,6 +304,27 @@ public:
     }
   }
 
+public:
+  // Infer the return type of dict.{setdefault, get, pop} from args[1]'s AST shape:
+  // "list"/"dict"/"set"/"tuple" for literal defaults,
+  // "Any" for anything else,
+  // "" when there is no default arg.
+  static std::string infer_type_from_default_arg_shape(const Json &args_node)
+  {
+    if (!args_node.is_array() || args_node.size() < 2)
+      return std::string();
+    const std::string def_type = args_node[1].value("_type", std::string());
+    if (def_type == "List")
+      return "list";
+    if (def_type == "Dict")
+      return "dict";
+    if (def_type == "Set")
+      return "set";
+    if (def_type == "Tuple")
+      return "tuple";
+    return "Any";
+  }
+
 private:
   bool has_annotation(const Json &node)
   {
@@ -2710,6 +2731,43 @@ private:
         return obj_type;
     }
 
+    // Method calls on inline dict/list/set literals (e.g. {"a":1}.get("x", 3)).
+    // The receiver has no symbol name, so apply the builtin rules directly
+    // before the name-based lookup below kicks in.
+    if (call["func"].contains("value"))
+    {
+      const std::string &recv_kind =
+        call["func"]["value"].value("_type", std::string());
+      if (recv_kind == "Dict" || recv_kind == "List" || recv_kind == "Set")
+      {
+        const std::string lit_obj_type = (recv_kind == "Dict")   ? "dict"
+                                         : (recv_kind == "List") ? "list"
+                                                                 : "set";
+        const std::string method =
+          call["func"].contains("attr")
+            ? call["func"]["attr"].template get<std::string>()
+            : std::string();
+
+        // setdefault/get/pop: return the value's container shape.
+        if (
+          lit_obj_type == "dict" &&
+          (method == "setdefault" || method == "get" || method == "pop"))
+        {
+          std::string t = infer_type_from_default_arg_shape(call["args"]);
+          if (!t.empty())
+            return t;
+        }
+
+        // keys/values/items views behave like lists for type inference.
+        if (
+          lit_obj_type == "dict" &&
+          (method == "keys" || method == "values" || method == "items"))
+          return "list";
+
+        return lit_obj_type;
+      }
+    }
+
     // Handle method calls on subscript expressions: e.g. nested[i].pop()
     // get_object_name() returns "" for Subscript nodes (no "id" field), which
     // would cause a spurious "Object not found" throw further below.
@@ -3191,6 +3249,17 @@ private:
         obj_type == "str" && call["func"].contains("attr") &&
         call["func"]["attr"] == "split")
         return "list";
+      // setdefault/get/pop return the value, not the dict — recover its
+      // container shape from the default arg when the dict is untyped.
+      if (
+        obj_type == "dict" && call["func"].contains("attr") &&
+        (call["func"]["attr"] == "setdefault" ||
+         call["func"]["attr"] == "get" || call["func"]["attr"] == "pop"))
+      {
+        std::string t = infer_type_from_default_arg_shape(call["args"]);
+        if (!t.empty())
+          return t;
+      }
       type = obj_type;
     }
     else

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -304,16 +304,16 @@ public:
     }
   }
 
-public:
-  // Infer the return type of dict.{setdefault, get, pop} from args[1]'s AST shape:
-  // "list"/"dict"/"set"/"tuple" for literal defaults,
-  // "Any" for anything else,
-  // "" when there is no default arg.
+  // Return the builtin type of a dict.{get, setdefault, pop} default arg.
+  // Recognises literal shapes (list/dict/set/tuple) and scalar Constants
+  // (int/float/str/bool/None). Returns "Any" for non-literals (variables,
+  // calls), "" when the call has no default argument.
   static std::string infer_type_from_default_arg_shape(const Json &args_node)
   {
     if (!args_node.is_array() || args_node.size() < 2)
       return std::string();
-    const std::string def_type = args_node[1].value("_type", std::string());
+    const Json &def = args_node[1];
+    const std::string def_type = def.value("_type", std::string());
     if (def_type == "List")
       return "list";
     if (def_type == "Dict")
@@ -322,6 +322,22 @@ public:
       return "set";
     if (def_type == "Tuple")
       return "tuple";
+    // Scalar literals: read the builtin type off the constant's JSON value
+    // so that e.g. `.get(k, 3)` does not fall back to `Any`.
+    if (def_type == "Constant" && def.contains("value"))
+    {
+      const Json &v = def["value"];
+      if (v.is_null())
+        return "None";
+      if (v.is_boolean())
+        return "bool";
+      if (v.is_number_integer())
+        return "int";
+      if (v.is_number_float())
+        return "float";
+      if (v.is_string())
+        return "str";
+    }
     return "Any";
   }
 
@@ -2731,40 +2747,32 @@ private:
         return obj_type;
     }
 
-    // Method calls on inline dict/list/set literals (e.g. {"a":1}.get("x", 3)).
-    // The receiver has no symbol name, so apply the builtin rules directly
-    // before the name-based lookup below kicks in.
+    // Inline dict-literal method calls, e.g. `{"a":1}.get("x", 3)`.
+    // The receiver has no symbol name, so resolve the types we model here
+    // (get/setdefault/pop/keys/values/items)
+    // and let anything else fall through to the regular resolution path below.
     if (call["func"].contains("value"))
     {
       const std::string &recv_kind =
         call["func"]["value"].value("_type", std::string());
-      if (recv_kind == "Dict" || recv_kind == "List" || recv_kind == "Set")
+      if (recv_kind == "Dict")
       {
-        const std::string lit_obj_type = (recv_kind == "Dict")   ? "dict"
-                                         : (recv_kind == "List") ? "list"
-                                                                 : "set";
         const std::string method =
           call["func"].contains("attr")
             ? call["func"]["attr"].template get<std::string>()
             : std::string();
 
-        // setdefault/get/pop: return the value's container shape.
-        if (
-          lit_obj_type == "dict" &&
-          (method == "setdefault" || method == "get" || method == "pop"))
+        // get/setdefault/pop: return type comes from the default arg.
+        if (method == "setdefault" || method == "get" || method == "pop")
         {
           std::string t = infer_type_from_default_arg_shape(call["args"]);
           if (!t.empty())
             return t;
         }
 
-        // keys/values/items views behave like lists for type inference.
-        if (
-          lit_obj_type == "dict" &&
-          (method == "keys" || method == "values" || method == "items"))
+        // keys/values/items: views behave like lists for type inference.
+        if (method == "keys" || method == "values" || method == "items")
           return "list";
-
-        return lit_obj_type;
       }
     }
 

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -304,10 +304,8 @@ public:
     }
   }
 
-  // Return the builtin type of a dict.{get, setdefault, pop} default arg.
-  // Recognises literal shapes (list/dict/set/tuple) and scalar Constants
-  // (int/float/str/bool/None). Returns "Any" for non-literals (variables,
-  // calls), "" when the call has no default argument.
+  // Infer the builtin type of a dict.{get, setdefault, pop} default arg.
+  // Returns "" when there is no default, "Any" for non-literal defaults.
   static std::string infer_type_from_default_arg_shape(const Json &args_node)
   {
     if (!args_node.is_array() || args_node.size() < 2)
@@ -322,21 +320,15 @@ public:
       return "set";
     if (def_type == "Tuple")
       return "tuple";
-    // Scalar literals: read the builtin type off the constant's JSON value
-    // so that e.g. `.get(k, 3)` does not fall back to `Any`.
+    // Scalar literal: narrow to the concrete builtin type (int/float/str/
+    // bool/None) so the caller does not have to fall back to Any.
     if (def_type == "Constant" && def.contains("value"))
     {
-      const Json &v = def["value"];
-      if (v.is_null())
+      const std::string t = get_type_from_json(def["value"]);
+      if (t == "null")
         return "None";
-      if (v.is_boolean())
-        return "bool";
-      if (v.is_number_integer())
-        return "int";
-      if (v.is_number_float())
-        return "float";
-      if (v.is_string())
-        return "str";
+      if (t == "bool" || t == "int" || t == "float" || t == "str")
+        return t;
     }
     return "Any";
   }
@@ -2042,7 +2034,7 @@ private:
     return node["annotation"]["id"];
   }
 
-  std::string get_type_from_json(const Json &value)
+  static std::string get_type_from_json(const Json &value)
   {
     if (value.is_null())
       return "null";

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5666,7 +5666,18 @@ symbolt *python_converter::create_symbol_for_unannotated_assign(
         inferred_type = dict_handler_->resolve_expected_type_for_dict_subscript(
           symbol_expr(*obj_sym));
         if (inferred_type.is_nil() || inferred_type.is_empty())
-          inferred_type = long_int_type();
+        {
+          // Untyped dict (e.g. `a = {}`): derive the result type from the
+          // default arg's shape; A literal list/dict beats the int fallback.
+          const std::string shape = python_annotation<nlohmann::json>::
+            infer_type_from_default_arg_shape(ast_node["value"]["args"]);
+          if (shape == "list")
+            inferred_type = type_handler_.get_list_type();
+          else if (shape == "dict")
+            inferred_type = dict_handler_->get_dict_struct_type();
+          if (inferred_type.is_nil() || inferred_type.is_empty())
+            inferred_type = long_int_type();
+        }
       }
     }
     else

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5667,14 +5667,19 @@ symbolt *python_converter::create_symbol_for_unannotated_assign(
           symbol_expr(*obj_sym));
         if (inferred_type.is_nil() || inferred_type.is_empty())
         {
-          // Untyped dict (e.g. `a = {}`): derive the result type from the
-          // default arg's shape; A literal list/dict beats the int fallback.
+          // Untyped dict (e.g. `a = {}`): infer the return type from the default arg.
+          // Any concrete literal (list, dict, int, float, str, bool, None)
+          // is more precise than the `long_int` fallback applied just below.
           const std::string shape = python_annotation<nlohmann::json>::
             infer_type_from_default_arg_shape(ast_node["value"]["args"]);
           if (shape == "list")
             inferred_type = type_handler_.get_list_type();
           else if (shape == "dict")
             inferred_type = dict_handler_->get_dict_struct_type();
+          else if (
+            !shape.empty() && shape != "Any" &&
+            type_utils::is_builtin_type(shape))
+            inferred_type = type_handler_.get_typet(shape, 0);
           if (inferred_type.is_nil() || inferred_type.is_empty())
             inferred_type = long_int_type();
         }


### PR DESCRIPTION
This pr
-  Fix dict method calls crashed like `{"a":1}.get("x", 3)` .
- Fix `dict.{setdefault, get, pop}` returning the wrong type when the dict was untyped. Prevent type-check failures like `a.setdefault(k, []).append(x)`