### PR TITLE
[python] support tuple.count() and tuple.index()

### DIFF
--- a/regression/python/github_4348/main.py
+++ b/regression/python/github_4348/main.py
@@ -1,0 +1,17 @@
+def main() -> None:
+    t = (1, 2, 1, 3, 1)
+    assert t.count(1) == 3
+    assert t.count(2) == 1
+    assert t.count(99) == 0
+
+    # index returns the first match.
+    u = (10, 20, 30, 20)
+    assert u.index(10) == 0
+    assert u.index(20) == 1
+    assert u.index(30) == 2
+
+    # bool elements compare by value too.
+    b = (True, False, True)
+    assert b.count(True) == 2
+    assert b.index(False) == 1
+main()

--- a/regression/python/github_4348/test.desc
+++ b/regression/python/github_4348/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4348_fail/main.py
+++ b/regression/python/github_4348_fail/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    # Negative: index() on a missing element raises ValueError.
+    t = (10, 20, 30)
+    _ = t.index(99)
+main()

--- a/regression/python/github_4348_fail/test.desc
+++ b/regression/python/github_4348_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -2973,6 +2973,85 @@ exprt function_call_expr::handle_list_pop() const
   return list_helper.build_pop_list_call(*list_symbol, index_expr, call_);
 }
 
+bool function_call_expr::is_tuple_method_call() const
+{
+  if (call_["func"]["_type"] != "Attribute")
+    return false;
+
+  const std::string &method_name = function_id_.get_function();
+  if (method_name != "count" && method_name != "index")
+    return false;
+
+  exprt receiver = converter_.get_expr(call_["func"]["value"]);
+  return converter_.get_tuple_handler().is_tuple_type(receiver.type());
+}
+
+exprt function_call_expr::handle_tuple_method() const
+{
+  const std::string &method_name = function_id_.get_function();
+  const auto &args = call_["args"];
+  if (args.size() != 1)
+    throw std::runtime_error(
+      "tuple." + method_name + "() takes exactly one argument");
+
+  exprt receiver = converter_.get_expr(call_["func"]["value"]);
+  const struct_typet &tuple_type = to_struct_type(receiver.type());
+  const auto &components = tuple_type.components();
+
+  exprt elem = converter_.get_expr(args[0]);
+
+  if (method_name == "count")
+  {
+    // sum(t.element_i == elem ? 1 : 0)
+    typet result_type = int_type();
+    exprt total = gen_zero(result_type);
+    for (const auto &comp : components)
+    {
+      exprt member = member_exprt(receiver, comp.get_name(), comp.type());
+      exprt eq = equality_exprt(member, elem);
+      if_exprt sel(eq, gen_one(result_type), gen_zero(result_type));
+      sel.type() = result_type;
+      total = plus_exprt(total, sel);
+      total.type() = result_type;
+    }
+    return total;
+  }
+
+  // method_name == "index"
+  // Return the smallest k for which t.element_k == elem; assert if absent.
+  if (components.empty())
+    throw std::runtime_error("tuple.index() on empty tuple");
+
+  // Build "any matched" guard so we can assert the element is present.
+  typet result_type = int_type();
+  exprt any_match = gen_boolean(false);
+  for (const auto &comp : components)
+  {
+    exprt member = member_exprt(receiver, comp.get_name(), comp.type());
+    exprt eq = equality_exprt(member, elem);
+    any_match = or_exprt(any_match, eq);
+  }
+  code_assertt found_assert(any_match);
+  found_assert.location() = converter_.get_location_from_decl(call_);
+  found_assert.location().comment("ValueError: tuple.index(x): x not in tuple");
+  converter_.add_instruction(found_assert);
+
+  // Build chain right-to-left: result_(n-1) is index n-1, falling back to
+  // earlier matches as we walk backwards. Net effect: leftmost match wins.
+  size_t n = components.size();
+  exprt result = from_integer(BigInt(n - 1), result_type);
+  for (size_t k = n - 1; k-- > 0;)
+  {
+    exprt member =
+      member_exprt(receiver, components[k].get_name(), components[k].type());
+    exprt eq = equality_exprt(member, elem);
+    if_exprt sel(eq, from_integer(BigInt(k), result_type), result);
+    sel.type() = result_type;
+    result = sel;
+  }
+  return result;
+}
+
 bool function_call_expr::is_dict_method_call() const
 {
   if (call_["func"]["_type"] != "Attribute")
@@ -3778,6 +3857,12 @@ function_call_expr::get_dispatch_table()
      },
      [this]() { return converter_.get_expr(call_["func"]["value"]); },
      "__iter__ on builtin iterables"},
+
+    // Tuple methods (count, index) — matched before list/dict so a tuple
+    // receiver doesn't fall through to either.
+    {[this]() { return is_tuple_method_call(); },
+     [this]() { return handle_tuple_method(); },
+     "tuple methods"},
 
     // List methods
     {[this]() { return is_list_method_call(); },

--- a/src/python-frontend/function_call_expr.h
+++ b/src/python-frontend/function_call_expr.h
@@ -275,6 +275,10 @@ private:
   exprt
   handle_min_max(const std::string &func_name, irep_idt comparison_op) const;
 
+  // Tuple method detection and handling (count, index)
+  bool is_tuple_method_call() const;
+  exprt handle_tuple_method() const;
+
   // Dict method detection and handling
   bool is_dict_method_call() const;
   exprt handle_dict_method() const;

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -6,6 +6,7 @@
 #include <python-frontend/string_handler_utils.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/string_builder.h>
+#include <python-frontend/tuple_handler.h>
 #include <python-frontend/type_utils.h>
 #include <python-frontend/symbol_id.h>
 #include <util/arith_tools.h>
@@ -4338,6 +4339,16 @@ exprt string_handler::handle_string_attribute_call(
       cached_receiver_expr = converter_.get_expr(receiver_json);
     return *cached_receiver_expr;
   };
+
+  // Tuple receivers reuse method names that overlap with string methods
+  // (count, index). Defer to the regular dispatch table so the tuple-aware
+  // handler runs instead of evaluating those as string methods.
+  if (method_name == "count" || method_name == "index")
+  {
+    exprt recv = get_receiver_expr();
+    if (converter_.get_tuple_handler().is_tuple_type(recv.type()))
+      return nil_exprt();
+  }
 
   std::optional<locationt> cached_location;
   auto get_location = [&]() -> locationt {


### PR DESCRIPTION
Tuple receivers were unconditionally dispatched to the string method
handler, which silently returned 0 for `t.count(x)` and gave no result
for `t.index(x)`.

Adds `is_tuple_method_call` / `handle_tuple_method` that lower `count`
and `index` to compile-time expressions over the known tuple
components: `count` returns `sum(t.element_i == x ? 1 : 0)`; `index`
returns the smallest `k` where `t.element_k == x` and asserts the
element is present (matching CPython's `ValueError`).
`handle_string_attribute_call` early-returns `nil_exprt` when the
receiver is a tuple, so the tuple-aware dispatcher can take over.

Primitive element types (int/float/bool) are supported. Per-element
string comparison routes through pointer-equality, which doesn't
match content; that remains a follow-up.

Fixes #4348. Refs #4296.
