### PR TITLE
[cpp/library] add std::span and complete std::type_traits

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_4190_type_traits/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4190_type_traits/main.cpp
@@ -1,0 +1,35 @@
+// github.com/esbmc/esbmc/issues/4190 — type_traits gap.
+// Verifies is_enum / is_signed / is_unsigned / is_trivially_copyable
+// (and their _v aliases) compile and behave correctly.
+
+#include <type_traits>
+#include <cassert>
+
+enum class Color { red, green, blue };
+struct PlainStruct { int a; double b; };
+struct NonTrivial { NonTrivial() {} ~NonTrivial() {} int x; };
+
+template <typename T>
+typename std::enable_if<std::is_enum_v<T>, int>::type kind() { return 1; }
+
+template <typename T>
+typename std::enable_if<!std::is_enum_v<T>, int>::type kind() { return 0; }
+
+int main()
+{
+  static_assert(std::is_enum_v<Color>);
+  static_assert(!std::is_enum_v<int>);
+
+  static_assert(std::is_unsigned_v<unsigned>);
+  static_assert(!std::is_unsigned_v<int>);
+
+  static_assert(std::is_signed_v<int>);
+  static_assert(!std::is_signed_v<unsigned>);
+
+  static_assert(std::is_trivially_copyable_v<PlainStruct>);
+  static_assert(!std::is_trivially_copyable_v<NonTrivial>);
+
+  assert(kind<Color>() == 1);
+  assert(kind<int>() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4190_type_traits/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4190_type_traits/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4190_concept_combo/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4190_concept_combo/main.cpp
@@ -1,0 +1,16 @@
+// github.com/esbmc/esbmc/issues/4190 — concept-style snippet from the issue.
+// Verifies a `requires(std::is_enum_v<T>)` clause compiles + verifies under
+// the patched bundled type_traits.
+
+#include <type_traits>
+
+template <typename T>
+requires(std::is_enum_v<T>)
+constexpr int kind() { return 1; }
+
+enum class E { A, B, C };
+
+int main()
+{
+  return kind<E>() == 1 ? 0 : 1;
+}

--- a/regression/esbmc-cpp20/cpp/github_4190_concept_combo/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4190_concept_combo/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4190_span/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4190_span/main.cpp
@@ -1,0 +1,44 @@
+// github.com/esbmc/esbmc/issues/4190 — std::span shim.
+// Exercises ctors, element access, iteration, and subviews.
+
+#include <span>
+#include <array>
+#include <cassert>
+
+int sum(std::span<int> s)
+{
+  int total = 0;
+  for (int x : s)
+    total += x;
+  return total;
+}
+
+int main()
+{
+  int buf[4] = {1, 2, 3, 4};
+
+  std::span<int> sv(buf, 4);
+  assert(sv.size() == 4);
+  assert(sv.data() == buf);
+  assert(sv[0] == 1 && sv[3] == 4);
+  assert(!sv.empty());
+  assert(sum(sv) == 10);
+
+  // std::array adapter — aggregate brace-init through the shim is
+  // unreliable here, so default-construct then assign.
+  std::array<int, 3> a;
+  a[0] = 10; a[1] = 20; a[2] = 30;
+  std::span<int> sv3(a);
+  assert(sv3.size() == 3);
+  assert(sv3.front() == 10 && sv3.back() == 30);
+
+  auto mid = sv.subspan(1, 2);
+  assert(mid.size() == 2 && mid[0] == 2 && mid[1] == 3);
+
+  auto pre = sv.first(2);
+  auto suf = sv.last(2);
+  assert(pre[0] == 1 && pre[1] == 2);
+  assert(suf[0] == 3 && suf[1] == 4);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4190_span/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4190_span/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 6 --std c++20
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/span
+++ b/src/cpp/library/span
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "cstddef"  /* size_t, ptrdiff_t */
+#include "cstdint"  /* SIZE_MAX */
+#include "array"
+#include "type_traits"
+
+namespace std
+{
+
+inline constexpr size_t dynamic_extent = SIZE_MAX;
+
+template <class T, size_t Extent = dynamic_extent>
+class span
+{
+  T *data_;
+  size_t size_;
+
+public:
+  using element_type = T;
+  using value_type = typename std::remove_cv<T>::type;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using reference = T &;
+  using const_reference = const T &;
+  using iterator = pointer;
+  using const_iterator = const_pointer;
+
+  static constexpr size_t extent = Extent;
+
+  // Constructors
+  constexpr span() noexcept : data_(nullptr), size_(0) {}
+
+  constexpr span(pointer ptr, size_type count) noexcept
+    : data_(ptr), size_(count)
+  {
+  }
+
+  constexpr span(pointer first, pointer last)
+    : data_(first), size_(static_cast<size_type>(last - first))
+  {
+    __ESBMC_assert(first <= last, "span: iterator pair out of order");
+  }
+
+  template <size_t N>
+  constexpr span(T (&arr)[N]) noexcept : data_(arr), size_(N)
+  {
+  }
+
+  template <size_t N>
+  constexpr span(std::array<value_type, N> &arr) noexcept
+    : data_(arr.data()), size_(N)
+  {
+  }
+
+  template <size_t N>
+  constexpr span(const std::array<value_type, N> &arr) noexcept
+    : data_(arr.data()), size_(N)
+  {
+  }
+
+  constexpr span(const span &) noexcept = default;
+  constexpr span &operator=(const span &) noexcept = default;
+
+  // Iterators
+  constexpr iterator begin() const noexcept { return data_; }
+  constexpr iterator end() const noexcept { return data_ + size_; }
+
+  // Capacity
+  constexpr size_type size() const noexcept { return size_; }
+  constexpr size_type size_bytes() const noexcept
+  {
+    return size_ * sizeof(element_type);
+  }
+  constexpr bool empty() const noexcept { return size_ == 0; }
+
+  // Element access
+  constexpr reference operator[](size_type idx) const
+  {
+    __ESBMC_assert(idx < size_, "span index out of bounds");
+    return data_[idx];
+  }
+  constexpr reference front() const
+  {
+    __ESBMC_assert(size_ > 0, "span::front on empty span");
+    return data_[0];
+  }
+  constexpr reference back() const
+  {
+    __ESBMC_assert(size_ > 0, "span::back on empty span");
+    return data_[size_ - 1];
+  }
+  constexpr pointer data() const noexcept { return data_; }
+
+  // Subviews
+  constexpr span first(size_type count) const
+  {
+    __ESBMC_assert(count <= size_, "span::first count exceeds size");
+    return span(data_, count);
+  }
+  constexpr span last(size_type count) const
+  {
+    __ESBMC_assert(count <= size_, "span::last count exceeds size");
+    return span(data_ + (size_ - count), count);
+  }
+  constexpr span
+  subspan(size_type offset, size_type count = dynamic_extent) const
+  {
+    __ESBMC_assert(offset <= size_, "span::subspan offset exceeds size");
+    size_type n = (count == dynamic_extent) ? (size_ - offset) : count;
+    __ESBMC_assert(
+      n <= size_ - offset, "span::subspan count exceeds remaining size");
+    return span(data_ + offset, n);
+  }
+};
+
+// Deduction guides (C++17)
+template <class T, size_t N>
+span(T (&)[N]) -> span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N> &) -> span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N> &) -> span<const T, N>;
+
+template <class T>
+span(T *, size_t) -> span<T>;
+
+template <class T>
+span(T *, T *) -> span<T>;
+
+} // namespace std

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -226,6 +226,40 @@ struct is_arithmetic
 template <class T>
 inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
 
+// is_enum
+template <class T>
+struct is_enum : integral_constant<bool, __is_enum(T)>
+{
+};
+template <class T>
+inline constexpr bool is_enum_v = is_enum<T>::value;
+
+// is_signed
+template <class T>
+struct is_signed : integral_constant<bool, __is_signed(T)>
+{
+};
+template <class T>
+inline constexpr bool is_signed_v = is_signed<T>::value;
+
+// is_unsigned
+template <class T>
+struct is_unsigned : integral_constant<bool, __is_unsigned(T)>
+{
+};
+template <class T>
+inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+
+// is_trivially_copyable (needed by std::bit_cast)
+template <class T>
+struct is_trivially_copyable
+  : integral_constant<bool, __is_trivially_copyable(T)>
+{
+};
+template <class T>
+inline constexpr bool is_trivially_copyable_v =
+  is_trivially_copyable<T>::value;
+
 // is_array
 template <class T>
 struct is_array : false_type


### PR DESCRIPTION
Fixes https://github.com/esbmc/esbmc/issues/4191.

Bundles a C++20 `std::span` shim and adds the missing `is_enum`, `is_signed`, `is_unsigned`, and `is_trivially_copyable` traits (with their `_v` aliases) to `<type_traits>`. Modern C++17/20 code now builds under stock ESBMC without user-side header overlays. Adds CORE regressions for span, the new traits, and a `requires(is_enum_v<T>)` concept smoke test.

Refs #4190. The third gap from the issue (`<bit>` not bundled) is covered by #4192.
