### PR TITLE
[build] bump pytest to >=9.0.3 (CVE-2025-71176)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ dependencies = [
 [dependency-groups]
 dev = [
     "hypothesis>=6.0",
-    "pytest>=8.0",
+    "pytest>=9.0.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "hypothesis", specifier = ">=6.0" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -270,9 +270,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:7d0d549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:d424a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617", size = 375249, upload-time = "2026-04-07T17:16:16.130Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pytest < 9.0.3 creates /tmp/pytest-of-{user} directories with insecure permissions, allowing local privilege escalation or DoS (CVSS 6.8). Update the dev-group lower bound and regenerate uv.lock to resolve to the patched 9.0.3 release.