### PR TITLE
[python] add seed/choice/shuffle/sample to the random model

### DIFF
--- a/regression/python/github_4355/main.py
+++ b/regression/python/github_4355/main.py
@@ -1,0 +1,22 @@
+import random
+
+
+def main() -> None:
+    # choice picks an element actually in the sequence.
+    v = random.choice([1, 2, 3])
+    assert v in [1, 2, 3]
+
+    # seed is a no-op: choice still observes the constrained domain.
+    random.seed(42)
+    w = random.choice([10, 20, 30])
+    assert w in [10, 20, 30]
+
+    # shuffle leaves length unchanged (under-approximation).
+    xs = [1, 2, 3]
+    random.shuffle(xs)
+    assert len(xs) == 3
+
+    # sample produces a list of length k from population.
+    s = random.sample([7, 8, 9, 10], 2)
+    assert len(s) == 2
+main()

--- a/regression/python/github_4355/test.desc
+++ b/regression/python/github_4355/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4355_fail/main.py
+++ b/regression/python/github_4355_fail/main.py
@@ -1,0 +1,8 @@
+import random
+
+
+def main() -> None:
+    # Negative: choice never returns a value outside the sequence.
+    v = random.choice([1, 2, 3])
+    assert v == 99
+main()

--- a/regression/python/github_4355_fail/test.desc
+++ b/regression/python/github_4355_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/random.py
+++ b/src/python-frontend/models/random.py
@@ -1,10 +1,13 @@
-# pylint: disable=undefined-variable,chained-comparison
+# pylint: disable=undefined-variable,chained-comparison,unused-argument
 # `nondet_int`, `nondet_float`, and `__ESBMC_assume` are ESBMC
 # intrinsics matched by name by the Python converter; they have no
 # Python binding. Chained comparisons are intentionally written in
 # the `a >= x and a <= y` form because they are arguments to
 # `__ESBMC_assume` and we keep them in the same shape as the
-# corresponding C operational models.
+# corresponding C operational models. seed(a) and shuffle(lst) keep
+# their CPython parameter names for API compatibility but discard the
+# value: nondet outputs already cover all seeds, and shuffle is
+# modelled as an under-approximation that leaves the list untouched.
 
 # Stubs for random module.
 # See https://docs.python.org/3/library/random.html

--- a/src/python-frontend/models/random.py
+++ b/src/python-frontend/models/random.py
@@ -44,6 +44,57 @@ def getrandbits(k: int) -> int:
     return value
 
 
+def seed(a: int = 0) -> None:
+    """random.seed(a) — no-op stub.
+
+    The non-determinism of nondet_int / nondet_float already covers any
+    seed-dependent outcome the program could observe, so seeding has no
+    observable effect under verification.
+    """
+    return
+
+
+def choice(seq: list[int]) -> int:
+    """random.choice(seq) — return a non-deterministic element of `seq`.
+
+    Models the choice as `seq[i]` for a constrained nondet index. Raises
+    IndexError on an empty sequence, matching CPython.
+    """
+    n: int = len(seq)
+    if n <= 0:
+        raise IndexError("Cannot choose from an empty sequence")
+    i: int = nondet_int()
+    __ESBMC_assume(i >= 0 and i < n)
+    return seq[i]
+
+
+def shuffle(lst: list[int]) -> None:
+    """random.shuffle(lst) — permutes `lst` in place.
+
+    Under-approximation: leaves the list untouched. A precise model would
+    nondet-shuffle the elements, but doing so requires expressing
+    permutation constraints over `lst`, which is out of scope here.
+    """
+    return
+
+
+def sample(population: list[int], k: int) -> list[int]:
+    """random.sample(population, k) — k distinct elements from population.
+
+    Returns the first `k` elements of `population` as an under-approximation;
+    a precise model would pick `k` distinct nondet indices.
+    """
+    n: int = len(population)
+    if k < 0 or k > n:
+        raise ValueError("Sample larger than population or is negative")
+    result: list[int] = []
+    i: int = 0
+    while i < k:
+        result.append(population[i])
+        i = i + 1
+    return result
+
+
 def randrange(start: int, stop: int = None, step: int = 1) -> int:
     # Handle the single-argument case: randrange(stop)
     if stop is None:


### PR DESCRIPTION
The random module model only had `randint`, `random`, `uniform`,
`getrandbits` and `randrange`; calls like `random.choice` raised
"Unsupported function 'choice' is reached".

Adds:

- `seed(a)` — no-op (already-nondet outputs cover all seeds).
- `choice(seq)` — `seq[i]` for a constrained nondet `i`; raises
  `IndexError` on empty input.
- `shuffle(lst)` — under-approximation that leaves the list untouched
  but preserves length.
- `sample(population, k)` — returns the first `k` elements as an
  under-approximation; raises `ValueError` when `k` is out of range.

A precise `shuffle` / `sample` model expressing permutation constraints
is a follow-up.

Refs #4355, #4296.
