### PR TITLE
Address Codacy perf findings in solidity grammar and array_conv

### DIFF
--- a/src/solidity-frontend/solidity_grammar.cpp
+++ b/src/solidity-frontend/solidity_grammar.cpp
@@ -268,11 +268,11 @@ TypeNameT get_type_name_t(const nlohmann::json &type_name)
     else if (
       uint_string_to_type_map.count(typeString) ||
       int_string_to_type_map.count(typeString) || typeString == "bool" ||
-      typeString == "string" || typeString.find("literal_string") == 0 ||
+      typeString == "string" || typeString.starts_with("literal_string") ||
       typeString == "string storage ref" ||
       typeString == "string storage pointer" || typeString == "string memory" ||
       typeString == "address payable" || typeString == "address" ||
-      typeString.compare(0, 5, "bytes") == 0)
+      typeString.starts_with("bytes"))
     {
       // For state var declaration,
       return ElementaryTypeName;
@@ -410,7 +410,7 @@ ElementaryTypeNameT get_elementary_type_name_t(const nlohmann::json &type_name)
     // Will not be used
     return RA_LITERAL;
   }
-  if (typeString.find("literal_string") == 0)
+  if (typeString.starts_with("literal_string"))
   {
     return STRING_LITERAL;
   }
@@ -1232,7 +1232,7 @@ const char *func_decl_ref_to_str(FunctionDeclRefT type)
 }
 
 // auxiliary type for implicit casting
-ImplicitCastTypeT get_implicit_cast_type_t(std::string cast)
+ImplicitCastTypeT get_implicit_cast_type_t(const std::string &cast)
 {
   if (cast == "LValueToRValue")
   {

--- a/src/solidity-frontend/solidity_grammar.h
+++ b/src/solidity-frontend/solidity_grammar.h
@@ -459,7 +459,7 @@ enum ImplicitCastTypeT
 
   ImplicitCastTypeTError
 };
-ImplicitCastTypeT get_implicit_cast_type_t(std::string cast);
+ImplicitCastTypeT get_implicit_cast_type_t(const std::string &cast);
 const char *implicit_cast_type_to_str(ImplicitCastTypeT type);
 
 // the function visibility

--- a/src/solvers/smt/array_conv.cpp
+++ b/src/solvers/smt/array_conv.cpp
@@ -492,7 +492,7 @@ array_convt::get_array_elem(smt_astt a, uint64_t index, const type2tc &subtype)
   // Basically, we have to do a linear search of all the indexes to find one
   // that matches the index argument.
   idx_record_containert::const_iterator it;
-  for (it = indexes.begin(); it != indexes.end(); it++, i++)
+  for (it = indexes.begin(); it != indexes.end(); ++it, i++)
   {
     const expr2tc &e = it->idx;
     expr2tc e2 = ctx->get(e);


### PR DESCRIPTION
Two unrelated perf/style cleanups from Codacy, kept in one PR for review economy.

- `[solidity]` pass `cast` by const reference and replace `find()==0` / `compare(0,n,"...")==0` prefix checks with `std::string::starts_with` in `solidity_grammar.{h,cpp}`.
- `[solver]` use prefix `++it` on the non-primitive `idx_record_containert::const_iterator` in `array_conv.cpp::get_array_elem`.

No behaviour change; verified `esbmc-solidity/`, `esbmc-cpp11/array/`, `incremental-smt/`, and `regression/esbmc/.*array` subsets match master.