### PR TITLE
[goto-cover] skip ASSUME in condition coverage (#4291)

### DIFF
--- a/regression/goto-coverage/github_2071_1/test.desc
+++ b/regression/goto-coverage/github_2071_1/test.desc
@@ -1,7 +1,7 @@
 THOROUGH
 main.c
 --condition-coverage --k-induction --base-k-step 2 --no-standard-checks
-^Reached Conditions:  22
+^Reached Conditions:  16
 ^Short Circuited Conditions:  2
-^Total Conditions:  24
+^Total Conditions:  18
 ^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_2106_1/test.desc
+++ b/regression/goto-coverage/github_2106_1/test.desc
@@ -1,7 +1,7 @@
 THOROUGH
 main.c
 --condition-coverage --k-induction --base-k-step 3 --no-standard-checks --max-k-step 10
-^Reached Conditions:  8
+^Reached Conditions:  6
 ^Short Circuited Conditions:  10
-^Total Conditions:  18
+^Total Conditions:  12
 ^VERIFICATION UNKNOWN$

--- a/regression/goto-coverage/github_2365_3/test.desc
+++ b/regression/goto-coverage/github_2365_3/test.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --condition-coverage-claims
 ^Reached Conditions:  8$
-^Short Circuited Conditions:  10$
-^Total Conditions:  18$
-^Condition Properties - SATISFIED:  5$
-^Condition Properties - UNSATISFIED:  3$
+^Short Circuited Conditions:  14$
+^Total Conditions:  22$
+^Condition Properties - SATISFIED:  4$
+^Condition Properties - UNSATISFIED:  4$
 ^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_2365_3/test.desc
+++ b/regression/goto-coverage/github_2365_3/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --condition-coverage-claims
-^Reached Conditions:  8$
-^Short Circuited Conditions:  14$
-^Total Conditions:  22$
-^Condition Properties - SATISFIED:  4$
-^Condition Properties - UNSATISFIED:  4$
+^Reached Conditions:  6$
+^Short Circuited Conditions:  10$
+^Total Conditions:  16$
+^Condition Properties - SATISFIED:  3$
+^Condition Properties - UNSATISFIED:  3$
 ^VERIFICATION FAILED$

--- a/regression/goto-coverage/github_4291_1/main.c
+++ b/regression/goto-coverage/github_4291_1/main.c
@@ -1,0 +1,22 @@
+#include <stdbool.h>
+
+void __VERIFIER_assume(int cond);
+int __VERIFIER_nondet_int(void);
+
+bool foo(int x)
+{
+  if (x > 0 && x < 100)
+  {
+    return true;
+  }
+  return false;
+}
+
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  __VERIFIER_assume(x >= -1000);
+  __VERIFIER_assume(x <= 1000);
+  foo(x);
+  return 0;
+}

--- a/regression/goto-coverage/github_4291_1/test.desc
+++ b/regression/goto-coverage/github_4291_1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--condition-coverage-claims
+^Reached Conditions:  4$
+^Short Circuited Conditions:  0$
+^Total Conditions:  4$
+^Condition Properties - SATISFIED:  4$
+^Condition Properties - UNSATISFIED:  0$
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -442,25 +442,26 @@ void goto_coveraget::condition_coverage()
           check there operands.
         */
 
+        // Skip ASSUME instructions: __VERIFIER_assume / __ESBMC_assume
+        // express path constraints, not program logic, so their guards
+        // must not contribute to condition-coverage claims (issue #4291).
+        if (it->is_assume())
+          continue;
+
         // e.g. assert(a == 1);
         if (
-          it->is_assume() ||
-          (it->is_assert() &&
-           it->location.property().as_string() != "replaced assertion"))
+          it->is_assert() &&
+          it->location.property().as_string() != "replaced assertion")
         {
           if (!is_nil_expr(it->guard))
           {
             expr2tc guard = handle_single_guard(it->guard, true);
             gen_cond_cov_assert(guard, expr2tc(), goto_program, it);
             // after adding the instrumentation, we neutralize the original assert
-            if (!it->is_assume())
-            {
-              // do not change assume, as it will modify program's logic
-              if (cov_assume_asserts)
-                replace_assert_to_assume(it);
-              else
-                replace_assert_to_guard(gen_true_expr(), it, false);
-            }
+            if (cov_assume_asserts)
+              replace_assert_to_assume(it);
+            else
+              replace_assert_to_guard(gen_true_expr(), it, false);
           }
         }
 


### PR DESCRIPTION
__VERIFIER_assume / __ESBMC_assume lower to ASSUME instructions and express path constraints, not program logic. Treating their guards as condition-coverage claims inflated Total Conditions (12 instead of 4 on the issue's reproducer). Skip ASSUME in condition_coverage(); ASSERT handling is unchanged.

Fixes #4291.
