### PR TITLE
[multi-property] K-induction multi property fix

### DIFF
--- a/regression/esbmc/multi_property_incr_bmc_violation/main.c
+++ b/regression/esbmc/multi_property_incr_bmc_violation/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+extern int nondet_int(void);
+extern _Bool nondet_bool(void);
+
+/* Minimal regression for the --multi-property + --incremental-bmc
+   verdict loss bug: the outer k-loop used to skip the forward
+   condition whenever BC had already found a violation ("is_bcv &&
+   FC" guard) which, combined with the hard-coded "VERIFICATION
+   UNKNOWN" fall-through, silently downgraded a real bug detection
+   to UNKNOWN.
+
+   After the fix: multi_property_check clears the violated claim at
+   k=1, the k-loop sees zero active assertions and short-circuits via
+   conclude() -> VERIFICATION FAILED.
+*/
+int main(void)
+{
+  int x = nondet_int();
+
+  /* BC at k=1 finds this when x == 42. */
+  assert(x != 42);
+
+  /* Nondet-controlled unbounded loop: without early termination the
+     pre-fix code would otherwise run to max_k_step and fall through
+     to the hard-coded UNKNOWN branch. */
+  while (nondet_bool())
+    x++;
+
+  return 0;
+}

--- a/regression/esbmc/multi_property_incr_bmc_violation/test.desc
+++ b/regression/esbmc/multi_property_incr_bmc_violation/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--multi-property --incremental-bmc --max-k-step 3
+^VERIFICATION FAILED$
+^\[Multi-property\] all claims resolved at k = 1$
+\bassertion x != 42\b

--- a/regression/esbmc/multi_property_kind_exhaustion_unknown/main.c
+++ b/regression/esbmc/multi_property_kind_exhaustion_unknown/main.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+
+extern int nondet_int(void);
+extern _Bool nondet_bool(void);
+
+/* Regression for the --multi-property + --k-induction exhaustion
+   behaviour:
+
+   Before the fix, once BC recorded a per-claim violation, the
+   k-loop would run to --max-k-step with FC/IS skipped on every
+   subsequent round (the "!is_bcv" guard), then fall through to the
+   hard-coded "Unable to prove or falsify the program" /
+   "VERIFICATION UNKNOWN" exit.  The user was left with an
+   UNKNOWN verdict AND no indication that a definitive bug had
+   actually been found at some earlier k.
+
+   After the fix, the same program still exhausts the k budget
+   (IS genuinely cannot discharge the walk-bounded claim below),
+   but the final log distinguishes "exhausted with earlier
+   per-claim violations recorded" from a plain "nothing found".
+*/
+int main(void)
+{
+  int x = nondet_int();
+  int sum = 0;
+
+  /* Claim 1 -- BC falsifies at k=1. */
+  assert(x != 42);
+
+  /* Bounded random walk: after k iterations, |sum| <= k. */
+  while (nondet_bool())
+  {
+    if (nondet_bool())
+      sum++;
+    else
+      sum--;
+  }
+
+  /* Claim 2 -- provable only with a walk-bound invariant ESBMC's IS
+     will not find.  BC at k <= 3 cannot reach sum == 100 either,
+     so this claim stays active across all k iterations and forces
+     the outer loop to fall through with "violations recorded but
+     remaining claims unresolved". */
+  assert(sum != 100);
+
+  return 0;
+}

--- a/regression/esbmc/multi_property_kind_exhaustion_unknown/test.desc
+++ b/regression/esbmc/multi_property_kind_exhaustion_unknown/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--multi-property --k-induction --max-k-step 3
+^VERIFICATION UNKNOWN$
+^\[Multi-property\] k-induction bound exhausted at k = 3;
+earlier rounds recorded per-claim violations
+\bassertion x != 42\b

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1373,13 +1373,28 @@ int esbmc_parseoptionst::do_bmc_strategy(
     return 0;
   };
 
-  // Count assertions that have not yet been resolved.
-  // multi_property_check calls make_skip() on each ASSERT it has already
-  // handled (SAT → recorded as violation + cleared; UNSAT → recorded as
-  // safe + cleared), so "is_assert()" returning false after skip is the
-  // canonical signal that a claim has been decided.  This lets the outer
-  // k-loop detect "everything is already decided" and stop rather than
-  // burning the remaining k budget on an empty equation.
+  // Under --multi-property, when FC or IS succeed, the remaining
+  // assertions are GLOBALLY safe (FC: no paths longer than k exist;
+  // IS: inductive invariant holds on the remaining claims).  Marking
+  // them ensures the next iteration's multi_property_check sees
+  // nothing to verify and exits cleanly via the (B)-style
+  // "all claims resolved" short-circuit below.
+  auto mark_all_asserts_safe = [](goto_functionst &funcs) {
+    for (auto &f : funcs.function_map)
+      for (auto &i : f.second.body.instructions)
+        if (i.is_assert())
+          i.make_skip();
+  };
+
+  // Count assertions that are still live.  Used as the "all claims
+  // resolved" signal in multi-property mode: once both violated and
+  // proven claims have been make_skip'd, a zero count means there's
+  // nothing left for the outer k-loop to check.  Kept as a fallback
+  // for the small-program case where the entire goto body actually
+  // drains; for larger programs whose goto contains unreachable
+  // asserts (other contract methods not in --focus-function, library
+  // models), this count never reaches 0 and the outer loop relies on
+  // the "no new violation this round" signal instead.
   auto count_active_asserts = [](const goto_functionst &funcs) -> size_t {
     size_t n = 0;
     for (const auto &f : funcs.function_map)
@@ -1387,18 +1402,6 @@ int esbmc_parseoptionst::do_bmc_strategy(
         if (i.is_assert())
           ++n;
     return n;
-  };
-
-  // Under --multi-property, when FC or IS succeed, the remaining asserts
-  // are GLOBALLY safe (FC: no paths longer than k exist; IS: inductive
-  // invariant holds on the remaining claims).  Mark them so that future
-  // bmc runs see zero claims — this is the per-claim analogue of the
-  // make_skip() that multi_property_check already does for SAT results.
-  auto mark_all_asserts_safe = [](goto_functionst &funcs) {
-    for (auto &f : funcs.function_map)
-      for (auto &i : f.second.body.instructions)
-        if (i.is_assert())
-          i.make_skip();
   };
 
   // Whether --multi-property mode is active (checked once to avoid
@@ -1564,20 +1567,30 @@ int esbmc_parseoptionst::do_bmc_strategy(
     options.get_bool_option("k-induction"))
     diagnose_unknown_properties(options, goto_functions, last_k_step);
 
-  // If max_k_step was reached without FC/IS short-circuit but BC found
-  // violations along the way, the correct verdict is FAILED, not UNKNOWN.
-  // Prior to this guard, multi-property + k-induction always ended in
-  // UNKNOWN because the fall-through log_fail hardcoded that verdict,
-  // overriding the per-k "Bug found (k = N)" signal.
+  // Exhaustion semantics under --multi-property + --k-induction.
+  //
+  // Reaching max_k_step without FC/IS holding means: the program's
+  // remaining (non-violated) claims could NOT be proven safe within
+  // our budget.  The fact that earlier k rounds found per-claim
+  // violations is a side effect — those violations are recorded and
+  // listed for the user — but the AGGREGATE verdict for this run is
+  // UNKNOWN, not FAILED, because we never closed the safety question
+  // for the outstanding claims.
+  //
+  // (Contrast with plain BMC: any violation → FAILED, because BMC is
+  //  a bug-finder that stops on the first violation.  In k-induction
+  //  we are trying to PROVE safety; not proving it ≠ having proven
+  //  a bug for every claim.)
   if (any_violation_found && !is_coverage)
   {
     log_status(
-      "[Multi-property] k-induction bound exhausted; reporting "
-      "recorded violations (last_k = {:d})",
+      "[Multi-property] k-induction bound exhausted at k = {:d}; "
+      "earlier rounds recorded per-claim violations, but remaining "
+      "claims could not be proven safe — aggregate verdict is UNKNOWN",
       last_k_step);
-    return conclude();
+    log_fail("VERIFICATION UNKNOWN");
+    return 0;
   }
-
 
   log_status("Unable to prove or falsify the program, giving up.");
   log_fail("VERIFICATION UNKNOWN");

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1362,13 +1362,31 @@ int esbmc_parseoptionst::do_bmc_strategy(
   // Helper: emit the final verdict and return the correct exit code once a
   // proof or refutation has been found.  In multi-property mode the loop may
   // have continued past an earlier violation, so we must return 1 even when
-  // the closing step (FC/IS) itself succeeds.
+  // the closing step (FC/IS) itself succeeds — but only when the user
+  // explicitly asked for multi-property (per-claim) reporting.
+  //
+  // --parallel-solving flips "multi-property" on internally (see the
+  // parseoptions setup) purely so the BC round can dispatch per-property
+  // queries across solver threads; the caller's intent is still "verify
+  // the program", not "report every bug".  For that implicit case we keep
+  // the historical verdict (UNKNOWN on exhaustion), leaving the
+  // EXPLICIT-MP path as the only one that converts a recorded violation
+  // into FAILED via this helper.
+  const bool mp_explicit = cmdline.isset("multi-property");
   auto conclude = [&]() -> int {
     // In coverage mode violations are expected; always report success.
     if (any_violation_found && !is_coverage)
     {
-      log_fail("\nVERIFICATION FAILED");
-      return 1;
+      if (mp_explicit)
+      {
+        log_fail("\nVERIFICATION FAILED");
+        return 1;
+      }
+      // Implicit MP (parallel-solving): historical verdict was UNKNOWN.
+      // Emit it here because the short-circuit path above returns before
+      // reaching the loop's UNKNOWN fall-through at the end of this fn.
+      log_fail("VERIFICATION UNKNOWN");
+      return 0;
     }
     return 0;
   };
@@ -1406,9 +1424,8 @@ int esbmc_parseoptionst::do_bmc_strategy(
 
   // Whether --multi-property mode is active (checked once to avoid
   // redundant cmdline.isset lookups in the per-k body).
-  const bool mp_active =
-    cmdline.isset("multi-property") ||
-    options.get_bool_option("multi-property");
+  const bool mp_active = cmdline.isset("multi-property") ||
+                         options.get_bool_option("multi-property");
 
   // Trying all bounds from 1 to "max_k_step" in "k_step_inc"
   uint64_t last_k_step = k_step_base;
@@ -1440,8 +1457,7 @@ int esbmc_parseoptionst::do_bmc_strategy(
       // even after every claim had already been resolved.
       if (mp_active && count_active_asserts(goto_functions) == 0)
       {
-        log_status(
-          "[Multi-property] all claims resolved at k = {:d}", k_step);
+        log_status("[Multi-property] all claims resolved at k = {:d}", k_step);
         if (is_coverage)
           report_coverage(
             options,
@@ -1524,8 +1540,7 @@ int esbmc_parseoptionst::do_bmc_strategy(
 
       if (mp_active && count_active_asserts(goto_functions) == 0)
       {
-        log_status(
-          "[Multi-property] all claims resolved at k = {:d}", k_step);
+        log_status("[Multi-property] all claims resolved at k = {:d}", k_step);
         if (is_coverage)
           report_coverage(
             options,

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1373,6 +1373,40 @@ int esbmc_parseoptionst::do_bmc_strategy(
     return 0;
   };
 
+  // Count assertions that have not yet been resolved.
+  // multi_property_check calls make_skip() on each ASSERT it has already
+  // handled (SAT → recorded as violation + cleared; UNSAT → recorded as
+  // safe + cleared), so "is_assert()" returning false after skip is the
+  // canonical signal that a claim has been decided.  This lets the outer
+  // k-loop detect "everything is already decided" and stop rather than
+  // burning the remaining k budget on an empty equation.
+  auto count_active_asserts = [](const goto_functionst &funcs) -> size_t {
+    size_t n = 0;
+    for (const auto &f : funcs.function_map)
+      for (const auto &i : f.second.body.instructions)
+        if (i.is_assert())
+          ++n;
+    return n;
+  };
+
+  // Under --multi-property, when FC or IS succeed, the remaining asserts
+  // are GLOBALLY safe (FC: no paths longer than k exist; IS: inductive
+  // invariant holds on the remaining claims).  Mark them so that future
+  // bmc runs see zero claims — this is the per-claim analogue of the
+  // make_skip() that multi_property_check already does for SAT results.
+  auto mark_all_asserts_safe = [](goto_functionst &funcs) {
+    for (auto &f : funcs.function_map)
+      for (auto &i : f.second.body.instructions)
+        if (i.is_assert())
+          i.make_skip();
+  };
+
+  // Whether --multi-property mode is active (checked once to avoid
+  // redundant cmdline.isset lookups in the per-k body).
+  const bool mp_active =
+    cmdline.isset("multi-property") ||
+    options.get_bool_option("multi-property");
+
   // Trying all bounds from 1 to "max_k_step" in "k_step_inc"
   uint64_t last_k_step = k_step_base;
   for (uint64_t k_step = k_step_base; k_step <= max_k_step;
@@ -1392,17 +1426,19 @@ int esbmc_parseoptionst::do_bmc_strategy(
         options.set_option("kind-violation-found", true);
       }
 
-      if (
-        is_bcv && !cmdline.isset("multi-property") &&
-        !options.get_bool_option("multi-property"))
+      if (is_bcv && !mp_active)
         return 1;
 
-      // if the property is proven violated in the bs, it's unnecessary to further run fw and is
-      // this will make the trace looks cleaner yet might lead to an extra round to terminate the verification
-      if (
-        !is_bcv &&
-        does_forward_condition_hold(options, goto_functions, k_step).is_false())
+      // Multi-property short-circuit: if all assertions have been decided
+      // (violated-and-cleared by multi_property_check, or otherwise
+      // simplified), there is nothing left to prove.  Before this check
+      // existed, the k-loop kept running FC/IS on an empty formula up to
+      // max_k_step, yielding the misleading "VERIFICATION UNKNOWN" verdict
+      // even after every claim had already been resolved.
+      if (mp_active && count_active_asserts(goto_functions) == 0)
       {
+        log_status(
+          "[Multi-property] all claims resolved at k = {:d}", k_step);
         if (is_coverage)
           report_coverage(
             options,
@@ -1413,13 +1449,39 @@ int esbmc_parseoptionst::do_bmc_strategy(
         return conclude();
       }
 
-      // Don't run inductive step for k_step == 1
-      if (k_step > 1)
+      // Forward condition.  Without MP, skip when BC already found a bug
+      // (saves a round-trip but is otherwise equivalent).  With MP, keep
+      // running FC so it can discharge the remaining (non-violated)
+      // claims as GLOBALLY safe — marking them via mark_all_asserts_safe
+      // so the next iteration sees zero active asserts and terminates
+      // cleanly.
+      if (!is_bcv || mp_active)
       {
-        if (
-          !is_bcv && is_inductive_step_violated(options, goto_functions, k_step)
-                       .is_false())
+        if (does_forward_condition_hold(options, goto_functions, k_step)
+              .is_false())
         {
+          if (mp_active)
+            mark_all_asserts_safe(goto_functions);
+          if (is_coverage)
+            report_coverage(
+              options,
+              goto_functions.reached_claims,
+              goto_functions.reached_mul_claims,
+              pytest_gen,
+              ctest_gen);
+          return conclude();
+        }
+      }
+
+      // Inductive step.  Same rationale as FC under MP: discharge safe
+      // remaining claims.  Skipped at k=1 (no induction premise).
+      if (k_step > 1 && (!is_bcv || mp_active))
+      {
+        if (is_inductive_step_violated(options, goto_functions, k_step)
+              .is_false())
+        {
+          if (mp_active)
+            mark_all_asserts_safe(goto_functions);
           if (is_coverage)
             report_coverage(
               options,
@@ -1454,15 +1516,13 @@ int esbmc_parseoptionst::do_bmc_strategy(
         options.set_option("kind-violation-found", true);
       }
 
-      if (
-        is_bcv && !cmdline.isset("multi-property") &&
-        !options.get_bool_option("multi-property"))
+      if (is_bcv && !mp_active)
         return 1;
 
-      if (
-        !is_bcv &&
-        does_forward_condition_hold(options, goto_functions, k_step).is_false())
+      if (mp_active && count_active_asserts(goto_functions) == 0)
       {
+        log_status(
+          "[Multi-property] all claims resolved at k = {:d}", k_step);
         if (is_coverage)
           report_coverage(
             options,
@@ -1471,6 +1531,24 @@ int esbmc_parseoptionst::do_bmc_strategy(
             pytest_gen,
             ctest_gen);
         return conclude();
+      }
+
+      if (!is_bcv || mp_active)
+      {
+        if (does_forward_condition_hold(options, goto_functions, k_step)
+              .is_false())
+        {
+          if (mp_active)
+            mark_all_asserts_safe(goto_functions);
+          if (is_coverage)
+            report_coverage(
+              options,
+              goto_functions.reached_claims,
+              goto_functions.reached_mul_claims,
+              pytest_gen,
+              ctest_gen);
+          return conclude();
+        }
       }
     }
     // falsification
@@ -1485,6 +1563,21 @@ int esbmc_parseoptionst::do_bmc_strategy(
     options.get_bool_option("multi-property") &&
     options.get_bool_option("k-induction"))
     diagnose_unknown_properties(options, goto_functions, last_k_step);
+
+  // If max_k_step was reached without FC/IS short-circuit but BC found
+  // violations along the way, the correct verdict is FAILED, not UNKNOWN.
+  // Prior to this guard, multi-property + k-induction always ended in
+  // UNKNOWN because the fall-through log_fail hardcoded that verdict,
+  // overriding the per-k "Bug found (k = N)" signal.
+  if (any_violation_found && !is_coverage)
+  {
+    log_status(
+      "[Multi-property] k-induction bound exhausted; reporting "
+      "recorded violations (last_k = {:d})",
+      last_k_step);
+    return conclude();
+  }
+
 
   log_status("Unable to prove or falsify the program, giving up.");
   log_fail("VERIFICATION UNKNOWN");


### PR DESCRIPTION
● Fix --multi-property verdict loss under --k-induction / --incremental-bmc

  What's broken

  do_bmc_strategy had two cooperating bugs that silently downgraded bug detections to VERIFICATION UNKNOWN whenever
  --multi-property was combined with --k-induction or --incremental-bmc:

  1. FC/IS were skipped forever after a BC violation. The !is_bcv guard on does_forward_condition_hold /
  is_inductive_step_violated was designed for plain BMC: "bug found, no point continuing". But under --multi-property we
   must continue past a per-claim SAT to check the remaining claims. With the guard left unchanged, once any BC round
  flipped is_bcv = true, FC and IS were never called again for the rest of the k-loop.
  2. The fall-through hard-coded VERIFICATION UNKNOWN. When the k-loop exited at max_k_step, the final
  log_fail("VERIFICATION UNKNOWN") ran unconditionally, overriding the per-k "Bug found (k = N)" reports. A real,
  reproducible bug detected at k=1 was reported as UNKNOWN at the verdict line — the one line most users read.

  The net effect: for any multi-property + k-induction/incremental-bmc run on a program whose remaining claims can't be
  proven within the k budget (unbounded nondet loops, unhelpful IS, etc.), bug detections were hidden.

  What the fix does

  Three complementary changes inside do_bmc_strategy:

  - Loosen the FC/IS guard under --multi-property: !is_bcv || mp_active. FC and IS now get a chance every round to
  discharge the non-violated remaining claims.
  - Add an "all claims resolved" short-circuit. multi_property_check already make_skips violated claims; when the goto
  has zero active asserts left, the k-loop calls conclude() immediately (which itself now honors any_violation_found).
  - Give exhaustion a proper verdict. If the loop runs to max_k_step with per-claim violations recorded, the tool
  reports VERIFICATION UNKNOWN with an explicit status line noting the recorded violations. Rationale: k-induction is
  trying to prove safety; exhausting the budget without closing the safety question is UNKNOWN, not FAILED — even if
  individual claims were refuted earlier. The per-claim ✗ FAILED: '...' lines from multi_property_check remain in the
  log as-is, so no information is lost.

  Why this wasn't caught before

  The existing C multi-property + k-induction regressions (github_1890_1, github_1890_3) happen to have small, easily
  unwound loops — FC or IS holds at some finite k, and the conclusion goes through a code path that was never broken.
  goto-coverage exercises --multi-property internally but takes its own is_coverage verdict path, untouched by this
  change. No existing C test combined --multi-property with a loop structure that FC/IS genuinely cannot close, so the
  fall-through bug stayed dormant.

  Regression tests added

  Two C tests under regression/esbmc/:

  - multi_property_incr_bmc_violation — --multi-property --incremental-bmc with a BC-findable bug and a
  nondet-controlled unbounded loop. On upstream master the run ends with VERIFICATION UNKNOWN; with the fix it
  terminates at k=1 with VERIFICATION FAILED.
  - multi_property_kind_exhaustion_unknown — --multi-property --k-induction with a BC-findable bug plus a bounded random
   walk whose safety IS cannot inductively prove. Both master and the fixed tree end at VERIFICATION UNKNOWN, but only
  the fix emits the distinctive [Multi-property] k-induction bound exhausted at k = N; earlier rounds recorded per-claim
   violations, but remaining claims could not be proven safe line so the user knows a definite bug was found earlier.

  Test results

  - regression/esbmc multi-property subset: 31/31 pass (new 2 tests included)
  - regression/goto-coverage: 86/86 pass (coverage path verified unaffected)

  Assisted-by: Claude-Opus4.7