### PR TITLE
[cleanup] replace string::find()==0 with starts_with()

### DIFF
--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -692,7 +692,7 @@ void code_contractst::havoc_static_globals(
 
     // Skip internal ESBMC symbols
     std::string sym_name = id2string(s.name);
-    if (sym_name.find("__ESBMC_") == 0)
+    if (sym_name.starts_with("__ESBMC_"))
       return;
 
     // Build LHS symbol expression

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -77,7 +77,7 @@ bool goto_symext::is_python_exception_subtype(
     std::string base_name = base.id().as_string();
 
     // Remove "tag-" prefix to get the class name
-    if (base_name.find("tag-") == 0)
+    if (base_name.starts_with("tag-"))
       base_name = base_name.substr(4);
 
     // Recursively check if this base class matches or inherits from catch_type


### PR DESCRIPTION
Replace two `string::find() == 0` prefix checks with `string::starts_with()`.
Both are in hot paths (contracts havoc loop and exception subtype walk); the new form avoids scanning the full string and makes the intent explicit.