### PR TITLE
[python] honour start in sum(iterable, start)

### DIFF
--- a/regression/python/github_4342/main.py
+++ b/regression/python/github_4342/main.py
@@ -1,0 +1,10 @@
+def main() -> None:
+    # Positional start.
+    assert sum([1, 2, 3], 10) == 16
+    # Keyword start.
+    assert sum([4, 5, 6], start=100) == 115
+    # Default start (no second arg) still works.
+    assert sum([1, 2, 3]) == 6
+    # Empty iterable returns the start.
+    assert sum([], 7) == 7
+main()

--- a/regression/python/github_4342/test.desc
+++ b/regression/python/github_4342/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4342_fail/main.py
+++ b/regression/python/github_4342_fail/main.py
@@ -1,0 +1,4 @@
+def main() -> None:
+    # Negative: with start=10, the sum is 16, not 6.
+    assert sum([1, 2, 3], 10) == 6
+main()

--- a/regression/python/github_4342_fail/test.desc
+++ b/regression/python/github_4342_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4566,9 +4566,8 @@ exprt function_call_expr::handle_general_function_call()
   const bool is_sorted_min_max =
     func_name == "min" || func_name == "max" || func_name == "sorted";
   if (
-    !is_user_imported &&
-    ((is_sorted_min_max && n_args == 1) ||
-     (func_name == "sum" && (n_args == 1 || n_args == 2))))
+    !is_user_imported && ((is_sorted_min_max && n_args == 1) ||
+                          (func_name == "sum" && (n_args == 1 || n_args == 2))))
   {
     exprt list_arg = converter_.get_expr(call_["args"][0]);
     typet elem_type;

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4559,11 +4559,16 @@ exprt function_call_expr::handle_general_function_call()
     return handle_round(arg);
   }
 
+  // sum() accepts an optional start argument (sum(iterable, start)); accept
+  // both 1- and 2-arg forms so the typed dispatch picks sum / sum_float
+  // consistently. The other builtins below remain 1-arg only.
+  const size_t n_args = call_["args"].size();
+  const bool is_sorted_min_max =
+    func_name == "min" || func_name == "max" || func_name == "sorted";
   if (
     !is_user_imported &&
-    (func_name == "min" || func_name == "max" || func_name == "sorted" ||
-     func_name == "sum") &&
-    call_["args"].size() == 1)
+    ((is_sorted_min_max && n_args == 1) ||
+     (func_name == "sum" && (n_args == 1 || n_args == 2))))
   {
     exprt list_arg = converter_.get_expr(call_["args"][0]);
     typet elem_type;

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -154,9 +154,9 @@ def min_str(iterable: list[str]) -> str:
 #     return False
 
 
-def sum(iterable: list[int]) -> int:
-    """Return the sum of all elements in an iterable of integers."""
-    result: int = 0
+def sum(iterable: list[int], start: int = 0) -> int:
+    """Return start plus the sum of all elements in an iterable of integers."""
+    result: int = start
     i: int = 0
     length: int = len(iterable)
     while i < length:
@@ -166,9 +166,9 @@ def sum(iterable: list[int]) -> int:
     return result
 
 
-def sum_float(iterable: list[float]) -> float:
-    """Return the sum of all elements in an iterable of floats."""
-    result: float = 0.0
+def sum_float(iterable: list[float], start: float = 0.0) -> float:
+    """Return start plus the sum of all elements in an iterable of floats."""
+    result: float = start
     i: int = 0
     length: int = len(iterable)
     while i < length:


### PR DESCRIPTION
`sum(iterable, start)` previously dropped the second argument silently:
the call-site dispatch only routed 1-arg sum to the typed `sum`/`sum_float`
model, and the model itself took one argument, so `sum([1,2,3], 10)`
returned 6 instead of 16.

The models now accept an optional `start` (defaulting to `0`/`0.0`) and
the dispatch accepts both 1- and 2-arg forms so float sums still go to
`sum_float`.

Fixes #4342. Refs #4296.
