### PR TITLE
[python] honour reverse= on list.sort() and sorted()

### DIFF
--- a/regression/python/github_4345/main.py
+++ b/regression/python/github_4345/main.py
@@ -1,0 +1,24 @@
+def main() -> None:
+    # list.sort(reverse=True)
+    xs = [3, 1, 2]
+    xs.sort(reverse=True)
+    assert xs[0] == 3 and xs[1] == 2 and xs[2] == 1
+
+    # list.sort with no args still ascending.
+    ys = [3, 1, 2]
+    ys.sort()
+    assert ys[0] == 1 and ys[2] == 3
+
+    # sorted(reverse=True) over a literal list.
+    zs = sorted([3, 1, 2], reverse=True)
+    assert zs[0] == 3 and zs[2] == 1
+
+    # sorted(reverse=True) over a list variable.
+    src = [10, 30, 20]
+    out = sorted(src, reverse=True)
+    assert out[0] == 30 and out[2] == 10
+
+    # sorted with no kwargs still ascending.
+    asc = sorted([5, 2, 4])
+    assert asc[0] == 2
+main()

--- a/regression/python/github_4345/test.desc
+++ b/regression/python/github_4345/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4345_fail/main.py
+++ b/regression/python/github_4345_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # Negative: reverse=True puts 3 first, not 1.
+    xs = [3, 1, 2]
+    xs.sort(reverse=True)
+    assert xs[0] == 1
+main()

--- a/regression/python/github_4345_fail/test.desc
+++ b/regression/python/github_4345_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -3111,6 +3111,29 @@ exprt function_call_expr::handle_list_sort() const
       "sort() positional arguments are not supported; "
       "use sort() with no arguments");
 
+  // sort() supports a `reverse=` keyword. `key=` is not handled yet; reject
+  // explicitly rather than dropping it silently.
+  bool reverse = false;
+  if (call_.contains("keywords"))
+  {
+    for (const auto &kw : call_["keywords"])
+    {
+      const std::string name = kw.value("arg", "");
+      if (name == "reverse")
+      {
+        exprt v = converter_.get_expr(kw["value"]);
+        if (!v.is_constant())
+          throw std::runtime_error(
+            "sort(reverse=...) requires a constant boolean");
+        reverse = v.is_true();
+      }
+      else
+        throw std::runtime_error(
+          "sort() keyword argument '" + name +
+          "' is not supported (only reverse=)");
+    }
+  }
+
   std::string list_display_name;
   const symbolt *list_symbol = get_object_list_symbol(list_display_name);
   materialize_list_symbol(list_symbol);
@@ -3150,7 +3173,29 @@ exprt function_call_expr::handle_list_sort() const
   sort_call.type() = empty_typet();
   sort_call.location() = converter_.get_location_from_decl(call_);
 
-  return sort_call;
+  // For reverse=True, sort ascending then reverse in place via the existing
+  // __ESBMC_list_reverse model. Wrap both calls in a code_blockt.
+  if (!reverse)
+    return sort_call;
+
+  const symbolt *reverse_func =
+    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_reverse");
+  if (!reverse_func)
+    throw std::runtime_error(
+      "__ESBMC_list_reverse function not found in symbol table");
+
+  code_function_callt reverse_call;
+  reverse_call.function() = symbol_expr(*reverse_func);
+  reverse_call.arguments().push_back(symbol_expr(*list_symbol));
+  reverse_call.type() = empty_typet();
+  reverse_call.location() = converter_.get_location_from_decl(call_);
+
+  python_list::reverse_type_info(list_id);
+
+  code_blockt block;
+  block.copy_to_operands(sort_call);
+  block.copy_to_operands(reverse_call);
+  return block;
 }
 
 exprt function_call_expr::handle_list_reverse() const
@@ -4466,8 +4511,32 @@ exprt function_call_expr::handle_general_function_call()
 
   // Fast-path: sorted() over a concrete int list can be materialized directly
   // in the frontend, avoiding expensive runtime list sorting/equality paths.
+  // Honour reverse=<constant bool>; bail to the model for any other keyword.
   if (func_name == "sorted" && call_["args"].size() == 1)
   {
+    bool fast_path_reverse = false;
+    bool fast_path_ok = true;
+    if (call_.contains("keywords"))
+    {
+      for (const auto &kw : call_["keywords"])
+      {
+        if (kw.value("arg", "") != "reverse")
+        {
+          fast_path_ok = false;
+          break;
+        }
+        exprt v = converter_.get_expr(kw["value"]);
+        if (!v.is_constant())
+        {
+          fast_path_ok = false;
+          break;
+        }
+        fast_path_reverse = v.is_true();
+      }
+    }
+
+    if (fast_path_ok)
+    {
     exprt list_arg = converter_.get_expr(call_["args"][0]);
     if (list_arg.is_symbol())
     {
@@ -4519,6 +4588,9 @@ exprt function_call_expr::handle_general_function_call()
               return a.key < b.key;
             });
 
+          if (fast_path_reverse)
+            std::reverse(elems.begin(), elems.end());
+
           nlohmann::json sorted_list;
           sorted_list["_type"] = "List";
           sorted_list["elts"] = nlohmann::json::array();
@@ -4537,6 +4609,7 @@ exprt function_call_expr::handle_general_function_call()
           return sorted_list_expr.get();
         }
       }
+    }
     }
   }
 
@@ -5507,6 +5580,31 @@ exprt function_call_expr::handle_general_function_call()
       call.arguments().push_back(arg);
 
     arg_index++;
+  }
+
+  // Forward keyword arguments to their parameter slots so the callee
+  // receives the supplied value. The validation loop below only fills in
+  // default values for *missing* params, so kwargs would otherwise be
+  // marked "provided" yet never actually passed.
+  if (call_.contains("keywords") && call_["keywords"].is_array())
+  {
+    for (const auto &kw : call_["keywords"])
+    {
+      if (!kw.contains("arg") || kw["arg"].is_null())
+        continue; // skip **kwargs unpacking
+      const std::string kw_name = kw["arg"].get<std::string>();
+      for (size_t i = 0; i < params.size(); ++i)
+      {
+        if (params[i].get_base_name().as_string() == kw_name)
+        {
+          exprt kw_val = converter_.get_expr(kw["value"]);
+          if (call.arguments().size() <= i)
+            call.arguments().resize(i + 1);
+          call.arguments()[i] = kw_val;
+          break;
+        }
+      }
+    }
   }
 
   // Add default arguments for missing parameters

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -4537,79 +4537,79 @@ exprt function_call_expr::handle_general_function_call()
 
     if (fast_path_ok)
     {
-    exprt list_arg = converter_.get_expr(call_["args"][0]);
-    if (list_arg.is_symbol())
-    {
-      const std::string list_id = list_arg.identifier().as_string();
-      const size_t map_size = python_list::get_list_type_map_size(list_id);
-      if (map_size > 0 && map_size <= 32)
+      exprt list_arg = converter_.get_expr(call_["args"][0]);
+      if (list_arg.is_symbol())
       {
-        struct sortable_elem
+        const std::string list_id = list_arg.identifier().as_string();
+        const size_t map_size = python_list::get_list_type_map_size(list_id);
+        if (map_size > 0 && map_size <= 32)
         {
-          BigInt key;
-          size_t pos;
-        };
-
-        std::vector<sortable_elem> elems;
-        elems.reserve(map_size);
-        bool all_constant_ints = true;
-
-        for (size_t i = 0; i < map_size; ++i)
-        {
-          const std::string elem_id =
-            python_list::get_list_element_id(list_id, i);
-          if (elem_id.empty())
+          struct sortable_elem
           {
-            all_constant_ints = false;
-            break;
+            BigInt key;
+            size_t pos;
+          };
+
+          std::vector<sortable_elem> elems;
+          elems.reserve(map_size);
+          bool all_constant_ints = true;
+
+          for (size_t i = 0; i < map_size; ++i)
+          {
+            const std::string elem_id =
+              python_list::get_list_element_id(list_id, i);
+            if (elem_id.empty())
+            {
+              all_constant_ints = false;
+              break;
+            }
+
+            const symbolt *elem_sym = converter_.find_symbol(elem_id);
+            if (
+              !elem_sym || !elem_sym->value.is_constant() ||
+              !(elem_sym->type.is_signedbv() || elem_sym->type.is_unsignedbv()))
+            {
+              all_constant_ints = false;
+              break;
+            }
+
+            BigInt key = binary2integer(elem_sym->value.value().c_str(), true);
+            elems.push_back({key, i});
           }
 
-          const symbolt *elem_sym = converter_.find_symbol(elem_id);
-          if (
-            !elem_sym || !elem_sym->value.is_constant() ||
-            !(elem_sym->type.is_signedbv() || elem_sym->type.is_unsignedbv()))
+          if (all_constant_ints)
           {
-            all_constant_ints = false;
-            break;
+            std::stable_sort(
+              elems.begin(),
+              elems.end(),
+              [](const sortable_elem &a, const sortable_elem &b) {
+                if (a.key == b.key)
+                  return a.pos < b.pos;
+                return a.key < b.key;
+              });
+
+            if (fast_path_reverse)
+              std::reverse(elems.begin(), elems.end());
+
+            nlohmann::json sorted_list;
+            sorted_list["_type"] = "List";
+            sorted_list["elts"] = nlohmann::json::array();
+            converter_.copy_location_fields_from_decl(call_, sorted_list);
+            for (const auto &elem : elems)
+            {
+              nlohmann::json cst;
+              cst["_type"] = "Constant";
+              cst["value"] = elem.key.to_int64();
+              cst["kind"] = nullptr;
+              converter_.copy_location_fields_from_decl(call_, cst);
+              sorted_list["elts"].push_back(cst);
+            }
+
+            python_list sorted_list_expr(converter_, sorted_list);
+            return sorted_list_expr.get();
           }
-
-          BigInt key = binary2integer(elem_sym->value.value().c_str(), true);
-          elems.push_back({key, i});
-        }
-
-        if (all_constant_ints)
-        {
-          std::stable_sort(
-            elems.begin(),
-            elems.end(),
-            [](const sortable_elem &a, const sortable_elem &b) {
-              if (a.key == b.key)
-                return a.pos < b.pos;
-              return a.key < b.key;
-            });
-
-          if (fast_path_reverse)
-            std::reverse(elems.begin(), elems.end());
-
-          nlohmann::json sorted_list;
-          sorted_list["_type"] = "List";
-          sorted_list["elts"] = nlohmann::json::array();
-          converter_.copy_location_fields_from_decl(call_, sorted_list);
-          for (const auto &elem : elems)
-          {
-            nlohmann::json cst;
-            cst["_type"] = "Constant";
-            cst["value"] = elem.key.to_int64();
-            cst["kind"] = nullptr;
-            converter_.copy_location_fields_from_decl(call_, cst);
-            sorted_list["elts"].push_back(cst);
-          }
-
-          python_list sorted_list_expr(converter_, sorted_list);
-          return sorted_list_expr.get();
         }
       }
-    }
     }
   }
 

--- a/src/python-frontend/models/builtins.py
+++ b/src/python-frontend/models/builtins.py
@@ -178,7 +178,7 @@ def sum_float(iterable: list[float]) -> float:
     return result
 
 
-def sorted(iterable: list[int]) -> list[int]:
+def sorted(iterable: list[int], reverse: bool = False) -> list[int]:
     """Return a new sorted list from the items in iterable."""
     # Create a copy of the list
     result: list[int] = []
@@ -190,7 +190,7 @@ def sorted(iterable: list[int]) -> list[int]:
         result.append(iterable[i])
         i = i + 1
 
-    # Bubble sort (simple and verifier-friendly)
+    # Bubble sort ascending (simple and verifier-friendly)
     n: int = len(result)
     i = 0
     while i < n:
@@ -204,10 +204,20 @@ def sorted(iterable: list[int]) -> list[int]:
             j = j + 1
         i = i + 1
 
+    # Reverse in place for descending order.
+    if reverse:
+        i = 0
+        half: int = n // 2
+        while i < half:
+            t: int = result[i]
+            result[i] = result[n - 1 - i]
+            result[n - 1 - i] = t
+            i = i + 1
+
     return result
 
 
-def sorted_float(iterable: list[float]) -> list[float]:
+def sorted_float(iterable: list[float], reverse: bool = False) -> list[float]:
     """Return a new sorted list from the items in iterable."""
     result: list[float] = []
     i: int = 0
@@ -229,10 +239,19 @@ def sorted_float(iterable: list[float]) -> list[float]:
             j = j + 1
         i = i + 1
 
+    if reverse:
+        i = 0
+        half: int = n // 2
+        while i < half:
+            t: float = result[i]
+            result[i] = result[n - 1 - i]
+            result[n - 1 - i] = t
+            i = i + 1
+
     return result
 
 
-def sorted_str(iterable: list[str]) -> list[str]:
+def sorted_str(iterable: list[str], reverse: bool = False) -> list[str]:
     """Return a new sorted list from the items in iterable."""
     result: list[str] = []
     i: int = 0
@@ -253,5 +272,14 @@ def sorted_str(iterable: list[str]) -> list[str]:
                 result[j + 1] = temp
             j = j + 1
         i = i + 1
+
+    if reverse:
+        i = 0
+        half: int = n // 2
+        while i < half:
+            t: str = result[i]
+            result[i] = result[n - 1 - i]
+            result[n - 1 - i] = t
+            i = i + 1
 
     return result


### PR DESCRIPTION
`list.sort(reverse=True)` and `sorted(..., reverse=True)` silently
dropped the keyword. Three layers needed touching:

- `handle_list_sort()` rejected positional args but never inspected
  keywords; now reads `reverse=` and emits `__ESBMC_list_reverse`
  after `__ESBMC_list_sort` when set.
- The frontend constant-folding fast-path for `sorted([...])` over an
  int literal list ignored keywords entirely; now it honours
  `reverse=<constant bool>` and bails to the model for anything else.
- `sorted` / `sorted_float` / `sorted_str` models now take
  `reverse: bool = False` and reverse the result in place.
- The generic call dispatch never forwarded keyword-argument *values*
  to their parameter slots — only marked them "provided". Now
  forwards them, fixing keyword passing across all model functions.

`key=` is split into a follow-up issue and not addressed here.

Refs #4345, #4296.
