### PR TITLE
[python] support tuple slicing t[a:b:c]

### DIFF
--- a/regression/python/github_4350/main.py
+++ b/regression/python/github_4350/main.py
@@ -1,0 +1,26 @@
+def main() -> None:
+    t = (1, 2, 3, 4, 5)
+
+    # Basic slice [start:stop].
+    s = t[1:3]
+    assert s[0] == 2
+    assert s[1] == 3
+
+    # Open ends.
+    a = t[:2]
+    assert a[0] == 1 and a[1] == 2
+    b = t[3:]
+    assert b[0] == 4 and b[1] == 5
+
+    # Negative bounds.
+    c = t[-2:]
+    assert c[0] == 4 and c[1] == 5
+
+    # Step.
+    d = t[::2]
+    assert d[0] == 1 and d[1] == 3 and d[2] == 5
+
+    # Reverse via step=-1.
+    e = t[::-1]
+    assert e[0] == 5 and e[4] == 1
+main()

--- a/regression/python/github_4350/test.desc
+++ b/regression/python/github_4350/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4350_fail/main.py
+++ b/regression/python/github_4350_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # Negative: t[1:3] yields (2, 3), so s[0] is 2, not 99.
+    t = (1, 2, 3, 4, 5)
+    s = t[1:3]
+    assert s[0] == 99
+main()

--- a/regression/python/github_4350_fail/test.desc
+++ b/regression/python/github_4350_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -106,6 +106,90 @@ exprt tuple_handler::handle_tuple_subscript(
       "Subscript on non-tuple struct type: " + tuple_type.tag().as_string());
   }
 
+  // Slicing: t[lower:upper:step]. Build a fresh sub-tuple at compile time.
+  if (slice.contains("_type") && slice["_type"] == "Slice")
+  {
+    const auto &components = tuple_type.components();
+    const long long n = static_cast<long long>(components.size());
+
+    auto resolve_const = [&](const std::string &key,
+                             long long fallback) -> long long {
+      if (!slice.contains(key) || slice[key].is_null())
+        return fallback;
+      exprt e = converter_.get_expr(slice[key]);
+      if (e.is_constant())
+        return binary2integer(to_constant_expr(e).value().c_str(), true)
+          .to_int64();
+      if (
+        e.id() == "unary-" && e.operands().size() == 1 &&
+        e.operands()[0].is_constant())
+        return -binary2integer(
+                  to_constant_expr(e.operands()[0]).value().c_str(), true)
+                  .to_int64();
+      throw std::runtime_error(
+        "Tuple slice with non-constant " + key + " is not supported");
+    };
+
+    long long step = resolve_const("step", 1);
+    if (step == 0)
+      throw std::runtime_error("slice step cannot be zero");
+
+    long long lower = resolve_const(
+      "lower", step > 0 ? 0 : n - 1);
+    long long upper = resolve_const(
+      "upper", step > 0 ? n : -n - 1);
+
+    auto clamp = [n](long long v, bool is_lower, long long step) -> long long {
+      if (v < 0)
+        v += n;
+      if (step > 0)
+      {
+        if (v < 0)
+          v = 0;
+        if (v > n)
+          v = n;
+      }
+      else
+      {
+        // step < 0: clamp to [-1, n-1]
+        if (v < -1)
+          v = -1;
+        if (v >= n)
+          v = n - 1;
+      }
+      (void)is_lower;
+      return v;
+    };
+
+    lower = clamp(lower, true, step);
+    upper = clamp(upper, false, step);
+
+    // Collect the indices that survive the slice.
+    std::vector<size_t> kept;
+    if (step > 0)
+      for (long long i = lower; i < upper; i += step)
+        kept.push_back(static_cast<size_t>(i));
+    else
+      for (long long i = lower; i > upper; i += step)
+        kept.push_back(static_cast<size_t>(i));
+
+    // Build the sub-tuple struct.
+    std::vector<typet> elem_types;
+    elem_types.reserve(kept.size());
+    for (size_t k : kept)
+      elem_types.push_back(components[k].type());
+    struct_typet new_type = create_tuple_struct_type(elem_types);
+
+    struct_exprt result(new_type);
+    for (size_t k : kept)
+      result.copy_to_operands(
+        member_exprt(array, components[k].get_name(), components[k].type()));
+
+    if (element.contains("lineno"))
+      result.location() = converter_.get_location_from_decl(element);
+    return result;
+  }
+
   // Convert subscript to member access
   exprt index_expr = converter_.get_expr(slice);
 

--- a/src/python-frontend/tuple_handler.cpp
+++ b/src/python-frontend/tuple_handler.cpp
@@ -112,8 +112,8 @@ exprt tuple_handler::handle_tuple_subscript(
     const auto &components = tuple_type.components();
     const long long n = static_cast<long long>(components.size());
 
-    auto resolve_const = [&](const std::string &key,
-                             long long fallback) -> long long {
+    auto resolve_const =
+      [&](const std::string &key, long long fallback) -> long long {
       if (!slice.contains(key) || slice[key].is_null())
         return fallback;
       exprt e = converter_.get_expr(slice[key]);
@@ -134,10 +134,8 @@ exprt tuple_handler::handle_tuple_subscript(
     if (step == 0)
       throw std::runtime_error("slice step cannot be zero");
 
-    long long lower = resolve_const(
-      "lower", step > 0 ? 0 : n - 1);
-    long long upper = resolve_const(
-      "upper", step > 0 ? n : -n - 1);
+    long long lower = resolve_const("lower", step > 0 ? 0 : n - 1);
+    long long upper = resolve_const("upper", step > 0 ? n : -n - 1);
 
     auto clamp = [n](long long v, bool is_lower, long long step) -> long long {
       if (v < 0)


### PR DESCRIPTION
Tuple slicing was rejected with "Unsupported expression Slice at line N"
because `handle_tuple_subscript` treated the slice node as an index
expression. It now recognises slice nodes and builds a fresh sub-tuple
at compile time, with the same struct tag/layout convention as other
tuples (so `is_tuple_type` and downstream subscript handling still
work).

- `lower` / `upper` / `step` from constant integer expressions
  (positive or unary-minus); defaults match Python (`0..n` step `1`,
  step `-1` reverses).
- Negative indices normalised by adding `n`; bounds clamped per
  step direction.
- Variable-bound slices raise a clear error rather than guessing.

Fixes #4350. Refs #4296.
