### PR TITLE
[python] silence Codacy redefined-builtin on operational models

### DIFF
--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -1,3 +1,7 @@
+# pylint: disable=redefined-builtin
+# These functions intentionally shadow Python built-ins: they are the
+# operational models ESBMC uses to verify Python programs, so they must
+# match the built-in names exactly.
 # def abs(x:float) -> float:
 #     if x >= 0:
 #         return x

--- a/src/python-frontend/models/consensus.py
+++ b/src/python-frontend/models/consensus.py
@@ -1,3 +1,8 @@
+# pylint: disable=redefined-builtin
+# `hash` here intentionally shadows the Python built-in: it is the
+# operational model ESBMC uses to verify Python programs, so it must
+# match the built-in name exactly.
+
 # Stubs used for consensus specification verification
 
 

--- a/src/python-frontend/models/exceptions.py
+++ b/src/python-frontend/models/exceptions.py
@@ -1,3 +1,7 @@
+# pylint: disable=redefined-builtin
+# These classes intentionally shadow Python built-ins: they are the
+# operational models ESBMC uses to verify Python programs, so they must
+# match the built-in names exactly.
 class BaseException:
     message: str = ""
 

--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -1,3 +1,7 @@
+# pylint: disable=redefined-builtin
+# This class intentionally shadows the Python built-in `int`: it is the
+# operational model ESBMC uses to verify Python programs, so it must
+# match the built-in name exactly.
 class int:
 
     @classmethod

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -1,3 +1,7 @@
+# pylint: disable=redefined-builtin
+# Some functions in this module intentionally shadow Python built-ins
+# (e.g. `pow`): they are the operational models ESBMC uses to verify
+# Python programs, so they must match the built-in names exactly.
 def __ESBMC_expm1(x: float) -> float:
     ...
 

--- a/src/python-frontend/models/numpy.py
+++ b/src/python-frontend/models/numpy.py
@@ -1,3 +1,8 @@
+# pylint: disable=redefined-builtin
+# Some functions in this module intentionally shadow Python built-ins
+# (e.g. `round`): they are the operational models ESBMC uses to verify
+# Python programs, so they must match the built-in names exactly.
+
 # Stubs for type inference.
 def array(l: list[Any]) -> list[Any]:
     return l


### PR DESCRIPTION
The shims under \`src/python-frontend/models/\` deliberately shadow Python built-ins (\`int\`, \`sum\`, \`hash\`, \`Exception\`, ...) because ESBMC matches them by name when verifying Python programs, so renaming is not an option.

Add a module-level \`# pylint: disable=redefined-builtin\` plus a short rationale comment to each affected file so Codacy stops flagging these intentional redefinitions.