### PR TITLE
[clang-c-frontend] fix aggregate-init crash for derived struct with bitfield base (#4232)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4232/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4232/main.cpp
@@ -1,0 +1,29 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4232
+// Derived struct with bitfield base + switch on static_cast<enum>(field).
+// Was crashing: assert(r) in to_solver_smt_ast due to wrong aggregate init.
+#include <cstdint>
+
+enum class E : uint8_t { A = 0 };
+
+struct Base { uint8_t hi : 4; uint8_t lo : 4; };
+struct Req : Base { uint8_t data[2]; };
+
+extern "C" uint8_t nondet_u8();
+
+int main()
+{
+    uint8_t idx = nondet_u8();
+    __ESBMC_assume(idx >= 1);
+
+    Req req{};
+    req.data[1] = nondet_u8();
+
+    switch (static_cast<E>(req.data[0])) {
+        case E::A:
+            __ESBMC_assert(idx < 1, "OOB");
+            (void)req.data[1];
+            break;
+        default: break;
+    }
+    return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4232/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4232/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$
+^.*OOB.*$

--- a/regression/esbmc-cpp/cpp/github_4232_pass/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4232_pass/main.cpp
@@ -1,0 +1,24 @@
+// Passing variant for https://github.com/esbmc/esbmc/issues/4232
+// Same struct/enum pattern, but the assertion holds.
+#include <cstdint>
+
+enum class E : uint8_t { A = 0 };
+
+struct Base { uint8_t hi : 4; uint8_t lo : 4; };
+struct Req : Base { uint8_t data[2]; };
+
+extern "C" uint8_t nondet_u8();
+
+int main()
+{
+    Req req{};
+    req.data[1] = nondet_u8();
+
+    switch (static_cast<E>(req.data[0])) {
+        case E::A:
+            __ESBMC_assert(req.data[1] < 256, "always true");
+            break;
+        default: break;
+    }
+    return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4232_pass/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4232_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1604,8 +1604,8 @@ static void get_base_flattened_inits(
   {
     const clang::Expr *e = init.getInit(j);
     const clang::Type *etype = e->getType().getCanonicalType().getTypePtr();
-    bool is_base = llvm::any_of(
-      cxxrd->bases(), [&](const clang::CXXBaseSpecifier &base) {
+    bool is_base =
+      llvm::any_of(cxxrd->bases(), [&](const clang::CXXBaseSpecifier &base) {
         return base.getType().getCanonicalType().getTypePtr() == etype;
       });
     if (is_base)

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1574,6 +1574,57 @@ bool clang_c_convertert::get_bitfield_type(
   return false;
 }
 
+// Flatten Clang's InitListExpr for a struct into a linear sequence of Expr*
+// that matches ESBMC's flat component layout.
+//
+// In C++17/20, aggregate-initializing a derived struct `struct D : B { ... }`
+// produces an InitListExpr where the first sub-expressions are themselves
+// InitListExprs for each base-class sub-object.  ESBMC's IR instead pulls all
+// base-class components into D's own component list (see
+// get_base_components_methods).  This helper recursively expands base-class
+// sub-object InitListExprs so that the resulting flat_inits vector is
+// element-for-element with ESBMC's component list.
+//
+// Note: get_base_components_methods uses an alphabetically-ordered base_map,
+// so for multiple-inheritance the component order may not match declaration
+// order.  Single-inheritance (the common case) is unaffected.
+static void get_base_flattened_inits(
+  const clang::InitListExpr &init,
+  std::vector<const clang::Expr *> &flat)
+{
+  const auto *cxxrd = init.getType()->getAsCXXRecordDecl();
+  if (!cxxrd || cxxrd->getNumBases() == 0)
+  {
+    for (unsigned j = 0, n = init.getNumInits(); j < n; ++j)
+      flat.push_back(init.getInit(j));
+    return;
+  }
+
+  for (unsigned j = 0, n = init.getNumInits(); j < n; ++j)
+  {
+    const clang::Expr *e = init.getInit(j);
+    const clang::Type *etype = e->getType().getCanonicalType().getTypePtr();
+    bool is_base = llvm::any_of(
+      cxxrd->bases(), [&](const clang::CXXBaseSpecifier &base) {
+        return base.getType().getCanonicalType().getTypePtr() == etype;
+      });
+    if (is_base)
+    {
+      if (const auto *nested = llvm::dyn_cast<clang::InitListExpr>(e))
+      {
+        get_base_flattened_inits(*nested, flat);
+        continue;
+      }
+      log_warning(
+        "clang-c-frontend",
+        "base-class initializer is not an InitListExpr; "
+        "flat initializer may be misaligned for type {}",
+        e->getType().getAsString());
+    }
+    flat.push_back(e);
+  }
+}
+
 bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 {
   locationt location;
@@ -2240,7 +2291,13 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
        * padding is taken care of later in adjust() */
       inits = gen_zero(t);
 
-      unsigned int num = init_stmt.getNumInits();
+      // In C++17/20 aggregate-init of a derived struct, Clang places one
+      // InitListExpr per base-class sub-object, but ESBMC's IR flattens all
+      // base-class components into the struct. Flatten before matching.
+      std::vector<const clang::Expr *> flat_inits;
+      get_base_flattened_inits(init_stmt, flat_inits);
+
+      unsigned int num = static_cast<unsigned>(flat_inits.size());
       for (unsigned int i = 0, j = 0; (i < inits.operands().size() && j < num);
            ++i)
       {
@@ -2255,7 +2312,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 
         // Get the value being initialized
         exprt init;
-        if (get_expr(*init_stmt.getInit(j++), init))
+        if (get_expr(*flat_inits[j++], init))
           return true;
 
         typet elem_type;


### PR DESCRIPTION
Fixes #4232.

In C++17/20 aggregate-init of `struct Req : Base`, Clang emits a nested `InitListExpr` for the `Base` sub-object, but ESBMC's IR flattens all base-class components into the derived struct's component list. The one-to-one matching loop assigned the entire `Base` struct literal to the first bitfield component, producing a sort mismatch that crashed at `to_solver_smt_ast` (Crash A) and `mk_eq` (Crash B).

The fix adds `get_base_flattened_inits()` to recursively expand base-class nested `InitListExpr` nodes into a flat initializer list before component matching. It is a no-op for non-derived structs and plain arrays/vectors. Adds two regression tests for #4232.