### PR TITLE
[clang-cpp-frontend] skip implicit object arg for static operator()

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_static_call/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_static_call/main.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+
+struct F
+{
+  static int operator()(int x) { return x + 1; }
+};
+
+struct A
+{
+  static int operator[](int i) { return i * 10; }
+};
+
+int main()
+{
+  F f;
+  assert(f(2) == 3);
+
+  A a;
+  assert(a[3] == 30);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_static_call/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_static_call/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_static_call_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_static_call_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+
+struct F
+{
+  static int operator()(int x) { return x + 1; }
+};
+
+int main()
+{
+  F f;
+  // f(2) returns 3; the assertion below must fail.
+  assert(f(2) == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_static_call_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_static_call_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -683,11 +683,26 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     call.function() = callee_expr;
     call.type() = type;
 
-    // Do args
-    for (const clang::Expr *arg : operator_call.arguments())
+    // C++23 allows a static operator(): `static int operator()(int);`. Clang
+    // still puts the object expression as arg 0 of the CXXOperatorCallExpr,
+    // but a static method has no implicit-object parameter, so passing the
+    // object would clash with the function's actual signature. Skip it.
+    auto args = operator_call.arguments();
+    auto begin = args.begin();
+    const auto *direct = operator_call.getDirectCallee();
+    if (
+      const auto *md =
+        llvm::dyn_cast_or_null<clang::CXXMethodDecl>(direct);
+      md && md->isStatic())
+    {
+      assert(begin != args.end());
+      ++begin;
+    }
+
+    for (auto it = begin; it != args.end(); ++it)
     {
       exprt single_arg;
-      if (get_expr(*arg, single_arg))
+      if (get_expr(**it, single_arg))
         return true;
 
       call.arguments().push_back(single_arg);

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -690,10 +690,8 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     auto args = operator_call.arguments();
     auto begin = args.begin();
     const auto *direct = operator_call.getDirectCallee();
-    if (
-      const auto *md =
-        llvm::dyn_cast_or_null<clang::CXXMethodDecl>(direct);
-      md && md->isStatic())
+    if (const auto *md = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(direct);
+        md && md->isStatic())
     {
       assert(begin != args.end());
       ++begin;


### PR DESCRIPTION
C++23 allows static `operator()` / `operator[]`:

```cpp
struct F { static int operator()(int x) { return x + 1; } };
F f; f(2);  // was: function call: argument type mismatch — got struct, expected signedbv
```

Clang still emits the call as a `CXXOperatorCallExpr` with the object as arg 0, but the called `CXXMethodDecl::isStatic()` has no implicit-object parameter, so passing the object as a regular argument clashed with the actual signature. Detect the static case via `getDirectCallee()` + `CXXMethodDecl::isStatic()` and skip arg 0 when building the call.

Adds passing + failing regression tests under `regression/esbmc-cpp20/cpp/github_4377_static_call{,_fail}/` (covering both static `operator()` and static `operator[]`). `esbmc-cpp17`/`esbmc-cpp20` suites all green; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the static `operator()` item from the C++17/20/23 audit umbrella in #4377.
