### PR TITLE
[witness] render struct fields and floats unambiguously

### DIFF
--- a/regression/esbmc/github_4312-float-precision/main.c
+++ b/regression/esbmc/github_4312-float-precision/main.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <float.h>
 
 // Regression for issue #4312-C: bit-distinct floats must render with
 // round-trippable precision so users can tell witnesses apart. Before
@@ -7,12 +8,19 @@
 // the default 6-digit precision. The fix passes presentationt::WITNESS
 // at the witness print site, which enables UNIQUE_FLOAT_REPR (8 digits
 // for binary32 — enough to round-trip).
+//
+// Pin x to the finite near-(-FLT_MAX) regime where the original bug
+// manifested. Without the assume the solver is also free to pick NaN,
+// -Infinity, or near-zero denormals — all valid violating inputs but
+// not what this regression is here to exercise. NaN comparisons are
+// false so `x >= -FLT_MAX` filters NaN as well as -Infinity.
 
 extern float nondet_float(void);
 
 int main(void)
 {
   float x = nondet_float();
+  __ESBMC_assume(x < -1.0e+38f && x >= -FLT_MAX);
   assert(x > 0);
   return 0;
 }

--- a/regression/esbmc/github_4312-float-precision/main.c
+++ b/regression/esbmc/github_4312-float-precision/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+// Regression for issue #4312-C: bit-distinct floats must render with
+// round-trippable precision so users can tell witnesses apart. Before
+// #4312, six witnesses on `assert(x > 0)` for a nondet float printed
+// four near-FLT_MAX entries as the same `-1.701412e+38f` string at
+// the default 6-digit precision. The fix passes presentationt::WITNESS
+// at the witness print site, which enables UNIQUE_FLOAT_REPR (8 digits
+// for binary32 — enough to round-trip).
+
+extern float nondet_float(void);
+
+int main(void)
+{
+  float x = nondet_float();
+  assert(x > 0);
+  return 0;
+}

--- a/regression/esbmc/github_4312-float-precision/test.desc
+++ b/regression/esbmc/github_4312-float-precision/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--all-witnesses --max-witnesses 6 --floatbv --incremental-bmc
+^VERIFICATION FAILED$
+\[Counterexamples - 6 witnesses\]
+^[^\n]*Inputs : \[0\] = -?\d\.\d{7,}e[+-]\d+f$

--- a/regression/esbmc/github_4312-nested-struct/main.c
+++ b/regression/esbmc/github_4312-nested-struct/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+// Regression for issue #4312-A nested case: zero-fill must descend
+// into a nested struct, so the inner field is rendered for every
+// witness even when the SMT model leaves it unconstrained.
+
+struct inner
+{
+  int a;
+  int b;
+};
+
+struct outer
+{
+  struct inner i;
+  int c;
+};
+
+int main(void)
+{
+  struct outer o;
+  if (o.i.a < -1 || o.i.a > 1)
+    return 0;
+  if (o.c < -1 || o.c > 1)
+    return 0;
+  // .i.b is unconstrained; the witness must still render it as 0.
+  int absa = o.i.a < 0 ? -o.i.a : o.i.a;
+  int absc = o.c < 0 ? -o.c : o.c;
+  assert(absa + absc > 1);
+  return 0;
+}

--- a/regression/esbmc/github_4312-nested-struct/test.desc
+++ b/regression/esbmc/github_4312-nested-struct/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--all-witnesses --max-witnesses 4 --incremental-bmc
+^VERIFICATION FAILED$
+\[Counterexamples - 4 witnesses\]
+^[^\n]*Inputs : \[0\] = \{ \.i=\{ \.a=-?\d+, \.b=-?\d+ \}, \.c=-?\d+ \}$

--- a/regression/esbmc/github_4312-struct-fields/main.c
+++ b/regression/esbmc/github_4312-struct-fields/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+// Regression for issue #4312-A: struct nondets must render every
+// declared field, not silently drop ones the SMT model left
+// unconstrained. Same input as github_4309-struct, but the test
+// asserts both .x= and .y= appear in every witness.
+
+struct point
+{
+  int x;
+  int y;
+};
+
+int main(void)
+{
+  struct point p;
+  if (p.x < -1 || p.x > 1)
+    return 0;
+  if (p.y < -1 || p.y > 1)
+    return 0;
+  int absx = p.x < 0 ? -p.x : p.x;
+  int absy = p.y < 0 ? -p.y : p.y;
+  assert(absx + absy > 1);
+  return 0;
+}

--- a/regression/esbmc/github_4312-struct-fields/test.desc
+++ b/regression/esbmc/github_4312-struct-fields/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--all-witnesses --incremental-bmc
+^VERIFICATION FAILED$
+\[Counterexamples - 5 witnesses\]
+Witness 1 of 5[^\n]*\n[^\n]*Inputs[^\n]*\.x=[^\n]*\.y=
+Witness 2 of 5[^\n]*\n[^\n]*Inputs[^\n]*\.x=[^\n]*\.y=
+Witness 3 of 5[^\n]*\n[^\n]*Inputs[^\n]*\.x=[^\n]*\.y=
+Witness 4 of 5[^\n]*\n[^\n]*Inputs[^\n]*\.x=[^\n]*\.y=
+Witness 5 of 5[^\n]*\n[^\n]*Inputs[^\n]*\.x=[^\n]*\.y=

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -532,8 +532,12 @@ void bmct::report_multi_property_trace(
       {
         if (k)
           oss << ", ";
-        oss << "[" << k
-            << "] = " << from_expr(ns, "", w.nondet_inputs[k].value_expr);
+        // Use WITNESS presentation to render bit-distinct floats with
+        // round-trippable precision; otherwise the default HUMAN flags
+        // collapse e.g. several near-MAX floats to the same string.
+        oss << "[" << k << "] = "
+            << from_expr(
+                 ns, "", w.nondet_inputs[k].value_expr, presentationt::WITNESS);
       }
       oss << "\n";
     }

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1153,42 +1153,68 @@ bool find_nondet_in_expr(const expr2tc &expr)
 }
 
 #include <util/prefix.h>
+#include <util/c_types.h>
 #include <boost/property_tree/detail/xml_parser_writer_settings.hpp>
 #include <cassert>
 #include <goto-symex/slice.h>
 #include <irep2/irep2_utils.h>
 
-// Replace nil and missing aggregate components with zero so every
+// Replace nil and missing aggregate components with zero (and
+// re-query the solver for partially-resolved aggregates) so every
 // witness renders a complete initialiser. SMT models leave
 // unconstrained fields/elements unspecified; per the SMT-LIB
 // default-model convention we surface them as zero rather than
 // silently dropping them. Walks the *type* (not the value) so missing
 // trailing members of a constant_struct2t are filled, and recurses
-// into nested structs, unions and arrays. The expected type comes from
-// the nondet symbol; the value comes from smt_convt::get() and may be
-// nil at any level.
-static expr2tc
-zero_fill_aggregate(const type2tc &expected_type, const expr2tc &value)
+// into nested structs, unions and arrays.
+//
+// The expected type comes from the nondet symbol; `value` is what
+// smt_convt::get() returned for `root_expr` and may be nil at any
+// level. Some backends (notably Z3) return outer aggregates whose
+// nested struct/array fields are not expanded — e.g. `{ .c=N,
+// .i=member(sym).i }` for a struct whose `.i` member is itself a
+// struct, because smt_convt::get's member-id case skips the tuple
+// re-query when the result is struct-typed. When `value` isn't the
+// matching constant_* for an aggregate type, we re-resolve it via
+// get_by_ast on the converted root expression — that path goes
+// through the AST-based tuple_get which recurses through nested
+// tuple-selects and produces fully materialised leaves. This keeps
+// the multi-witness blocking clause sound: make_blocking_expr builds
+// equalities against value_expr, so any unresolved subterm there
+// would block nothing.
+static expr2tc zero_fill_aggregate(
+  const type2tc &expected_type,
+  const expr2tc &value,
+  const expr2tc &root_expr,
+  smt_convt &smt_conv)
 {
-  if (!value)
-    return gen_zero(expected_type);
-
-  if (is_struct_type(expected_type) && is_constant_struct2t(value))
+  if (is_struct_type(expected_type))
   {
     const struct_type2t &st = to_struct_type(expected_type);
-    const constant_struct2t &cs = to_constant_struct2t(value);
+    expr2tc effective = value;
+    if (!effective || !is_constant_struct2t(effective))
+      effective = smt_conv.get_by_ast(
+        expected_type, smt_conv.convert_ast(root_expr));
+    const constant_struct2t *cs =
+      (effective && is_constant_struct2t(effective))
+        ? &to_constant_struct2t(effective)
+        : nullptr;
     std::vector<expr2tc> members;
     members.reserve(st.members.size());
     for (size_t i = 0; i < st.members.size(); ++i)
     {
-      const expr2tc &op =
-        i < cs.datatype_members.size() ? cs.datatype_members[i] : expr2tc();
-      members.push_back(zero_fill_aggregate(st.members[i], op));
+      expr2tc field_root =
+        member2tc(st.members[i], root_expr, st.member_names[i]);
+      expr2tc field_val =
+        (cs && i < cs->datatype_members.size()) ? cs->datatype_members[i]
+                                                : expr2tc();
+      members.push_back(
+        zero_fill_aggregate(st.members[i], field_val, field_root, smt_conv));
     }
     return constant_struct2tc(expected_type, members);
   }
 
-  if (is_union_type(expected_type) && is_constant_union2t(value))
+  if (is_union_type(expected_type) && value && is_constant_union2t(value))
   {
     const union_type2t &ut = to_union_type(expected_type);
     const constant_union2t &cu = to_constant_union2t(value);
@@ -1207,35 +1233,53 @@ zero_fill_aggregate(const type2tc &expected_type, const expr2tc &value)
       assert(
         idx < ut.member_names.size() &&
         "constant_union2t::init_field not in union_type2t::member_names");
-      std::vector<expr2tc> ops = {
-        zero_fill_aggregate(ut.members[idx], cu.datatype_members[0])};
+      expr2tc field_root = member2tc(ut.members[idx], root_expr, cu.init_field);
+      std::vector<expr2tc> ops = {zero_fill_aggregate(
+        ut.members[idx], cu.datatype_members[0], field_root, smt_conv)};
       return constant_union2tc(expected_type, cu.init_field, ops);
     }
   }
 
-  if (is_array_type(expected_type) && is_constant_array2t(value))
+  if (is_array_type(expected_type))
   {
     const array_type2t &at = to_array_type(expected_type);
-    const constant_array2t &ca = to_constant_array2t(value);
-    // For concrete-size arrays the SMT layer (smt_convt::get_array) and
-    // frontend migrators populate one element per declared index, so
-    // datatype_members.size() must match array_size. A shortfall is an
-    // upstream invariant violation and would silently truncate the
-    // witness; refuse to mis-render. Symbolic sizes (VLAs, flexible
-    // arrays) cannot be checked here.
-    if (is_constant_int2t(at.array_size))
+    expr2tc effective = value;
+    if (!effective || !is_constant_array2t(effective))
+      effective = smt_conv.get_by_ast(
+        expected_type, smt_conv.convert_ast(root_expr));
+    if (effective && is_constant_array2t(effective))
     {
-      const BigInt &n = to_constant_int2t(at.array_size).value;
-      assert(
-        n == BigInt(ca.datatype_members.size()) &&
-        "constant_array2t element count != array_type2t::array_size");
+      const constant_array2t &ca = to_constant_array2t(effective);
+      // For concrete-size arrays the SMT layer (smt_convt::get_array) and
+      // frontend migrators populate one element per declared index, so
+      // datatype_members.size() must match array_size. A shortfall is an
+      // upstream invariant violation and would silently truncate the
+      // witness; refuse to mis-render. Symbolic sizes (VLAs, flexible
+      // arrays) cannot be checked here.
+      if (is_constant_int2t(at.array_size))
+      {
+        const BigInt &n = to_constant_int2t(at.array_size).value;
+        assert(
+          n == BigInt(ca.datatype_members.size()) &&
+          "constant_array2t element count != array_type2t::array_size");
+      }
+      std::vector<expr2tc> members;
+      members.reserve(ca.datatype_members.size());
+      for (size_t i = 0; i < ca.datatype_members.size(); ++i)
+      {
+        expr2tc idx_root =
+          index2tc(at.subtype, root_expr, constant_int2tc(index_type2(), i));
+        members.push_back(zero_fill_aggregate(
+          at.subtype, ca.datatype_members[i], idx_root, smt_conv));
+      }
+      return constant_array2tc(expected_type, members);
     }
-    std::vector<expr2tc> members;
-    members.reserve(ca.datatype_members.size());
-    for (const auto &elem : ca.datatype_members)
-      members.push_back(zero_fill_aggregate(at.subtype, elem));
-    return constant_array2tc(expected_type, members);
   }
+
+  // Primitive (or unhandled aggregate) leaf. A nil or non-constant value
+  // means the solver didn't materialise it — fall back to zero.
+  if (!value || !is_constant_expr(value))
+    return gen_zero(expected_type);
 
   return value;
 }
@@ -1283,9 +1327,12 @@ collect_nondet_values(const symex_target_equationt &target, smt_convt &smt_conv)
 
       // Get concrete value, model-completing unconstrained aggregate
       // components to zero so witnesses render with all fields present
-      // and consistent across the witness set.
-      auto concrete_value =
-        zero_fill_aggregate(nondet_expr->type, smt_conv.get(nondet_expr));
+      // and consistent across the witness set. `nondet_expr` is the live
+      // root for re-querying any nested aggregate the backend left
+      // unexpanded (e.g. Z3 returns `{ .c=N, .i=member(sym).i }` for a
+      // struct whose nested `.i` field is itself a struct).
+      auto concrete_value = zero_fill_aggregate(
+        nondet_expr->type, smt_conv.get(nondet_expr), nondet_expr, smt_conv);
 
       // Store the collected value
       collected_nondet_value val;

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1217,6 +1217,19 @@ zero_fill_aggregate(const type2tc &expected_type, const expr2tc &value)
   {
     const array_type2t &at = to_array_type(expected_type);
     const constant_array2t &ca = to_constant_array2t(value);
+    // For concrete-size arrays the SMT layer (smt_convt::get_array) and
+    // frontend migrators populate one element per declared index, so
+    // datatype_members.size() must match array_size. A shortfall is an
+    // upstream invariant violation and would silently truncate the
+    // witness; refuse to mis-render. Symbolic sizes (VLAs, flexible
+    // arrays) cannot be checked here.
+    if (is_constant_int2t(at.array_size))
+    {
+      const BigInt &n = to_constant_int2t(at.array_size).value;
+      assert(
+        n == BigInt(ca.datatype_members.size()) &&
+        "constant_array2t element count != array_type2t::array_size");
+    }
     std::vector<expr2tc> members;
     members.reserve(ca.datatype_members.size());
     for (const auto &elem : ca.datatype_members)

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1193,21 +1193,20 @@ static expr2tc zero_fill_aggregate(
     const struct_type2t &st = to_struct_type(expected_type);
     expr2tc effective = value;
     if (!effective || !is_constant_struct2t(effective))
-      effective = smt_conv.get_by_ast(
-        expected_type, smt_conv.convert_ast(root_expr));
-    const constant_struct2t *cs =
-      (effective && is_constant_struct2t(effective))
-        ? &to_constant_struct2t(effective)
-        : nullptr;
+      effective =
+        smt_conv.get_by_ast(expected_type, smt_conv.convert_ast(root_expr));
+    const constant_struct2t *cs = (effective && is_constant_struct2t(effective))
+                                    ? &to_constant_struct2t(effective)
+                                    : nullptr;
     std::vector<expr2tc> members;
     members.reserve(st.members.size());
     for (size_t i = 0; i < st.members.size(); ++i)
     {
       expr2tc field_root =
         member2tc(st.members[i], root_expr, st.member_names[i]);
-      expr2tc field_val =
-        (cs && i < cs->datatype_members.size()) ? cs->datatype_members[i]
-                                                : expr2tc();
+      expr2tc field_val = (cs && i < cs->datatype_members.size())
+                            ? cs->datatype_members[i]
+                            : expr2tc();
       members.push_back(
         zero_fill_aggregate(st.members[i], field_val, field_root, smt_conv));
     }
@@ -1245,8 +1244,8 @@ static expr2tc zero_fill_aggregate(
     const array_type2t &at = to_array_type(expected_type);
     expr2tc effective = value;
     if (!effective || !is_constant_array2t(effective))
-      effective = smt_conv.get_by_ast(
-        expected_type, smt_conv.convert_ast(root_expr));
+      effective =
+        smt_conv.get_by_ast(expected_type, smt_conv.convert_ast(root_expr));
     if (effective && is_constant_array2t(effective))
     {
       const constant_array2t &ca = to_constant_array2t(effective);

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1154,6 +1154,7 @@ bool find_nondet_in_expr(const expr2tc &expr)
 
 #include <util/prefix.h>
 #include <boost/property_tree/detail/xml_parser_writer_settings.hpp>
+#include <cassert>
 #include <goto-symex/slice.h>
 #include <irep2/irep2_utils.h>
 
@@ -1193,16 +1194,19 @@ zero_fill_aggregate(const type2tc &expected_type, const expr2tc &value)
     const constant_union2t &cu = to_constant_union2t(value);
     if (cu.datatype_members.size() == 1 && !ut.member_names.empty())
     {
-      // Resolve the active member's declared type; fall back to the
-      // first member if init_field doesn't match (an upstream
-      // inconsistency we should not silently mis-render).
-      size_t idx = 0;
+      // Resolve the active member's declared type. init_field must
+      // name a declared member; a mismatch is an upstream invariant
+      // violation and we refuse to silently emit a malformed witness.
+      size_t idx = ut.member_names.size();
       for (size_t i = 0; i < ut.member_names.size(); ++i)
         if (ut.member_names[i] == cu.init_field)
         {
           idx = i;
           break;
         }
+      assert(
+        idx < ut.member_names.size() &&
+        "constant_union2t::init_field not in union_type2t::member_names");
       std::vector<expr2tc> ops = {
         zero_fill_aggregate(ut.members[idx], cu.datatype_members[0])};
       return constant_union2tc(expected_type, cu.init_field, ops);

--- a/src/goto-symex/witnesses.cpp
+++ b/src/goto-symex/witnesses.cpp
@@ -1155,6 +1155,73 @@ bool find_nondet_in_expr(const expr2tc &expr)
 #include <util/prefix.h>
 #include <boost/property_tree/detail/xml_parser_writer_settings.hpp>
 #include <goto-symex/slice.h>
+#include <irep2/irep2_utils.h>
+
+// Replace nil and missing aggregate components with zero so every
+// witness renders a complete initialiser. SMT models leave
+// unconstrained fields/elements unspecified; per the SMT-LIB
+// default-model convention we surface them as zero rather than
+// silently dropping them. Walks the *type* (not the value) so missing
+// trailing members of a constant_struct2t are filled, and recurses
+// into nested structs, unions and arrays. The expected type comes from
+// the nondet symbol; the value comes from smt_convt::get() and may be
+// nil at any level.
+static expr2tc
+zero_fill_aggregate(const type2tc &expected_type, const expr2tc &value)
+{
+  if (!value)
+    return gen_zero(expected_type);
+
+  if (is_struct_type(expected_type) && is_constant_struct2t(value))
+  {
+    const struct_type2t &st = to_struct_type(expected_type);
+    const constant_struct2t &cs = to_constant_struct2t(value);
+    std::vector<expr2tc> members;
+    members.reserve(st.members.size());
+    for (size_t i = 0; i < st.members.size(); ++i)
+    {
+      const expr2tc &op =
+        i < cs.datatype_members.size() ? cs.datatype_members[i] : expr2tc();
+      members.push_back(zero_fill_aggregate(st.members[i], op));
+    }
+    return constant_struct2tc(expected_type, members);
+  }
+
+  if (is_union_type(expected_type) && is_constant_union2t(value))
+  {
+    const union_type2t &ut = to_union_type(expected_type);
+    const constant_union2t &cu = to_constant_union2t(value);
+    if (cu.datatype_members.size() == 1 && !ut.member_names.empty())
+    {
+      // Resolve the active member's declared type; fall back to the
+      // first member if init_field doesn't match (an upstream
+      // inconsistency we should not silently mis-render).
+      size_t idx = 0;
+      for (size_t i = 0; i < ut.member_names.size(); ++i)
+        if (ut.member_names[i] == cu.init_field)
+        {
+          idx = i;
+          break;
+        }
+      std::vector<expr2tc> ops = {
+        zero_fill_aggregate(ut.members[idx], cu.datatype_members[0])};
+      return constant_union2tc(expected_type, cu.init_field, ops);
+    }
+  }
+
+  if (is_array_type(expected_type) && is_constant_array2t(value))
+  {
+    const array_type2t &at = to_array_type(expected_type);
+    const constant_array2t &ca = to_constant_array2t(value);
+    std::vector<expr2tc> members;
+    members.reserve(ca.datatype_members.size());
+    for (const auto &elem : ca.datatype_members)
+      members.push_back(zero_fill_aggregate(at.subtype, elem));
+    return constant_array2tc(expected_type, members);
+  }
+
+  return value;
+}
 
 // Shared nondet collection logic (used by both TestComp and CTest)
 std::vector<collected_nondet_value>
@@ -1197,8 +1264,11 @@ collect_nondet_values(const symex_target_equationt &target, smt_convt &smt_conv)
 
       seen_nondets.insert(sym.thename.as_string());
 
-      // Get concrete value
-      auto concrete_value = smt_conv.get(nondet_expr);
+      // Get concrete value, model-completing unconstrained aggregate
+      // components to zero so witnesses render with all fields present
+      // and consistent across the witness set.
+      auto concrete_value =
+        zero_fill_aggregate(nondet_expr->type, smt_conv.get(nondet_expr));
 
       // Store the collected value
       collected_nondet_value val;


### PR DESCRIPTION
Fixes #4312 issues A (struct fields silently omitted), B (formatting drift between `from_expr` calls), and C (bit-distinct floats render identically).

Issue B is resolved implicitly by A: once every witness goes through `convert_struct_union_body` with all members present, the spacing converges. The platform-fragile path blacklist (sibling concern in the issue) is tracked separately and will land in its own PR.