### PR TITLE
[cpp-library] make bundled std::array an aggregate (fix #4243)

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4243/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4243/main.cpp
@@ -4,7 +4,8 @@
 int main()
 {
   std::array<int32_t, 4> buf{};
-  __ESBMC_assert(
-    buf[0] == 0, "value-init must zero-initialise std::array elements");
+  for (std::size_t i = 0; i < buf.size(); ++i)
+    __ESBMC_assert(
+      buf[i] == 0, "value-init must zero-initialise std::array elements");
   return 0;
 }

--- a/regression/esbmc-cpp20/cpp/github_4243/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4243/main.cpp
@@ -1,0 +1,10 @@
+#include <array>
+#include <cstdint>
+
+int main()
+{
+  std::array<int32_t, 4> buf{};
+  __ESBMC_assert(
+    buf[0] == 0, "value-init must zero-initialise std::array elements");
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4243/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4243/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4243_sma/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4243_sma/main.cpp
@@ -1,0 +1,20 @@
+#include <array>
+#include <cstdint>
+
+struct SmaFilter
+{
+  std::array<int32_t, 4> _buffer{};
+  int32_t _sum{};
+
+  void update(int32_t x)
+  {
+    _sum += x - _buffer[0];
+  }
+};
+
+int main()
+{
+  SmaFilter f;
+  f.update(53248);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4243_sma/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4243_sma/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc --overflow-check
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/array
+++ b/src/cpp/library/array
@@ -9,9 +9,8 @@ namespace std
 {
 #if __cplusplus >= 201103L
 template <typename T, std::size_t N>
-class array
+struct array
 {
-public:
   typedef T value_type;
   typedef std::size_t size_type;
   typedef std::ptrdiff_t difference_type;
@@ -22,10 +21,8 @@ public:
   typedef std::reverse_iterator<pointer> reverse_iterator;
   typedef std::reverse_iterator<const_pointer> const_reverse_iterator;
 
-private:
   value_type elems[N];
 
-public:
   reference operator[](size_type index)
   {
     __ESBMC_assert(index < N, "Index out of bounds");


### PR DESCRIPTION
Bundled `<array>` declared `elems[N]` as private, so the frontend's
`isPOD()`-based aggregate check rejected it and value-init `array{}`
left elements nondet — producing false-positive.
Convert to a struct with public `elems`, restoring both standards
conformance ([array.overview]) and zero-initialisation on `{}`.

Fixes #4243
