### PR TITLE
[python] fix pydocstyle documentation violations in Python frontend

### DIFF
--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -2,7 +2,6 @@ class Field:
 
     def __class_getitem__(cls, item):
         """Return the class itself for subscription-style type usage."""
-
         return cls
 
 
@@ -10,7 +9,6 @@ class InitVar:
 
     def __class_getitem__(cls, item):
         """Return the class itself for subscription-style type usage."""
-
         return cls
 
 

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -1,5 +1,4 @@
-"""
-Operational model for non-deterministic collection functions in ESBMC Python frontend.
+"""Operational model for non-deterministic collection functions in ESBMC Python frontend.
 
 KNOWN LIMITATIONS:
 (why we implemented mothod in preprocessor instead of here)

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -1,4 +1,5 @@
-"""Operational model for non-deterministic collection functions in ESBMC Python frontend.
+"""
+Operational model for non-deterministic collection functions in ESBMC Python frontend.
 
 KNOWN LIMITATIONS:
 (why we implemented mothod in preprocessor instead of here)

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -74,8 +74,11 @@ def _nondet_size(max_size: int) -> int:
     Args:
         max_size: Maximum size (inclusive).
 
-    Returns:
-        int: A non-deterministic integer in [0, max_size].
+    Returns
+    -------
+    int
+        A non-deterministic integer in [0, max_size].
+
     """
     size: int = nondet_int()
     __ESBMC_assume(size >= 0)

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -5,84 +5,98 @@ def TypeVar(name, *args, **kwargs) -> type:
 class Any:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Callable:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class ClassVar:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Dict:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Generic:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Iterable:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Iterator:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class List:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Optional:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Set:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Sized:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Tuple:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Type:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 
 class Union:
 
     def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
         return cls
 
 

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -202,7 +202,8 @@ module_imports = {}
 
 
 def process_imports(node, output_dir):
-    """Process import statements in the AST node.
+    """
+    Process import statements in the AST node.
 
     Parameters
     ----------

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -166,8 +166,8 @@ def expand_star_import(module) -> list[str] | None:
 
 
 def get_referenced_names(node):
-    """
-    Find all functions and classes referenced in a function or class definition.
+    """Find all functions and classes referenced in a function or class definition.
+
     Returns a set of names that are called as functions or used in type annotations.
     """
     referenced = set()

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -285,7 +285,9 @@ def resolve_module_file(module_qualname: str, output_dir: str) -> str | None:
 
 
 def filter_imports(tree: ast.AST) -> ast.AST:
-    """Remove import statements for verification-agnostic testing frameworks(import pytest) from the AST.
+    """
+    Remove import statements for verification-agnostic testing frameworks(import pytest) from the AST.
+
     This prevents the C++ backend from trying to open JSON files for
     imported testing frameworks that we intentionally skip.
     """

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -202,14 +202,16 @@ module_imports = {}
 
 
 def process_imports(node, output_dir):
-    """
-    Process import statements in the AST node.
+    """Process import statements in the AST node.
 
-    Parameters:
-        - node: The import node to process.
-        - output_dir: The directory to save the generated JSON files.
-    """
+    Parameters
+    ----------
+    node
+        The import node to process.
+    output_dir
+        The directory to save the generated JSON files.
 
+    """
     if isinstance(node, (ast.Import)):
         module_names = []
         for alias_node in node.names:


### PR DESCRIPTION
Fix 14 Codacy documentation violations (D105, D202, D205, D212, D213,
D406, D407, D413, D417) across four files in the Python frontend:
`parser.py`, `models/nondet.py`, `models/typing.py`, and
`models/dataclasses.py`.

Changes include converting section headers to numpy style, moving
docstring summaries to the correct line, adding missing blank lines,
removing disallowed blank lines after docstrings, and adding one-line
docstrings to all `__class_getitem__` magic methods.