### PR TITLE
[cleanup] remove unused variables and add ForwardRef typing stub

### DIFF
--- a/regression/python/typing_forwardref/main.py
+++ b/regression/python/typing_forwardref/main.py
@@ -1,0 +1,4 @@
+from typing import ForwardRef
+
+x: int = 42
+assert x == 42

--- a/regression/python/typing_forwardref/test.desc
+++ b/regression/python/typing_forwardref/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/typing_forwardref_fail/main.py
+++ b/regression/python/typing_forwardref_fail/main.py
@@ -1,0 +1,4 @@
+from typing import ForwardRef
+
+x: int = 42
+assert x != 42

--- a/regression/python/typing_forwardref_fail/test.desc
+++ b/regression/python/typing_forwardref_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -95,10 +95,7 @@ class Type:
 
 
 class ForwardRef:
-
-    def __class_getitem__(cls, item):
-        """Return cls for generic-alias subscription support."""
-        return cls
+    pass
 
 
 class Union:

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -94,6 +94,13 @@ class Type:
         return cls
 
 
+class ForwardRef:
+
+    def __class_getitem__(cls, item):
+        """Return cls for generic-alias subscription support."""
+        return cls
+
+
 class Union:
 
     def __class_getitem__(cls, item):

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -558,7 +558,7 @@ def detect_and_process_submodules(node, processed_submodules, output_dir):
             else:
                 module_dir = os.path.dirname(file_path)
 
-            for root, dirs, files in os.walk(module_dir):
+            for root, _dirs, files in os.walk(module_dir):
                 for file in files:
                     if file.endswith('.py'):
                         full_path = os.path.join(root, file)

--- a/src/solvers/smt/tuple/smt_tuple_node.cpp
+++ b/src/solvers/smt/tuple/smt_tuple_node.cpp
@@ -132,9 +132,6 @@ expr2tc smt_tuple_node_flattener::tuple_get(const type2tc &, smt_astt sym)
 expr2tc smt_tuple_node_flattener::tuple_get(const expr2tc &expr)
 {
   assert(is_symbol2t(expr) && "Non-symbol in smtlib expr get()");
-  const symbol2t &sym = to_symbol2t(expr);
-  std::string name = sym.get_symbol_name();
-
   tuple_node_smt_astt a = to_tuple_node_ast(ctx->convert_ast(expr));
   return tuple_get_rec(a);
 }


### PR DESCRIPTION
Three independent dead-code removals flagged by static analysis.

- Add `ForwardRef` bare stub to `src/python-frontend/models/typing.py`; Python 3.14 moved `typing.ForwardRef` to `annotationlib`, causing analysers to flag the missing symbol. Stub follows the same `pass`-body pattern as `IO`/`BinaryIO`/`TextIO`. Regression tests added.
- Rename unused `dirs` to `_dirs` in the `os.walk` loop in `parser.py` to make the intent explicit.
- Remove dead `sym`/`name` locals in `smt_tuple_node_flattener::tuple_get`; `sym` existed only to produce `name`, which was never read.