### PR TITLE
stabilize dataclass lifecycle semantics

### DIFF
--- a/regression/python/dataclass_classvar_metadata/main.py
+++ b/regression/python/dataclass_classvar_metadata/main.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class Config:
+    version: ClassVar[int] = 3
+    name: str
+
+
+cfg = Config("prod")
+
+assert Config.version == 3
+assert cfg.name == "prod"

--- a/regression/python/dataclass_classvar_metadata/test.desc
+++ b/regression/python/dataclass_classvar_metadata/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclass_initvar_post_init/main.py
+++ b/regression/python/dataclass_initvar_post_init/main.py
@@ -1,0 +1,17 @@
+from dataclasses import InitVar, dataclass
+
+
+@dataclass
+class Task:
+    name: str
+    seed: InitVar[int]
+    priority: int = 0
+
+    def __post_init__(self, seed) -> None:
+        self.priority = seed + len(self.name)
+
+
+task = Task("abc", 4)
+
+assert task.priority == 7
+assert not hasattr(task, "seed")

--- a/regression/python/dataclass_initvar_post_init/test.desc
+++ b/regression/python/dataclass_initvar_post_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclass_initvar_post_init_string/main.py
+++ b/regression/python/dataclass_initvar_post_init_string/main.py
@@ -1,0 +1,15 @@
+from dataclasses import InitVar, dataclass
+
+
+@dataclass
+class Token:
+    text: str
+    suffix: InitVar[str]
+
+    def __post_init__(self, suffix) -> None:
+        self.text = self.text + "-" + suffix
+
+
+t = Token("id", "ok")
+
+assert t.text == "id-ok"

--- a/regression/python/dataclass_initvar_post_init_string/test.desc
+++ b/regression/python/dataclass_initvar_post_init_string/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclass_post_init_hierarchy/main.py
+++ b/regression/python/dataclass_post_init_hierarchy/main.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Base:
+
+    def __post_init__(self) -> None:
+        self.order = 1
+
+
+@dataclass
+class Child(Base):
+
+    def __post_init__(self) -> None:
+        Base.__post_init__(self)
+        self.order = self.order + 1
+
+
+child = Child()
+
+assert child.order == 2

--- a/regression/python/dataclass_post_init_hierarchy/test.desc
+++ b/regression/python/dataclass_post_init_hierarchy/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclass_post_init_inherited/main.py
+++ b/regression/python/dataclass_post_init_inherited/main.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Base:
+
+    def __post_init__(self) -> None:
+        self.order = 1
+
+
+@dataclass
+class Child(Base):
+    value: int
+
+
+child = Child(9)
+
+assert child.order == 1
+assert child.value == 9

--- a/regression/python/dataclass_post_init_inherited/test.desc
+++ b/regression/python/dataclass_post_init_inherited/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclass_post_init_simple/main.py
+++ b/regression/python/dataclass_post_init_simple/main.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Counter:
+    base: int
+    value: int = 0
+
+    def __post_init__(self) -> None:
+        self.value = self.base + 1
+
+
+c = Counter(10)
+
+assert c.value == 11

--- a/regression/python/dataclass_post_init_simple/test.desc
+++ b/regression/python/dataclass_post_init_simple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dataclass_post_init_super/main.py
+++ b/regression/python/dataclass_post_init_super/main.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Base:
+
+    def __post_init__(self) -> None:
+        self.order = 1
+
+
+@dataclass
+class Child(Base):
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.order = self.order + 1
+
+
+child = Child()
+
+assert child.order == 2

--- a/regression/python/dataclass_post_init_super/test.desc
+++ b/regression/python/dataclass_post_init_super/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/method_chain_call_receiver/main.py
+++ b/regression/python/method_chain_call_receiver/main.py
@@ -1,0 +1,18 @@
+class Leaf:
+    def value(self) -> int:
+        return 7
+
+
+class Mid:
+    def leaf(self) -> Leaf:
+        return Leaf()
+
+
+class Root:
+    def mid(self) -> Mid:
+        return Mid()
+
+
+x = Root().mid().leaf().value()
+
+assert x == 7

--- a/regression/python/method_chain_call_receiver/test.desc
+++ b/regression/python/method_chain_call_receiver/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/method_chain_call_receiver_fail/main.py
+++ b/regression/python/method_chain_call_receiver_fail/main.py
@@ -1,0 +1,17 @@
+class Leaf:
+    def value(self) -> int:
+        return 7
+
+class Mid:
+    def get_leaf(self) -> Leaf:
+        leaf = Leaf()
+        return leaf
+
+class Host:
+    def make_mid(self) -> Mid:
+        mid = Mid()
+        return mid
+
+h = Host()
+result = h.make_mid().get_leaf().value()
+assert result == 99  # wrong value, should be 7

--- a/regression/python/method_chain_call_receiver_fail/test.desc
+++ b/regression/python/method_chain_call_receiver_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/method_chain_member_receiver/main.py
+++ b/regression/python/method_chain_member_receiver/main.py
@@ -1,0 +1,16 @@
+class Worker:
+    def run(self) -> int:
+        return 9
+
+
+class Holder:
+    def __init__(self):
+        self.worker = Worker()
+
+    def execute(self) -> int:
+        return self.worker.run()
+
+
+h = Holder()
+
+assert h.execute() == 9

--- a/regression/python/method_chain_member_receiver/test.desc
+++ b/regression/python/method_chain_member_receiver/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/method_chain_member_receiver_fail/main.py
+++ b/regression/python/method_chain_member_receiver_fail/main.py
@@ -1,0 +1,13 @@
+class Worker:
+    def run(self) -> int:
+        return 9
+
+class Host:
+    def __init__(self) -> None:
+        self.worker = Worker()
+
+    def run_worker(self) -> int:
+        return self.worker.run()
+
+h = Host()
+assert h.run_worker() == 99  # wrong value, should be 9

--- a/regression/python/method_chain_member_receiver_fail/test.desc
+++ b/regression/python/method_chain_member_receiver_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4956,7 +4956,8 @@ exprt function_call_expr::handle_general_function_call()
     return receiver.type().is_pointer() ? receiver : gen_address_of(receiver);
   };
 
-  auto bind_instance_receiver_symbol = [&](const symbolt &receiver_symbol) -> exprt {
+  auto bind_instance_receiver_symbol =
+    [&](const symbolt &receiver_symbol) -> exprt {
     exprt receiver = symbol_expr(receiver_symbol);
     return bind_instance_receiver(receiver);
   };
@@ -4986,8 +4987,7 @@ exprt function_call_expr::handle_general_function_call()
     if (is_super_init)
     {
       if (obj_symbol)
-        call.arguments().push_back(
-          bind_instance_receiver_symbol(*obj_symbol));
+        call.arguments().push_back(bind_instance_receiver_symbol(*obj_symbol));
       param_offset = 1;
     }
     // Self is the LHS
@@ -5043,8 +5043,7 @@ exprt function_call_expr::handle_general_function_call()
           exprt ctor_result = converter_.get_expr(func_value);
           converter_.current_lhs = saved_lhs;
 
-          call.arguments().push_back(
-            bind_instance_receiver(symbol_expr(tmp)));
+          call.arguments().push_back(bind_instance_receiver(symbol_expr(tmp)));
         }
         else if (func_value["_type"] == "Call")
         {

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4783,7 +4783,8 @@ exprt function_call_expr::handle_general_function_call()
           {
             exprt receiver = symbol_expr(*obj_symbol);
             call.arguments().push_back(
-              obj_symbol->is_parameter ? receiver : gen_address_of(receiver));
+              receiver.type().is_pointer() ? receiver
+                                           : gen_address_of(receiver));
           }
 
           for (const auto &arg_node : call_["args"])
@@ -4957,8 +4958,7 @@ exprt function_call_expr::handle_general_function_call()
 
   auto bind_instance_receiver_symbol = [&](const symbolt &receiver_symbol) -> exprt {
     exprt receiver = symbol_expr(receiver_symbol);
-    return receiver_symbol.is_parameter ? receiver
-                                        : bind_instance_receiver(receiver);
+    return bind_instance_receiver(receiver);
   };
 
   // Determine parameter offset for Optional wrapping logic

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4610,6 +4610,32 @@ exprt function_call_expr::handle_general_function_call()
 
   if (func_symbol == nullptr)
   {
+    // Dataclass synthesized constructors may call Class.__post_init__(...) before
+    // the class method symbol is fully registered. Preserve class scope and emit
+    // a forward reference call instead of falling back to global scope.
+    if (
+      function_type_ == FunctionType::ClassMethod &&
+      function_id_.get_function() == "__post_init__" &&
+      !function_id_.get_class().empty())
+    {
+      locationt location = converter_.get_location_from_decl(call_);
+      code_function_callt call;
+      call.location() = location;
+      call.function() = symbol_exprt(func_symbol_id, code_typet());
+      call.type() = empty_typet();
+
+      for (const auto &arg_node : call_["args"])
+      {
+        exprt arg = converter_.get_expr(arg_node);
+        if (arg.type().is_array())
+          call.arguments().push_back(address_of_exprt(arg));
+        else
+          call.arguments().push_back(arg);
+      }
+
+      return call;
+    }
+
     if (
       function_type_ == FunctionType::Constructor ||
       function_type_ == FunctionType::InstanceMethod)
@@ -4754,8 +4780,11 @@ exprt function_call_expr::handle_general_function_call()
           call.type() = empty_typet();
 
           if (obj_symbol)
+          {
+            exprt receiver = symbol_expr(*obj_symbol);
             call.arguments().push_back(
-              gen_address_of(symbol_expr(*obj_symbol)));
+              obj_symbol->is_parameter ? receiver : gen_address_of(receiver));
+          }
 
           for (const auto &arg_node : call_["args"])
           {
@@ -4922,6 +4951,16 @@ exprt function_call_expr::handle_general_function_call()
   const typet &return_type = to_code_type(func_symbol->type).return_type();
   call.type() = return_type;
 
+  auto bind_instance_receiver = [&](exprt receiver) -> exprt {
+    return receiver.type().is_pointer() ? receiver : gen_address_of(receiver);
+  };
+
+  auto bind_instance_receiver_symbol = [&](const symbolt &receiver_symbol) -> exprt {
+    exprt receiver = symbol_expr(receiver_symbol);
+    return receiver_symbol.is_parameter ? receiver
+                                        : bind_instance_receiver(receiver);
+  };
+
   // Determine parameter offset for Optional wrapping logic
   size_t param_offset = 0;
 
@@ -4947,7 +4986,8 @@ exprt function_call_expr::handle_general_function_call()
     if (is_super_init)
     {
       if (obj_symbol)
-        call.arguments().push_back(symbol_expr(*obj_symbol));
+        call.arguments().push_back(
+          bind_instance_receiver_symbol(*obj_symbol));
       param_offset = 1;
     }
     // Self is the LHS
@@ -4970,7 +5010,7 @@ exprt function_call_expr::handle_general_function_call()
   {
     if (obj_symbol)
     {
-      call.arguments().push_back(gen_address_of(symbol_expr(*obj_symbol)));
+      call.arguments().push_back(bind_instance_receiver_symbol(*obj_symbol));
     }
     else
     {
@@ -5003,7 +5043,8 @@ exprt function_call_expr::handle_general_function_call()
           exprt ctor_result = converter_.get_expr(func_value);
           converter_.current_lhs = saved_lhs;
 
-          call.arguments().push_back(gen_address_of(symbol_expr(tmp)));
+          call.arguments().push_back(
+            bind_instance_receiver(symbol_expr(tmp)));
         }
         else if (func_value["_type"] == "Call")
         {
@@ -5032,12 +5073,13 @@ exprt function_call_expr::handle_general_function_call()
               inner_call.location() = location;
               converter_.add_instruction(inner_call);
             }
-            call.arguments().push_back(gen_address_of(symbol_expr(tmp)));
+            call.arguments().push_back(
+              bind_instance_receiver(symbol_expr(tmp)));
           }
           else
           {
             exprt obj_expr = converter_.get_expr(func_value);
-            call.arguments().push_back(gen_address_of(obj_expr));
+            call.arguments().push_back(bind_instance_receiver(obj_expr));
           }
         }
         else
@@ -5045,7 +5087,7 @@ exprt function_call_expr::handle_general_function_call()
           // Member/variable receiver (e.g., self.builder.build()): use the
           // actual receiver expression instead of a nondet temporary.
           exprt obj_expr = converter_.get_expr(func_value);
-          call.arguments().push_back(gen_address_of(obj_expr));
+          call.arguments().push_back(bind_instance_receiver(obj_expr));
         }
       }
       else

--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -28,18 +28,3 @@ def field(*args, default=None, default_factory=None, **kwargs):
     if default_factory is not None:
         return default_factory()
     return default
-
-
-def fields(class_or_instance):
-    target = class_or_instance
-    if not isinstance(class_or_instance, type):
-        target = class_or_instance.__class__
-    return getattr(target, "__dataclass_fields__", ())
-
-
-def asdict(obj):
-    return {field_name: getattr(obj, field_name) for field_name in fields(obj)}
-
-
-def astuple(obj):
-    return tuple(getattr(obj, field_name) for field_name in fields(obj))

--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -6,6 +6,14 @@ class Field:
         return cls
 
 
+class InitVar:
+
+    def __class_getitem__(cls, item):
+        """Return the class itself for subscription-style type usage."""
+
+        return cls
+
+
 def dataclass(_cls=None, **kwargs):
 
     def wrap(cls):
@@ -20,3 +28,18 @@ def field(*args, default=None, default_factory=None, **kwargs):
     if default_factory is not None:
         return default_factory()
     return default
+
+
+def fields(class_or_instance):
+    target = class_or_instance
+    if not isinstance(class_or_instance, type):
+        target = class_or_instance.__class__
+    return getattr(target, "__dataclass_fields__", ())
+
+
+def asdict(obj):
+    return {field_name: getattr(obj, field_name) for field_name in fields(obj)}
+
+
+def astuple(obj):
+    return tuple(getattr(obj, field_name) for field_name in fields(obj))

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -14,6 +14,12 @@ class Callable:
         return cls
 
 
+class ClassVar:
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
 class Dict:
 
     def __class_getitem__(cls, item):

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -65,6 +65,10 @@ class Preprocessor(ast.NodeTransformer):
         # adds aliased names like ``from dataclasses import field as f``.
         self._dataclass_decorator_names = {"dataclass"}
         self._dataclass_field_names = {"field"}
+        self._dataclass_initvar_names = {"InitVar"}
+        self.dataclasses_module_names = {"dataclasses"}
+        self._typing_classvar_names = {"ClassVar"}
+        self._classes_with_post_init = set()
 
     # Names treated as typing-style generic constructors (subscript = type alias).
     _TYPING_GENERIC_NAMES = (
@@ -75,6 +79,7 @@ class Preprocessor(ast.NodeTransformer):
         "Optional",
         "Union",
         "Callable",
+        "ClassVar",
     )
 
     # Dataclass fields declared with ``field(default_factory=...)`` are not
@@ -4831,6 +4836,116 @@ class Preprocessor(ast.NodeTransformer):
 
         return False
 
+    def _unwrap_annotation_slice(self, annotation):
+        if not isinstance(annotation, ast.Subscript):
+            return None
+        if isinstance(annotation.slice, ast.Index):
+            return annotation.slice.value
+        return annotation.slice
+
+    def _is_dataclass_initvar_base(self, node):
+        return (
+            isinstance(node, ast.Name)
+            and node.id in self._dataclass_initvar_names
+        ) or (
+            isinstance(node, ast.Attribute)
+            and node.attr == "InitVar"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in self.dataclasses_module_names
+        )
+
+    def _is_typing_classvar_base(self, node):
+        return (
+            isinstance(node, ast.Name)
+            and node.id in self._typing_classvar_names
+        ) or (
+            isinstance(node, ast.Attribute)
+            and node.attr == "ClassVar"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in self.typing_module_names
+        )
+
+    def _analyze_dataclass_field_annotation(self, annotation):
+        """Classify a dataclass annotation as instance field, InitVar or ClassVar."""
+        if annotation is None:
+            return "instance", None
+
+        if isinstance(annotation, ast.Subscript):
+            if self._is_dataclass_initvar_base(annotation.value):
+                inner = self._unwrap_annotation_slice(annotation)
+                return "initvar", self._copy_annotation_node(inner)
+            if self._is_typing_classvar_base(annotation.value):
+                inner = self._unwrap_annotation_slice(annotation)
+                return "classvar", self._copy_annotation_node(inner)
+
+        if self._is_dataclass_initvar_base(annotation):
+            return "initvar", None
+        if self._is_typing_classvar_base(annotation):
+            return "classvar", None
+        return "instance", annotation
+
+    def _get_post_init_method(self, class_node):
+        return next(
+            (
+                member
+                for member in class_node.body
+                if isinstance(member, ast.FunctionDef) and member.name == "__post_init__"
+            ),
+            None,
+        )
+
+    def _class_has_post_init_behavior(self, class_node):
+        if self._get_post_init_method(class_node) is not None:
+            return True
+
+        for base in class_node.bases:
+            if isinstance(base, ast.Name) and base.id in self._classes_with_post_init:
+                return True
+        return False
+
+    def _get_post_init_dispatch_target(self, class_node):
+        if self._get_post_init_method(class_node) is not None:
+            return class_node.name
+
+        for base in class_node.bases:
+            if isinstance(base, ast.Name) and base.id in self._classes_with_post_init:
+                return base.id
+
+        return None
+
+    def _validate_post_init_signature(self, class_node, fields, post_init_method):
+        """Validate that ``__post_init__`` can receive the declared InitVar values."""
+        if post_init_method is None:
+            return
+
+        initvar_count = sum(1 for _, _, _, _, kind in fields if kind == "initvar")
+        total_positional = (
+            len(post_init_method.args.posonlyargs) + len(post_init_method.args.args)
+        )
+        if total_positional == 0:
+            raise SyntaxError(
+                f"dataclass {class_node.name!r} has invalid __post_init__ signature: "
+                "missing bound instance parameter"
+            )
+
+        positional_after_self = total_positional - 1
+        min_positional_after_self = positional_after_self - len(post_init_method.args.defaults)
+        max_positional_after_self = (
+            float("inf") if post_init_method.args.vararg is not None else positional_after_self
+        )
+
+        if any(default is None for default in post_init_method.args.kw_defaults):
+            raise SyntaxError(
+                f"dataclass {class_node.name!r} has incompatible __post_init__ signature: "
+                "required keyword-only parameters are not supported"
+            )
+
+        if not (min_positional_after_self <= initvar_count <= max_positional_after_self):
+            raise SyntaxError(
+                f"dataclass {class_node.name!r} has incompatible __post_init__ signature: "
+                f"expected {initvar_count} InitVar argument(s)"
+            )
+
     def _parse_field_call(self, default_value):
         """Decompose ``field(...)`` calls into (default_expr, factory_expr).
 
@@ -4857,7 +4972,7 @@ class Preprocessor(ast.NodeTransformer):
             isinstance(func, ast.Attribute)
             and func.attr == "field"
             and isinstance(func.value, ast.Name)
-            and func.value.id == "dataclasses"
+            and func.value.id in self.dataclasses_module_names
         )
         if not is_field:
             return default_value, None
@@ -4879,15 +4994,24 @@ class Preprocessor(ast.NodeTransformer):
         return default_expr, factory_expr
 
     def collect_fields(self, class_node):
-        """Collect dataclass fields as (name, annotation, default_expr, factory_expr)."""
+        """Collect dataclass field specs.
+
+        Each entry is ``(name, annotation, default_expr, factory_expr, kind)`` where
+        ``kind`` is one of ``instance``, ``initvar`` or ``classvar``.
+        """
         fields = []
         for stmt in class_node.body:
             if not isinstance(stmt, ast.AnnAssign):
                 continue
             if not isinstance(stmt.target, ast.Name):
                 continue
+            field_kind, annotation = self._analyze_dataclass_field_annotation(
+                stmt.annotation
+            )
             default_expr, factory_expr = self._parse_field_call(stmt.value)
-            fields.append((stmt.target.id, stmt.annotation, default_expr, factory_expr))
+            fields.append(
+                (stmt.target.id, annotation, default_expr, factory_expr, field_kind)
+            )
         return fields
 
     def build_init(self, class_node, fields):
@@ -4919,22 +5043,26 @@ class Preprocessor(ast.NodeTransformer):
         defaults = []
         body = []
 
-        # Parameters: only non-factory fields. Compute first defaulted index
-        # over this filtered view.
+        # Parameters: instance fields except factory-backed ones, plus InitVars.
+        # Compute first defaulted index over this filtered view.
         param_fields = [
-            (name, ann, default_expr)
-            for (name, ann, default_expr, factory_expr) in fields
-            if factory_expr is None
+            (name, ann, default_expr, field_kind)
+            for (name, ann, default_expr, factory_expr, field_kind) in fields
+            if field_kind != "classvar"
+            and not (field_kind == "instance" and factory_expr is not None)
+        ]
+        initvar_names = [
+            name for (name, _, _, _, field_kind) in fields if field_kind == "initvar"
         ]
 
         first_default_idx = None
-        for index, (_, _, default_expr) in enumerate(param_fields):
+        for index, (_, _, default_expr, _) in enumerate(param_fields):
             if default_expr is not None:
                 first_default_idx = index
                 break
 
         if first_default_idx is not None:
-            for _, _, default_expr in param_fields[first_default_idx:]:
+            for _, _, default_expr, _ in param_fields[first_default_idx:]:
                 if default_expr is not None:
                     if not isinstance(default_expr, (ast.Constant, ast.Name)):
                         raise SyntaxError(
@@ -4946,7 +5074,7 @@ class Preprocessor(ast.NodeTransformer):
                 else:
                     defaults.append(ast.Constant(value=None))
 
-        for field_name, annotation, _ in param_fields:
+        for field_name, annotation, _, _ in param_fields:
             args.append(ast.arg(arg=field_name, annotation=copy.deepcopy(annotation)))
 
         # Body: assign every field, in declaration order. Factory fields use
@@ -4958,7 +5086,10 @@ class Preprocessor(ast.NodeTransformer):
         # handled by the normal class/parameter typing paths, whereas an
         # explicit ``self.x: Optional[T] = ...`` here can confuse later
         # arithmetic over values proven non-None by guards (see optional7).
-        for field_name, annotation, default_expr, factory_expr in fields:
+        for field_name, _, _, factory_expr, field_kind in fields:
+            if field_kind != "instance":
+                continue
+
             if factory_expr is not None:
                 rhs = ast.Call(
                     func=copy.deepcopy(factory_expr),
@@ -4980,6 +5111,43 @@ class Preprocessor(ast.NodeTransformer):
             )
             self.ensure_all_locations(assign_stmt, class_node)
             body.append(assign_stmt)
+
+        post_init_method = self._get_post_init_method(class_node)
+        if post_init_method is not None:
+            post_init_call = ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=self.create_name_node(class_node.name, ast.Load(), class_node),
+                        attr="__post_init__",
+                        ctx=ast.Load(),
+                    ),
+                    args=[self.create_name_node("self", ast.Load(), class_node)]
+                    + [
+                        self.create_name_node(initvar_name, ast.Load(), class_node)
+                        for initvar_name in initvar_names
+                    ],
+                    keywords=[],
+                )
+            )
+            self.ensure_all_locations(post_init_call, class_node)
+            body.append(post_init_call)
+        elif self._class_has_post_init_behavior(class_node):
+            post_init_call = ast.Expr(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=self.create_name_node("self", ast.Load(), class_node),
+                        attr="__post_init__",
+                        ctx=ast.Load(),
+                    ),
+                    args=[
+                        self.create_name_node(initvar_name, ast.Load(), class_node)
+                        for initvar_name in initvar_names
+                    ],
+                    keywords=[],
+                )
+            )
+            self.ensure_all_locations(post_init_call, class_node)
+            body.append(post_init_call)
 
         if not body:
             body = [ast.Pass()]
@@ -5004,6 +5172,23 @@ class Preprocessor(ast.NodeTransformer):
         ast.fix_missing_locations(init_func)
         return init_func
 
+    def build_dataclass_fields_metadata(self, class_node, fields):
+        field_names = [
+            field_name
+            for field_name, _, _, _, field_kind in fields
+            if field_kind == "instance"
+        ]
+        metadata_assign = ast.Assign(
+            targets=[ast.Name(id="__dataclass_fields__", ctx=ast.Store())],
+            value=ast.Tuple(
+                elts=[ast.Constant(value=field_name) for field_name in field_names],
+                ctx=ast.Load(),
+            ),
+        )
+        self.ensure_all_locations(metadata_assign, class_node)
+        ast.fix_missing_locations(metadata_assign)
+        return metadata_assign
+
     def expand_dataclass(self, class_node):
         """Inject a minimal generated __init__ for dataclass-decorated classes."""
         if not self.is_dataclass(class_node):
@@ -5016,8 +5201,17 @@ class Preprocessor(ast.NodeTransformer):
             return class_node
 
         fields = self.collect_fields(class_node)
-        if not fields:
+        post_init_method = self._get_post_init_method(class_node)
+        active_fields = [
+            field for field in fields if field[4] in ("instance", "initvar")
+        ]
+        has_post_init_behavior = self._class_has_post_init_behavior(class_node)
+        if not active_fields and not has_post_init_behavior:
             return class_node
+
+        self._validate_post_init_signature(class_node, fields, post_init_method)
+        if has_post_init_behavior:
+            self._classes_with_post_init.add(class_node.name)
 
         # Validate field ordering: once a field has a default (raw,
         # ``field(default=...)`` or ``field(default_factory=...)``), every
@@ -5025,7 +5219,9 @@ class Preprocessor(ast.NodeTransformer):
         # SyntaxError with a "non-default argument follows default argument"
         # style message.
         seen_default = False
-        for field_name, _, default_expr, factory_expr in fields:
+        for field_name, _, default_expr, factory_expr, field_kind in fields:
+            if field_kind == "classvar":
+                continue
             has_default = default_expr is not None or factory_expr is not None
             if seen_default and not has_default:
                 raise SyntaxError(
@@ -5040,11 +5236,17 @@ class Preprocessor(ast.NodeTransformer):
         # though the synthesized ``__init__`` now uses plain Assign nodes.
         if class_node.name not in self.class_attr_annotations:
             self.class_attr_annotations[class_node.name] = {}
-        for field_name, annotation, _, _ in fields:
+        for field_name, annotation, _, _, field_kind in fields:
+            if field_kind != "instance":
+                continue
             if annotation is not None:
                 self.class_attr_annotations[class_node.name][field_name] = annotation
 
-        field_names = {field_name for field_name, _, _, _ in fields}
+        field_names = {
+            field_name
+            for field_name, _, _, _, field_kind in fields
+            if field_kind in ("instance", "initvar")
+        }
         class_node.body = [
             stmt
             for stmt in class_node.body
@@ -5068,6 +5270,9 @@ class Preprocessor(ast.NodeTransformer):
             ):
                 insert_index = 1
         class_node.body.insert(insert_index, self.build_init(class_node, fields))
+        class_node.body.insert(
+            insert_index + 1, self.build_dataclass_fields_metadata(class_node, fields)
+        )
         return class_node
 
     def _collect_class_attr_annotations(self, class_node):
@@ -5103,10 +5308,13 @@ class Preprocessor(ast.NodeTransformer):
                     self._dataclass_decorator_names.add(alias.asname or "dataclass")
                 elif alias.name == "field":
                     self._dataclass_field_names.add(alias.asname or "field")
+                elif alias.name == "InitVar":
+                    self._dataclass_initvar_names.add(alias.asname or "InitVar")
                 elif alias.name == "*":
                     # ``from dataclasses import *`` exposes both canonical names.
                     self._dataclass_decorator_names.add("dataclass")
                     self._dataclass_field_names.add("field")
+                    self._dataclass_initvar_names.add("InitVar")
         if node.module == "typing":
             for alias in node.names:
                 if alias.name == "NewType":
@@ -5114,8 +5322,11 @@ class Preprocessor(ast.NodeTransformer):
                 elif alias.name == "*":
                     self.newtype_names.add("NewType")
                     self._typing_imported_names.update(self._TYPING_GENERIC_NAMES)
+                    self._typing_classvar_names.add("ClassVar")
                 if alias.name in self._TYPING_GENERIC_NAMES:
                     self._typing_imported_names.add(alias.asname or alias.name)
+                if alias.name == "ClassVar":
+                    self._typing_classvar_names.add(alias.asname or alias.name)
         self.generic_visit(node)
         return node
 
@@ -5131,6 +5342,8 @@ class Preprocessor(ast.NodeTransformer):
                     self.collections_module_alias = alias.asname
             if alias.name == "typing":
                 self.typing_module_names.add(alias.asname or "typing")
+            if alias.name == "dataclasses":
+                self.dataclasses_module_names.add(alias.asname or "dataclasses")
         self.generic_visit(node)
         return node
 

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -4903,16 +4903,6 @@ class Preprocessor(ast.NodeTransformer):
                 return True
         return False
 
-    def _get_post_init_dispatch_target(self, class_node):
-        if self._get_post_init_method(class_node) is not None:
-            return class_node.name
-
-        for base in class_node.bases:
-            if isinstance(base, ast.Name) and base.id in self._classes_with_post_init:
-                return base.id
-
-        return None
-
     def _validate_post_init_signature(self, class_node, fields, post_init_method):
         """Validate that ``__post_init__`` can receive the declared InitVar values."""
         if post_init_method is None:
@@ -5206,7 +5196,8 @@ class Preprocessor(ast.NodeTransformer):
             field for field in fields if field[4] in ("instance", "initvar")
         ]
         has_post_init_behavior = self._class_has_post_init_behavior(class_node)
-        if not active_fields and not has_post_init_behavior:
+        has_classvars = any(f[4] == "classvar" for f in fields)
+        if not active_fields and not has_post_init_behavior and not has_classvars:
             return class_node
 
         self._validate_post_init_signature(class_node, fields, post_init_method)

--- a/unit/python-frontend/test_preprocessor_dataclass_lifecycle.py
+++ b/unit/python-frontend/test_preprocessor_dataclass_lifecycle.py
@@ -1,0 +1,226 @@
+"""Tests for dataclass lifecycle support: InitVar, ClassVar and __post_init__."""
+
+import ast
+import importlib.util
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+PY_FRONTEND_DIR = os.path.join(ROOT, "src", "python-frontend")
+
+if PY_FRONTEND_DIR not in sys.path:
+    sys.path.insert(0, PY_FRONTEND_DIR)
+
+
+def _load_module(module_name, rel_path):
+    spec = importlib.util.spec_from_file_location(
+        module_name, os.path.join(ROOT, rel_path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+preprocessor_mod = _load_module(
+    "esbmc_preprocessor_dataclass_lifecycle", "src/python-frontend/preprocessor.py"
+)
+
+
+def _make_pre():
+    return preprocessor_mod.Preprocessor("test_module")
+
+
+def _transform(src):
+    return _make_pre().visit(ast.parse(src))
+
+
+def _get_class(module, name):
+    return next(
+        (s for s in module.body if isinstance(s, ast.ClassDef) and s.name == name),
+        None,
+    )
+
+
+def _get_init(cls):
+    return next(
+        (s for s in cls.body if isinstance(s, ast.FunctionDef) and s.name == "__init__"),
+        None,
+    )
+
+
+def _get_metadata_assign(cls):
+    return next(
+        (
+            s
+            for s in cls.body
+            if isinstance(s, ast.Assign)
+            and len(s.targets) == 1
+            and isinstance(s.targets[0], ast.Name)
+            and s.targets[0].id == "__dataclass_fields__"
+        ),
+        None,
+    )
+
+
+def test_initvar_becomes_init_param_and_post_init_argument():
+    src = (
+        "from dataclasses import dataclass, InitVar\n"
+        "@dataclass\n"
+        "class Config:\n"
+        "    name: str\n"
+        "    seed: InitVar[int]\n"
+        "    priority: int = 0\n"
+        "    def __post_init__(self, seed):\n"
+        "        self.priority = seed\n"
+    )
+    module = _transform(src)
+    cls = _get_class(module, "Config")
+    init = _get_init(cls)
+    assert init is not None
+
+    arg_names = [arg.arg for arg in init.args.args]
+    assert arg_names == ["self", "name", "seed", "priority"]
+    assert len(init.args.defaults) == 1
+    assert isinstance(init.args.defaults[0], ast.Constant)
+    assert init.args.defaults[0].value == 0
+
+    assigned_attrs = [
+        stmt.targets[0].attr
+        for stmt in init.body
+        if isinstance(stmt, ast.Assign)
+        and isinstance(stmt.targets[0], ast.Attribute)
+    ]
+    assert assigned_attrs == ["name", "priority"]
+
+    post_init_stmt = init.body[-1]
+    assert isinstance(post_init_stmt, ast.Expr)
+    post_init_call = post_init_stmt.value
+    assert isinstance(post_init_call, ast.Call)
+    assert isinstance(post_init_call.func, ast.Attribute)
+    assert post_init_call.func.attr == "__post_init__"
+    assert isinstance(post_init_call.func.value, ast.Name)
+    assert post_init_call.func.value.id == "Config"
+    assert [arg.id for arg in post_init_call.args] == ["self", "seed"]
+
+
+def test_classvar_is_excluded_from_init_and_metadata():
+    src = (
+        "from dataclasses import dataclass\n"
+        "from typing import ClassVar\n"
+        "@dataclass\n"
+        "class Config:\n"
+        "    version: ClassVar[int] = 3\n"
+        "    name: str\n"
+    )
+    module = _transform(src)
+    cls = _get_class(module, "Config")
+    init = _get_init(cls)
+    assert init is not None
+
+    arg_names = [arg.arg for arg in init.args.args]
+    assert arg_names == ["self", "name"]
+
+    metadata = _get_metadata_assign(cls)
+    assert metadata is not None
+    assert isinstance(metadata.value, ast.Tuple)
+    field_names = [elt.value for elt in metadata.value.elts]
+    assert field_names == ["name"]
+
+    classvar_annassign = next(
+        (
+            stmt
+            for stmt in cls.body
+            if isinstance(stmt, ast.AnnAssign)
+            and isinstance(stmt.target, ast.Name)
+            and stmt.target.id == "version"
+        ),
+        None,
+    )
+    assert classvar_annassign is not None
+
+
+def test_post_init_only_dataclass_still_gets_synthesized_init():
+    src = (
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Hook:\n"
+        "    def __post_init__(self):\n"
+        "        self.ready = True\n"
+    )
+    module = _transform(src)
+    cls = _get_class(module, "Hook")
+    init = _get_init(cls)
+    assert init is not None
+    assert [arg.arg for arg in init.args.args] == ["self"]
+    assert len(init.body) == 1
+    assert isinstance(init.body[0], ast.Expr)
+    assert isinstance(init.body[0].value.func.value, ast.Name)
+    assert init.body[0].value.func.value.id == "Hook"
+
+
+def test_inherited_post_init_still_triggers_guarded_call():
+    src = (
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Base:\n"
+        "    def __post_init__(self):\n"
+        "        self.base_ready = True\n"
+        "@dataclass\n"
+        "class Child(Base):\n"
+        "    value: int\n"
+    )
+    module = _transform(src)
+    child = _get_class(module, "Child")
+    init = _get_init(child)
+    assert init is not None
+    assert isinstance(init.body[-1], ast.Expr)
+    post_init_call = init.body[-1].value
+    assert isinstance(post_init_call, ast.Call)
+    assert isinstance(post_init_call.func, ast.Attribute)
+    assert post_init_call.func.attr == "__post_init__"
+    assert isinstance(post_init_call.func.value, ast.Name)
+    assert post_init_call.func.value.id == "self"
+    assert len(post_init_call.args) == 0
+
+
+def test_incompatible_post_init_signature_raises_syntax_error():
+    src = (
+        "from dataclasses import dataclass, InitVar\n"
+        "@dataclass\n"
+        "class Bad:\n"
+        "    seed: InitVar[int]\n"
+        "    def __post_init__(self):\n"
+        "        pass\n"
+    )
+    with pytest.raises(SyntaxError, match="incompatible __post_init__ signature"):
+        _transform(src)
+
+
+def test_post_init_with_extra_required_positional_parameter_is_rejected():
+    src = (
+        "from dataclasses import dataclass, InitVar\n"
+        "@dataclass\n"
+        "class Bad:\n"
+        "    seed: InitVar[int]\n"
+        "    def __post_init__(self, seed, extra):\n"
+        "        pass\n"
+    )
+    with pytest.raises(SyntaxError, match="incompatible __post_init__ signature"):
+        _transform(src)
+
+
+def test_required_keyword_only_post_init_parameter_is_rejected():
+    src = (
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Bad:\n"
+        "    value: int\n"
+        "    def __post_init__(self, *, extra):\n"
+        "        pass\n"
+    )
+    with pytest.raises(
+        SyntaxError, match="required keyword-only parameters are not supported"
+    ):
+        _transform(src)


### PR DESCRIPTION
stabilizes dataclass lifecycle semantics for  and adds dedicated coverage for initvar, classvar, and post_init dispatch scenarios.


- Add support for InitVar in dataclass lifecycle handling.
- Add support for ClassVar in dataclass lifecycle handling.
- Add dataclass post_init lifecycle synthesis in generated constructors.
- Add signature validation for post_init to reject incompatible forms.
- Add stable metadata generation for instance fields, excluding ClassVar.
- Add runtime fix for class-scoped post_init call resolution.
- Add receiver-lowering fix to avoid incorrect self/address handling.