### PR TITLE
[python] coerce struct class instance to pointer for reference-identity (#4116)

### DIFF
--- a/regression/python/github_4116/main.py
+++ b/regression/python/github_4116/main.py
@@ -1,0 +1,18 @@
+# Cyclic reference: a.next.next == a and a.next.next is a (github #4116).
+# `a` is stored by value as tag-Node while `a.next.next` is reached through
+# pointer-to-Node fields. The frontend coerces the struct side to its address
+# so the comparison matches Python's reference-identity semantics.
+
+class Node:
+    def __init__(self):
+        self.next = None
+
+
+a = Node()
+b = Node()
+
+a.next = b
+b.next = a
+
+assert a.next.next == a
+assert a.next.next is a

--- a/regression/python/github_4116/test.desc
+++ b/regression/python/github_4116/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4116_fail/main.py
+++ b/regression/python/github_4116_fail/main.py
@@ -1,0 +1,16 @@
+# Negative counterpart of github #4116: ensure the coercion doesn't turn the
+# comparison into a tautology. After closing the cycle, a.next.next.next is b
+# (not a), so the assertion must fail.
+
+class Node:
+    def __init__(self):
+        self.next = None
+
+
+a = Node()
+b = Node()
+
+a.next = b
+b.next = a
+
+assert a.next.next.next == a

--- a/regression/python/github_4116_fail/test.desc
+++ b/regression/python/github_4116_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1746,6 +1746,29 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
   if (!list_result.is_nil())
     return list_result;
 
+  // Python reference-identity for class instances: class objects are stored
+  // by value (tag-X) while attribute chains reach them through pointer fields
+  // (tag-X *). When one operand is a struct instance and the other is a
+  // pointer to the same class, take the address of the struct so both sides
+  // compare as references. Covers `a.next.next == a` / `is a` on cyclic
+  // linked structures (github #4116).
+  if (
+    (op == "Eq" || op == "NotEq" || op == "Is" || op == "IsNot") &&
+    lhs.type().is_pointer() != rhs.type().is_pointer())
+  {
+    exprt &struct_side = lhs.type().is_pointer() ? rhs : lhs;
+    const exprt &ptr_side = lhs.type().is_pointer() ? lhs : rhs;
+    auto class_tag = [&](const typet &t) -> irep_idt {
+      typet r = t;
+      if (r.id() == "symbol")
+        r = ns.follow(r);
+      return r.is_struct() ? to_struct_type(r).tag() : irep_idt();
+    };
+    const irep_idt s_tag = class_tag(struct_side.type());
+    if (!s_tag.empty() && s_tag == class_tag(ptr_side.type().subtype()))
+      struct_side = gen_address_of(struct_side);
+  }
+
   // Handle identity comparisons
   if (op == "Is")
     return get_binary_operator_expr_for_is(lhs, rhs);


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/4116.

Class instances live by value as tag-X while attribute chains reach them through pointer fields (tag-X *). Comparisons such as `a.next.next == a (or `is a`)` mixed the two and aborted with "Unsupported comparison between pointer-backed and non-pointer values" or crashed the SMT tuple encoder. Before `Eq/NotEq/Is/IsNot` dispatch, when one operand is a struct, and the other is a pointer to the same class tag, take the address of the struct so both sides compare as references.