### PR TITLE
[cpp-library] bundled <bit> bit_cast<T*> must accept const From (fix #4247)

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4247/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4247/main.cpp
@@ -1,0 +1,34 @@
+#include <bit>
+#include <cstdint>
+
+struct Packet
+{
+  uint8_t data[8];
+
+  // bit_cast<uint8_t*>(this) inside a const method: this is `const
+  // Packet*`, target is non-const `uint8_t*`. Standard bit_cast accepts
+  // this; the bundled overload must too (esbmc#4247).
+  const uint8_t *first_byte_const() const
+  {
+    return std::bit_cast<const uint8_t *>(this);
+  }
+
+  uint8_t *first_byte_mutable() const
+  {
+    return std::bit_cast<uint8_t *>(this);
+  }
+};
+
+int main()
+{
+  Packet pkt{};
+  pkt.data[0] = 0xAB;
+  pkt.data[7] = 0xCD;
+
+  const uint8_t *p_const = pkt.first_byte_const();
+  uint8_t *p_mut = pkt.first_byte_mutable();
+
+  __ESBMC_assert(p_const[0] == 0xAB, "const-qualified view of byte 0");
+  __ESBMC_assert(p_mut[7] == 0xCD, "cv-stripped view of byte 7");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4247/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4247/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --overflow-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4247_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4247_fail/main.cpp
@@ -1,0 +1,26 @@
+#include <bit>
+#include <cstdint>
+
+struct Packet
+{
+  uint8_t data[8];
+
+  // bit_cast<uint8_t*>(this) inside a const method must produce a
+  // pointer that aliases data[]; symex must see the actual byte values
+  // — assertion below is intentionally false to confirm the bytes
+  // really are routed through to the cast result (esbmc#4247).
+  uint8_t *bytes() const
+  {
+    return std::bit_cast<uint8_t *>(this);
+  }
+};
+
+int main()
+{
+  Packet pkt{};
+  pkt.data[0] = 0xAB;
+
+  uint8_t *p = pkt.bytes();
+  __ESBMC_assert(p[0] == 0x00, "intentionally wrong: byte 0 is 0xAB");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4247_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4247_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --overflow-check --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/bit
+++ b/src/cpp/library/bit
@@ -11,6 +11,13 @@ namespace std
 // memcpy-into-temporary lowering used by stock libc++ shims, which
 // breaks ESBMC's symex pointer-aliasing tracking and yields
 // internally-inconsistent counterexamples (esbmc#4191).
+//
+// std::bit_cast has memcpy semantics — [bit.cast] places no
+// cv-preservation requirement on the pointed-to type, so this overload
+// must accept a const From (e.g. bit_cast<uint8_t*>(this) inside a
+// const member function, esbmc#4247). reinterpret_cast alone cannot
+// drop cv-qualifiers (per [expr.reinterpret.cast]/3), so strip them
+// first with const_cast (well-defined per [expr.const.cast]).
 template <
   class To,
   class From,
@@ -19,7 +26,9 @@ template <
     int>::type = 0>
 constexpr To bit_cast(const From &src) noexcept
 {
-  return reinterpret_cast<To>(src);
+  using FromMutable =
+    typename remove_cv<typename remove_pointer<From>::type>::type *;
+  return reinterpret_cast<To>(const_cast<FromMutable>(src));
 }
 
 // Generic case: defer to Clang's __builtin_bit_cast, which the C


### PR DESCRIPTION
reinterpret_cast cannot drop cv-qualifiers per [expr.reinterpret.cast]/3,
so the bundled `<bit>` pointer overload failed to compile on
`bit_cast<T*>(this)` inside const member functions. Compose const_cast +
reinterpret_cast to match [bit.cast]'s memcpy semantics while preserving
the #4191 aliasing fix. Adds passing/failing regression tests under
`regression/esbmc-cpp/cpp/github_4247{,_fail}/`.

Fixes #4247
