### PR TITLE
[om] add C++20 <compare> with three-way comparison support

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct/main.cpp
@@ -1,0 +1,21 @@
+// Exercise the APValue::Struct lowering added in clang_c_convertert::
+// get_APValue_expr (PR #4386).  A `consteval` constructor wraps the
+// CXXConstructExpr in a ConstantExpr whose APValueResult is
+// APValue::Struct with N fields, which is the same shape that
+// std::strong_ordering category values produce.
+#include <cassert>
+
+struct Pair
+{
+  int x;
+  int y;
+  consteval Pair(int a, int b) noexcept : x(a), y(b) {}
+};
+
+int main()
+{
+  Pair p{3, 4};
+  assert(p.x == 3);
+  assert(p.y == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct_fail/main.cpp
@@ -1,0 +1,18 @@
+// Failing companion to github_4377_apvalue_struct: the consteval-folded
+// struct value still flows through APValue::Struct lowering, but the
+// assertion reads back the wrong field value so verification must fail.
+#include <cassert>
+
+struct Pair
+{
+  int x;
+  int y;
+  consteval Pair(int a, int b) noexcept : x(a), y(b) {}
+};
+
+int main()
+{
+  Pair p{3, 4};
+  assert(p.x == 99);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_apvalue_struct_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4377_compare/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_compare/main.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+#include <compare>
+
+std::strong_ordering compare(int a, int b)
+{
+  if (a < b)
+    return std::strong_ordering::less;
+  if (a > b)
+    return std::strong_ordering::greater;
+  return std::strong_ordering::equal;
+}
+
+int main()
+{
+  // Direct use of strong_ordering values and comparison against 0.
+  auto less = compare(1, 2);
+  assert(less < 0);
+  assert(less != 0);
+  assert(!(less > 0));
+
+  auto eq = compare(5, 5);
+  assert(eq == 0);
+
+  auto greater = compare(7, 3);
+  assert(greater > 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_compare/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_compare/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_compare_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_compare_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <cassert>
+#include <compare>
+
+int main()
+{
+  std::strong_ordering o = std::strong_ordering::less;
+  // o < 0 holds; the assertion below must fail.
+  assert(o > 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_compare_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_compare_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2458,7 +2458,8 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (c.hasAPValueResult())
     {
       clang::APValue value = c.getAPValueResult();
-      if (!get_APValue_expr(value, new_expr))
+      clang::QualType ct = c.getType();
+      if (!get_APValue_expr(value, new_expr, &ct))
         break;
     }
 
@@ -4489,8 +4490,10 @@ bool clang_c_convertert::is_member_decl_static(const clang::MemberExpr &member)
 
 bool clang_c_convertert::get_APValue_expr(
   const clang::APValue &value,
-  exprt &new_expr)
+  exprt &new_expr,
+  const clang::QualType *type_ptr)
 {
+  const clang::QualType type = type_ptr ? *type_ptr : clang::QualType();
   switch (value.getKind())
   {
   case clang::APValue::LValue:
@@ -4515,6 +4518,63 @@ bool clang_c_convertert::get_APValue_expr(
     break;
   }
 
+  case clang::APValue::Struct:
+  {
+    // Lower a constexpr struct value (e.g. C++20 std::strong_ordering::less)
+    // to a struct exprt. Bases come first, then fields, mirroring how
+    // ESBMC flattens base sub-objects into the struct components.
+    if (type.isNull())
+      return true;
+    typet t;
+    if (get_type(type, t))
+      return true;
+    t = get_complete_type(t, ns);
+    if (!t.is_struct())
+      return true;
+    new_expr = gen_zero(t);
+
+    const auto *cxxrd = type->getAsCXXRecordDecl();
+    const auto *rd = type->getAsRecordDecl();
+    unsigned op_idx = 0;
+
+    if (cxxrd)
+    {
+      unsigned base_idx = 0;
+      for (const clang::CXXBaseSpecifier &base : cxxrd->bases())
+      {
+        if (base_idx >= value.getStructNumBases())
+          break;
+        exprt sub;
+        clang::QualType bt = base.getType();
+        if (get_APValue_expr(value.getStructBase(base_idx), sub, &bt))
+          return true;
+        if (op_idx < new_expr.operands().size())
+          new_expr.operands().at(op_idx) = sub;
+        ++base_idx;
+        ++op_idx;
+      }
+    }
+
+    if (rd)
+    {
+      unsigned field_idx = 0;
+      for (const clang::FieldDecl *fd : rd->fields())
+      {
+        if (field_idx >= value.getStructNumFields())
+          break;
+        exprt sub;
+        clang::QualType ft = fd->getType();
+        if (get_APValue_expr(value.getStructField(field_idx), sub, &ft))
+          return true;
+        if (op_idx < new_expr.operands().size())
+          new_expr.operands().at(op_idx) = sub;
+        ++field_idx;
+        ++op_idx;
+      }
+    }
+    break;
+  }
+
   /*
     case clang::APValue::None:
     case clang::APValue::Indeterminate:
@@ -4522,7 +4582,6 @@ bool clang_c_convertert::get_APValue_expr(
     case clang::APValue::FixedPoint:
     case clang::APValue::Vector:
     case clang::APValue::Array:
-    case clang::APValue::Struct:
     case clang::APValue::Union:
     case clang::APValue::AddrLabelDiff:
     case clang::APValue::MemberPointer:

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -339,7 +339,10 @@ protected:
 
   virtual bool is_aggregate_type(const clang::QualType &q_type);
 
-  bool get_APValue_expr(const clang::APValue &value, exprt &new_expr);
+  bool get_APValue_expr(
+    const clang::APValue &value,
+    exprt &new_expr,
+    const clang::QualType *type = nullptr);
 
   /*
    * Function to check whether a MemberExpr references to a static variable

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -663,6 +663,19 @@ bool clang_cpp_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
+  // C++20 rewritten comparisons: when only operator<=> (or operator==) is
+  // declared, clang synthesises operator</>/<=/>= from it and wraps the
+  // synthesised call as a CXXRewrittenBinaryOperator. The semantic form
+  // is the actual rewrite (e.g. `(a <=> b) < 0`); forward to it.
+  case clang::Stmt::CXXRewrittenBinaryOperatorClass:
+  {
+    const clang::CXXRewrittenBinaryOperator &rb =
+      static_cast<const clang::CXXRewrittenBinaryOperator &>(stmt);
+    if (get_expr(*rb.getSemanticForm(), new_expr))
+      return true;
+    break;
+  }
+
   case clang::Stmt::CXXOperatorCallExprClass:
   {
     const clang::CXXOperatorCallExpr &operator_call =

--- a/src/cpp/library/compare
+++ b/src/cpp/library/compare
@@ -1,0 +1,315 @@
+#ifndef ESBMC_COMPARE
+#define ESBMC_COMPARE
+
+// Minimal C++20 <compare> operational model: enough to declare the three
+// comparison categories so user types can default operator<=> per
+// [class.spaceship] in N4861, and to compare those category values
+// against the literal 0 per [cmp.categories].
+//
+// The signed-char value layout matches the one libc++ and libstdc++ use,
+// which is also what Clang's compiler hooks for default <=> assume.
+
+namespace std
+{
+
+namespace __cmp_detail
+{
+// Sentinel type so that `cat == 0` is well-formed but `cat == 1` is not,
+// per [cmp.categories.pre]/p3: comparison operators take a literal-zero
+// argument and SFINAE on the literal-zero property.
+struct __zero_cmp
+{
+  consteval __zero_cmp(int v) noexcept
+  {
+    if (v != 0)
+      __builtin_unreachable();
+  }
+};
+} // namespace __cmp_detail
+
+class partial_ordering
+{
+  signed char __value_;
+  bool __is_ordered_;
+
+  constexpr explicit partial_ordering(signed char v, bool o) noexcept
+    : __value_(v), __is_ordered_(o)
+  {
+  }
+
+public:
+  static const partial_ordering less;
+  static const partial_ordering equivalent;
+  static const partial_ordering greater;
+  static const partial_ordering unordered;
+
+  friend constexpr bool
+  operator==(partial_ordering, partial_ordering) noexcept = default;
+
+  friend constexpr bool
+  operator==(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__is_ordered_ && v.__value_ == 0;
+  }
+  friend constexpr bool
+  operator<(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__is_ordered_ && v.__value_ < 0;
+  }
+  friend constexpr bool
+  operator>(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__is_ordered_ && v.__value_ > 0;
+  }
+  friend constexpr bool
+  operator<=(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__is_ordered_ && v.__value_ <= 0;
+  }
+  friend constexpr bool
+  operator>=(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__is_ordered_ && v.__value_ >= 0;
+  }
+  friend constexpr bool
+  operator<(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
+  {
+    return v.__is_ordered_ && 0 < v.__value_;
+  }
+  friend constexpr bool
+  operator>(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
+  {
+    return v.__is_ordered_ && 0 > v.__value_;
+  }
+  friend constexpr bool
+  operator<=(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
+  {
+    return v.__is_ordered_ && 0 <= v.__value_;
+  }
+  friend constexpr bool
+  operator>=(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
+  {
+    return v.__is_ordered_ && 0 >= v.__value_;
+  }
+
+  friend constexpr partial_ordering
+  operator<=>(partial_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v;
+  }
+  friend constexpr partial_ordering
+  operator<=>(__cmp_detail::__zero_cmp, partial_ordering v) noexcept
+  {
+    return partial_ordering(-v.__value_, v.__is_ordered_);
+  }
+};
+inline constexpr partial_ordering partial_ordering::less{-1, true};
+inline constexpr partial_ordering partial_ordering::equivalent{0, true};
+inline constexpr partial_ordering partial_ordering::greater{1, true};
+inline constexpr partial_ordering partial_ordering::unordered{0, false};
+
+class weak_ordering
+{
+  signed char __value_;
+
+  constexpr explicit weak_ordering(signed char v) noexcept : __value_(v)
+  {
+  }
+
+public:
+  static const weak_ordering less;
+  static const weak_ordering equivalent;
+  static const weak_ordering greater;
+
+  constexpr operator partial_ordering() const noexcept
+  {
+    if (__value_ == 0)
+      return partial_ordering::equivalent;
+    return __value_ < 0 ? partial_ordering::less : partial_ordering::greater;
+  }
+
+  friend constexpr bool
+  operator==(weak_ordering, weak_ordering) noexcept = default;
+
+  friend constexpr bool
+  operator==(weak_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ == 0;
+  }
+  friend constexpr bool
+  operator<(weak_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ < 0;
+  }
+  friend constexpr bool
+  operator>(weak_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ > 0;
+  }
+  friend constexpr bool
+  operator<=(weak_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ <= 0;
+  }
+  friend constexpr bool
+  operator>=(weak_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ >= 0;
+  }
+  friend constexpr bool
+  operator<(__cmp_detail::__zero_cmp, weak_ordering v) noexcept
+  {
+    return 0 < v.__value_;
+  }
+  friend constexpr bool
+  operator>(__cmp_detail::__zero_cmp, weak_ordering v) noexcept
+  {
+    return 0 > v.__value_;
+  }
+  friend constexpr bool
+  operator<=(__cmp_detail::__zero_cmp, weak_ordering v) noexcept
+  {
+    return 0 <= v.__value_;
+  }
+  friend constexpr bool
+  operator>=(__cmp_detail::__zero_cmp, weak_ordering v) noexcept
+  {
+    return 0 >= v.__value_;
+  }
+
+  friend constexpr weak_ordering
+  operator<=>(weak_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v;
+  }
+  friend constexpr weak_ordering
+  operator<=>(__cmp_detail::__zero_cmp, weak_ordering v) noexcept
+  {
+    return weak_ordering(-v.__value_);
+  }
+};
+inline constexpr weak_ordering weak_ordering::less{-1};
+inline constexpr weak_ordering weak_ordering::equivalent{0};
+inline constexpr weak_ordering weak_ordering::greater{1};
+
+class strong_ordering
+{
+  signed char __value_;
+
+  constexpr explicit strong_ordering(signed char v) noexcept : __value_(v)
+  {
+  }
+
+public:
+  static const strong_ordering less;
+  static const strong_ordering equal;
+  static const strong_ordering equivalent;
+  static const strong_ordering greater;
+
+  constexpr operator partial_ordering() const noexcept
+  {
+    if (__value_ == 0)
+      return partial_ordering::equivalent;
+    return __value_ < 0 ? partial_ordering::less : partial_ordering::greater;
+  }
+  constexpr operator weak_ordering() const noexcept
+  {
+    if (__value_ == 0)
+      return weak_ordering::equivalent;
+    return __value_ < 0 ? weak_ordering::less : weak_ordering::greater;
+  }
+
+  friend constexpr bool
+  operator==(strong_ordering, strong_ordering) noexcept = default;
+
+  friend constexpr bool
+  operator==(strong_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ == 0;
+  }
+  friend constexpr bool
+  operator<(strong_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ < 0;
+  }
+  friend constexpr bool
+  operator>(strong_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ > 0;
+  }
+  friend constexpr bool
+  operator<=(strong_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ <= 0;
+  }
+  friend constexpr bool
+  operator>=(strong_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v.__value_ >= 0;
+  }
+  friend constexpr bool
+  operator<(__cmp_detail::__zero_cmp, strong_ordering v) noexcept
+  {
+    return 0 < v.__value_;
+  }
+  friend constexpr bool
+  operator>(__cmp_detail::__zero_cmp, strong_ordering v) noexcept
+  {
+    return 0 > v.__value_;
+  }
+  friend constexpr bool
+  operator<=(__cmp_detail::__zero_cmp, strong_ordering v) noexcept
+  {
+    return 0 <= v.__value_;
+  }
+  friend constexpr bool
+  operator>=(__cmp_detail::__zero_cmp, strong_ordering v) noexcept
+  {
+    return 0 >= v.__value_;
+  }
+
+  friend constexpr strong_ordering
+  operator<=>(strong_ordering v, __cmp_detail::__zero_cmp) noexcept
+  {
+    return v;
+  }
+  friend constexpr strong_ordering
+  operator<=>(__cmp_detail::__zero_cmp, strong_ordering v) noexcept
+  {
+    return strong_ordering(-v.__value_);
+  }
+};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::equivalent{0};
+inline constexpr strong_ordering strong_ordering::greater{1};
+
+// Common helpers: is_eq, is_neq, is_lt, is_lteq, is_gt, is_gteq.
+constexpr bool is_eq(partial_ordering c) noexcept
+{
+  return c == 0;
+}
+constexpr bool is_neq(partial_ordering c) noexcept
+{
+  return c != 0;
+}
+constexpr bool is_lt(partial_ordering c) noexcept
+{
+  return c < 0;
+}
+constexpr bool is_lteq(partial_ordering c) noexcept
+{
+  return c <= 0;
+}
+constexpr bool is_gt(partial_ordering c) noexcept
+{
+  return c > 0;
+}
+constexpr bool is_gteq(partial_ordering c) noexcept
+{
+  return c >= 0;
+}
+
+} // namespace std
+
+#endif


### PR DESCRIPTION
Add a C++20 `<compare>` operational model and the converter pieces that make it usable end-to-end:

* **`<compare>` header** under `src/cpp/library/` — defines `std::partial_ordering`, `std::weak_ordering`, and `std::strong_ordering` with their static category values, cross-category narrowing operators, and the literal-zero comparison + spaceship overloads required by [cmp.categories] in N4861. Without this header any TU including `<compare>` failed parsing, and any class with a defaulted `operator<=>` hit `cannot default 'operator<=>' because type 'std::strong_ordering' was not found`.

* **`CXXRewrittenBinaryOperator` forwarding** in `clang_cpp_convertert::get_expr()`. Clang synthesises `operator</>/<=/>=` from `operator<=>` (or `operator==`) and wraps the synthesised call as `CXXRewrittenBinaryOperator`. Forward to `getSemanticForm()`.

* **`APValue::Struct` support** in `clang_c_convertert::get_APValue_expr()`. Constexpr struct values such as `std::strong_ordering::less` arrive as `APValue::Struct` on a `ConstantExpr`; build a struct exprt by walking base sub-objects and fields recursively. `get_APValue_expr()` now optionally takes a clang `QualType` (defaults to `nullptr`) so it can iterate bases/fields in declaration order; the existing integer/lvalue paths are unchanged.

**Caveat / out of scope:** defaulting `operator<=>` on a user struct trips a `value_set` assertion deeper in symex, and `partial_ordering`'s narrowing-to-bool comparison on a defaulted result needs more operator-rewrite plumbing. Direct use of category values and literal-zero comparisons (the common path for container ordering and sort comparators) does work — see the regression tests.

Adds passing + failing tests under `regression/esbmc-cpp20/cpp/github_4377_compare{,_fail}/`. `esbmc-cpp17` (21) and `esbmc-cpp20` (22) suites all pass; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the `<compare>` item from the C++17/20/23 audit umbrella in #4377.
