### PR TITLE
[python] honour __exit__ True return for context-manager suppression

### DIFF
--- a/regression/python/github_4352/main.py
+++ b/regression/python/github_4352/main.py
@@ -1,0 +1,17 @@
+class CM:
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb) -> bool:
+        return True
+
+
+def main() -> None:
+    suppressed = False
+    try:
+        with CM():
+            raise ValueError("x")
+        suppressed = True
+    except ValueError:
+        pass
+    assert suppressed
+main()

--- a/regression/python/github_4352/test.desc
+++ b/regression/python/github_4352/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4352_fail/main.py
+++ b/regression/python/github_4352_fail/main.py
@@ -1,0 +1,18 @@
+class CMFalse:
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb) -> bool:
+        return False
+
+
+def main() -> None:
+    # Negative: __exit__ returns False, so the exception still propagates.
+    suppressed = False
+    try:
+        with CMFalse():
+            raise ValueError("x")
+        suppressed = True
+    except ValueError:
+        pass
+    assert suppressed
+main()

--- a/regression/python/github_4352_fail/test.desc
+++ b/regression/python/github_4352_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -2832,8 +2832,8 @@ class Preprocessor(ast.NodeTransformer):
                     self.ensure_all_locations(ast.Expr(value=enter_call), node)
                 )
 
-        result.extend(node.body)
-
+        # Build the list of __exit__ calls (reverse order, non-exceptional path).
+        exit_calls = []
         for i in range(len(node.items) - 1, -1, -1):
             mgr_name = f"__esbmc_mgr_{exit_start + i}"
             exit_call = ast.Call(
@@ -2849,7 +2849,43 @@ class Preprocessor(ast.NodeTransformer):
                 ],
                 keywords=[],
             )
-            result.append(self.ensure_all_locations(ast.Expr(value=exit_call), node))
+            exit_calls.append(self.ensure_all_locations(ast.Expr(value=exit_call), node))
+
+        # If every context manager's __exit__ statically returns True, wrap the
+        # body and exit calls in a try/except BaseException: pass so any
+        # exception raised inside the with block is suppressed, matching
+        # CPython semantics. Other __exit__ shapes preserve today's behaviour
+        # (exception propagates without consulting __exit__).
+        suppress = (
+            hasattr(self, "_exit_suppresses_all")
+            and len(node.items) > 0
+            and all(
+                isinstance(item.context_expr, ast.Call)
+                and isinstance(item.context_expr.func, ast.Name)
+                and item.context_expr.func.id in self._exit_suppresses_all
+                for item in node.items
+            )
+        )
+
+        if suppress:
+            try_node = ast.Try(
+                body=list(node.body) + exit_calls,
+                handlers=[
+                    ast.ExceptHandler(
+                        type=ast.Name(id="BaseException", ctx=ast.Load()),
+                        name=None,
+                        body=[ast.Pass()],
+                    )
+                ],
+                orelse=[],
+                finalbody=[],
+            )
+            self.ensure_all_locations(try_node, node)
+            ast.fix_missing_locations(try_node)
+            result.append(try_node)
+        else:
+            result.extend(node.body)
+            result.extend(exit_calls)
 
         return result
 
@@ -5859,10 +5895,28 @@ class Preprocessor(ast.NodeTransformer):
 
         node = self.expand_dataclass(node)
         self._collect_class_attr_annotations(node)
+        self._record_exit_suppresses_all(node)
         self.generic_visit(node)
 
         self.current_class_name = old_class_name
         return node
+
+    def _record_exit_suppresses_all(self, class_node):
+        """Cache classes whose __exit__ unconditionally returns True so
+        visit_With can suppress exceptions from the body."""
+        if not hasattr(self, "_exit_suppresses_all"):
+            self._exit_suppresses_all = set()
+        for member in class_node.body:
+            if (
+                isinstance(member, ast.FunctionDef)
+                and member.name == "__exit__"
+                and len(member.body) == 1
+                and isinstance(member.body[0], ast.Return)
+                and isinstance(member.body[0].value, ast.Constant)
+                and member.body[0].value.value is True
+            ):
+                self._exit_suppresses_all.add(class_node.name)
+                return
 
     def is_dataclass(self, class_node):
         """Return True when a class is decorated with @dataclass.


### PR DESCRIPTION
`visit_With` desugars `with EXPR as VAR: BODY` into `__enter__` /
`__exit__` calls but never consults `__exit__`'s return value, so an
exception raised inside the body bypasses `__exit__` and propagates.

When every context manager in a `with` clause is an instance of a
class whose `__exit__` statically returns the constant `True`, wrap
the body plus the non-exceptional `__exit__` calls in
`try ... except BaseException: pass` so the exception is suppressed
(CPython semantics for that case). `_record_exit_suppresses_all` in
`visit_ClassDef` detects the literal `def __exit__(...): return True`
body and caches the class name.

Other `__exit__` shapes (return `False`, return a runtime value,
multiple statements) preserve today's behaviour and remain a follow-up
under #4296.

Fixes #4352. Refs #4296.
