### PR TITLE
[python] accept set and Set-literal iterables in any() / all()

### DIFF
--- a/regression/python/github_4344/main.py
+++ b/regression/python/github_4344/main.py
@@ -1,0 +1,22 @@
+def main() -> None:
+    # Tuple variable.
+    t = (False, True, False)
+    assert any(t)
+    assert not all(t)
+
+    # Tuple literal in argument position.
+    assert any((False, True))
+    assert all((True, True))
+
+    # Set literal.
+    assert any({False, True})
+
+    # Set variable.
+    s = {False, True, False}
+    assert any(s)
+
+    # Empty cases.
+    assert not any(())
+    assert all(())
+    assert not any(set())
+main()

--- a/regression/python/github_4344/test.desc
+++ b/regression/python/github_4344/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4344_fail/main.py
+++ b/regression/python/github_4344_fail/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    # Negative: any of an all-False tuple is False.
+    t = (False, False, False)
+    assert any(t)
+main()

--- a/regression/python/github_4344_fail/test.desc
+++ b/regression/python/github_4344_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -3490,7 +3490,7 @@ bool function_call_expr::is_any_call() const
   return func_name == "any";
 }
 
-exprt function_call_expr::handle_any() const
+exprt function_call_expr::handle_any()
 {
   const auto keywords =
     call_.contains("keywords") ? call_["keywords"] : nlohmann::json::array();
@@ -3508,15 +3508,21 @@ exprt function_call_expr::handle_any() const
   const auto &arg = args[0];
   const std::string &arg_type = arg["_type"];
 
-  if (arg_type == "List" || arg_type == "Tuple")
+  if (arg_type == "List" || arg_type == "Tuple" || arg_type == "Set")
     return reduce_iterable_literal_truthiness(arg, ReduceOp::Any);
 
   exprt arg_expr = converter_.get_expr(arg);
   if (converter_.get_tuple_handler().is_tuple_type(arg_expr.type()))
     return reduce_tuple_expr_truthiness(arg_expr, ReduceOp::Any);
 
+  // Set / frozenset variables share the PyListObject* representation, so
+  // forward to the list-backed any() model.
+  if (arg_expr.type() == converter_.get_type_handler().get_list_type())
+    return handle_general_function_call();
+
   throw std::runtime_error(
-    "any() currently only supports list/tuple literals or tuple variables");
+    "any() currently only supports list/tuple/set literals or list, set, or "
+    "tuple variables");
 }
 
 bool function_call_expr::is_all_call() const
@@ -3544,7 +3550,7 @@ exprt function_call_expr::handle_all()
   const auto &arg = args[0];
   const std::string &arg_type = arg["_type"];
 
-  if (arg_type == "List" || arg_type == "Tuple")
+  if (arg_type == "List" || arg_type == "Tuple" || arg_type == "Set")
     return reduce_iterable_literal_truthiness(arg, ReduceOp::All);
 
   // Non-literal argument: forward to the Python operational model only
@@ -3557,11 +3563,13 @@ exprt function_call_expr::handle_all()
   if (converter_.get_tuple_handler().is_tuple_type(arg_expr.type()))
     return reduce_tuple_expr_truthiness(arg_expr, ReduceOp::All);
 
+  // Sets share the PyListObject* representation, so the list-backed all()
+  // model handles set variables transparently.
   if (arg_expr.type() == converter_.get_type_handler().get_list_type())
     return handle_general_function_call();
 
   throw std::runtime_error(
-    "all() currently only supports list/tuple literals, list variables, or "
+    "all() currently only supports list/tuple/set literals, list, set, or "
     "tuple variables");
 }
 

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -309,7 +309,7 @@ private:
   exprt validate_re_module_args() const;
 
   bool is_any_call() const;
-  exprt handle_any() const;
+  exprt handle_any();
   bool is_all_call() const;
   exprt handle_all();
 

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -142,16 +142,16 @@ def min_str(iterable: list[str]) -> str:
     return result
 
 
-# def any(iterable: list[Any]) -> bool:
-#     """Return True if any element of the iterable is true."""
-#     i: int = 0
-#     length: int = len(iterable)
-#     while i < length:
-#         element: bool = iterable[i]
-#         if element:
-#             return True
-#         i = i + 1
-#     return False
+def any(iterable: list[Any]) -> bool:
+    """Return True if any element of the iterable is true."""
+    i: int = 0
+    length: int = len(iterable)
+    while i < length:
+        element: bool = iterable[i]
+        if element:
+            return True
+        i = i + 1
+    return False
 
 
 def sum(iterable: list[int]) -> int:


### PR DESCRIPTION
`any()` previously rejected set values with "any() currently only supports
list/tuple literals or tuple variables", and neither `any()` nor `all()`
recognised Set literals. Sets share the `PyListObject*` representation, so
route set-typed variables through the list-backed model and accept `Set`
in the literal-truthiness path. The `any()` model is uncommented to
mirror the existing `all()` model.

Tuple-variable support already works on master (added by an earlier
change); this completes the set part of #4344. `frozenset(...)`
construction is a separate gap tracked under the set-methods child
(#4346).

Fixes #4344. Refs #4296.
