### PR TITLE
add support tuple type aliases and harden list literal folding

### DIFF
--- a/regression/python/tuples/test.desc
+++ b/regression/python/tuples/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc
+--unwind 5 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1428,6 +1428,46 @@ class Preprocessor(ast.NodeTransformer):
             return prefix + [node]
         return node
 
+    def visit_Subscript(self, node):
+        """Fold constant indexing over tracked list literals when safe.
+
+        Only folds when the indexed element is a pure literal (Constant or a
+        unary +/- over a Constant). Folding non-pure expressions such as
+        ``nondet_int()`` calls would break value correlation, since each
+        substitution would produce a fresh, independent symbolic value.
+        """
+        node = self.generic_visit(node)
+
+        if (
+            isinstance(node.value, ast.Name)
+            and node.value.id in self.list_literal_values
+        ):
+            list_node = self.list_literal_values[node.value.id]
+
+            idx_node = node.slice
+            if isinstance(idx_node, ast.Index):
+                idx_node = idx_node.value
+
+            if isinstance(idx_node, ast.Constant) and isinstance(idx_node.value, int):
+                idx = idx_node.value
+                elts = list_node.elts
+                if idx < 0:
+                    idx = len(elts) + idx
+                if 0 <= idx < len(elts):
+                    elt = elts[idx]
+                    is_pure_literal = isinstance(elt, ast.Constant) or (
+                        isinstance(elt, ast.UnaryOp)
+                        and isinstance(elt.op, (ast.UAdd, ast.USub))
+                        and isinstance(elt.operand, ast.Constant)
+                    )
+                    if is_pure_literal:
+                        folded = copy.deepcopy(elt)
+                        self.ensure_all_locations(folded, node)
+                        ast.fix_missing_locations(folded)
+                        return folded
+
+        return node
+
     def visit_Expr(self, node):
         node = self.generic_visit(node)
 
@@ -1855,6 +1895,23 @@ class Preprocessor(ast.NodeTransformer):
             # Handle dict.items() for loops
             self.is_range_loop = False
             return self._transform_items_for(node)
+        elif (
+            isinstance(node.iter, ast.Name)
+            and node.iter.id in self.list_literal_values
+            and self._can_safely_unroll_list_literal_for(
+                node, self.list_literal_values[node.iter.id]
+            )
+        ):
+            # For direct iteration over a known list literal variable, unroll the loop
+            # to avoid introducing len()/index machinery in the generated model.
+            # Skip the unroll if the body contains break/continue/return, since
+            # straight-line unrolling would leave those statements without a
+            # surrounding loop/function context. Skip too when elements are not
+            # homogeneous pure literals to preserve runtime isinstance semantics.
+            self.is_range_loop = False
+            return self._unroll_list_literal_for(
+                node, self.list_literal_values[node.iter.id]
+            )
         else:
             # Check if iterating over a generator variable
             if isinstance(node.iter, ast.Name) and node.iter.id in self.generator_vars:
@@ -1890,6 +1947,77 @@ class Preprocessor(ast.NodeTransformer):
             # Handle general iteration over iterables (strings, lists, etc.)
             self.is_range_loop = False
             return self._transform_iterable_for(node)
+
+    def _can_safely_unroll_list_literal_for(self, node, list_literal):
+        """Decide whether a `for` over a tracked list literal is safe to unroll.
+
+        Skip the unroll when:
+          * the loop body contains ``break``/``continue``/``return`` (these
+            need a surrounding loop/function context);
+          * elements are constants of heterogeneous types (e.g. mixed ``int``
+            and ``str``), which would silently drop runtime ``isinstance``
+            checks during unrolling and constant folding.
+        """
+        for stmt in node.body:
+            for n in ast.walk(stmt):
+                if isinstance(n, (ast.Break, ast.Continue, ast.Return)):
+                    return False
+
+        const_types = set()
+        all_constants = True
+        for elt in list_literal.elts:
+            if isinstance(elt, ast.Constant):
+                const_types.add(type(elt.value).__name__)
+            elif (
+                isinstance(elt, ast.UnaryOp)
+                and isinstance(elt.op, (ast.UAdd, ast.USub))
+                and isinstance(elt.operand, ast.Constant)
+            ):
+                const_types.add(type(elt.operand.value).__name__)
+            else:
+                all_constants = False
+                break
+        if all_constants and len(const_types) > 1:
+            return False
+        return True
+
+    def _unroll_list_literal_for(self, node, list_literal):
+        """Unroll `for` over a tracked list literal variable into straight-line code."""
+        unrolled = []
+        for idx, elt in enumerate(list_literal.elts):
+            elt_copy = copy.deepcopy(elt)
+
+            if isinstance(node.target, ast.Name):
+                target_assign = ast.Assign(
+                    targets=[ast.Name(id=node.target.id, ctx=ast.Store())],
+                    value=elt_copy,
+                )
+                self.ensure_all_locations(target_assign, node)
+                unrolled.append(target_assign)
+            elif isinstance(node.target, (ast.Tuple, ast.List)):
+                # Keep tuple/list unpacking as a single assignment so the
+                # converter's tuple-unpacking path handles element extraction.
+                unpack_assign = ast.Assign(
+                    targets=[copy.deepcopy(node.target)],
+                    value=elt_copy,
+                )
+                self.ensure_all_locations(unpack_assign, node)
+                unrolled.append(unpack_assign)
+            else:
+                iter_assign = ast.Assign(
+                    targets=[copy.deepcopy(node.target)], value=elt_copy
+                )
+                self.ensure_all_locations(iter_assign, node)
+                unrolled.append(iter_assign)
+
+            for stmt in node.body:
+                stmt_copy = copy.deepcopy(stmt)
+                self.ensure_all_locations(stmt_copy, node)
+                unrolled.append(stmt_copy)
+
+        for stmt in unrolled:
+            ast.fix_missing_locations(stmt)
+        return unrolled
 
     def visit_With(self, node):
         """Desugar 'with EXPR as VAR: BODY' into __enter__/__exit__ calls.
@@ -3832,6 +3960,15 @@ class Preprocessor(ast.NodeTransformer):
         """
         Handle assignment nodes, including multiple assignments and tuple unpacking.
         """
+        # Invalidate tracked list literals on subscript writes: l[i] = v
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id in self.list_literal_values
+            ):
+                self.list_literal_values.pop(target.value.id, None)
+
         # Check if this is a type alias assignment (e.g., Coordinate = Tuple[int, int])
         if (
             len(node.targets) == 1
@@ -4107,6 +4244,14 @@ class Preprocessor(ast.NodeTransformer):
 
     def visit_AugAssign(self, node):
         """Lower augmented assignment into a simple assignment."""
+        # Invalidate tracked list literals on subscript writes: l[i] op= v
+        if (
+            isinstance(node.target, ast.Subscript)
+            and isinstance(node.target.value, ast.Name)
+            and node.target.value.id in self.list_literal_values
+        ):
+            self.list_literal_values.pop(node.target.value.id, None)
+
         # Transform children first so nested expressions are already lowered.
         node = self.generic_visit(node)
 
@@ -4145,6 +4290,72 @@ class Preprocessor(ast.NodeTransformer):
 
     # This method is responsible for visiting and transforming Call nodes in the AST.
     def visit_Call(self, node):
+        # Invalidate tracked list literals on mutating method calls:
+        # name.append/clear/extend/insert/pop/remove/reverse/sort(...)
+        _MUTATING_LIST_METHODS = {
+            "append",
+            "clear",
+            "extend",
+            "insert",
+            "pop",
+            "remove",
+            "reverse",
+            "sort",
+        }
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.attr in _MUTATING_LIST_METHODS
+            and node.func.value.id in self.list_literal_values
+        ):
+            self.list_literal_values.pop(node.func.value.id, None)
+
+        # Conservatively invalidate tracked list literals when passed as an
+        # argument to a non-builtin call: the callee may mutate the list
+        # (e.g. ``func2(l8)`` where ``func2`` does ``l[0] = ...``).
+        # Skip well-known pure builtins that read but never mutate the
+        # argument; some of their lowering handlers also rely on the literal
+        # still being tracked (e.g. ``sorted(pairs, key=...)``).
+        _PURE_LIST_CONSUMERS = {
+            "abs",
+            "all",
+            "any",
+            "bool",
+            "dict",
+            "enumerate",
+            "filter",
+            "float",
+            "frozenset",
+            "hash",
+            "id",
+            "int",
+            "isinstance",
+            "iter",
+            "len",
+            "list",
+            "map",
+            "max",
+            "min",
+            "next",
+            "print",
+            "range",
+            "repr",
+            "reversed",
+            "set",
+            "sorted",
+            "str",
+            "sum",
+            "tuple",
+            "type",
+            "zip",
+        }
+        if not (
+            isinstance(node.func, ast.Name) and node.func.id in _PURE_LIST_CONSUMERS
+        ):
+            for arg in list(node.args) + [kw.value for kw in node.keywords]:
+                if isinstance(arg, ast.Name) and arg.id in self.list_literal_values:
+                    self.list_literal_values.pop(arg.id, None)
+
         # NewType is an identity callable: X(v) → v
         if (isinstance(node.func, ast.Name) and
                 node.func.id in self.newtype_vars and

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -52,6 +52,114 @@ class Preprocessor(ast.NodeTransformer):
         self.newtype_names = {"NewType"}  # local names bound to typing.NewType (covers aliased imports)
         self.typing_module_names = set()  # module names for typing (e.g. 'typing' or its alias)
         self._with_counter = 0  # Counter for unique context manager temp names
+        self.type_aliases = (
+            {}
+        )  # {alias_name: annotation_ast} for type alias assignments (Coordinate = Tuple[int, int])
+
+    def _is_type_alias_expression(self, value):
+        """Check if value is a type annotation expression (Tuple[...], List[...], Optional[...], etc.)"""
+        if isinstance(value, ast.Subscript):
+            # Check if the value is a Name that looks like a type (Tuple, List, Dict, Optional, etc.)
+            if isinstance(value.value, ast.Name):
+                type_name = value.value.id
+                return type_name in (
+                    "Tuple",
+                    "List",
+                    "Dict",
+                    "Set",
+                    "Optional",
+                    "Union",
+                    "Callable",
+                )
+            # Handle cases like typing.Tuple, typing.List
+            if isinstance(value.value, ast.Attribute):
+                return value.value.attr in (
+                    "Tuple",
+                    "List",
+                    "Dict",
+                    "Set",
+                    "Optional",
+                    "Union",
+                    "Callable",
+                )
+        return False
+
+    def _copy_annotation_node(self, node):
+        """Deep copy an annotation AST node"""
+        if node is None:
+            return None
+        if isinstance(node, ast.Name):
+            return ast.Name(id=node.id, ctx=ast.Load())
+        elif isinstance(node, ast.Subscript):
+            return ast.Subscript(
+                value=self._copy_annotation_node(node.value),
+                slice=self._copy_annotation_node(node.slice),
+                ctx=ast.Load(),
+            )
+        elif isinstance(node, ast.Index):
+            return ast.Index(value=self._copy_annotation_node(node.value))
+        elif isinstance(node, ast.Tuple):
+            return ast.Tuple(
+                elts=[self._copy_annotation_node(e) for e in node.elts], ctx=ast.Load()
+            )
+        elif isinstance(node, ast.Constant):
+            return ast.Constant(value=node.value)
+        elif isinstance(node, ast.Str):
+            return ast.Str(s=node.s)
+        elif isinstance(node, ast.Attribute):
+            return ast.Attribute(
+                value=self._copy_annotation_node(node.value),
+                attr=node.attr,
+                ctx=ast.Load(),
+            )
+        else:
+            # For other node types, return as-is
+            return node
+
+    def _resolve_annotation_aliases(self, annotation):
+        """Recursively resolve type aliases in an annotation AST node"""
+        if annotation is None:
+            return None
+
+        if isinstance(annotation, ast.Name):
+            # If this name is an alias, return a copy of the aliased type
+            if annotation.id in self.type_aliases:
+                # Copy then recursively resolve transitive aliases (e.g. TaskSchedule → List[TaskInstance] → List[Tuple[int,Task]])
+                copied = self._copy_annotation_node(self.type_aliases[annotation.id])
+                return self._resolve_annotation_aliases(copied)
+            return annotation
+
+        elif isinstance(annotation, ast.Subscript):
+            # Recursively resolve value and slice
+            resolved_value = self._resolve_annotation_aliases(annotation.value)
+            resolved_slice = annotation.slice
+            if isinstance(annotation.slice, ast.Index):
+                resolved_slice = ast.Index(
+                    value=self._resolve_annotation_aliases(annotation.slice.value)
+                )
+            elif not isinstance(annotation.slice, (ast.Slice, ast.ExtSlice)):
+                resolved_slice = self._resolve_annotation_aliases(annotation.slice)
+            return ast.Subscript(
+                value=resolved_value, slice=resolved_slice, ctx=ast.Load()
+            )
+
+        elif isinstance(annotation, ast.Tuple):
+            # Recursively resolve each element
+            resolved_elts = [
+                self._resolve_annotation_aliases(e) for e in annotation.elts
+            ]
+            return ast.Tuple(elts=resolved_elts, ctx=ast.Load())
+
+        elif isinstance(annotation, ast.Attribute):
+            # Recursively resolve the value
+            resolved_value = self._resolve_annotation_aliases(annotation.value)
+            return ast.Attribute(
+                value=resolved_value, attr=annotation.attr, ctx=ast.Load()
+            )
+
+        else:
+            # For other types (Constant, Str, etc.), return as-is
+            return annotation
 
     def _create_helper_functions(self):
         """Create the ESBMC helper function definitions"""
@@ -2721,6 +2829,32 @@ class Preprocessor(ast.NodeTransformer):
     def _create_loop_body(self, node, target_var_name, iter_var_name, annotation_id, index_var,
                           element_type):
         """Create the body of the while loop with proper type annotations."""
+        # Current iterable element expression: iter_var[index]
+        current_item = ast.Subscript(
+            value=ast.Name(id=iter_var_name, ctx=ast.Load()),
+            slice=ast.Name(id=index_var, ctx=ast.Load()),
+            ctx=ast.Load(),
+        )
+        self.ensure_all_locations(current_item, node)
+
+        unpack_assigns = []
+        # Support tuple/list unpacking targets in for-loops:
+        # for a, b in items: ...
+        if isinstance(node.target, (ast.Tuple, ast.List)):
+            for i, elt in enumerate(node.target.elts):
+                if not isinstance(elt, ast.Name):
+                    continue
+                unpack_assign = ast.Assign(
+                    targets=[ast.Name(id=elt.id, ctx=ast.Store())],
+                    value=ast.Subscript(
+                        value=ast.Name(id=target_var_name, ctx=ast.Load()),
+                        slice=ast.Constant(value=i),
+                        ctx=ast.Load(),
+                    ),
+                )
+                self.ensure_all_locations(unpack_assign, node)
+                unpack_assigns.append(unpack_assign)
+
         # Create target variable annotation
         if element_type and element_type != 'Any':
             target_annotation = ast.Name(id=element_type, ctx=ast.Load())
@@ -2728,14 +2862,12 @@ class Preprocessor(ast.NodeTransformer):
             target_annotation = ast.Name(id='Any', ctx=ast.Load())
 
         # Create: target: element_type = iter_var[index]
-        target_assign = ast.AnnAssign(target=ast.Name(id=target_var_name, ctx=ast.Store()),
-                                      annotation=target_annotation,
-                                      value=ast.Subscript(value=ast.Name(id=iter_var_name,
-                                                                         ctx=ast.Load()),
-                                                          slice=ast.Name(id=index_var,
-                                                                         ctx=ast.Load()),
-                                                          ctx=ast.Load()),
-                                      simple=1)
+        target_assign = ast.AnnAssign(
+            target=ast.Name(id=target_var_name, ctx=ast.Store()),
+            annotation=target_annotation,
+            value=current_item,
+            simple=1,
+        )
         self.ensure_all_locations(target_assign, node)
 
         # Create: index += 1
@@ -2747,7 +2879,9 @@ class Preprocessor(ast.NodeTransformer):
                                         simple=1)
         self.ensure_all_locations(index_increment, node)
 
-        # Combine with original body
+        # Combine with original body (include unpack assignments when needed)
+        if unpack_assigns:
+            return [target_assign] + unpack_assigns + [index_increment] + node.body
         return [target_assign, index_increment] + node.body
 
     def _create_item_assignment(self,
@@ -3698,6 +3832,17 @@ class Preprocessor(ast.NodeTransformer):
         """
         Handle assignment nodes, including multiple assignments and tuple unpacking.
         """
+        # Check if this is a type alias assignment (e.g., Coordinate = Tuple[int, int])
+        if (
+            len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and self._is_type_alias_expression(node.value)
+        ):
+            # Store the alias and skip execution (return None to remove from AST)
+            alias_name = node.targets[0].id
+            self.type_aliases[alias_name] = node.value
+            return None
+
         # First visit child nodes
         node = self.generic_visit(node)
 
@@ -3880,6 +4025,10 @@ class Preprocessor(ast.NodeTransformer):
     def visit_AnnAssign(self, node):
         """Track type annotations from annotated assignments like x: int = 5.
         Also handles defaultdict rewriting and list comprehension lowering."""
+        # Resolve type aliases in annotation
+        if node.annotation is not None:
+            node.annotation = self._resolve_annotation_aliases(node.annotation)
+
         # First visit child nodes
         node = self.generic_visit(node)
 
@@ -4243,6 +4392,29 @@ class Preprocessor(ast.NodeTransformer):
         return node  # transformed node
 
     def visit_FunctionDef(self, node):
+        # Resolve type aliases in return type annotation
+        if node.returns is not None:
+            node.returns = self._resolve_annotation_aliases(node.returns)
+
+        # Resolve type aliases in parameter annotations
+        for arg in node.args.args:
+            if arg.annotation is not None:
+                arg.annotation = self._resolve_annotation_aliases(arg.annotation)
+
+        if node.args.vararg and node.args.vararg.annotation is not None:
+            node.args.vararg.annotation = self._resolve_annotation_aliases(
+                node.args.vararg.annotation
+            )
+
+        if node.args.kwarg and node.args.kwarg.annotation is not None:
+            node.args.kwarg.annotation = self._resolve_annotation_aliases(
+                node.args.kwarg.annotation
+            )
+
+        for arg in node.args.kwonlyargs:
+            if arg.annotation is not None:
+                arg.annotation = self._resolve_annotation_aliases(arg.annotation)
+
         # Detect generator functions: any function that contains yield
         is_generator = any(isinstance(n, (ast.Yield, ast.YieldFrom)) for n in ast.walk(node))
         if is_generator:
@@ -4457,7 +4629,19 @@ class Preprocessor(ast.NodeTransformer):
             )
         ]
 
-        class_node.body.insert(0, self.build_init(class_node, fields))
+        # Insert __init__ after docstring (if present) to preserve class docstring semantics
+        insert_index = 0
+        if class_node.body:
+            first_stmt = class_node.body[0]
+            if isinstance(first_stmt, ast.Expr) and (
+                (
+                    isinstance(first_stmt.value, ast.Constant)
+                    and isinstance(first_stmt.value.value, str)
+                )
+                or isinstance(first_stmt.value, ast.Str)
+            ):
+                insert_index = 1
+        class_node.body.insert(insert_index, self.build_init(class_node, fields))
         return class_node
 
     def _collect_class_attr_annotations(self, class_node):

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -4913,6 +4913,14 @@ python_converter::extract_type_info(const nlohmann::json &var_node)
     {
       if (ann.contains("value") && ann["value"].contains("id"))
         var_type_str = ann["value"]["id"];
+
+      // Preserve concrete tuple element types for Tuple[...] annotations
+      // instead of resolving to the typing.Tuple class type.
+      if (var_type_str == "Tuple" || var_type_str == "tuple")
+      {
+        var_typet = get_type_from_annotation(ann, var_node);
+        return {var_type_str, var_typet};
+      }
     }
     else if (
       ann.contains("_type") && ann["_type"] == "Attribute" &&

--- a/unit/python-frontend/test_preprocessor_type_aliases.py
+++ b/unit/python-frontend/test_preprocessor_type_aliases.py
@@ -1,0 +1,518 @@
+"""Tests for type alias handling and dataclass docstring preservation in the preprocessor.
+
+Covers three features added to preprocessor.py:
+  1. _is_type_alias_expression(): detects Tuple[...]/List[...]/etc. as type alias RHS
+  2. visit_Assign() type alias removal: strips alias assignments from runtime AST
+  3. _resolve_annotation_aliases(): expands alias names in annotation contexts
+  4. visit_AnnAssign(): resolves aliases in variable annotations
+  5. visit_FunctionDef(): resolves aliases in return type and parameter annotations
+  6. expand_dataclass(): inserts __init__ after docstring (not before it)
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PY_FRONTEND_DIR = os.path.join(ROOT, "src", "python-frontend")
+
+if PY_FRONTEND_DIR not in sys.path:
+    sys.path.insert(0, PY_FRONTEND_DIR)
+
+
+def _load_module(module_name: str, rel_path: str):
+    module_path = os.path.join(ROOT, rel_path)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+preprocessor_mod = _load_module("esbmc_preprocessor_type_aliases",
+                                "src/python-frontend/preprocessor.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pre():
+    return preprocessor_mod.Preprocessor("test_module")
+
+
+def _get_annotation_name(node):
+    """Return the string id of an annotation Name node, or None."""
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _get_subscript_name(node):
+    """Return the string id of the outer Name in a Subscript annotation."""
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+        return node.value.id
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 1. _is_type_alias_expression
+# ---------------------------------------------------------------------------
+
+def test_is_type_alias_expression_tuple():
+    pre = _make_pre()
+    value = ast.parse("Tuple[int, int]", mode="eval").body
+    assert pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_list():
+    pre = _make_pre()
+    value = ast.parse("List[str]", mode="eval").body
+    assert pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_optional():
+    pre = _make_pre()
+    value = ast.parse("Optional[int]", mode="eval").body
+    assert pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_dict():
+    pre = _make_pre()
+    value = ast.parse("Dict[str, int]", mode="eval").body
+    assert pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_union():
+    pre = _make_pre()
+    value = ast.parse("Union[int, str]", mode="eval").body
+    assert pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_plain_name_is_false():
+    pre = _make_pre()
+    value = ast.parse("int", mode="eval").body
+    assert not pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_call_is_false():
+    pre = _make_pre()
+    value = ast.parse("int()", mode="eval").body
+    assert not pre._is_type_alias_expression(value)
+
+
+def test_is_type_alias_expression_typing_attribute():
+    """typing.Tuple[int, int] (attribute access) must also be recognized."""
+    pre = _make_pre()
+    value = ast.parse("typing.Tuple[int, int]", mode="eval").body
+    assert pre._is_type_alias_expression(value)
+
+
+# ---------------------------------------------------------------------------
+# 2. visit_Assign – type alias assignments are removed from runtime AST
+# ---------------------------------------------------------------------------
+
+def test_type_alias_assignment_removed_from_ast():
+    """Coordinate = Tuple[int, int] must not appear in the transformed module."""
+    src = "from typing import Tuple\nCoordinate = Tuple[int, int]\n"
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    names = [
+        stmt.targets[0].id
+        for stmt in transformed.body
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.targets[0], ast.Name)
+    ]
+    assert "Coordinate" not in names, "type alias assignment should be removed"
+
+
+def test_type_alias_stored_in_dict():
+    """After visiting, the alias must be present in pre.type_aliases."""
+    src = "from typing import Tuple\nCoordinate = Tuple[int, int]\n"
+    module = ast.parse(src)
+    pre = _make_pre()
+    pre.visit(module)
+
+    assert "Coordinate" in pre.type_aliases
+    alias_node = pre.type_aliases["Coordinate"]
+    assert _get_subscript_name(alias_node) == "Tuple"
+
+
+def test_multiple_type_aliases_all_removed():
+    src = (
+        "from typing import Tuple, List\n"
+        "Point = Tuple[int, int]\n"
+        "Tags = List[str]\n"
+        "x: int = 1\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    names = [
+        stmt.targets[0].id
+        for stmt in transformed.body
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.targets[0], ast.Name)
+    ]
+    assert "Point" not in names
+    assert "Tags" not in names
+    assert "Point" in pre.type_aliases
+    assert "Tags" in pre.type_aliases
+
+
+def test_normal_assignment_not_removed():
+    """Regular x = 1 must NOT be removed."""
+    src = "x = 1\n"
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    names = [
+        stmt.targets[0].id
+        for stmt in transformed.body
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.targets[0], ast.Name)
+    ]
+    assert "x" in names
+
+
+# ---------------------------------------------------------------------------
+# 3. _resolve_annotation_aliases
+# ---------------------------------------------------------------------------
+
+def test_resolve_annotation_aliases_simple_name():
+    """A Name that is a known alias must be expanded to the aliased Subscript."""
+    pre = _make_pre()
+    pre.type_aliases["Coordinate"] = ast.parse("Tuple[int, int]", mode="eval").body
+
+    annotation = ast.Name(id="Coordinate", ctx=ast.Load())
+    resolved = pre._resolve_annotation_aliases(annotation)
+
+    assert _get_subscript_name(resolved) == "Tuple"
+
+
+def test_resolve_annotation_aliases_unknown_name_unchanged():
+    pre = _make_pre()
+    annotation = ast.Name(id="int", ctx=ast.Load())
+    resolved = pre._resolve_annotation_aliases(annotation)
+    assert _get_annotation_name(resolved) == "int"
+
+
+def test_resolve_annotation_aliases_none_returns_none():
+    pre = _make_pre()
+    assert pre._resolve_annotation_aliases(None) is None
+
+
+def test_resolve_annotation_aliases_nested():
+    """List[Coordinate] where Coordinate = Tuple[int,int] → List[Tuple[int,int]]"""
+    pre = _make_pre()
+    pre.type_aliases["Coordinate"] = ast.parse("Tuple[int, int]", mode="eval").body
+
+    annotation = ast.parse("List[Coordinate]", mode="eval").body
+    resolved = pre._resolve_annotation_aliases(annotation)
+
+    assert _get_subscript_name(resolved) == "List"
+    # The slice of the outer List should now be Tuple[int, int]
+    inner = resolved.slice
+    # Python 3.9+ stores the slice directly; 3.8 wraps in ast.Index
+    if isinstance(inner, ast.Index):
+        inner = inner.value
+    assert _get_subscript_name(inner) == "Tuple"
+
+
+def test_resolve_annotation_aliases_tuple_elements():
+    """Tuple[Coordinate, int] → Tuple[Tuple[int,int], int]"""
+    pre = _make_pre()
+    pre.type_aliases["Coordinate"] = ast.parse("Tuple[int, int]", mode="eval").body
+
+    annotation = ast.parse("Tuple[Coordinate, int]", mode="eval").body
+    resolved = pre._resolve_annotation_aliases(annotation)
+
+    assert _get_subscript_name(resolved) == "Tuple"
+    # First element of the slice tuple should be expanded
+    inner = resolved.slice
+    if isinstance(inner, ast.Index):
+        inner = inner.value
+    assert isinstance(inner, ast.Tuple)
+    first_elt = inner.elts[0]
+    assert _get_subscript_name(first_elt) == "Tuple"
+
+
+# ---------------------------------------------------------------------------
+# 4. visit_AnnAssign – aliases resolved in variable annotations
+# ---------------------------------------------------------------------------
+
+def test_annassign_alias_resolved():
+    """coord: Coordinate should resolve to coord: Tuple[int, int] after visit."""
+    src = (
+        "from typing import Tuple\n"
+        "Coordinate = Tuple[int, int]\n"
+        "coord: Coordinate = (0, 0)\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    # Find the AnnAssign for coord
+    ann_assign = next(
+        (s for s in transformed.body
+         if isinstance(s, ast.AnnAssign) and isinstance(s.target, ast.Name)
+         and s.target.id == "coord"),
+        None,
+    )
+    assert ann_assign is not None, "AnnAssign for coord not found"
+    assert _get_subscript_name(ann_assign.annotation) == "Tuple", (
+        f"Expected Tuple annotation, got {ast.dump(ann_assign.annotation)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. visit_FunctionDef – aliases resolved in return type and param annotations
+# ---------------------------------------------------------------------------
+
+def test_function_return_alias_resolved():
+    """-> Coordinate should become -> Tuple[int, int]."""
+    src = (
+        "from typing import Tuple\n"
+        "Coordinate = Tuple[int, int]\n"
+        "def make(x: int, y: int) -> Coordinate:\n"
+        "    return (x, y)\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    func = next(
+        (s for s in transformed.body if isinstance(s, ast.FunctionDef) and s.name == "make"),
+        None,
+    )
+    assert func is not None
+    assert _get_subscript_name(func.returns) == "Tuple", (
+        f"Expected Tuple return annotation, got {ast.dump(func.returns)}"
+    )
+
+
+def test_function_param_alias_resolved():
+    """param: Coordinate should become param: Tuple[int, int]."""
+    src = (
+        "from typing import Tuple\n"
+        "Coordinate = Tuple[int, int]\n"
+        "def distance(a: Coordinate, b: Coordinate) -> int:\n"
+        "    return 0\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    func = next(
+        (s for s in transformed.body
+         if isinstance(s, ast.FunctionDef) and s.name == "distance"),
+        None,
+    )
+    assert func is not None
+    for arg in func.args.args:
+        if arg.arg in ("a", "b"):
+            assert _get_subscript_name(arg.annotation) == "Tuple", (
+                f"Param {arg.arg}: expected Tuple, got {ast.dump(arg.annotation)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 6. expand_dataclass – __init__ inserted after docstring, not before
+# ---------------------------------------------------------------------------
+
+def test_dataclass_init_inserted_after_docstring():
+    """When a dataclass has a docstring, __init__ must come after it."""
+    src = (
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Point:\n"
+        '    """A 2-D point."""\n'
+        "    x: int\n"
+        "    y: int\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    cls = next(
+        (s for s in transformed.body if isinstance(s, ast.ClassDef) and s.name == "Point"),
+        None,
+    )
+    assert cls is not None, "Class Point not found after transform"
+
+    # First statement must still be the docstring
+    first = cls.body[0]
+    assert isinstance(first, ast.Expr), "First stmt should be Expr (docstring)"
+    assert isinstance(first.value, ast.Constant) and isinstance(first.value.value, str), (
+        "First stmt should be a string constant (docstring)"
+    )
+
+    # Second statement must be the generated __init__
+    second = cls.body[1]
+    assert isinstance(second, ast.FunctionDef) and second.name == "__init__", (
+        "__init__ must be the second statement after the docstring"
+    )
+
+
+def test_dataclass_init_inserted_at_index_0_without_docstring():
+    """Without a docstring, __init__ must be the first statement."""
+    src = (
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    cls = next(
+        (s for s in transformed.body if isinstance(s, ast.ClassDef) and s.name == "Point"),
+        None,
+    )
+    assert cls is not None
+    first = cls.body[0]
+    assert isinstance(first, ast.FunctionDef) and first.name == "__init__", (
+        "__init__ must be the first statement when there is no docstring"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. for-loop tuple unpacking in iterable lowering
+# ---------------------------------------------------------------------------
+
+def test_iterable_for_tuple_unpack_inserts_target_assignments():
+    """for a, b in xs must define a and b in transformed loop body."""
+    src = (
+        "from typing import List, Tuple\n"
+        "def get_xs() -> List[Tuple[int, int]]:\n"
+        "    return [(1, 2)]\n"
+        "xs: List[Tuple[int, int]] = get_xs()\n"
+        "for a, b in xs:\n"
+        "    c = a + b\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    while_node = next((s for s in transformed.body if isinstance(s, ast.While)), None)
+    assert while_node is not None, "Expected transformed while-loop"
+
+    assigned_names = []
+    for stmt in while_node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            assigned_names.append(stmt.target.id)
+        elif isinstance(stmt, ast.Assign):
+            for tgt in stmt.targets:
+                if isinstance(tgt, ast.Name):
+                    assigned_names.append(tgt.id)
+
+    assert "a" in assigned_names, "Tuple-unpacked variable 'a' must be assigned"
+    assert "b" in assigned_names, "Tuple-unpacked variable 'b' must be assigned"
+
+
+def test_iterable_for_tuple_unpack_before_body_use():
+    """Tuple unpack assignments must be emitted before original loop body statements."""
+    src = (
+        "from typing import List, Tuple\n"
+        "def get_xs() -> List[Tuple[int, int]]:\n"
+        "    return [(1, 2)]\n"
+        "xs: List[Tuple[int, int]] = get_xs()\n"
+        "for time, task in xs:\n"
+        "    print(time)\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    while_node = next((s for s in transformed.body if isinstance(s, ast.While)), None)
+    assert while_node is not None
+
+    # Locate first usage of 'time' in loop body and ensure an assignment to
+    # 'time' appears before that statement.
+    first_time_use_idx = None
+    for i, stmt in enumerate(while_node.body):
+        if isinstance(stmt, ast.Expr):
+            has_time = any(isinstance(n, ast.Name) and n.id == "time" for n in ast.walk(stmt))
+            if has_time:
+                first_time_use_idx = i
+                break
+
+    assert first_time_use_idx is not None, "Expected a statement using 'time'"
+
+    has_prior_time_assign = any(
+        (
+            isinstance(stmt, ast.AnnAssign)
+            and isinstance(stmt.target, ast.Name)
+            and stmt.target.id == "time"
+        )
+        or (
+            isinstance(stmt, ast.Assign)
+            and any(isinstance(tgt, ast.Name) and tgt.id == "time" for tgt in stmt.targets)
+        )
+        for stmt in while_node.body[:first_time_use_idx]
+    )
+    assert has_prior_time_assign, "'time' must be assigned before first use"
+
+
+# ---------------------------------------------------------------------------
+# 8. for-loop unrolling over tracked list literals
+# ---------------------------------------------------------------------------
+
+def test_for_over_list_literal_var_is_unrolled():
+    src = (
+        "xs = [1, 2, 3]\n"
+        "total = 0\n"
+        "for x in xs:\n"
+        "    total = total + x\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    # Unrolled form should not contain a while-loop for this case.
+    while_nodes = [n for n in transformed.body if isinstance(n, ast.While)]
+    assert len(while_nodes) == 0
+
+    # Expect direct assignments to x for each literal element.
+    x_assigns = [
+        s for s in transformed.body
+        if (
+            isinstance(s, ast.AnnAssign)
+            and isinstance(s.target, ast.Name)
+            and s.target.id == "x"
+        )
+        or (
+            isinstance(s, ast.Assign)
+            and any(isinstance(tgt, ast.Name) and tgt.id == "x" for tgt in s.targets)
+        )
+    ]
+    assert len(x_assigns) == 3
+
+
+def test_for_tuple_unpack_over_list_literal_var_is_unrolled():
+    src = (
+        "pairs = [(1, 10), (2, 20)]\n"
+        "for a, b in pairs:\n"
+        "    c = a + b\n"
+    )
+    module = ast.parse(src)
+    pre = _make_pre()
+    transformed = pre.visit(module)
+
+    while_nodes = [n for n in transformed.body if isinstance(n, ast.While)]
+    assert len(while_nodes) == 0
+
+    tuple_unpack_assigns = [
+        s
+        for s in transformed.body
+        if isinstance(s, ast.Assign)
+        and len(s.targets) == 1
+        and isinstance(s.targets[0], ast.Tuple)
+        and len(s.targets[0].elts) == 2
+        and all(isinstance(e, ast.Name) for e in s.targets[0].elts)
+        and [e.id for e in s.targets[0].elts] == ["a", "b"]
+    ]
+    assert len(tuple_unpack_assigns) == 2


### PR DESCRIPTION
Adds support for module-level tuple/typing aliases (e.g. Coordinate = Tuple[int, int]) in the Python frontend and fixes soundness/robustness gaps in the existing list-literal constant-folding optimization. 


