### PR TITLE
[cpp] add std::clamp to bundled <algorithm>

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4251/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4251/main.cpp
@@ -1,0 +1,17 @@
+// Reproducer for https://github.com/esbmc/esbmc/issues/4251
+// std::clamp must be available from the bundled <algorithm> header.
+#include <algorithm>
+#include <cstdint>
+
+int32_t clamp_example(int32_t v)
+{
+  return std::clamp(v, int32_t{0}, int32_t{100});
+}
+
+int main()
+{
+  __ESBMC_assert(clamp_example(150) == 100, "clamp hi");
+  __ESBMC_assert(clamp_example(-10) == 0, "clamp lo");
+  __ESBMC_assert(clamp_example(50) == 50, "clamp mid");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4251/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4251/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4251_comp/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4251_comp/main.cpp
@@ -1,0 +1,19 @@
+// Comparator overload for https://github.com/esbmc/esbmc/issues/4251
+// Exercises std::clamp(v, lo, hi, comp) — i.e. the 4-argument template.
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+
+int32_t clamp_reverse(int32_t v)
+{
+  // With std::greater<>, the ordering is inverted: lo and hi roles flip.
+  return std::clamp(v, int32_t{100}, int32_t{0}, std::greater<int32_t>{});
+}
+
+int main()
+{
+  __ESBMC_assert(clamp_reverse(150) == 100, "clamp_reverse hi");
+  __ESBMC_assert(clamp_reverse(-10) == 0, "clamp_reverse lo");
+  __ESBMC_assert(clamp_reverse(50) == 50, "clamp_reverse mid");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4251_comp/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4251_comp/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4251_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4251_fail/main.cpp
@@ -1,0 +1,16 @@
+// Negative reproducer for https://github.com/esbmc/esbmc/issues/4251
+// std::clamp must clamp to [lo, hi]; this assertion contradicts that and
+// should fail.
+#include <algorithm>
+#include <cstdint>
+
+int32_t clamp_example(int32_t v)
+{
+  return std::clamp(v, int32_t{0}, int32_t{100});
+}
+
+int main()
+{
+  __ESBMC_assert(clamp_example(150) == 150, "clamp must not modify value");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4251_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4251_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -2469,6 +2469,29 @@ const T &min(const T &left, const T &right)
     return right;
 }
 
+// Returns by value (T) rather than the standard's `const T&` to avoid an IR
+// materialisation issue where `const T&` returns lose their value across the
+// callee scope exit (see issue #4251).
+template <class T>
+T clamp(const T &v, const T &lo, const T &hi)
+{
+  if (v < lo)
+    return lo;
+  if (hi < v)
+    return hi;
+  return v;
+}
+
+template <class T, class Compare>
+T clamp(const T &v, const T &lo, const T &hi, Compare comp)
+{
+  if (comp(v, lo))
+    return lo;
+  if (comp(hi, v))
+    return hi;
+  return v;
+}
+
 template <class FwdIt>
 FwdIt max_element(FwdIt first, FwdIt last)
 {


### PR DESCRIPTION
Adds the two C++17 `std::clamp` overloads (default `operator<` and user `Compare`) to the bundled `<algorithm>` header. Returns by value (`T`) rather than the standard's `const T&` to sidestep a separate GOTO IR materialisation issue noted in the same report; the divergence is documented inline.

Fixes #4251.
