### PR TITLE
Clang 22 now adds record kind for elaborated types

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3914,7 +3914,7 @@ void clang_c_convertert::get_decl_name(
     }
     else
 #if CLANG_VERSION_MAJOR >= 22
-      name = getFullyQualifiedName(
+      name = rd.getKindName().str() + " " + getFullyQualifiedName(
         ASTContext->getTypeDeclType(llvm::cast<clang::TypeDecl>(&rd)),
         *ASTContext);
 #else

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3914,9 +3914,10 @@ void clang_c_convertert::get_decl_name(
     }
     else
 #if CLANG_VERSION_MAJOR >= 22
-      name = rd.getKindName().str() + " " + getFullyQualifiedName(
-        ASTContext->getTypeDeclType(llvm::cast<clang::TypeDecl>(&rd)),
-        *ASTContext);
+      name = rd.getKindName().str() + " " +
+             getFullyQualifiedName(
+               ASTContext->getTypeDeclType(llvm::cast<clang::TypeDecl>(&rd)),
+               *ASTContext);
 #else
       name =
         getFullyQualifiedName(ASTContext->getTagDeclType(&rd), *ASTContext);


### PR DESCRIPTION
Solves https://github.com/esbmc/esbmc/issues/4139

The issue is that in Clang < 22, elaborated types were handled through PrettyPrinter. This changed, and the kind of type is now a member of the Record itself.