### PR TITLE
[python] fix crash on nested attribute assignment (#4115)

### DIFF
--- a/regression/python/github_4115/main.py
+++ b/regression/python/github_4115/main.py
@@ -1,0 +1,13 @@
+class Leaf:
+    def __init__(self, v):
+        self.value = v
+
+
+class Holder:
+    def __init__(self):
+        self.leaf = Leaf(1)
+
+
+h = Holder()
+h.leaf.value = 99
+assert h.leaf.value == 99

--- a/regression/python/github_4115/test.desc
+++ b/regression/python/github_4115/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4115_fail/main.py
+++ b/regression/python/github_4115_fail/main.py
@@ -1,0 +1,13 @@
+class Leaf:
+    def __init__(self, v):
+        self.value = v
+
+
+class Holder:
+    def __init__(self):
+        self.leaf = Leaf(1)
+
+
+h = Holder()
+h.leaf.value = 99
+assert h.leaf.value == 100

--- a/regression/python/github_4115_fail/test.desc
+++ b/regression/python/github_4115_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -3881,6 +3881,12 @@ private:
     // Get LHS from members access on assignments. e.g.: x.data = 10
     else if (target["_type"] == "Attribute")
     {
+      // Only single-level obj.attr = ... is annotatable here. Nested writes
+      // like obj.a.b = ... mutate an already-declared field and need no
+      // inferred annotation; the inner value is an Attribute (no "id"),
+      // not a Name, so reading "id" would throw json::type_error.
+      if (!target["value"].is_object() || !target["value"].contains("id"))
+        return;
       id = target["value"]["id"].template get<std::string>() + "." +
            target["attr"].template get<std::string>();
     }


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/4115.

`update_assignment_node` assumed the Attribute target's inner value was a Name node and read its "id" unconditionally, which throws a `nlohmann::json::type_error` at parse time for nested LHS such as `obj.a.b = value`. 

This PR guards the dotted-id construction to single-level attribute writes and skips the annotation conversion otherwise: nested writes mutate an already-declared field, so no inferred AnnAssign is needed. 

This PR mirrors the existing Subscript early-return.