### PR TITLE
[cpp-library] add bundled <optional> and <chrono> shims (fix #4245)

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4245_chrono_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4245_chrono_fail/main.cpp
@@ -1,0 +1,13 @@
+// github.com/esbmc/esbmc/issues/4245 — wrong cross-period count comparison.
+#include <chrono>
+#include <cassert>
+
+int main()
+{
+  // microseconds(2000) and milliseconds(2) represent the same time, but
+  // their raw counts (2000 vs 2) must differ — this assertion is false.
+  assert(
+    std::chrono::microseconds(2000).count() ==
+    std::chrono::milliseconds(2).count());
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4245_chrono_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4245_chrono_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --std c++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4245_chrono_pass/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4245_chrono_pass/main.cpp
@@ -1,0 +1,30 @@
+// github.com/esbmc/esbmc/issues/4245 — std::chrono shim.
+#include <chrono>
+#include <cassert>
+
+int main()
+{
+  std::chrono::microseconds us(100);
+  assert(us.count() == 100);
+
+  std::chrono::milliseconds ms(2);
+  assert(ms.count() == 2);
+
+  auto sum = us + std::chrono::microseconds(50);
+  assert(sum.count() == 150);
+
+  auto diff = std::chrono::milliseconds(5) - std::chrono::milliseconds(2);
+  assert(diff.count() == 3);
+
+  assert(us < std::chrono::microseconds(101));
+  assert(us == std::chrono::microseconds(100));
+
+  auto as_us = std::chrono::duration_cast<std::chrono::microseconds>(ms);
+  assert(as_us.count() == 2000);
+
+  std::chrono::seconds s(1);
+  auto s_as_ms = std::chrono::duration_cast<std::chrono::milliseconds>(s);
+  assert(s_as_ms.count() == 1000);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4245_chrono_pass/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4245_chrono_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --std c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4245_optional_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4245_optional_fail/main.cpp
@@ -1,0 +1,8 @@
+// github.com/esbmc/esbmc/issues/4245 — disengaged optional must trip value().
+#include <optional>
+
+int main()
+{
+  std::optional<int> o;
+  return o.value();
+}

--- a/regression/esbmc-cpp20/cpp/github_4245_optional_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4245_optional_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --std c++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4245_optional_pass/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4245_optional_pass/main.cpp
@@ -1,0 +1,37 @@
+// github.com/esbmc/esbmc/issues/4245 — std::optional shim.
+#include <optional>
+#include <cassert>
+
+int main()
+{
+  std::optional<int> empty;
+  assert(!empty.has_value());
+  assert(!empty);
+  assert(empty == std::nullopt);
+
+  std::optional<int> v(42);
+  assert(v.has_value());
+  assert(static_cast<bool>(v));
+  assert(*v == 42);
+  assert(v.value() == 42);
+  assert(v != std::nullopt);
+
+  std::optional<int> w = std::nullopt;
+  assert(!w);
+  assert(w.value_or(7) == 7);
+
+  w = 5;
+  assert(w.has_value() && *w == 5);
+
+  std::optional<int> copy = v;
+  assert(copy.has_value() && *copy == 42);
+
+  v.reset();
+  assert(!v.has_value());
+
+  std::optional<int> engaged(9);
+  engaged = std::nullopt;
+  assert(!engaged.has_value());
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4245_optional_pass/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4245_optional_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --std c++20
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/chrono
+++ b/src/cpp/library/chrono
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "cstdint"
+
+namespace std
+{
+
+template <intmax_t Num, intmax_t Den = 1>
+struct ratio
+{
+  static constexpr intmax_t num = Num;
+  static constexpr intmax_t den = Den;
+  using type = ratio<Num, Den>;
+};
+
+using nano = ratio<1, 1000000000>;
+using micro = ratio<1, 1000000>;
+using milli = ratio<1, 1000>;
+
+namespace chrono
+{
+
+template <class Rep, class Period = std::ratio<1>>
+class duration
+{
+  Rep rep_;
+
+public:
+  using rep = Rep;
+  using period = Period;
+
+  constexpr duration() noexcept : rep_(0) {}
+  constexpr explicit duration(const Rep &r) noexcept : rep_(r) {}
+  constexpr duration(const duration &) noexcept = default;
+  duration &operator=(const duration &) noexcept = default;
+
+  constexpr Rep count() const noexcept
+  {
+    return rep_;
+  }
+};
+
+template <class Rep, class Period>
+constexpr duration<Rep, Period>
+operator+(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return duration<Rep, Period>(a.count() + b.count());
+}
+template <class Rep, class Period>
+constexpr duration<Rep, Period>
+operator-(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return duration<Rep, Period>(a.count() - b.count());
+}
+
+template <class Rep, class Period>
+constexpr bool
+operator==(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return a.count() == b.count();
+}
+template <class Rep, class Period>
+constexpr bool
+operator!=(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return !(a == b);
+}
+template <class Rep, class Period>
+constexpr bool
+operator<(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return a.count() < b.count();
+}
+template <class Rep, class Period>
+constexpr bool
+operator<=(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return !(b < a);
+}
+template <class Rep, class Period>
+constexpr bool
+operator>(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return b < a;
+}
+template <class Rep, class Period>
+constexpr bool
+operator>=(const duration<Rep, Period> &a, const duration<Rep, Period> &b)
+{
+  return !(a < b);
+}
+
+template <class ToDur, class Rep, class Period>
+constexpr ToDur duration_cast(const duration<Rep, Period> &d)
+{
+  using ToRep = typename ToDur::rep;
+  using ToPeriod = typename ToDur::period;
+  // d.count() * (Period::num / Period::den) / (ToPeriod::num / ToPeriod::den)
+  // == d.count() * Period::num * ToPeriod::den
+  //               / (Period::den * ToPeriod::num)
+  return ToDur(static_cast<ToRep>(
+    (static_cast<intmax_t>(d.count()) * Period::num * ToPeriod::den) /
+    (Period::den * ToPeriod::num)));
+}
+
+using nanoseconds = duration<long long, nano>;
+using microseconds = duration<long long, micro>;
+using milliseconds = duration<long long, milli>;
+using seconds = duration<long long>;
+using minutes = duration<long long, ratio<60>>;
+using hours = duration<long long, ratio<3600>>;
+
+} // namespace chrono
+} // namespace std

--- a/src/cpp/library/optional
+++ b/src/cpp/library/optional
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "utility"
+
+namespace std
+{
+
+struct nullopt_t
+{
+  explicit constexpr nullopt_t(int) {}
+};
+
+inline constexpr nullopt_t nullopt{0};
+
+template <class T>
+class optional
+{
+  T value_;
+  bool engaged_;
+
+public:
+  using value_type = T;
+
+  constexpr optional() noexcept : value_(), engaged_(false) {}
+  constexpr optional(nullopt_t) noexcept : value_(), engaged_(false) {}
+  constexpr optional(const T &v) : value_(v), engaged_(true) {}
+  constexpr optional(const optional &) = default;
+
+  optional &operator=(nullopt_t) noexcept
+  {
+    engaged_ = false;
+    return *this;
+  }
+
+  optional &operator=(const T &v)
+  {
+    value_ = v;
+    engaged_ = true;
+    return *this;
+  }
+
+  optional &operator=(const optional &) = default;
+
+  constexpr bool has_value() const noexcept
+  {
+    return engaged_;
+  }
+  constexpr explicit operator bool() const noexcept
+  {
+    return engaged_;
+  }
+
+  T &operator*()
+  {
+    __ESBMC_assert(engaged_, "optional: dereference on disengaged value");
+    return value_;
+  }
+  const T &operator*() const
+  {
+    __ESBMC_assert(engaged_, "optional: dereference on disengaged value");
+    return value_;
+  }
+
+  T *operator->()
+  {
+    __ESBMC_assert(engaged_, "optional: arrow on disengaged value");
+    return &value_;
+  }
+  const T *operator->() const
+  {
+    __ESBMC_assert(engaged_, "optional: arrow on disengaged value");
+    return &value_;
+  }
+
+  T &value()
+  {
+    __ESBMC_assert(engaged_, "optional: value() on disengaged value");
+    return value_;
+  }
+  const T &value() const
+  {
+    __ESBMC_assert(engaged_, "optional: value() on disengaged value");
+    return value_;
+  }
+
+  template <class U>
+  T value_or(U &&def) const
+  {
+    return engaged_ ? value_ : static_cast<T>(std::forward<U>(def));
+  }
+
+  void reset() noexcept
+  {
+    engaged_ = false;
+  }
+};
+
+template <class T>
+constexpr bool operator==(const optional<T> &o, nullopt_t) noexcept
+{
+  return !o.has_value();
+}
+template <class T>
+constexpr bool operator==(nullopt_t, const optional<T> &o) noexcept
+{
+  return !o.has_value();
+}
+template <class T>
+constexpr bool operator!=(const optional<T> &o, nullopt_t) noexcept
+{
+  return o.has_value();
+}
+template <class T>
+constexpr bool operator!=(nullopt_t, const optional<T> &o) noexcept
+{
+  return o.has_value();
+}
+
+template <class T>
+constexpr bool operator==(const optional<T> &a, const optional<T> &b)
+{
+  if (a.has_value() != b.has_value())
+    return false;
+  return !a.has_value() || (*a == *b);
+}
+template <class T>
+constexpr bool operator!=(const optional<T> &a, const optional<T> &b)
+{
+  return !(a == b);
+}
+
+} // namespace std


### PR DESCRIPTION
Adds minimal `std::optional<T>` (with `nullopt`/`nullopt_t`, `value`/`value_or`/`reset`/`has_value`) and `std::chrono::duration` with SI aliases plus `duration_cast` and `std::ratio`. Both headers auto-register via the wildcard mangle in `abstract_includes/CMakeLists.txt`; no build-system changes needed.

Four `github_4245_*` regression tests cover successful verification, disengaged `optional::value()` detection, chrono arithmetic, and cross-period `count()` semantics.

Fixes #4245
