### PR TITLE
[ctestgen] align nondet_long/ulong with frontend declarations

### DIFF
--- a/regression/witnesses/test_case_generation/ctest_gen_long_int64/main.c
+++ b/regression/witnesses/test_case_generation/ctest_gen_long_int64/main.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+
+long __VERIFIER_nondet_long(void);
+double __VERIFIER_nondet_double(void);
+
+int main(void)
+{
+  int64_t timestamp_ns = (int64_t)__VERIFIER_nondet_long();
+  double timestamp_s = (double)timestamp_ns / 1.0e9;
+
+  double last_output_s = __VERIFIER_nondet_double();
+
+  if (last_output_s > 0.0)
+  {
+    double elapsed = timestamp_s - last_output_s;
+    if (elapsed >= 0.1)
+      return 1;
+  }
+  return 0;
+}

--- a/regression/witnesses/test_case_generation/ctest_gen_long_int64/test.desc
+++ b/regression/witnesses/test_case_generation/ctest_gen_long_int64/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--condition-coverage --generate-ctest-testcase --unwind 1 --no-unwinding-assertions --no-bounds-check --force-malloc-success
+^Generated [0-9]+ CTest test case\(s\) with CMakeLists\.txt
+^VERIFICATION FAILED$

--- a/src/goto-symex/ctest.cpp
+++ b/src/goto-symex/ctest.cpp
@@ -132,7 +132,7 @@ std::string ctest_generator::type_to_c_string(const type2tc &type) const
       if (width == 32)
         return "int";
       if (width == 64)
-        return "long long";
+        return "long";
       return "int"; // Default
     }
     else
@@ -144,7 +144,7 @@ std::string ctest_generator::type_to_c_string(const type2tc &type) const
       if (width == 32)
         return "unsigned int";
       if (width == 64)
-        return "unsigned long long";
+        return "unsigned long";
       return "unsigned int"; // Default
     }
   }
@@ -462,11 +462,11 @@ static void write_verifier_header()
   h << "char __VERIFIER_nondet_char(void);\n";
   h << "short __VERIFIER_nondet_short(void);\n";
   h << "int __VERIFIER_nondet_int(void);\n";
-  h << "long long __VERIFIER_nondet_long(void);\n";
+  h << "long __VERIFIER_nondet_long(void);\n";
   h << "unsigned char __VERIFIER_nondet_uchar(void);\n";
   h << "unsigned short __VERIFIER_nondet_ushort(void);\n";
   h << "unsigned int __VERIFIER_nondet_uint(void);\n";
-  h << "unsigned long long __VERIFIER_nondet_ulong(void);\n";
+  h << "unsigned long __VERIFIER_nondet_ulong(void);\n";
   h << "float __VERIFIER_nondet_float(void);\n";
   h << "double __VERIFIER_nondet_double(void);\n";
   h << "/* In C++ 'bool' is a built-in type; in C use _Bool (native C99\n";


### PR DESCRIPTION
This pr fixes a type-mapping inconsistency between ESBMC's frontend and the CTest generator that prevented users from running `--generate-ctest-testcase` on any source using `long`/`unsigned long` 64-bit nondet values.
- uses long (matches the frontend): ESBMC verification succeeds and `--generate-ctest-testcase` runs to completion, but the generated test cases fail to compile because esbmc_verifier.h declares the function as long long.
- uses long long (matches the buggy testgen header): ESBMC parsing fails with conflicting types; the verification never starts.