### PR TITLE
Add dataclasses module import infrastructure

### DIFF
--- a/regression/python/dataclasses_from_import/main.py
+++ b/regression/python/dataclasses_from_import/main.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Task:
+
+    def __init__(self, value: int):
+        self.value = value
+
+
+task = Task(7)
+
+assert task.value == 7

--- a/regression/python/dataclasses_from_import/test.desc
+++ b/regression/python/dataclasses_from_import/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclasses_module_import/main.py
+++ b/regression/python/dataclasses_module_import/main.py
@@ -1,0 +1,1 @@
+import dataclasses

--- a/regression/python/dataclasses_module_import/test.desc
+++ b/regression/python/dataclasses_module_import/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/optional7/test.desc
+++ b/regression/python/optional7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -5,6 +5,7 @@ class Field:
 
 
 def dataclass(_cls=None, **kwargs):
+
     def wrap(cls):
         return cls
 

--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -1,6 +1,8 @@
 class Field:
 
     def __class_getitem__(cls, item):
+        """Return the class itself for subscription-style type usage."""
+
         return cls
 
 

--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -1,0 +1,19 @@
+class Field:
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+def dataclass(_cls=None, **kwargs):
+    def wrap(cls):
+        return cls
+
+    if _cls is None:
+        return wrap
+    return _cls
+
+
+def field(*args, default=None, default_factory=None, **kwargs):
+    if default_factory is not None:
+        return default_factory()
+    return default

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -17,6 +17,7 @@ import json
 import os
 import glob
 import base64
+import tempfile
 from preprocessor import Preprocessor
 
 
@@ -27,7 +28,10 @@ def run_mypy_strict(filename):
     except ImportError:
         return 0, ""
 
-    stdout, stderr, exit_status = mypy_api.run(["--strict", filename])
+    with tempfile.TemporaryDirectory(prefix="esbmc-mypy-cache-") as cache_dir:
+        stdout, stderr, exit_status = mypy_api.run(
+            ["--strict", "--cache-dir", cache_dir, filename]
+        )
     output = stdout
     if stderr:
         output += stderr

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -48,6 +48,7 @@ def is_imported_model(module_name):
         "esbmc",
         "decimal",
         "collections",
+        "dataclasses",
         "typing",
         "time",
     ]


### PR DESCRIPTION
This PR adds the first dataclasses infrastructure for the Python frontend
- Register dataclasses as a supported imported model in the Python parser.
- Add a minimal dataclasses model stub  .
- Limited to module import infrastructure