### PR TITLE
[clang-cpp] support C++11 inheriting constructors (using Base::Base)

### DIFF
--- a/regression/esbmc-cpp11/constructors/UsingConstructor-chain/main.cpp
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor-chain/main.cpp
@@ -1,0 +1,26 @@
+#include <cassert>
+
+struct A
+{
+  int v;
+  explicit A(int x) : v(x)
+  {
+  }
+};
+
+struct B : A
+{
+  using A::A;
+};
+
+struct C : B
+{
+  using B::B;
+};
+
+int main()
+{
+  C c(7);
+  assert(c.v == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp11/constructors/UsingConstructor-chain/test.desc
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor-chain/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/UsingConstructor-fail/main.cpp
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor-fail/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+
+struct Base
+{
+  int value;
+  explicit Base(int v) : value(v)
+  {
+  }
+};
+
+struct Derived : Base
+{
+  using Base::Base;
+};
+
+int main()
+{
+  Derived d(42);
+  assert(d.value == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp11/constructors/UsingConstructor-fail/test.desc
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor-fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp11/constructors/UsingConstructor-multi/main.cpp
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor-multi/main.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+
+struct Base
+{
+  int a;
+  int b;
+  Base(int x, int y) : a(x), b(y)
+  {
+  }
+};
+
+struct Derived : Base
+{
+  using Base::Base;
+};
+
+int main()
+{
+  Derived d(3, 5);
+  assert(d.a == 3);
+  assert(d.b == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp11/constructors/UsingConstructor-multi/test.desc
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor-multi/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp11/constructors/UsingConstructor/main.cpp
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor/main.cpp
@@ -1,0 +1,21 @@
+#include <cassert>
+
+struct Base
+{
+  int value;
+  explicit Base(int v) : value(v)
+  {
+  }
+};
+
+struct Derived : Base
+{
+  using Base::Base;
+};
+
+int main()
+{
+  Derived d(42);
+  assert(d.value == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp11/constructors/UsingConstructor/test.desc
+++ b/regression/esbmc-cpp11/constructors/UsingConstructor/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--std c++11
+
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -137,6 +137,7 @@ bool clang_cpp_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   case clang::Decl::Using:
   case clang::Decl::UsingEnum:
   case clang::Decl::UsingShadow:
+  case clang::Decl::ConstructorUsingShadow:
   case clang::Decl::UsingDirective:
   case clang::Decl::TypeAlias:
   case clang::Decl::NamespaceAlias:
@@ -204,6 +205,23 @@ void clang_cpp_convertert::get_decl_name(
       name += "::" + std::to_string(pd.getFunctionScopeIndex());
       id_suffix = "::" + std::to_string(pd.getFunctionScopeIndex());
       break;
+    }
+    // Unnamed parameter of an inheriting constructor (`using Base::Base;`).
+    // Sema synthesises these params without identifiers; we still need a
+    // stable name so the inheriting ctor body can forward them.
+    if (const auto *ctor = llvm::dyn_cast_or_null<clang::CXXConstructorDecl>(
+          pd.getParentFunctionOrMethod()))
+    {
+      if (ctor->isInheritingConstructor())
+      {
+        std::string parent_name, parent_id;
+        get_decl_name(*ctor, parent_name, parent_id);
+        std::string suffix =
+          "::p" + std::to_string(pd.getFunctionScopeIndex());
+        name = parent_name + suffix;
+        id = parent_id + suffix;
+        return;
+      }
     }
     clang_c_convertert::get_decl_name(nd, name, id);
     return;
@@ -883,6 +901,62 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_constructor_call(cxxtoe, new_expr))
       return true;
 
+    break;
+  }
+
+  case clang::Stmt::CXXInheritedCtorInitExprClass:
+  {
+    // Synthesised inside a constructor introduced by `using Base::Base;`.
+    // Lower it to a base-ctor call that forwards the enclosing inheriting
+    // constructor's parameters.
+    const clang::CXXInheritedCtorInitExpr &ice =
+      static_cast<const clang::CXXInheritedCtorInitExpr &>(stmt);
+
+    // Virtual bases follow a different lowering: only the most-derived
+    // object constructs them, so naively forwarding here can double-init.
+    // Reject rather than silently miscompile.
+    if (ice.constructsVBase())
+    {
+      log_error(
+        "Inherited constructor for virtual base is not supported yet "
+        "(see #4271)");
+      return true;
+    }
+
+    if (!new_expr.base_ctor_derived())
+    {
+      log_error(
+        "CXXInheritedCtorInitExpr encountered outside a base-class "
+        "initializer context");
+      return true;
+    }
+
+    exprt callee_decl;
+    if (get_decl_ref(*ice.getConstructor(), callee_decl))
+      return true;
+
+    typet type;
+    if (get_type(ice.getType(), type))
+      return true;
+
+    side_effect_expr_function_callt call;
+    call.function() = callee_decl;
+    call.type() = type;
+
+    gen_typecast_base_ctor_call(callee_decl, call, new_expr);
+
+    // Forward the enclosing inheriting constructor's parameters.
+    assert(current_functionDecl);
+    for (const clang::ParmVarDecl *p : current_functionDecl->parameters())
+    {
+      exprt arg;
+      if (get_decl_ref(*p, arg))
+        return true;
+      call.arguments().push_back(arg);
+    }
+
+    call.set("constructor", 1);
+    new_expr.swap(call);
     break;
   }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -209,15 +209,15 @@ void clang_cpp_convertert::get_decl_name(
     // Unnamed parameter of an inheriting constructor (`using Base::Base;`).
     // Sema synthesises these params without identifiers; we still need a
     // stable name so the inheriting ctor body can forward them.
-    if (const auto *ctor = llvm::dyn_cast_or_null<clang::CXXConstructorDecl>(
-          pd.getParentFunctionOrMethod()))
+    if (
+      const auto *ctor = llvm::dyn_cast_or_null<clang::CXXConstructorDecl>(
+        pd.getParentFunctionOrMethod()))
     {
       if (ctor->isInheritingConstructor())
       {
         std::string parent_name, parent_id;
         get_decl_name(*ctor, parent_name, parent_id);
-        std::string suffix =
-          "::p" + std::to_string(pd.getFunctionScopeIndex());
+        std::string suffix = "::p" + std::to_string(pd.getFunctionScopeIndex());
         name = parent_name + suffix;
         id = parent_id + suffix;
         return;


### PR DESCRIPTION
Lower `using Base::Base;` instead of aborting on the synthetic
`ConstructorUsingShadow` decl and `CXXInheritedCtorInitExpr` that Sema
emits for inheriting constructors. The inheriting `CXXConstructorDecl`'s
unnamed parameters are now given stable names so the synthesised body
can forward them positionally to the base ctor. Virtual bases are
rejected explicitly rather than silently miscompiled.

Adds four regression tests under `regression/esbmc-cpp11/constructors/`:
single-arg, single-arg failing assert, multi-arg, and a two-level
`using A::A` / `using B::B` chain.

Fixes #4271
