### PR TITLE
[python] route dict.copy() to a dict-aware handler

### DIFF
--- a/regression/python/github_4341/main.py
+++ b/regression/python/github_4341/main.py
@@ -1,0 +1,9 @@
+def main() -> None:
+    d = {1: 10, 2: 20}
+    e = d.copy()
+    assert e[1] == 10
+    assert e[2] == 20
+    # Mutating the copy must not affect the original.
+    e[1] = 99
+    assert d[1] == 10
+main()

--- a/regression/python/github_4341/test.desc
+++ b/regression/python/github_4341/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4341_fail/main.py
+++ b/regression/python/github_4341_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    d = {1: 10, 2: 20}
+    e = d.copy()
+    # Negative: the copied dict's value at key 1 is 10, not 99.
+    assert e[1] == 99
+main()

--- a/regression/python/github_4341_fail/test.desc
+++ b/regression/python/github_4341_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -3044,6 +3044,9 @@ exprt function_call_expr::handle_dict_method() const
   if (method_name == "popitem")
     return converter_.get_dict_handler()->handle_dict_popitem(dict_expr, call_);
 
+  if (method_name == "copy")
+    return converter_.get_dict_handler()->handle_dict_copy(dict_expr, call_);
+
   throw std::runtime_error("Unsupported dict method: " + method_name);
 }
 
@@ -3208,6 +3211,25 @@ bool function_call_expr::is_list_method_call() const
     // A BinOp receiver (e.g., (s1 - s2).pop()) is always a set/list: dicts
     // do not support arithmetic operators. handle_list_pop() already handles
     // this case, so route it here before the symbol-type check.
+    if (
+      call_["func"].contains("value") &&
+      call_["func"]["value"].contains("_type") &&
+      call_["func"]["value"]["_type"] == "BinOp")
+      return true;
+
+    std::string dummy;
+    const symbolt *sym = get_object_list_symbol(dummy);
+    const typet list_type = type_handler_.get_list_type();
+    return sym != nullptr && sym->type == list_type;
+  }
+
+  // "copy" is shared between list and dict. Treat as list.copy() only when
+  // the receiver resolves to a list symbol; otherwise let dispatch fall
+  // through to handle_dict_method().
+  if (method_name == "copy")
+  {
+    // BinOp receivers (e.g. (s1 - s2).copy()) are list-like, since dicts do
+    // not support arithmetic operators.
     if (
       call_["func"].contains("value") &&
       call_["func"]["value"].contains("_type") &&

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -5765,6 +5765,11 @@ symbolt *python_converter::create_symbol_for_unannotated_assign(
         inferred_type =
           dict_handler_->get_popitem_tuple_type(symbol_expr(*obj_sym));
       }
+      else if (method == "copy")
+      {
+        // copy() returns a new dict, not a single element value.
+        inferred_type = dict_handler_->get_dict_struct_type();
+      }
       else
       {
         inferred_type = dict_handler_->resolve_expected_type_for_dict_subscript(

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -2062,11 +2062,57 @@ exprt python_dict_handler::handle_dict_setdefault(
   return symbol_expr(result_var);
 }
 
+exprt python_dict_handler::handle_dict_copy(
+  const exprt &dict_expr,
+  const nlohmann::json &call_node)
+{
+  if (!call_node["args"].empty())
+    throw std::runtime_error("dict.copy() takes no arguments");
+
+  locationt location = converter_.get_location_from_decl(call_node);
+  struct_typet dict_type = get_dict_struct_type();
+  typet list_type = type_handler_.get_list_type();
+
+  // Resolve __ESBMC_list_copy: returns a new PyListObject* with the same
+  // elements as its argument. Used here on both keys and values lists.
+  const symbolt *list_copy_func =
+    symbol_table_.find_symbol("c:@F@__ESBMC_list_copy");
+  if (!list_copy_func)
+    throw std::runtime_error("__ESBMC_list_copy not found");
+
+  // Allocate destination dict.
+  symbolt &new_dict_sym = converter_.create_tmp_symbol(
+    call_node, "$dict_copy$", dict_type, exprt());
+  code_declt new_dict_decl(symbol_expr(new_dict_sym));
+  new_dict_decl.location() = location;
+  converter_.add_instruction(new_dict_decl);
+
+  // Copy each list independently so mutating the copy leaves the source
+  // untouched.
+  auto copy_list_member = [&](const irep_idt &name) {
+    member_exprt src(dict_expr, name, list_type);
+    member_exprt dst(symbol_expr(new_dict_sym), name, list_type);
+    code_function_callt copy_call;
+    copy_call.function() = symbol_expr(*list_copy_func);
+    copy_call.arguments().push_back(src);
+    copy_call.lhs() = dst;
+    copy_call.type() = list_type;
+    copy_call.location() = location;
+    converter_.add_instruction(copy_call);
+  };
+
+  copy_list_member("keys");
+  copy_list_member("values");
+
+  return symbol_expr(new_dict_sym);
+}
+
 bool python_dict_handler::is_value_returning_method(
   const std::string &method_name)
 {
   return method_name == "pop" || method_name == "get" ||
-         method_name == "setdefault" || method_name == "popitem";
+         method_name == "setdefault" || method_name == "popitem" ||
+         method_name == "copy";
 }
 
 // Retrieve a typed value from a PyObj's void* value field.

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -2081,8 +2081,8 @@ exprt python_dict_handler::handle_dict_copy(
     throw std::runtime_error("__ESBMC_list_copy not found");
 
   // Allocate destination dict.
-  symbolt &new_dict_sym = converter_.create_tmp_symbol(
-    call_node, "$dict_copy$", dict_type, exprt());
+  symbolt &new_dict_sym =
+    converter_.create_tmp_symbol(call_node, "$dict_copy$", dict_type, exprt());
   code_declt new_dict_decl(symbol_expr(new_dict_sym));
   new_dict_decl.location() = location;
   converter_.add_instruction(new_dict_decl);

--- a/src/python-frontend/python_dict_handler.h
+++ b/src/python-frontend/python_dict_handler.h
@@ -472,6 +472,18 @@ public:
   handle_dict_update(const exprt &dict_expr, const nlohmann::json &call_node);
 
   /**
+   * @brief Handles dict.copy() method calls.
+   * Returns a shallow copy of the dictionary: a new dict whose keys and
+   * values lists are independent copies of the source's, so mutating the
+   * copy does not affect the original.
+   * @param dict_expr The source dictionary expression
+   * @param call_node The function call AST node
+   * @return Expression representing the copied dict.
+   */
+  exprt
+  handle_dict_copy(const exprt &dict_expr, const nlohmann::json &call_node);
+
+  /**
    * @brief Handles dict.fromkeys() class method calls.
    *
    * Implements dict.fromkeys(iterable, value=None):


### PR DESCRIPTION
Routes `dict.copy()` to a dedicated handler instead of the list-copy path,
which previously called `__ESBMC_list_copy` with a dict struct argument and
tripped a type-mismatch error.

`copy` is now disambiguated between list and dict by receiver type, mirroring
the existing handling of `pop`. `handle_dict_copy` produces a shallow copy by
deep-copying the underlying keys and values lists.

Fixes #4341. Refs #4296.
