### PR TITLE
[python] suppress pylint rules unsafe to rewrite in operational models

### DIFF
--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -4,6 +4,11 @@
 # have no Python binding: they are the operational models ESBMC uses
 # to verify Python programs, so they must match the built-in names
 # exactly.
+#
+# pylint: disable=consider-using-max-builtin,consider-using-min-builtin
+# This module is itself the source of max() / min() for the verification
+# model. Rewriting the explicit branch forms here as max()/min() would
+# create a self-reference: the model would call into itself.
 # def abs(x:float) -> float:
 #     if x >= 0:
 #         return x

--- a/src/python-frontend/models/cmath.py
+++ b/src/python-frontend/models/cmath.py
@@ -1,3 +1,17 @@
+# pylint: disable=invalid-unary-operand-type
+# Pylint infers None for math.acosh / math.asinh because their underlying
+# __ESBMC_* stubs in math.py have abstract `...` bodies. ESBMC intercepts
+# those calls and replaces them with symbolic floats; the unary-minus
+# operations below are sound under verification.
+#
+# pylint: disable=consider-using-max-builtin,consider-using-min-builtin
+# These branch-form bound clamps are NOT rewritten to max()/min(): doing
+# so would chain into builtins.py's own max/min model, widening the
+# trusted base of every cmath function for zero verification benefit.
+#
+# pylint: disable=consider-using-in,chained-comparison
+# Equality / range checks are kept as explicit Compare-And-Compare
+# AST nodes; the converter has direct, audited support for those forms.
 import math
 
 pi: float = math.pi

--- a/src/python-frontend/models/collections.py
+++ b/src/python-frontend/models/collections.py
@@ -1,5 +1,13 @@
 # Operational model for collections module
 # pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
+# pylint: disable=keyword-arg-before-vararg,unused-argument
+# defaultdict's signature is pinned: callers in regression/python/
+# (e.g. github_3841_*) pass `default_factory` positionally as in
+# `defaultdict(int)`, so it must come first; and the no-arg form
+# `defaultdict()` is recognised by preprocessor.py:_get_defaultdict_factory,
+# so the default value cannot be removed. *args / **kwargs are part of
+# the API contract; the body silently ignores them by design (see the
+# docstring below for the verification approximation).
 
 from typing import Any, Optional
 

--- a/src/python-frontend/models/consensus.py
+++ b/src/python-frontend/models/consensus.py
@@ -1,7 +1,9 @@
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,unused-argument
 # `hash` here intentionally shadows the Python built-in: it is the
 # operational model ESBMC uses to verify Python programs, so it must
-# match the built-in name exactly.
+# match the built-in name exactly. Argument names on the abstract stub
+# are part of the API contract matched by ESBMC's Python converter,
+# even when the body does not reference them.
 
 # Stubs used for consensus specification verification
 

--- a/src/python-frontend/models/dataclasses.py
+++ b/src/python-frontend/models/dataclasses.py
@@ -1,3 +1,9 @@
+# pylint: disable=unused-argument
+# Operational-model stubs: argument names are part of the API contract
+# matched by ESBMC's Python converter, even when the body does not
+# reference them.
+
+
 class Field:
 
     def __class_getitem__(cls, item):

--- a/src/python-frontend/models/esbmc.py
+++ b/src/python-frontend/models/esbmc.py
@@ -1,3 +1,8 @@
+# pylint: disable=unused-argument,unnecessary-pass
+# These intrinsic stubs are intercepted by ESBMC's Python converter and
+# replaced with symbolic operations. Argument names are part of the API
+# contract; the `pass` body is required so the converter sees a parsed
+# function definition.
 """
 ESBMC Python intrinsic stubs.
 

--- a/src/python-frontend/models/heapq.py
+++ b/src/python-frontend/models/heapq.py
@@ -1,3 +1,12 @@
+# pylint: disable=unused-argument,useless-return,unidiomatic-typecheck
+# Operational-model stubs for heapq. Argument names on heapify (whose
+# body is intentionally abstract) are part of the API contract matched
+# by ESBMC's converter. The explicit `return None` keeps the function's
+# return-type analysis aligned with the `-> None` annotation. The
+# `type(item) is tuple` test is intentional: in a closed-world FV model
+# the strict identity check is more correct than isinstance(), which
+# would also accept tuple subclasses with potentially different
+# semantics under verification.
 from typing import Any
 
 

--- a/src/python-frontend/models/math.py
+++ b/src/python-frontend/models/math.py
@@ -3,6 +3,19 @@
 # (e.g. `pow`) and call ESBMC intrinsics (e.g. `__ESBMC_sin`) that have
 # no Python binding: they are the operational models ESBMC uses to
 # verify Python programs, so they must match the built-in names exactly.
+#
+# pylint: disable=unused-argument
+# Argument names on the abstract __ESBMC_* stubs are part of the API
+# contract matched by ESBMC's converter; the bodies are intentionally
+# `...` and ESBMC supplies the semantics.
+#
+# pylint: disable=consider-using-max-builtin,consider-using-min-builtin,consider-using-in,no-else-return,chained-comparison
+# Branch and comparison shapes in the math model are pinned to the
+# converter's audited support for Compare-And-Compare and explicit
+# if/else forms. Rewriting them as max()/min() / `x in (a, b)` /
+# multi-op Compare would either chain into builtins.py's own max/min
+# model (widening the trusted base) or swap an audited AST shape for
+# one whose semantics the converter would need to re-validate.
 def __ESBMC_expm1(x: float) -> float:
     ...
 

--- a/src/python-frontend/models/numpy.py
+++ b/src/python-frontend/models/numpy.py
@@ -6,6 +6,7 @@
 # exactly. Argument names are part of the API contract matched by ESBMC's
 # Python converter, even when the abstract body does not reference them.
 
+
 # Stubs for type inference.
 def array(data: list[Any]) -> list[Any]:
     return data

--- a/src/python-frontend/models/numpy.py
+++ b/src/python-frontend/models/numpy.py
@@ -1,9 +1,10 @@
-# pylint: disable=redefined-builtin,undefined-variable
+# pylint: disable=redefined-builtin,undefined-variable,unused-argument
 # Some functions in this module intentionally shadow Python built-ins
 # (e.g. `round`) and reference typing forward-declarations (e.g. `Any`)
 # that have no Python binding: they are the operational models ESBMC
 # uses to verify Python programs, so they must match the built-in names
-# exactly.
+# exactly. Argument names are part of the API contract matched by ESBMC's
+# Python converter, even when the abstract body does not reference them.
 
 # Stubs for type inference.
 def array(data: list[Any]) -> list[Any]:

--- a/src/python-frontend/models/numpy/linalg.py
+++ b/src/python-frontend/models/numpy/linalg.py
@@ -1,2 +1,6 @@
+# pylint: disable=unused-argument
+# Operational-model stubs: argument names are part of the API contract
+# matched by ESBMC's Python converter, even when the abstract body does
+# not reference them.
 def det(a: float, b: float) -> float:
     return 2.0

--- a/src/python-frontend/models/os.py
+++ b/src/python-frontend/models/os.py
@@ -1,6 +1,8 @@
-# pylint: disable=undefined-variable
+# pylint: disable=undefined-variable,unused-argument
 # `nondet_bool` is an ESBMC intrinsic matched by name by the Python
-# converter; it has no Python binding.
+# converter; it has no Python binding. Argument names on the abstract
+# stubs below are part of the API contract matched by ESBMC's Python
+# converter, even when the body does not reference them.
 
 # Stubs for os module - operating system interfaces
 

--- a/src/python-frontend/models/os/path.py
+++ b/src/python-frontend/models/os/path.py
@@ -1,3 +1,8 @@
+# pylint: disable=unused-argument
+# Operational-model stubs: argument names are part of the API contract
+# matched by ESBMC's Python converter, even when the body does not
+# reference them.
+
 # Stubs for os.path module
 
 

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -1,6 +1,19 @@
 # pylint: disable=undefined-variable
 # `__VERIFIER_nondet_bool` is an ESBMC intrinsic matched by name by
 # the Python converter; it has no Python binding.
+#
+# pylint: disable=too-many-locals,too-many-branches,too-many-boolean-expressions,line-too-long
+# This module hosts a hand-rolled regex matcher whose control-flow shape
+# is matched to the converter's audited support for Compare/BoolOp nodes.
+# Pylint's complexity thresholds (max-locals=15, max-branches=15,
+# max-bool-expr=5) are tripped by the literal-set tests below; mechanical
+# refactors (extract helper, split function) would require re-validating
+# every regression in regression/python/ that exercises re.match. The
+# matcher is rewritten only when changed for a real reason.
+#
+# pylint: disable=consider-using-in,chained-comparison
+# Equality and range checks are kept as explicit Compare-And-Compare AST
+# nodes; the converter has direct, audited support for those forms.
 
 # Regular Expression Operational Model
 # TODO: Currently, the regex model uses manual pattern recognizers with

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -1,4 +1,8 @@
-# pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
+# pylint: disable=function-redefined,unused-argument
+# Operational-model stubs: stdlib shadows for ESBMC models. Argument
+# names on `__class_getitem__` and `TypeVar` are part of the API contract
+# matched by ESBMC's Python converter, even when the abstract body does
+# not reference them.
 def TypeVar(name, *args, **kwargs) -> type:
     return object
 

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -1,3 +1,13 @@
+# pylint: disable=wrong-import-position
+# Imports below the PY3 check are intentional: the check is a hard fail
+# under Python 2 and must run before the Python-3-only imports (ast,
+# importlib.util, etc.) to produce a clean error message instead of an
+# ImportError stack trace.
+#
+# pylint: disable=c-extension-no-member
+# `mypy.api.run` is a real (typed) entry point; pylint only flags it
+# because mypy ships as a compiled extension and is not always installed
+# in the lint environment.
 from __future__ import annotations
 
 import sys
@@ -24,7 +34,7 @@ from preprocessor import Preprocessor
 def run_mypy_strict(filename):
     """Run mypy in-process when available; skip otherwise."""
     try:
-        from mypy import api as mypy_api
+        from mypy import api as mypy_api  # pylint: disable=import-outside-toplevel
     except ImportError:
         return 0, ""
 
@@ -202,6 +212,7 @@ import_aliases = {}
 module_imports = {}
 
 
+# pylint: disable-next=too-many-locals,too-many-branches
 def process_imports(node, output_dir):
     """
     Process import statements in the AST node.
@@ -439,6 +450,7 @@ def rewrite_relative_import(node, parent_module: str | None):
     node.level = 0
 
 
+# pylint: disable-next=too-many-locals,too-many-branches
 def generate_ast_json(tree, python_filename, elements_to_import, output_dir, module_qualname=None):
     """
     Generate AST JSON from the given Python AST tree.
@@ -524,6 +536,7 @@ def generate_ast_json(tree, python_filename, elements_to_import, output_dir, mod
         print("Error writing JSON file: {}".format(e))
 
 
+# pylint: disable-next=too-many-locals,too-many-nested-blocks
 def detect_and_process_submodules(node, processed_submodules, output_dir):
     """
     Detect submodule usage in the AST and process each unseen submodule.


### PR DESCRIPTION
Suppress pylint rules whose recommended fixes would either widen
ESBMC's trusted base, create self-references inside the verification
model, or break load-bearing API contracts on Python operational-model
stubs. Each disable is co-located with the code it covers and carries
the rationale; the prospector global config is left untouched so non-
model code still gets the full rule set.

Five logical groups, one commit each:
- numpy / os / esbmc / dataclasses / consensus / typing — unused-argument
  on stub signatures matched by the converter.
- cmath — invalid-unary-operand-type from `__ESBMC_*` `...` bodies, plus
  consider-using-max/min-builtin / consider-using-in / chained-comparison
  whose rewrites would chain into builtins.py's max/min model.
- re — too-many-{locals,branches,boolean-expressions} / line-too-long /
  consider-using-in on the hand-rolled regex matcher.
- heapq / builtins / math / collections — unidiomatic-typecheck (strict
  identity is more correct under FV), self-referential max/min rewrites
  in builtins, defaultdict signature pinned by callers and preprocessor.
- parser.py — wrong-import-position, lazy mypy import, c-extension-no-
  member, complexity thresholds tripped by 1–2.

Python regression suite passes (3 Boolector-gated tests excluded; they
were already failing on master because this build does not link
boolector).
