### PR TITLE
[python] fix PEP8 E275/E501 in transform.py and models/re.py

### DIFF
--- a/src/clang-c-frontend/headers/transform.py
+++ b/src/clang-c-frontend/headers/transform.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     print('extern "C"\n{\n')
     for filename in files:
         name, ext = os.path.splitext(filename)
-        assert(len(ext) == 2)
+        assert len(ext) == 2
 
         name_ = name.replace('-', '_')
         print("extern char " + name_ + "_buf[];")
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     print('struct hooked_header clang_headers[] = {')
     for filename in files:
         name, ext = os.path.splitext(filename)
-        assert(len(ext) == 2)
+        assert len(ext) == 2
 
         name_ = name.replace('-', '_')
         print(f'{{"{filename}", {name_}_buf, &{name_}_buf_size}},')

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -236,7 +236,9 @@ def match(pattern: str, string: str) -> bool:
             i: int = 0
             while i < prefix_len:
                 c: str = pattern[i]
-                if c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '(' or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\':
+                if (c == '.' or c == '*' or c == '+' or c == '?'
+                        or c == '[' or c == ']' or c == '(' or c == ')'
+                        or c == '|' or c == '^' or c == '$' or c == '\\'):
                     has_meta_in_prefix = True
                     break
                 i = i + 1
@@ -256,7 +258,9 @@ def match(pattern: str, string: str) -> bool:
     k: int = 0
     while k < pattern_len - 1:
         ch: str = pattern[k]
-        if ch == '.' or ch == '*' or ch == '+' or ch == '?' or ch == '[' or ch == ']' or ch == '(' or ch == ')' or ch == '|' or ch == '^' or ch == '$' or ch == '\\':
+        if (ch == '.' or ch == '*' or ch == '+' or ch == '?'
+                or ch == '[' or ch == ']' or ch == '(' or ch == ')'
+                or ch == '|' or ch == '^' or ch == '$' or ch == '\\'):
             has_meta = True
             break
         k = k + 1

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -236,9 +236,8 @@ def match(pattern: str, string: str) -> bool:
             i: int = 0
             while i < prefix_len:
                 c: str = pattern[i]
-                if (c == '.' or c == '*' or c == '+' or c == '?'
-                        or c == '[' or c == ']' or c == '(' or c == ')'
-                        or c == '|' or c == '^' or c == '$' or c == '\\'):
+                if (c == '.' or c == '*' or c == '+' or c == '?' or c == '[' or c == ']' or c == '('
+                        or c == ')' or c == '|' or c == '^' or c == '$' or c == '\\'):
                     has_meta_in_prefix = True
                     break
                 i = i + 1
@@ -258,9 +257,8 @@ def match(pattern: str, string: str) -> bool:
     k: int = 0
     while k < pattern_len - 1:
         ch: str = pattern[k]
-        if (ch == '.' or ch == '*' or ch == '+' or ch == '?'
-                or ch == '[' or ch == ']' or ch == '(' or ch == ')'
-                or ch == '|' or ch == '^' or ch == '$' or ch == '\\'):
+        if (ch == '.' or ch == '*' or ch == '+' or ch == '?' or ch == '[' or ch == ']' or ch == '('
+                or ch == ')' or ch == '|' or ch == '^' or ch == '$' or ch == '\\'):
             has_meta = True
             break
         k = k + 1


### PR DESCRIPTION
Drop parentheses around `assert` in clang headers `transform.py` (E275), and wrap two long metacharacter `or`-chains in `re.py` across three lines each (E501, max 159 cols). Semantics-preserving in both files; all applicable `re`-related Python regression tests pass locally.