### PR TITLE
[python] add deque and OrderedDict to the collections model

### DIFF
--- a/regression/python/github_4357/main.py
+++ b/regression/python/github_4357/main.py
@@ -1,0 +1,23 @@
+from collections import deque, OrderedDict
+
+
+def main() -> None:
+    # deque construction from a list, then list-style append.
+    d = deque([1, 2, 3])
+    d.append(4)
+    assert len(d) == 4
+    assert d[0] == 1
+    assert d[3] == 4
+
+    # Empty deque.
+    e = deque()
+    e.append(7)
+    assert len(e) == 1
+
+    # OrderedDict supports the dict interface.
+    od = OrderedDict()
+    od[1] = 10
+    od[2] = 20
+    assert od[1] == 10
+    assert od[2] == 20
+main()

--- a/regression/python/github_4357/test.desc
+++ b/regression/python/github_4357/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4357_fail/main.py
+++ b/regression/python/github_4357_fail/main.py
@@ -1,0 +1,9 @@
+from collections import deque
+
+
+def main() -> None:
+    # Negative: a fresh deque has length 1 after one append, not 99.
+    d = deque()
+    d.append(1)
+    assert len(d) == 99
+main()

--- a/regression/python/github_4357_fail/test.desc
+++ b/regression/python/github_4357_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/collections.py
+++ b/src/python-frontend/models/collections.py
@@ -27,6 +27,36 @@ def defaultdict(default_factory: Optional[Any] = None, *args, **kwargs) -> dict:
     return {}
 
 
+def deque(iterable: list[int] = None, maxlen: int = -1) -> list[int]:
+    """collections.deque(iterable=()) — modelled as a plain list.
+
+    Approximation: deque is treated as a list backing store, exposing the
+    same `append` / `pop` / `__len__` / subscript surface that the
+    frontend already supports for lists. `appendleft` / `popleft` /
+    `extendleft` and the `maxlen` rollover are NOT modelled; programs
+    relying on the FIFO end will need a richer model.
+    """
+    if iterable is None:
+        return []
+    result: list[int] = []
+    i: int = 0
+    n: int = len(iterable)
+    while i < n:
+        result.append(iterable[i])
+        i = i + 1
+    return result
+
+
+def OrderedDict(*args, **kwargs) -> dict:
+    """collections.OrderedDict — modelled as a plain dict.
+
+    Insertion order is already preserved by the dict model, so the
+    OrderedDict-specific methods (`move_to_end`) are the only divergence;
+    `popitem` is already available via the dict interface.
+    """
+    return {}
+
+
 class Counter:
     """Simplified Counter model: maps (int, int) keys to integer counts."""
 


### PR DESCRIPTION
`from collections import deque` raised "NameError: name 'deque' is not
defined" because the model only knew about `defaultdict` and `Counter`.

Adds:

- `deque(iterable=())` — modelled as a plain list, exposing the
  existing list dispatch (`append` / `pop` / `__len__` / subscript).
  `appendleft` / `popleft` / `extendleft` and `maxlen` rollover are
  follow-ups.
- `OrderedDict(*args, **kwargs)` — alias for dict; the dict model
  already preserves insertion order. `move_to_end` is not yet exposed.

`namedtuple` (needs a class factory) and `ChainMap` (needs
reference-semantics merging) remain follow-ups under #4296.

Refs #4357, #4296.
