### PR TITLE
[cpp] add state-reset destructors to stack-backed OM containers (#3983)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_3983/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3983/main.cpp
@@ -1,0 +1,29 @@
+#include <deque>
+#include <queue>
+#include <set>
+#include <stack>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+
+int main()
+{
+  {
+    std::deque<int> d;
+    d.push_back(1);
+    std::set<int> s;
+    s.insert(2);
+    std::multiset<int> ms;
+    ms.insert(2);
+    std::stack<int> st;
+    st.push(3);
+    std::queue<int> q;
+    q.push(4);
+    std::unordered_map<int, int> m;
+    m[4] = 5;
+    std::unordered_set<int> us;
+    us.insert(6);
+    std::tuple<int, int> t(1, 2);
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3983/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3983/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --multi-property
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3983/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3983/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.cpp
---std c++17 --multi-property
+--incremental-bmc --std c++17 --multi-property
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_3983_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3983_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <stack>
+
+int main()
+{
+  std::stack<int> st;
+  st.push(10);
+  st.pop();
+  int x = st.top(); // stack underflow: __ESBMC_assert fires inside top()
+  (void)x;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_3983_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_3983_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --multi-property
+^VERIFICATION FAILED$

--- a/src/cpp/library/bitset
+++ b/src/cpp/library/bitset
@@ -89,6 +89,10 @@ public:
     }
   }
 
+  ~bitset()
+  {
+  }
+
   bitset(unsigned long val)
   {
     data[0] = val;

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -416,6 +416,11 @@ public:
     _capacity = 1;
   }
 
+  ~deque()
+  {
+    _size = 0;
+  }
+
   explicit deque(iterator t1, iterator t2) : _size(0)
   {
     int n = 1;

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -702,7 +702,7 @@ public:
 
   void verify_capacity()
   {
-    while (_size >= _capacity)
+    while (_size >= _capacity && _capacity < DEQUE_CAPACITY)
       _capacity *= 2;
   }
 

--- a/src/cpp/library/queue
+++ b/src/cpp/library/queue
@@ -27,6 +27,11 @@ public:
   {
   }
 
+  ~priority_queue()
+  {
+    _size = 0;
+  }
+
   // Constructor that takes const reference (handles temporaries)
   priority_queue(const Compare &x) : _size(0), head(0), tail(0), comp(x)
   {
@@ -116,6 +121,11 @@ class queue
 public:
   queue() : _size(0), head(0), tail(0)
   {
+  }
+
+  ~queue()
+  {
+    _size = 0;
   }
   queue(std::deque<int> &x) : _size(x.size()), head(0), tail(0)
   {

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -433,6 +433,11 @@ public:
     _size = 0;
   }
 
+  ~multiset()
+  {
+    this->clear();
+  }
+
   multiset(const multiset &x)
   {
     _size = 0;
@@ -1136,6 +1141,11 @@ public:
 
   set() : _size(0), rule(Compare())
   {
+  }
+
+  ~set()
+  {
+    this->clear();
   }
 
   set(const set &x)

--- a/src/cpp/library/stack
+++ b/src/cpp/library/stack
@@ -30,6 +30,11 @@ public:
     _top = 0;
   }
 
+  ~stack()
+  {
+    _top = 0;
+  }
+
   void inc_top()
   {
     _top++;
@@ -94,6 +99,11 @@ public:
     size_t container_size = ctnr.size();
     __ESBMC_assert(
       container_size <= STACK_CAPACITY, "container too large for stack");
+    _top = 0;
+  }
+
+  ~stack()
+  {
     _top = 0;
   }
 
@@ -169,6 +179,11 @@ public:
     _top = container_size;
   }
 
+  ~stack()
+  {
+    _top = 0;
+  }
+
   void inc_top()
   {
     _top++;
@@ -239,6 +254,11 @@ public:
       buf[i] = ctnr[i];
     }
     _top = container_size;
+  }
+
+  ~stack()
+  {
+    _top = 0;
   }
 
   void inc_top()

--- a/src/cpp/library/tuple
+++ b/src/cpp/library/tuple
@@ -68,6 +68,10 @@ public:
     other.head = temp;
     this->tail.swap(other.tail);
   }
+
+  ~tuple()
+  {
+  }
 };
 
 template <std::size_t I, typename Tuple>

--- a/src/cpp/library/unordered_map
+++ b/src/cpp/library/unordered_map
@@ -190,7 +190,9 @@ private:
 public:
     // Constructors
     unordered_map() : size_(0) {}
-    
+
+    ~unordered_map() { size_ = 0; }
+
     explicit unordered_map(size_type /*bucket_count*/) : size_(0) {}
     
     // Iterator range constructor

--- a/src/cpp/library/unordered_set
+++ b/src/cpp/library/unordered_set
@@ -128,7 +128,9 @@ private:
 public:
     // Constructors
     unordered_set() : size_(0) {}
-    
+
+    ~unordered_set() { size_ = 0; }
+
     explicit unordered_set(size_type /*bucket_count*/) : size_(0) {}
     
     // Iterator range constructor

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -141,6 +141,10 @@ struct pair
     std::swap(first, p.first);
     std::swap(second, p.second);
   }
+
+  ~pair()
+  {
+  }
 };
 
 template <class T1, class T2>


### PR DESCRIPTION
Closes #3983. 

This PR mirrors the post-#3981 list/map pattern across deque, set/multiset, queue/priority_queue, stack (all 4 specializations), bitset, tuple, pair (in utility), and unordered_map/unordered_set.

Heap-owning OMs (vector, basic_string, valarray, auto_ptr) are deliberately left unchanged: ESBMC shallow-copies temporaries, so a delete-based destructor would double-free. 

See PR #2515 and the XLiZHI comment on #3983; fixing that requires front-end work tracked separately.