### PR TITLE
[goto-symex,goto-programs,util] prefer prefix ++/-- for iterators

### DIFF
--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -325,7 +325,7 @@ static void ingest_symbol(
   if (range.first == range.second)
     return;
 
-  for (it = range.first; it != range.second; it++)
+  for (it = range.first; it != range.second; ++it)
     to_include.push_back(it->second);
 
   deps.erase(name);
@@ -453,7 +453,7 @@ void add_cprover_library(contextt &context, const languaget *language)
    */
   for (std::list<irep_idt>::const_iterator nameit = to_include.begin();
        nameit != to_include.end();
-       nameit++)
+       ++nameit)
   {
     symbolt *s;
 

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -1199,7 +1199,7 @@ void goto_checkt::goto_check(goto_programt &goto_program)
   for (goto_programt::instructionst::iterator it =
          goto_program.instructions.begin();
        it != goto_program.instructions.end();
-       it++)
+       ++it)
   {
     goto_programt::instructiont &i = *it;
     const locationt &loc = i.location;
@@ -1250,7 +1250,7 @@ void goto_checkt::goto_check(goto_programt &goto_program)
     {
       goto_program.insert_swap(it, new_code.instructions.front());
       new_code.instructions.pop_front();
-      it++;
+      ++it;
     }
   }
 }

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -105,7 +105,7 @@ void goto_inlinet::replace_return(goto_programt &dest, const expr2tc &lhs)
 {
   for (goto_programt::instructionst::iterator it = dest.instructions.begin();
        it != dest.instructions.end();
-       it++)
+       ++it)
   {
     if (!it->is_return())
       continue;

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -60,7 +60,7 @@ void goto_programt::instructiont::output_instruction(
 
     for (instructiont::targetst::const_iterator gt_it = targets.begin();
          gt_it != targets.end();
-         gt_it++)
+         ++gt_it)
     {
       if (gt_it != targets.begin())
         out << ", ";
@@ -363,7 +363,7 @@ void goto_programt::compute_target_numbers()
 
   for (instructionst::iterator it = instructions.begin();
        it != instructions.end();
-       it++)
+       ++it)
   {
     if (it->is_target())
     {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -510,7 +510,7 @@ void goto_symex_statet::print_stack_trace(unsigned int indent, std::ostream &os)
 
   // Iterate through each call frame printing func name and location.
   src = source;
-  for (it = call_stack.rbegin(); it != call_stack.rend(); it++)
+  for (it = call_stack.rbegin(); it != call_stack.rend(); ++it)
   {
     if (it->function_identifier == "")
     { // Top level call
@@ -545,7 +545,7 @@ std::vector<stack_framet> goto_symex_statet::gen_stack_trace() const
   // Format is a vector of strings, each recording a particular function
   // invocation.
 
-  for (it = call_stack.rbegin(); it != call_stack.rend(); it++)
+  for (it = call_stack.rbegin(); it != call_stack.rend(); ++it)
   {
     src = it->calling_location;
 

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -208,7 +208,7 @@ bool simple_slice::run(symex_target_equationt::SSA_stepst &steps)
 
   for (symex_target_equationt::SSA_stepst::iterator it = steps.begin();
        it != steps.end();
-       it++)
+       ++it)
     if (it->is_assert())
       last_assertion = it;
 
@@ -216,7 +216,7 @@ bool simple_slice::run(symex_target_equationt::SSA_stepst &steps)
   symex_target_equationt::SSA_stepst::iterator s_it = last_assertion;
 
   if (s_it != steps.end())
-    for (s_it++; s_it != steps.end(); s_it++)
+    for (++s_it; s_it != steps.end(); ++s_it)
     {
       s_it->ignore = true;
       ++sliced;

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -383,7 +383,7 @@ void goto_symext::update_throw_target(
     // contains the function containing the target instruction.
     goto_symex_statet::call_stackt::reverse_iterator i;
     for (i = cur_state->call_stack.rbegin(); i != cur_state->call_stack.rend();
-         i++)
+         ++i)
     {
       irep_idt id = i->function_identifier.empty() ? "__ESBMC_main"
                                                    : i->function_identifier;

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -170,7 +170,7 @@ unsigned goto_symext::argument_assignments(
       ++va_count;
 
     va_index = va_count;
-    for (; it1 != arguments.end(); it1++, va_count++)
+    for (; it1 != arguments.end(); ++it1, va_count++)
     {
       irep_idt identifier =
         id2string(function_identifier) + "::va_arg" + std::to_string(va_count);

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -422,7 +422,7 @@ void symex_target_equationt::check_for_duplicate_assigns() const
   for (std::map<std::string, unsigned int>::const_iterator it =
          countmap.begin();
        it != countmap.end();
-       it++)
+       ++it)
   {
     if (it->second != 1)
     {
@@ -437,7 +437,7 @@ unsigned int symex_target_equationt::clear_assertions()
 {
   unsigned int num_asserts = 0;
 
-  for (SSA_stepst::iterator it = SSA_steps.begin(); it != SSA_steps.end(); it++)
+  for (SSA_stepst::iterator it = SSA_steps.begin(); it != SSA_steps.end(); ++it)
   {
     if (it->type == goto_trace_stept::ASSERT)
     {
@@ -512,7 +512,7 @@ void runtime_encoded_equationt::flush_latest_instructions()
   }
   else
   {
-    run_it++;
+    ++run_it;
     if (run_it == SSA_steps.end())
     {
       // There is in fact, nothing to do
@@ -531,7 +531,7 @@ void runtime_encoded_equationt::flush_latest_instructions()
     convert_internal_step(
       conv, assumpt_chain.back(), assert_vec_list.back(), *run_it);
 
-  run_it--;
+  --run_it;
   cvt_progress = run_it;
 }
 

--- a/src/irep2/irep2_type.cpp
+++ b/src/irep2/irep2_type.cpp
@@ -205,7 +205,7 @@ unsigned int struct_type2t::get_width() const
   // Iterate over members accumulating width.
   std::vector<type2tc>::const_iterator it;
   unsigned int width = 0;
-  for (it = members.begin(); it != members.end(); it++)
+  for (it = members.begin(); it != members.end(); ++it)
     width += (*it)->get_width();
 
   return width;
@@ -216,7 +216,7 @@ unsigned int union_type2t::get_width() const
   // Iterate over members accumulating width.
   std::vector<type2tc>::const_iterator it;
   unsigned int width = 0;
-  for (it = members.begin(); it != members.end(); it++)
+  for (it = members.begin(); it != members.end(); ++it)
     width = std::max(width, (*it)->get_width());
 
   return width;
@@ -236,7 +236,7 @@ unsigned int complex_type2t::get_width() const
 {
   std::vector<type2tc>::const_iterator it;
   unsigned int width = 0;
-  for (it = members.begin(); it != members.end(); it++)
+  for (it = members.begin(); it != members.end(); ++it)
     width += (*it)->get_width();
 
   return width;

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -60,7 +60,7 @@ void value_sett::output(std::ostream &out) const
 
     for (object_mapt::const_iterator o_it = e.object_map.begin();
          o_it != e.object_map.end();
-         o_it++)
+         ++o_it)
     {
       const expr2tc &o = object_numbering[o_it->first];
 
@@ -1444,7 +1444,7 @@ void value_sett::do_function_call(
   std::vector<type2tc>::const_iterator it2 = argument_types.begin();
   for (std::vector<irep_idt>::const_iterator it = argument_names.begin();
        it != argument_names.end();
-       it++, it2++)
+       ++it, ++it2)
   {
     const std::string &identifier = it->as_string();
     if (identifier == "")

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -426,7 +426,7 @@ smt_astt smt_convt::convert_typecast_to_ptr(const typecast2t &cast)
   unsigned int i;
   for (it = addr_space_data.back().begin(), i = 0;
        it != addr_space_data.back().end();
-       it++, i++)
+       ++it, i++)
   {
     unsigned id = it->first;
     obj_ids[i] = convert_terminal(constant_int2tc(int_type, BigInt(id)));

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -236,7 +236,7 @@ bool full_eq(const irept &i1, const irept &i2)
     irept::named_subt::const_iterator i1_it = i1_named_sub.begin();
     irept::named_subt::const_iterator i2_it = i2_named_sub.begin();
 
-    for (; i1_it != i1_named_sub.end(); i1_it++, i2_it++)
+    for (; i1_it != i1_named_sub.end(); ++i1_it, ++i2_it)
       if (
         i1_it->first != i2_it->first || !full_eq(i1_it->second, i2_it->second))
         return false;
@@ -246,7 +246,7 @@ bool full_eq(const irept &i1, const irept &i2)
     irept::named_subt::const_iterator i1_it = i1_comments.begin();
     irept::named_subt::const_iterator i2_it = i2_comments.begin();
 
-    for (; i1_it != i1_comments.end(); i1_it++, i2_it++)
+    for (; i1_it != i1_comments.end(); ++i1_it, ++i2_it)
       if (
         i1_it->first != i2_it->first || !full_eq(i1_it->second, i2_it->second))
         return false;
@@ -337,7 +337,7 @@ int irept::compare(const irept &i) const
 
     for (it1 = get_sub().begin(), it2 = i.get_sub().begin();
          it1 != get_sub().end() && it2 != i.get_sub().end();
-         it1++, it2++)
+         ++it1, ++it2)
     {
       r = it1->compare(*it2);
       if (r != 0)
@@ -357,7 +357,7 @@ int irept::compare(const irept &i) const
 
     for (it1 = get_named_sub().begin(), it2 = i.get_named_sub().begin();
          it1 != get_named_sub().end() && it2 != i.get_named_sub().end();
-         it1++, it2++)
+         ++it1, ++it2)
     {
       r = it1->first.compare(it2->first);
       if (r != 0)


### PR DESCRIPTION
Replace postfix increment/decrement with prefix form on all iterator
types across 13 files (23 occurrences). The postfix form creates an
unneeded temporary copy of the iterator before advancing; the prefix
form is semantically identical in loop increment and standalone
statement positions and avoids the copy.

Primitive types mixed in the same expression (e.g. `unsigned int i`)
are left unchanged as they have no copy overhead.