### PR TITLE
[clang-c-frontend] handle index on non-array struct base

### DIFF
--- a/regression/esbmc/github_1210-2-array/test.desc
+++ b/regression/esbmc/github_1210-2-array/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 incomplete-array.c
 incomplete-lib.c
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -479,8 +479,7 @@ void clang_c_adjust::adjust_index(index_exprt &index)
     index.move_to_operands(addition);
     index.id("dereference");
   }
-  else if (
-    !final_array_type.is_array() && !final_array_type.is_vector())
+  else if (!final_array_type.is_array() && !final_array_type.is_vector())
   {
     // The base isn't array, vector, or pointer — typically a struct that
     // appears in array context because two TUs declared the same external

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -479,6 +479,34 @@ void clang_c_adjust::adjust_index(index_exprt &index)
     index.move_to_operands(addition);
     index.id("dereference");
   }
+  else if (
+    !final_array_type.is_array() && !final_array_type.is_vector())
+  {
+    // The base isn't array, vector, or pointer — typically a struct that
+    // appears in array context because two TUs declared the same external
+    // symbol with conflicting types (e.g. `extern int JJ[]` in one TU,
+    // `struct complete JJ` in another). After AST merging the symbol's
+    // type follows the more-complete declaration but the indexing
+    // reference in the other TU's body is still typed as the array's
+    // element type. Rewrite `base[i]` as `*((T*)&base + i)` where `T` is
+    // the index expression's declared element type so the byte-level
+    // access reaches dereferencet's well-tested path.
+    typet elem_type = index.type();
+    typet ptr_type = pointer_typet(elem_type);
+
+    exprt addr_of("address_of", pointer_typet(array_expr.type()));
+    addr_of.move_to_operands(array_expr);
+
+    exprt cast = addr_of;
+    gen_typecast(ns, cast, ptr_type);
+
+    exprt addition("+", ptr_type);
+    addition.copy_to_operands(cast, index_expr);
+
+    index.operands().clear();
+    index.move_to_operands(addition);
+    index.id("dereference");
+  }
 }
 
 void clang_c_adjust::adjust_expr_rel(exprt &expr)


### PR DESCRIPTION
## Summary

When two TUs declare an external symbol with conflicting types — e.g. `extern int JJ[]` in one TU and `struct complete JJ` in another — clang's `ASTImporter` merges them into the more-complete decl (the struct), but the indexing reference `JJ[i]` from the first TU's body keeps its declared element type from the local `extern int JJ[]` view.

After typecheck, the `index_exprt` has a struct-typed `array_expr`, which `migrate_expr` then tries to lower into `index2tc(struct, i)` and aborts on `is_array_type(source) || is_vector_type(source)`. \`DebugOpt\` builds catch this; \`RelWithDebInfo\` silently falls through.

\`clang_c_adjust::adjust_index\` already rewrites the pointer case (\`p[i]\` → \`*(p+i)\`); this PR extends it to cover the struct/non-array case by emitting \`*((T*)&base + i)\` where \`T\` is the index expression's declared element type. The byte-level access goes through \`dereferencet\`'s well-tested path, which already handles arbitrary-typed storage.

Promotes \`regression/esbmc/github_1210-2-array\` from \`KNOWNBUG\` to \`CORE\` — the test now verifies successfully under \`DebugOpt\` as well.

## Test plan

- [x] \`regression/esbmc/github_1210-2-array\` passes under \`DebugOpt\`
- [ ] CI green on full regression suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)