### PR TITLE
[Abstract-interpretation] add linear equality analysis

### DIFF
--- a/scripts/competitions/svcomp/esbmc-wrapper.py
+++ b/scripts/competitions/svcomp/esbmc-wrapper.py
@@ -288,7 +288,7 @@ def get_command_line(strat, prop, arch, benchmark, concurrency, dargs, esbmc_ci)
     if concurrency:
       command_line += "--no-pointer-check --no-bounds-check "
     else:
-      command_line += "--no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind "
+      command_line += "--no-pointer-check --interval-analysis --no-bounds-check --error-label ERROR --goto-unwind --unlimited-goto-unwind --linear-equality-analysis "
   elif prop == Property.datarace:
     # TODO: can we do better in case 'concurrency == False'?
     command_line += "--no-pointer-check --no-bounds-check --data-races-check-only --no-assertions "

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -34,6 +34,7 @@ extern "C"
 #include <goto-programs/goto_k_induction.h>
 #include <goto-programs/goto_loop_invariant.h>
 #include <goto-programs/abstract-interpretation/interval_analysis.h>
+#include <goto-programs/abstract-interpretation/linear_equality_analysis.h>
 #include <goto-programs/abstract-interpretation/gcse.h>
 #include <goto-programs/loop_numbers.h>
 #include <goto-programs/goto_binary_reader.h>
@@ -2107,6 +2108,11 @@ bool esbmc_parseoptionst::process_goto_program(
     if (cmdline.isset("interval-analysis") || cmdline.isset("goto-contractor"))
     {
       interval_analysis(goto_functions, ns, options);
+    }
+
+    if (cmdline.isset("linear-equality-analysis"))
+    {
+      linear_equality_analysis(goto_functions, ns, options);
     }
 
     bool is_k_induction = cmdline.isset("inductive-step") ||

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -645,6 +645,13 @@ const struct group_opt_templ all_cmd_options[] = {
      NULL,
      "Use interval-based assertion pruning during symbolic execution to "
      "skip assertions that are provably true under the tracked intervals"}}},
+  {"Linear Equality Analysis",
+   {{"linear-equality-analysis",
+     NULL,
+     "Infer linear equality invariants between integer variables"},
+    {"linear-equality-analysis-dump",
+     NULL,
+     "Print the inferred linear equality equations at each program point"}}},
   {"Coverage options",
    {
      {"assertion-coverage", NULL, "Show the coverage of assertion statements"},

--- a/src/goto-programs/abstract-interpretation/CMakeLists.txt
+++ b/src/goto-programs/abstract-interpretation/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_library(abstract-interpretation ai.cpp ai_domain.cpp interval_domain.cpp interval_analysis.cpp gcse.cpp)
+add_library(abstract-interpretation
+  ai.cpp
+  ai_domain.cpp
+  interval_domain.cpp
+  interval_analysis.cpp
+  gcse.cpp
+  linear_equality_domain.cpp
+  linear_equality_analysis.cpp
+)
 target_include_directories(abstract-interpretation
         PUBLIC ${Boost_INCLUDE_DIRS})
 

--- a/src/goto-programs/abstract-interpretation/linear_equality_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/linear_equality_analysis.cpp
@@ -1,0 +1,132 @@
+/// \file
+/// Linear Equality Analysis
+///
+/// Algorithm:
+///   1. Run ait<linear_equality_domaint> to compute a fixedpoint of linear
+///      equality states over the full GOTO control-flow graph.
+///   2. For each loop, collect the variables modified or read inside it.
+///   3. At the loop body entry (the instruction after the loop-condition IF),
+///      insert ASSUME(invariant) where invariant is the conjunction of all
+///      inferred equalities restricted to loop-relevant variables.
+///      The ASSUME is tagged with inductive_step_instruction so that k-induction
+///      can exploit it when reasoning about arbitrarily many loop iterations.
+
+#include <goto-programs/abstract-interpretation/linear_equality_analysis.h>
+
+#include <goto-programs/abstract-interpretation/linear_equality_domain.h>
+#include <goto-programs/goto_loops.h>
+#include <irep2/irep2_utils.h>
+#include <util/dstring.h>
+#include <util/message.h>
+#include <util/time_stopping.h>
+
+#include <sstream>
+#include <unordered_set>
+
+using loop_var_set = std::unordered_set<irep_idt, dstring_hash>;
+
+static loop_var_set collect_loop_vars(const loopst &loop)
+{
+  loop_var_set vars;
+  for (const auto &v : loop.get_modified_loop_vars())
+    if (is_symbol2t(v))
+      vars.insert(to_symbol2t(v).thename);
+  for (const auto &v : loop.get_unmodified_loop_vars())
+    if (is_symbol2t(v))
+      vars.insert(to_symbol2t(v).thename);
+  return vars;
+}
+
+static void instrument_loop(
+  const linear_equality_analysist &analysis,
+  const loopst &loop,
+  const loop_var_set &loop_vars,
+  goto_functiont &goto_function)
+{
+  auto head_it = loop.get_original_loop_head();
+  auto state_it = analysis.state_map.find(head_it);
+  if (state_it == analysis.state_map.end())
+    return;
+
+  const linear_equality_domaint &state = state_it->second;
+  if (state.is_bottom() || state.is_top())
+    return;
+
+  expr2tc invariant = state.to_predicate(loop_vars);
+  if (is_true(invariant))
+    return;
+
+  // head_it points to the loop-condition IF; insert after it so the ASSUME
+  // lands at the body entry and is assumed on every iteration.
+  auto body_it = std::next(head_it);
+  goto_programt::instructiont assume_insn;
+  assume_insn.make_assumption(invariant);
+  assume_insn.inductive_step_instruction = config.options.is_kind();
+  assume_insn.location = body_it->location;
+  assume_insn.function = body_it->function;
+  goto_function.body.insert_swap(body_it, assume_insn);
+}
+
+void linear_equality_analysis(
+  goto_functionst &goto_functions,
+  const namespacet &ns,
+  const optionst &options)
+{
+  fine_timet t_start = current_time();
+
+  linear_equality_analysist lin_analysis;
+  lin_analysis(goto_functions, ns);
+
+  const bool dump = options.get_bool_option("linear-equality-analysis-dump");
+  std::ostringstream oss;
+  if (dump)
+    oss << "=== Linear Equality Analysis: inferred loop invariants ===\n";
+
+  Forall_goto_functions (f_it, goto_functions)
+  {
+    if (!f_it->second.body_available)
+      continue;
+
+    goto_loopst loops(f_it->first, goto_functions, f_it->second);
+    unsigned loop_num = 0;
+
+    for (auto &loop : loops.get_loops())
+    {
+      loop_var_set vars = collect_loop_vars(loop);
+
+      if (dump)
+      {
+        auto head_it = loop.get_original_loop_head();
+        auto state_it = lin_analysis.state_map.find(head_it);
+        if (state_it != lin_analysis.state_map.end())
+        {
+          const linear_equality_domaint &state = state_it->second;
+          bool first = true;
+          for (const auto &kv : *state.equations)
+          {
+            if (!vars.count(kv.first))
+              continue;
+            if (first)
+            {
+              oss << "Function " << f_it->first << ", loop " << loop_num << " ("
+                  << head_it->location.as_string() << "):\n";
+              first = false;
+            }
+            oss << "  " << kv.first << " == " << kv.second.to_string() << "\n";
+          }
+        }
+      }
+
+      instrument_loop(lin_analysis, loop, vars, f_it->second);
+      ++loop_num;
+    }
+  }
+
+  if (dump)
+    log_status("{}", oss.str());
+
+  goto_functions.update();
+  log_status(
+    "Linear Equality Analysis time: {}s",
+    time2string(current_time() - t_start));
+}

--- a/src/goto-programs/abstract-interpretation/linear_equality_analysis.h
+++ b/src/goto-programs/abstract-interpretation/linear_equality_analysis.h
@@ -1,0 +1,22 @@
+/// \file
+/// Linear Equality Analysis
+
+#pragma once
+
+#include <goto-programs/goto_functions.h>
+#include <util/options.h>
+
+/**
+ * @brief Run the linear equality analysis over goto_functions and instrument
+ *        each loop with ASSUME(invariant) at the loop body entry.
+ *
+ * @param goto_functions  GOTO program to analyse and instrument (modified in-place).
+ * @param ns              Namespace for type/symbol resolution.
+ * @param options         Command-line options; recognises:
+ *                          --linear-equality-analysis
+ *                          --linear-equality-analysis-dump
+ */
+void linear_equality_analysis(
+  goto_functionst &goto_functions,
+  const namespacet &ns,
+  const optionst &options);

--- a/src/goto-programs/abstract-interpretation/linear_equality_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/linear_equality_domain.cpp
@@ -250,30 +250,31 @@ bool linear_equality_domaint::try_as_affine(
 
 expr2tc linear_equality_domaint::make_equality_expr(
   const irep_idt &lhs,
+  const type2tc &lhs_type,
   const AffineExpr &rhs)
 {
-  const type2tc int_type = get_int_type(config.ansi_c.word_size);
-  expr2tc rhs_expr = constant_int2tc(int_type, rhs.constant);
+  // Use lhs_type for every sub-expression so all bitvector widths are uniform.
+  expr2tc rhs_expr = constant_int2tc(lhs_type, rhs.constant);
 
   for (const auto &kv : rhs.coeffs)
   {
-    expr2tc var_expr = symbol2tc(int_type, kv.first);
+    expr2tc var_expr = symbol2tc(lhs_type, kv.first);
     expr2tc term;
     if (kv.second == 1)
       term = var_expr;
     else if (kv.second == -1)
-      term = neg2tc(int_type, var_expr);
+      term = neg2tc(lhs_type, var_expr);
     else
-      term = mul2tc(int_type, constant_int2tc(int_type, kv.second), var_expr);
+      term = mul2tc(lhs_type, constant_int2tc(lhs_type, kv.second), var_expr);
 
     // Skip adding 0 as the initial accumulator to keep the expression clean.
     if (is_constant_int2t(rhs_expr) && to_constant_int2t(rhs_expr).value == 0)
       rhs_expr = term;
     else
-      rhs_expr = add2tc(int_type, rhs_expr, term);
+      rhs_expr = add2tc(lhs_type, rhs_expr, term);
   }
 
-  return equality2tc(symbol2tc(int_type, lhs), rhs_expr);
+  return equality2tc(symbol2tc(lhs_type, lhs), rhs_expr);
 }
 
 const AffineExpr *
@@ -316,6 +317,8 @@ void linear_equality_domaint::transform(
       forget(lhs_name);
       break;
     }
+
+    symbol_types[lhs_name] = ca.target->type;
 
     AffineExpr rhs_affine;
     if (try_as_affine(ca.source, rhs_affine))
@@ -385,9 +388,13 @@ bool linear_equality_domaint::merge(
   {
     // First reachable predecessor — inherit its state.
     equations = src.equations;
+    symbol_types = src.symbol_types;
     bottom = false;
     return true;
   }
+
+  for (const auto &kv : src.symbol_types)
+    symbol_types.insert(kv);
 
   // Keep only equations both predecessors agree on (intersection / meet).
   bool changed = false;
@@ -432,7 +439,10 @@ expr2tc linear_equality_domaint::to_predicate() const
   std::vector<expr2tc> conjuncts;
   for (const auto &kv : *equations)
   {
-    expr2tc eq = make_equality_expr(kv.first, kv.second);
+    auto type_it = symbol_types.find(kv.first);
+    if (type_it == symbol_types.end())
+      continue;
+    expr2tc eq = make_equality_expr(kv.first, type_it->second, kv.second);
     if (!is_nil_expr(eq))
       conjuncts.push_back(eq);
   }
@@ -451,9 +461,11 @@ expr2tc linear_equality_domaint::to_predicate(
   for (const auto &kv : *equations)
   {
     if (!vars.count(kv.first))
-      // skip variables unrelated to the target loop
       continue;
-    expr2tc eq = make_equality_expr(kv.first, kv.second);
+    auto type_it = symbol_types.find(kv.first);
+    if (type_it == symbol_types.end())
+      continue;
+    expr2tc eq = make_equality_expr(kv.first, type_it->second, kv.second);
     if (!is_nil_expr(eq))
       conjuncts.push_back(eq);
   }

--- a/src/goto-programs/abstract-interpretation/linear_equality_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/linear_equality_domain.cpp
@@ -1,0 +1,485 @@
+/// \file
+/// Linear Equality Domain
+
+#include <goto-programs/abstract-interpretation/linear_equality_domain.h>
+
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_utils.h>
+#include <util/message.h>
+
+#include <sstream>
+
+AffineExpr AffineExpr::operator+(const AffineExpr &rhs) const
+{
+  AffineExpr result;
+  result.constant = constant + rhs.constant;
+  result.coeffs = coeffs;
+  for (const auto &kv : rhs.coeffs)
+  {
+    auto &slot = result.coeffs[kv.first];
+    slot += kv.second;
+    if (slot == 0)
+      // cancel out if coefficients sum to zero
+      result.coeffs.erase(kv.first);
+  }
+  return result;
+}
+
+AffineExpr AffineExpr::operator-(const AffineExpr &rhs) const
+{
+  return *this + (rhs * BigInt(-1));
+}
+
+AffineExpr AffineExpr::operator*(const BigInt &scalar) const
+{
+  if (scalar == 0)
+    return AffineExpr(BigInt(0));
+  AffineExpr result;
+  result.constant = constant * scalar;
+  for (const auto &kv : coeffs)
+    result.coeffs[kv.first] = kv.second * scalar;
+  return result;
+}
+
+std::string AffineExpr::to_string() const
+{
+  std::ostringstream oss;
+  if (coeffs.empty())
+  {
+    oss << constant;
+    return oss.str();
+  }
+  bool first = true;
+  for (const auto &kv : coeffs)
+  {
+    if (!first)
+      oss << " + ";
+    first = false;
+    if (kv.second != 1)
+      oss << kv.second << "*";
+    oss << kv.first;
+  }
+  if (constant != 0)
+    oss << " + " << constant;
+  return oss.str();
+}
+
+void linear_equality_domaint::copy_if_needed()
+{
+  if (equations.use_count() > 1)
+    equations = std::make_shared<equation_map>(*equations);
+}
+
+AffineExpr linear_equality_domaint::substitute(
+  const AffineExpr &target,
+  const irep_idt &var,
+  const AffineExpr &expr)
+{
+  auto it = target.coeffs.find(var);
+  if (it == target.coeffs.end())
+    return target; // var does not appear — nothing to do
+
+  // Remove the var term, then add coeff * expr in its place.
+  const BigInt coeff = it->second;
+  AffineExpr result;
+  result.constant = target.constant;
+  for (const auto &kv : target.coeffs)
+    if (kv.first != var)
+      result.coeffs[kv.first] = kv.second;
+  return result + (expr * coeff);
+}
+
+void linear_equality_domaint::assign_affine(
+  const irep_idt &var,
+  const AffineExpr &rhs)
+{
+  copy_if_needed();
+
+  auto var_coeff_it = rhs.coeffs.find(var);
+
+  if (var_coeff_it == rhs.coeffs.end())
+  {
+    // Case A: x = f(others) — substitute x_old -> rhs in every other equation.
+    for (auto &kv : *equations)
+      if (kv.first != var)
+        kv.second = substitute(kv.second, var, rhs);
+    (*equations)[var] = rhs;
+  }
+  else if (var_coeff_it->second == 1)
+  {
+    // Case B: x = x + delta.
+    // Invert to x_old = x_new - delta, then substitute into other equations.
+    AffineExpr rhs_no_x;
+    rhs_no_x.constant = rhs.constant;
+    for (const auto &kv : rhs.coeffs)
+      if (kv.first != var)
+        rhs_no_x.coeffs[kv.first] = kv.second;
+
+    AffineExpr inverse_expr = AffineExpr(var, BigInt(1)) - rhs_no_x;
+
+    // Save x's old equation before modifying the map.
+    AffineExpr old_eq;
+    bool had_equation = false;
+    auto cur_it = equations->find(var);
+    if (cur_it != equations->end())
+    {
+      old_eq = cur_it->second;
+      had_equation = true;
+    }
+
+    for (auto &kv : *equations)
+      if (kv.first != var)
+        kv.second = substitute(kv.second, var, inverse_expr);
+
+    if (had_equation)
+      // x_new = x_old + delta
+      (*equations)[var] = old_eq + rhs_no_x;
+    else
+      // x was free; still free after increment
+      equations->erase(var);
+  }
+  else
+  {
+    // Case C: coefficient != 1 — inversion is not integer-linear; forget x.
+    forget(var);
+  }
+}
+
+void linear_equality_domaint::forget(const irep_idt &var)
+{
+  copy_if_needed();
+  equations->erase(var);
+  // Also drop any equation whose RHS mentions var — those are no longer sound.
+  for (auto it = equations->begin(); it != equations->end();)
+  {
+    if (it->second.coeffs.count(var))
+      it = equations->erase(it);
+    else
+      ++it;
+  }
+}
+
+bool linear_equality_domaint::try_as_affine(
+  const expr2tc &expr,
+  AffineExpr &out) const
+{
+  if (is_nil_expr(expr))
+    return false;
+
+  if (is_constant_int2t(expr))
+  {
+    out = AffineExpr(to_constant_int2t(expr).value);
+    return true;
+  }
+
+  if (is_symbol2t(expr))
+  {
+    if (
+      !is_signedbv_type(expr->type) && !is_unsignedbv_type(expr->type) &&
+      !is_bool_type(expr->type))
+      return false;
+    // Represent as a coefficient-1 linear term; do not substitute through the
+    // equation map — keeping symbols raw lets merge preserve relative equalities
+    // such as "y == x" across loop iterations.
+    out = AffineExpr(to_symbol2t(expr).thename, BigInt(1));
+    return true;
+  }
+
+  if (is_typecast2t(expr))
+  {
+    const auto &tc = to_typecast2t(expr);
+    if (
+      !is_signedbv_type(tc.type) && !is_unsignedbv_type(tc.type) &&
+      !is_bool_type(tc.type))
+      return false;
+    return try_as_affine(tc.from, out);
+  }
+
+  if (is_neg2t(expr))
+  {
+    AffineExpr inner;
+    if (!try_as_affine(to_neg2t(expr).value, inner))
+      return false;
+    out = inner * BigInt(-1);
+    return true;
+  }
+
+  if (is_add2t(expr))
+  {
+    const auto &a = to_add2t(expr);
+    AffineExpr lhs, rhs;
+    if (!try_as_affine(a.side_1, lhs) || !try_as_affine(a.side_2, rhs))
+      return false;
+    out = lhs + rhs;
+    return true;
+  }
+
+  if (is_sub2t(expr))
+  {
+    const auto &s = to_sub2t(expr);
+    AffineExpr lhs, rhs;
+    if (!try_as_affine(s.side_1, lhs) || !try_as_affine(s.side_2, rhs))
+      return false;
+    out = lhs - rhs;
+    return true;
+  }
+
+  if (is_mul2t(expr))
+  {
+    // Linear only when at least one operand is a known constant.
+    const auto &m = to_mul2t(expr);
+    AffineExpr lhs, rhs;
+    if (!try_as_affine(m.side_1, lhs) || !try_as_affine(m.side_2, rhs))
+      return false;
+    if (lhs.is_constant())
+    {
+      out = rhs * lhs.constant;
+      return true;
+    }
+    if (rhs.is_constant())
+    {
+      out = lhs * rhs.constant;
+      return true;
+    }
+    // non-linear: both operands contain variables
+    return false;
+  }
+
+  return false;
+}
+
+expr2tc linear_equality_domaint::make_equality_expr(
+  const irep_idt &lhs,
+  const AffineExpr &rhs)
+{
+  const type2tc int_type = get_int_type(config.ansi_c.word_size);
+  expr2tc rhs_expr = constant_int2tc(int_type, rhs.constant);
+
+  for (const auto &kv : rhs.coeffs)
+  {
+    expr2tc var_expr = symbol2tc(int_type, kv.first);
+    expr2tc term;
+    if (kv.second == 1)
+      term = var_expr;
+    else if (kv.second == -1)
+      term = neg2tc(int_type, var_expr);
+    else
+      term = mul2tc(int_type, constant_int2tc(int_type, kv.second), var_expr);
+
+    // Skip adding 0 as the initial accumulator to keep the expression clean.
+    if (is_constant_int2t(rhs_expr) && to_constant_int2t(rhs_expr).value == 0)
+      rhs_expr = term;
+    else
+      rhs_expr = add2tc(int_type, rhs_expr, term);
+  }
+
+  return equality2tc(symbol2tc(int_type, lhs), rhs_expr);
+}
+
+const AffineExpr *
+linear_equality_domaint::lookup(const irep_idt &var_name) const
+{
+  if (!equations)
+    return nullptr;
+  auto it = equations->find(var_name);
+  return it == equations->end() ? nullptr : &it->second;
+}
+
+void linear_equality_domaint::transform(
+  goto_programt::const_targett from,
+  goto_programt::const_targett to,
+  ai_baset &,
+  const namespacet &)
+{
+  if (is_bottom())
+    return;
+
+  const goto_programt::instructiont &insn = *from;
+
+  switch (insn.type)
+  {
+  case ASSIGN:
+  {
+    if (!is_code_assign2t(insn.code))
+      break;
+    const code_assign2t &ca = to_code_assign2t(insn.code);
+    if (!is_symbol2t(ca.target))
+      // non-scalar lhs — leave state unchanged (conservative)
+      break;
+
+    const irep_idt &lhs_name = to_symbol2t(ca.target).thename;
+    if (
+      !is_signedbv_type(ca.target->type) &&
+      !is_unsignedbv_type(ca.target->type) && !is_bool_type(ca.target->type))
+    {
+      // non-integer type — kill any equation for lhs
+      forget(lhs_name);
+      break;
+    }
+
+    AffineExpr rhs_affine;
+    if (try_as_affine(ca.source, rhs_affine))
+      assign_affine(lhs_name, rhs_affine);
+    else
+      // non-linear rhs — lose information about lhs
+      forget(lhs_name);
+    break;
+  }
+
+  case DECL:
+    // Variable enters scope uninitialised — value is non-deterministic.
+    if (is_code_decl2t(insn.code))
+      forget(to_code_decl2t(insn.code).value);
+    break;
+
+  case DEAD:
+    if (is_code_dead2t(insn.code))
+      forget(to_code_dead2t(insn.code).value);
+    break;
+
+  case ASSUME:
+  {
+    // If the assumed condition is an equality x == expr, record it.
+    if (!is_equality2t(insn.guard))
+      break;
+    const equality2t &eq = to_equality2t(insn.guard);
+    AffineExpr affine;
+    if (
+      is_symbol2t(eq.side_1) && is_signedbv_type(eq.side_1->type) &&
+      try_as_affine(eq.side_2, affine))
+      assign_affine(to_symbol2t(eq.side_1).thename, affine);
+    else if (
+      is_symbol2t(eq.side_2) && is_signedbv_type(eq.side_2->type) &&
+      try_as_affine(eq.side_1, affine))
+      assign_affine(to_symbol2t(eq.side_2).thename, affine);
+    break;
+  }
+
+  case FUNCTION_CALL:
+    // The callee may write any value into the return variable.
+    if (is_code_function_call2t(insn.code))
+    {
+      const code_function_call2t &call = to_code_function_call2t(insn.code);
+      if (!is_nil_expr(call.ret) && is_symbol2t(call.ret))
+        forget(to_symbol2t(call.ret).thename);
+    }
+    break;
+
+  default:
+    break;
+  }
+
+  (void)to;
+}
+
+bool linear_equality_domaint::merge(
+  const linear_equality_domaint &src,
+  goto_programt::const_targett,
+  goto_programt::const_targett)
+{
+  if (src.is_bottom())
+    // unreachable predecessor — nothing to add
+    return false;
+
+  if (is_bottom())
+  {
+    // First reachable predecessor — inherit its state.
+    equations = src.equations;
+    bottom = false;
+    return true;
+  }
+
+  // Keep only equations both predecessors agree on (intersection / meet).
+  bool changed = false;
+  copy_if_needed();
+  for (auto it = equations->begin(); it != equations->end();)
+  {
+    auto src_it = src.equations->find(it->first);
+    if (src_it == src.equations->end() || src_it->second != it->second)
+    {
+      it = equations->erase(it);
+      changed = true;
+    }
+    else
+      ++it;
+  }
+  return changed;
+}
+
+void linear_equality_domaint::output(std::ostream &out) const
+{
+  if (is_bottom())
+  {
+    out << "  [BOTTOM]\n";
+    return;
+  }
+  if (is_top())
+  {
+    out << "  [TOP]\n";
+    return;
+  }
+  for (const auto &kv : *equations)
+    out << "  " << kv.first << " == " << kv.second.to_string() << "\n";
+}
+
+expr2tc linear_equality_domaint::to_predicate() const
+{
+  if (is_bottom())
+    return gen_false_expr();
+  if (is_top())
+    return gen_true_expr();
+
+  std::vector<expr2tc> conjuncts;
+  for (const auto &kv : *equations)
+  {
+    expr2tc eq = make_equality_expr(kv.first, kv.second);
+    if (!is_nil_expr(eq))
+      conjuncts.push_back(eq);
+  }
+  return conjuncts.empty() ? gen_true_expr() : conjunction(conjuncts);
+}
+
+expr2tc linear_equality_domaint::to_predicate(
+  const std::unordered_set<irep_idt, dstring_hash> &vars) const
+{
+  if (is_bottom())
+    return gen_false_expr();
+  if (is_top())
+    return gen_true_expr();
+
+  std::vector<expr2tc> conjuncts;
+  for (const auto &kv : *equations)
+  {
+    if (!vars.count(kv.first))
+      // skip variables unrelated to the target loop
+      continue;
+    expr2tc eq = make_equality_expr(kv.first, kv.second);
+    if (!is_nil_expr(eq))
+      conjuncts.push_back(eq);
+  }
+  return conjuncts.empty() ? gen_true_expr() : conjunction(conjuncts);
+}
+
+bool linear_equality_domaint::ai_simplify(
+  expr2tc &condition,
+  const namespacet &) const
+{
+  if (is_bottom() || is_top() || !is_equality2t(condition))
+    return true;
+
+  const equality2t &eq = to_equality2t(condition);
+  AffineExpr lhs_affine, rhs_affine;
+  if (
+    !try_as_affine(eq.side_1, lhs_affine) ||
+    !try_as_affine(eq.side_2, rhs_affine))
+    return true;
+
+  AffineExpr diff = lhs_affine - rhs_affine;
+  if (!diff.is_constant())
+    // free variables remain — cannot decide
+    return true;
+
+  condition = (diff.constant == 0) ? gen_true_expr() : gen_false_expr();
+  // condition was changed
+  return false;
+}

--- a/src/goto-programs/abstract-interpretation/linear_equality_domain.h
+++ b/src/goto-programs/abstract-interpretation/linear_equality_domain.h
@@ -1,0 +1,167 @@
+/// \file
+/// Linear Equality Domain
+///
+/// Implements Karr's algorithm for inferring linear equality invariants.
+/// The domain tracks a set of affine equalities of the form
+///   x = c0 + c1*y1 + c2*y2 + ...
+/// that hold simultaneously at each program point.
+///
+/// Lattice (top to bottom):
+///   top    = {} (empty equation set — no information)
+///   ...    = finite sets of consistent equations
+///   bottom = contradictory state (unreachable program point)
+///
+/// Convergence: equations are only removed at merge points, never added,
+/// so the fixedpoint terminates in at most O(n) merge steps without widening.
+
+#pragma once
+
+#include <goto-programs/abstract-interpretation/ai.h>
+#include <irep2/irep2_utils.h>
+#include <util/dstring.h>
+#include <util/mp_arith.h>
+
+#include <map>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+/// Linear combination: value = constant + sum_i( coeffs[var_i] * var_i ).
+/// Only non-zero coefficients are stored; a missing entry implies zero.
+struct AffineExpr
+{
+  BigInt constant = 0;
+  std::map<irep_idt, BigInt> coeffs;
+
+  AffineExpr() = default;
+  explicit AffineExpr(BigInt c) : constant(c)
+  {
+  }
+  AffineExpr(irep_idt var, BigInt coeff) : constant(0)
+  {
+    if (coeff != 0)
+      coeffs[var] = coeff;
+  }
+
+  AffineExpr operator+(const AffineExpr &rhs) const;
+  AffineExpr operator-(const AffineExpr &rhs) const;
+  AffineExpr operator*(const BigInt &scalar) const;
+
+  bool is_constant() const
+  {
+    return coeffs.empty();
+  }
+  bool operator==(const AffineExpr &rhs) const
+  {
+    return constant == rhs.constant && coeffs == rhs.coeffs;
+  }
+  bool operator!=(const AffineExpr &rhs) const
+  {
+    return !(*this == rhs);
+  }
+
+  std::string to_string() const;
+};
+
+/// Abstract domain tracking linear equalities between integer variables.
+/// The state at each program point is a map var -> AffineExpr meaning
+/// "var == AffineExpr" holds on every execution reaching this point.
+/// An absent entry means the variable's value is unconstrained (top)..
+class linear_equality_domaint : public ai_domain_baset
+{
+public:
+  // Map from variable name to the affine expression it equals.
+  // If a key exists: var == equations[var] at this program point.
+  // Absent key: variable is unconstrained (top for that variable).
+  using equation_map = std::map<irep_idt, AffineExpr>;
+
+  std::shared_ptr<equation_map> equations;
+  // true when the state unreachable
+  bool bottom = true;
+
+  linear_equality_domaint() : equations(std::make_shared<equation_map>())
+  {
+  }
+
+  void transform(
+    goto_programt::const_targett from,
+    goto_programt::const_targett to,
+    ai_baset &ai,
+    const namespacet &ns) override;
+
+  bool merge(
+    const linear_equality_domaint &src,
+    goto_programt::const_targett from,
+    goto_programt::const_targett to);
+
+  void output(std::ostream &out) const override;
+
+  void make_bottom() override
+  {
+    equations = std::make_shared<equation_map>();
+    bottom = true;
+  }
+  void make_top() override
+  {
+    equations = std::make_shared<equation_map>();
+    bottom = false;
+  }
+  void make_entry() override
+  {
+    make_top();
+  }
+  bool is_bottom() const override
+  {
+    return bottom;
+  }
+  bool is_top() const override
+  {
+    return !bottom && equations->empty();
+  }
+
+  bool ai_simplify(expr2tc &condition, const namespacet &ns) const override;
+
+  /// Convert the full domain state to a conjunctive boolean predicate.
+  expr2tc to_predicate() const override;
+
+  /// Convert the domain state to a predicate restricted to [vars].
+  /// Only equations whose LHS is in [vars] are included — used during loop
+  /// instrumentation to emit only invariants for loop-relevant variables.
+  expr2tc
+  to_predicate(const std::unordered_set<irep_idt, dstring_hash> &vars) const;
+
+  /// Look up the affine expression known for [var_name], or nullptr if absent.
+  const AffineExpr *lookup(const irep_idt &var_name) const;
+
+  size_t size() const
+  {
+    return equations ? equations->size() : 0;
+  }
+
+private:
+  void copy_if_needed();
+  bool try_as_affine(const expr2tc &expr, AffineExpr &out) const;
+
+  /// Record var = rhs and propagate consistently through other equations.
+  /// Three cases:
+  ///   A) rhs does not mention var: substitute var_old -> rhs elsewhere.
+  ///   B) rhs = var + delta (coefficient 1): invert to var_old = var_new - delta.
+  ///   C) rhs mentions var with other coefficient: forget var (non-invertible).
+  void assign_affine(const irep_idt &var, const AffineExpr &rhs);
+
+  /// Remove all equations that mention [var] (variable becomes unconstrained).
+  void forget(const irep_idt &var);
+
+  /// Substitute every occurrence of [var] in [target] with [expr].
+  static AffineExpr substitute(
+    const AffineExpr &target,
+    const irep_idt &var,
+    const AffineExpr &expr);
+
+  /// Build the irep2 expression  lhs_sym == rhs_affine.
+  static expr2tc make_equality_expr(const irep_idt &lhs, const AffineExpr &rhs);
+};
+
+using linear_equality_analysist = ait<linear_equality_domaint>;

--- a/src/goto-programs/abstract-interpretation/linear_equality_domain.h
+++ b/src/goto-programs/abstract-interpretation/linear_equality_domain.h
@@ -78,8 +78,11 @@ public:
   using equation_map = std::map<irep_idt, AffineExpr>;
 
   std::shared_ptr<equation_map> equations;
-  // true when the state unreachable
-  bool bottom = true;
+  bool bottom = true; // true when the state is ⊥ (unreachable)
+
+  // Actual irep2 type of each LHS variable, recorded during transform().
+  // Used by make_equality_expr to build expressions with the correct bit width.
+  std::map<irep_idt, type2tc> symbol_types;
 
   linear_equality_domaint() : equations(std::make_shared<equation_map>())
   {
@@ -160,8 +163,12 @@ private:
     const irep_idt &var,
     const AffineExpr &expr);
 
-  /// Build the irep2 expression  lhs_sym == rhs_affine.
-  static expr2tc make_equality_expr(const irep_idt &lhs, const AffineExpr &rhs);
+  /// Build the irep2 expression  lhs_sym == rhs_affine using [lhs_type] for
+  /// every sub-expression so all bitvector widths are consistent.
+  static expr2tc make_equality_expr(
+    const irep_idt &lhs,
+    const type2tc &lhs_type,
+    const AffineExpr &rhs);
 };
 
 using linear_equality_analysist = ait<linear_equality_domaint>;


### PR DESCRIPTION
```c
int main(void) {
  unsigned int x = __VERIFIER_nondet_uint();
  unsigned int y = x;

  while (x < 1024) {
    x++;
    y++;
  }

  assert(x == y);
}
```
  Step 1: State Before the Loop:

```
  y = x → Case A (RHS does not mention y), record y == 1·x + 0:
  state: { y == x }
```

  Step 2: Merge at the Loop Head

```
  The loop head has two incoming edges — take their intersection.

  Edge 1 (first entry into loop): { y == x }

  Edge 2 (back-edge): simulate one loop body first:

  x = x + 1 → Case B (x appears on RHS with coefficient 1)

  Invert: x_old = x_new - 1, substitute into other equations:

  y == x_old  →  y == x_new - 1

  state: { y == x - 1 }

  y = y + 1 → Case B again

  Invert: y_old = y_new - 1. y has an old equation old_eq = x - 1, update it:

  y_new == old_eq + 1 == (x - 1) + 1 == x

  state: { y == x }   ← identical to the entry state

  Intersection:

  edge 1: { y == x }
  edge 2: { y == x }
  merge:  { y == x }   ← both agree, fixed point reached after one iteration
```

  Step 3: Inject the Invariant

  `esbmc main.c --linear-equality-analysis --k-induction`