### PR TITLE
[python] silence Codacy pyflakes F821 on operational models

### DIFF
--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -9,7 +9,7 @@
 #         return -x
 
 
-def all(iterable: list[Any]) -> bool:
+def all(iterable: list[Any]) -> bool:  # noqa: F821
     """Return True if all elements of the iterable are true (or if empty)."""
     i: int = 0
     length: int = len(iterable)

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -5,9 +5,11 @@ class Enum:
         self.name: str = name
 
     def __eq__(self, other: Enum) -> bool:  # noqa: F821
+        """Return True if both enum members share the same value."""
         return self.value == other.value
 
     def __ne__(self, other: Enum) -> bool:  # noqa: F821
+        """Return True if the enum members have different values."""
         return self.value != other.value
 
     def __hash__(self) -> int:

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -4,10 +4,10 @@ class Enum:
         self.value: int = value
         self.name: str = name
 
-    def __eq__(self, other: Enum) -> bool:
+    def __eq__(self, other: Enum) -> bool:  # noqa: F821
         return self.value == other.value
 
-    def __ne__(self, other: Enum) -> bool:
+    def __ne__(self, other: Enum) -> bool:  # noqa: F821
         return self.value != other.value
 
     def __hash__(self) -> int:

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -82,11 +82,11 @@ def comb(n: int, k: int) -> int:
 
 
 def isinf(x: float) -> bool:
-    return __ESBMC_isinf(x)
+    return __ESBMC_isinf(x)  # noqa: F821
 
 
 def isnan(x: float) -> bool:
-    return __ESBMC_isnan(x)
+    return __ESBMC_isnan(x)  # noqa: F821
 
 
 def floor(x: float) -> int:
@@ -131,7 +131,7 @@ def sin(x: float) -> float:
     Returns:
         Sine of x
     """
-    return __ESBMC_sin(x)
+    return __ESBMC_sin(x)  # noqa: F821
 
 
 def cos(x: float) -> float:
@@ -144,14 +144,14 @@ def cos(x: float) -> float:
     Returns:
         Cosine of x
     """
-    return __ESBMC_cos(x)
+    return __ESBMC_cos(x)  # noqa: F821
 
 
 def tan(x: float) -> float:
     """
     Calculate tangent of x (in radians)
     """
-    return __ESBMC_tan(x)
+    return __ESBMC_tan(x)  # noqa: F821
 
 
 def sqrt(x: float) -> float:
@@ -170,7 +170,7 @@ def sqrt(x: float) -> float:
     if x < 0:
         raise ValueError("math domain error")
 
-    return __ESBMC_sqrt(x)
+    return __ESBMC_sqrt(x)  # noqa: F821
 
 
 def exp(x: float) -> float:
@@ -183,7 +183,7 @@ def exp(x: float) -> float:
     Returns:
         e^x
     """
-    return __ESBMC_exp(x)
+    return __ESBMC_exp(x)  # noqa: F821
 
 
 def log(x: float) -> float:
@@ -201,7 +201,7 @@ def log(x: float) -> float:
     """
     if x <= 0:
         raise ValueError("math domain error")
-    return __ESBMC_log(x)
+    return __ESBMC_log(x)  # noqa: F821
 
 
 def factorial(n: int) -> int:
@@ -331,7 +331,7 @@ def asin(x: float) -> float:
     """
     if x < -1.0 or x > 1.0:
         raise ValueError("math domain error")
-    return __ESBMC_asin(x)
+    return __ESBMC_asin(x)  # noqa: F821
 
 
 def acos(x: float) -> float:
@@ -343,21 +343,21 @@ def acos(x: float) -> float:
     """
     if x < -1.0 or x > 1.0:
         raise ValueError("math domain error")
-    return __ESBMC_acos(x)
+    return __ESBMC_acos(x)  # noqa: F821
 
 
 def atan(x: float) -> float:
     """
     Calculate arctangent of x (in radians)
     """
-    return __ESBMC_atan(x)
+    return __ESBMC_atan(x)  # noqa: F821
 
 
 def atan2(y: float, x: float) -> float:
     """
     Calculate two-argument arctangent (in radians)
     """
-    return __ESBMC_atan2(y, x)
+    return __ESBMC_atan2(y, x)  # noqa: F821
 
 
 def log2(x: float) -> float:
@@ -369,7 +369,7 @@ def log2(x: float) -> float:
     """
     if x <= 0:
         raise ValueError("math domain error")
-    return __ESBMC_log2(x)
+    return __ESBMC_log2(x)  # noqa: F821
 
 
 def log10(x: float) -> float:
@@ -381,7 +381,7 @@ def log10(x: float) -> float:
     """
     if x <= 0:
         raise ValueError("math domain error")
-    return __ESBMC_log10(x)
+    return __ESBMC_log10(x)  # noqa: F821
 
 
 def asinh(x: float) -> float:
@@ -420,14 +420,14 @@ def pow(x: float, y: float) -> float:
     """
     Calculate x raised to the power of y
     """
-    return __ESBMC_pow(x, y)
+    return __ESBMC_pow(x, y)  # noqa: F821
 
 
 def fabs(x: float) -> float:
     """
     Calculate absolute value of x
     """
-    return __ESBMC_fabs(x)
+    return __ESBMC_fabs(x)  # noqa: F821
 
 
 def trunc(x: float) -> int:
@@ -441,35 +441,35 @@ def fmod(x: float, y: float) -> float:
     """
     Floating-point remainder of x / y
     """
-    return __ESBMC_fmod(x, y)
+    return __ESBMC_fmod(x, y)  # noqa: F821
 
 
 def copysign(x: float, y: float) -> float:
     """
     Return x with the sign of y
     """
-    return __ESBMC_copysign(x, y)
+    return __ESBMC_copysign(x, y)  # noqa: F821
 
 
 def sinh(x: float) -> float:
     """
     Calculate hyperbolic sine of x
     """
-    return __ESBMC_sinh(x)
+    return __ESBMC_sinh(x)  # noqa: F821
 
 
 def cosh(x: float) -> float:
     """
     Calculate hyperbolic cosine of x
     """
-    return __ESBMC_cosh(x)
+    return __ESBMC_cosh(x)  # noqa: F821
 
 
 def tanh(x: float) -> float:
     """
     Calculate hyperbolic tangent of x
     """
-    return __ESBMC_tanh(x)
+    return __ESBMC_tanh(x)  # noqa: F821
 
 
 def isfinite(x: float) -> bool:

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -81,9 +81,9 @@ def _nondet_size(max_size: int) -> int:
         A non-deterministic integer in [0, max_size].
 
     """
-    size: int = nondet_int()
-    __ESBMC_assume(size >= 0)
-    __ESBMC_assume(size <= max_size)
+    size: int = nondet_int()  # noqa: F821
+    __ESBMC_assume(size >= 0)  # noqa: F821
+    __ESBMC_assume(size <= max_size)  # noqa: F821
     return size
 
 
@@ -116,7 +116,7 @@ def nondet_list(max_size: int = _DEFAULT_NONDET_SIZE, elem_type: Any = None) -> 
     """
     # Default to nondet_int if no type specified
     if elem_type is None:
-        elem_type = nondet_int()
+        elem_type = nondet_int()  # noqa: F821
 
     result: list = []
     size: int = _nondet_size(max_size)
@@ -168,9 +168,9 @@ def nondet_dict(max_size: int = _DEFAULT_NONDET_SIZE,
     """
     # Default to nondet_int if no types specified
     if key_type is None:
-        key_type = nondet_int()
+        key_type = nondet_int()  # noqa: F821
     if value_type is None:
-        value_type = nondet_int()
+        value_type = nondet_int()  # noqa: F821
 
     result: dict = {}
     size: int = _nondet_size(max_size)

--- a/src/python-frontend/models/numpy.py
+++ b/src/python-frontend/models/numpy.py
@@ -4,7 +4,7 @@
 # Python programs, so they must match the built-in names exactly.
 
 # Stubs for type inference.
-def array(l: list[Any]) -> list[Any]:
+def array(l: list[Any]) -> list[Any]:  # noqa: F821
     return l
 
 

--- a/src/python-frontend/models/os.py
+++ b/src/python-frontend/models/os.py
@@ -12,24 +12,24 @@ def listdir(path: str) -> list[str]:
 
 def makedirs(path: str, exist_ok: bool = False) -> None:
     if not exist_ok:
-        dir_exists: bool = nondet_bool()
+        dir_exists: bool = nondet_bool()  # noqa: F821
         if dir_exists:
             raise FileExistsError("File exists")
 
 
 def remove(path: str) -> None:
-    file_exists: bool = nondet_bool()
+    file_exists: bool = nondet_bool()  # noqa: F821
     if not file_exists:
         raise FileNotFoundError("No such file or directory")
 
 
 def mkdir(path: str) -> None:
-    dir_not_exists: bool = nondet_bool()
+    dir_not_exists: bool = nondet_bool()  # noqa: F821
     if not dir_not_exists:
         raise FileExistsError("Directory already exists")
 
 
 def rmdir(path: str) -> None:
-    is_empty: bool = nondet_bool()
+    is_empty: bool = nondet_bool()  # noqa: F821
     if not is_empty:
         raise OSError("Directory not empty")

--- a/src/python-frontend/models/random.py
+++ b/src/python-frontend/models/random.py
@@ -3,23 +3,23 @@
 
 
 def randint(a: int, b: int) -> int:
-    value: int = nondet_int()
-    __ESBMC_assume(value >= a and value <= b)
+    value: int = nondet_int()  # noqa: F821
+    __ESBMC_assume(value >= a and value <= b)  # noqa: F821
     return value  # Ensures value is within [a, b]
 
 
 def random() -> float:
-    value: float = nondet_float()
-    __ESBMC_assume(value >= 0.0 and value < 1.0)
+    value: float = nondet_float()  # noqa: F821
+    __ESBMC_assume(value >= 0.0 and value < 1.0)  # noqa: F821
     return value  #  Returns a floating number [0,1.0).
 
 
 def uniform(a: float, b: float) -> float:
-    value: float = nondet_float()
+    value: float = nondet_float()  # noqa: F821
     if a <= b:
-        __ESBMC_assume(value >= a and value <= b)
+        __ESBMC_assume(value >= a and value <= b)  # noqa: F821
     else:
-        __ESBMC_assume(value >= b and value <= a)
+        __ESBMC_assume(value >= b and value <= a)  # noqa: F821
     return value
 
 
@@ -30,9 +30,9 @@ def getrandbits(k: int) -> int:
     if k == 0:
         return 0
 
-    value: int = nondet_int()
+    value: int = nondet_int()  # noqa: F821
     max_val: int = (1 << k) - 1  # 2**k - 1
-    __ESBMC_assume(value >= 0 and value <= max_val)
+    __ESBMC_assume(value >= 0 and value <= max_val)  # noqa: F821
     return value
 
 
@@ -62,7 +62,7 @@ def randrange(start: int, stop: int = None, step: int = 1) -> int:
         raise ValueError("empty range for randrange()")
 
     # Select random index
-    index: int = nondet_int()
-    __ESBMC_assume(index >= 0 and index < count)
+    index: int = nondet_int()  # noqa: F821
+    __ESBMC_assume(index >= 0 and index < count)  # noqa: F821
 
     return actual_start + (index * actual_step)

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -258,7 +258,7 @@ def match(pattern: str, string: str) -> bool:
         return True
 
     # Nondeterministic fallback
-    has_match: bool = __VERIFIER_nondet_bool()
+    has_match: bool = __VERIFIER_nondet_bool()  # noqa: F821
     return has_match
 
 
@@ -309,7 +309,7 @@ def search(pattern: str, string: str) -> bool:
         return False
 
     # For patterns with metacharacters, use nondeterministic behavior
-    has_match: bool = __VERIFIER_nondet_bool()
+    has_match: bool = __VERIFIER_nondet_bool()  # noqa: F821
     return has_match
 
 
@@ -373,5 +373,5 @@ def fullmatch(pattern: str, string: str) -> bool:
         return True
 
     # For patterns with metacharacters, use nondeterministic behavior
-    has_match: bool = __VERIFIER_nondet_bool()
+    has_match: bool = __VERIFIER_nondet_bool()  # noqa: F821
     return has_match


### PR DESCRIPTION
The shims under `src/python-frontend/models/` deliberately reference ESBMC built-ins (`__ESBMC_assume`, `__ESBMC_sin`, …) and nondet intrinsics (`nondet_bool`, `nondet_int`, …) that have no Python declaration — they are matched by name when ESBMC verifies Python programs. Pyflakes flags these as F821 (undefined name).

Add a trailing `# noqa: F821` per affected line so Codacy stops flagging these intentional references. Comments only — no behaviour change.