### PR TITLE
[clang-cpp] fix double-adjustment crash on C++20 padded struct members

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -198,6 +198,7 @@ if(APPLE)
                     ${REGRESSIONS_CPP11}
                     ${REGRESSIONS_CPP14}
                     ${REGRESSIONS_CPP17}
+                    ${REGRESSIONS_CPP20}
                     extensions
                     ${REGRESSIONS_CHERI}
                     ${REGRESSIONS_PYTHON}

--- a/regression/esbmc-cpp20/cpp/github_4214/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4214/main.cpp
@@ -1,0 +1,11 @@
+#include <cstdint>
+#include <cassert>
+
+struct S { uint8_t a; uint16_t b; };
+class C { public: C() = default; S s{}; };
+
+int main()
+{
+  C c{};
+  assert(c.s.a == 0 && c.s.b == 0);
+}

--- a/regression/esbmc-cpp20/cpp/github_4214/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4214/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4214_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4214_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cstdint>
+#include <cassert>
+
+struct S { uint8_t a; uint16_t b; };
+class C { public: C() = default; S s{}; };
+
+int main()
+{
+  C c{};
+  assert(c.s.a == 1);
+}

--- a/regression/esbmc-cpp20/cpp/github_4214_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4214_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -140,20 +140,32 @@ void clang_c_adjust::adjust_expr(exprt &expr)
     const typet &t = ns.follow(expr.type());
     /* can't be an initializer of an incomplete type, it's not allowed by C */
     assert(!t.incomplete());
-    /* adjust_type() above may have added padding members.
-     * Adjust the init expression accordingly. */
     const struct_union_typet::componentst &new_comp =
       to_struct_union_type(t).components();
     exprt::operandst &ops = expr.operands();
-    for (size_t i = 0; i < new_comp.size(); i++)
+    if (ops.size() < new_comp.size())
     {
-      const struct_union_typet::componentt &c = new_comp[i];
-      if (c.get_is_padding())
+      /* adjust_type() above may have added padding members.
+       * Adjust the init expression accordingly. */
+      for (size_t i = 0; i < new_comp.size(); i++)
       {
-        // TODO: should we initialize pads with nondet values?
-        ops.insert(ops.begin() + i, gen_zero(c.type()));
+        const struct_union_typet::componentt &c = new_comp[i];
+        if (c.get_is_padding())
+        {
+          // TODO: should we initialize pads with nondet values?
+          ops.insert(ops.begin() + i, gen_zero(c.type()));
+        }
+        adjust_expr(ops[i]);
       }
-      adjust_expr(ops[i]);
+    }
+    else
+    {
+      /* Padding already present — the struct expression was re-adjusted
+       * (e.g. adjust_operands followed by a second adjust_expr on the
+       * same node).  Skip insertion; just recursively adjust in place. */
+      assert(ops.size() == new_comp.size());
+      for (auto &op : ops)
+        adjust_expr(op);
     }
     assert(new_comp.size() == ops.size());
   }


### PR DESCRIPTION
In C++20 (P1008), a class with any user-declared constructor (including `= default` in the class body) is no longer an aggregate, so `C c{}` calls the constructor instead of aggregate-initialising. The `#member_init` branch in `adjust_side_effect_assign` called `adjust_operands(expr)` — which already runs `adjust_expr` on the RHS struct and correctly inserts padding operands — and then called `adjust_expr(rhs)` a second time. That second call re-entered the struct branch, tried to insert padding again, and tripped the assertion `new_comp.size() == ops.size()`.

The fix makes struct padding insertion idempotent: if `ops.size()` is already equal to `new_comp.size()`, padding was already inserted, so the loop skips insertion and just recursively adjusts operands in place. Two regression tests are added for issue #4214, and the `esbmc-cpp20` suite is enabled on macOS in `regression/CMakeLists.txt` (it was already present on Linux).

Fixes #4214