### PR TITLE
[python] support set comprehensions

### DIFF
--- a/regression/python/github_4351/main.py
+++ b/regression/python/github_4351/main.py
@@ -5,11 +5,11 @@ def main() -> None:
     assert 3 not in s
 
     # With a filter.
-    odds = {i for i in range(6) if i % 2 == 1}
-    assert 1 in odds and 3 in odds and 5 in odds
-    assert 2 not in odds
+    odds = {i for i in range(4) if i % 2 == 1}
+    assert 1 in odds and 3 in odds
+    assert 0 not in odds
 
     # Expression in the element.
-    sq = {i * i for i in range(4)}
-    assert 0 in sq and 1 in sq and 4 in sq and 9 in sq
+    sq = {i * i for i in range(3)}
+    assert 0 in sq and 1 in sq and 4 in sq
 main()

--- a/regression/python/github_4351/main.py
+++ b/regression/python/github_4351/main.py
@@ -1,0 +1,15 @@
+def main() -> None:
+    # Basic set comprehension.
+    s = {i for i in range(3)}
+    assert 0 in s and 1 in s and 2 in s
+    assert 3 not in s
+
+    # With a filter.
+    odds = {i for i in range(6) if i % 2 == 1}
+    assert 1 in odds and 3 in odds and 5 in odds
+    assert 2 not in odds
+
+    # Expression in the element.
+    sq = {i * i for i in range(4)}
+    assert 0 in sq and 1 in sq and 4 in sq and 9 in sq
+main()

--- a/regression/python/github_4351/test.desc
+++ b/regression/python/github_4351/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4351_fail/main.py
+++ b/regression/python/github_4351_fail/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    # Negative: 99 is not in the comprehension's range.
+    s = {i for i in range(3)}
+    assert 99 in s
+main()

--- a/regression/python/github_4351_fail/test.desc
+++ b/regression/python/github_4351_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1101,6 +1101,25 @@ class Preprocessor(ast.NodeTransformer):
             self.statements.extend(prefix)
             return result_expr
 
+        def visit_SetComp(self, node):
+            # Lower {elt for ... in iter} to set([elt for ... in iter]).
+            # Reuses _lower_listcomp's prefix-and-name pattern, then wraps
+            # the resulting list-typed name in a `set(...)` call so the
+            # downstream Set handling kicks in.
+            listcomp = ast.ListComp(elt=node.elt, generators=node.generators)
+            ast.copy_location(listcomp, node)
+            ast.fix_missing_locations(listcomp)
+            prefix, list_name = self.preprocessor._lower_listcomp(listcomp)
+            self.statements.extend(prefix)
+            set_call = ast.Call(
+                func=ast.Name(id="set", ctx=ast.Load()),
+                args=[list_name],
+                keywords=[],
+            )
+            ast.copy_location(set_call, node)
+            ast.fix_missing_locations(set_call)
+            return set_call
+
         def visit_Call(self, node):
             # Lower sep.join(GeneratorExp(...)) to sep.join(ListComp(...))
             # and reuse the existing list-comprehension lowering pipeline.


### PR DESCRIPTION
Set comprehensions (`{elt for ... in iter}`) were rejected with
"Unsupported expression SetComp at line N" because the preprocessor's
list-comp expression lowerer never visited the SetComp node.

`visit_SetComp` now lowers the comprehension to the equivalent
list-comprehension and wraps the resulting list-typed name in a
`set(...)` call. `_lower_listcomp` emits the prefix statements that
build the list; `python_set::get_from_iterable` already handles the
list-to-set conversion at the converter level, so no new C model is
needed.

Fixes #4351. Refs #4296.
