### PR TITLE
[overflow] skip C++20 signed shl claim only for non-negative E1

### DIFF
--- a/regression/esbmc-cpp/cpp/cpp17_shl_old_rule_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp17_shl_old_rule_fail/main.cpp
@@ -1,0 +1,16 @@
+// Same expression as cpp20_shl_uint8_promoted_defined but compiled at
+// `--std c++17`. Under C++17, the [expr.shift]/2 rule required
+// E1 * 2^E2 to be representable in the *result* type; for byte = 128,
+// 128 << 24 = 2^31 is not representable as int -> UB. The skip in
+// goto_check.cpp must therefore NOT fire under pre-C++20 standards;
+// this regression confirms standard-discrimination.
+#include <cstdint>
+
+extern "C" unsigned char nondet_uchar();
+
+int main()
+{
+  uint8_t  b = nondet_uchar();
+  uint32_t r = static_cast<uint32_t>(b << 24);
+  return r == 0 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/cpp17_shl_old_rule_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp17_shl_old_rule_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/cpp20_shl_clang_2a_alias_defined/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_clang_2a_alias_defined/main.cpp
@@ -1,0 +1,12 @@
+// Same expression compiled with --std c++2a (Clang's pre-finalisation
+// alias for C++20). Confirms is_cxx20_or_later() recognises the alias.
+#include <cstdint>
+
+extern "C" unsigned char nondet_uchar();
+
+int main()
+{
+  uint8_t  b = nondet_uchar();
+  uint32_t r = static_cast<uint32_t>(b << 24);
+  return r == 0 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_shl_clang_2a_alias_defined/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_clang_2a_alias_defined/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++2a --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp20_shl_gnu_alias_defined/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_gnu_alias_defined/main.cpp
@@ -1,0 +1,13 @@
+// Same OpenSMA-style byte deserialiser as cpp20_shl_uint8_promoted_defined,
+// compiled with --std gnu++20. Confirms the gnu++ prefix is recognised by
+// is_cxx20_or_later() and the skip applies.
+#include <cstdint>
+
+extern "C" unsigned char nondet_uchar();
+
+int main()
+{
+  uint8_t  b = nondet_uchar();
+  uint32_t r = static_cast<uint32_t>(b << 24);
+  return r == 0 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_shl_gnu_alias_defined/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_gnu_alias_defined/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std gnu++20 --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp20_shl_signed_unknown_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_signed_unknown_fail/main.cpp
@@ -1,0 +1,11 @@
+// Unconstrained signed int may be negative; the type-driven non-negativity
+// predicate falls through and the overflow claim is preserved.
+
+extern "C" int nondet_int();
+
+int main()
+{
+  int x = nondet_int();
+  int y = x << 1;
+  return y;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_shl_signed_unknown_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_signed_unknown_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --overflow-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/cpp20_shl_ub_shift_check_negative/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_ub_shift_check_negative/main.cpp
@@ -1,0 +1,11 @@
+// Orthogonality check: even after the --overflow-check skip for
+// non-negative-E1 lands, --ub-shift-check must still flag the
+// "negative left operand" UB case in C++20 ([expr.shift]/2 explicitly
+// leaves negative-E1 left-shift undefined).
+
+int main()
+{
+  int x = -1;
+  int y = x << 1;
+  return y;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_shl_ub_shift_check_negative/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_ub_shift_check_negative/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --ub-shift-check
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/cpp20_shl_uint8_promoted_defined/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_uint8_promoted_defined/main.cpp
@@ -1,0 +1,15 @@
+// `uint8_t b; b << 24` is the firmware byte-deserialiser idiom that
+// motivated #4201. After integer promotion the operand has type `int`
+// and value in [0, 255] -- statically non-negative. Under C++20
+// [expr.shift]/2 the shift is the unique value congruent to b * 2^24
+// modulo 2^32, well-defined.
+#include <cstdint>
+
+extern "C" unsigned char nondet_uchar();
+
+int main()
+{
+  uint8_t  b = nondet_uchar();
+  uint32_t r = static_cast<uint32_t>(b << 24);
+  return r == 0 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_shl_uint8_promoted_defined/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_uint8_promoted_defined/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp20_shl_unsigned_defined/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_unsigned_defined/main.cpp
@@ -1,0 +1,12 @@
+// Unsigned left-shift wrap is defined under every C++ standard.
+// Under --overflow-check + --std c++20, we must not flag it.
+#include <cstdint>
+
+extern "C" unsigned int nondet_uint();
+
+int main()
+{
+  uint32_t a = nondet_uint();
+  uint32_t r = a << 1;
+  return r == 0 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_shl_unsigned_defined/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_shl_unsigned_defined/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp98_shl_legacy_kept_check_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp98_shl_legacy_kept_check_fail/main.cpp
@@ -1,0 +1,14 @@
+// Legacy `--std c++98` numerically parses as 98 in is_cxx20_or_later;
+// the year-range bound (year >= 20 && year <= 50) must reject it so the
+// pre-C++20 overflow rule still applies. Confirms the predicate does
+// not silently mistake the legacy spelling for C++20+.
+#include <stdint.h>
+
+extern "C" unsigned char nondet_uchar();
+
+int main()
+{
+  uint8_t  b = nondet_uchar();
+  uint32_t r = static_cast<uint32_t>(b << 24);
+  return r == 0 ? 0 : 1;
+}

--- a/regression/esbmc-cpp/cpp/cpp98_shl_legacy_kept_check_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp98_shl_legacy_kept_check_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++98 --overflow-check
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -331,8 +331,25 @@ bool clang_c_languaget::parse(const std::string &path)
   return false;
 }
 
+void clang_c_languaget::set_language_version()
+{
+  const auto &ls =
+    clang::LangStandard::getLangStandardForKind(AST->getLangOpts().LangStd);
+  if (ls.isC2x())
+    config.language.version = 23;
+  else if (ls.isC17())
+    config.language.version = 17;
+  else if (ls.isC11())
+    config.language.version = 11;
+  else if (ls.isC99())
+    config.language.version = 99;
+  else
+    config.language.version = 89;
+}
+
 bool clang_c_languaget::typecheck(contextt &context, const std::string &)
 {
+  set_language_version();
   clang_c_convertert converter(context, AST, "C");
   if (converter.convert())
     return true;

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -335,8 +335,15 @@ void clang_c_languaget::set_language_version()
 {
   const auto &ls =
     clang::LangStandard::getLangStandardForKind(AST->getLangOpts().LangStd);
+#if LLVM_VERSION_MAJOR >= 17
+  if (ls.isC2y())
+    config.language.version = 26;
+  else if (ls.isC23())
+    config.language.version = 23;
+#else
   if (ls.isC2x())
     config.language.version = 23;
+#endif
   else if (ls.isC17())
     config.language.version = 17;
   else if (ls.isC11())

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -337,21 +337,21 @@ void clang_c_languaget::set_language_version()
     clang::LangStandard::getLangStandardForKind(AST->getLangOpts().LangStd);
 #if LLVM_VERSION_MAJOR >= 17
   if (ls.isC2y())
-    config.language.version = 26;
+    config.language.c_std = c_stdt::c26;
   else if (ls.isC23())
-    config.language.version = 23;
+    config.language.c_std = c_stdt::c23;
 #else
   if (ls.isC2x())
-    config.language.version = 23;
+    config.language.c_std = c_stdt::c23;
 #endif
   else if (ls.isC17())
-    config.language.version = 17;
+    config.language.c_std = c_stdt::c17;
   else if (ls.isC11())
-    config.language.version = 11;
+    config.language.c_std = c_stdt::c11;
   else if (ls.isC99())
-    config.language.version = 99;
+    config.language.c_std = c_stdt::c99;
   else
-    config.language.version = 89;
+    config.language.c_std = c_stdt::c89;
 }
 
 bool clang_c_languaget::typecheck(contextt &context, const std::string &)

--- a/src/clang-c-frontend/clang_c_language.h
+++ b/src/clang-c-frontend/clang_c_language.h
@@ -103,7 +103,8 @@ protected:
 
   std::unique_ptr<clang::ASTUnit> AST;
 
-  virtual void set_language_version();
+private:
+  void set_language_version();
 };
 
 languaget *new_clang_c_language();

--- a/src/clang-c-frontend/clang_c_language.h
+++ b/src/clang-c-frontend/clang_c_language.h
@@ -102,6 +102,8 @@ protected:
   }
 
   std::unique_ptr<clang::ASTUnit> AST;
+
+  virtual void set_language_version();
 };
 
 languaget *new_clang_c_language();

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -90,8 +90,27 @@ extern "C" {
   return intrinsics;
 }
 
+void clang_cpp_languaget::set_language_version()
+{
+  const auto &ls =
+    clang::LangStandard::getLangStandardForKind(AST->getLangOpts().LangStd);
+  if (ls.isCPlusPlus2b())
+    config.language.version = 23;
+  else if (ls.isCPlusPlus20())
+    config.language.version = 20;
+  else if (ls.isCPlusPlus17())
+    config.language.version = 17;
+  else if (ls.isCPlusPlus14())
+    config.language.version = 14;
+  else if (ls.isCPlusPlus11())
+    config.language.version = 11;
+  else
+    config.language.version = 98;
+}
+
 bool clang_cpp_languaget::typecheck(contextt &context, const std::string &)
 {
+  set_language_version();
   clang_cpp_convertert converter(context, AST, "C++");
   if (converter.convert())
     return true;

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -94,8 +94,15 @@ void clang_cpp_languaget::set_language_version()
 {
   const auto &ls =
     clang::LangStandard::getLangStandardForKind(AST->getLangOpts().LangStd);
+#if LLVM_VERSION_MAJOR >= 17
+  if (ls.isCPlusPlus26())
+    config.language.version = 26;
+  else if (ls.isCPlusPlus23())
+    config.language.version = 23;
+#else
   if (ls.isCPlusPlus2b())
     config.language.version = 23;
+#endif
   else if (ls.isCPlusPlus20())
     config.language.version = 20;
   else if (ls.isCPlusPlus17())

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -96,23 +96,23 @@ void clang_cpp_languaget::set_language_version()
     clang::LangStandard::getLangStandardForKind(AST->getLangOpts().LangStd);
 #if LLVM_VERSION_MAJOR >= 17
   if (ls.isCPlusPlus26())
-    config.language.version = 26;
+    config.language.cpp_std = cxx_stdt::cpp26;
   else if (ls.isCPlusPlus23())
-    config.language.version = 23;
+    config.language.cpp_std = cxx_stdt::cpp23;
 #else
   if (ls.isCPlusPlus2b())
-    config.language.version = 23;
+    config.language.cpp_std = cxx_stdt::cpp23;
 #endif
   else if (ls.isCPlusPlus20())
-    config.language.version = 20;
+    config.language.cpp_std = cxx_stdt::cpp20;
   else if (ls.isCPlusPlus17())
-    config.language.version = 17;
+    config.language.cpp_std = cxx_stdt::cpp17;
   else if (ls.isCPlusPlus14())
-    config.language.version = 14;
+    config.language.cpp_std = cxx_stdt::cpp14;
   else if (ls.isCPlusPlus11())
-    config.language.version = 11;
+    config.language.cpp_std = cxx_stdt::cpp11;
   else
-    config.language.version = 98;
+    config.language.cpp_std = cxx_stdt::cpp98;
 }
 
 bool clang_cpp_languaget::typecheck(contextt &context, const std::string &)

--- a/src/clang-cpp-frontend/clang_cpp_language.h
+++ b/src/clang-cpp-frontend/clang_cpp_language.h
@@ -41,6 +41,7 @@ protected:
   std::string internal_additions() override;
   void force_file_type(std::vector<std::string> &compiler_args) override;
   void build_include_args(std::vector<std::string> &compiler_args) override;
+  void set_language_version() override;
 };
 
 languaget *new_clang_cpp_language();

--- a/src/clang-cpp-frontend/clang_cpp_language.h
+++ b/src/clang-cpp-frontend/clang_cpp_language.h
@@ -41,7 +41,9 @@ protected:
   std::string internal_additions() override;
   void force_file_type(std::vector<std::string> &compiler_args) override;
   void build_include_args(std::vector<std::string> &compiler_args) override;
-  void set_language_version() override;
+
+private:
+  void set_language_version();
 };
 
 languaget *new_clang_cpp_language();

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -373,8 +373,8 @@ void goto_checkt::overflow_check(
   {
     const expr2tc &E1 = *expr->get_sub_expr(0);
     if (
-      is_signedbv_type(E1) && config.language.lid == language_idt::CPP &&
-      config.language.version >= 20 && shl_E1_is_known_nonneg(E1))
+      is_signedbv_type(E1) && config.language.cpp_std >= cxx_stdt::cpp20 &&
+      shl_E1_is_known_nonneg(E1))
       return;
   }
 

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -3,6 +3,7 @@
 #include <util/arith_tools.h>
 #include <util/array_name.h>
 #include <util/base_type.h>
+#include <util/config.h>
 #include <util/expr_util.h>
 #include <util/guard.h>
 #include <util/i2string.h>
@@ -275,6 +276,99 @@ void goto_checkt::cast_overflow_check(
     guard);
 }
 
+/// Returns true when the active C++ standard selected via `--std` is
+/// C++20 or later. Recognises `c++NN` and `gnu++NN` with numeric NN as
+/// well as the Clang aliases `2a` (C++20), `2b` (C++23) and `2c` (C++26).
+/// Legacy spellings (`98`, `03`) and anything else, including the empty
+/// default and unknown spellings, are conservatively treated as pre-C++20.
+///
+/// TODO(post-PR): hoist this string-based classification into a
+/// `config.language.cpp_standard` enum populated once by
+/// `clang_cpp_languaget` (which already inspects `config.language.std`
+/// before forwarding `-std=...` to clang). A core transformation pass
+/// is the wrong home for `--std` parsing; this lives here only because
+/// no such enum is currently exposed.
+static bool is_cxx20_or_later()
+{
+  if (config.language.lid != language_idt::CPP)
+    return false;
+
+  const std::string &s = config.language.std;
+  std::string suffix;
+  if (s.compare(0, 3, "c++") == 0)
+    suffix = s.substr(3);
+  else if (s.compare(0, 5, "gnu++") == 0)
+    suffix = s.substr(5);
+  else
+    return false;
+
+  // TODO: extend the alias list when clang publishes `3a`/`3b`/... for
+  // C++30+ working drafts; the `[20, 50]` numeric bound below will also
+  // need bumping once C++50 is on the horizon. Both touchpoints are
+  // local to this function.
+  if (suffix == "2a" || suffix == "2b" || suffix == "2c")
+    return true;
+
+  // Canonical C++ standard years are post-C++11 two-digit numerics
+  // (11, 14, 17, 20, 23, 26, ...). Hand-rolled non-throwing parser so
+  // legacy `98` / `03` and obvious garbage do not satisfy "C++20+";
+  // suffix length is capped to keep year representable.
+  if (suffix.empty() || suffix.size() > 2)
+    return false;
+
+  unsigned year = 0;
+  for (char c : suffix)
+  {
+    if (c < '0' || c > '9')
+      return false;
+    year = year * 10 + static_cast<unsigned>(c - '0');
+  }
+
+  return year >= 20 && year <= 50;
+}
+
+/// Returns true when the left operand `e1` of a left-shift is provably
+/// non-negative from its expression shape alone (no symbolic reasoning).
+/// Covers the firmware/protocol byte-deserialisation idioms that
+/// produced false positives under the strict pre-C++20 shl rule:
+///   - operand has unsigned bit-vector type;
+///   - operand is an integer *widening* promotion of an unsigned-typed
+///     sub-expression (e.g. `int(uint8_t)` after the standard promotion
+///     of `buf[i]`). Same-width or narrowing casts are rejected because
+///     a narrower destination can hold a negative value even when the
+///     source type is unsigned (e.g. `int(uint64_t(-1)) == -1`);
+///   - operand is a non-negative integer constant.
+/// Other shapes (signed `int` symbols, arithmetic on signed values, etc.)
+/// fall through and the caller keeps the overflow claim. This errs on
+/// the side of soundness — a flagged-but-defined shift is a false
+/// positive, never a missed bug.
+///
+/// TODO(layer 2): hook into `--interval-analysis` so a path-qualified
+/// signed `int` known to be `>= 0` (e.g. inside `if (x > 0) { x << 1; }`)
+/// gets the skip too. The value-range table is populated at symex time,
+/// while this check runs at goto-conversion time — closing that phase
+/// gap is the follow-up. Until then the limitation stands; symbolic
+/// non-negativity reasoning is deferred.
+static bool shl_E1_is_known_nonneg(const expr2tc &e1)
+{
+  if (is_unsignedbv_type(e1->type))
+    return true;
+
+  if (is_typecast2t(e1))
+  {
+    const expr2tc &from = to_typecast2t(e1).from;
+    if (
+      is_unsignedbv_type(from->type) &&
+      from->type->get_width() < e1->type->get_width())
+      return true;
+  }
+
+  if (is_constant_int2t(e1) && !to_constant_int2t(e1).value.is_negative())
+    return true;
+
+  return false;
+}
+
 void goto_checkt::overflow_check(
   const expr2tc &expr,
   const guardt &guard,
@@ -304,6 +398,35 @@ void goto_checkt::overflow_check(
   // Don't check pointer overflow
   if (is_pointer_type(*expr->get_sub_expr(0)))
     return;
+
+  // C++20 [expr.shift]/2, as rewritten by P0907 ("Signed integers are
+  // two's complement"), defines the value of `E1 << E2` as the unique
+  // value congruent to `E1 * 2^E2` modulo `2^N`, where `N` is the width
+  // of the result type, *for unsigned `E1` and for signed `E1` with a
+  // non-negative value*. The pre-P0907 "result must be representable in
+  // the result type, otherwise UB" clause was removed: under C++20+,
+  // a signed-`E1` shift whose mathematical product exceeds the signed
+  // range is no longer UB -- the result is the modular value, and the
+  // surrounding cast (e.g. `static_cast<uint32_t>(byte << 24)` in
+  // firmware byte deserialisers) recovers the intended bit pattern.
+  //
+  // The single remaining UB clause is "the behavior is undefined if E1
+  // is negative". The `shl_E1_is_known_nonneg` predicate isolates the
+  // shapes where E1 is provably non-negative; only there does the
+  // arithmetic-overflow claim get suppressed. For signed `E1` that may
+  // be negative the predicate falls through and the claim is preserved,
+  // and `--ub-shift-check` additionally pins the negative-`E1` case
+  // (orthogonal to this site, see goto_checkt::shift_check). Pre-C++20
+  // standards keep the original strict behaviour via
+  // `is_cxx20_or_later`.
+  if (is_shl2t(expr))
+  {
+    const expr2tc &E1 = *expr->get_sub_expr(0);
+    if (
+      is_signedbv_type(E1) && is_cxx20_or_later() &&
+      shl_E1_is_known_nonneg(E1))
+      return;
+  }
 
   // add overflow subgoal
   expr2tc overflow =

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -423,8 +423,7 @@ void goto_checkt::overflow_check(
   {
     const expr2tc &E1 = *expr->get_sub_expr(0);
     if (
-      is_signedbv_type(E1) && is_cxx20_or_later() &&
-      shl_E1_is_known_nonneg(E1))
+      is_signedbv_type(E1) && is_cxx20_or_later() && shl_E1_is_known_nonneg(E1))
       return;
   }
 

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -1,4 +1,5 @@
 #include <goto-programs/goto_check.h>
+#include <cctype>
 #include <util/c_expr2string.h>
 #include <util/arith_tools.h>
 #include <util/array_name.h>
@@ -276,57 +277,6 @@ void goto_checkt::cast_overflow_check(
     guard);
 }
 
-/// Returns true when the active C++ standard selected via `--std` is
-/// C++20 or later. Recognises `c++NN` and `gnu++NN` with numeric NN as
-/// well as the Clang aliases `2a` (C++20), `2b` (C++23) and `2c` (C++26).
-/// Legacy spellings (`98`, `03`) and anything else, including the empty
-/// default and unknown spellings, are conservatively treated as pre-C++20.
-///
-/// TODO(post-PR): hoist this string-based classification into a
-/// `config.language.cpp_standard` enum populated once by
-/// `clang_cpp_languaget` (which already inspects `config.language.std`
-/// before forwarding `-std=...` to clang). A core transformation pass
-/// is the wrong home for `--std` parsing; this lives here only because
-/// no such enum is currently exposed.
-static bool is_cxx20_or_later()
-{
-  if (config.language.lid != language_idt::CPP)
-    return false;
-
-  const std::string &s = config.language.std;
-  std::string suffix;
-  if (s.compare(0, 3, "c++") == 0)
-    suffix = s.substr(3);
-  else if (s.compare(0, 5, "gnu++") == 0)
-    suffix = s.substr(5);
-  else
-    return false;
-
-  // TODO: extend the alias list when clang publishes `3a`/`3b`/... for
-  // C++30+ working drafts; the `[20, 50]` numeric bound below will also
-  // need bumping once C++50 is on the horizon. Both touchpoints are
-  // local to this function.
-  if (suffix == "2a" || suffix == "2b" || suffix == "2c")
-    return true;
-
-  // Canonical C++ standard years are post-C++11 two-digit numerics
-  // (11, 14, 17, 20, 23, 26, ...). Hand-rolled non-throwing parser so
-  // legacy `98` / `03` and obvious garbage do not satisfy "C++20+";
-  // suffix length is capped to keep year representable.
-  if (suffix.empty() || suffix.size() > 2)
-    return false;
-
-  unsigned year = 0;
-  for (char c : suffix)
-  {
-    if (c < '0' || c > '9')
-      return false;
-    year = year * 10 + static_cast<unsigned>(c - '0');
-  }
-
-  return year >= 20 && year <= 50;
-}
-
 /// Returns true when the left operand `e1` of a left-shift is provably
 /// non-negative from its expression shape alone (no symbolic reasoning).
 /// Covers the firmware/protocol byte-deserialisation idioms that
@@ -423,7 +373,8 @@ void goto_checkt::overflow_check(
   {
     const expr2tc &E1 = *expr->get_sub_expr(0);
     if (
-      is_signedbv_type(E1) && is_cxx20_or_later() && shl_E1_is_known_nonneg(E1))
+      is_signedbv_type(E1) && config.language.lid == language_idt::CPP &&
+      config.language.version >= 20 && shl_E1_is_known_nonneg(E1))
       return;
   }
 

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -51,6 +51,8 @@ public:
   {
     language_idt lid;
     std::string std;
+    // C: 89/99/11/17/23.  C++: 98/11/14/17/20/23.  0 = unknown.
+    int version = 0;
   } language = {language_idt::NONE, ""};
 
   struct ansi_ct

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -7,6 +7,32 @@
 #include <langapi/mode.h>
 #include <util/compiler_defs.h>
 #include <util/cache_defs.h>
+
+/// C standard version, ordered so that comparisons work naturally.
+enum class c_stdt
+{
+  unknown,
+  c89,
+  c99,
+  c11,
+  c17,
+  c23,
+  c26,
+};
+
+/// C++ standard version, ordered so that comparisons work naturally.
+enum class cxx_stdt
+{
+  unknown,
+  cpp98,
+  cpp11,
+  cpp14,
+  cpp17,
+  cpp20,
+  cpp23,
+  cpp26,
+};
+
 class configt
 {
 public:
@@ -51,8 +77,9 @@ public:
   {
     language_idt lid;
     std::string std;
-    // C: 89/99/11/17/23.  C++: 98/11/14/17/20/23.  0 = unknown.
-    int version = 0;
+    // Set by the Clang frontend after typecheck().
+    c_stdt c_std = c_stdt::unknown;
+    cxx_stdt cpp_std = cxx_stdt::unknown;
   } language = {language_idt::NONE, ""};
 
   struct ansi_ct


### PR DESCRIPTION
  Refines the reverted #4203 to match P0907's actual contract: under                                                                        
  [expr.shift]/2, signed left-shift wrap is defined only when E1 is                                                                         
  non-negative; negative-E1 left-shift remains UB. The shape-only                                                                           
  predicate accepts unsigned-type operands, widening promotions of                                                                          
  unsigned types, and non-negative integer constants. Other shapes                                                                          
  keep the overflow claim. Pre-C++20 paths are unaffected.    
