### PR TITLE
[clang-cpp-frontend] fix switch-case type mismatch for scoped enum conditions

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4216/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4216/main.cpp
@@ -1,0 +1,28 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4216
+// Expected: VERIFICATION FAILED ("OOB")
+// Was crashing: assert(a->sort->get_data_width() == b->sort->get_data_width()) in mk_eq
+#include <cstdint>
+
+enum class E : uint8_t { A = 0 };
+
+struct Req { uint8_t data[2]; };
+
+extern "C" uint8_t nondet_u8();
+
+int main()
+{
+    uint8_t idx = nondet_u8();
+    __ESBMC_assume(idx >= 1);
+
+    Req req{};
+    req.data[1] = nondet_u8();
+
+    switch (static_cast<E>(req.data[0])) {
+        case E::A:
+            __ESBMC_assert(idx < 1, "OOB");
+            (void)req.data[1];
+            break;
+        default: break;
+    }
+    return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4216/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4216/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$
+^.*OOB.*$

--- a/regression/esbmc-cpp/cpp/github_4216_pass/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4216_pass/main.cpp
@@ -1,0 +1,27 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4216 — passing variant
+// The assertion is always satisfied, so VERIFICATION SUCCESSFUL is expected.
+#include <cstdint>
+
+enum class E : uint8_t { A = 0 };
+
+struct Req { uint8_t data[2]; };
+
+extern "C" uint8_t nondet_u8();
+
+int main()
+{
+    uint8_t idx = nondet_u8();
+    __ESBMC_assume(idx < 10);
+
+    Req req{};
+    req.data[1] = nondet_u8();
+
+    switch (static_cast<E>(req.data[0])) {
+        case E::A:
+            __ESBMC_assert(idx < 10, "always true");
+            (void)req.data[1];
+            break;
+        default: break;
+    }
+    return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4216_pass/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4216_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_adjust.h
+++ b/src/clang-cpp-frontend/clang_cpp_adjust.h
@@ -37,6 +37,7 @@ public:
   void adjust_decl_block(codet &code) override;
   void adjust_catch(codet &code);
   void adjust_throw_decl(codet &code);
+  void adjust_switch_case_ops(exprt &stmt, const typet &switch_type);
 
   /**
    * methods for expression (exprt) adjustment

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
@@ -1,4 +1,5 @@
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
+#include <clang-c-frontend/typecast.h>
 
 void clang_cpp_adjust::convert_expression_to_code(exprt &expr)
 {
@@ -88,6 +89,31 @@ void clang_cpp_adjust::adjust_while(codet &code)
     clang_c_adjust::adjust_while(code);
 }
 
+void clang_cpp_adjust::adjust_switch_case_ops(
+  exprt &expr,
+  const typet &switch_type)
+{
+  if (!expr.is_code())
+    return;
+
+  codet &c = to_code(expr);
+  if (c.get_statement() == "switch_case")
+  {
+    code_switch_caset &sc = to_code_switch_case(c);
+    if (!sc.is_default() && sc.case_op().type() != switch_type)
+      gen_typecast(ns, sc.case_op(), switch_type);
+
+    return;
+  }
+
+  // Don't recurse into nested switch statements
+  if (c.get_statement() == "switch")
+    return;
+
+  Forall_operands (it, c)
+    adjust_switch_case_ops(*it, switch_type);
+}
+
 void clang_cpp_adjust::adjust_switch(codet &code)
 {
   // In addition to the C syntax, C++ also allows a declaration
@@ -109,13 +135,18 @@ void clang_cpp_adjust::adjust_switch(codet &code)
     code.op0() = decl.op0();
     clang_c_adjust::adjust_switch(code);
 
+    adjust_switch_case_ops(code.op1(), code.op0().type());
+
     // Create new block
     code_blockt code_block;
     code_block.move_to_operands(decl_block.op0(), code);
     code.swap(code_block);
   }
   else
+  {
     clang_c_adjust::adjust_switch(code);
+    adjust_switch_case_ops(code.op1(), code.op0().type());
+  }
 }
 
 void clang_cpp_adjust::adjust_for(codet &code)

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1412,29 +1412,6 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   }
 
-  // Extend the narrower BV operand when the two sides have mismatched widths.
-  // This can arise from the frontend emitting case constants with a wider
-  // integer type than the switch discriminant (e.g. enum class E : uint8_t
-  // with case values typed as int).
-  auto align_bv_widths = [this](
-                           smt_astt &lhs,
-                           const expr2tc &lhs_expr,
-                           smt_astt &rhs,
-                           const expr2tc &rhs_expr) {
-    if (
-      int_encoding || !is_bv_type(lhs_expr) || !is_bv_type(rhs_expr) ||
-      lhs->sort->id != SMT_SORT_BV || rhs->sort->id != SMT_SORT_BV)
-      return;
-    unsigned lw = lhs->sort->get_data_width();
-    unsigned rw = rhs->sort->get_data_width();
-    if (lw < rw)
-      lhs = is_signedbv_type(lhs_expr) ? mk_sign_ext(lhs, rw - lw)
-                                       : mk_zero_ext(lhs, rw - lw);
-    else if (rw < lw)
-      rhs = is_signedbv_type(rhs_expr) ? mk_sign_ext(rhs, lw - rw)
-                                       : mk_zero_ext(rhs, lw - rw);
-  };
-
   smt_astt a;
   switch (expr->expr_id)
   {
@@ -2344,10 +2321,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       is_floatbv_type(eq.side_1) && is_floatbv_type(eq.side_2) && !int_encoding)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
-    {
-      align_bv_widths(args[0], eq.side_1, args[1], eq.side_2);
       a = args[0]->eq(this, args[1]);
-    }
     break;
   }
   case expr2t::notequal_id:
@@ -2362,10 +2336,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       !int_encoding)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
-    {
-      align_bv_widths(args[0], neq.side_1, args[1], neq.side_2);
       a = args[0]->eq(this, args[1]);
-    }
     a = mk_not(a);
     break;
   }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2321,7 +2321,29 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       is_floatbv_type(eq.side_1) && is_floatbv_type(eq.side_2) && !int_encoding)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
+    {
+      if (
+        !int_encoding && is_bv_type(eq.side_1) && is_bv_type(eq.side_2) &&
+        args[0]->sort->id == SMT_SORT_BV && args[1]->sort->id == SMT_SORT_BV &&
+        args[0]->sort->get_data_width() != args[1]->sort->get_data_width())
+      {
+        unsigned w = std::max(
+          args[0]->sort->get_data_width(), args[1]->sort->get_data_width());
+        if (args[0]->sort->get_data_width() < w)
+        {
+          unsigned ext = w - args[0]->sort->get_data_width();
+          args[0] = is_signedbv_type(eq.side_1) ? mk_sign_ext(args[0], ext)
+                                                 : mk_zero_ext(args[0], ext);
+        }
+        else
+        {
+          unsigned ext = w - args[1]->sort->get_data_width();
+          args[1] = is_signedbv_type(eq.side_2) ? mk_sign_ext(args[1], ext)
+                                                 : mk_zero_ext(args[1], ext);
+        }
+      }
       a = args[0]->eq(this, args[1]);
+    }
     break;
   }
   case expr2t::notequal_id:
@@ -2336,7 +2358,29 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       !int_encoding)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
+    {
+      if (
+        !int_encoding && is_bv_type(neq.side_1) && is_bv_type(neq.side_2) &&
+        args[0]->sort->id == SMT_SORT_BV && args[1]->sort->id == SMT_SORT_BV &&
+        args[0]->sort->get_data_width() != args[1]->sort->get_data_width())
+      {
+        unsigned w = std::max(
+          args[0]->sort->get_data_width(), args[1]->sort->get_data_width());
+        if (args[0]->sort->get_data_width() < w)
+        {
+          unsigned ext = w - args[0]->sort->get_data_width();
+          args[0] = is_signedbv_type(neq.side_1) ? mk_sign_ext(args[0], ext)
+                                                  : mk_zero_ext(args[0], ext);
+        }
+        else
+        {
+          unsigned ext = w - args[1]->sort->get_data_width();
+          args[1] = is_signedbv_type(neq.side_2) ? mk_sign_ext(args[1], ext)
+                                                  : mk_zero_ext(args[1], ext);
+        }
+      }
       a = args[0]->eq(this, args[1]);
+    }
     a = mk_not(a);
     break;
   }

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1412,6 +1412,29 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
   }
   }
 
+  // Extend the narrower BV operand when the two sides have mismatched widths.
+  // This can arise from the frontend emitting case constants with a wider
+  // integer type than the switch discriminant (e.g. enum class E : uint8_t
+  // with case values typed as int).
+  auto align_bv_widths = [this](
+                           smt_astt &lhs,
+                           const expr2tc &lhs_expr,
+                           smt_astt &rhs,
+                           const expr2tc &rhs_expr) {
+    if (
+      int_encoding || !is_bv_type(lhs_expr) || !is_bv_type(rhs_expr) ||
+      lhs->sort->id != SMT_SORT_BV || rhs->sort->id != SMT_SORT_BV)
+      return;
+    unsigned lw = lhs->sort->get_data_width();
+    unsigned rw = rhs->sort->get_data_width();
+    if (lw < rw)
+      lhs = is_signedbv_type(lhs_expr) ? mk_sign_ext(lhs, rw - lw)
+                                       : mk_zero_ext(lhs, rw - lw);
+    else if (rw < lw)
+      rhs = is_signedbv_type(rhs_expr) ? mk_sign_ext(rhs, lw - rw)
+                                       : mk_zero_ext(rhs, lw - rw);
+  };
+
   smt_astt a;
   switch (expr->expr_id)
   {
@@ -2322,26 +2345,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
     {
-      if (
-        !int_encoding && is_bv_type(eq.side_1) && is_bv_type(eq.side_2) &&
-        args[0]->sort->id == SMT_SORT_BV && args[1]->sort->id == SMT_SORT_BV &&
-        args[0]->sort->get_data_width() != args[1]->sort->get_data_width())
-      {
-        unsigned w = std::max(
-          args[0]->sort->get_data_width(), args[1]->sort->get_data_width());
-        if (args[0]->sort->get_data_width() < w)
-        {
-          unsigned ext = w - args[0]->sort->get_data_width();
-          args[0] = is_signedbv_type(eq.side_1) ? mk_sign_ext(args[0], ext)
-                                                 : mk_zero_ext(args[0], ext);
-        }
-        else
-        {
-          unsigned ext = w - args[1]->sort->get_data_width();
-          args[1] = is_signedbv_type(eq.side_2) ? mk_sign_ext(args[1], ext)
-                                                 : mk_zero_ext(args[1], ext);
-        }
-      }
+      align_bv_widths(args[0], eq.side_1, args[1], eq.side_2);
       a = args[0]->eq(this, args[1]);
     }
     break;
@@ -2359,26 +2363,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
       a = fp_api->mk_smt_fpbv_eq(args[0], args[1]);
     else
     {
-      if (
-        !int_encoding && is_bv_type(neq.side_1) && is_bv_type(neq.side_2) &&
-        args[0]->sort->id == SMT_SORT_BV && args[1]->sort->id == SMT_SORT_BV &&
-        args[0]->sort->get_data_width() != args[1]->sort->get_data_width())
-      {
-        unsigned w = std::max(
-          args[0]->sort->get_data_width(), args[1]->sort->get_data_width());
-        if (args[0]->sort->get_data_width() < w)
-        {
-          unsigned ext = w - args[0]->sort->get_data_width();
-          args[0] = is_signedbv_type(neq.side_1) ? mk_sign_ext(args[0], ext)
-                                                  : mk_zero_ext(args[0], ext);
-        }
-        else
-        {
-          unsigned ext = w - args[1]->sort->get_data_width();
-          args[1] = is_signedbv_type(neq.side_2) ? mk_sign_ext(args[1], ext)
-                                                  : mk_zero_ext(args[1], ext);
-        }
-      }
+      align_bv_widths(args[0], neq.side_1, args[1], neq.side_2);
       a = args[0]->eq(this, args[1]);
     }
     a = mk_not(a);


### PR DESCRIPTION
Fixes #4216.

When a `switch` has a condition of the form `static_cast<E>(val)` where `E` is `enum class E : uint8_t`, the case constants are `IntegerLiteral` with type `int` (32-bit) while the switch condition is 8-bit. This width mismatch propagates to the SMT equality encoding and triggers an assertion in both Bitwuzla and Z3 that both BV operands must have equal widths.

The fix adds `adjust_switch_case_ops()` to `clang_cpp_adjust`, which walks the switch body and inserts a typecast on each `switch_case` operand whose type differs from the switch condition type. This normalizes case operands at the IR level, before the expression ever reaches the SMT backend.

Adds two regression tests for #4216.