### PR TITLE
[python] tidy operational-model stubs in models/

### DIFF
--- a/src/python-frontend/models/datetime.py
+++ b/src/python-frontend/models/datetime.py
@@ -1,5 +1,5 @@
 # Operational model for datetime module
-# pylint: disable=function-redefined  # intentional stdlib shadow for ESBMC models
+# pylint: disable=function-redefined,unused-wildcard-import  # intentional stdlib shadow for ESBMC models
 
 
 class datetime:

--- a/src/python-frontend/models/range.py
+++ b/src/python-frontend/models/range.py
@@ -5,7 +5,6 @@ def ESBMC_range_next_(curr: int, step: int) -> int:
 def ESBMC_range_has_next_(curr: int, end: int, step: int) -> bool:
     if step > 0:
         return curr < end
-    elif step < 0:
+    if step < 0:
         return curr > end
-    else:
-        return False  # step == 0 is invalid
+    return False  # step == 0 is invalid

--- a/src/python-frontend/models/typing.py
+++ b/src/python-frontend/models/typing.py
@@ -1,4 +1,4 @@
-# pylint: disable=function-redefined,unused-argument
+# pylint: disable=function-redefined,unused-argument,unused-import
 # Operational-model stubs: stdlib shadows for ESBMC models. Argument
 # names on `__class_getitem__` and `TypeVar` are part of the API contract
 # matched by ESBMC's Python converter, even when the abstract body does


### PR DESCRIPTION
Drop the no-else-return chain in `ESBMC_range_has_next_` — successive returns are clearer. Extend the module-level pylint disables on `datetime.py` and `typing.py` to silence the `unused-wildcard-import` and `unused-import` false positives that surface because pylint resolves these stub names against the real stdlib (`_pydatetime`, `annotationlib`).