### PR TITLE
[goto-check] flag negative shift distance under --overflow-check

### DIFF
--- a/regression/esbmc/github_2789/main.c
+++ b/regression/esbmc/github_2789/main.c
@@ -1,0 +1,12 @@
+// https://github.com/esbmc/esbmc/issues/2789
+// C11 §6.5.7p3: shift by a negative amount is undefined behavior.
+#include <assert.h>
+
+int nondet_int();
+
+int main()
+{
+  int a = nondet_int();
+  assert((0 >> a) == 0);
+  return 0;
+}

--- a/regression/esbmc/github_2789/test.desc
+++ b/regression/esbmc/github_2789/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_2789_pass/main.c
+++ b/regression/esbmc/github_2789_pass/main.c
@@ -1,0 +1,14 @@
+// https://github.com/esbmc/esbmc/issues/2789
+// Companion to github_2789: when the shift distance is constrained to the
+// well-defined range [0, width), no UB is reported.
+#include <assert.h>
+
+int nondet_int();
+
+int main()
+{
+  int a = nondet_int();
+  __ESBMC_assume(a >= 0 && a < 32);
+  assert((0 >> a) == 0);
+  return 0;
+}

--- a/regression/esbmc/github_2789_pass/test.desc
+++ b/regression/esbmc/github_2789_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -559,7 +559,12 @@ void goto_checkt::shift_check(
 {
   overflow_check(expr, guard, loc);
 
-  if (!enable_ub_shift_check)
+  // Negative shift distance and distance >= width are UB per C11 §6.5.7p3
+  // and C++ [expr.shift]/1. Run the UB-distance assertions whenever the user
+  // asked for shift UB checks or for general overflow checking.
+  if (
+    !enable_ub_shift_check && !enable_overflow_check &&
+    !enable_unsigned_overflow_check)
     return;
 
   assert(is_lshr2t(expr) || is_ashr2t(expr) || is_shl2t(expr));


### PR DESCRIPTION
Per C11 §6.5.7p3 and C++ [expr.shift]/1, a shift by a negative or out-of-range distance is undefined behavior. The shift-distance UB assertions in `shift_check()` were previously gated only on `--ub-shift-check`; extend the gate so they also fire under `--overflow-check` / `--unsigned-overflow-check`, since shift-distance UB is a form of shift-related overflow.

Fixes #2789.