### PR TITLE
[python] support tuple + (concat) and * (repeat)

### DIFF
--- a/regression/python/github_4349/main.py
+++ b/regression/python/github_4349/main.py
@@ -1,0 +1,25 @@
+def main() -> None:
+    # Concatenation of two int tuples extends the tuple type.
+    a = (1, 2)
+    b = (3, 4)
+    c = a + b
+    assert c[0] == 1
+    assert c[2] == 3
+    assert c[3] == 4
+
+    # Concatenation with mixed-element types is also allowed; the result
+    # tuple keeps each element's type.
+    d = (10, 20)
+    e = (30, 40, 50)
+    f = d + e
+    assert f[4] == 50
+
+    # Repetition with a constant int builds an n-fold repeat.
+    g = (7, 8)
+    h = g * 3
+    assert h[0] == 7
+    assert h[5] == 8
+
+    # Concat result is a fresh tuple; original a/b unchanged.
+    assert a[0] == 1 and a[1] == 2
+main()

--- a/regression/python/github_4349/test.desc
+++ b/regression/python/github_4349/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4349_fail/main.py
+++ b/regression/python/github_4349_fail/main.py
@@ -1,0 +1,7 @@
+def main() -> None:
+    # Negative: a + b has 4 elements, so c[3] is 4, not 99.
+    a = (1, 2)
+    b = (3, 4)
+    c = a + b
+    assert c[3] == 99
+main()

--- a/regression/python/github_4349_fail/test.desc
+++ b/regression/python/github_4349_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -1740,6 +1740,13 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
     return dict_handler_->compare(lhs, rhs, op);
   }
 
+  // Handle tuple +/* before list operations (tuple structs would otherwise
+  // fall through to the generic struct-arithmetic path and silently produce
+  // a struct of the original size).
+  exprt tuple_result = handle_tuple_operations(op, lhs, rhs, element);
+  if (!tuple_result.is_nil())
+    return tuple_result;
+
   // Handle list operations
   exprt list_result =
     handle_list_operations(op, lhs, rhs, left, right, element);
@@ -1950,6 +1957,83 @@ exprt python_converter::handle_array_operations(
   if (op == "Add")
     return string_handler_.handle_string_concatenation_with_promotion(
       lhs, rhs, left, right);
+
+  return nil_exprt();
+}
+
+exprt python_converter::handle_tuple_operations(
+  const std::string &op,
+  exprt &lhs,
+  exprt &rhs,
+  const nlohmann::json &element)
+{
+  const bool lhs_is_tuple = tuple_handler_->is_tuple_type(lhs.type());
+  const bool rhs_is_tuple = tuple_handler_->is_tuple_type(rhs.type());
+
+  // Concatenation: (a, b) + (c, d) == (a, b, c, d).
+  if (op == "Add" && lhs_is_tuple && rhs_is_tuple)
+  {
+    const auto &lhs_components = to_struct_type(lhs.type()).components();
+    const auto &rhs_components = to_struct_type(rhs.type()).components();
+
+    std::vector<typet> element_types;
+    element_types.reserve(lhs_components.size() + rhs_components.size());
+    for (const auto &c : lhs_components)
+      element_types.push_back(c.type());
+    for (const auto &c : rhs_components)
+      element_types.push_back(c.type());
+
+    struct_typet new_type =
+      tuple_handler_->create_tuple_struct_type(element_types);
+
+    struct_exprt result(new_type);
+    for (const auto &c : lhs_components)
+      result.copy_to_operands(member_exprt(lhs, c.get_name(), c.type()));
+    for (const auto &c : rhs_components)
+      result.copy_to_operands(member_exprt(rhs, c.get_name(), c.type()));
+
+    if (element.contains("lineno"))
+      result.location() = get_location_from_decl(element);
+    return result;
+  }
+
+  // Repetition: (a, b) * 3 == (a, b, a, b, a, b). Requires a constant
+  // non-negative repeat count, since the result type must be known.
+  if (op == "Mult" && (lhs_is_tuple || rhs_is_tuple))
+  {
+    exprt &tuple = lhs_is_tuple ? lhs : rhs;
+    exprt &count = lhs_is_tuple ? rhs : lhs;
+
+    if (!count.is_constant() ||
+        !(count.type().is_signedbv() || count.type().is_unsignedbv()))
+      return nil_exprt();
+
+    BigInt n_big = binary2integer(
+      to_constant_expr(count).value().c_str(), count.type().is_signedbv());
+    if (n_big < 0)
+      n_big = 0;
+    const size_t n = n_big.to_int64();
+
+    const auto &components = to_struct_type(tuple.type()).components();
+
+    std::vector<typet> element_types;
+    element_types.reserve(components.size() * n);
+    for (size_t i = 0; i < n; ++i)
+      for (const auto &c : components)
+        element_types.push_back(c.type());
+
+    struct_typet new_type =
+      tuple_handler_->create_tuple_struct_type(element_types);
+
+    struct_exprt result(new_type);
+    for (size_t i = 0; i < n; ++i)
+      for (const auto &c : components)
+        result.copy_to_operands(member_exprt(tuple, c.get_name(), c.type()));
+
+    if (element.contains("lineno"))
+      result.location() = get_location_from_decl(element);
+    return result;
+  }
 
   return nil_exprt();
 }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2004,8 +2004,9 @@ exprt python_converter::handle_tuple_operations(
     exprt &tuple = lhs_is_tuple ? lhs : rhs;
     exprt &count = lhs_is_tuple ? rhs : lhs;
 
-    if (!count.is_constant() ||
-        !(count.type().is_signedbv() || count.type().is_unsignedbv()))
+    if (
+      !count.is_constant() ||
+      !(count.type().is_signedbv() || count.type().is_unsignedbv()))
       return nil_exprt();
 
     BigInt n_big = binary2integer(

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -767,6 +767,20 @@ private:
     const nlohmann::json &element);
 
   /**
+   * @brief Handles tuple `+` (concat) and `*` (repeat) operators.
+   *
+   * Concatenation builds a new tuple struct whose components are the
+   * concatenation of the operand tuples; repetition with a constant int
+   * builds an n-fold repeat. Returns nil_exprt for non-tuple operands or
+   * unsupported variants (e.g. variable repeat count).
+   */
+  exprt handle_tuple_operations(
+    const std::string &op,
+    exprt &lhs,
+    exprt &rhs,
+    const nlohmann::json &element);
+
+  /**
    * @brief Handles type mismatches in relational operations.
    *
    * Processes single-character comparisons and float-vs-string comparisons.


### PR DESCRIPTION
`a + b` on tuples previously fell through to the generic struct-binop
path and produced a struct of the original lhs size, so accesses past
the lhs bound raised "Tuple index out of range". `*` (repeat) was
similarly unhandled.

`handle_tuple_operations` (dispatched before list operations) builds a
fresh tuple struct via `tuple_handler::create_tuple_struct_type`:

- `Add`: concatenated components, per-slot type preserved (mixed-type
  concat works).
- `Mult` with constant non-negative integer count: n-fold repeat.

A variable repeat count returns nil_exprt rather than guessing.

Fixes #4349. Refs #4296.
