### PR TITLE
[refactor] use prefix increment on iterator loop variables

### DIFF
--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -377,7 +377,7 @@ void goto_programt::compute_target_numbers()
 
   for (instructionst::const_iterator it = instructions.begin();
        it != instructions.end();
-       it++)
+       ++it)
   {
     for (auto t : it->targets)
     {

--- a/src/goto-symex/slice.cpp
+++ b/src/goto-symex/slice.cpp
@@ -238,7 +238,7 @@ bool claim_slicer::run(symex_target_equationt::SSA_stepst &steps)
   size_t counter = 1;
   for (symex_target_equationt::SSA_stepst::iterator it = steps.begin();
        it != steps.end();
-       it++)
+       ++it)
   {
     // just find the next assertion
     if (it->is_assert())

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1260,7 +1260,7 @@ void value_sett::do_free(const expr2tc &op)
 
     for (object_mapt::const_iterator o_it = value.second.object_map.begin();
          o_it != value.second.object_map.end();
-         o_it++)
+         ++o_it)
     {
       const expr2tc &object = object_numbering[o_it->first];
 


### PR DESCRIPTION
Codacy MEDIUM Performance findings: postfix `++` on non-primitive iterator types incurs an unnecessary copy. Switch the three flagged loops to prefix `++`:

- `src/pointer-analysis/value_set.cpp:1263`
- `src/goto-programs/goto_program.cpp:380`
- `src/goto-symex/slice.cpp:241`