### PR TITLE
[goto-cover] --k-path-coverage Phase 1 (issue #4325)

### DIFF
--- a/regression/goto-coverage/k_path_cov_1/main.c
+++ b/regression/goto-coverage/k_path_cov_1/main.c
@@ -1,0 +1,18 @@
+// Two independent if statements — exercises k=2 prefix.
+// Branch coverage needs 2 tests; k=2 path coverage exposes 4 paths
+// (TT, TF, FT, FF) — all feasible.
+int main()
+{
+  int a, b;
+  if (a > 0)
+    a = 1;
+  else
+    a = -1;
+
+  if (b > 0)
+    b = 1;
+  else
+    b = -1;
+
+  return a + b;
+}

--- a/regression/goto-coverage/k_path_cov_1/test.desc
+++ b/regression/goto-coverage/k_path_cov_1/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=2 --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 6$
+^Reached : 6$
+^k-Path Coverage: 100%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_10_witness_depth_baseline/main.c
+++ b/regression/goto-coverage/k_path_cov_10_witness_depth_baseline/main.c
@@ -1,0 +1,22 @@
+// Regression for #4330 review. Companion to k_path_cov_9: pins the
+// baseline witness count at the default --k-path-witness-depth=8 so a
+// future regression that lowered the default silently (and thereby
+// inflated apparent coverage by reducing the denominator) would fail
+// here. Same source as k_path_cov_9 to make the contrast explicit:
+// 14 witnesses at default depth, 2 at depth=2.
+int main()
+{
+  int a, b, c;
+  if (a > 0)
+    ;
+  else
+    ;
+  if (b > 0)
+    ;
+  else
+    ;
+  if (c > 0)
+    ;
+  else
+    ;
+}

--- a/regression/goto-coverage/k_path_cov_10_witness_depth_baseline/test.desc
+++ b/regression/goto-coverage/k_path_cov_10_witness_depth_baseline/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=3 --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 14$
+^Reached : 14$
+^k-Path Coverage: 100%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_11_witness_depth_zero_rejected/main.c
+++ b/regression/goto-coverage/k_path_cov_11_witness_depth_zero_rejected/main.c
@@ -1,0 +1,14 @@
+// Regression for #4330 review. The `read_positive` lambda in
+// parseoptions guards `--k-path-witness-depth` and `--k-path-max-goals`
+// against non-positive values. k_path_cov_6 already covers the equivalent
+// check on `--k-path-coverage` itself, but the lambda fires per-flag —
+// a regression that broke just the witness-depth path would not be
+// caught there. This test exercises that specific guard: setting
+// --k-path-witness-depth=0 must abort at parse time, not silently coerce
+// the cap to 0 (which would emit zero witnesses and report a vacuous
+// "N/A" coverage that could be mistaken for "no branches").
+int main()
+{
+  int a;
+  return a > 0 ? 1 : 0;
+}

--- a/regression/goto-coverage/k_path_cov_11_witness_depth_zero_rejected/test.desc
+++ b/regression/goto-coverage/k_path_cov_11_witness_depth_zero_rejected/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-path-coverage=2 --k-path-witness-depth=0 --unwind 2 --no-unwinding-assertions
+^ERROR: --k-path-witness-depth requires a positive integer \(got 0\)$

--- a/regression/goto-coverage/k_path_cov_2/main.c
+++ b/regression/goto-coverage/k_path_cov_2/main.c
@@ -1,0 +1,14 @@
+// Loop body with one branch; tests that prefix extends across
+// unrolled iterations (Huang, Meyer & Weber, ICTSS 2025).
+int main()
+{
+  int x;
+  for (int i = 0; i < 3; i++)
+  {
+    if (x > 0)
+      x = x - 1;
+    else
+      x = x + 1;
+  }
+  return x;
+}

--- a/regression/goto-coverage/k_path_cov_2/test.desc
+++ b/regression/goto-coverage/k_path_cov_2/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=2 --unwind 4 --no-unwinding-assertions
+^k-Path Witnesses : 6$
+^Reached : 4$
+^k-Path Coverage: 66\.66666666666667%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_3/main.c
+++ b/regression/goto-coverage/k_path_cov_3/main.c
@@ -1,0 +1,17 @@
+// Function call: instrumentation visits each function independently
+// (per-function k-path scope, #4325). Each function contributes its own
+// branch witnesses; goal count adds up across callers and callees.
+int helper(int z)
+{
+  if (z > 0)
+    return z + 1;
+  return -z;
+}
+
+int main()
+{
+  int a;
+  if (a > 0)
+    return helper(a);
+  return helper(-a);
+}

--- a/regression/goto-coverage/k_path_cov_3/test.desc
+++ b/regression/goto-coverage/k_path_cov_3/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=2 --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 4$
+^Reached : 4$
+^k-Path Coverage: 100%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_4/main.c
+++ b/regression/goto-coverage/k_path_cov_4/main.c
@@ -1,0 +1,21 @@
+// Infeasible-prefix scenario: the second branch is fully determined by
+// the first, so only 2 of the 4 (prefix × direction) combinations are
+// reachable. Demonstrates k-path coverage's natural under-coverage when
+// branches are correlated; spanning-set scoring (Marré & Bertolino, IEEE
+// TSE 2003) is Phase 2.
+int main()
+{
+  int a;
+  int taken;
+  if (a > 0)
+    taken = 1;
+  else
+    taken = 0;
+
+  if (taken)
+    a = a;
+  else
+    a = -a;
+
+  return a;
+}

--- a/regression/goto-coverage/k_path_cov_4/test.desc
+++ b/regression/goto-coverage/k_path_cov_4/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=2 --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 6$
+^Reached : 4$
+^k-Path Coverage: 66\.66666666666667%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_5_implicit_n/main.c
+++ b/regression/goto-coverage/k_path_cov_5_implicit_n/main.c
@@ -1,0 +1,19 @@
+// Regression for #4330 Copilot-1: `--k-path-coverage` without `=N` must
+// produce a coverage report. Earlier the implicit-value sentinel (0) was
+// stored verbatim, so `optionst::get_bool_option` (atoi) returned false
+// and the report was silently dropped even though instrumentation ran.
+int main()
+{
+  int a, b;
+  if (a > 0)
+    a = 1;
+  else
+    a = -1;
+
+  if (b > 0)
+    b = 1;
+  else
+    b = -1;
+
+  return a + b;
+}

--- a/regression/goto-coverage/k_path_cov_5_implicit_n/test.desc
+++ b/regression/goto-coverage/k_path_cov_5_implicit_n/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 6$
+^Reached : 6$
+^k-Path Coverage: 100%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_6_zero_n/main.c
+++ b/regression/goto-coverage/k_path_cov_6_zero_n/main.c
@@ -1,0 +1,18 @@
+// Regression for #4330 Copilot-2: `--k-path-coverage=0` must be rejected
+// at parse time, not silently fall back to --unwind/4. Same code as
+// k_path_cov_1.
+int main()
+{
+  int a, b;
+  if (a > 0)
+    a = 1;
+  else
+    a = -1;
+
+  if (b > 0)
+    b = 1;
+  else
+    b = -1;
+
+  return a + b;
+}

--- a/regression/goto-coverage/k_path_cov_6_zero_n/test.desc
+++ b/regression/goto-coverage/k_path_cov_6_zero_n/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-path-coverage=0 --unwind 2 --no-unwinding-assertions
+^ERROR: --k-path-coverage=N requires 1 <= N <= 30 \(got 0\)$

--- a/regression/goto-coverage/k_path_cov_7_n_too_large/main.c
+++ b/regression/goto-coverage/k_path_cov_7_n_too_large/main.c
@@ -1,0 +1,9 @@
+// Regression for #4330 Copilot-3: N above the safe cap (30) must be
+// rejected. Without the cap, `1 << pdepth` would overflow size_t for
+// pdepth >= 64 and underflow goal-budget arithmetic for pdepth >= 62 —
+// both unsound for a formal-verification tool.
+int main()
+{
+  int a;
+  return a > 0 ? 1 : 0;
+}

--- a/regression/goto-coverage/k_path_cov_7_n_too_large/test.desc
+++ b/regression/goto-coverage/k_path_cov_7_n_too_large/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-path-coverage=31 --unwind 2 --no-unwinding-assertions
+^ERROR: --k-path-coverage=N requires 1 <= N <= 30 \(got 31\)$

--- a/regression/goto-coverage/k_path_cov_8_chain_contradiction/main.c
+++ b/regression/goto-coverage/k_path_cov_8_chain_contradiction/main.c
@@ -1,0 +1,25 @@
+// Regression for #4330 review (LukeW1999): when the same guard appears
+// multiple times in the prefix sliding window, mask combinations that
+// assign opposing polarities to it produce chained contradictions like
+// `g ∧ q ∧ ¬g`. ESBMC's simplifier folds the 2-term case but not the
+// chained one, so without a contradiction check at instrumentation time
+// these tautological `assert(¬(g ∧ q ∧ ¬g))` assertions sat permanently
+// uncovered, inflating the denominator. Three sequential branches on
+// the same guard with k=3 should yield exactly 6 reachable witnesses
+// (2 per branch), all covered.
+int main()
+{
+  int a;
+  if (a > 0)
+    ;
+  else
+    ;
+  if (a > 0)
+    ;
+  else
+    ;
+  if (a > 0)
+    ;
+  else
+    ;
+}

--- a/regression/goto-coverage/k_path_cov_8_chain_contradiction/test.desc
+++ b/regression/goto-coverage/k_path_cov_8_chain_contradiction/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=3 --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 6$
+^Reached : 6$
+^k-Path Coverage: 100%$
+^VERIFICATION FAILED$

--- a/regression/goto-coverage/k_path_cov_9_witness_depth_cap_drops/main.c
+++ b/regression/goto-coverage/k_path_cov_9_witness_depth_cap_drops/main.c
@@ -1,0 +1,33 @@
+// Regression for #4330 review (witness-depth cap path). Three sequential
+// branches on distinct variables produce 14 witnesses at the default
+// depth cap (--k-path-witness-depth=8): 2 (branch 1) + 4 (branch 2) +
+// 8 (branch 3). With a tight cap of 2, post-simplification expression
+// depth strictly above 2 is dropped at instrumentation time. Branch 1's
+// single-atom witnesses (e.g. `a > 0`, depth 2) survive; branch 2/3
+// chained-conjunction witnesses (depth >= 3) are dropped.
+//
+// Soundness rationale: dropping a witness removes it from BOTH the
+// numerator (reached_claims for that goal) and the denominator
+// (total_kpath / all_claims). The reported percentage stays accurate
+// over the emitted subset; the user simply gets a less complete
+// measurement, which is the documented contract of the tractability
+// knob. The test asserts that:
+//   - the reduced witness count is observed (2, not 14),
+//   - the surviving subset is fully reached (100%, not a vacuous N/A
+//     and not a false 0%).
+int main()
+{
+  int a, b, c;
+  if (a > 0)
+    ;
+  else
+    ;
+  if (b > 0)
+    ;
+  else
+    ;
+  if (c > 0)
+    ;
+  else
+    ;
+}

--- a/regression/goto-coverage/k_path_cov_9_witness_depth_cap_drops/test.desc
+++ b/regression/goto-coverage/k_path_cov_9_witness_depth_cap_drops/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--k-path-coverage=3 --k-path-witness-depth=2 --unwind 2 --no-unwinding-assertions
+^k-Path Witnesses : 2$
+^Reached : 2$
+^k-Path Coverage: 100%$
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -714,8 +714,12 @@ void report_coverage(
   bool is_branch_func_cov =
     options.get_bool_option("branch-function-coverage") ||
     options.get_bool_option("branch-function-coverage-claims");
-  bool is_k_path_cov = options.get_bool_option("k-path-coverage") ||
-                       options.get_bool_option("k-path-coverage-claims");
+  // `k-path-coverage` itself stores the CLI integer N; the dedicated
+  // boolean enable flag is set by parseoptions when either CLI flag is
+  // present. This avoids `get_bool_option("k-path-coverage")` returning 0
+  // (false) for valid invocations like `--k-path-coverage` (no value) or
+  // `--k-path-coverage=0` (rejected at parse time, but defensive here).
+  bool is_k_path_cov = options.get_bool_option("k-path-coverage-enabled");
 
   if (is_assert_cov)
   {

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -714,6 +714,8 @@ void report_coverage(
   bool is_branch_func_cov =
     options.get_bool_option("branch-function-coverage") ||
     options.get_bool_option("branch-function-coverage-claims");
+  bool is_k_path_cov = options.get_bool_option("k-path-coverage") ||
+                       options.get_bool_option("k-path-coverage-claims");
 
   if (is_assert_cov)
   {
@@ -916,6 +918,24 @@ void report_coverage(
       log_result("Branch Coverage: N/A (no branches)");
   }
 
+  else if (is_k_path_cov)
+  {
+    const size_t total = goto_coveraget::total_kpath;
+    const size_t tracked_instance = reached_claims.size();
+    log_success("\n[Coverage]\n");
+    log_result("k-Path Witnesses : {}", total);
+    log_result("Reached : {}", tracked_instance);
+
+    if (options.get_bool_option("k-path-coverage-claims"))
+      for (const auto &claim : reached_claims)
+        log_status("  {}", prettify_solidity_expr(claim));
+
+    if (total != 0)
+      log_result("k-Path Coverage: {}%", tracked_instance * 100.0 / total);
+    else
+      log_result("k-Path Coverage: N/A (no k-path goals)");
+  }
+
   // Generate JSON coverage report
   if (options.get_bool_option("cov-report-json"))
   {
@@ -926,6 +946,8 @@ void report_coverage(
       cov_type = "branch";
     else if (is_branch_func_cov)
       cov_type = "branch-function";
+    else if (is_k_path_cov)
+      cov_type = "k-path";
     else if (is_cond_cov)
       cov_type = "condition";
     else if (is_assert_cov)
@@ -1703,7 +1725,8 @@ smt_convt::resultt bmct::multi_property_check(
                        &is,
                        &is_color,
                        &YELLOW,
-                       &runtime_solver](const size_t &i) {
+                       &runtime_solver](const size_t &i)
+  {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;
@@ -1771,9 +1794,9 @@ smt_convt::resultt bmct::multi_property_check(
     }
 
     // Store solver name initially but not again
-    std::call_once(summary.solver_name_flag, [&]() {
-      summary.solver_name = solver_ptr->solver_text();
-    });
+    std::call_once(
+      summary.solver_name_flag,
+      [&]() { summary.solver_name = solver_ptr->solver_text(); });
     // In coverage mode, only report instrumented coverage claims
     bool is_cov_silent =
       is_goto_cov && claim.claim_property != "instrumented assertion";

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1662,6 +1662,11 @@ smt_convt::resultt bmct::multi_property_check(
   bool is_branch_func_cov =
     options.get_bool_option("branch-function-coverage") ||
     options.get_bool_option("branch-function-coverage-claims");
+  // "k-Path Cov" — keyed off the dedicated boolean (see line ~717
+  // comment); needed in the is_goto_cov disjunction so the
+  // claim_slicer reads the witness comment, matching the form stored
+  // in goto_coveraget::all_claims.
+  bool is_k_path_cov = options.get_bool_option("k-path-coverage-enabled");
 
   // is_vb: enable verbose output coverage info if the option "--verbosity coverage:N" is set, where N should larger than 0
   // By enabling this, we will output the coverage information when handling each instrumentation assertion.
@@ -1720,6 +1725,7 @@ smt_convt::resultt bmct::multi_property_check(
                        &is_vb,
                        &is_branch_cov,
                        &is_branch_func_cov,
+                       &is_k_path_cov,
                        &is_keep_verified,
                        &is_fail_fast,
                        &fail_fast_limit,
@@ -1729,7 +1735,8 @@ smt_convt::resultt bmct::multi_property_check(
                        &is,
                        &is_color,
                        &YELLOW,
-                       &runtime_solver](const size_t &i) {
+                       &runtime_solver](const size_t &i)
+  {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;
@@ -1737,9 +1744,18 @@ smt_convt::resultt bmct::multi_property_check(
     // Since this is just a copy, we probably don't need a lock
     symex_target_equationt local_eq = eq;
 
-    // Set up the current claim and disable slice info output
-    bool is_goto_cov =
-      is_assert_cov || is_cond_cov || is_branch_cov || is_branch_func_cov;
+    // Set up the current claim and disable slice info output.
+    // `is_goto_cov` flips claim_slicer's `claim_msg` source: in goto-cov
+    // modes the slicer reads the comment (the original witness/guard
+    // text we stored in insert_assert); otherwise it reads the negated
+    // assertion expression. k-path goals are stored the same way as
+    // branch / condition goals, so they must be in this disjunction —
+    // otherwise the claim_sig built at line ~1751 disagrees with the
+    // form in goto_coveraget::all_claims and every JSON entry shows up
+    // as uncovered even when reached_claims has the matching reached
+    // signature (PR #4330 review).
+    bool is_goto_cov = is_assert_cov || is_cond_cov || is_branch_cov ||
+                       is_branch_func_cov || is_k_path_cov;
     claim_slicer claim(i, false, is_goto_cov, ns);
     claim.run(local_eq.SSA_steps);
 
@@ -1797,9 +1813,9 @@ smt_convt::resultt bmct::multi_property_check(
     }
 
     // Store solver name initially but not again
-    std::call_once(summary.solver_name_flag, [&]() {
-      summary.solver_name = solver_ptr->solver_text();
-    });
+    std::call_once(
+      summary.solver_name_flag,
+      [&]() { summary.solver_name = solver_ptr->solver_text(); });
     // In coverage mode, only report instrumented coverage claims
     bool is_cov_silent =
       is_goto_cov && claim.claim_property != "instrumented assertion";

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1735,8 +1735,7 @@ smt_convt::resultt bmct::multi_property_check(
                        &is,
                        &is_color,
                        &YELLOW,
-                       &runtime_solver](const size_t &i)
-  {
+                       &runtime_solver](const size_t &i) {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;
@@ -1813,9 +1812,9 @@ smt_convt::resultt bmct::multi_property_check(
     }
 
     // Store solver name initially but not again
-    std::call_once(
-      summary.solver_name_flag,
-      [&]() { summary.solver_name = solver_ptr->solver_text(); });
+    std::call_once(summary.solver_name_flag, [&]() {
+      summary.solver_name = solver_ptr->solver_text();
+    });
     // In coverage mode, only report instrumented coverage claims
     bool is_cov_silent =
       is_goto_cov && claim.claim_property != "instrumented assertion";

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -1725,8 +1725,7 @@ smt_convt::resultt bmct::multi_property_check(
                        &is,
                        &is_color,
                        &YELLOW,
-                       &runtime_solver](const size_t &i)
-  {
+                       &runtime_solver](const size_t &i) {
     //"multi-fail-fast n": stop after first n SATs found.
     if (is_fail_fast && fail_fast_cnt >= fail_fast_limit)
       return;
@@ -1794,9 +1793,9 @@ smt_convt::resultt bmct::multi_property_check(
     }
 
     // Store solver name initially but not again
-    std::call_once(
-      summary.solver_name_flag,
-      [&]() { summary.solver_name = solver_ptr->solver_text(); });
+    std::call_once(summary.solver_name_flag, [&]() {
+      summary.solver_name = solver_ptr->solver_text();
+    });
     // In coverage mode, only report instrumented coverage claims
     bool is_cov_silent =
       is_goto_cov && claim.claim_property != "instrumented assertion";

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -24,6 +24,7 @@ extern "C"
 #include <util/filesystem.h>
 #include <csignal>
 #include <cstdlib>
+#include <limits>
 #include <util/expr_util.h>
 #include <iostream>
 #include <goto-programs/add_race_assertions.h>
@@ -2449,10 +2450,24 @@ bool esbmc_parseoptionst::process_goto_program(
       cmdline.isset("k-path-coverage") ||
       cmdline.isset("k-path-coverage-claims"))
     {
+      // Hard cap on the prefix depth. Goal count per branch grows as
+      // 2^(N-1), and (N-1) >= 64 would overflow size_t in `1 << pdepth`.
+      // 30 leaves 2^29 goals/branch — already far above any reasonable
+      // --k-path-max-goals — and gives a comfortable safety margin from
+      // the size_t shift limit. Defense-in-depth: also enforced inside
+      // goto_coveraget::k_path_coverage().
+      static constexpr int K_PATH_N_MAX = 30;
+
       options.set_option("base-case", true);
       options.set_option("multi-property", true);
       options.set_option("keep-verified-claims", false);
       options.set_option("no-pointer-check", true);
+      // Separate boolean enable flag in the option_map. Required because
+      // `optionst::get_bool_option(name)` is `atoi(value)`, so storing the
+      // CLI int value of `--k-path-coverage` (which is `0` for the no-arg
+      // case under boost's implicit_value, or any user-supplied integer)
+      // would silently mis-report the feature as disabled in bmc.cpp.
+      options.set_option("k-path-coverage-enabled", true);
 
       if (cmdline.isset("unwind"))
         options.set_option("no-unwinding-assertions", true);
@@ -2464,23 +2479,47 @@ bool esbmc_parseoptionst::process_goto_program(
       tmp.cov_assume_asserts = cmdline.isset("cov-assume-asserts");
 
       // Resolve N: explicit --k-path-coverage=N > --unwind > fallback 4.
-      // Reject non-positive values explicitly — `--unwind -1` (used elsewhere
-      // for "unbounded") would otherwise cast to SIZE_MAX and disable the
-      // per-function deque trim, growing goals without bound.
-      int n_arg = 0;
+      // The CLI option uses implicit_value(INT_MIN), so `--k-path-coverage`
+      // without `=N` parses as INT_MIN (the "no value" sentinel) and falls
+      // through to --unwind / 4. Any other non-positive value (incl.
+      // explicit `=0` or `=-1`) is rejected — silently falling through
+      // would defeat the user's intent.
+      const int K_PATH_N_SENTINEL = std::numeric_limits<int>::min();
+      int n_arg = K_PATH_N_SENTINEL;
       if (cmdline.isset("k-path-coverage"))
         n_arg = atoi(cmdline.getval("k-path-coverage"));
       if (n_arg > 0)
+      {
+        if (n_arg > K_PATH_N_MAX)
+        {
+          log_error(
+            "--k-path-coverage=N requires 1 <= N <= {} (got {})",
+            K_PATH_N_MAX,
+            n_arg);
+          return true;
+        }
         tmp.k_path_n = static_cast<size_t>(n_arg);
+      }
+      else if (n_arg != K_PATH_N_SENTINEL)
+      {
+        // Explicit non-positive value — reject rather than silently
+        // falling back.
+        log_error(
+          "--k-path-coverage=N requires 1 <= N <= {} (got {})",
+          K_PATH_N_MAX,
+          n_arg);
+        return true;
+      }
       else if (cmdline.isset("unwind"))
       {
         int u = atoi(cmdline.getval("unwind"));
-        if (u <= 0)
+        if (u <= 0 || u > K_PATH_N_MAX)
         {
           log_error(
-            "--k-path-coverage cannot derive N from --unwind={}; pass "
-            "--k-path-coverage=N explicitly",
-            u);
+            "--k-path-coverage cannot derive N from --unwind={} (must be "
+            "in 1..{}); pass --k-path-coverage=N explicitly",
+            u,
+            K_PATH_N_MAX);
           return true;
         }
         tmp.k_path_n = static_cast<size_t>(u);

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1456,7 +1456,8 @@ int esbmc_parseoptionst::do_bmc_strategy(
   // proof or refutation has been found.  In multi-property mode the loop may
   // have continued past an earlier violation, so we must return 1 even when
   // the closing step (FC/IS) itself succeeds.
-  auto conclude = [&]() -> int {
+  auto conclude = [&]() -> int
+  {
     // In coverage mode violations are expected; always report success.
     if (any_violation_found && !is_coverage)
     {
@@ -2098,7 +2099,9 @@ bool esbmc_parseoptionst::process_goto_program(
                   cmdline.isset("branch-coverage") ||
                   cmdline.isset("branch-coverage-claims") ||
                   cmdline.isset("branch-function-coverage") ||
-                  cmdline.isset("branch-function-coverage-claims");
+                  cmdline.isset("branch-function-coverage-claims") ||
+                  cmdline.isset("k-path-coverage") ||
+                  cmdline.isset("k-path-coverage-claims");
 
     // For coverage mode, treat extra input files (cmdline.args[1:]) as include
     // files so that the coverage location_pool covers all input sources.
@@ -2443,6 +2446,75 @@ bool esbmc_parseoptionst::process_goto_program(
       tmp.branch_function_coverage();
     }
 
+    if (
+      cmdline.isset("k-path-coverage") ||
+      cmdline.isset("k-path-coverage-claims"))
+    {
+      options.set_option("base-case", true);
+      options.set_option("multi-property", true);
+      options.set_option("keep-verified-claims", false);
+      options.set_option("no-pointer-check", true);
+
+      if (cmdline.isset("unwind"))
+        options.set_option("no-unwinding-assertions", true);
+
+      std::string filename = cmdline.args[0];
+      goto_coveraget tmp(ns, goto_functions, filename);
+      if (cmdline.isset("function"))
+        tmp.set_target(cmdline.getval("function"));
+      tmp.cov_assume_asserts = cmdline.isset("cov-assume-asserts");
+
+      // Resolve N: explicit --k-path-coverage=N > --unwind > fallback 4.
+      // Reject non-positive values explicitly — `--unwind -1` (used elsewhere
+      // for "unbounded") would otherwise cast to SIZE_MAX and disable the
+      // per-function deque trim, growing goals without bound.
+      int n_arg = 0;
+      if (cmdline.isset("k-path-coverage"))
+        n_arg = atoi(cmdline.getval("k-path-coverage"));
+      if (n_arg > 0)
+        tmp.k_path_n = static_cast<size_t>(n_arg);
+      else if (cmdline.isset("unwind"))
+      {
+        int u = atoi(cmdline.getval("unwind"));
+        if (u <= 0)
+        {
+          log_error(
+            "--k-path-coverage cannot derive N from --unwind={}; pass "
+            "--k-path-coverage=N explicitly",
+            u);
+          return true;
+        }
+        tmp.k_path_n = static_cast<size_t>(u);
+      }
+      else
+      {
+        tmp.k_path_n = 4;
+        log_status(
+          "--k-path-coverage: no N or --unwind specified; defaulting to "
+          "N=4");
+      }
+
+      auto read_positive = [&](const char *flag, size_t &dst) -> bool
+      {
+        if (!cmdline.isset(flag))
+          return true;
+        int v = atoi(cmdline.getval(flag));
+        if (v <= 0)
+        {
+          log_error("--{} requires a positive integer (got {})", flag, v);
+          return false;
+        }
+        dst = static_cast<size_t>(v);
+        return true;
+      };
+      if (!read_positive("k-path-witness-depth", tmp.k_path_witness_depth))
+        return true;
+      if (!read_positive("k-path-max-goals", tmp.k_path_max_goals))
+        return true;
+
+      tmp.k_path_coverage();
+    }
+
     if (cmdline.isset("negating-property"))
     {
       std::string tgt_fname = cmdline.getval("negating-property");
@@ -2690,18 +2762,20 @@ void esbmc_parseoptionst::add_property_monitors(
 {
   std::map<std::string, std::pair<std::set<std::string>, expr2tc>> monitors;
 
-  context.foreach_operand([this, &monitors](const symbolt &s) {
-    if (
-      !has_prefix(s.name, "__ESBMC_property_") ||
-      s.name.as_string().find("$type") != std::string::npos)
-      return;
+  context.foreach_operand(
+    [this, &monitors](const symbolt &s)
+    {
+      if (
+        !has_prefix(s.name, "__ESBMC_property_") ||
+        s.name.as_string().find("$type") != std::string::npos)
+        return;
 
-    // strip prefix "__ESBMC_property_"
-    std::string prop_name = s.name.as_string().substr(17);
-    std::set<std::string> used_syms;
-    expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
-    monitors[prop_name] = std::pair{used_syms, main_expr};
-  });
+      // strip prefix "__ESBMC_property_"
+      std::string prop_name = s.name.as_string().substr(17);
+      std::set<std::string> used_syms;
+      expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
+      monitors[prop_name] = std::pair{used_syms, main_expr};
+    });
 
   if (monitors.size() == 0)
     return;
@@ -2796,10 +2870,12 @@ static void collect_symbol_names(
   }
   else
   {
-    e->foreach_operand([&prefix, &used_syms](const expr2tc &e) {
-      if (!is_nil_expr(e))
-        collect_symbol_names(e, prefix, used_syms);
-    });
+    e->foreach_operand(
+      [&prefix, &used_syms](const expr2tc &e)
+      {
+        if (!is_nil_expr(e))
+          collect_symbol_names(e, prefix, used_syms);
+      });
   }
 }
 
@@ -2891,9 +2967,8 @@ static unsigned int calc_globals_used(const namespacet &ns, const expr2tc &expr)
   {
     unsigned int globals = 0;
 
-    expr->foreach_operand([&globals, &ns](const expr2tc &e) {
-      globals += calc_globals_used(ns, e);
-    });
+    expr->foreach_operand([&globals, &ns](const expr2tc &e)
+                          { globals += calc_globals_used(ns, e); });
     return globals;
   }
 
@@ -2982,42 +3057,43 @@ void esbmc_parseoptionst::process_function_contracts(
   // This includes functions with:
   // 1. Explicit contract clauses (__ESBMC_requires, __ESBMC_ensures, __ESBMC_assigns)
   // 2. __attribute__((annotate("__ESBMC_contract"))) annotation
-  auto collect_functions_with_contracts =
-    [&contracts, &goto_functions, &ctx]() {
-      std::set<std::string> result;
-      forall_goto_functions (it, goto_functions)
+  auto collect_functions_with_contracts = [&contracts, &goto_functions, &ctx]()
+  {
+    std::set<std::string> result;
+    forall_goto_functions (it, goto_functions)
+    {
+      if (!it->second.body_available)
+        continue;
+
+      std::string func_name = id2string(it->first);
+
+      // Use is_compiler_generated (which correctly handles C++ USR IDs like
+      // "c:@F@fst#*1I#") instead of a raw '#' string filter, which would
+      // incorrectly skip all C++ functions with parameters.
+      if (contracts.is_compiler_generated(func_name))
+        continue;
+
+      // Check for explicit contract clauses in function body
+      if (contracts.has_contracts(it->second.body))
       {
-        if (!it->second.body_available)
-          continue;
-
-        std::string func_name = id2string(it->first);
-
-        // Use is_compiler_generated (which correctly handles C++ USR IDs like
-        // "c:@F@fst#*1I#") instead of a raw '#' string filter, which would
-        // incorrectly skip all C++ functions with parameters.
-        if (contracts.is_compiler_generated(func_name))
-          continue;
-
-        // Check for explicit contract clauses in function body
-        if (contracts.has_contracts(it->second.body))
-        {
-          result.insert(func_name);
-          continue;
-        }
-
-        // Check for __attribute__((annotate("__ESBMC_contract"))) annotation
-        symbolt *func_sym = ctx.find_symbol(it->first);
-        if (func_sym && contracts.is_annotated_contract_function(*func_sym))
-        {
-          result.insert(func_name);
-        }
+        result.insert(func_name);
+        continue;
       }
-      return result;
-    };
+
+      // Check for __attribute__((annotate("__ESBMC_contract"))) annotation
+      symbolt *func_sym = ctx.find_symbol(it->first);
+      if (func_sym && contracts.is_annotated_contract_function(*func_sym))
+      {
+        result.insert(func_name);
+      }
+    }
+    return result;
+  };
 
   // Lambda function to process function list (handles "*" wildcard)
-  auto process_function_list = [&collect_functions_with_contracts](
-                                 const std::list<std::string> &func_list) {
+  auto process_function_list =
+    [&collect_functions_with_contracts](const std::list<std::string> &func_list)
+  {
     std::set<std::string> result;
     for (const auto &func : func_list)
     {
@@ -3072,21 +3148,22 @@ void esbmc_parseoptionst::process_function_contracts(
 
   // Lambda to collect ONLY functions with __ESBMC_contract annotation
   auto collect_annotated_contract_functions =
-    [&contracts, &goto_functions, &ctx]() {
-      std::set<std::string> result;
-      forall_goto_functions (it, goto_functions)
-      {
-        if (!it->second.body_available)
-          continue;
-        std::string func_name = id2string(it->first);
-        if (contracts.is_compiler_generated(func_name))
-          continue;
-        symbolt *func_sym = ctx.find_symbol(it->first);
-        if (func_sym && contracts.is_annotated_contract_function(*func_sym))
-          result.insert(func_name);
-      }
-      return result;
-    };
+    [&contracts, &goto_functions, &ctx]()
+  {
+    std::set<std::string> result;
+    forall_goto_functions (it, goto_functions)
+    {
+      if (!it->second.body_available)
+        continue;
+      std::string func_name = id2string(it->first);
+      if (contracts.is_compiler_generated(func_name))
+        continue;
+      symbolt *func_sym = ctx.find_symbol(it->first);
+      if (func_sym && contracts.is_annotated_contract_function(*func_sym))
+        result.insert(func_name);
+    }
+    return result;
+  };
 
   // Process --enforce-all-contracts
   if (has_enforce_all)

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -1456,8 +1456,7 @@ int esbmc_parseoptionst::do_bmc_strategy(
   // proof or refutation has been found.  In multi-property mode the loop may
   // have continued past an earlier violation, so we must return 1 even when
   // the closing step (FC/IS) itself succeeds.
-  auto conclude = [&]() -> int
-  {
+  auto conclude = [&]() -> int {
     // In coverage mode violations are expected; always report success.
     if (any_violation_found && !is_coverage)
     {
@@ -2494,8 +2493,7 @@ bool esbmc_parseoptionst::process_goto_program(
           "N=4");
       }
 
-      auto read_positive = [&](const char *flag, size_t &dst) -> bool
-      {
+      auto read_positive = [&](const char *flag, size_t &dst) -> bool {
         if (!cmdline.isset(flag))
           return true;
         int v = atoi(cmdline.getval(flag));
@@ -2762,20 +2760,18 @@ void esbmc_parseoptionst::add_property_monitors(
 {
   std::map<std::string, std::pair<std::set<std::string>, expr2tc>> monitors;
 
-  context.foreach_operand(
-    [this, &monitors](const symbolt &s)
-    {
-      if (
-        !has_prefix(s.name, "__ESBMC_property_") ||
-        s.name.as_string().find("$type") != std::string::npos)
-        return;
+  context.foreach_operand([this, &monitors](const symbolt &s) {
+    if (
+      !has_prefix(s.name, "__ESBMC_property_") ||
+      s.name.as_string().find("$type") != std::string::npos)
+      return;
 
-      // strip prefix "__ESBMC_property_"
-      std::string prop_name = s.name.as_string().substr(17);
-      std::set<std::string> used_syms;
-      expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
-      monitors[prop_name] = std::pair{used_syms, main_expr};
-    });
+    // strip prefix "__ESBMC_property_"
+    std::string prop_name = s.name.as_string().substr(17);
+    std::set<std::string> used_syms;
+    expr2tc main_expr = calculate_a_property_monitor(prop_name, used_syms);
+    monitors[prop_name] = std::pair{used_syms, main_expr};
+  });
 
   if (monitors.size() == 0)
     return;
@@ -2870,12 +2866,10 @@ static void collect_symbol_names(
   }
   else
   {
-    e->foreach_operand(
-      [&prefix, &used_syms](const expr2tc &e)
-      {
-        if (!is_nil_expr(e))
-          collect_symbol_names(e, prefix, used_syms);
-      });
+    e->foreach_operand([&prefix, &used_syms](const expr2tc &e) {
+      if (!is_nil_expr(e))
+        collect_symbol_names(e, prefix, used_syms);
+    });
   }
 }
 
@@ -2967,8 +2961,9 @@ static unsigned int calc_globals_used(const namespacet &ns, const expr2tc &expr)
   {
     unsigned int globals = 0;
 
-    expr->foreach_operand([&globals, &ns](const expr2tc &e)
-                          { globals += calc_globals_used(ns, e); });
+    expr->foreach_operand([&globals, &ns](const expr2tc &e) {
+      globals += calc_globals_used(ns, e);
+    });
     return globals;
   }
 
@@ -3057,43 +3052,42 @@ void esbmc_parseoptionst::process_function_contracts(
   // This includes functions with:
   // 1. Explicit contract clauses (__ESBMC_requires, __ESBMC_ensures, __ESBMC_assigns)
   // 2. __attribute__((annotate("__ESBMC_contract"))) annotation
-  auto collect_functions_with_contracts = [&contracts, &goto_functions, &ctx]()
-  {
-    std::set<std::string> result;
-    forall_goto_functions (it, goto_functions)
-    {
-      if (!it->second.body_available)
-        continue;
-
-      std::string func_name = id2string(it->first);
-
-      // Use is_compiler_generated (which correctly handles C++ USR IDs like
-      // "c:@F@fst#*1I#") instead of a raw '#' string filter, which would
-      // incorrectly skip all C++ functions with parameters.
-      if (contracts.is_compiler_generated(func_name))
-        continue;
-
-      // Check for explicit contract clauses in function body
-      if (contracts.has_contracts(it->second.body))
+  auto collect_functions_with_contracts =
+    [&contracts, &goto_functions, &ctx]() {
+      std::set<std::string> result;
+      forall_goto_functions (it, goto_functions)
       {
-        result.insert(func_name);
-        continue;
-      }
+        if (!it->second.body_available)
+          continue;
 
-      // Check for __attribute__((annotate("__ESBMC_contract"))) annotation
-      symbolt *func_sym = ctx.find_symbol(it->first);
-      if (func_sym && contracts.is_annotated_contract_function(*func_sym))
-      {
-        result.insert(func_name);
+        std::string func_name = id2string(it->first);
+
+        // Use is_compiler_generated (which correctly handles C++ USR IDs like
+        // "c:@F@fst#*1I#") instead of a raw '#' string filter, which would
+        // incorrectly skip all C++ functions with parameters.
+        if (contracts.is_compiler_generated(func_name))
+          continue;
+
+        // Check for explicit contract clauses in function body
+        if (contracts.has_contracts(it->second.body))
+        {
+          result.insert(func_name);
+          continue;
+        }
+
+        // Check for __attribute__((annotate("__ESBMC_contract"))) annotation
+        symbolt *func_sym = ctx.find_symbol(it->first);
+        if (func_sym && contracts.is_annotated_contract_function(*func_sym))
+        {
+          result.insert(func_name);
+        }
       }
-    }
-    return result;
-  };
+      return result;
+    };
 
   // Lambda function to process function list (handles "*" wildcard)
-  auto process_function_list =
-    [&collect_functions_with_contracts](const std::list<std::string> &func_list)
-  {
+  auto process_function_list = [&collect_functions_with_contracts](
+                                 const std::list<std::string> &func_list) {
     std::set<std::string> result;
     for (const auto &func : func_list)
     {
@@ -3148,22 +3142,21 @@ void esbmc_parseoptionst::process_function_contracts(
 
   // Lambda to collect ONLY functions with __ESBMC_contract annotation
   auto collect_annotated_contract_functions =
-    [&contracts, &goto_functions, &ctx]()
-  {
-    std::set<std::string> result;
-    forall_goto_functions (it, goto_functions)
-    {
-      if (!it->second.body_available)
-        continue;
-      std::string func_name = id2string(it->first);
-      if (contracts.is_compiler_generated(func_name))
-        continue;
-      symbolt *func_sym = ctx.find_symbol(it->first);
-      if (func_sym && contracts.is_annotated_contract_function(*func_sym))
-        result.insert(func_name);
-    }
-    return result;
-  };
+    [&contracts, &goto_functions, &ctx]() {
+      std::set<std::string> result;
+      forall_goto_functions (it, goto_functions)
+      {
+        if (!it->second.body_available)
+          continue;
+        std::string func_name = id2string(it->first);
+        if (contracts.is_compiler_generated(func_name))
+          continue;
+        symbolt *func_sym = ctx.find_symbol(it->first);
+        if (func_sym && contracts.is_annotated_contract_function(*func_sym))
+          result.insert(func_name);
+      }
+      return result;
+    };
 
   // Process --enforce-all-contracts
   if (has_enforce_all)

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -700,6 +700,24 @@ const struct group_opt_templ all_cmd_options[] = {
      {"branch-function-coverage-claims",
       NULL,
       "Enable branch-coverage-ext and shows all reached claims"},
+     {"k-path-coverage",
+      boost::program_options::value<int>()->implicit_value(0)->value_name("N"),
+      "Show the coverage of k-path witnesses (PathCrawler-style; "
+      "Williams et al., EDCC 2005). N is the prefix depth; if omitted, "
+      "tied to --unwind, falling back to 4 when --unwind is unset"},
+     {"k-path-coverage-claims",
+      NULL,
+      "Enable --k-path-coverage with default N (use --k-path-coverage=N "
+      "directly to override) and show all reached claims"},
+     {"k-path-witness-depth",
+      boost::program_options::value<int>()->default_value(8)->value_name("D"),
+      "Cap on post-simplification witness expression depth in --k-path-"
+      "coverage; deeper witnesses are dropped (default 8)"},
+     {"k-path-max-goals",
+      boost::program_options::value<int>()->default_value(10000)->value_name(
+        "M"),
+      "Per-function goal cap for --k-path-coverage; on overflow the "
+      "instrumentation aborts rather than truncating (default 10000)"},
      {"assign-param-nondet",
       NULL,
       "Explicitly assign every function parameters to NONDET in function "

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -1,6 +1,7 @@
 #include <boost/program_options/value_semantic.hpp>
 #include <esbmc/esbmc_parseoptions.h>
 #include <fstream>
+#include <limits>
 #include <solvers/solver_config.h>
 #include <util/cmdline.h>
 
@@ -701,10 +702,15 @@ const struct group_opt_templ all_cmd_options[] = {
       NULL,
       "Enable branch-coverage-ext and shows all reached claims"},
      {"k-path-coverage",
-      boost::program_options::value<int>()->implicit_value(0)->value_name("N"),
+      // INT_MIN is the implicit_value sentinel for "no =N supplied".
+      // -1 / 0 are explicit user inputs and rejected at parse time;
+      // INT_MIN is unambiguous since no user would ever type it.
+      boost::program_options::value<int>()
+        ->implicit_value(std::numeric_limits<int>::min())
+        ->value_name("N"),
       "Show the coverage of k-path witnesses (PathCrawler-style; "
-      "Williams et al., EDCC 2005). N is the prefix depth; if omitted, "
-      "tied to --unwind, falling back to 4 when --unwind is unset"},
+      "Williams et al., EDCC 2005). N is the prefix depth (1..30); if "
+      "omitted, tied to --unwind, falling back to 4 when --unwind is unset"},
      {"k-path-coverage-claims",
       NULL,
       "Enable --k-path-coverage with default N (use --k-path-coverage=N "

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -434,19 +434,67 @@ void goto_coveraget::k_path_coverage()
 
         for (size_t mask = 0; mask < pcombos; ++mask)
         {
-          // Build the prefix witness for this direction mask.
+          // Build the prefix witness for this direction mask, while
+          // tracking (stored-guard, polarity) pairs so we can drop mask
+          // combinations that are unsat by construction.
+          //
+          // ESBMC's `simplify` recognises 2-term `p ∧ ¬p` but does not
+          // fold chained forms like `p ∧ q ∧ ¬p` to FALSE — it would
+          // instrument a tautological `assert(¬(p ∧ q ∧ ¬p))` that can
+          // never be falsified, permanently inflating the denominator.
+          // Catching this at construction time is sound (we only drop
+          // witnesses we can prove unsat by syntactic structure) and
+          // preserves the single-term behaviour of the simplifier.
+          //
+          // Phase-1 limitation: this only catches *syntactic* same-atom
+          // contradictions (same stored guard with opposing polarities).
+          // Semantically contradictory pairs across different stored
+          // expressions — e.g. `(x == 1) ∧ (x == 2)` from successive
+          // switch-case branches — require comparison-domain reasoning
+          // and are out of scope for this PR.
           expr2tc pwit;
+          std::vector<std::pair<expr2tc, bool>> atoms;
+          atoms.reserve(pdepth);
+          bool contradictory = false;
           for (size_t i = 0; i < pdepth; ++i)
           {
-            expr2tc d =
-              (mask & (size_t(1) << i)) ? active[i] : gen_not_expr(active[i]);
+            const bool pol = (mask & (size_t(1) << i)) != 0;
+            for (const auto &[h, p] : atoms)
+            {
+              if (h == active[i] && p != pol)
+              {
+                contradictory = true;
+                break;
+              }
+            }
+            if (contradictory)
+              break;
+            atoms.emplace_back(active[i], pol);
+            expr2tc d = pol ? active[i] : gen_not_expr(active[i]);
             pwit = is_nil_expr(pwit) ? d : gen_and_expr(pwit, d);
           }
+          if (contradictory)
+            continue;
 
-          // Emit one goal per current direction.
+          // Emit one goal per current direction. Skip the direction if
+          // it would contradict an atom already in the prefix.
           const expr2tc current_neg = gen_not_expr(current_guard);
-          for (const expr2tc &cdir : {current_guard, current_neg})
+          for (size_t cd = 0; cd < 2; ++cd)
           {
+            const bool cdir_pol = (cd == 0);
+            bool cdir_conflict = false;
+            for (const auto &[h, p] : atoms)
+            {
+              if (h == current_guard && p != cdir_pol)
+              {
+                cdir_conflict = true;
+                break;
+              }
+            }
+            if (cdir_conflict)
+              continue;
+
+            const expr2tc &cdir = cdir_pol ? current_guard : current_neg;
             expr2tc full = is_nil_expr(pwit) ? cdir : gen_and_expr(pwit, cdir);
             simplify(full);
 
@@ -753,7 +801,8 @@ void goto_coveraget::gen_cond_cov_assert(
   if (n == 0)
     return; // atom
 
-  auto recurse_all = [&]() {
+  auto recurse_all = [&]()
+  {
     for (std::size_t i = 0; i < n; ++i)
       gen_cond_cov_assert(*ptr->get_sub_expr(i), pre_cond, goto_program, it);
   };
@@ -908,9 +957,8 @@ expr2tc goto_coveraget::handle_single_guard(
   if (is_nil_expr(expr))
     return expr;
   const std::size_t n = expr->get_num_sub_exprs();
-  auto recurse = [this](const expr2tc &e, bool tl) {
-    return handle_single_guard(e, tl);
-  };
+  auto recurse = [this](const expr2tc &e, bool tl)
+  { return handle_single_guard(e, tl); };
 
   // --- Rule 1: Atomic expressions ---
   // If the expression has no operands (a symbol or constant),
@@ -1010,8 +1058,8 @@ void goto_coveraget::handle_operands_guard(
     {
       // we do not need to add a !=false at top level
       // e.g. return x?1:0 != return (x?1:0)!=false
-      target->Foreach_operand(
-        [this](expr2tc &op) { op = handle_single_guard(op, false); });
+      target->Foreach_operand([this](expr2tc &op)
+                              { op = handle_single_guard(op, false); });
     }
     gen_cond_cov_assert(target, pre_cond, goto_program, it);
   }

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -739,8 +739,7 @@ void goto_coveraget::gen_cond_cov_assert(
   if (n == 0)
     return; // atom
 
-  auto recurse_all = [&]()
-  {
+  auto recurse_all = [&]() {
     for (std::size_t i = 0; i < n; ++i)
       gen_cond_cov_assert(*ptr->get_sub_expr(i), pre_cond, goto_program, it);
   };
@@ -895,8 +894,9 @@ expr2tc goto_coveraget::handle_single_guard(
   if (is_nil_expr(expr))
     return expr;
   const std::size_t n = expr->get_num_sub_exprs();
-  auto recurse = [this](const expr2tc &e, bool tl)
-  { return handle_single_guard(e, tl); };
+  auto recurse = [this](const expr2tc &e, bool tl) {
+    return handle_single_guard(e, tl);
+  };
 
   // --- Rule 1: Atomic expressions ---
   // If the expression has no operands (a symbol or constant),
@@ -996,8 +996,8 @@ void goto_coveraget::handle_operands_guard(
     {
       // we do not need to add a !=false at top level
       // e.g. return x?1:0 != return (x?1:0)!=false
-      target->Foreach_operand([this](expr2tc &op)
-                              { op = handle_single_guard(op, false); });
+      target->Foreach_operand(
+        [this](expr2tc &op) { op = handle_single_guard(op, false); });
     }
     gen_cond_cov_assert(target, pre_cond, goto_program, it);
   }

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -801,8 +801,7 @@ void goto_coveraget::gen_cond_cov_assert(
   if (n == 0)
     return; // atom
 
-  auto recurse_all = [&]()
-  {
+  auto recurse_all = [&]() {
     for (std::size_t i = 0; i < n; ++i)
       gen_cond_cov_assert(*ptr->get_sub_expr(i), pre_cond, goto_program, it);
   };
@@ -957,8 +956,9 @@ expr2tc goto_coveraget::handle_single_guard(
   if (is_nil_expr(expr))
     return expr;
   const std::size_t n = expr->get_num_sub_exprs();
-  auto recurse = [this](const expr2tc &e, bool tl)
-  { return handle_single_guard(e, tl); };
+  auto recurse = [this](const expr2tc &e, bool tl) {
+    return handle_single_guard(e, tl);
+  };
 
   // --- Rule 1: Atomic expressions ---
   // If the expression has no operands (a symbol or constant),
@@ -1058,8 +1058,8 @@ void goto_coveraget::handle_operands_guard(
     {
       // we do not need to add a !=false at top level
       // e.g. return x?1:0 != return (x?1:0)!=false
-      target->Foreach_operand([this](expr2tc &op)
-                              { op = handle_single_guard(op, false); });
+      target->Foreach_operand(
+        [this](expr2tc &op) { op = handle_single_guard(op, false); });
     }
     gen_cond_cov_assert(target, pre_cond, goto_program, it);
   }

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -2,6 +2,7 @@
 #include <irep2/irep2_utils.h>
 
 #include <algorithm>
+#include <cassert>
 #include <deque>
 #include <vector>
 
@@ -338,9 +339,17 @@ void goto_coveraget::k_path_coverage()
   log_progress("Adding k-path coverage assertions (n={})...", k_path_n);
   total_kpath = 0;
 
-  if (k_path_n == 0)
+  // Defense-in-depth: parseoptions rejects N==0 and N>30 at the CLI, but
+  // re-check here in case the method is invoked via another code path.
+  // 30 keeps `1 << pdepth` well below the size_t shift limit and below
+  // any reasonable goal cap.
+  static constexpr size_t K_PATH_N_MAX = 30;
+  if (k_path_n == 0 || k_path_n > K_PATH_N_MAX)
   {
-    log_error("--k-path-coverage requires N >= 1");
+    log_error(
+      "--k-path-coverage requires 1 <= N <= {} (got {})",
+      K_PATH_N_MAX,
+      k_path_n);
     abort();
   }
 
@@ -396,17 +405,22 @@ void goto_coveraget::k_path_coverage()
           target_num = it->target_number;
 
         const expr2tc current_guard = it->guard;
+        // pdepth is bounded by k_path_n - 1 <= K_PATH_N_MAX - 1 = 29
+        // (enforced above), so the shift below cannot overflow. Assert as
+        // a tripwire — silent overflow would be unsound.
         const size_t pdepth = std::min(prefix.size(), k_path_n - 1);
-        const size_t pcombos = pdepth >= 64 ? 0 : (size_t(1) << pdepth);
+        assert(pdepth < 30 && "pdepth bounded by parseoptions cap");
+        const size_t pcombos = size_t(1) << pdepth;
         const size_t branch_goals = 2 * pcombos;
 
-        if (function_goals + branch_goals > k_path_max_goals)
+        if (
+          branch_goals > k_path_max_goals ||
+          function_goals > k_path_max_goals - branch_goals)
         {
           log_error(
             "k-path coverage: per-function goal count would exceed "
             "--k-path-max-goals={} in '{}'. Lower --k-path-coverage=N "
-            "(currently {}) or use --branch-coverage / "
-            "--prime-path-coverage (Phase 2).",
+            "(currently {}) or raise --k-path-max-goals.",
             k_path_max_goals,
             id2string(f_it->first),
             k_path_n);

--- a/src/goto-programs/goto_coverage.cpp
+++ b/src/goto-programs/goto_coverage.cpp
@@ -1,10 +1,16 @@
 #include <goto-programs/goto_coverage.h>
+#include <irep2/irep2_utils.h>
+
+#include <algorithm>
+#include <deque>
+#include <vector>
 
 size_t goto_coveraget::total_assert = 0;
 size_t goto_coveraget::total_assert_ins = 0;
 std::set<std::pair<std::string, std::string>> goto_coveraget::total_cond;
 size_t goto_coveraget::total_branch = 0;
 size_t goto_coveraget::total_func_branch = 0;
+size_t goto_coveraget::total_kpath = 0;
 std::set<std::pair<std::string, std::string>> goto_coveraget::all_claims;
 
 std::string goto_coveraget::get_filename_from_path(std::string path)
@@ -284,6 +290,185 @@ void goto_coveraget::branch_coverage()
   goto_functions.update();
 }
 
+// Post-simplification depth of an expression tree, capped early once the
+// caller's threshold is exceeded. Used to gate emission of the structural
+// witness (issue #4325).
+static size_t expr_depth(const expr2tc &e, size_t cap)
+{
+  if (is_nil_expr(e))
+    return 0;
+  size_t n = e->get_num_sub_exprs();
+  if (n == 0)
+    return 1;
+  size_t d = 0;
+  for (size_t i = 0; i < n; ++i)
+  {
+    const expr2tc *sub = e->get_sub_expr(i);
+    if (sub == nullptr)
+      continue;
+    d = std::max(d, expr_depth(*sub, cap));
+    if (d > cap)
+      return d + 1;
+  }
+  return 1 + d;
+}
+
+/*
+k-path coverage (Phase 1 — see GitHub issue #4325).
+
+For each branching `IF g GOTO L`, emit one coverage goal per combination of
+the last (n-1) prior branch directions × the two outcomes of the current
+branch. Each goal is `assert(!witness)` where `witness = d_1 ∧ … ∧ d_k`
+with each d_i either a prior branch guard or its negation; multi_property
+marks a goal as reached when the assertion is falsifiable, i.e. when the
+corresponding path is feasible. This mirrors the existing branch_coverage
+inversion convention.
+
+Bounded by the textual order of branches within a function (cheap and
+deterministic). Joins make this an *over-approximation* of true path
+coverage — some witnesses may be infeasible and stay uncovered, which is
+correct under the spanning-set scoring proposed in #4325.
+
+Goal count per branch: 2^min(prefix_size+1, n). Capped per function by
+`k_path_max_goals`; on overflow the instrumentation aborts with an
+actionable error rather than silently truncating (decision locked in #4325).
+*/
+void goto_coveraget::k_path_coverage()
+{
+  log_progress("Adding k-path coverage assertions (n={})...", k_path_n);
+  total_kpath = 0;
+
+  if (k_path_n == 0)
+  {
+    log_error("--k-path-coverage requires N >= 1");
+    abort();
+  }
+
+  std::unordered_set<std::string> location_pool = {};
+  location_pool.insert(get_filename_from_path(filename));
+  for (auto const &inc : config.ansi_c.include_files)
+    location_pool.insert(get_filename_from_path(inc));
+
+  Forall_goto_functions (f_it, goto_functions)
+  {
+    if (!f_it->second.body_available || f_it->first == "__ESBMC_main")
+      continue;
+
+    goto_programt &goto_program = f_it->second.body;
+    if (filter(f_it->first, goto_program))
+      continue;
+
+    // Sliding window of the last (n-1) prior branch guards in textual order.
+    // Reset per function: each function is its own k-path scope (#4325).
+    std::deque<expr2tc> prefix;
+    size_t function_goals = 0;
+
+    Forall_goto_program_instructions (it, goto_program)
+    {
+      std::string cur_filename =
+        get_filename_from_path(it->location.file().as_string());
+      if (location_pool.count(cur_filename) == 0)
+        continue;
+
+      if (it->location.property().as_string() == "skipped")
+        continue;
+
+      // Mirror branch_coverage: neutralise existing assertions so they don't
+      // confuse multi_property_check.
+      if (
+        it->is_assert() &&
+        it->location.property().as_string() != "replaced assertion" &&
+        it->location.property().as_string() != "instrumented assertion")
+      {
+        if (cov_assume_asserts)
+          replace_assert_to_assume(it);
+        else
+          replace_assert_to_guard(gen_true_expr(), it, false);
+        continue;
+      }
+
+      // Conditional forward branch. Backward unconditional gotos (loop
+      // back-edges) carry guard=true and are skipped here; iteration
+      // semantics are picked up later by ESBMC's --unwind unrolling.
+      if (it->is_goto() && !is_true(it->guard))
+      {
+        if (it->is_target())
+          target_num = it->target_number;
+
+        const expr2tc current_guard = it->guard;
+        const size_t pdepth = std::min(prefix.size(), k_path_n - 1);
+        const size_t pcombos = pdepth >= 64 ? 0 : (size_t(1) << pdepth);
+        const size_t branch_goals = 2 * pcombos;
+
+        if (function_goals + branch_goals > k_path_max_goals)
+        {
+          log_error(
+            "k-path coverage: per-function goal count would exceed "
+            "--k-path-max-goals={} in '{}'. Lower --k-path-coverage=N "
+            "(currently {}) or use --branch-coverage / "
+            "--prime-path-coverage (Phase 2).",
+            k_path_max_goals,
+            id2string(f_it->first),
+            k_path_n);
+          abort();
+        }
+
+        // The deque is trimmed to ≤ (n-1) entries at the bottom of every
+        // branch iteration, so its current contents are exactly the active
+        // prefix.
+        std::vector<expr2tc> active(prefix.begin(), prefix.end());
+
+        for (size_t mask = 0; mask < pcombos; ++mask)
+        {
+          // Build the prefix witness for this direction mask.
+          expr2tc pwit;
+          for (size_t i = 0; i < pdepth; ++i)
+          {
+            expr2tc d =
+              (mask & (size_t(1) << i)) ? active[i] : gen_not_expr(active[i]);
+            pwit = is_nil_expr(pwit) ? d : gen_and_expr(pwit, d);
+          }
+
+          // Emit one goal per current direction.
+          const expr2tc current_neg = gen_not_expr(current_guard);
+          for (const expr2tc &cdir : {current_guard, current_neg})
+          {
+            expr2tc full = is_nil_expr(pwit) ? cdir : gen_and_expr(pwit, cdir);
+            simplify(full);
+
+            if (is_false(full))
+              continue;
+            if (is_true(full))
+              continue;
+
+            if (expr_depth(full, k_path_witness_depth) > k_path_witness_depth)
+            {
+              // Phase 1: drop witnesses past the depth cap. The hashed
+              // ghost-flag fallback for deep prefixes is Phase 2 (#4325).
+              continue;
+            }
+
+            expr2tc neg_full = gen_not_expr(full);
+            simplify(neg_full);
+
+            std::string idf = from_expr(ns, "", full);
+            insert_assert(goto_program, it, neg_full, idf);
+            ++function_goals;
+          }
+        }
+
+        prefix.push_back(current_guard);
+        if (prefix.size() > k_path_n - 1)
+          prefix.pop_front();
+      }
+    }
+  }
+
+  total_kpath = get_total_instrument();
+  all_claims = get_total_cond_assert();
+  goto_functions.update();
+}
+
 void goto_coveraget::insert_assert(
   goto_programt &goto_program,
   goto_programt::targett &it,
@@ -554,7 +739,8 @@ void goto_coveraget::gen_cond_cov_assert(
   if (n == 0)
     return; // atom
 
-  auto recurse_all = [&]() {
+  auto recurse_all = [&]()
+  {
     for (std::size_t i = 0; i < n; ++i)
       gen_cond_cov_assert(*ptr->get_sub_expr(i), pre_cond, goto_program, it);
   };
@@ -709,9 +895,8 @@ expr2tc goto_coveraget::handle_single_guard(
   if (is_nil_expr(expr))
     return expr;
   const std::size_t n = expr->get_num_sub_exprs();
-  auto recurse = [this](const expr2tc &e, bool tl) {
-    return handle_single_guard(e, tl);
-  };
+  auto recurse = [this](const expr2tc &e, bool tl)
+  { return handle_single_guard(e, tl); };
 
   // --- Rule 1: Atomic expressions ---
   // If the expression has no operands (a symbol or constant),
@@ -811,8 +996,8 @@ void goto_coveraget::handle_operands_guard(
     {
       // we do not need to add a !=false at top level
       // e.g. return x?1:0 != return (x?1:0)!=false
-      target->Foreach_operand(
-        [this](expr2tc &op) { op = handle_single_guard(op, false); });
+      target->Foreach_operand([this](expr2tc &op)
+                              { op = handle_single_guard(op, false); });
     }
     gen_cond_cov_assert(target, pre_cond, goto_program, it);
   }

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -24,6 +24,16 @@ public:
   void branch_coverage();
   void branch_function_coverage();
 
+  // k-path coverage: at each branch, emit goals for every combination of the
+  // last (n-1) branch directions and the current direction (Williams et al.,
+  // EDCC 2005). A goal is `assert(!witness)`; SAT means the path is reachable
+  // and the goal is marked covered by multi_property_check, mirroring the
+  // branch_coverage convention. The structural AND-chain preserves SSA merge
+  // friendliness up to depth_cap; past depth_cap the witness is too deep to
+  // hand to the solver and is dropped (a Phase-2 ghost-flag fallback is
+  // tracked in #4325). Goal count is bounded by max_goals per function.
+  void k_path_coverage();
+
   void insert_assert(
     goto_programt &goto_program,
     goto_programt::targett &it,
@@ -73,11 +83,24 @@ public:
   static std::set<std::pair<std::string, std::string>> total_cond;
   static size_t total_branch;
   static size_t total_func_branch;
+  static size_t total_kpath;
   // all instrumented claims (condition, location) for JSON report
   static std::set<std::pair<std::string, std::string>> all_claims;
 
   std::string target_function = "";
   bool cov_assume_asserts = false;
+
+  // k-path coverage knobs (see #4325 "Decided defaults").
+  // n  : prefix depth — number of consecutive branches in each witness
+  //      (default 4 if --unwind is unset, else --unwind).
+  // d  : post-simplification depth cap on the witness expression tree.
+  //      Witnesses deeper than d are skipped in Phase 1 (no ghost-flag
+  //      fallback yet — see #4325).
+  // m  : per-function goal cap. On overflow, instrumentation aborts with
+  //      an actionable error rather than silently truncating.
+  size_t k_path_n = 4;
+  size_t k_path_witness_depth = 8;
+  size_t k_path_max_goals = 10000;
 
 protected:
   // turn a OP b OP c into a list a, b, c


### PR DESCRIPTION
Phase 1 of #4325. PathCrawler-style k-path coverage as a peer to `--branch-coverage`. Reuses `goto_coveraget`, `multi_property_check`, and the JSON report unchanged; adds four CLI knobs and one new instrumentation method.

## What

At each conditional branch `IF g GOTO L`, emit `assert(!witness)` goals for every combination of the last (n-1) prior branch directions × current direction. SAT marks the path reachable, mirroring `branch_coverage`'s falsification convention.

```
--k-path-coverage[=N]      N defaults to --unwind, falling back to 4
--k-path-coverage-claims   show reached claims
--k-path-witness-depth=D   post-simplification depth cap (default 8)
--k-path-max-goals=M       per-function goal cap (default 10000)
```

On goal-cap overflow, instrumentation aborts with an actionable error rather than truncating silently — decision per the issue's "Decided defaults" section.

## Phase-1 limitations (tracked in #4325 for follow-up PRs)

- Linear-walk prefix is an over-approximation when branches join (witnesses may reference variables mutated between branches). Phase 2 will move to a proper CFG analysis.
- No ghost-flag fallback when post-simplification depth > D — Phase 1 just drops the witness.
- No spanning-set scoring; infeasible witnesses count toward the denominator. Phase 2.

## Tests

Four regression tests under `regression/goto-coverage/k_path_cov_{1..4}/`:

| # | Scenario | Expected |
|---|---|---|
| 1 | Two independent `if`s | 6 witnesses, 6 reached, 100% |
| 2 | Loop body with one branch | 6 witnesses, 4 reached (loop-guard correlation) |
| 3 | Function call (per-function scope) | 4 witnesses, 4 reached, 100% |
| 4 | Correlated branches (infeasible prefixes) | 6 witnesses, 4 reached |

Existing branch / condition / assertion coverage tests still pass (sanity-checked locally).

## References

- Williams et al., *PathCrawler: Automatic Generation of Path Tests by Combining Static and Dynamic Analysis*, EDCC 2005, [doi:10.1007/11408901_21](https://doi.org/10.1007/11408901_21).
- Holzer et al., *FShell*, CAV 2008, [doi:10.1007/978-3-540-70545-1_20](https://doi.org/10.1007/978-3-540-70545-1_20).
- Huang, Meyer & Weber, *Loop Unrolling: Formal Definition and Application to Testing*, ICTSS 2025, [doi:10.1007/978-3-032-05188-2_2](https://doi.org/10.1007/978-3-032-05188-2_2).

Refs #4325.
