### PR TITLE
[clang-c-frontend] emit init-statement of C++17 if/switch

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_4377_if_init/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_if_init/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+int main()
+{
+  int outer = 1;
+
+  if (int x = 7; x > 0)
+  {
+    assert(x == 7);
+  }
+
+  // The init-statement variable must not leak out of the if.
+  assert(outer == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_if_init/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_if_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_4377_if_init_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_if_init_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+
+int main()
+{
+  // The init-statement initialises x to 7; the assertion below must fail.
+  if (int x = 7; x > 0)
+  {
+    assert(x == 8);
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_if_init_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_if_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp17/cpp/github_4377_switch_init/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_switch_init/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+
+int main()
+{
+  bool taken = false;
+  switch (int x = 7; x)
+  {
+  case 7:
+    assert(x == 7);
+    taken = true;
+    break;
+  default:
+    assert(0);
+  }
+  assert(taken);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_switch_init/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_switch_init/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_4377_switch_init_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_switch_init_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+int main()
+{
+  // The init-statement sets x to 7, so the default branch must be taken
+  // and the assertion below must fail.
+  switch (int x = 7; x)
+  {
+  case 0:
+    break;
+  default:
+    assert(0);
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_switch_init_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_switch_init_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2645,7 +2645,23 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
       if_expr.copy_to_operands(else_expr);
     }
 
-    new_expr = if_expr;
+    // C++17 init-statement: `if (init; cond)`. Wrap the init and the
+    // resulting if in a block so the init's side-effects (in particular,
+    // the initialiser of any variable declared there) are emitted.
+    if (const clang::Stmt *init_stmt = ifstmt.getInit())
+    {
+      exprt init;
+      if (get_expr(*init_stmt, init))
+        return true;
+      convert_expression_to_code(init);
+
+      code_blockt block;
+      block.move_to_operands(init);
+      block.copy_to_operands(if_expr);
+      new_expr = block;
+    }
+    else
+      new_expr = if_expr;
     break;
   }
 
@@ -2671,7 +2687,21 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     switch_code.value() = cond;
     switch_code.body() = body;
 
-    new_expr = switch_code;
+    // C++17 init-statement: `switch (init; cond)`. Wrap as for IfStmt.
+    if (const clang::Stmt *init_stmt = switch_stmt.getInit())
+    {
+      exprt init;
+      if (get_expr(*init_stmt, init))
+        return true;
+      convert_expression_to_code(init);
+
+      code_blockt block;
+      block.move_to_operands(init);
+      block.copy_to_operands(switch_code);
+      new_expr = block;
+    }
+    else
+      new_expr = switch_code;
     break;
   }
 


### PR DESCRIPTION
Lower the C++17 init-statement of `if`/`switch`:

```cpp
if (int x = 7; x > 0) { assert(x == 7); }   // spuriously failed before
switch (int x = 7; x) { case 7: ...; }      // same
```

`IfStmtClass`/`SwitchStmtClass` in `get_expr()` only emitted `getCond()` and `getBody()`/`getThen()`+`getElse()` but never `getInit()`. The init-declared variable landed in the symbol table without its initialiser, so reads picked up a non-deterministic value and the body's assertions failed spuriously. Per [stmt.if]/2 and [stmt.switch]/2 (N4861), the init-statement is equivalent to a preceding statement in an enclosing block; this PR wraps the lowered if/switch accordingly.

Adds 4 regression tests under `regression/esbmc-cpp17/cpp/github_4377_{if,switch}_init{,_fail}/` (passing and failing for each statement). `esbmc-cpp17`, `esbmc-cpp20`, and the unrelated-pre-existing-failure-set on `esbmc-cpp/cpp` confirmed unchanged.

Picks off the `if`/`switch` init-statement item from the C++17/20/23 audit umbrella in #4377.
