### PR TITLE
[cpp-library] bundled <span> must transitively include <bit> (fix #4248)

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4248_span_bit/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4248_span_bit/main.cpp
@@ -1,0 +1,19 @@
+// github.com/esbmc/esbmc/issues/4248 — bundled <span> must transitively
+// expose std::bit_cast, matching libc++/libstdc++.
+
+#include <span>
+#include <cstdint>
+#include <cassert>
+
+void process(std::span<const uint8_t> s)
+{
+  const uint8_t *p = std::bit_cast<const uint8_t *>(s.data());
+  assert(p == s.data());
+}
+
+int main()
+{
+  uint8_t buf[4] = {1, 2, 3, 4};
+  process(std::span<const uint8_t>(buf, 4));
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4248_span_bit/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4248_span_bit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4248_span_bit_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4248_span_bit_fail/main.cpp
@@ -1,0 +1,15 @@
+// github.com/esbmc/esbmc/issues/4248 — failing variant: bit_cast through
+// the bundled <span> shim still produces a real, asserting value.
+
+#include <span>
+#include <cstdint>
+#include <cassert>
+
+int main()
+{
+  uint8_t buf[2] = {7, 8};
+  std::span<const uint8_t> s(buf, 2);
+  // bit_cast preserves the pointer value, so it cannot be null here.
+  assert(std::bit_cast<uintptr_t>(s.data()) == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4248_span_bit_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4248_span_bit_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20
+^VERIFICATION FAILED$

--- a/src/cpp/library/span
+++ b/src/cpp/library/span
@@ -3,6 +3,7 @@
 #include "cstddef"  /* size_t, ptrdiff_t */
 #include "cstdint"  /* SIZE_MAX */
 #include "array"
+#include "bit"      /* std::bit_cast (transitive, matches libc++/libstdc++) */
 #include "type_traits"
 
 namespace std


### PR DESCRIPTION
Production C++20 standard library implementations of `<span>` pull in `<bit>` directly or transitively, so user code that uses `std::bit_cast` after only `#include <span>` compiles cleanly. ESBMC's bundled shim did not, causing spurious `'bit_cast' is not a member of 'std'` errors (reported against NVIDIA OpenSMA's `pdk-mctp-app-packet.h`).

Adds `#include "bit"` to `src/cpp/library/span` and two CORE regression tests under `regression/esbmc-cpp20/cpp/github_4248_span_bit*`.

Refs #4248
