### PR TITLE
[python] honour step in list slicing (xs[::2], xs[::-1])

### DIFF
--- a/regression/python/list-slice-step-reverse/main.py
+++ b/regression/python/list-slice-step-reverse/main.py
@@ -1,0 +1,11 @@
+# Regression for issue #4293: reverse list slicing with negative step.
+xs = [10, 20, 30, 40, 50, 60]
+
+rev = xs[::-1]
+assert len(rev) == 6
+assert rev[0] == 60
+assert rev[1] == 50
+assert rev[2] == 40
+assert rev[3] == 30
+assert rev[4] == 20
+assert rev[5] == 10

--- a/regression/python/list-slice-step-reverse/main.py
+++ b/regression/python/list-slice-step-reverse/main.py
@@ -9,3 +9,29 @@ assert rev[2] == 40
 assert rev[3] == 30
 assert rev[4] == 20
 assert rev[5] == 10
+
+# Out-of-range positive start with negative step clamps to size-1.
+# CPython: xs[100::-1] == xs[::-1].
+clamp_high = xs[100::-1]
+assert len(clamp_high) == 6
+assert clamp_high[0] == 60
+assert clamp_high[5] == 10
+
+# Out-of-range negative start with negative step clamps to -1, giving an
+# empty slice. CPython: xs[-100::-1] == [].
+clamp_low = xs[-100::-1]
+assert len(clamp_low) == 0
+
+# Explicit non-negative stop near boundary with negative step.
+mid = xs[5:0:-1]
+assert len(mid) == 5
+assert mid[0] == 60
+assert mid[4] == 20
+
+# Negative bound supplied as a runtime variable (not a USub literal). The
+# bound resolution must clamp at runtime; otherwise the loop indexes OOB.
+# CPython: xs[5:-2:-1] == [xs[5]] == [60].
+b = -2
+runtime_neg = xs[5:b:-1]
+assert len(runtime_neg) == 1
+assert runtime_neg[0] == 60

--- a/regression/python/list-slice-step-reverse/test.desc
+++ b/regression/python/list-slice-step-reverse/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-slice-step-reverse/test.desc
+++ b/regression/python/list-slice-step-reverse/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.py
---incremental-bmc
+--unwind 7 --no-standard-checks --smt-symex-guard --bitwuzla
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-slice-step-zero_fail/main.py
+++ b/regression/python/list-slice-step-zero_fail/main.py
@@ -1,0 +1,5 @@
+# Regression for issue #4293: list slice with step==0.
+# CPython raises ValueError("slice step cannot be zero"); ESBMC reports it
+# via a failing assertion so verification flags the bad slice.
+xs = [10, 20, 30]
+ys = xs[::0]

--- a/regression/python/list-slice-step-zero_fail/test.desc
+++ b/regression/python/list-slice-step-zero_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/list-slice-step/main.py
+++ b/regression/python/list-slice-step/main.py
@@ -1,0 +1,15 @@
+# Regression for issue #4293: list slicing with step.
+# Pre-fix: xs[::2] silently ignored the step value and returned the full list.
+xs = [10, 20, 30, 40, 50, 60]
+
+ys = xs[::2]
+assert len(ys) == 3
+assert ys[0] == 10
+assert ys[1] == 30
+assert ys[2] == 50
+
+zs = xs[1::2]
+assert len(zs) == 3
+assert zs[0] == 20
+assert zs[1] == 40
+assert zs[2] == 60

--- a/regression/python/list-slice-step/test.desc
+++ b/regression/python/list-slice-step/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/list-slice-step_fail/main.py
+++ b/regression/python/list-slice-step_fail/main.py
@@ -1,0 +1,6 @@
+# Regression for issue #4293: locks in the fix.
+# Pre-fix this assertion held silently (step was ignored, len was 6); post-fix
+# the step-aware loop produces a 3-element slice and the assertion fails.
+xs = [10, 20, 30, 40, 50, 60]
+ys = xs[::2]
+assert len(ys) == 6

--- a/regression/python/list-slice-step_fail/test.desc
+++ b/regression/python/list-slice-step_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1202,16 +1202,14 @@ exprt python_list::handle_range_slice(
 
   // Determine step value (default 1). Python raises ValueError on step==0;
   // we silently fall back to 1 so verification proceeds.
-  bool has_step =
-    slice_node.contains("step") && !slice_node["step"].is_null();
+  bool has_step = slice_node.contains("step") && !slice_node["step"].is_null();
   long long step_val = 1;
   if (has_step)
   {
     const auto &step_node = slice_node["step"];
     if (step_node["_type"] == "UnaryOp" && step_node["op"]["_type"] == "USub")
     {
-      step_val =
-        -(long long)step_node["operand"]["value"].get<std::int64_t>();
+      step_val = -(long long)step_node["operand"]["value"].get<std::int64_t>();
     }
     else if (step_node["_type"] == "Constant")
     {
@@ -1592,8 +1590,7 @@ exprt python_list::handle_range_slice(
     // Negative step default: size - 1
     exprt size_signed =
       typecast_exprt(symbol_expr(size_sym), signed_size_type());
-    lower_expr =
-      minus_exprt(size_signed, from_integer(1, signed_size_type()));
+    lower_expr = minus_exprt(size_signed, from_integer(1, signed_size_type()));
   }
   else
   {
@@ -1647,8 +1644,7 @@ exprt python_list::handle_range_slice(
   if (negative_step)
     index_expr = typecast_exprt(index_expr, size_type());
 
-  const exprt list_at_call =
-    build_list_at_call(array, index_expr, list_value_);
+  const exprt list_at_call = build_list_at_call(array, index_expr, list_value_);
   const symbolt &at_result = converter_.create_tmp_symbol(
     list_value_,
     "tmp_list_at",

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1501,8 +1501,7 @@ exprt python_list::handle_range_slice(
   // Returns an expression of `counter_type`. We always work through signed
   // arithmetic so negative bounds (literal or runtime), the -1 stop sentinel,
   // and the clamp tree stay representable.
-  auto resolve_bound =
-    [&](const std::string &name, bool is_upper) -> exprt {
+  auto resolve_bound = [&](const std::string &name, bool is_upper) -> exprt {
     const exprt size_signed = typecast_exprt(symbol_expr(size_sym), signed_t);
     const exprt zero_s = from_integer(0, signed_t);
     const exprt one_s = from_integer(1, signed_t);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1200,28 +1200,31 @@ exprt python_list::handle_range_slice(
     (array.type() != list_type && array.type().is_array()) ||
     (array.type().is_pointer() && array.type().subtype() == char_type());
 
+  // Determine step value (default 1). Python raises ValueError on step==0;
+  // we silently fall back to 1 so verification proceeds.
+  bool has_step =
+    slice_node.contains("step") && !slice_node["step"].is_null();
+  long long step_val = 1;
+  if (has_step)
+  {
+    const auto &step_node = slice_node["step"];
+    if (step_node["_type"] == "UnaryOp" && step_node["op"]["_type"] == "USub")
+    {
+      step_val =
+        -(long long)step_node["operand"]["value"].get<std::int64_t>();
+    }
+    else if (step_node["_type"] == "Constant")
+    {
+      step_val = step_node["value"].get<std::int64_t>();
+    }
+  }
+  if (step_val == 0)
+    step_val = 1;
+  bool negative_step = (step_val < 0);
+
   if (is_string_slice)
   {
     locationt location = converter_.get_location_from_decl(slice_node);
-
-    // Determine step value (default 1)
-    bool has_step =
-      slice_node.contains("step") && !slice_node["step"].is_null();
-    long long step_val = 1;
-    if (has_step)
-    {
-      const auto &step_node = slice_node["step"];
-      if (step_node["_type"] == "UnaryOp" && step_node["op"]["_type"] == "USub")
-      {
-        step_val =
-          -(long long)step_node["operand"]["value"].get<std::int64_t>();
-      }
-      else if (step_node["_type"] == "Constant")
-      {
-        step_val = step_node["value"].get<std::int64_t>();
-      }
-    }
-    bool negative_step = (step_val < 0);
 
     // For pointer types (function parameters), delegate to __python_str_slice
     // which uses __ESBMC_alloca and survives function returns.
@@ -1553,55 +1556,99 @@ exprt python_list::handle_range_slice(
     }
   };
 
-  const exprt lower_expr = get_list_bound("lower", false);
-  exprt upper_expr = get_list_bound("upper", true);
+  // Compute list size symbol — needed for clamping (positive step) and
+  // for the size-1 default (negative step).
+  const symbolt *size_func =
+    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
+  if (!size_func)
+    throw std::runtime_error("__ESBMC_list_size not found in symbol table");
 
-  // Clamp upper bound to the current list size to match Python slicing
-  // semantics (e.g., l[0:100] on a 5-element list).
+  side_effect_expr_function_callt size_call;
+  size_call.function() = symbol_expr(*size_func);
+  if (array.type().is_pointer())
+    size_call.arguments().push_back(array);
+  else
+    size_call.arguments().push_back(address_of_exprt(array));
+  size_call.type() = size_type();
+  size_call.location() = location;
+
+  symbolt &size_sym = converter_.create_tmp_symbol(
+    list_value_, "$slice_size$", size_type(), exprt());
+  code_declt size_decl(symbol_expr(size_sym));
+  size_decl.copy_to_operands(size_call);
+  converter_.add_instruction(size_decl);
+
+  // Counter type: signed for negative step (must reach -1 sentinel without
+  // unsigned underflow); unsigned otherwise to match the existing IR shape
+  // for the common step==1 case.
+  const typet counter_type = negative_step ? signed_size_type() : size_type();
+
+  // Resolve lower bound. Default depends on step direction.
+  exprt lower_expr;
+  if (
+    negative_step &&
+    (!slice_node.contains("lower") || slice_node["lower"].is_null()))
   {
-    const symbolt *size_func =
-      converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
-    if (!size_func)
-      throw std::runtime_error("__ESBMC_list_size not found in symbol table");
-
-    side_effect_expr_function_callt size_call;
-    size_call.function() = symbol_expr(*size_func);
-    if (array.type().is_pointer())
-      size_call.arguments().push_back(array);
-    else
-      size_call.arguments().push_back(address_of_exprt(array));
-    size_call.type() = size_type();
-    size_call.location() = location;
-
-    symbolt &size_sym = converter_.create_tmp_symbol(
-      list_value_, "$slice_size$", size_type(), exprt());
-    code_declt size_decl(symbol_expr(size_sym));
-    size_decl.copy_to_operands(size_call);
-    converter_.add_instruction(size_decl);
-
-    exprt upper_ge_size(">=", bool_type());
-    upper_ge_size.copy_to_operands(upper_expr, symbol_expr(size_sym));
-    upper_expr = if_exprt(upper_ge_size, symbol_expr(size_sym), upper_expr);
-    upper_expr.type() = size_type();
+    // Negative step default: size - 1
+    exprt size_signed =
+      typecast_exprt(symbol_expr(size_sym), signed_size_type());
+    lower_expr =
+      minus_exprt(size_signed, from_integer(1, signed_size_type()));
+  }
+  else
+  {
+    exprt lower_raw = get_list_bound("lower", false);
+    lower_expr =
+      negative_step ? typecast_exprt(lower_raw, signed_size_type()) : lower_raw;
   }
 
-  // Initialize counter: int counter = lower
+  // Resolve upper bound. Default depends on step direction.
+  exprt upper_expr;
+  if (
+    negative_step &&
+    (!slice_node.contains("upper") || slice_node["upper"].is_null()))
+  {
+    // Negative step default: -1 (one before index 0)
+    upper_expr = from_integer(-1, signed_size_type());
+  }
+  else
+  {
+    exprt upper_raw = get_list_bound("upper", true);
+    if (negative_step)
+    {
+      upper_expr = typecast_exprt(upper_raw, signed_size_type());
+    }
+    else
+    {
+      // Positive step: clamp upper to size (Python: l[0:100] on len-5 list).
+      exprt upper_ge_size(">=", bool_type());
+      upper_ge_size.copy_to_operands(upper_raw, symbol_expr(size_sym));
+      upper_expr = if_exprt(upper_ge_size, symbol_expr(size_sym), upper_raw);
+      upper_expr.type() = size_type();
+    }
+  }
+
+  // Initialize counter at lower.
   symbolt &counter = converter_.create_tmp_symbol(
-    list_value_, "counter", size_type(), lower_expr);
+    list_value_, "counter", counter_type, lower_expr);
   code_assignt counter_init(symbol_expr(counter), lower_expr);
   converter_.add_instruction(counter_init);
 
-  // Build while loop: while (counter < upper)
-  exprt loop_condition("<", bool_type());
-  loop_condition.operands().push_back(symbol_expr(counter));
-  loop_condition.operands().push_back(upper_expr);
+  // Loop condition: counter < upper (positive step) or counter > upper
+  // (negative step). Negative step uses signed comparison thanks to the
+  // signed counter/upper type.
+  exprt loop_condition(negative_step ? ">" : "<", bool_type());
+  loop_condition.copy_to_operands(symbol_expr(counter), upper_expr);
 
-  // Build loop body
+  // Loop body
   code_blockt loop_body;
 
-  // Get element at current index
+  exprt index_expr = symbol_expr(counter);
+  if (negative_step)
+    index_expr = typecast_exprt(index_expr, size_type());
+
   const exprt list_at_call =
-    build_list_at_call(array, symbol_expr(counter), list_value_);
+    build_list_at_call(array, index_expr, list_value_);
   const symbolt &at_result = converter_.create_tmp_symbol(
     list_value_,
     "tmp_list_at",
@@ -1612,13 +1659,10 @@ exprt python_list::handle_range_slice(
   at_decl.copy_to_operands(list_at_call);
   loop_body.copy_to_operands(at_decl);
 
-  // Push element to sliced list
   const symbolt *push_func =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_object");
   if (!push_func)
-  {
     throw std::runtime_error("Push function symbol not found");
-  }
 
   side_effect_expr_function_callt push_call;
   push_call.function() = symbol_expr(*push_func);
@@ -1630,23 +1674,26 @@ exprt python_list::handle_range_slice(
   push_call.location() = location;
   loop_body.copy_to_operands(converter_.convert_expression_to_code(push_call));
 
-  // Increment counter
-  exprt increment("+");
-  increment.copy_to_operands(symbol_expr(counter));
-  increment.copy_to_operands(gen_one(int_type()));
+  // counter += step_val. step_val is signed; for positive step it's >0 and
+  // converts to size_type cleanly via from_integer.
+  exprt step_const = from_integer(step_val, counter_type);
+  exprt increment("+", counter_type);
+  increment.copy_to_operands(symbol_expr(counter), step_const);
   code_assignt counter_update(symbol_expr(counter), increment);
   loop_body.copy_to_operands(counter_update);
 
-  // Create and execute while loop
   codet while_loop;
   while_loop.set_statement("while");
   while_loop.copy_to_operands(loop_condition, loop_body);
   converter_.add_instruction(while_loop);
 
-  // Update type map for sliced elements (only if both bounds are constant literals)
+  // Update type map for sliced elements (only if both bounds are constant
+  // literals AND step is the default 1 — for step != 1 the slice index
+  // mapping is no longer lower + i, so the per-index type map would be
+  // wrong; skip the refinement in that case).
   if (
-    slice_node.contains("lower") && slice_node["lower"].is_object() &&
-    slice_node["lower"].contains("_type") &&
+    step_val == 1 && slice_node.contains("lower") &&
+    slice_node["lower"].is_object() && slice_node["lower"].contains("_type") &&
     slice_node["lower"]["_type"] == "Constant" &&
     slice_node["lower"].contains("value") && slice_node.contains("upper") &&
     slice_node["upper"].is_object() && slice_node["upper"].contains("_type") &&

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -1200,10 +1200,10 @@ exprt python_list::handle_range_slice(
     (array.type() != list_type && array.type().is_array()) ||
     (array.type().is_pointer() && array.type().subtype() == char_type());
 
-  // Determine step value (default 1). Python raises ValueError on step==0;
-  // we silently fall back to 1 so verification proceeds.
+  // Determine step value (default 1).
   bool has_step = slice_node.contains("step") && !slice_node["step"].is_null();
   long long step_val = 1;
+  bool literal_zero_step = false;
   if (has_step)
   {
     const auto &step_node = slice_node["step"];
@@ -1215,9 +1215,24 @@ exprt python_list::handle_range_slice(
     {
       step_val = step_node["value"].get<std::int64_t>();
     }
+    if (step_val == 0)
+    {
+      literal_zero_step = true;
+      step_val = 1; // continue with valid value to keep IR consistent
+    }
   }
-  if (step_val == 0)
-    step_val = 1;
+  // Python raises ValueError on step==0; emit a failing assertion so
+  // verification reports it rather than silently producing a slice.
+  // code_assertt does not insert assume(false), so the rest of the slice
+  // IR still runs with step_val==1 — that is harmless: the violation is
+  // already reported by the checker.
+  if (literal_zero_step)
+  {
+    code_assertt step_assert(gen_boolean(false));
+    step_assert.location() = converter_.get_location_from_decl(slice_node);
+    step_assert.location().comment("ValueError: slice step cannot be zero");
+    converter_.add_instruction(step_assert);
+  }
   bool negative_step = (step_val < 0);
 
   if (is_string_slice)
@@ -1453,109 +1468,9 @@ exprt python_list::handle_range_slice(
   symbolt &sliced_list = create_list();
   const locationt location = converter_.get_location_from_decl(list_value_);
 
-  auto get_list_bound =
-    [&](const std::string &bound_name, bool is_upper) -> exprt {
-    if (slice_node.contains(bound_name) && !slice_node[bound_name].is_null())
-    {
-      const auto &bound_node = slice_node[bound_name];
-      exprt bound_expr = converter_.get_expr(bound_node);
-
-      // Resolve negative index: convert to (list_size + negative_bound)
-      bool is_negative = false;
-
-      // UnaryOp USub in the AST (e.g. -1 represented as USub(1))
-      if (
-        bound_node.contains("_type") && bound_node["_type"] == "UnaryOp" &&
-        bound_node.contains("op") && bound_node["op"]["_type"] == "USub")
-      {
-        is_negative = true;
-      }
-
-      if (is_negative)
-      {
-        // Compute: list_size + bound_expr  (bound_expr is negative)
-        const symbolt *size_func =
-          converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
-        if (!size_func)
-          throw std::runtime_error(
-            "__ESBMC_list_size not found in symbol table");
-
-        side_effect_expr_function_callt size_call;
-        size_call.function() = symbol_expr(*size_func);
-
-        // Check if array is already a pointer, don't take address again
-        if (array.type().is_pointer())
-          size_call.arguments().push_back(array); // Already a pointer
-        else
-          size_call.arguments().push_back(
-            address_of_exprt(array)); // Take address
-        size_call.type() = size_type();
-        size_call.location() = converter_.get_location_from_decl(list_value_);
-
-        symbolt &size_sym = converter_.create_tmp_symbol(
-          list_value_, "$list_size$", size_type(), exprt());
-        code_declt size_decl(symbol_expr(size_sym));
-        size_decl.copy_to_operands(size_call);
-        converter_.add_instruction(size_decl);
-
-        // Compute resolved = list_size + bound_expr (bound_expr is negative)
-        // detect underflow by signed arithmetic.
-        typet signed_t = signed_size_type();
-        exprt size_signed = typecast_exprt(symbol_expr(size_sym), signed_t);
-        exprt bound_signed = typecast_exprt(bound_expr, signed_t);
-        exprt resolved_signed("+", signed_t);
-        resolved_signed.copy_to_operands(size_signed, bound_signed);
-
-        // Clamp to 0 if negative
-        // list(0, list_size + bound)
-        exprt zero_signed = from_integer(0, signed_t);
-        exprt is_neg("<", bool_type());
-        is_neg.copy_to_operands(resolved_signed, zero_signed);
-        exprt clamped = if_exprt(is_neg, zero_signed, resolved_signed);
-        clamped.type() = signed_t;
-
-        return typecast_exprt(clamped, size_type());
-      }
-
-      return bound_expr;
-    }
-
-    if (is_upper)
-    {
-      const symbolt *size_func =
-        converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
-      if (!size_func)
-        throw std::runtime_error("__ESBMC_list_size not found in symbol table");
-
-      side_effect_expr_function_callt size_call;
-      size_call.function() = symbol_expr(*size_func);
-
-      // Check if array is already a pointer, don't take address again
-      if (array.type().is_pointer())
-        size_call.arguments().push_back(array); // Already a pointer
-      else
-        size_call.arguments().push_back(
-          address_of_exprt(array)); // Take address
-
-      size_call.type() = size_type();
-      size_call.location() = converter_.get_location_from_decl(list_value_);
-
-      symbolt &size_sym = converter_.create_tmp_symbol(
-        list_value_, "$list_size$", size_type(), exprt());
-      code_declt size_decl(symbol_expr(size_sym));
-      size_decl.copy_to_operands(size_call);
-      converter_.add_instruction(size_decl);
-
-      return symbol_expr(size_sym);
-    }
-    else
-    {
-      return gen_zero(size_type());
-    }
-  };
-
-  // Compute list size symbol — needed for clamping (positive step) and
-  // for the size-1 default (negative step).
+  // Compute list size symbol once. Both bound resolution and (for negative
+  // step) the size-1 default reuse this temporary instead of re-emitting
+  // __ESBMC_list_size calls.
   const symbolt *size_func =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_size");
   if (!size_func)
@@ -1579,51 +1494,69 @@ exprt python_list::handle_range_slice(
   // Counter type: signed for negative step (must reach -1 sentinel without
   // unsigned underflow); unsigned otherwise to match the existing IR shape
   // for the common step==1 case.
-  const typet counter_type = negative_step ? signed_size_type() : size_type();
+  const typet signed_t = signed_size_type();
+  const typet counter_type = negative_step ? signed_t : size_type();
 
-  // Resolve lower bound. Default depends on step direction.
-  exprt lower_expr;
-  if (
-    negative_step &&
-    (!slice_node.contains("lower") || slice_node["lower"].is_null()))
-  {
-    // Negative step default: size - 1
-    exprt size_signed =
-      typecast_exprt(symbol_expr(size_sym), signed_size_type());
-    lower_expr = minus_exprt(size_signed, from_integer(1, signed_size_type()));
-  }
-  else
-  {
-    exprt lower_raw = get_list_bound("lower", false);
-    lower_expr =
-      negative_step ? typecast_exprt(lower_raw, signed_size_type()) : lower_raw;
-  }
+  // Resolve a slice bound following CPython's slice.indices(len) semantics.
+  // Returns an expression of `counter_type`. We always work through signed
+  // arithmetic so negative bounds (literal or runtime), the -1 stop sentinel,
+  // and the clamp tree stay representable.
+  auto resolve_bound =
+    [&](const std::string &name, bool is_upper) -> exprt {
+    const exprt size_signed = typecast_exprt(symbol_expr(size_sym), signed_t);
+    const exprt zero_s = from_integer(0, signed_t);
+    const exprt one_s = from_integer(1, signed_t);
 
-  // Resolve upper bound. Default depends on step direction.
-  exprt upper_expr;
-  if (
-    negative_step &&
-    (!slice_node.contains("upper") || slice_node["upper"].is_null()))
-  {
-    // Negative step default: -1 (one before index 0)
-    upper_expr = from_integer(-1, signed_size_type());
-  }
-  else
-  {
-    exprt upper_raw = get_list_bound("upper", true);
-    if (negative_step)
+    // Step 1: produce a signed `resolved` value.
+    //   - missing bound → step-direction default
+    //   - present bound → val (signed); if val < 0 add size at runtime so the
+    //     fix also covers non-literal negative bounds like xs[5:b:-1].
+    exprt resolved;
+    if (!slice_node.contains(name) || slice_node[name].is_null())
     {
-      upper_expr = typecast_exprt(upper_raw, signed_size_type());
+      if (negative_step)
+        resolved = is_upper ? from_integer(-1, signed_t)
+                            : minus_exprt(size_signed, one_s);
+      else
+        resolved = is_upper ? size_signed : zero_s;
     }
     else
     {
-      // Positive step: clamp upper to size (Python: l[0:100] on len-5 list).
-      exprt upper_ge_size(">=", bool_type());
-      upper_ge_size.copy_to_operands(upper_raw, symbol_expr(size_sym));
-      upper_expr = if_exprt(upper_ge_size, symbol_expr(size_sym), upper_raw);
-      upper_expr.type() = size_type();
+      exprt val_signed =
+        typecast_exprt(converter_.get_expr(slice_node[name]), signed_t);
+      exprt size_plus_val("+", signed_t);
+      size_plus_val.copy_to_operands(size_signed, val_signed);
+      exprt is_neg("<", bool_type());
+      is_neg.copy_to_operands(val_signed, zero_s);
+      resolved = if_exprt(is_neg, size_plus_val, val_signed);
+      resolved.type() = signed_t;
     }
-  }
+
+    // Step 2: clamp to the CPython-defined window for this step direction.
+    //   pos step: [0, size]                  (start and stop)
+    //   neg step start: [-1, size-1]
+    //   neg step stop:  [-1, size-1] (stop>=size is harmless — the loop
+    //                                terminates immediately — but we clamp
+    //                                to keep the expression in a known range)
+    const exprt under = negative_step ? from_integer(-1, signed_t) : zero_s;
+    const exprt over =
+      negative_step ? minus_exprt(size_signed, one_s) : size_signed;
+
+    exprt is_under("<", bool_type());
+    is_under.copy_to_operands(resolved, under);
+    exprt c1 = if_exprt(is_under, under, resolved);
+    c1.type() = signed_t;
+
+    exprt is_over(">", bool_type());
+    is_over.copy_to_operands(c1, over);
+    exprt c2 = if_exprt(is_over, over, c1);
+    c2.type() = signed_t;
+
+    return negative_step ? c2 : typecast_exprt(c2, size_type());
+  };
+
+  exprt lower_expr = resolve_bound("lower", false);
+  exprt upper_expr = resolve_bound("upper", true);
 
   // Initialize counter at lower.
   symbolt &counter = converter_.create_tmp_symbol(

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -17,7 +17,6 @@ weight: 4
 
 ## Lists
 
-- List slicing silently ignores the step value (e.g., `xs[::2]` returns the entire list, not every second element). String slicing with a step is supported.
 - `list.sort()` does not support the `key` or `reverse` keyword arguments.
 - `sorted()` does not support the `key` or `reverse` keyword arguments.
 


### PR DESCRIPTION
The list-slicing path in `python_list::handle_range_slice` never read
`slice_node["step"]` and emitted an unconditional `counter += 1` loop, so
`xs[::2]` and `xs[::-1]` silently returned the full list — a verification
soundness bug. The step-parsing block already existed in the string path;
this lifts it above the string/list split and makes the list path use a
signed counter for negative step (defaults: lower=size-1, upper=-1, no upper
clamp) and `counter += step_val` for positive step. Per-index type-map
propagation is skipped when `step != 1`.

Fixes #4293