### PR TITLE
[clang-c-frontend] map char8_t builtin to unsigned 8-bit integer

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_char8/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_char8/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+int main()
+{
+  char8_t c = u8'A';
+  assert(c == 65);
+
+  char8_t s[] = u8"hi";
+  assert(s[0] == 0x68);
+  assert(s[1] == 0x69);
+  assert(s[2] == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_char8/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_char8/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_char8_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_char8_fail/main.cpp
@@ -1,0 +1,9 @@
+#include <cassert>
+
+int main()
+{
+  char8_t c = u8'A';
+  // 'A' is 0x41 = 65; the assertion below must fail.
+  assert(c == 66);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_char8_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_char8_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -1394,6 +1394,11 @@ bool clang_c_convertert::get_builtin_type(
     c_type = "unsigned_wchar_t";
     break;
 
+  case clang::BuiltinType::Char8:
+    new_type = unsigned_char_type();
+    c_type = "char8_t";
+    break;
+
   case clang::BuiltinType::Char16:
     new_type = char16_type();
     c_type = "char16_t";


### PR DESCRIPTION
Map the C++20 `char8_t` builtin in `get_builtin_type()` to `unsigned_char_type()` (an 8-bit unsigned integer per [basic.fundamental]/N4861), mirroring the existing `Char16`/`Char32` cases. Adds passing and failing regression tests under `regression/esbmc-cpp20/cpp/github_4377_char8{,_fail}`.

Picks off the `char8_t` item from the C++17/20/23 audit umbrella in #4377.
