### PR TITLE
[goto-programs] port assign_params_as_non_det to native irep2

### DIFF
--- a/src/goto-programs/assign_params_as_non_det.cpp
+++ b/src/goto-programs/assign_params_as_non_det.cpp
@@ -29,9 +29,12 @@ static expr2tc sym_to_expr2tc(const symbolt &sym)
 
 /// Append @p instr (with location and function copied from @p it) before @p it
 /// in @p program, leaving @p it pointing at the same original instruction.
-static void
-insert_before(goto_programt &program, goto_programt::targett &it, expr2tc code,
-              goto_program_instruction_typet type, const locationt &loc)
+static void insert_before(
+  goto_programt &program,
+  goto_programt::targett &it,
+  expr2tc code,
+  goto_program_instruction_typet type,
+  const locationt &loc)
 {
   goto_programt::instructiont instr;
   instr.type = type;

--- a/src/goto-programs/assign_params_as_non_det.cpp
+++ b/src/goto-programs/assign_params_as_non_det.cpp
@@ -21,19 +21,39 @@ symbolt *assign_params_as_non_det::get_default_symbol(
   return new_sym;
 }
 
+/// Build an irep2 symbol expression referring to @p sym.
+static expr2tc sym_to_expr2tc(const symbolt &sym)
+{
+  return symbol2tc(migrate_type(sym.type), sym.id);
+}
+
+/// Append @p instr (with location and function copied from @p it) before @p it
+/// in @p program, leaving @p it pointing at the same original instruction.
+static void
+insert_before(goto_programt &program, goto_programt::targett &it, expr2tc code,
+              goto_program_instruction_typet type, const locationt &loc)
+{
+  goto_programt::instructiont instr;
+  instr.type = type;
+  instr.code = std::move(code);
+  instr.location = loc;
+  instr.function = it->location.get_function();
+  program.insert_swap(it++, instr);
+  --it;
+}
+
 bool assign_params_as_non_det::runOnFunction(
   std::pair<const dstring, goto_functiont> &F)
 {
-  if (context.find_symbol(F.first) == nullptr)
+  const symbolt *fn_sym = context.find_symbol(F.first);
+  if (fn_sym == nullptr)
     return false; // Not exist
 
-  exprt symbol = symbol_expr(*context.find_symbol(F.first));
-
-  if (!symbol.type().is_code())
+  if (!fn_sym->type.is_code())
     return false; // Not expected
-  code_typet t = to_code_type(symbol.type());
+  const code_typet t = to_code_type(fn_sym->type);
 
-  if (symbol.name().as_string() != target_function)
+  if (fn_sym->name.as_string() != target_function)
     return false; // Not target function
 
   if (!F.second.body_available)
@@ -46,236 +66,148 @@ bool assign_params_as_non_det::runOnFunction(
     func(int x, bool y)  { x = nondet_int(); y = nondet_bool(); ...}
   */
   goto_programt &goto_program = F.second.body;
-  auto it = (goto_program).instructions.begin();
-  locationt l = context.find_symbol(F.first)->location;
+  auto it = goto_program.instructions.begin();
+  const locationt l = fn_sym->location;
 
   for (const auto &arg : t.arguments())
   {
-    // lhs
     const auto &_id = arg.get("#identifier");
-    if (context.find_symbol(_id) == nullptr)
+    const symbolt *lhs_sym = context.find_symbol(_id);
+    if (lhs_sym == nullptr)
       return false; // Not expected
-    exprt lhs = symbol_expr(*context.find_symbol(_id));
+    expr2tc lhs = sym_to_expr2tc(*lhs_sym);
+    type2tc l_t = lhs->type;
 
-    typet l_t = lhs.type();
-
-    // rhs
-    exprt rhs = exprt("sideeffect", l_t);
-    rhs.statement("nondet");
-    rhs.location() = l;
-
-    // assignment
-    goto_programt tmp;
-    goto_programt::targett assignment = tmp.add_instruction(ASSIGN);
-    assignment->location = l;
-    assignment->function = it->location.get_function();
-
-    code_assignt code_assign(lhs, rhs);
-    code_assign.location() = it->location;
-    expr2tc new_assign_expr;
-    migrate_expr(code_assign, new_assign_expr);
-    assignment->code = new_assign_expr;
-
-    // insert
-    goto_program.insert_swap(it++, *assignment);
-    --it;
+    insert_before(
+      goto_program, it, code_assign2tc(lhs, gen_nondet(l_t)), ASSIGN, l);
 
     // additional handling for non-void pointer
     // so the pointer can point to an array (decay), which is covered above
     // also, the pointer can point to an object/variable, which is covered below
-    if (l_t.is_pointer() && l_t.subtype() != empty_typet())
+    if (!is_pointer_type(l_t))
+      continue;
+    const type2tc &subtype = to_pointer_type(l_t).subtype;
+    if (is_empty_type(subtype))
+      continue;
+
+    /*
+      e.g. int* lhs;
+      to
+      bool lhs#temp_bool;
+      lhs#temp_bool = nondet();
+      if(!lhs#temp_bool)
+      {
+        int lhs#temp;
+        lhs#temp = nondet();
+        assume(lhs#temp != 0);
+        lhs = &lhs#temp;
+      }
+    */
+
+    // lhs = nondet();  (initial null/nondet pointer assignment)
+    insert_before(
+      goto_program, it, code_assign2tc(lhs, gen_nondet(l_t)), ASSIGN, l);
+
+    // resolve named subtypes for the temp object's symbol
+    typet obj_typet = lhs_sym->type.subtype();
+    if (obj_typet.is_symbol())
+      obj_typet = context.find_symbol(obj_typet.identifier())->type;
+
+    symbolt *obj_sym = get_default_symbol(
+      obj_typet,
+      lhs_sym->name.as_string() + "#temp",
+      lhs_sym->id.as_string() + "#temp",
+      l);
+
+    symbolt *flag_sym = get_default_symbol(
+      bool_typet(),
+      lhs_sym->name.as_string() + "#temp_bool",
+      lhs_sym->id.as_string() + "#temp_bool",
+      l);
+
+    // declare temp boolean variable: bool lhs#temp_bool;
+    insert_before(
+      goto_program,
+      it,
+      code_decl2tc(migrate_type(flag_sym->type), flag_sym->id),
+      DECL,
+      l);
+
+    // lhs#temp_bool = nondet();
+    expr2tc flag = sym_to_expr2tc(*flag_sym);
+    insert_before(
+      goto_program,
+      it,
+      code_assign2tc(flag, gen_nondet(flag->type)),
+      ASSIGN,
+      l);
+
+    // declare temp object: T lhs#temp;
+    insert_before(
+      goto_program,
+      it,
+      code_decl2tc(migrate_type(obj_sym->type), obj_sym->id),
+      DECL,
+      l);
+
+    // lhs#temp = nondet();
+    expr2tc obj = sym_to_expr2tc(*obj_sym);
+    insert_before(
+      goto_program, it, code_assign2tc(obj, gen_nondet(obj->type)), ASSIGN, l);
+
+    // assume((bool)lhs#temp);  (skipped: branch not counted in coverage)
     {
-      /*
-        e.g. int* lhs;
-        to
-        bool lhs#temp_bool;
-        lhs#temp_bool = nondet();
-        if(!lhs#temp_bool)
-        {
-          int lhs#temp;
-          lhs#temp = nondet();
-          assume(lhs#temp != 0);
-          lhs = &lhs#temp;
-        }
-        
-        During this process we create two auxiliary variable. One for the boolean flag, and one for the object.
-        - We need to consider the situation where pointers can be null, thus we put the assignment under an if-statement
-        - If the flag (`lhs#temp_bool`) is true, we create an object (`lhs#temp`) and assign its address to the pointer.
-      */
-
-      // lhs = null;
-      exprt zero_rhs = exprt("sideeffect", l_t);
-      zero_rhs.statement("nondet");
-      zero_rhs.location() = l;
-
-      // assignment
-      goto_programt zero_program;
-      goto_programt::targett zero_assignment =
-        zero_program.add_instruction(ASSIGN);
-      zero_assignment->location = l;
-      zero_assignment->function = it->location.get_function();
-
-      code_assignt zero_assign(lhs, zero_rhs);
-      zero_assign.location() = it->location;
-      expr2tc new_zero_assign;
-      migrate_expr(zero_assign, new_zero_assign);
-      zero_assignment->code = new_zero_assign;
-
-      // insert
-      goto_program.insert_swap(it++, *zero_assignment);
+      goto_programt::instructiont assume;
+      assume.make_assumption(typecast2tc(get_bool_type(), obj));
+      assume.location = l;
+      assume.location.property("skipped");
+      assume.function = it->location.get_function();
+      goto_program.insert_swap(it++, assume);
       --it;
-
-      // get subType() => int
-      typet subt = l_t.subtype();
-      // if it's symbol, get the original type
-      if (subt.is_symbol())
-        subt = context.find_symbol(subt.identifier())->type;
-
-      // create obj and move it to the symbol table
-      symbolt *new_sym = get_default_symbol(
-        subt,
-        lhs.name().as_string() + "#temp",
-        lhs.identifier().as_string() + "#temp",
-        l);
-
-      code_declt _decl(symbol_expr(*new_sym));
-
-      // declare temp boolean variable
-      exprt _rhs = exprt("sideeffect", bool_typet());
-      _rhs.statement("nondet");
-      _rhs.location() = l;
-
-      symbolt *new_sym2 = get_default_symbol(
-        bool_typet(),
-        lhs.name().as_string() + "#temp_bool",
-        lhs.identifier().as_string() + "#temp_bool",
-        l);
-      code_declt _decl2(symbol_expr(*new_sym2));
-      goto_programt tmp2;
-      goto_programt::targett decl_statement2 = tmp2.add_instruction(DECL);
-      decl_statement2->location = l;
-      decl_statement2->function = it->location.get_function();
-      expr2tc new_decl2;
-      migrate_expr(_decl2, new_decl2);
-      decl_statement2->code = new_decl2;
-      goto_program.insert_swap(it++, *decl_statement2);
-      --it;
-
-      // assign nondet_bool
-      goto_programt bool_tmp;
-      goto_programt::targett bool_assignment = bool_tmp.add_instruction(ASSIGN);
-      bool_assignment->location = l;
-      bool_assignment->function = it->location.get_function();
-      code_assignt bool_assign(symbol_expr(*new_sym2), _rhs);
-      bool_assign.location() = l;
-      expr2tc new_bool_assign;
-      migrate_expr(bool_assign, new_bool_assign);
-      bool_assignment->code = new_bool_assign;
-      goto_program.insert_swap(it++, *bool_assignment);
-      --it;
-
-      // create a goto_instructiont DECL and insert to the original program  => DECL _temp
-      goto_programt decl_tmp;
-      goto_programt::targett decl_statement = decl_tmp.add_instruction(DECL);
-      decl_statement->location = l;
-      decl_statement->function = it->location.get_function();
-      expr2tc new_decl;
-      migrate_expr(_decl, new_decl);
-      decl_statement->code = new_decl;
-
-      // insert
-      goto_program.insert_swap(it++, *decl_statement);
-      --it;
-
-      // set value of _temp; => temp = nondet
-      _rhs = exprt("sideeffect", subt);
-      _rhs.statement("nondet");
-      _rhs.location() = l;
-
-      // assignment
-      goto_programt assign_tmp;
-      goto_programt::targett assignment = assign_tmp.add_instruction(ASSIGN);
-      assignment->location = l;
-      assignment->function = it->location.get_function();
-
-      code_assignt code_assign(symbol_expr(*new_sym), _rhs);
-      code_assign.location() = l;
-      expr2tc new_assign_expr;
-      migrate_expr(code_assign, new_assign_expr);
-      assignment->code = new_assign_expr;
-      goto_program.insert_swap(it++, *assignment);
-      --it;
-
-      // do assume
-      exprt n_lhs = typecast_exprt(symbol_expr(*new_sym), bool_type());
-      expr2tc n_guard;
-      migrate_expr(n_lhs, n_guard);
-      goto_programt::instructiont instruction;
-      instruction.make_assumption(n_guard);
-      instruction.location = l;
-      instruction.location.property(
-        "skipped"); // we do not calculate this condition/branch
-      instruction.function = it->location.get_function();
-      goto_program.insert_swap(it++, instruction);
-      --it;
-
-      // do assignment => lhs = &_temp
-      goto_programt obj_address;
-      goto_programt::targett addr_assignment =
-        obj_address.add_instruction(ASSIGN);
-      addr_assignment->location = l;
-      addr_assignment->function = it->location.get_function();
-
-      exprt _addr = address_of_exprt(symbol_expr(*new_sym));
-      code_assignt addr_assign(lhs, _addr);
-      addr_assign.location() = l;
-      expr2tc new_addr_assign;
-      migrate_expr(addr_assign, new_addr_assign);
-      addr_assignment->code = new_addr_assign;
-
-      goto_program.insert_swap(it++, *addr_assignment);
-      --it;
-
-      // create if statement => if(nondet_bool()) lhs = &_temp;
-      //! hack: we do not do reverse !(nondet_bool)
-      //! such that this condition will not be counted in the goto_coverage
-      expr2tc not_guard;
-      migrate_expr(symbol_expr(*new_sym2), not_guard);
-      // make not: !lhs#temp_bool
-      make_not(not_guard);
-
-      // inser if statement to the goto program
-      goto_programt tmp4;
-      goto_programt::targett if_statement = tmp4.add_instruction();
-      if_statement->location = l;
-      if_statement->location.property(
-        "skipped"); // we do not calculate this condition/branch
-      if_statement->function = it->location.get_function();
-
-      if_statement->make_goto(it);
-      if_statement->guard = not_guard;
-
-      /* insert      
-       Instrument_1
-       Instrument_2  <-- we want to insert a statement before here
-       Instrument_3
-       Instrument_4  
-       Origin_1        <-- 'it' is currently here
-      */
-      --it;
-      --it;
-      --it;
-      --it;
-      goto_program.insert_swap(it++, *if_statement);
-
-      /* reset
-        After insertion, reset the pointer `it`'s position to the `origin_1`
-      */
-      ++it;
-      ++it;
-      ++it;
-      goto_program.compute_target_numbers();
     }
+
+    // lhs = &lhs#temp;
+    insert_before(
+      goto_program,
+      it,
+      code_assign2tc(lhs, address_of2tc(obj->type, obj)),
+      ASSIGN,
+      l);
+
+    // Wrap the four instructions just inserted (DECL flag, ASSIGN flag, DECL
+    // obj, ASSIGN obj, ASSUME, ASSIGN addr) so they are guarded by the flag.
+    //! hack: we use !flag (forward jump over the body) so the condition is not
+    //! counted in goto_coverage.
+    goto_programt::instructiont if_instr;
+    if_instr.location = l;
+    if_instr.location.property("skipped");
+    if_instr.function = it->location.get_function();
+    if_instr.make_goto(it);
+    if_instr.guard = not2tc(flag);
+
+    /* insert
+       Instrument_1   <-- DECL flag
+       Instrument_2   <-- ASSIGN flag
+       Instrument_3   <-- DECL obj
+       Instrument_4   <-- ASSIGN obj
+       Instrument_5   <-- ASSUME
+       Instrument_6   <-- ASSIGN lhs = &obj
+       Origin_1       <-- 'it' is here; we want IF !flag GOTO Origin_1
+                          inserted before Instrument_1
+    */
+    --it; // ASSIGN lhs = &obj
+    --it; // ASSUME
+    --it; // ASSIGN obj
+    --it; // DECL obj
+    --it; // ASSIGN flag
+    --it; // DECL flag
+    goto_program.insert_swap(it++, if_instr);
+    ++it; // ASSIGN flag
+    ++it; // DECL obj
+    ++it; // ASSIGN obj
+    ++it; // ASSUME
+    ++it; // ASSIGN lhs = &obj
+    goto_program.compute_target_numbers();
   }
 
   goto_program.update();


### PR DESCRIPTION
Construct DECL, ASSIGN, ASSUME, and the conditional GOTO directly as
`code_*2tc` / `address_of2tc` / `typecast2tc` / `not2tc` instead of
building legacy `codet` trees and migrating at every insertion site.
Removes thirteen `migrate_expr` round-trips; behaviour unchanged.

Tested against `regression/python-intensive/problem2_1*` (the
representative `--function`-mode tests) — all pass.