### PR TITLE
[python] disable Pyflakes F821 via .prospector.yaml

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,20 @@
+# Prospector configuration for ESBMC.
+#
+# Codacy runs Prospector, which in turn runs Pyflakes, pylint, pydocstyle,
+# and other Python linters.
+#
+# We disable Pyflakes F821 ("undefined name") globally because the
+# operational-model shims under src/python-frontend/models/ deliberately
+# reference ESBMC intrinsics (__ESBMC_assume, __ESBMC_sin, nondet_bool,
+# nondet_int, __VERIFIER_nondet_bool, ...) that have no Python binding:
+# they are matched by name by ESBMC's Python converter, not resolved at
+# Python runtime. Pyflakes does not honor `# noqa` markers, so per-line
+# suppression is not available.
+#
+# Pylint's E0602 (undefined-variable) still runs via Prospector and
+# catches genuine undefined-name bugs across the rest of the codebase,
+# so we do not lose meaningful coverage.
+
+pyflakes:
+  disable:
+    - F821

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -1,7 +1,9 @@
-# pylint: disable=redefined-builtin
-# These functions intentionally shadow Python built-ins: they are the
-# operational models ESBMC uses to verify Python programs, so they must
-# match the built-in names exactly.
+# pylint: disable=redefined-builtin,undefined-variable
+# These functions intentionally shadow Python built-ins and reference
+# typing forward-declarations (e.g. `Any`) and ESBMC intrinsics that
+# have no Python binding: they are the operational models ESBMC uses
+# to verify Python programs, so they must match the built-in names
+# exactly.
 # def abs(x:float) -> float:
 #     if x >= 0:
 #         return x

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -9,7 +9,7 @@
 #         return -x
 
 
-def all(iterable: list[Any]) -> bool:  # noqa: F821
+def all(iterable: list[Any]) -> bool:
     """Return True if all elements of the iterable are true (or if empty)."""
     i: int = 0
     length: int = len(iterable)

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -1,3 +1,7 @@
+# pylint: disable=undefined-variable
+# `Enum` self-references in method signatures are forward declarations
+# resolved by ESBMC's Python converter; they have no Python binding.
+
 class Enum:
 
     def __init__(self, value: int, name: str):

--- a/src/python-frontend/models/enum.py
+++ b/src/python-frontend/models/enum.py
@@ -4,11 +4,11 @@ class Enum:
         self.value: int = value
         self.name: str = name
 
-    def __eq__(self, other: Enum) -> bool:  # noqa: F821
+    def __eq__(self, other: Enum) -> bool:
         """Return True if both enum members share the same value."""
         return self.value == other.value
 
-    def __ne__(self, other: Enum) -> bool:  # noqa: F821
+    def __ne__(self, other: Enum) -> bool:
         """Return True if the enum members have different values."""
         return self.value != other.value
 

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -1,7 +1,8 @@
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,undefined-variable
 # Some functions in this module intentionally shadow Python built-ins
-# (e.g. `pow`): they are the operational models ESBMC uses to verify
-# Python programs, so they must match the built-in names exactly.
+# (e.g. `pow`) and call ESBMC intrinsics (e.g. `__ESBMC_sin`) that have
+# no Python binding: they are the operational models ESBMC uses to
+# verify Python programs, so they must match the built-in names exactly.
 def __ESBMC_expm1(x: float) -> float:
     ...
 

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -82,11 +82,11 @@ def comb(n: int, k: int) -> int:
 
 
 def isinf(x: float) -> bool:
-    return __ESBMC_isinf(x)  # noqa: F821
+    return __ESBMC_isinf(x)
 
 
 def isnan(x: float) -> bool:
-    return __ESBMC_isnan(x)  # noqa: F821
+    return __ESBMC_isnan(x)
 
 
 def floor(x: float) -> int:
@@ -131,7 +131,7 @@ def sin(x: float) -> float:
     Returns:
         Sine of x
     """
-    return __ESBMC_sin(x)  # noqa: F821
+    return __ESBMC_sin(x)
 
 
 def cos(x: float) -> float:
@@ -144,14 +144,14 @@ def cos(x: float) -> float:
     Returns:
         Cosine of x
     """
-    return __ESBMC_cos(x)  # noqa: F821
+    return __ESBMC_cos(x)
 
 
 def tan(x: float) -> float:
     """
     Calculate tangent of x (in radians)
     """
-    return __ESBMC_tan(x)  # noqa: F821
+    return __ESBMC_tan(x)
 
 
 def sqrt(x: float) -> float:
@@ -170,7 +170,7 @@ def sqrt(x: float) -> float:
     if x < 0:
         raise ValueError("math domain error")
 
-    return __ESBMC_sqrt(x)  # noqa: F821
+    return __ESBMC_sqrt(x)
 
 
 def exp(x: float) -> float:
@@ -183,7 +183,7 @@ def exp(x: float) -> float:
     Returns:
         e^x
     """
-    return __ESBMC_exp(x)  # noqa: F821
+    return __ESBMC_exp(x)
 
 
 def log(x: float) -> float:
@@ -201,7 +201,7 @@ def log(x: float) -> float:
     """
     if x <= 0:
         raise ValueError("math domain error")
-    return __ESBMC_log(x)  # noqa: F821
+    return __ESBMC_log(x)
 
 
 def factorial(n: int) -> int:
@@ -331,7 +331,7 @@ def asin(x: float) -> float:
     """
     if x < -1.0 or x > 1.0:
         raise ValueError("math domain error")
-    return __ESBMC_asin(x)  # noqa: F821
+    return __ESBMC_asin(x)
 
 
 def acos(x: float) -> float:
@@ -343,21 +343,21 @@ def acos(x: float) -> float:
     """
     if x < -1.0 or x > 1.0:
         raise ValueError("math domain error")
-    return __ESBMC_acos(x)  # noqa: F821
+    return __ESBMC_acos(x)
 
 
 def atan(x: float) -> float:
     """
     Calculate arctangent of x (in radians)
     """
-    return __ESBMC_atan(x)  # noqa: F821
+    return __ESBMC_atan(x)
 
 
 def atan2(y: float, x: float) -> float:
     """
     Calculate two-argument arctangent (in radians)
     """
-    return __ESBMC_atan2(y, x)  # noqa: F821
+    return __ESBMC_atan2(y, x)
 
 
 def log2(x: float) -> float:
@@ -369,7 +369,7 @@ def log2(x: float) -> float:
     """
     if x <= 0:
         raise ValueError("math domain error")
-    return __ESBMC_log2(x)  # noqa: F821
+    return __ESBMC_log2(x)
 
 
 def log10(x: float) -> float:
@@ -381,7 +381,7 @@ def log10(x: float) -> float:
     """
     if x <= 0:
         raise ValueError("math domain error")
-    return __ESBMC_log10(x)  # noqa: F821
+    return __ESBMC_log10(x)
 
 
 def asinh(x: float) -> float:
@@ -420,14 +420,14 @@ def pow(x: float, y: float) -> float:
     """
     Calculate x raised to the power of y
     """
-    return __ESBMC_pow(x, y)  # noqa: F821
+    return __ESBMC_pow(x, y)
 
 
 def fabs(x: float) -> float:
     """
     Calculate absolute value of x
     """
-    return __ESBMC_fabs(x)  # noqa: F821
+    return __ESBMC_fabs(x)
 
 
 def trunc(x: float) -> int:
@@ -441,35 +441,35 @@ def fmod(x: float, y: float) -> float:
     """
     Floating-point remainder of x / y
     """
-    return __ESBMC_fmod(x, y)  # noqa: F821
+    return __ESBMC_fmod(x, y)
 
 
 def copysign(x: float, y: float) -> float:
     """
     Return x with the sign of y
     """
-    return __ESBMC_copysign(x, y)  # noqa: F821
+    return __ESBMC_copysign(x, y)
 
 
 def sinh(x: float) -> float:
     """
     Calculate hyperbolic sine of x
     """
-    return __ESBMC_sinh(x)  # noqa: F821
+    return __ESBMC_sinh(x)
 
 
 def cosh(x: float) -> float:
     """
     Calculate hyperbolic cosine of x
     """
-    return __ESBMC_cosh(x)  # noqa: F821
+    return __ESBMC_cosh(x)
 
 
 def tanh(x: float) -> float:
     """
     Calculate hyperbolic tangent of x
     """
-    return __ESBMC_tanh(x)  # noqa: F821
+    return __ESBMC_tanh(x)
 
 
 def isfinite(x: float) -> bool:

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -81,9 +81,9 @@ def _nondet_size(max_size: int) -> int:
         A non-deterministic integer in [0, max_size].
 
     """
-    size: int = nondet_int()  # noqa: F821
-    __ESBMC_assume(size >= 0)  # noqa: F821
-    __ESBMC_assume(size <= max_size)  # noqa: F821
+    size: int = nondet_int()
+    __ESBMC_assume(size >= 0)
+    __ESBMC_assume(size <= max_size)
     return size
 
 
@@ -116,7 +116,7 @@ def nondet_list(max_size: int = _DEFAULT_NONDET_SIZE, elem_type: Any = None) -> 
     """
     # Default to nondet_int if no type specified
     if elem_type is None:
-        elem_type = nondet_int()  # noqa: F821
+        elem_type = nondet_int()
 
     result: list = []
     size: int = _nondet_size(max_size)
@@ -168,9 +168,9 @@ def nondet_dict(max_size: int = _DEFAULT_NONDET_SIZE,
     """
     # Default to nondet_int if no types specified
     if key_type is None:
-        key_type = nondet_int()  # noqa: F821
+        key_type = nondet_int()
     if value_type is None:
-        value_type = nondet_int()  # noqa: F821
+        value_type = nondet_int()
 
     result: dict = {}
     size: int = _nondet_size(max_size)

--- a/src/python-frontend/models/nondet.py
+++ b/src/python-frontend/models/nondet.py
@@ -62,6 +62,11 @@ USAGE:
     d = nondet_dict(max_size=10, key_type=nondet_int(), value_type=nondet_bool())
 """
 
+# pylint: disable=undefined-variable
+# `nondet_int`, `nondet_bool`, `__ESBMC_assume`, etc. are ESBMC
+# intrinsics matched by name by the Python converter; they have no
+# Python binding.
+
 from typing import Any
 
 # Shared default maximum size for nondet collections

--- a/src/python-frontend/models/numpy.py
+++ b/src/python-frontend/models/numpy.py
@@ -4,7 +4,7 @@
 # Python programs, so they must match the built-in names exactly.
 
 # Stubs for type inference.
-def array(l: list[Any]) -> list[Any]:  # noqa: F821
+def array(l: list[Any]) -> list[Any]:
     return l
 
 

--- a/src/python-frontend/models/numpy.py
+++ b/src/python-frontend/models/numpy.py
@@ -1,21 +1,23 @@
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,undefined-variable
 # Some functions in this module intentionally shadow Python built-ins
-# (e.g. `round`): they are the operational models ESBMC uses to verify
-# Python programs, so they must match the built-in names exactly.
+# (e.g. `round`) and reference typing forward-declarations (e.g. `Any`)
+# that have no Python binding: they are the operational models ESBMC
+# uses to verify Python programs, so they must match the built-in names
+# exactly.
 
 # Stubs for type inference.
-def array(l: list[Any]) -> list[Any]:
-    return l
+def array(data: list[Any]) -> list[Any]:
+    return data
 
 
 def zeros(shape: int) -> list[float]:
-    l: list[float] = [0.0]
-    return l
+    result: list[float] = [0.0]
+    return result
 
 
 def ones(shape: int) -> list[float]:
-    l: list[float] = [1.0]
-    return l
+    result: list[float] = [1.0]
+    return result
 
 
 def add(a: int, b: int) -> float:

--- a/src/python-frontend/models/os.py
+++ b/src/python-frontend/models/os.py
@@ -12,24 +12,24 @@ def listdir(path: str) -> list[str]:
 
 def makedirs(path: str, exist_ok: bool = False) -> None:
     if not exist_ok:
-        dir_exists: bool = nondet_bool()  # noqa: F821
+        dir_exists: bool = nondet_bool()
         if dir_exists:
             raise FileExistsError("File exists")
 
 
 def remove(path: str) -> None:
-    file_exists: bool = nondet_bool()  # noqa: F821
+    file_exists: bool = nondet_bool()
     if not file_exists:
         raise FileNotFoundError("No such file or directory")
 
 
 def mkdir(path: str) -> None:
-    dir_not_exists: bool = nondet_bool()  # noqa: F821
+    dir_not_exists: bool = nondet_bool()
     if not dir_not_exists:
         raise FileExistsError("Directory already exists")
 
 
 def rmdir(path: str) -> None:
-    is_empty: bool = nondet_bool()  # noqa: F821
+    is_empty: bool = nondet_bool()
     if not is_empty:
         raise OSError("Directory not empty")

--- a/src/python-frontend/models/os.py
+++ b/src/python-frontend/models/os.py
@@ -1,3 +1,7 @@
+# pylint: disable=undefined-variable
+# `nondet_bool` is an ESBMC intrinsic matched by name by the Python
+# converter; it has no Python binding.
+
 # Stubs for os module - operating system interfaces
 
 

--- a/src/python-frontend/models/random.py
+++ b/src/python-frontend/models/random.py
@@ -1,3 +1,11 @@
+# pylint: disable=undefined-variable,chained-comparison
+# `nondet_int`, `nondet_float`, and `__ESBMC_assume` are ESBMC
+# intrinsics matched by name by the Python converter; they have no
+# Python binding. Chained comparisons are intentionally written in
+# the `a >= x and a <= y` form because they are arguments to
+# `__ESBMC_assume` and we keep them in the same shape as the
+# corresponding C operational models.
+
 # Stubs for random module.
 # See https://docs.python.org/3/library/random.html
 

--- a/src/python-frontend/models/random.py
+++ b/src/python-frontend/models/random.py
@@ -3,23 +3,23 @@
 
 
 def randint(a: int, b: int) -> int:
-    value: int = nondet_int()  # noqa: F821
-    __ESBMC_assume(value >= a and value <= b)  # noqa: F821
+    value: int = nondet_int()
+    __ESBMC_assume(value >= a and value <= b)
     return value  # Ensures value is within [a, b]
 
 
 def random() -> float:
-    value: float = nondet_float()  # noqa: F821
-    __ESBMC_assume(value >= 0.0 and value < 1.0)  # noqa: F821
+    value: float = nondet_float()
+    __ESBMC_assume(value >= 0.0 and value < 1.0)
     return value  #  Returns a floating number [0,1.0).
 
 
 def uniform(a: float, b: float) -> float:
-    value: float = nondet_float()  # noqa: F821
+    value: float = nondet_float()
     if a <= b:
-        __ESBMC_assume(value >= a and value <= b)  # noqa: F821
+        __ESBMC_assume(value >= a and value <= b)
     else:
-        __ESBMC_assume(value >= b and value <= a)  # noqa: F821
+        __ESBMC_assume(value >= b and value <= a)
     return value
 
 
@@ -30,9 +30,9 @@ def getrandbits(k: int) -> int:
     if k == 0:
         return 0
 
-    value: int = nondet_int()  # noqa: F821
+    value: int = nondet_int()
     max_val: int = (1 << k) - 1  # 2**k - 1
-    __ESBMC_assume(value >= 0 and value <= max_val)  # noqa: F821
+    __ESBMC_assume(value >= 0 and value <= max_val)
     return value
 
 
@@ -62,7 +62,7 @@ def randrange(start: int, stop: int = None, step: int = 1) -> int:
         raise ValueError("empty range for randrange()")
 
     # Select random index
-    index: int = nondet_int()  # noqa: F821
-    __ESBMC_assume(index >= 0 and index < count)  # noqa: F821
+    index: int = nondet_int()
+    __ESBMC_assume(index >= 0 and index < count)
 
     return actual_start + (index * actual_step)

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -258,7 +258,7 @@ def match(pattern: str, string: str) -> bool:
         return True
 
     # Nondeterministic fallback
-    has_match: bool = __VERIFIER_nondet_bool()  # noqa: F821
+    has_match: bool = __VERIFIER_nondet_bool()
     return has_match
 
 
@@ -309,7 +309,7 @@ def search(pattern: str, string: str) -> bool:
         return False
 
     # For patterns with metacharacters, use nondeterministic behavior
-    has_match: bool = __VERIFIER_nondet_bool()  # noqa: F821
+    has_match: bool = __VERIFIER_nondet_bool()
     return has_match
 
 
@@ -373,5 +373,5 @@ def fullmatch(pattern: str, string: str) -> bool:
         return True
 
     # For patterns with metacharacters, use nondeterministic behavior
-    has_match: bool = __VERIFIER_nondet_bool()  # noqa: F821
+    has_match: bool = __VERIFIER_nondet_bool()
     return has_match

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -1,3 +1,7 @@
+# pylint: disable=undefined-variable
+# `__VERIFIER_nondet_bool` is an ESBMC intrinsic matched by name by
+# the Python converter; it has no Python binding.
+
 # Regular Expression Operational Model
 # TODO: Currently, the regex model uses manual pattern recognizers with
 # nondeterministic fallbacks. A proper string solver would handle


### PR DESCRIPTION
Codacy's Prospector then Pyflakes does not honor `# noqa` markers (a flake8-only convention), so the per-line suppressions added in #4256 had no effect. This adds a repo-level `.prospector.yaml` that disables F821 globally and strips the now-dead markers from the operational-model files. Pylint's E0602 (undefined-variable) still runs via Prospector, so genuine undefined-name bugs are still caught.
