### PR TITLE
[python] tighten chained comparison in int.from_bytes loop

### DIFF
--- a/src/python-frontend/models/int.py
+++ b/src/python-frontend/models/int.py
@@ -18,7 +18,7 @@ class int:
 
         bytes_len: int = len(bytes_data)
 
-        while index >= 0 and index < bytes_len:
+        while 0 <= index < bytes_len:
             byte: int = bytes_data[index]
             result: int = (result << 8) + byte
             index: int = index + step


### PR DESCRIPTION
Rewrite the `int.from_bytes` while-loop guard as a chained comparison
to clear pylint's chained-comparison warning. The two forms differ in
AST (BoolOp(And) vs a single multi-op Compare); the int_from_bytes
regression continues to pass, confirming ESBMC's Python converter
handles the chained form correctly.
