### PR TITLE
[cpp/library] add std::underlying_type and underlying_type_t

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_4190_underlying_type/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4190_underlying_type/main.cpp
@@ -1,0 +1,23 @@
+// github.com/esbmc/esbmc/issues/4190 — underlying_type gap.
+// Verifies std::underlying_type<E>::type and underlying_type_t<E>
+// resolve to the correct integer type for enum classes.
+
+#include <type_traits>
+#include <cassert>
+
+enum class Color : unsigned char { red, green, blue };
+enum class Priority : int { low, medium, high };
+
+int main()
+{
+  static_assert(
+    std::is_same_v<std::underlying_type_t<Color>, unsigned char>,
+    "Color underlying type must be unsigned char");
+  static_assert(
+    std::is_same_v<std::underlying_type_t<Priority>, int>,
+    "Priority underlying type must be int");
+  static_assert(
+    std::is_same_v<std::underlying_type<Color>::type, unsigned char>,
+    "underlying_type<Color>::type must be unsigned char");
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4190_underlying_type/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4190_underlying_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_4190_underlying_type_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4190_underlying_type_fail/main.cpp
@@ -1,0 +1,13 @@
+// Negative test: assert a wrong underlying type so ESBMC produces VERIFICATION FAILED.
+
+#include <cassert>
+#include <type_traits>
+
+enum class Color : unsigned char { red, green, blue };
+
+int main()
+{
+  // underlying_type_t<Color> is unsigned char, NOT int — assertion must fail
+  assert((std::is_same_v<std::underlying_type_t<Color>, int>));
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4190_underlying_type_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4190_underlying_type_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/type_traits
+++ b/src/cpp/library/type_traits
@@ -234,6 +234,19 @@ struct is_enum : integral_constant<bool, __is_enum(T)>
 template <class T>
 inline constexpr bool is_enum_v = is_enum<T>::value;
 
+// underlying_type — ::type is only present when T is an enumeration type
+template <class T, bool = is_enum<T>::value>
+struct underlying_type
+{
+};
+template <class T>
+struct underlying_type<T, true>
+{
+  typedef __underlying_type(T) type;
+};
+template <class T>
+using underlying_type_t = typename underlying_type<T>::type;
+
 // is_signed
 template <class T>
 struct is_signed : integral_constant<bool, __is_signed(T)>


### PR DESCRIPTION
The bundled \`<type_traits>\` shim was missing \`std::underlying_type\`, the last gap from #4190 not addressed by #4194. Uses the \`__underlying_type()\` Clang builtin with a partial-specialisation guard so the trait is SFINAE-friendly (\`::type\` is only present when \`T\` is an enumeration type, matching the standard and libstdc++/libc++ behaviour).

Two regression tests added: one verifying correct underlying-type resolution for \`unsigned char\`- and \`int\`-backed enum classes, one asserting the wrong type to confirm \`VERIFICATION FAILED\`.

Refs #4190