### PR TITLE
[clang-cpp-frontend] fix mk_eq crash on switch with fall-through enum cases (#4234)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4234/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4234/main.cpp
@@ -1,0 +1,28 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4234
+// switch(static_cast<enum class : uint8_t>(...)) with fall-through cases.
+// The second case constant was not being type-normalized, causing a width
+// mismatch (8-bit vs 32-bit) in mk_eq.  Expected: VERIFICATION FAILED.
+#include <cstdint>
+
+enum class Op : uint8_t
+{
+  A = 0,
+  B = 1
+};
+
+int main()
+{
+  uint8_t x = 0;
+  int result = 0;
+  switch(static_cast<Op>(x))
+  {
+  case Op::A:
+  case Op::B:
+    result = 1;
+    break;
+  default:
+    break;
+  }
+  __ESBMC_assert(result == 0, "should fail: x=0 matches Op::A, falls through to Op::B body");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4234/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4234/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_4234_default_fallthrough/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4234_default_fallthrough/main.cpp
@@ -1,0 +1,29 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4234 — default: case A: variant
+// When default: falls through into a case with an enum class : uint8_t constant,
+// the case constant inside the default body was not being type-normalized,
+// causing the same mk_eq width mismatch.  Expected: VERIFICATION SUCCESSFUL.
+#include <cstdint>
+
+enum class Op : uint8_t
+{
+  A = 0,
+  B = 1
+};
+
+int main()
+{
+  uint8_t x = 2; // no named case matches → takes default
+  int result = 0;
+  switch(static_cast<Op>(x))
+  {
+  default:
+  case Op::A:
+    result = 1;
+    break;
+  case Op::B:
+    result = 2;
+    break;
+  }
+  __ESBMC_assert(result == 1, "x=2 → default falls through to Op::A body, result is 1");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4234_default_fallthrough/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4234_default_fallthrough/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4234_pass/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4234_pass/main.cpp
@@ -1,0 +1,27 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4234 — passing variant
+// switch with fall-through cases; assertion is always true.
+// Expected: VERIFICATION SUCCESSFUL.
+#include <cstdint>
+
+enum class Op : uint8_t
+{
+  A = 0,
+  B = 1
+};
+
+int main()
+{
+  uint8_t x = 0;
+  int result = 0;
+  switch(static_cast<Op>(x))
+  {
+  case Op::A:
+  case Op::B:
+    result = 1;
+    break;
+  default:
+    break;
+  }
+  __ESBMC_assert(result == 1, "x=0 → Op::A falls through to Op::B body, result is 1");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4234_pass/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4234_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code.cpp
@@ -103,6 +103,7 @@ void clang_cpp_adjust::adjust_switch_case_ops(
     if (!sc.is_default() && sc.case_op().type() != switch_type)
       gen_typecast(ns, sc.case_op(), switch_type);
 
+    adjust_switch_case_ops(sc.code(), switch_type);
     return;
   }
 


### PR DESCRIPTION
Fixes #4234.

`adjust_switch_case_ops` normalised the case constant for the first label in a fall-through chain (`case A: case B: body`) but immediately returned without recursing into the case body, which for fall-through chains is another `switch_case` node. The un-normalised constant for the second label then reached `mk_eq` with a different bit-width from the switch condition (e.g. 8-bit `enum class : uint8_t` vs 32-bit promoted condition), crashing the SMT backend with `assert(a->sort->get_data_width() == b->sort->get_data_width())`.

The fix adds one line — `adjust_switch_case_ops(sc.code(), switch_type)` before the `return` in the `switch_case` handler — so every label in a fall-through chain is normalised. This covers chains of any depth and the `default: case A:` variant. Adds three regression tests.