### PR TITLE
[om] add minimal C++20 <source_location>

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_source_location/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_source_location/main.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include <source_location>
+
+int main()
+{
+  std::source_location sl = std::source_location::current();
+
+  // The OM produces a non-zero line and a non-empty file name; checking
+  // exact values would expose ESBMC's default-argument call-site
+  // materialisation (orthogonal to having <source_location> at all).
+  assert(sl.line() > 0);
+  assert(sl.column() > 0);
+  assert(sl.file_name() != nullptr);
+  assert(sl.function_name() != nullptr);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_source_location/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_source_location/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_source_location_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_source_location_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <cassert>
+#include <source_location>
+
+int main()
+{
+  std::source_location sl = std::source_location::current();
+  // current() must produce a non-zero line; the assertion below must fail.
+  assert(sl.line() == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_source_location_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_source_location_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/source_location
+++ b/src/cpp/library/source_location
@@ -1,0 +1,65 @@
+#ifndef ESBMC_SOURCE_LOCATION
+#define ESBMC_SOURCE_LOCATION
+
+#include "cstdint"
+
+// Minimal C++20 <source_location> operational model: enough for code that
+// captures std::source_location::current() at call sites and reads back
+// line/column/file_name/function_name.  Wider library surface (formatter
+// integration, derived utilities) is out of scope for ESBMC's bundled OMs.
+//
+// Per [support.srcloc] in N4861. The clang built-ins __builtin_LINE() etc.
+// expand at the call site (with default arguments evaluated in the caller),
+// which is exactly the semantics current() requires.
+
+namespace std
+{
+
+struct source_location
+{
+  // current() must capture the caller's location.  Each parameter defaults
+  // to a built-in that is evaluated at the call site (not at the call to
+  // current()) per [support.srcloc.cons]/p1.
+  static constexpr source_location current(
+    const char *file = __builtin_FILE(),
+    const char *function = __builtin_FUNCTION(),
+    uint_least32_t line = __builtin_LINE(),
+    uint_least32_t column = __builtin_COLUMN()) noexcept
+  {
+    source_location sl;
+    sl.file_ = file;
+    sl.function_ = function;
+    sl.line_ = line;
+    sl.column_ = column;
+    return sl;
+  }
+
+  constexpr source_location() noexcept = default;
+
+  constexpr uint_least32_t line() const noexcept
+  {
+    return line_;
+  }
+  constexpr uint_least32_t column() const noexcept
+  {
+    return column_;
+  }
+  constexpr const char *file_name() const noexcept
+  {
+    return file_;
+  }
+  constexpr const char *function_name() const noexcept
+  {
+    return function_;
+  }
+
+private:
+  const char *file_ = "";
+  const char *function_ = "";
+  uint_least32_t line_ = 0;
+  uint_least32_t column_ = 0;
+};
+
+} // namespace std
+
+#endif


### PR DESCRIPTION
Add a minimal C++20 `<source_location>` operational model under `src/cpp/library/`. Until now, including the header failed with `fatal error: 'source_location' file not found`.

The OM defines `std::source_location` with `line()`/`column()`/`file_name()`/`function_name()` accessors and the static `current()` factory. `current()`'s default arguments delegate to `__builtin_FILE`/`__builtin_FUNCTION`/`__builtin_LINE`/`__builtin_COLUMN`, the same strategy libc++ and libstdc++ use ([support.srcloc] in N4861).

Caveat: ESBMC currently materialises `CXXDefaultArgExpr` at the function-declaration site rather than the caller, so `line()` returns the location inside the OM, not the caller's line. Code that asserts a specific caller line will not pass — but code that just needs `<source_location>` to compile, capture a value, and read fields back now works. Lifting that limitation is a separate, deeper fix in the default-argument lowering and not in scope here.

Adds passing + failing regression tests under `regression/esbmc-cpp20/cpp/github_4377_source_location{,_fail}/`. `esbmc-cpp17`/`esbmc-cpp20` suites all green.

Picks off the `<source_location>` item from the C++17/20/23 audit umbrella in #4377.
