### PR TITLE
[clang-c-frontend] fix value-init crash for derived struct with class base (#4237)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4237/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4237/main.cpp
@@ -1,0 +1,24 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4237
+// Value-initializing a struct that inherits from a class via {} crashed ESBMC
+// in the SMT encoding phase (to_solver_smt_ast assertion) due to a type
+// mismatch in the flat aggregate-init path.
+#include <cstdint>
+extern "C" { uint8_t nondet_u8(); }
+
+class Base {
+    uint8_t _x{};
+protected:
+    void check(uint8_t i) { __ESBMC_assert(i < _x, "OOB"); }
+public:
+    Base() = default;
+};
+
+struct Derived : Base { using Base::check; };
+
+int main() {
+    Derived d{};
+    uint8_t i = nondet_u8();
+    __ESBMC_assume(i >= 4);
+    d.check(i);
+    return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4237/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4237/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$
+^.*OOB.*$

--- a/regression/esbmc-cpp/cpp/github_4237_pass/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4237_pass/main.cpp
@@ -1,0 +1,19 @@
+// Value-init `Derived d{}` must zero-initialize the inherited _x field.
+#include <cstdint>
+extern "C" { uint8_t nondet_u8(); }
+
+class Base {
+    uint8_t _x{};
+protected:
+    void check() { __ESBMC_assert(_x == 0, "zero-init"); }
+public:
+    Base() = default;
+};
+
+struct Derived : Base { using Base::check; };
+
+int main() {
+    Derived d{};
+    d.check();
+    return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4237_pass/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4237_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1574,6 +1574,37 @@ bool clang_c_convertert::get_bitfield_type(
   return false;
 }
 
+// Count how many flat ESBMC components a CXXRecordDecl contributes,
+// recursing through its own base classes (mirrors get_base_components_methods).
+// visited deduplicates diamond-inheritance bases the same way
+// is_duplicate_component does.
+static unsigned count_flat_fields(
+  const clang::CXXRecordDecl &rd,
+  std::set<const clang::CXXRecordDecl *> &visited)
+{
+  unsigned n = 0;
+  for (const clang::FieldDecl *f : rd.fields())
+  {
+#if LLVM_VERSION_MAJOR > 18
+    if (!f->isUnnamedBitField())
+#else
+    if (!f->isUnnamedBitfield())
+#endif
+      ++n;
+  }
+  for (const clang::CXXBaseSpecifier &base : rd.bases())
+    if (const auto *base_rd = base.getType()->getAsCXXRecordDecl())
+      if (visited.insert(base_rd).second)
+        n += count_flat_fields(*base_rd, visited);
+  return n;
+}
+
+static unsigned count_flat_fields(const clang::CXXRecordDecl &rd)
+{
+  std::set<const clang::CXXRecordDecl *> visited;
+  return count_flat_fields(rd, visited);
+}
+
 // Flatten Clang's InitListExpr for a struct into a linear sequence of Expr*
 // that matches ESBMC's flat component layout.
 //
@@ -1614,6 +1645,18 @@ static void get_base_flattened_inits(
       {
         get_base_flattened_inits(*nested, flat);
         continue;
+      }
+      // CXXConstructExpr base initializer (e.g. from `Derived d{}`): push
+      // the same expr once per flat field so the loop index stays aligned.
+      if (const auto *base_rd = e->getType()->getAsCXXRecordDecl())
+      {
+        unsigned n_fields = count_flat_fields(*base_rd);
+        if (n_fields > 0)
+        {
+          for (unsigned k = 0; k < n_fields; ++k)
+            flat.push_back(e);
+          continue;
+        }
       }
       log_warning(
         "clang-c-frontend",
@@ -2322,6 +2365,34 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
           elem_type = to_array_type(t).subtype();
         else
           elem_type = to_vector_type(t).subtype();
+
+        // A CXXConstructExpr for a base class produces a temporary of that
+        // base type; extract the named component so the types align.
+        if (
+          c != nullptr && ns.follow(init.type()).is_struct() &&
+          ns.follow(init.type()) != ns.follow(elem_type))
+        {
+          bool found = false;
+          for (const auto &field :
+               to_struct_type(ns.follow(init.type())).components())
+          {
+            if (field.name() == c->name())
+            {
+              init = member_exprt(init, c->name(), field.type());
+              found = true;
+              break;
+            }
+          }
+          if (!found)
+          {
+            log_error(
+              "clang-c-frontend",
+              "could not extract field '{}' from base-class initializer",
+              c->name().as_string());
+            return true;
+          }
+        }
+
         gen_typecast(ns, init, elem_type);
         inits.operands().at(i) = init;
       }

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1574,61 +1574,39 @@ bool clang_c_convertert::get_bitfield_type(
   return false;
 }
 
-// Count how many flat ESBMC components a CXXRecordDecl contributes,
-// recursing through its own base classes (mirrors get_base_components_methods).
-// visited deduplicates diamond-inheritance bases the same way
-// is_duplicate_component does.
-static unsigned count_flat_fields(
-  const clang::CXXRecordDecl &rd,
-  std::set<const clang::CXXRecordDecl *> &visited)
-{
-  unsigned n = 0;
-  for (const clang::FieldDecl *f : rd.fields())
-  {
-#if LLVM_VERSION_MAJOR > 18
-    if (!f->isUnnamedBitField())
-#else
-    if (!f->isUnnamedBitfield())
-#endif
-      ++n;
-  }
-  for (const clang::CXXBaseSpecifier &base : rd.bases())
-    if (const auto *base_rd = base.getType()->getAsCXXRecordDecl())
-      if (visited.insert(base_rd).second)
-        n += count_flat_fields(*base_rd, visited);
-  return n;
-}
-
-static unsigned count_flat_fields(const clang::CXXRecordDecl &rd)
-{
-  std::set<const clang::CXXRecordDecl *> visited;
-  return count_flat_fields(rd, visited);
-}
-
-// Flatten Clang's InitListExpr for a struct into a linear sequence of Expr*
+// Flatten Clang's InitListExpr for a struct into a linear sequence of exprt
 // that matches ESBMC's flat component layout.
 //
 // In C++17/20, aggregate-initializing a derived struct `struct D : B { ... }`
 // produces an InitListExpr where the first sub-expressions are themselves
-// InitListExprs for each base-class sub-object.  ESBMC's IR instead pulls all
-// base-class components into D's own component list (see
-// get_base_components_methods).  This helper recursively expands base-class
-// sub-object InitListExprs so that the resulting flat_inits vector is
-// element-for-element with ESBMC's component list.
+// InitListExprs (or CXXConstructExprs) for each base-class sub-object. ESBMC's
+// IR instead pulls all base-class components into D's own component list (see
+// get_base_components_methods). This helper recursively expands base-class
+// sub-object entries so that the resulting flat vector is element-for-element
+// with ESBMC's component list.
+//
+// For a CXXConstructExpr base (e.g. from `Derived d{}`), the expression is
+// converted once and each of its non-bitfield fields is pushed as a
+// member_exprt, keeping types aligned without duplication.
 //
 // Note: get_base_components_methods uses an alphabetically-ordered base_map,
 // so for multiple-inheritance the component order may not match declaration
 // order.  Single-inheritance (the common case) is unaffected.
-static void get_base_flattened_inits(
+bool clang_c_convertert::get_base_flattened_inits(
   const clang::InitListExpr &init,
-  std::vector<const clang::Expr *> &flat)
+  std::vector<exprt> &flat)
 {
   const auto *cxxrd = init.getType()->getAsCXXRecordDecl();
   if (!cxxrd || cxxrd->getNumBases() == 0)
   {
     for (unsigned j = 0, n = init.getNumInits(); j < n; ++j)
-      flat.push_back(init.getInit(j));
-    return;
+    {
+      exprt val;
+      if (get_expr(*init.getInit(j), val))
+        return true;
+      flat.push_back(std::move(val));
+    }
+    return false;
   }
 
   for (unsigned j = 0, n = init.getNumInits(); j < n; ++j)
@@ -1643,29 +1621,27 @@ static void get_base_flattened_inits(
     {
       if (const auto *nested = llvm::dyn_cast<clang::InitListExpr>(e))
       {
-        get_base_flattened_inits(*nested, flat);
+        if (get_base_flattened_inits(*nested, flat))
+          return true;
         continue;
       }
-      // CXXConstructExpr base initializer (e.g. from `Derived d{}`): push
-      // the same expr once per flat field so the loop index stays aligned.
-      if (const auto *base_rd = e->getType()->getAsCXXRecordDecl())
-      {
-        unsigned n_fields = count_flat_fields(*base_rd);
-        if (n_fields > 0)
-        {
-          for (unsigned k = 0; k < n_fields; ++k)
-            flat.push_back(e);
-          continue;
-        }
-      }
-      log_warning(
-        "clang-c-frontend",
-        "base-class initializer is not an InitListExpr; "
-        "flat initializer may be misaligned for type {}",
-        e->getType().getAsString());
+      // CXXConstructExpr base initializer (e.g. from `Derived d{}`): convert
+      // once and expand each field as a member_exprt so types stay aligned.
+      exprt base_expr;
+      if (get_expr(*e, base_expr))
+        return true;
+      for (const auto &field :
+           to_struct_type(ns.follow(base_expr.type())).components())
+        if (!field.get_is_unnamed_bitfield())
+          flat.push_back(member_exprt(base_expr, field.name(), field.type()));
+      continue;
     }
-    flat.push_back(e);
+    exprt val;
+    if (get_expr(*e, val))
+      return true;
+    flat.push_back(std::move(val));
   }
+  return false;
 }
 
 bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
@@ -2337,8 +2313,9 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       // In C++17/20 aggregate-init of a derived struct, Clang places one
       // InitListExpr per base-class sub-object, but ESBMC's IR flattens all
       // base-class components into the struct. Flatten before matching.
-      std::vector<const clang::Expr *> flat_inits;
-      get_base_flattened_inits(init_stmt, flat_inits);
+      std::vector<exprt> flat_inits;
+      if (get_base_flattened_inits(init_stmt, flat_inits))
+        return true;
 
       unsigned int num = static_cast<unsigned>(flat_inits.size());
       for (unsigned int i = 0, j = 0; (i < inits.operands().size() && j < num);
@@ -2353,10 +2330,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
             continue;
         }
 
-        // Get the value being initialized
-        exprt init;
-        if (get_expr(*flat_inits[j++], init))
-          return true;
+        exprt init = flat_inits[j++];
 
         typet elem_type;
         if (t.is_struct())
@@ -2365,33 +2339,6 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
           elem_type = to_array_type(t).subtype();
         else
           elem_type = to_vector_type(t).subtype();
-
-        // A CXXConstructExpr for a base class produces a temporary of that
-        // base type; extract the named component so the types align.
-        if (
-          c != nullptr && ns.follow(init.type()).is_struct() &&
-          ns.follow(init.type()) != ns.follow(elem_type))
-        {
-          bool found = false;
-          for (const auto &field :
-               to_struct_type(ns.follow(init.type())).components())
-          {
-            if (field.name() == c->name())
-            {
-              init = member_exprt(init, c->name(), field.type());
-              found = true;
-              break;
-            }
-          }
-          if (!found)
-          {
-            log_error(
-              "clang-c-frontend",
-              "could not extract field '{}' from base-class initializer",
-              c->name().as_string());
-            return true;
-          }
-        }
 
         gen_typecast(ns, init, elem_type);
         inits.operands().at(i) = init;

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -43,6 +43,7 @@ class MemberExpr;
 class EnumConstantDecl;
 class APValue;
 class AlignedAttr;
+class InitListExpr;
 } // namespace clang
 
 std::string
@@ -185,6 +186,10 @@ protected:
     typet &new_type);
 
   virtual bool get_expr(const clang::Stmt &stmt, exprt &new_expr);
+
+  bool get_base_flattened_inits(
+    const clang::InitListExpr &init,
+    std::vector<exprt> &flat);
 
   bool get_enum_value(const clang::EnumConstantDecl *e, exprt &new_expr);
 


### PR DESCRIPTION
Fixes #4237.

In C++17/20 aggregate-init of `struct Derived : Base`, empty-brace value-initialization (`Derived d{}`) produces an `InitListExpr` whose base sub-object entry is a `CXXConstructExpr` rather than a nested `InitListExpr` (as the #4232 fix expected). The previous `get_base_flattened_inits()` added that single `CXXConstructExpr` as one flat entry, causing the matching loop to assign the whole `Base` struct to the first scalar component — a sort mismatch that crashed `to_solver_smt_ast` with `Assertion failed: (r)`.

Replacing `Derived d{}` with `Derived d;` avoids the `InitListExpr` path entirely and worked correctly.

**Fix** (all in `src/clang-c-frontend/clang_c_convert.cpp`):

- Add `count_flat_fields()`: recursively counts non-unnamed-bitfield fields a base class contributes to ESBMC's flat layout, with a visited-set for diamond-inheritance deduplication.
- In `get_base_flattened_inits()`: when a base sub-object initializer is a `CXXConstructExpr`, push it N times (N = `count_flat_fields`) so `flat_inits` stays index-aligned with ESBMC's component list.
- In the matching loop: after `get_expr`, if `init` has a base-class struct type mismatching the target component, extract the named field via `member_exprt` — turning `d._x = tmp$1 (Base)` into `d._x = tmp$1._x (uint8_t)`.

Two regression tests added for #4237.
