### PR TITLE
[refactor] remove unused bvnxor / bitnxor irep

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -529,7 +529,6 @@ T interval_domaint::get_interval(const expr2tc &e) const
   case expr2t::bitxor_id:
   case expr2t::bitnand_id:
   case expr2t::bitnor_id:
-  case expr2t::bitnxor_id:
     if (enable_interval_bitwise_arithmetic)
     {
       const auto &bit_op = dynamic_cast<const bit_2ops &>(*e);
@@ -558,8 +557,6 @@ T interval_domaint::get_interval(const expr2tc &e) const
         result = T::bitnot(lhs & rhs);
       else if (is_bitnor2t(e))
         result = T::bitnot(lhs | rhs);
-      else if (is_bitnxor2t(e))
-        result = T::bitnot(lhs ^ rhs);
     }
     break;
 

--- a/src/goto-symex/features.cpp
+++ b/src/goto-symex/features.cpp
@@ -59,7 +59,6 @@ void ssa_features::check(const expr2tc &e)
   case expr2t::bitxor_id:
   case expr2t::bitnand_id:
   case expr2t::bitnor_id:
-  case expr2t::bitnxor_id:
   {
     features.insert(SSA_FEATURES::BITWISE_OPERATIONS);
     const auto &bit_op = dynamic_cast<const bit_2ops &>(*e);

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -55,7 +55,6 @@
   BOOST_PP_LIST_CONS(bitxor,                                                   \
   BOOST_PP_LIST_CONS(bitnand,                                                  \
   BOOST_PP_LIST_CONS(bitnor,                                                   \
-  BOOST_PP_LIST_CONS(bitnxor,                                                  \
   BOOST_PP_LIST_CONS(bitnot,                                                   \
   BOOST_PP_LIST_CONS(lshr,                                                     \
   BOOST_PP_LIST_CONS(neg,                                                      \
@@ -136,7 +135,7 @@
   BOOST_PP_LIST_CONS(isinstance,                                               \
   BOOST_PP_LIST_CONS(hasattr,                                                  \
   BOOST_PP_LIST_CONS(isnone,                                                   \
-  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -41,7 +41,6 @@ static const char *expr_names[] = {
   "bitxor",
   "bitnand",
   "bitnor",
-  "bitnxor",
   "bitnot",
   "lshr",
   "neg",

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1504,7 +1504,6 @@ irep_typedefs(bitor, bit_2ops);
 irep_typedefs(bitxor, bit_2ops);
 irep_typedefs(bitnand, bit_2ops);
 irep_typedefs(bitnor, bit_2ops);
-irep_typedefs(bitnxor, bit_2ops);
 irep_typedefs(lshr, bit_2ops);
 irep_typedefs(bitnot, bitnot_data);
 irep_typedefs(neg, arith_1op);
@@ -2330,26 +2329,6 @@ public:
   {
   }
   bitnor2t(const bitnor2t &ref) = default;
-
-  expr2tc do_simplify() const override;
-
-  static std::string field_names[esbmct::num_type_fields];
-};
-
-/** Bit nxor operation. Perform bit nxor between two bitvector operands. Types of
- *  this expr and both operands must match. @extends bit_2ops */
-class bitnxor2t : public bitnxor_expr_methods
-{
-public:
-  /** Primary constructor.
-   *  @param t Type of this expr.
-   *  @param s1 Operand 1.
-   *  @param s2 Operand 2. */
-  bitnxor2t(const type2tc &t, const expr2tc &s1, const expr2tc &s2)
-    : bitnxor_expr_methods(t, bitnxor_id, s1, s2)
-  {
-  }
-  bitnxor2t(const bitnxor2t &ref) = default;
 
   expr2tc do_simplify() const override;
 

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -100,8 +100,6 @@ std::string bitnand2t::field_names[esbmct::num_type_fields] =
   {"side_1", "side_2", "", "", ""};
 std::string bitnor2t::field_names[esbmct::num_type_fields] =
   {"side_1", "side_2", "", "", ""};
-std::string bitnxor2t::field_names[esbmct::num_type_fields] =
-  {"side_1", "side_2", "", "", ""};
 std::string lshr2t::field_names[esbmct::num_type_fields] =
   {"side_1", "side_2", "", "", ""};
 std::string bitnot2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates_expr_ops.cpp
+++ b/src/irep2/templates/irep2_templates_expr_ops.cpp
@@ -12,7 +12,6 @@ expr_typedefs2(bitor, bit_2ops);
 expr_typedefs2(bitxor, bit_2ops);
 expr_typedefs2(bitnand, bit_2ops);
 expr_typedefs2(bitnor, bit_2ops);
-expr_typedefs2(bitnxor, bit_2ops);
 expr_typedefs2(lshr, bit_2ops);
 expr_typedefs1(bitnot, bitnot_data);
 expr_typedefs1(neg, arith_1op);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -560,7 +560,7 @@ void value_sett::get_value_set_rec(
 
   if (
     is_bitor2t(expr) || is_bitand2t(expr) || is_bitxor2t(expr) ||
-    is_bitnand2t(expr) || is_bitnor2t(expr) || is_bitnxor2t(expr))
+    is_bitnand2t(expr) || is_bitnor2t(expr))
   {
     assert(expr->get_num_sub_exprs() == 2);
     get_value_set_rec(*expr->get_sub_expr(0), dest, suffix, original_type);

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -252,20 +252,6 @@ smt_astt bitwuzla_convt::mk_bvnot(smt_astt a)
     a->sort);
 }
 
-smt_astt bitwuzla_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    bitwuzla_mk_term2(
-      bitw_term_manager,
-      BITWUZLA_KIND_BV_XNOR,
-      to_solver_smt_ast<bitw_smt_ast>(a)->a,
-      to_solver_smt_ast<bitw_smt_ast>(b)->a),
-    a->sort);
-}
-
 smt_astt bitwuzla_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -45,7 +45,6 @@ public:
   smt_astt mk_bvlshr(smt_astt a, smt_astt b) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/solvers/boolector/boolector_conv.cpp
+++ b/src/solvers/boolector/boolector_conv.cpp
@@ -232,19 +232,6 @@ smt_astt boolector_convt::mk_bvnot(smt_astt a)
     boolector_not(btor, to_solver_smt_ast<btor_smt_ast>(a)->a), a->sort);
 }
 
-smt_astt boolector_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    boolector_xnor(
-      btor,
-      to_solver_smt_ast<btor_smt_ast>(a)->a,
-      to_solver_smt_ast<btor_smt_ast>(b)->a),
-    a->sort);
-}
-
 smt_astt boolector_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);

--- a/src/solvers/boolector/boolector_conv.h
+++ b/src/solvers/boolector/boolector_conv.h
@@ -45,7 +45,6 @@ public:
   smt_astt mk_bvlshr(smt_astt a, smt_astt b) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/solvers/cvc4/cvc_conv.cpp
+++ b/src/solvers/cvc4/cvc_conv.cpp
@@ -731,19 +731,6 @@ smt_astt cvc_convt::mk_bvnot(smt_astt a)
     a->sort);
 }
 
-smt_astt cvc_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    em.mkExpr(
-      CVC4::kind::BITVECTOR_XNOR,
-      to_solver_smt_ast<cvc_smt_ast>(a)->a,
-      to_solver_smt_ast<cvc_smt_ast>(b)->a),
-    a->sort);
-}
-
 smt_astt cvc_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);

--- a/src/solvers/cvc4/cvc_conv.h
+++ b/src/solvers/cvc4/cvc_conv.h
@@ -49,7 +49,6 @@ public:
   smt_astt mk_neg(smt_astt a) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/solvers/cvc5/cvc5_conv.cpp
+++ b/src/solvers/cvc5/cvc5_conv.cpp
@@ -743,19 +743,6 @@ smt_astt cvc5_convt::mk_bvnot(smt_astt a)
     a->sort);
 }
 
-smt_astt cvc5_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    slv.mkTerm(
-      cvc5::Kind::BITVECTOR_XNOR,
-      {to_solver_smt_ast<cvc5_smt_ast>(a)->a,
-       to_solver_smt_ast<cvc5_smt_ast>(b)->a}),
-    a->sort);
-}
-
 smt_astt cvc5_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);

--- a/src/solvers/cvc5/cvc5_conv.h
+++ b/src/solvers/cvc5/cvc5_conv.h
@@ -53,7 +53,6 @@ public:
   smt_astt mk_neg(smt_astt a) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2605,11 +2605,6 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     a = mk_bvnor(args[0], args[1]);
     break;
   }
-  case expr2t::bitnxor_id:
-  {
-    a = mk_bvnxor(args[0], args[1]);
-    break;
-  }
   case expr2t::bitnot_id:
   {
     a = mk_bvnot(args[0]);
@@ -5075,13 +5070,6 @@ smt_astt smt_convt::mk_bvneg(smt_astt a)
 smt_astt smt_convt::mk_bvnot(smt_astt a)
 {
   (void)a;
-  abort();
-}
-
-smt_astt smt_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  (void)a;
-  (void)b;
   abort();
 }
 

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -316,7 +316,6 @@ public:
   virtual smt_astt mk_neg(smt_astt a);
   virtual smt_astt mk_bvneg(smt_astt a);
   virtual smt_astt mk_bvnot(smt_astt a);
-  virtual smt_astt mk_bvnxor(smt_astt a, smt_astt b);
   virtual smt_astt mk_bvnor(smt_astt a, smt_astt b);
   virtual smt_astt mk_bvnand(smt_astt a, smt_astt b);
   virtual smt_astt mk_bvxor(smt_astt a, smt_astt b);

--- a/src/solvers/smtlib/smtlib_conv.cpp
+++ b/src/solvers/smtlib/smtlib_conv.cpp
@@ -46,7 +46,6 @@ static const std::array smt_func_name_table = {
   "bvneg",                  /* SMT_FUNC_BVNEG, */
   "bvlshr",                 /* SMT_FUNC_BVLSHR, */
   "bvnot",                  /* SMT_FUNC_BVNOT, */
-  "bvnxor",                 /* SMT_FUNC_BVNXOR, */
   "bvnor",                  /* SMT_FUNC_BVNOR, */
   "vnand",                  /* SMT_FUNC_BVNAND, */
   "bvxor",                  /* SMT_FUNC_BVXOR, */
@@ -1180,17 +1179,6 @@ smt_astt smtlib_convt::mk_bvnot(smt_astt a)
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
   smtlib_smt_ast *ast = new smtlib_smt_ast(this, a->sort, SMT_FUNC_BVNOT);
   ast->args.push_back(a);
-  return ast;
-}
-
-smt_astt smtlib_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  smtlib_smt_ast *ast = new smtlib_smt_ast(this, a->sort, SMT_FUNC_BVNXOR);
-  ast->args.push_back(a);
-  ast->args.push_back(b);
   return ast;
 }
 

--- a/src/solvers/smtlib/smtlib_conv.h
+++ b/src/solvers/smtlib/smtlib_conv.h
@@ -50,7 +50,6 @@ enum smt_func_kind
   SMT_FUNC_BVNEG,
   SMT_FUNC_BVLSHR,
   SMT_FUNC_BVNOT,
-  SMT_FUNC_BVNXOR,
   SMT_FUNC_BVNOR,
   SMT_FUNC_BVNAND,
   SMT_FUNC_BVXOR,
@@ -203,7 +202,6 @@ public:
   smt_astt mk_neg(smt_astt a) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/solvers/yices/yices_conv.cpp
+++ b/src/solvers/yices/yices_conv.cpp
@@ -322,18 +322,6 @@ smt_astt yices_convt::mk_bvnot(smt_astt a)
   return new_ast(yices_bvnot(to_solver_smt_ast<yices_smt_ast>(a)->a), a->sort);
 }
 
-smt_astt yices_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);
-  assert(b->sort->id != SMT_SORT_INT && b->sort->id != SMT_SORT_REAL);
-  assert(a->sort->get_data_width() == b->sort->get_data_width());
-  return new_ast(
-    yices_bvxnor(
-      to_solver_smt_ast<yices_smt_ast>(a)->a,
-      to_solver_smt_ast<yices_smt_ast>(b)->a),
-    a->sort);
-}
-
 smt_astt yices_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(a->sort->id != SMT_SORT_INT && a->sort->id != SMT_SORT_REAL);

--- a/src/solvers/yices/yices_conv.h
+++ b/src/solvers/yices/yices_conv.h
@@ -70,7 +70,6 @@ public:
   smt_astt mk_neg(smt_astt a) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/solvers/z3/z3_conv.cpp
+++ b/src/solvers/z3/z3_conv.cpp
@@ -402,17 +402,6 @@ smt_astt z3_convt::mk_bvnot(smt_astt a)
   }
 }
 
-smt_astt z3_convt::mk_bvnxor(smt_astt a, smt_astt b)
-{
-  assert(
-    (a->sort->id == SMT_SORT_INT) || (b->sort->id == SMT_SORT_INT) ||
-    (a->sort->get_data_width() == b->sort->get_data_width()));
-  return new_ast(
-    !(to_solver_smt_ast<z3_smt_ast>(a)->a ^
-      to_solver_smt_ast<z3_smt_ast>(b)->a),
-    a->sort);
-}
-
 smt_astt z3_convt::mk_bvnor(smt_astt a, smt_astt b)
 {
   assert(

--- a/src/solvers/z3/z3_conv.h
+++ b/src/solvers/z3/z3_conv.h
@@ -68,7 +68,6 @@ public:
   smt_astt mk_neg(smt_astt a) override;
   smt_astt mk_bvneg(smt_astt a) override;
   smt_astt mk_bvnot(smt_astt a) override;
-  smt_astt mk_bvnxor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnor(smt_astt a, smt_astt b) override;
   smt_astt mk_bvnand(smt_astt a, smt_astt b) override;
   smt_astt mk_bvxor(smt_astt a, smt_astt b) override;

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -386,7 +386,6 @@ irep_idt exprt::i_bitor = dstring("bitor");
 irep_idt exprt::i_bitxor = dstring("bitxor");
 irep_idt exprt::i_bitnand = dstring("bitnand");
 irep_idt exprt::i_bitnor = dstring("bitnor");
-irep_idt exprt::i_bitnxor = dstring("bitnxor");
 irep_idt exprt::i_bitnot = dstring("bitnot");
 irep_idt exprt::i_ashr = dstring("ashr");
 irep_idt exprt::i_lshr = dstring("lshr");

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -255,7 +255,6 @@ public:
   static irep_idt i_bitxor;
   static irep_idt i_bitnand;
   static irep_idt i_bitnor;
-  static irep_idt i_bitnxor;
   static irep_idt i_bitnot;
   static irep_idt i_ashr;
   static irep_idt i_lshr;

--- a/src/util/expr_simplifier.cpp
+++ b/src/util/expr_simplifier.cpp
@@ -2337,22 +2337,6 @@ expr2tc bitnor2t::do_simplify() const
   return do_bit_munge_operation<bitnor2t>(op, type, side_1, side_2);
 }
 
-expr2tc bitnxor2t::do_simplify() const
-{
-  auto op = [](uint64_t op1, uint64_t op2) { return ~(op1 ^ op2); };
-
-  // Is a vector operation ? Apply the op
-  if (is_constant_vector2t(side_1) || is_constant_vector2t(side_2))
-  {
-    auto op = [](type2tc t, expr2tc e1, expr2tc e2) {
-      return bitnxor2tc(t, e1, e2);
-    };
-    return distribute_vector_operation(op, side_1, side_2);
-  }
-
-  return do_bit_munge_operation<bitnxor2t>(op, type, side_1, side_2);
-}
-
 expr2tc bitnot2t::do_simplify() const
 {
   // ~(~x) = x (double complement)

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -1094,23 +1094,6 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     return;
   }
 
-  if (expr.id() == exprt::i_bitnxor)
-  {
-    type = migrate_type(expr.type());
-
-    expr2tc side1, side2;
-    if (expr.operands().size() > 2)
-    {
-      splice_expr(expr, new_expr_ref);
-      return;
-    }
-
-    convert_operand_pair(expr, side1, side2);
-
-    new_expr_ref = bitnxor2tc(type, side1, side2);
-    return;
-  }
-
   if (expr.id() == exprt::i_bitnot)
   {
     type = migrate_type(expr.type());
@@ -2792,15 +2775,6 @@ exprt migrate_expr_back(const expr2tc &ref)
     bitnorval.copy_to_operands(
       migrate_expr_back(ref2.side_1), migrate_expr_back(ref2.side_2));
     return bitnorval;
-  }
-  case expr2t::bitnxor_id:
-  {
-    const bitnxor2t &ref2 = to_bitnxor2t(ref);
-    typet thetype = migrate_type_back(ref->type);
-    exprt bitnxorval("bitnxor", thetype);
-    bitnxorval.copy_to_operands(
-      migrate_expr_back(ref2.side_1), migrate_expr_back(ref2.side_2));
-    return bitnxorval;
   }
   case expr2t::bitnot_id:
   {


### PR DESCRIPTION
Drop bitnxor2t and mk_bvnxor — no frontend or transform generates the
irep, so the ~100 lines of solver-backend boilerplate are dead code
inherited from CBMC's hardware modelling layer.

Fixes #80
