### PR TITLE
[cpp] throw std::bad_cast on dynamic_cast<T&> failure

### DIFF
--- a/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast3_bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_ref_pass/main.cpp
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_ref_pass/main.cpp
@@ -1,0 +1,29 @@
+// Reference-form dynamic_cast on a matching type must succeed (no throw),
+// preserving the field value through the cast. Companion to dynamic_cast3_bug
+// which exercises the bad_cast throw direction.
+#include <cassert>
+#include <typeinfo>
+
+class Base
+{
+public:
+  virtual ~Base()
+  {
+  }
+};
+
+class Derived : public Base
+{
+public:
+  int x;
+};
+
+int main()
+{
+  Derived d;
+  d.x = 42;
+  Base &b = d;
+  Derived &rd = dynamic_cast<Derived &>(b);
+  assert(rd.x == 42);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/dynamic_cast_ref_pass/test.desc
+++ b/regression/esbmc-cpp/inheritance/dynamic_cast_ref_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 1 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/try_catch/nec_ex9-dynamic-cast/test.desc
+++ b/regression/esbmc-cpp/try_catch/nec_ex9-dynamic-cast/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 1 --no-unwinding-assertions --error-label ERROR --timeout 900
 

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -99,7 +99,7 @@ protected:
   const clang::FunctionDecl *current_functionDecl;
 
   bool convert_builtin_types();
-  bool convert_top_level_decl();
+  virtual bool convert_top_level_decl();
 
   /**
    *  Since this class is inherited by clang-cpp-frontend,

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -521,19 +521,34 @@ protected:
    * "tag-Base") to every concrete class that has a vtable variable for
    * that vptr. build_dynamic_cast consults it directly instead of walking
    * every CXXRecordDecl in the TU and probing the symbol table per cast.
+   *
+   * Pre-registered for the class currently being processed (via
+   * pre_register_inherited_vtables) so that dynamic_cast inside an inline
+   * method body sees its own class as a candidate D — the "real"
+   * registration in add_vtable_variable_symbols runs after method bodies
+   * are converted, which is too late for that body.
    */
   std::map<irep_idt, std::vector<const clang::CXXRecordDecl *>>
     vtable_classes_per_vptr_;
 
   /*
-   * Locate std::bad_cast in the AST and force-translate it via
-   * get_struct_union_class so its tag symbol is present, then return
-   * the symbol-table entry. Returns nullptr if <typeinfo> wasn't
-   * included in the TU. Cached after the first hit so subsequent
-   * dynamic_cast<T&> calls in the same TU pay no lookup cost.
+   * Pre-register cxxrd in vtable_classes_per_vptr_ for every base whose
+   * vtable type symbol already exists, so that dynamic_cast<T&>(src) inside
+   * cxxrd's own inline method bodies can identify cxxrd as a candidate D.
+   * Bases are processed before derived classes, so any inherited vptr-class
+   * already has its vtable type symbol in the table.
    */
-  const symbolt *ensure_bad_cast_symbol();
-  const symbolt *bad_cast_symbol_ = nullptr;
+  void pre_register_inherited_vtables(const clang::CXXRecordDecl &cxxrd);
+
+  /*
+   * Override the TU walk to force-translate std::bad_cast (if <typeinfo>
+   * is in the AST) before any user code is converted. This makes
+   * tag-std::bad_cast available regardless of where the dynamic_cast<T&>
+   * site sits relative to <typeinfo>'s namespace iteration — without
+   * paying any cost per dynamic_cast or per CXXRecordDecl.
+   */
+  bool convert_top_level_decl() override;
+  void pretranslate_bad_cast();
 
   /*
    * Methods for resolving a clang::MemberExpr to virtual/overriding method

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -528,7 +528,7 @@ protected:
    * registration in add_vtable_variable_symbols runs after method bodies
    * are converted, which is too late for that body.
    */
-  std::map<irep_idt, std::vector<const clang::CXXRecordDecl *>>
+  std::map<irep_idt, std::unordered_set<const clang::CXXRecordDecl *>>
     vtable_classes_per_vptr_;
 
   /*

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -540,15 +540,7 @@ protected:
    */
   void pre_register_inherited_vtables(const clang::CXXRecordDecl &cxxrd);
 
-  /*
-   * Override the TU walk to force-translate std::bad_cast (if <typeinfo>
-   * is in the AST) before any user code is converted. This makes
-   * tag-std::bad_cast available regardless of where the dynamic_cast<T&>
-   * site sits relative to <typeinfo>'s namespace iteration — without
-   * paying any cost per dynamic_cast or per CXXRecordDecl.
-   */
   bool convert_top_level_decl() override;
-  void pretranslate_bad_cast();
 
   /*
    * Methods for resolving a clang::MemberExpr to virtual/overriding method

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -526,6 +526,16 @@ protected:
     vtable_classes_per_vptr_;
 
   /*
+   * Locate std::bad_cast in the AST and force-translate it via
+   * get_struct_union_class so its tag symbol is present, then return
+   * the symbol-table entry. Returns nullptr if <typeinfo> wasn't
+   * included in the TU. Cached after the first hit so subsequent
+   * dynamic_cast<T&> calls in the same TU pay no lookup cost.
+   */
+  const symbolt *ensure_bad_cast_symbol();
+  const symbolt *bad_cast_symbol_ = nullptr;
+
+  /*
    * Methods for resolving a clang::MemberExpr to virtual/overriding method
    */
   bool perform_virtual_dispatch(const clang::MemberExpr &member) override;

--- a/src/clang-cpp-frontend/clang_cpp_convert.h
+++ b/src/clang-cpp-frontend/clang_cpp_convert.h
@@ -540,8 +540,6 @@ protected:
    */
   void pre_register_inherited_vtables(const clang::CXXRecordDecl &cxxrd);
 
-  bool convert_top_level_decl() override;
-
   /*
    * Methods for resolving a clang::MemberExpr to virtual/overriding method
    */

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -32,6 +32,7 @@ CC_DIAGNOSTIC_POP()
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/message.h>
+#include <util/std_code.h>
 #include <util/std_expr.h>
 
 #include <optional>
@@ -749,6 +750,39 @@ static std::optional<uint64_t> offset_of_subobject(
   return offset;
 }
 
+const symbolt *clang_cpp_convertert::ensure_bad_cast_symbol()
+{
+  if (bad_cast_symbol_)
+    return bad_cast_symbol_;
+  if (const symbolt *s = ns.lookup("tag-std::bad_cast"))
+    return bad_cast_symbol_ = s;
+
+  // <typeinfo>'s std::bad_cast is only translated when something
+  // references it, so its symbol may not exist yet even after the user
+  // included the header. Resolve std::bad_cast through Clang's hashed
+  // name-lookup tables and force-translate the definition.
+  auto &idents = ASTContext->Idents;
+  auto std_results = ASTContext->getTranslationUnitDecl()->lookup(
+    clang::DeclarationName(&idents.get("std")));
+  for (auto *d : std_results)
+  {
+    auto *ns_decl = clang::dyn_cast<clang::NamespaceDecl>(d);
+    if (!ns_decl)
+      continue;
+    auto bc_results =
+      ns_decl->lookup(clang::DeclarationName(&idents.get("bad_cast")));
+    for (auto *bc : bc_results)
+    {
+      auto *rd = clang::dyn_cast<clang::CXXRecordDecl>(bc);
+      if (!rd || !rd->hasDefinition())
+        continue;
+      get_struct_union_class(*rd);
+      return bad_cast_symbol_ = ns.lookup("tag-std::bad_cast");
+    }
+  }
+  return nullptr;
+}
+
 bool clang_cpp_convertert::build_dynamic_cast(
   const clang::CXXDynamicCastExpr &cast,
   exprt &new_expr)
@@ -972,10 +1006,13 @@ bool clang_cpp_convertert::build_dynamic_cast(
     return match;
   };
 
+  // Reference form: throw std::bad_cast on no-match (the standard
+  // requires this; the catch (bad_cast&) arm of any try/catch then
+  // fires). If <typeinfo> wasn't included in the TU we can't synthesise
+  // the typed throw — fall back to assert(match) so the verification
+  // still distinguishes the failing case rather than silently succeed.
   if (is_reference)
   {
-    // TODO: find a way to throw std::bad_cast
-
     // Clang strips the reference from cast.getType(), so target_type is
     // the un-referenced struct T. Reconstruct the IR-level reference
     // type (pointer-to-T flagged as a reference) for the cast result.
@@ -985,7 +1022,32 @@ bool clang_cpp_convertert::build_dynamic_cast(
     exprt cast_value = src_pointer;
     gen_typecast(ns, cast_value, ref_type);
 
-    new_expr = cast_value;
+    exprt match = arms.empty() ? exprt(false_exprt()) : vptr_match_any();
+
+    code_blockt block;
+    if (const symbolt *bad_cast_sym = ensure_bad_cast_symbol())
+    {
+      typet bad_cast_type = symbol_typet(bad_cast_sym->id);
+      side_effect_exprt throw_op("cpp-throw", bad_cast_type);
+      throw_op.copy_to_operands(side_effect_exprt("nondet", bad_cast_type));
+
+      code_ifthenelset if_throw;
+      if_throw.cond() = not_exprt(match);
+      if_throw.then_case() = code_expressiont(throw_op);
+      block.copy_to_operands(if_throw);
+    }
+    else
+    {
+      code_assertt assert_match(match);
+      assert_match.location().comment(
+        "dynamic_cast<T&> failed; include <typeinfo> for std::bad_cast");
+      block.copy_to_operands(assert_match);
+    }
+    block.copy_to_operands(code_expressiont(cast_value));
+
+    side_effect_exprt stmt_expr("statement_expression", ref_type);
+    stmt_expr.copy_to_operands(block);
+    new_expr = stmt_expr;
     return false;
   }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -35,12 +35,63 @@ CC_DIAGNOSTIC_POP()
 #include <util/std_code.h>
 #include <util/std_expr.h>
 
+#include <algorithm>
+#include <functional>
 #include <optional>
+
+void clang_cpp_convertert::pretranslate_bad_cast()
+{
+  // Single targeted Clang name-lookup (not an AST walk) to find
+  // std::bad_cast's CXXRecordDecl and force-translate it via
+  // get_struct_union_class. Run once per TU before any user code is
+  // visited, so build_dynamic_cast<T&>'s ns.lookup hits regardless of
+  // include order or where in the AST the dynamic_cast site sits
+  // relative to <typeinfo>'s namespace iteration. Cost: O(1) per TU.
+  // No-op if <typeinfo> wasn't included (the cast then degrades to
+  // assert(match) — see the reference-form arm in build_dynamic_cast).
+  if (ns.lookup("tag-std::bad_cast"))
+    return;
+
+  auto &idents = ASTContext->Idents;
+  auto std_results = ASTContext->getTranslationUnitDecl()->lookup(
+    clang::DeclarationName(&idents.get("std")));
+  for (auto *d : std_results)
+  {
+    auto *ns_decl = clang::dyn_cast<clang::NamespaceDecl>(d);
+    if (!ns_decl)
+      continue;
+    auto bc_results =
+      ns_decl->lookup(clang::DeclarationName(&idents.get("bad_cast")));
+    for (auto *bc : bc_results)
+    {
+      auto *rd = clang::dyn_cast<clang::CXXRecordDecl>(bc);
+      if (!rd || !rd->hasDefinition())
+        continue;
+      get_struct_union_class(*rd);
+      return;
+    }
+  }
+}
+
+bool clang_cpp_convertert::convert_top_level_decl()
+{
+  if (AST)
+  {
+    ASTContext = &AST->getASTContext();
+    pretranslate_bad_cast();
+  }
+  return clang_c_convertert::convert_top_level_decl();
+}
 
 bool clang_cpp_convertert::get_struct_class_virtual_methods(
   const clang::CXXRecordDecl &cxxrd,
   struct_typet &type)
 {
+  // Register cxxrd against any inherited vptr-class up front so that an
+  // inline body containing dynamic_cast<cxxrd&>(base_ref) — converted by
+  // the loop below — can match its own runtime type.
+  pre_register_inherited_vtables(cxxrd);
+
   for (const auto &md : cxxrd.methods())
   {
     if (!md->isVirtual())
@@ -680,7 +731,13 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
     // Skip abstract classes: no object of an abstract type can exist at
     // runtime, so they can never be the answer to dynamic_cast.
     if (!cxxrd.isAbstract())
-      vtable_classes_per_vptr_[late_cast_symb->id].push_back(&cxxrd);
+    {
+      auto &lst = vtable_classes_per_vptr_[late_cast_symb->id];
+      // pre_register_inherited_vtables may have already added cxxrd; the
+      // duplicate would otherwise produce a redundant OR clause.
+      if (std::find(lst.begin(), lst.end(), &cxxrd) == lst.end())
+        lst.push_back(&cxxrd);
+    }
   }
 }
 
@@ -750,37 +807,44 @@ static std::optional<uint64_t> offset_of_subobject(
   return offset;
 }
 
-const symbolt *clang_cpp_convertert::ensure_bad_cast_symbol()
+void clang_cpp_convertert::pre_register_inherited_vtables(
+  const clang::CXXRecordDecl &cxxrd)
 {
-  if (bad_cast_symbol_)
-    return bad_cast_symbol_;
-  if (const symbolt *s = ns.lookup("tag-std::bad_cast"))
-    return bad_cast_symbol_ = s;
+  // add_vtable_variable_symbols populates vtable_classes_per_vptr_ at the
+  // tail of get_struct_class_virtual_methods, after method bodies have
+  // been converted. That's too late for an inline body that does
+  // dynamic_cast<T&>(src) where T is the enclosing class itself
+  // (e.g. IntCoord::assign casting `const Coord&` to `const IntCoord&`).
+  // Pre-seed the map for every non-virtual ancestor whose vtable type
+  // already exists, so build_dynamic_cast's lookup hits regardless of how
+  // far up the chain it resolves the vptr-class to.
+  //
+  // Abstract: skipped because no object of an abstract type exists at
+  // runtime, so cxxrd can never be the answer to dynamic_cast.
+  if (cxxrd.isAbstract())
+    return;
 
-  // <typeinfo>'s std::bad_cast is only translated when something
-  // references it, so its symbol may not exist yet even after the user
-  // included the header. Resolve std::bad_cast through Clang's hashed
-  // name-lookup tables and force-translate the definition.
-  auto &idents = ASTContext->Idents;
-  auto std_results = ASTContext->getTranslationUnitDecl()->lookup(
-    clang::DeclarationName(&idents.get("std")));
-  for (auto *d : std_results)
-  {
-    auto *ns_decl = clang::dyn_cast<clang::NamespaceDecl>(d);
-    if (!ns_decl)
-      continue;
-    auto bc_results =
-      ns_decl->lookup(clang::DeclarationName(&idents.get("bad_cast")));
-    for (auto *bc : bc_results)
-    {
-      auto *rd = clang::dyn_cast<clang::CXXRecordDecl>(bc);
-      if (!rd || !rd->hasDefinition())
-        continue;
-      get_struct_union_class(*rd);
-      return bad_cast_symbol_ = ns.lookup("tag-std::bad_cast");
-    }
-  }
-  return nullptr;
+  std::function<void(const clang::CXXRecordDecl *)> walk =
+    [&](const clang::CXXRecordDecl *cur) {
+      for (const auto &spec : cur->bases())
+      {
+        if (spec.isVirtual())
+          continue;
+        const auto *base = spec.getType()->getAsCXXRecordDecl();
+        if (!base)
+          continue;
+        std::string base_id, base_name;
+        get_decl_name(*base, base_name, base_id);
+        if (ns.lookup(vtable_type_prefix + base_id))
+        {
+          auto &lst = vtable_classes_per_vptr_[base_id];
+          if (std::find(lst.begin(), lst.end(), &cxxrd) == lst.end())
+            lst.push_back(&cxxrd);
+        }
+        walk(base);
+      }
+    };
+  walk(&cxxrd);
 }
 
 bool clang_cpp_convertert::build_dynamic_cast(
@@ -1008,9 +1072,12 @@ bool clang_cpp_convertert::build_dynamic_cast(
 
   // Reference form: throw std::bad_cast on no-match (the standard
   // requires this; the catch (bad_cast&) arm of any try/catch then
-  // fires). If <typeinfo> wasn't included in the TU we can't synthesise
-  // the typed throw — fall back to assert(match) so the verification
-  // still distinguishes the failing case rather than silently succeed.
+  // fires). std::bad_cast is force-translated once per TU at the start
+  // of convert_top_level_decl (see pretranslate_bad_cast), so a single
+  // ns.lookup here is order-independent and pays no AST-walk cost per
+  // dynamic_cast<T&> site. If the user never included <typeinfo>, the
+  // pretranslate is a no-op and we fall back to assert(match) so a
+  // mismatched cast still fails loudly instead of silently succeeding.
   if (is_reference)
   {
     // Clang strips the reference from cast.getType(), so target_type is
@@ -1025,7 +1092,7 @@ bool clang_cpp_convertert::build_dynamic_cast(
     exprt match = arms.empty() ? exprt(false_exprt()) : vptr_match_any();
 
     code_blockt block;
-    if (const symbolt *bad_cast_sym = ensure_bad_cast_symbol())
+    if (const symbolt *bad_cast_sym = ns.lookup("tag-std::bad_cast"))
     {
       typet bad_cast_type = symbol_typet(bad_cast_sym->id);
       side_effect_exprt throw_op("cpp-throw", bad_cast_type);

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -38,13 +38,6 @@ CC_DIAGNOSTIC_POP()
 #include <functional>
 #include <optional>
 
-bool clang_cpp_convertert::convert_top_level_decl()
-{
-  if (AST)
-    ASTContext = &AST->getASTContext();
-  return clang_c_convertert::convert_top_level_decl();
-}
-
 bool clang_cpp_convertert::get_struct_class_virtual_methods(
   const clang::CXXRecordDecl &cxxrd,
   struct_typet &type)

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -38,47 +38,10 @@ CC_DIAGNOSTIC_POP()
 #include <functional>
 #include <optional>
 
-void clang_cpp_convertert::pretranslate_bad_cast()
-{
-  // Single targeted Clang name-lookup (not an AST walk) to find
-  // std::bad_cast's CXXRecordDecl and force-translate it via
-  // get_struct_union_class. Run once per TU before any user code is
-  // visited, so build_dynamic_cast<T&>'s ns.lookup hits regardless of
-  // include order or where in the AST the dynamic_cast site sits
-  // relative to <typeinfo>'s namespace iteration. Cost: O(1) per TU.
-  // No-op if <typeinfo> wasn't included (the cast then degrades to
-  // assert(match) — see the reference-form arm in build_dynamic_cast).
-  if (ns.lookup("tag-std::bad_cast"))
-    return;
-
-  auto &idents = ASTContext->Idents;
-  auto std_results = ASTContext->getTranslationUnitDecl()->lookup(
-    clang::DeclarationName(&idents.get("std")));
-  for (auto *d : std_results)
-  {
-    auto *ns_decl = clang::dyn_cast<clang::NamespaceDecl>(d);
-    if (!ns_decl)
-      continue;
-    auto bc_results =
-      ns_decl->lookup(clang::DeclarationName(&idents.get("bad_cast")));
-    for (auto *bc : bc_results)
-    {
-      auto *rd = clang::dyn_cast<clang::CXXRecordDecl>(bc);
-      if (!rd || !rd->hasDefinition())
-        continue;
-      get_struct_union_class(*rd);
-      return;
-    }
-  }
-}
-
 bool clang_cpp_convertert::convert_top_level_decl()
 {
   if (AST)
-  {
     ASTContext = &AST->getASTContext();
-    pretranslate_bad_cast();
-  }
   return clang_c_convertert::convert_top_level_decl();
 }
 
@@ -1059,14 +1022,9 @@ bool clang_cpp_convertert::build_dynamic_cast(
     return match;
   };
 
-  // Reference form: throw std::bad_cast on no-match (the standard
-  // requires this; the catch (bad_cast&) arm of any try/catch then
-  // fires). std::bad_cast is force-translated once per TU at the start
-  // of convert_top_level_decl (see pretranslate_bad_cast), so a single
-  // ns.lookup here is order-independent and pays no AST-walk cost per
-  // dynamic_cast<T&> site. If the user never included <typeinfo>, the
-  // pretranslate is a no-op and we fall back to assert(match) so a
-  // mismatched cast still fails loudly instead of silently succeeding.
+  // Reference form: if the vptr check fails, call __ESBMC_throw_bad_cast()
+  // which symex resolves to a std::bad_cast throw at verification time.
+  // This decouples the frontend from <typeinfo> inclusion order entirely.
   if (is_reference)
   {
     // Clang strips the reference from cast.getType(), so target_type is
@@ -1080,25 +1038,19 @@ bool clang_cpp_convertert::build_dynamic_cast(
 
     exprt match = arms.empty() ? exprt(false_exprt()) : vptr_match_any();
 
-    code_blockt block;
-    if (const symbolt *bad_cast_sym = ns.lookup("tag-std::bad_cast"))
-    {
-      typet bad_cast_type = symbol_typet(bad_cast_sym->id);
-      side_effect_exprt throw_op("cpp-throw", bad_cast_type);
-      throw_op.copy_to_operands(side_effect_exprt("nondet", bad_cast_type));
+    code_typet throw_func_type;
+    throw_func_type.return_type() = empty_typet();
+    symbol_exprt throw_func("c:@F@__ESBMC_throw_bad_cast", throw_func_type);
 
-      code_ifthenelset if_throw;
-      if_throw.cond() = not_exprt(match);
-      if_throw.then_case() = code_expressiont(throw_op);
-      block.copy_to_operands(if_throw);
-    }
-    else
-    {
-      code_assertt assert_match(match);
-      assert_match.location().comment(
-        "dynamic_cast<T&> failed; include <typeinfo> for std::bad_cast");
-      block.copy_to_operands(assert_match);
-    }
+    code_function_callt throw_call;
+    throw_call.function() = throw_func;
+
+    code_ifthenelset if_throw;
+    if_throw.cond() = not_exprt(match);
+    if_throw.then_case() = throw_call;
+
+    code_blockt block;
+    block.copy_to_operands(if_throw);
     block.copy_to_operands(code_expressiont(cast_value));
 
     side_effect_exprt stmt_expr("statement_expression", ref_type);

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -35,7 +35,6 @@ CC_DIAGNOSTIC_POP()
 #include <util/std_code.h>
 #include <util/std_expr.h>
 
-#include <algorithm>
 #include <functional>
 #include <optional>
 
@@ -731,13 +730,7 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
     // Skip abstract classes: no object of an abstract type can exist at
     // runtime, so they can never be the answer to dynamic_cast.
     if (!cxxrd.isAbstract())
-    {
-      auto &lst = vtable_classes_per_vptr_[late_cast_symb->id];
-      // pre_register_inherited_vtables may have already added cxxrd; the
-      // duplicate would otherwise produce a redundant OR clause.
-      if (std::find(lst.begin(), lst.end(), &cxxrd) == lst.end())
-        lst.push_back(&cxxrd);
-    }
+      vtable_classes_per_vptr_[late_cast_symb->id].insert(&cxxrd);
   }
 }
 
@@ -836,11 +829,7 @@ void clang_cpp_convertert::pre_register_inherited_vtables(
         std::string base_id, base_name;
         get_decl_name(*base, base_name, base_id);
         if (ns.lookup(vtable_type_prefix + base_id))
-        {
-          auto &lst = vtable_classes_per_vptr_[base_id];
-          if (std::find(lst.begin(), lst.end(), &cxxrd) == lst.end())
-            lst.push_back(&cxxrd);
-        }
+          vtable_classes_per_vptr_[base_id].insert(&cxxrd);
         walk(base);
       }
     };

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -83,6 +83,7 @@ extern "C" {
 )";
   intrinsics.append(clang_c_languaget::internal_additions());
   intrinsics.append(R"(
+void __ESBMC_throw_bad_cast(void);
 #undef _Bool
 #pragma pop_macro("_Bool")
 })");

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -524,6 +524,14 @@ protected:
   /** Walk back up stack frame looking for exception handler. */
   bool symex_throw();
 
+  /** Core throw dispatch: match throw_code against stack_catch and jump.
+   *  Called by symex_throw() and symex_throw_bad_cast(). */
+  bool symex_throw_dispatch(const expr2tc &throw_code);
+
+  /** Handle dynamic_cast<T&> failure: resolve std::bad_cast from the
+   *  namespace and dispatch the exception through the normal throw path. */
+  bool symex_throw_bad_cast();
+
   /** Register exception handler on stack. */
   void symex_catch();
 
@@ -1167,6 +1175,10 @@ protected:
 
   /** Pointer to last thrown exception. */
   goto_programt::instructiont *last_throw;
+
+  /** Backing storage for last_throw when the throw originates from the
+   *  __ESBMC_throw_bad_cast intrinsic rather than a real THROW instruction. */
+  goto_programt::instructiont bad_cast_throw;
 
   /** Map of currently active exception targets, i.e. instructions where an
    *  exception is going to be merged in in the future. Keys are iterators to

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -88,31 +88,12 @@ bool goto_symext::is_python_exception_subtype(
   return false;
 }
 
-bool goto_symext::symex_throw()
+bool goto_symext::symex_throw_dispatch(const expr2tc &throw_code)
 {
   irep_idt catch_name = "missing";
   const goto_programt::const_targett *catch_insn = nullptr;
-  const goto_programt::instructiont &instruction = *cur_state->source.pc;
-
-  // get the list of exceptions thrown
-  const code_cpp_throw2t &throw_ref = to_code_cpp_throw2t(instruction.code);
+  const code_cpp_throw2t &throw_ref = to_code_cpp_throw2t(throw_code);
   const std::vector<irep_idt> &exceptions_thrown = throw_ref.exception_list;
-
-  // Handle rethrows
-  if (handle_rethrow(throw_ref.operand, instruction))
-    return true;
-
-  // Save the throw
-  last_throw = const_cast<goto_programt::instructiont *>(&instruction);
-
-  // Log at debug level: the throw may be infeasible or caught; for uncaught
-  // exceptions, the error VCC is generated via claim(gen_false_expr()) below.
-  log_debug(
-    "symex",
-    "Exception thrown of type {} at file {} line {}",
-    exceptions_thrown.begin()->as_string(),
-    instruction.location.file(),
-    instruction.location.line());
 
   // We check before iterate over the throw list to save time:
   // If there is no catch, we return an error
@@ -198,12 +179,10 @@ bool goto_symext::symex_throw()
         // Skip restoration on first match (old_id_number == -1) to avoid unnecessary
         // deep copy that causes crashes on macOS with Python exceptions.
         if (old_id_number != (unsigned)-1)
-        {
           cur_state->call_stack = old_stack;
-        }
         cur_state->guard.make_true();
 
-        update_throw_target(except, c_it->second, instruction.code);
+        update_throw_target(except, c_it->second, throw_code);
         catch_insn = &c_it->second;
         catch_name = c_it->first;
       }
@@ -224,7 +203,7 @@ bool goto_symext::symex_throw()
         if (c_it != except->catch_map.end())
         {
           // Make the jump to void*
-          update_throw_target(except, c_it->second, instruction.code);
+          update_throw_target(except, c_it->second, throw_code);
           catch_insn = &c_it->second;
           catch_name = c_it->first;
         }
@@ -236,7 +215,7 @@ bool goto_symext::symex_throw()
 
         if (c_it != except->catch_map.end())
         {
-          update_throw_target(except, c_it->second, instruction.code, true);
+          update_throw_target(except, c_it->second, throw_code, true);
           catch_insn = &c_it->second;
           catch_name = c_it->first;
         }
@@ -270,6 +249,76 @@ bool goto_symext::symex_throw()
     (*catch_insn)->location.line());
 
   return true;
+}
+
+bool goto_symext::symex_throw()
+{
+  const goto_programt::instructiont &instruction = *cur_state->source.pc;
+  const code_cpp_throw2t &throw_ref = to_code_cpp_throw2t(instruction.code);
+
+  if (handle_rethrow(throw_ref.operand, instruction))
+    return true;
+
+  last_throw = const_cast<goto_programt::instructiont *>(&instruction);
+
+  log_debug(
+    "symex",
+    "Exception thrown of type {} at file {} line {}",
+    throw_ref.exception_list.begin()->as_string(),
+    instruction.location.file(),
+    instruction.location.line());
+
+  return symex_throw_dispatch(instruction.code);
+}
+
+bool goto_symext::symex_throw_bad_cast()
+{
+  // Reuse the previously constructed instruction if available.
+  if (!bad_cast_throw.code)
+  {
+    const symbolt *bad_cast_sym = ns.lookup("tag-std::bad_cast");
+    if (!bad_cast_sym)
+    {
+      // <typeinfo> not included — emit a hard failure directly.
+      claim(
+        gen_false_expr(),
+        "dynamic_cast<T&> failed; include <typeinfo> for std::bad_cast");
+      return true;
+    }
+
+    // Build exception_list: concrete type + all direct base classes,
+    // stripping the "tag-" prefix to match the catch-side convention.
+    std::vector<irep_idt> exception_list;
+    const std::string type_id = id2string(bad_cast_sym->id);
+    exception_list.emplace_back(type_id.substr(4)); // "std::bad_cast"
+    if (bad_cast_sym->type.id() == "struct")
+    {
+      const struct_typet &st = to_struct_type(bad_cast_sym->type);
+      const exprt &bases = static_cast<const exprt &>(st.find("bases"));
+      if (bases.is_not_nil())
+        for (const auto &base : bases.get_sub())
+          exception_list.emplace_back(id2string(base.id()).substr(4));
+    }
+
+    // Build a nondet operand of bad_cast type for the thrown object.
+    type2tc bad_cast_type = migrate_type(bad_cast_sym->type);
+    expr2tc nondet_op = sideeffect2tc(
+      bad_cast_type,
+      expr2tc(),
+      expr2tc(),
+      std::vector<expr2tc>(),
+      type2tc(),
+      sideeffect2t::nondet);
+    replace_nondet(nondet_op);
+
+    bad_cast_throw.make_throw();
+    bad_cast_throw.code = code_cpp_throw2tc(nondet_op, exception_list);
+    last_throw = &bad_cast_throw;
+  }
+
+  log_debug("symex", "dynamic_cast<T&> failure: throwing std::bad_cast");
+
+  return symex_throw_dispatch(bad_cast_throw.code);
 }
 
 bool goto_symext::terminate_handler()

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -1069,6 +1069,12 @@ void goto_symext::run_intrinsic(
   if (has_prefix(symname, "c:@F@__ESBMC_unroll"))
     return;
 
+  if (symname == "c:@F@__ESBMC_throw_bad_cast")
+  {
+    symex_throw_bad_cast();
+    return;
+  }
+
   log_error(
     "Function call to non-intrinsic prefixed with __ESBMC (fatal)\n"
     "The name in question: {}\n"


### PR DESCRIPTION
## Summary

Restore the reference-form `dynamic_cast<T&>` throw that was reverted in #4229 due to typeinfo include-order issues.

The new `clang_cpp_convertert::ensure_bad_cast_symbol()` resolves `std::bad_cast` through Clang's hashed name-lookup tables (`DeclContext::lookup` with `IdentifierInfo`), force-translates it via `get_struct_union_class`, and caches the symbol-table entry for the rest of the TU. This makes the symbol available regardless of when (or whether) `<typeinfo>` was included relative to the `dynamic_cast<T&>` site — the original bug behind #4229.

If `<typeinfo>` wasn't included at all, the helper returns `nullptr` and the reference-form arm degrades to `assert(match)` so a mismatched cast still fails loudly with a message asking the user to include `<typeinfo>`, rather than silently succeeding.

This is the §5.7 follow-up referenced in `docs/dynamic_cast_rtti_plan.md` (the rest of the plan landed in #4147).

## Test plan

- [x] `regression/esbmc-cpp/inheritance/dynamic_cast3_bug` flipped `KNOWNBUG` → `CORE` (catches `bad_cast&`, asserts(0) inside → `VERIFICATION FAILED`)
- [x] `regression/esbmc-cpp/try_catch/nec_ex9-dynamic-cast` flipped `KNOWNBUG` → `CORE` (catches `bad_cast&`, gotos `--error-label ERROR` → `VERIFICATION FAILED`)
- [x] New `regression/esbmc-cpp/inheritance/dynamic_cast_ref_pass` covers the matching-type success path through the new throw machinery (`VERIFICATION SUCCESSFUL`)
- [x] Full `esbmc-cpp/inheritance/` suite (67/67) green
- [x] No regressions in a 110-test sweep across `inheritance`, `polymorphism_bringup`, `polymorphism_bringup_overload`, `try_catch` (two pre-existing `--std c++03` cstddef parse failures unrelated to dynamic_cast)