### PR TITLE
[clang-cpp-frontend] handle C++23 explicit object parameter (deducing this)

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_deducing_this/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_deducing_this/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+
+struct S
+{
+  int v = 7;
+  int g(this S const &self) { return self.v; }
+  int add(this S const &self, int x) { return self.v + x; }
+};
+
+int main()
+{
+  S s;
+  assert(s.g() == 7);
+  assert(s.add(5) == 12);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_deducing_this/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_deducing_this/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_deducing_this_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_deducing_this_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+struct S
+{
+  int v = 7;
+  int g(this S const &self) { return self.v; }
+};
+
+int main()
+{
+  S s;
+  // s.g() returns 7; the assertion below must fail.
+  assert(s.g() == 8);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_deducing_this_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_deducing_this_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4377_deducing_this_mut/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_deducing_this_mut/main.cpp
@@ -1,0 +1,18 @@
+#include <cassert>
+
+struct S
+{
+  int v = 0;
+  void inc(this S &self) { self.v++; }
+};
+
+int main()
+{
+  S s;
+  s.inc();
+  s.inc();
+  // The non-const explicit object reference must mutate the underlying
+  // object.
+  assert(s.v == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_deducing_this_mut/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_deducing_this_mut/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1795,10 +1795,18 @@ bool clang_cpp_convertert::get_function_params(
   const clang::CXXMethodDecl &cxxmd =
     static_cast<const clang::CXXMethodDecl &>(fd);
 
-  // If it's a C-style function, fallback to C mode
+  // If it's a C-style function, fallback to C mode.
   // Static methods don't have the this arg and can be handled as
-  // C functions
-  if (!fd.isCXXClassMember() || cxxmd.isStatic())
+  // C functions.  C++23 explicit object member functions (deducing this,
+  //
+  //   int g(this S const& self);
+  //
+  // [dcl.fct]/p6, N4861) likewise have no implicit this: the object
+  // expression is the first regular parameter, so route them through the
+  // same path.
+  if (
+    !fd.isCXXClassMember() || cxxmd.isStatic() ||
+    cxxmd.isExplicitObjectMemberFunction())
     return clang_c_convertert::get_function_params(fd, params);
 
   // Add this pointer to first arg


### PR DESCRIPTION
Fix C++23 explicit object parameter (deducing this):

```cpp
struct S { int v = 7; int g(this S const& self) { return self.v; } };
S s; s.g();   // was: VERIFICATION FAILED — "Incorrect alignment when accessing data object"
```

`get_function_params()` always inserted a synthetic `this` pointer for any non-static member, so the lowered `g` ended up with two parameters (synthetic `this` + `self`) while call sites pushed only one argument. The slot mismatch surfaced as a bogus alignment failure on `self.v`. Skip `get_function_this_pointer_param()` when `CXXMethodDecl::isExplicitObjectMemberFunction()` is true, mirroring the static-method path. The existing `CXXMemberCallExpr` handler already pushes `getImplicitObjectArgument()` as the first argument, which is what these functions expect for `self`.

Per [dcl.fct]/p6 in N4861.

Adds 3 regression tests under `regression/esbmc-cpp20/cpp/github_4377_deducing_this{,_fail,_mut}/` covering: `S const&` reads, wrong-value (failing), and `S&` mutation through `self`. `esbmc-cpp17`/`esbmc-cpp20` suites all pass; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the explicit-object-parameter item from the C++17/20/23 audit umbrella in #4377.
