### PR TITLE
[python] honour fill / align / width in f-string format spec

### DIFF
--- a/regression/python/github_4353/main.py
+++ b/regression/python/github_4353/main.py
@@ -1,0 +1,27 @@
+def main() -> None:
+    # Right-align with default fill (space).
+    s1 = f"{42:>10}"
+    assert len(s1) == 10
+    assert s1[8] == "4" and s1[9] == "2"
+    assert s1[0] == " "
+
+    # Left-align.
+    s2 = f"{42:<5}"
+    assert len(s2) == 5
+    assert s2[0] == "4" and s2[1] == "2"
+    assert s2[4] == " "
+
+    # Center align.
+    s3 = f"{7:^5}"
+    assert len(s3) == 5
+    assert s3[0] == " " and s3[2] == "7" and s3[4] == " "
+
+    # Custom fill.
+    s4 = f"{42:*>6}"
+    assert len(s4) == 6
+    assert s4[0] == "*" and s4[3] == "*" and s4[4] == "4" and s4[5] == "2"
+
+    # Width <= content length: no padding.
+    s5 = f"{12345:>3}"
+    assert len(s5) == 5
+main()

--- a/regression/python/github_4353/test.desc
+++ b/regression/python/github_4353/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4353_fail/main.py
+++ b/regression/python/github_4353_fail/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    # Negative: width 10 right-aligned makes len 10, not 2.
+    s = f"{42:>10}"
+    assert len(s) == 2
+main()

--- a/regression/python/github_4353_fail/test.desc
+++ b/regression/python/github_4353_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -1145,18 +1145,17 @@ static bool parse_format_padding(
   width = 0;
   rest = format;
 
-  if (format.size() >= 2 &&
-      (format[1] == '<' || format[1] == '>' || format[1] == '^' ||
-       format[1] == '='))
+  if (
+    format.size() >= 2 && (format[1] == '<' || format[1] == '>' ||
+                           format[1] == '^' || format[1] == '='))
   {
     fill = format[0];
     align = format[1];
     rest = format.substr(2);
   }
   else if (
-    !format.empty() &&
-    (format[0] == '<' || format[0] == '>' || format[0] == '^' ||
-     format[0] == '='))
+    !format.empty() && (format[0] == '<' || format[0] == '>' ||
+                        format[0] == '^' || format[0] == '='))
   {
     align = format[0];
     rest = format.substr(1);
@@ -1228,7 +1227,8 @@ exprt string_handler::apply_format_specification(
     // Extract the literal characters; bail out if the body isn't a
     // string-constant or constant char array we can read.
     std::string content = extract_string_from_array_operands(body);
-    if (content.empty() && !body.is_constant() && body.id() != "string-constant")
+    if (
+      content.empty() && !body.is_constant() && body.id() != "string-constant")
       return body;
     if (align == '\0')
       align = (expr.type().is_signedbv() || expr.type().is_unsignedbv() ||

--- a/src/python-frontend/string_handler.cpp
+++ b/src/python-frontend/string_handler.cpp
@@ -1130,6 +1130,83 @@ std::string string_handler::float_to_string(
   return oss.str();
 }
 
+// Parse the leading [[fill]align][width] portion of a Python format spec.
+// Returns true if any padding parameters were extracted; on success, *rest
+// is set to the remainder of the spec (precision/type) for further handling.
+static bool parse_format_padding(
+  const std::string &format,
+  char &fill,
+  char &align,
+  int &width,
+  std::string &rest)
+{
+  fill = ' ';
+  align = '\0';
+  width = 0;
+  rest = format;
+
+  if (format.size() >= 2 &&
+      (format[1] == '<' || format[1] == '>' || format[1] == '^' ||
+       format[1] == '='))
+  {
+    fill = format[0];
+    align = format[1];
+    rest = format.substr(2);
+  }
+  else if (
+    !format.empty() &&
+    (format[0] == '<' || format[0] == '>' || format[0] == '^' ||
+     format[0] == '='))
+  {
+    align = format[0];
+    rest = format.substr(1);
+  }
+
+  size_t i = 0;
+  while (i < rest.size() && std::isdigit(static_cast<unsigned char>(rest[i])))
+    ++i;
+  if (i > 0)
+  {
+    try
+    {
+      width = std::stoi(rest.substr(0, i));
+    }
+    catch (...)
+    {
+      width = 0;
+    }
+    rest = rest.substr(i);
+  }
+
+  return align != '\0' || width > 0;
+}
+
+// Apply fill/align/width padding to a literal string per Python's
+// format-spec mini-language. Returns padded as a fresh char_array expr.
+static std::string
+apply_padding(const std::string &input, char fill, char align, int width)
+{
+  if (width <= 0 || static_cast<int>(input.size()) >= width)
+    return input;
+
+  size_t pad = static_cast<size_t>(width) - input.size();
+  switch (align)
+  {
+  case '<':
+    return input + std::string(pad, fill);
+  case '^':
+  {
+    size_t left = pad / 2;
+    size_t right = pad - left;
+    return std::string(left, fill) + input + std::string(right, fill);
+  }
+  case '>':
+  case '=':
+  default:
+    return std::string(pad, fill) + input;
+  }
+}
+
 exprt string_handler::apply_format_specification(
   const exprt &expr,
   const std::string &format)
@@ -1137,6 +1214,34 @@ exprt string_handler::apply_format_specification(
   // Basic format specification handling
   if (format.empty())
     return convert_to_string(expr);
+
+  // Pad/align prefix ([[fill]align][width]). Default-align right for
+  // numerics and left for strings, matching CPython.
+  char fill, align;
+  int width;
+  std::string rest;
+  if (parse_format_padding(format, fill, align, width, rest) && rest.empty())
+  {
+    exprt body = convert_to_string(expr);
+    if (!body.type().is_array() || body.type().subtype() != char_type())
+      return body;
+    // Extract the literal characters; bail out if the body isn't a
+    // string-constant or constant char array we can read.
+    std::string content = extract_string_from_array_operands(body);
+    if (content.empty() && !body.is_constant() && body.id() != "string-constant")
+      return body;
+    if (align == '\0')
+      align = (expr.type().is_signedbv() || expr.type().is_unsignedbv() ||
+               expr.type().is_floatbv() || expr.type().is_bool())
+                ? '>'
+                : '<';
+    std::string padded = apply_padding(content, fill, align, width);
+    typet string_type =
+      type_handler_.build_array(char_type(), padded.size() + 1);
+    std::vector<unsigned char> chars(padded.begin(), padded.end());
+    chars.push_back('\0');
+    return make_char_array_expr(chars, string_type);
+  }
 
   // Handle integer formatting
   if (format == "d" || format == "i")


### PR DESCRIPTION
`apply_format_specification` dropped any spec it didn't recognise (it
only handled empty, `d`, `i`, and `.Nf`), so `f"{42:>10}"` produced
`"42"` with len 2 instead of `"        42"` with len 10.

`parse_format_padding` now peels the `[[fill]align][width]` prefix per
Python's mini-language; `apply_padding` splices the fill chars in
left/right/centre order. Default alignment matches CPython (right for
numeric / bool, left for everything else). Width ≤ content length is a
no-op. Type/precision suffixes still go through the existing paths.

Fixes #4353. Refs #4296.
