### PR TITLE
[ir-ieee] fix isinf/isfinite semantics under --ir-ieee encoding

### DIFF
--- a/regression/floats/isinf_ir_ieee/main.c
+++ b/regression/floats/isinf_ir_ieee/main.c
@@ -1,0 +1,29 @@
+// Verify isinf/isfinite/isnormal semantics under --ir-ieee integer encoding.
+// Any finite float is bounded by FLT_MAX, so f > FLT_MAX implies isinf(f).
+// Dually, isinf(f) implies !isfinite(f), and a normal float satisfies
+// min_normal <= |f| <= max_normal.
+#include <assert.h>
+#include <math.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float f = __VERIFIER_nondet_float();
+
+  // f > FLT_MAX  =>  isinf(f) must hold
+  if(f > 3.4028234663852886e+38f)
+    assert(isinf(f));
+
+  // isinf(f)  =>  !isfinite(f)
+  if(isinf(f))
+    assert(!isfinite(f));
+
+  // A value known to be finite is not infinite
+  float g = 1.0f;
+  assert(!isinf(g));
+  assert(isfinite(g));
+  assert(isnormal(g));
+
+  return 0;
+}

--- a/regression/floats/isinf_ir_ieee/test.desc
+++ b/regression/floats/isinf_ir_ieee/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/isinf_ir_ieee_fail/main.c
+++ b/regression/floats/isinf_ir_ieee_fail/main.c
@@ -1,0 +1,17 @@
+// isinf must return false for values known to be within the finite float range.
+// Claiming a value between 1.0 and 2.0 is infinite is unsound; ESBMC should
+// find a counterexample (e.g. f = 1.5).
+#include <assert.h>
+#include <math.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float f = __VERIFIER_nondet_float();
+
+  if(f >= 1.0f && f <= 2.0f)
+    assert(isinf(f)); // wrong: f is finite here
+
+  return 0;
+}

--- a/regression/floats/isinf_ir_ieee_fail/test.desc
+++ b/regression/floats/isinf_ir_ieee_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--ir-ieee --z3 --32
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1276,8 +1276,10 @@ smt_astt smt_convt::apply_ieee754_semantics(
 
 smt_astt smt_convt::get_double_max_normal()
 {
-  // IEEE 754 double precision maximum normal positive value (~(2-2^-52)*2^1023)
-  return mk_smt_real("1.7976931348623157e+308");
+  // IEEE 754 double: (2^53-1)*2^971 (exact rational, no rounding)
+  static const std::string val =
+    integer2string((power(2, 53) - 1) * power(2, 971));
+  return mk_smt_real(val);
 }
 
 smt_astt smt_convt::get_single_min_normal()
@@ -1294,8 +1296,10 @@ smt_astt smt_convt::get_single_min_subnormal()
 
 smt_astt smt_convt::get_single_max_normal()
 {
-  // IEEE 754 single precision maximum normal positive value (~(2-2^-23)*2^127)
-  return mk_smt_real("3.4028234663852886e+38");
+  // IEEE 754 single: (2^24-1)*2^104 (exact rational, no rounding)
+  static const std::string val =
+    integer2string((power(2, 24) - 1) * power(2, 104));
+  return mk_smt_real(val);
 }
 
 smt_astt smt_convt::get_double_eps_rel()
@@ -3063,8 +3067,30 @@ smt_astt smt_convt::convert_is_inf(const expr2tc &expr)
   const isinf2t &isinf = to_isinf2t(expr);
 
   // Anything other than floats will never be infs
-  if (!is_floatbv_type(isinf.value) || int_encoding)
+  if (!is_floatbv_type(isinf.value))
     return mk_smt_bool(false);
+
+  if (int_encoding)
+  {
+    // In integer/real encoding a float is "infinite" when its real value
+    // exceeds the maximum finite float magnitude: |f| > max_normal.
+    const floatbv_type2t &fbv_type = to_floatbv_type(isinf.value->type);
+    const auto single_spec = ieee_float_spect::single_precision();
+    const auto double_spec = ieee_float_spect::double_precision();
+    const bool is_single =
+      fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f;
+    const bool is_double =
+      fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f;
+    if (!is_single && !is_double)
+      return mk_smt_bool(false);
+
+    smt_astt max_val =
+      is_single ? get_single_max_normal() : get_double_max_normal();
+    smt_astt operand = convert_ast(isinf.value);
+    smt_astt pos_inf = mk_gt(operand, max_val);
+    smt_astt neg_inf = mk_lt(operand, mk_sub(get_zero_real(), max_val));
+    return mk_or(pos_inf, neg_inf);
+  }
 
   smt_astt operand = convert_ast(isinf.value);
   return fp_api->mk_smt_fpbv_is_inf(operand);
@@ -3087,8 +3113,29 @@ smt_astt smt_convt::convert_is_finite(const expr2tc &expr)
   const isfinite2t &isfinite = to_isfinite2t(expr);
 
   // Anything other than floats will always be finite
-  if (!is_floatbv_type(isfinite.value) || int_encoding)
+  if (!is_floatbv_type(isfinite.value))
     return mk_smt_bool(true);
+
+  if (int_encoding)
+  {
+    // In integer/real encoding a float is finite when |f| <= max_normal.
+    const floatbv_type2t &fbv_type = to_floatbv_type(isfinite.value->type);
+    const auto single_spec = ieee_float_spect::single_precision();
+    const auto double_spec = ieee_float_spect::double_precision();
+    const bool is_single =
+      fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f;
+    const bool is_double =
+      fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f;
+    if (!is_single && !is_double)
+      return mk_smt_bool(true);
+
+    smt_astt max_val =
+      is_single ? get_single_max_normal() : get_double_max_normal();
+    smt_astt operand = convert_ast(isfinite.value);
+    smt_astt pos_ok = mk_le(operand, max_val);
+    smt_astt neg_ok = mk_ge(operand, mk_sub(get_zero_real(), max_val));
+    return mk_and(pos_ok, neg_ok);
+  }
 
   smt_astt value = convert_ast(isfinite.value);
 

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -3062,6 +3062,31 @@ smt_astt smt_convt::convert_is_nan(const expr2tc &expr)
   return fp_api->mk_smt_fpbv_is_nan(operand);
 }
 
+// Returns the max-normal SMT real for single/double floatbv, or nullptr for
+// any other format (caller must handle the unsupported case explicitly).
+static smt_astt get_max_normal(smt_convt &conv, const floatbv_type2t &fbv_type)
+{
+  const auto single_spec = ieee_float_spect::single_precision();
+  const auto double_spec = ieee_float_spect::double_precision();
+  if (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+    return conv.get_single_max_normal();
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+    return conv.get_double_max_normal();
+  return nullptr;
+}
+
+// Returns the min-normal SMT real for single/double floatbv, or nullptr.
+static smt_astt get_min_normal(smt_convt &conv, const floatbv_type2t &fbv_type)
+{
+  const auto single_spec = ieee_float_spect::single_precision();
+  const auto double_spec = ieee_float_spect::double_precision();
+  if (fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f)
+    return conv.get_single_min_normal();
+  if (fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f)
+    return conv.get_double_min_normal();
+  return nullptr;
+}
+
 smt_astt smt_convt::convert_is_inf(const expr2tc &expr)
 {
   const isinf2t &isinf = to_isinf2t(expr);
@@ -3075,17 +3100,15 @@ smt_astt smt_convt::convert_is_inf(const expr2tc &expr)
     // In integer/real encoding a float is "infinite" when its real value
     // exceeds the maximum finite float magnitude: |f| > max_normal.
     const floatbv_type2t &fbv_type = to_floatbv_type(isinf.value->type);
-    const auto single_spec = ieee_float_spect::single_precision();
-    const auto double_spec = ieee_float_spect::double_precision();
-    const bool is_single =
-      fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f;
-    const bool is_double =
-      fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f;
-    if (!is_single && !is_double)
+    smt_astt max_val = get_max_normal(*this, fbv_type);
+    if (!max_val)
+    {
+      log_warning(
+        "isinf: unsupported float format (exp={}, frac={}); returning false",
+        fbv_type.exponent,
+        fbv_type.fraction);
       return mk_smt_bool(false);
-
-    smt_astt max_val =
-      is_single ? get_single_max_normal() : get_double_max_normal();
+    }
     smt_astt operand = convert_ast(isinf.value);
     smt_astt pos_inf = mk_gt(operand, max_val);
     smt_astt neg_inf = mk_lt(operand, mk_sub(get_zero_real(), max_val));
@@ -3101,8 +3124,36 @@ smt_astt smt_convt::convert_is_normal(const expr2tc &expr)
   const isnormal2t &isnormal = to_isnormal2t(expr);
 
   // Anything other than floats will always be normal
-  if (!is_floatbv_type(isnormal.value) || int_encoding)
+  if (!is_floatbv_type(isnormal.value))
     return mk_smt_bool(true);
+
+  if (int_encoding)
+  {
+    // In integer/real encoding a float is normal when min_normal <= |f| <=
+    // max_normal.  Zero and subnormals (|f| < min_normal) are not normal.
+    const floatbv_type2t &fbv_type = to_floatbv_type(isnormal.value->type);
+    smt_astt max_val = get_max_normal(*this, fbv_type);
+    smt_astt min_val = get_min_normal(*this, fbv_type);
+    if (!max_val || !min_val)
+    {
+      log_warning(
+        "isnormal: unsupported float format (exp={}, frac={}); returning true",
+        fbv_type.exponent,
+        fbv_type.fraction);
+      return mk_smt_bool(true);
+    }
+    smt_astt zero = get_zero_real();
+    smt_astt neg_max = mk_sub(zero, max_val);
+    smt_astt neg_min = mk_sub(zero, min_val);
+    smt_astt operand = convert_ast(isnormal.value);
+    // |f| >= min_normal: f >= min_normal || f <= -min_normal
+    smt_astt above_min =
+      mk_or(mk_ge(operand, min_val), mk_le(operand, neg_min));
+    // |f| <= max_normal: f <= max_normal && f >= -max_normal
+    smt_astt below_max =
+      mk_and(mk_le(operand, max_val), mk_ge(operand, neg_max));
+    return mk_and(above_min, below_max);
+  }
 
   smt_astt operand = convert_ast(isnormal.value);
   return fp_api->mk_smt_fpbv_is_normal(operand);
@@ -3120,17 +3171,15 @@ smt_astt smt_convt::convert_is_finite(const expr2tc &expr)
   {
     // In integer/real encoding a float is finite when |f| <= max_normal.
     const floatbv_type2t &fbv_type = to_floatbv_type(isfinite.value->type);
-    const auto single_spec = ieee_float_spect::single_precision();
-    const auto double_spec = ieee_float_spect::double_precision();
-    const bool is_single =
-      fbv_type.exponent == single_spec.e && fbv_type.fraction == single_spec.f;
-    const bool is_double =
-      fbv_type.exponent == double_spec.e && fbv_type.fraction == double_spec.f;
-    if (!is_single && !is_double)
+    smt_astt max_val = get_max_normal(*this, fbv_type);
+    if (!max_val)
+    {
+      log_warning(
+        "isfinite: unsupported float format (exp={}, frac={}); returning true",
+        fbv_type.exponent,
+        fbv_type.fraction);
       return mk_smt_bool(true);
-
-    smt_astt max_val =
-      is_single ? get_single_max_normal() : get_double_max_normal();
+    }
     smt_astt operand = convert_ast(isfinite.value);
     smt_astt pos_ok = mk_le(operand, max_val);
     smt_astt neg_ok = mk_ge(operand, mk_sub(get_zero_real(), max_val));


### PR DESCRIPTION
## Summary

Fix unsound `isinf` / `isfinite` semantics for `floatbv` values under `--ir-ieee` integer/real encoding.

## What changed

* `convert_is_inf()` no longer returns `false` unconditionally in `int_encoding`
* `convert_is_finite()` no longer returns `true` unconditionally in `int_encoding`
* both predicates are now encoded using exact max-normal IEEE thresholds
* `get_single_max_normal()` and `get_double_max_normal()` now use exact values instead of rounded decimal approximations.
