### PR TITLE
[cpp] use angle-bracket include for <array> in bundled <span>

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4270_span_array_stub/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4270_span_array_stub/main.cpp
@@ -1,0 +1,15 @@
+// Regression for esbmc#4270: bundled <span> must use angle-bracket include
+// for <array> so a user -I stub directory can override std::array.  Before
+// the fix, <span> did `#include "array"` which always pulled in ESBMC's
+// bundled array, conflicting with the stub and producing a redefinition.
+#include <span>
+#include <array>
+
+int main()
+{
+  int buf[3] = {7, 8, 9};
+  std::span<int> s(buf, 3);
+  std::array<int, 3> a;
+  a[0] = s[0];
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4270_span_array_stub/stubs/array
+++ b/regression/esbmc-cpp/cpp/github_4270_span_array_stub/stubs/array
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstddef>
+namespace std
+{
+template <typename T, std::size_t N>
+struct array
+{
+  T _data[N];
+  constexpr T &operator[](std::size_t i)
+  {
+    return _data[i];
+  }
+  constexpr const T &operator[](std::size_t i) const
+  {
+    return _data[i];
+  }
+};
+} // namespace std

--- a/regression/esbmc-cpp/cpp/github_4270_span_array_stub/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4270_span_array_stub/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc -I stubs
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_4270_span_no_stub/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_4270_span_no_stub/main.cpp
@@ -1,0 +1,15 @@
+// Baseline for esbmc#4270: with no -I override, <span> must still resolve
+// the bundled <array> correctly.  Confirms the fix to use angle-bracket
+// include does not regress the default lookup path.
+#include <span>
+#include <array>
+#include <cassert>
+
+int main()
+{
+  int buf[4] = {1, 2, 3, 4};
+  std::span<int> s(buf, 4);
+  std::array<int, 4> a{1, 2, 3, 4};
+  assert(s[2] == a[2]);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_4270_span_no_stub/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4270_span_no_stub/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/span
+++ b/src/cpp/library/span
@@ -2,7 +2,7 @@
 
 #include "cstddef"  /* size_t, ptrdiff_t */
 #include "cstdint"  /* SIZE_MAX */
-#include "array"
+#include <array>
 #include "bit"      /* std::bit_cast (transitive, matches libc++/libstdc++) */
 #include "type_traits"
 


### PR DESCRIPTION
The bundled `<span>` did `#include "array"`, a relative include that always resolved to ESBMC's own `<array>` and bypassed any user-supplied `-I` stub path. Switching to `#include <array>` lets the preprocessor honour the search path, so users can override `std::array` (e.g. to work around #4269) without triggering a redefinition error.

Fixes #4270.
