### PR TITLE
[clang-cpp-frontend] support C++17 structured bindings

### DIFF
--- a/regression/esbmc-cpp17/cpp/github_4377_structured_binding/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_structured_binding/main.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+
+struct P
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  // Struct destructure.
+  P p{1, 2};
+  auto [x, y] = p;
+  assert(x == 1);
+  assert(y == 2);
+
+  // Array destructure.
+  int arr[3] = {10, 20, 30};
+  auto [u, v, w] = arr;
+  assert(u == 10);
+  assert(v == 20);
+  assert(w == 30);
+
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_structured_binding/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_structured_binding/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp17/cpp/github_4377_structured_binding_fail/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_structured_binding_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+
+struct P
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  P p{1, 2};
+  auto [x, y] = p;
+  // The bindings hold (1, 2); the assertion below must fail.
+  assert(x == 9);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_structured_binding_fail/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_structured_binding_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp17/cpp/github_4377_structured_binding_ref/main.cpp
+++ b/regression/esbmc-cpp17/cpp/github_4377_structured_binding_ref/main.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+
+struct P
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  P p{1, 2};
+  // Reference binding: writing through the binding must mutate the
+  // underlying object.
+  auto &[x, y] = p;
+  x = 99;
+  y = 88;
+  assert(p.a == 99);
+  assert(p.b == 88);
+  return 0;
+}

--- a/regression/esbmc-cpp17/cpp/github_4377_structured_binding_ref/test.desc
+++ b/regression/esbmc-cpp17/cpp/github_4377_structured_binding_ref/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -118,10 +118,19 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   // Declaration of variables
   case clang::Decl::Var:
   case clang::Decl::VarTemplateSpecialization:
+  // C++17 structured binding: `auto [a, b] = expr;`. The DecompositionDecl
+  // holds the source object as an unnamed VarDecl; references to each
+  // BindingDecl expand to its getBinding() expression in get_decl_ref.
+  case clang::Decl::Decomposition:
   {
     const clang::VarDecl &vd = static_cast<const clang::VarDecl &>(decl);
     return get_var(vd, new_expr);
   }
+
+  // BindingDecls have no standalone storage; their references resolve to
+  // the holder's binding sub-expression in get_decl_ref. Skip here.
+  case clang::Decl::Binding:
+    break;
 
   // Declaration of function's parameter
   case clang::Decl::ParmVar:

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -184,6 +184,24 @@ void clang_cpp_convertert::get_decl_name(
       break;
     }
     break;
+
+  case clang::Decl::Decomposition:
+  {
+    // C++17 structured binding holder: synthesise a stable name from
+    // location since the DecompositionDecl is unnamed in the source.
+    // Clang's USR generator does not handle DecompositionDecl, so derive
+    // the id from the location too rather than falling through.
+    locationt location_begin;
+    get_location_from_decl(nd, location_begin);
+    std::string location_begin_str = location_begin.file().as_string() + "_" +
+                                     location_begin.function().as_string() +
+                                     "_" + location_begin.line().as_string() +
+                                     "_" + location_begin.column().as_string();
+    name = "__decomp_at_" + location_begin_str;
+    std::replace(name.begin(), name.end(), '.', '_');
+    id = "c:@" + name;
+    return;
+  }
   case clang::Decl::ParmVar:
   {
     const clang::ParmVarDecl &pd = static_cast<const clang::ParmVarDecl &>(nd);
@@ -1959,6 +1977,16 @@ bool clang_cpp_convertert::get_decl_ref(
 
   switch (decl.getKind())
   {
+  // C++17 structured binding: each name resolves to a sub-expression of
+  // the holder, e.g. `__decomp.first`, so references substitute directly.
+  case clang::Decl::Binding:
+  {
+    const auto &bd = static_cast<const clang::BindingDecl &>(decl);
+    if (const clang::Expr *e = bd.getBinding())
+      return get_expr(*e, new_expr);
+    break;
+  }
+
   case clang::Decl::ParmVar:
   {
     // first follow the base conversion flow to fill new_expr


### PR DESCRIPTION
Add C++17 structured-binding support to the clang frontend:

```cpp
struct P { int a; int b; };
P p{1, 2};
auto [x, y] = p;        // was: ERROR: unrecognized clang declaration Decomposition
auto& [u, v] = p;       // reference binding: writes through u/v mutate p
int arr[3] = {10, 20, 30};
auto [a, b, c] = arr;
std::pair<int,int> q{1, 2};
auto [m, n] = q;        // tuple-like destructure
```

Three pieces:

* `Decl::Decomposition` → routes through `get_var()` (DecompositionDecl is a VarDecl) so the holder lands in the symbol table with its initialiser.
* C++ `get_decl_name` override synthesises a stable name and id from source location for the (unnamed) DecompositionDecl, since Clang's USR generator does not produce one.
* `Decl::Binding` → no-op in `get_decl`; in `get_decl_ref`, each binding substitutes its `getBinding()` expression (a `MemberExpr` / `ArraySubscriptExpr` / `get<I>()` call into the holder). Substitution gives correct alias semantics for both `auto` and `auto&` forms.

Per [dcl.struct.bind] in N4861.

Adds 3 regression tests under `regression/esbmc-cpp17/cpp/github_4377_structured_binding{,_fail,_ref}/` covering struct + array destructure (passing), wrong-value (failing), and reference-binding mutation. `esbmc-cpp17`/`esbmc-cpp20` suites all pass; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the structured-bindings item from the C++17/20/23 audit umbrella in #4377.
