### PR TITLE
[cpp] add std::chrono::duration::max/min/zero static members

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4264_chrono_max_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4264_chrono_max_fail/main.cpp
@@ -1,0 +1,11 @@
+// github.com/esbmc/esbmc/issues/4264 — Usecs::max() must NOT be zero.
+#include <chrono>
+#include <cstdint>
+#include <cassert>
+
+int main()
+{
+  using Usecs = std::chrono::duration<int64_t, std::micro>;
+  assert(Usecs::max().count() == 0); // false — should be LLONG_MAX
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4264_chrono_max_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4264_chrono_max_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --std c++20
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4264_chrono_max_pass/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4264_chrono_max_pass/main.cpp
@@ -1,0 +1,24 @@
+// github.com/esbmc/esbmc/issues/4264 — duration::max/min/zero static members.
+#include <chrono>
+#include <cstdint>
+#include <climits>
+#include <cassert>
+
+using Usecs = std::chrono::duration<int64_t, std::micro>;
+
+static int64_t take(Usecs t = Usecs::max())
+{
+  return t.count();
+}
+
+int main()
+{
+  assert(Usecs::max().count() == LLONG_MAX);
+  assert(Usecs::min().count() == LLONG_MIN);
+  assert(Usecs::zero().count() == 0);
+
+  // Default-argument site — the original failure mode in #4264.
+  assert(take() == LLONG_MAX);
+  assert(take(Usecs(42)) == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4264_chrono_max_pass/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4264_chrono_max_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 2 --std c++20
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/chrono
+++ b/src/cpp/library/chrono
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cstdint"
+#include "limits"
 
 namespace std
 {
@@ -20,6 +21,22 @@ using milli = ratio<1, 1000>;
 namespace chrono
 {
 
+template <class Rep>
+struct duration_values
+{
+  static constexpr Rep zero() noexcept { return Rep(0); }
+  // lowest(), not min(), per [time.traits.duration_values]: for floating-point
+  // Rep, std::numeric_limits<Rep>::min() is the smallest positive value.
+  static constexpr Rep min() noexcept
+  {
+    return std::numeric_limits<Rep>::lowest();
+  }
+  static constexpr Rep max() noexcept
+  {
+    return std::numeric_limits<Rep>::max();
+  }
+};
+
 template <class Rep, class Period = std::ratio<1>>
 class duration
 {
@@ -37,6 +54,19 @@ public:
   constexpr Rep count() const noexcept
   {
     return rep_;
+  }
+
+  static constexpr duration zero() noexcept
+  {
+    return duration(duration_values<Rep>::zero());
+  }
+  static constexpr duration min() noexcept
+  {
+    return duration(duration_values<Rep>::min());
+  }
+  static constexpr duration max() noexcept
+  {
+    return duration(duration_values<Rep>::max());
   }
 };
 


### PR DESCRIPTION
The bundled `<chrono>` shim was missing the [time.duration.special] static members, so any TU calling e.g. `Usecs::max()` (commonly used as a default timeout sentinel) failed to compile in the C++ frontend.

Adds `duration_values<Rep>` and the matching `static constexpr duration zero/min/max() noexcept` members, delegating to the bundled `std::numeric_limits<Rep>`. Two regression tests under `regression/esbmc-cpp20/cpp/github_4264_chrono_max_{pass,fail}/` cover the issue reproducer and confirm the members return real extremes.

Fixes #4264