### PR TITLE
[goto-programs] use prefix increment for const_iterator in copy_from

### DIFF
--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -405,7 +405,7 @@ void goto_programt::copy_from(const goto_programt &src)
 
   for (instructionst::const_iterator it = src.instructions.begin();
        it != src.instructions.end();
-       it++)
+       ++it)
   {
     targett new_instruction = add_instruction();
     targets_mapping[it] = new_instruction;


### PR DESCRIPTION
Codacy flagged the postfix `it++` on `instructionst::const_iterator` in `goto_programt::copy_from` (`src/goto-programs/goto_program.cpp:408`) as a MEDIUM Performance issue. Switch to `++it` to avoid constructing a discarded iterator copy each iteration; behavior is unchanged.