### PR TITLE
Reduce variable scope in goto_coverage, smt_casts, smt_byteops, solidity_convert

### DIFF
--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -35,10 +35,10 @@ void goto_coveraget::replace_all_asserts_to_guard(
       if (filter(f_it->first, goto_program))
         continue;
 
-      std::string cur_filename;
       Forall_goto_program_instructions (it, goto_program)
       {
-        cur_filename = get_filename_from_path(it->location.file().as_string());
+        std::string cur_filename =
+          get_filename_from_path(it->location.file().as_string());
         if (location_pool.count(cur_filename) == 0)
           continue;
 
@@ -97,10 +97,10 @@ void goto_coveraget::replace_all_asserts_to_assume()
       if (filter(f_it->first, goto_program))
         continue;
 
-      std::string cur_filename;
       Forall_goto_program_instructions (it, goto_program)
       {
-        cur_filename = get_filename_from_path(it->location.file().as_string());
+        std::string cur_filename =
+          get_filename_from_path(it->location.file().as_string());
         if (location_pool.count(cur_filename) == 0)
           continue;
 
@@ -157,12 +157,12 @@ void goto_coveraget::branch_function_coverage()
       if (filter(f_it->first, goto_program))
         continue;
 
-      std::string cur_filename;
       bool flg = true;
 
       Forall_goto_program_instructions (it, goto_program)
       {
-        cur_filename = get_filename_from_path(it->location.file().as_string());
+        std::string cur_filename =
+          get_filename_from_path(it->location.file().as_string());
         // skip if it's not the verifying files
         // probably a library
         if (location_pool.count(cur_filename) == 0)
@@ -239,11 +239,10 @@ void goto_coveraget::branch_coverage()
       if (filter(f_it->first, goto_program))
         continue;
 
-      std::string cur_filename;
-
       Forall_goto_program_instructions (it, goto_program)
       {
-        cur_filename = get_filename_from_path(it->location.file().as_string());
+        std::string cur_filename =
+          get_filename_from_path(it->location.file().as_string());
         // skip if it's not the verifying files
         // probably a library
         if (location_pool.count(cur_filename) == 0)
@@ -415,10 +414,10 @@ void goto_coveraget::condition_coverage()
       if (filter(f_it->first, goto_program))
         continue;
 
-      std::string cur_filename;
       Forall_goto_program_instructions (it, goto_program)
       {
-        cur_filename = get_filename_from_path(it->location.file().as_string());
+        std::string cur_filename =
+          get_filename_from_path(it->location.file().as_string());
         if (location_pool.count(cur_filename) == 0)
           continue;
 
@@ -864,10 +863,10 @@ void goto_coveraget::negating_asserts(const std::string &tgt_fname)
       if (filter(f_it->first, goto_program))
         continue;
 
-      std::string cur_filename;
       Forall_goto_program_instructions (it, goto_program)
       {
-        cur_filename = get_filename_from_path(it->location.file().as_string());
+        std::string cur_filename =
+          get_filename_from_path(it->location.file().as_string());
         if (location_pool.count(cur_filename) == 0)
           continue;
 

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -1038,9 +1038,11 @@ bool solidity_convertert::populate_function_signature(
   bool is_library = json["contractKind"] == "library";
 
   // merge inherited nodes
-  std::set<std::string> dump;
   if (!is_library)
+  {
+    std::set<std::string> dump;
     merge_inheritance_ast(cname, json, dump);
+  }
 
   std::string func_name, func_id, visibility;
   code_typet type;

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -675,13 +675,12 @@ bool solidity_convertert::populate_auxilary_vars()
     {
       for (auto inherit_id : j.second)
       {
-        std::string base_cname = j.first;
-
         auto c_def = find_decl_ref(src_ast_json["nodes"], inherit_id);
         assert(!c_def.empty());
 
         if (cname == c_def["name"].get<std::string>())
         {
+          const std::string base_cname = j.first;
           inheritanceMap[cname].insert(base_cname);
           break;
         }

--- a/src/solvers/smt/smt_byteops.cpp
+++ b/src/solvers/smt/smt_byteops.cpp
@@ -507,7 +507,6 @@ smt_astt smt_convt::convert_byte_update_bv_mode(const byte_update2t &data)
   // the bottom, of the reconstructed / merged output. There might not be a
   // middle if the update byte is at the top or the bottom.
   unsigned int top_of_update = (8 * src_offset) + 8;
-  unsigned int bottom_of_update = (8 * src_offset);
 
   smt_astt top;
   if (top_of_update == width_op0)
@@ -534,7 +533,10 @@ smt_astt smt_convt::convert_byte_update_bv_mode(const byte_update2t &data)
     bottom = value;
   }
   else
+  {
+    unsigned int bottom_of_update = (8 * src_offset);
     bottom = mk_extract(src_value, bottom_of_update - 1, 0);
+  }
 
   // Concatenate the top and bottom, and possible middle, together.
   smt_astt concat;

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -104,7 +104,6 @@ smt_convt::convert_typecast_to_fixedbv_nonint_from_fixedbv(const expr2tc &expr)
   unsigned to_integer_bits = fbvt.integer_bits;
   unsigned from_fraction_bits = from_fbvt.width - from_fbvt.integer_bits;
   unsigned from_integer_bits = from_fbvt.integer_bits;
-  unsigned from_width = from_fbvt.width;
   smt_astt magnitude, fraction;
   smt_astt a = convert_ast(cast.from);
 
@@ -123,6 +122,7 @@ smt_convt::convert_typecast_to_fixedbv_nonint_from_fixedbv(const expr2tc &expr)
   else
   {
     assert(to_integer_bits > from_integer_bits);
+    unsigned from_width = from_fbvt.width;
     smt_astt ext = mk_extract(a, from_width - 1, from_fraction_bits);
 
     unsigned int additional_bits = to_integer_bits - from_integer_bits;

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -600,7 +600,6 @@ smt_astt smt_convt::convert_typecast_to_struct(const typecast2t &cast)
   // we just select out the common fields, which drops any additional data in
   // the subclass.
 
-  unsigned int i = 0;
   bool same_format = true;
   if (is_subclass_of(cast.from->type, cast.type, ns))
   {
@@ -613,6 +612,7 @@ smt_astt smt_convt::convert_typecast_to_struct(const typecast2t &cast)
   else
   {
     // Check that these two different structs have the same format.
+    unsigned int i = 0;
     for (auto const &it : struct_type_to.members)
     {
       if (!base_type_eq(struct_type_from.members[i], it, ns))


### PR DESCRIPTION
Six variables were declared at broader scope than necessary — before a loop, before an if-chain, or unconditionally when only one branch uses them. Each has been moved to its first (and only) point of use.

Files changed: `goto_coverage.cpp` (6 occurrences of `cur_filename`), `smt_casts.cpp` (`from_width`, `i`), `smt_byteops.cpp` (`bottom_of_update`), `solidity_convert.cpp` (`base_cname`, `dump`). No semantic change; `base_cname` also gains `const`.