### PR TITLE
[clang-cpp] fix segfault on C++23 `if consteval` (#4196)

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4196/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4196/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+
+int run()
+{
+  int x = 0;
+  if consteval
+  {
+    x = 42;
+  }
+  else
+  {
+    x = 1;
+  }
+  return x;
+}
+
+int main()
+{
+  assert(run() == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4196/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4196/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4196_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4196_fail/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+
+int run()
+{
+  int x = 0;
+  if !consteval
+  {
+    x = 7;
+  }
+  return x;
+}
+
+int main()
+{
+  assert(run() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4196_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4196_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4196_no_else/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4196_no_else/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+
+int run()
+{
+  int x = 0;
+  if consteval
+  {
+    x = 42;
+  }
+  return x;
+}
+
+int main()
+{
+  assert(run() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4196_no_else/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4196_no_else/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2521,10 +2521,10 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
         if (get_expr(*runtime_branch, new_expr))
           return true;
         convert_expression_to_code(new_expr);
-       }
-       else
-         new_expr = code_skipt();
-       break;
+      }
+      else
+        new_expr = code_skipt();
+      break;
     }
 
     const clang::Stmt *cond_expr = ifstmt.getConditionVariableDeclStmt();

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2513,9 +2513,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     // runtime-active branch only (or skip entirely).
     if (ifstmt.isConsteval())
     {
-      const clang::Stmt *runtime_branch = ifstmt.isNegatedConsteval()
-                                            ? ifstmt.getThen()
-                                            : ifstmt.getElse();
+      const clang::Stmt *runtime_branch =
+        ifstmt.isNegatedConsteval() ? ifstmt.getThen() : ifstmt.getElse();
 
       if (runtime_branch == nullptr)
       {

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2516,19 +2516,15 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       const clang::Stmt *runtime_branch =
         ifstmt.isNegatedConsteval() ? ifstmt.getThen() : ifstmt.getElse();
 
-      if (runtime_branch == nullptr)
+      if (runtime_branch != nullptr)
       {
-        new_expr = code_skipt();
-        break;
-      }
-
-      exprt branch_expr;
-      if (get_expr(*runtime_branch, branch_expr))
-        return true;
-
-      convert_expression_to_code(branch_expr);
-      new_expr = branch_expr;
-      break;
+        if (get_expr(*runtime_branch, new_expr))
+          return true;
+        convert_expression_to_code(new_expr);
+       }
+       else
+         new_expr = code_skipt();
+       break;
     }
 
     const clang::Stmt *cond_expr = ifstmt.getConditionVariableDeclStmt();

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2508,6 +2508,30 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
   {
     const clang::IfStmt &ifstmt = static_cast<const clang::IfStmt &>(stmt);
 
+    // C++23 `if consteval` / `if !consteval` carries no condition in the AST.
+    // At runtime the consteval branch is never taken, so lower to the
+    // runtime-active branch only (or skip entirely).
+    if (ifstmt.isConsteval())
+    {
+      const clang::Stmt *runtime_branch = ifstmt.isNegatedConsteval()
+                                            ? ifstmt.getThen()
+                                            : ifstmt.getElse();
+
+      if (runtime_branch == nullptr)
+      {
+        new_expr = code_skipt();
+        break;
+      }
+
+      exprt branch_expr;
+      if (get_expr(*runtime_branch, branch_expr))
+        return true;
+
+      convert_expression_to_code(branch_expr);
+      new_expr = branch_expr;
+      break;
+    }
+
     const clang::Stmt *cond_expr = ifstmt.getConditionVariableDeclStmt();
     if (cond_expr == nullptr)
       cond_expr = ifstmt.getCond();


### PR DESCRIPTION
Fixes #4196

Clang's `IfStmt` stores no condition for `if consteval` / `if !consteval`, so dereferencing `getCond()` crashed the converter. This PR detects `isConsteval()` and lower to the runtime-active branch (else for `if consteval`, then for `if !consteval`); emit a `code_skipt` when that branch is absent.