### PR TITLE
[python] fix two use-before-assignment bugs flagged by pylint

### DIFF
--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -10,9 +10,10 @@ class int:
         index: int = 0
         step: int = 1
         byte: int = 0
+        is_negative: bool = False
 
         ## If little endian
-        if big_endian == False:
+        if not big_endian:
             index: int = len(bytes_data) - 1
             step: int = -1
 

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -214,8 +214,9 @@ def process_imports(node, output_dir):
         The directory to save the generated JSON files.
 
     """
+    imported_elements = None
+    module_names = []
     if isinstance(node, (ast.Import)):
-        module_names = []
         for alias_node in node.names:
             module_name = alias_node.name
             alias = alias_node.asname or module_name
@@ -223,13 +224,10 @@ def process_imports(node, output_dir):
             module_names.append(module_name)
         if not module_names:
             return
-        imported_elements = None
     elif isinstance(node, ast.ImportFrom):
         module_name = node.module
-        # If it's a star import, set the list to None to import everything
-        if any(a.name == '*' for a in node.names):
-            imported_elements = None
-        else:
+        # If it's a star import, leave imported_elements as None to import everything
+        if not any(a.name == '*' for a in node.names):
             imported_elements = node.names
         if module_name:
             import_aliases[module_name] = module_name


### PR DESCRIPTION
Fix two genuine use-before-assignment defects surfaced by Codacy/Prospector.
`int.from_bytes` referenced `is_negative` only on the signed path but never
initialized it; `process_imports` referenced `imported_elements` and
`module_names` after an if/elif chain that didn't cover all node types.
Also replaces `big_endian == False` with `not big_endian` (singleton-comparison).
