### PR TITLE
[python] gracefully skip unresolvable imports instead of crashing

### DIFF
--- a/regression/python/github_4149/main.py
+++ b/regression/python/github_4149/main.py
@@ -1,0 +1,4 @@
+import flask
+
+x: int = 1
+assert x == 1

--- a/regression/python/github_4149/test.desc
+++ b/regression/python/github_4149/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4149_fail/main.py
+++ b/regression/python/github_4149_fail/main.py
@@ -1,0 +1,4 @@
+import flask
+
+x: int = 1
+assert x == 2

--- a/regression/python/github_4149_fail/test.desc
+++ b/regression/python/github_4149_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -62,6 +62,7 @@ ignored_dirs=(
   "github_3563_2"
   "github_3563_3"
   "github_3769"
+  "github_4149"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9936,8 +9936,8 @@ void python_converter::process_module_imports(
       if (elem.value("module_not_found", false))
       {
         const std::string module_name = (elem["_type"] == "ImportFrom")
-                                         ? elem["module"]
-                                         : elem["names"][0]["name"];
+                                          ? elem["module"]
+                                          : elem["names"][0]["name"];
         log_warning("skipping unresolvable import: {}", module_name);
         continue;
       }
@@ -10135,8 +10135,8 @@ void python_converter::convert()
         if (elem.value("module_not_found", false))
         {
           const std::string module_name = (elem["_type"] == "ImportFrom")
-                                           ? elem["module"]
-                                           : elem["names"][0]["name"];
+                                            ? elem["module"]
+                                            : elem["names"][0]["name"];
           log_warning("skipping unresolvable import: {}", module_name);
           continue;
         }
@@ -10168,8 +10168,8 @@ void python_converter::convert()
         if (stmt.value("module_not_found", false))
         {
           const std::string module_name = (stmt["_type"] == "ImportFrom")
-                                           ? stmt["module"]
-                                           : stmt["names"][0]["name"];
+                                            ? stmt["module"]
+                                            : stmt["names"][0]["name"];
           log_warning("skipping unresolvable import: {}", module_name);
           continue;
         }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9933,14 +9933,6 @@ void python_converter::process_module_imports(
   {
     if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
     {
-      if (elem.value("module_not_found", false))
-      {
-        const std::string module_name = (elem["_type"] == "ImportFrom")
-                                          ? elem["module"]
-                                          : elem["names"][0]["name"];
-        log_warning("skipping unresolvable import: {}", module_name);
-        continue;
-      }
       std::string saved_file = current_python_file;
       import_module_into_block(elem, locator, block);
       current_python_file = saved_file;
@@ -10165,14 +10157,6 @@ void python_converter::convert()
         if (stmt["_type"] != "ImportFrom" && stmt["_type"] != "Import")
           continue;
 
-        if (stmt.value("module_not_found", false))
-        {
-          const std::string module_name = (stmt["_type"] == "ImportFrom")
-                                            ? stmt["module"]
-                                            : stmt["names"][0]["name"];
-          log_warning("skipping unresolvable import: {}", module_name);
-          continue;
-        }
         is_importing_module = true;
         if (!import_module_into_block(stmt, locator, all_imports_block))
         {

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9933,6 +9933,14 @@ void python_converter::process_module_imports(
   {
     if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
     {
+      if (elem.value("module_not_found", false))
+      {
+        const std::string module_name = (elem["_type"] == "ImportFrom")
+                                         ? elem["module"]
+                                         : elem["names"][0]["name"];
+        log_warning("skipping unresolvable import: {}", module_name);
+        continue;
+      }
       std::string saved_file = current_python_file;
       import_module_into_block(elem, locator, block);
       current_python_file = saved_file;
@@ -10124,6 +10132,14 @@ void python_converter::convert()
     {
       if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
       {
+        if (elem.value("module_not_found", false))
+        {
+          const std::string module_name = (elem["_type"] == "ImportFrom")
+                                           ? elem["module"]
+                                           : elem["names"][0]["name"];
+          log_warning("skipping unresolvable import: {}", module_name);
+          continue;
+        }
         is_importing_module = true;
         if (!import_module_into_block(elem, locator, all_imports_block))
         {
@@ -10149,6 +10165,14 @@ void python_converter::convert()
         if (stmt["_type"] != "ImportFrom" && stmt["_type"] != "Import")
           continue;
 
+        if (stmt.value("module_not_found", false))
+        {
+          const std::string module_name = (stmt["_type"] == "ImportFrom")
+                                           ? stmt["module"]
+                                           : stmt["names"][0]["name"];
+          log_warning("skipping unresolvable import: {}", module_name);
+          continue;
+        }
         is_importing_module = true;
         if (!import_module_into_block(stmt, locator, all_imports_block))
         {


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/4149.

When a Python program imports a module that is not installed on the system, `parser.py` already sets `module_not_found=true` on the AST node (which is preserved in JSON by ast2json). 

In this PR, the C++ converter now checks this flag before calling `import_module_into_block` in all three import-processing paths (`process_module_imports`, and both loops in convert), emitting a warning and continuing rather than throwing `std::runtime_error`.

This PR also adds regression tests `github_4149` (VERIFICATION SUCCESSFUL) and `github_4149_fail` (VERIFICATION FAILED) to confirm both outcomes work despite the unresolvable import.