### PR TITLE
[python] suppress pylint function-redefined in model stubs

### DIFF
--- a/src/python-frontend/models/collections.py
+++ b/src/python-frontend/models/collections.py
@@ -1,4 +1,5 @@
 # Operational model for collections module
+# pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
 
 from typing import Any, Optional
 

--- a/src/python-frontend/models/datetime.py
+++ b/src/python-frontend/models/datetime.py
@@ -1,4 +1,5 @@
 # Operational model for datetime module
+# pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
 
 
 class datetime:

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -1,3 +1,4 @@
+# pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
 def TypeVar(name, *args, **kwargs) -> type:
     return object
 


### PR DESCRIPTION
Pylint's E0102 check flags every class and function in typing.py, datetime.py, and collections.py as a redefinition of the corresponding stdlib symbol. These files intentionally shadow the stdlib modules they model — renaming them is not viable because the C++ frontend resolves models by exact filename (e.g. `"/models/" + file`).

Add a file-level `# pylint: disable=function-redefined` comment to each of the three model files. The disable is scoped to the file, which is appropriate since every definition in these files is an intentional shadow. Pylint rates all three files at 10.00/10 after the change. Python regression tests pass.