### PR TITLE
[util] replace C-style casts in bigint and migrate

### DIFF
--- a/src/big-int/bigint.cpp
+++ b/src/big-int/bigint.cpp
@@ -533,7 +533,7 @@ char *BigInt::as_string(char *p, unsigned l, onedig_t b) const
     return p + l;
   }
   // Make a temporary copy of the digits.
-  onedig_t *dig = (onedig_t *)alloca(len * sizeof(onedig_t));
+  onedig_t *dig = static_cast<onedig_t *>(alloca(len * sizeof(onedig_t)));
   memcpy(dig, digit, len * sizeof(onedig_t));
   // Divide down by single, generating digits from right to left.
   do
@@ -1005,11 +1005,11 @@ void BigInt::div(BigInt const &x, BigInt const &y, BigInt &q, BigInt &r)
     // digit is initially no less than half base. This is essential
     // for guess_q() to work.
     unsigned al = x.length;
-    onedig_t *a = (onedig_t *)alloca((al + 2) * sizeof(onedig_t));
+    onedig_t *a = static_cast<onedig_t *>(alloca((al + 2) * sizeof(onedig_t)));
     memcpy(a, x.digit, al * sizeof(onedig_t));
 
     unsigned bl = y.length;
-    onedig_t *b = (onedig_t *)alloca(bl * sizeof(onedig_t));
+    onedig_t *b = static_cast<onedig_t *>(alloca(bl * sizeof(onedig_t)));
     memcpy(b, y.digit, bl * sizeof(onedig_t));
 
     onedig_t scale = onedig_t(base / (twodig_t(1) + b[bl - 1]));
@@ -1090,11 +1090,11 @@ BigInt &BigInt::operator/=(BigInt const &y)
   {
     // Copy and scale as above in div().
     unsigned al = length;
-    onedig_t *a = (onedig_t *)alloca((al + 2) * sizeof(onedig_t));
+    onedig_t *a = static_cast<onedig_t *>(alloca((al + 2) * sizeof(onedig_t)));
     memcpy(a, digit, al * sizeof(onedig_t));
 
     unsigned bl = y.length;
-    onedig_t *b = (onedig_t *)alloca(bl * sizeof(onedig_t));
+    onedig_t *b = static_cast<onedig_t *>(alloca(bl * sizeof(onedig_t)));
     memcpy(b, y.digit, bl * sizeof(onedig_t));
 
     onedig_t scale = onedig_t(base / (twodig_t(1) + b[bl - 1]));
@@ -1163,7 +1163,7 @@ BigInt &BigInt::operator%=(BigInt const &y)
     onedig_t *a = digit;
 
     unsigned bl = y.length;
-    onedig_t *b = (onedig_t *)alloca(bl * sizeof(onedig_t));
+    onedig_t *b = static_cast<onedig_t *>(alloca(bl * sizeof(onedig_t)));
     memcpy(b, y.digit, bl * sizeof(onedig_t));
 
     onedig_t scale = onedig_t(base / (twodig_t(1) + b[bl - 1]));

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -168,7 +168,7 @@ static type2tc migrate_type0(const typet &type)
       "Please, refer to: "
       "https://clang.llvm.org/docs/"
       "LanguageExtensions.html#vectors-and-extended-vectors");
-    exprt sz = (exprt &)type.find(typet::a_size);
+    exprt sz = static_cast<const exprt &>(type.find(typet::a_size));
     simplify(sz);
     migrate_expr(sz, size);
     size = fixup_containerof_in_sizeof(size);


### PR DESCRIPTION
Replace the remaining C-style casts in `src/big-int/bigint.cpp` (alloca results) and `src/util/migrate.cpp` (irept::find result) with `static_cast`. The migrate.cpp call now preserves `const` through the `static_cast` since the local `sz` is constructed by copy.