### PR TITLE
[python] honour default= keyword on min() and max()

### DIFF
--- a/regression/python/github_4343/main.py
+++ b/regression/python/github_4343/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    # Empty iterable returns the default.
+    assert min([], default=42) == 42
+    assert max([], default=-1) == -1
+    # Non-empty iterable ignores the default.
+    assert min([3, 1, 2], default=99) == 1
+    assert max([3, 1, 2], default=99) == 3
+main()

--- a/regression/python/github_4343/test.desc
+++ b/regression/python/github_4343/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4343_fail/main.py
+++ b/regression/python/github_4343_fail/main.py
@@ -1,0 +1,4 @@
+def main() -> None:
+    # Negative: default is 42, not 0.
+    assert min([], default=42) == 0
+main()

--- a/regression/python/github_4343_fail/test.desc
+++ b/regression/python/github_4343_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4668,6 +4668,25 @@ exprt function_call_expr::handle_general_function_call()
   const size_t n_args = call_["args"].size();
   const bool is_sorted_min_max =
     func_name == "min" || func_name == "max" || func_name == "sorted";
+
+  // min(iter, default=...) / max(iter, default=...) route to *_default
+  // variants that fall back to the supplied default when iter is empty
+  // instead of raising ValueError.
+  bool has_default_kwarg = false;
+  exprt default_kwarg_value;
+  if ((func_name == "min" || func_name == "max") && call_.contains("keywords"))
+  {
+    for (const auto &kw : call_["keywords"])
+    {
+      if (kw.value("arg", "") == "default")
+      {
+        has_default_kwarg = true;
+        default_kwarg_value = converter_.get_expr(kw["value"]);
+        break;
+      }
+    }
+  }
+
   if (
     !is_user_imported && ((is_sorted_min_max && n_args == 1) ||
                           (func_name == "sum" && (n_args == 1 || n_args == 2))))
@@ -4685,7 +4704,7 @@ exprt function_call_expr::handle_general_function_call()
       // when passing the list to max_float/min_float model functions.
       if (
         elem_type.is_floatbv() && (func_name == "min" || func_name == "max") &&
-        python_list::has_mixed_numeric_types(list_id))
+        python_list::has_mixed_numeric_types(list_id) && !has_default_kwarg)
       {
         irep_idt comparison_op =
           (func_name == "max") ? exprt::i_gt : exprt::i_lt;
@@ -4695,6 +4714,8 @@ exprt function_call_expr::handle_general_function_call()
       }
     }
     // Dispatch to typed builtin based on element type
+    if (has_default_kwarg)
+      actual_func_name += "_default";
     if (!elem_type.is_nil())
     {
       if (elem_type.is_floatbv())
@@ -5619,7 +5640,10 @@ exprt function_call_expr::handle_general_function_call()
   // Forward keyword arguments to their parameter slots so the callee
   // receives the supplied value. The validation loop below only fills in
   // default values for *missing* params, so kwargs would otherwise be
-  // marked "provided" yet never actually passed.
+  // marked "provided" yet never actually passed. Subsumes the
+  // min/max-default specific path: with the *_default models exposing a
+  // named `default` parameter, the generic forwarding lands the value in
+  // the right slot for free.
   if (call_.contains("keywords") && call_["keywords"].is_array())
   {
     for (const auto &kw : call_["keywords"])

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -88,6 +88,60 @@ def max_str(iterable: list[str]) -> str:
     return result
 
 
+def max_default(iterable: list[int], default: int) -> int:
+    """Return the max of an iterable of ints, or default if empty."""
+    if len(iterable) == 0:
+        return default
+
+    i: int = 1
+    length: int = len(iterable)
+    result: int = iterable[0]
+
+    while i < length:
+        element: int = iterable[i]
+        if element > result:
+            result = element
+        i = i + 1
+
+    return result
+
+
+def max_default_float(iterable: list[float], default: float) -> float:
+    """Return the max of an iterable of floats, or default if empty."""
+    if len(iterable) == 0:
+        return default
+
+    i: int = 1
+    length: int = len(iterable)
+    result: float = iterable[0]
+
+    while i < length:
+        element: float = iterable[i]
+        if element > result:
+            result = element
+        i = i + 1
+
+    return result
+
+
+def max_default_str(iterable: list[str], default: str) -> str:
+    """Return the max of an iterable of strings, or default if empty."""
+    if len(iterable) == 0:
+        return default
+
+    i: int = 1
+    length: int = len(iterable)
+    result: str = iterable[0]
+
+    while i < length:
+        element: str = iterable[i]
+        if element > result:
+            result = element
+        i = i + 1
+
+    return result
+
+
 def min(iterable: list[int]) -> int:
     """Return the minimum element from an iterable of integers."""
     if len(iterable) == 0:
@@ -152,6 +206,60 @@ def any(iterable: list[Any]) -> bool:
             return True
         i = i + 1
     return False
+
+
+def min_default(iterable: list[int], default: int) -> int:
+    """Return the min of an iterable of ints, or default if empty."""
+    if len(iterable) == 0:
+        return default
+
+    i: int = 1
+    length: int = len(iterable)
+    result: int = iterable[0]
+
+    while i < length:
+        element: int = iterable[i]
+        if element < result:
+            result = element
+        i = i + 1
+
+    return result
+
+
+def min_default_float(iterable: list[float], default: float) -> float:
+    """Return the min of an iterable of floats, or default if empty."""
+    if len(iterable) == 0:
+        return default
+
+    i: int = 1
+    length: int = len(iterable)
+    result: float = iterable[0]
+
+    while i < length:
+        element: float = iterable[i]
+        if element < result:
+            result = element
+        i = i + 1
+
+    return result
+
+
+def min_default_str(iterable: list[str], default: str) -> str:
+    """Return the min of an iterable of strings, or default if empty."""
+    if len(iterable) == 0:
+        return default
+
+    i: int = 1
+    length: int = len(iterable)
+    result: str = iterable[0]
+
+    while i < length:
+        element: str = iterable[i]
+        if element < result:
+            result = element
+        i = i + 1
+
+    return result
 
 
 def sum(iterable: list[int], start: int = 0) -> int:


### PR DESCRIPTION
`min(iterable, default=...)` and `max(iterable, default=...)` previously
silently dropped the keyword and raised `ValueError` on an empty iterable.
Add typed `*_default` model variants that fall back to the supplied default
when the iterable is empty, route to them when `default=` is present, and
forward the keyword's value as the second positional argument.

The harder `key=` keyword is split into a follow-up child of #4296 and is
not addressed here, so #4343 is partially closed by this PR.

Refs #4343, #4296.
