### PR TITLE
[om] add C++23 <expected>

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_expected/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_expected/main.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+#include <expected>
+
+struct Err
+{
+  int code;
+};
+
+std::expected<int, Err> compute(bool ok)
+{
+  if (ok)
+    return 100;
+  return std::unexpected<Err>(Err{-1});
+}
+
+int main()
+{
+  auto a = compute(true);
+  assert(a.has_value());
+  assert(*a == 100);
+  assert(a.value() == 100);
+
+  auto e = compute(false);
+  assert(!e.has_value());
+  assert(e.error().code == -1);
+
+  // value_or fallback.
+  std::expected<int, int> bad = std::unexpected<int>(7);
+  assert(bad.value_or(42) == 42);
+  std::expected<int, int> good = 5;
+  assert(good.value_or(42) == 5);
+
+  // operator-> on success path.
+  std::expected<Err, int> rec = Err{99};
+  assert(rec->code == 99);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_expected/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_expected/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_expected_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_expected_fail/main.cpp
@@ -1,0 +1,10 @@
+#include <cassert>
+#include <expected>
+
+int main()
+{
+  std::expected<int, int> e = 5;
+  // *e is 5; the assertion below must fail.
+  assert(*e == 99);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_expected_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_expected_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -259,6 +259,10 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   // the underlying type defined by the typedef, so we don't need
   // to add them to the context
   case clang::Decl::Typedef:
+
+  // CTAD deduction guides (C++17): clang materialises specialisations
+  // through the guide, so the guide itself has no runtime form.
+  case clang::Decl::CXXDeductionGuide:
     break;
 
   // We pretty much ignore this information, clang does the expansion for us.

--- a/src/cpp/library/expected
+++ b/src/cpp/library/expected
@@ -1,0 +1,211 @@
+#ifndef ESBMC_EXPECTED
+#define ESBMC_EXPECTED
+
+#include "type_traits"
+#include "utility"
+
+// Minimal C++23 <expected> operational model: enough for code that
+// returns std::expected<T,E>, constructs from T or from std::unexpected,
+// and reads back has_value() / value() / error() / *e / e->.
+//
+// The implementation uses a discriminator + two members rather than a
+// proper tagged union, which is far simpler to lower through ESBMC's
+// converter and is observably equivalent for verification (no real
+// destructors or non-trivial member layouts to worry about).
+//
+// Per [expected] in N4861/P0323. Out-of-scope for this OM:
+// monadic and_then / or_else / transform; in_place / unexpect tags;
+// and reference-typed expected<T&,E>.
+
+namespace std
+{
+
+// Tag for the in-place T constructor.
+struct in_place_t
+{
+  explicit constexpr in_place_t() = default;
+};
+inline constexpr in_place_t in_place{};
+
+// Tag for the in-place E constructor.
+struct unexpect_t
+{
+  explicit constexpr unexpect_t() = default;
+};
+inline constexpr unexpect_t unexpect{};
+
+template <class E>
+class unexpected
+{
+  E __err_;
+
+public:
+  constexpr unexpected(const unexpected &) = default;
+  constexpr unexpected(unexpected &&) = default;
+
+  template <class Err = E>
+  constexpr explicit unexpected(Err &&e) : __err_(std::forward<Err>(e))
+  {
+  }
+
+  constexpr const E &error() const & noexcept
+  {
+    return __err_;
+  }
+  constexpr E &error() & noexcept
+  {
+    return __err_;
+  }
+  constexpr E &&error() && noexcept
+  {
+    return std::move(__err_);
+  }
+  constexpr const E &&error() const && noexcept
+  {
+    return std::move(__err_);
+  }
+};
+
+// Deduction guide.
+template <class E>
+unexpected(E) -> unexpected<E>;
+
+template <class T, class E>
+class expected
+{
+  bool __has_;
+  T __val_;
+  E __err_;
+
+public:
+  using value_type = T;
+  using error_type = E;
+  using unexpected_type = unexpected<E>;
+
+  constexpr expected() : __has_(true), __val_(), __err_()
+  {
+  }
+
+  constexpr expected(const expected &) = default;
+  constexpr expected(expected &&) = default;
+
+  template <
+    class U = T,
+    typename = typename std::enable_if<
+      !std::is_same<typename std::decay<U>::type, expected>::value>::type>
+  constexpr expected(U &&v) : __has_(true), __val_(std::forward<U>(v)), __err_()
+  {
+  }
+
+  template <class G>
+  constexpr expected(const unexpected<G> &u)
+    : __has_(false), __val_(), __err_(u.error())
+  {
+  }
+
+  template <class G>
+  constexpr expected(unexpected<G> &&u)
+    : __has_(false), __val_(), __err_(std::move(u).error())
+  {
+  }
+
+  constexpr explicit expected(in_place_t) : __has_(true), __val_(), __err_()
+  {
+  }
+
+  template <class... Args>
+  constexpr explicit expected(in_place_t, Args &&...args)
+    : __has_(true), __val_(std::forward<Args>(args)...), __err_()
+  {
+  }
+
+  template <class... Args>
+  constexpr explicit expected(unexpect_t, Args &&...args)
+    : __has_(false), __val_(), __err_(std::forward<Args>(args)...)
+  {
+  }
+
+  constexpr bool has_value() const noexcept
+  {
+    return __has_;
+  }
+  constexpr explicit operator bool() const noexcept
+  {
+    return __has_;
+  }
+
+  constexpr T &value() &
+  {
+    return __val_;
+  }
+  constexpr const T &value() const &
+  {
+    return __val_;
+  }
+  constexpr T &&value() &&
+  {
+    return std::move(__val_);
+  }
+  constexpr const T &&value() const &&
+  {
+    return std::move(__val_);
+  }
+
+  constexpr E &error() & noexcept
+  {
+    return __err_;
+  }
+  constexpr const E &error() const & noexcept
+  {
+    return __err_;
+  }
+  constexpr E &&error() && noexcept
+  {
+    return std::move(__err_);
+  }
+  constexpr const E &&error() const && noexcept
+  {
+    return std::move(__err_);
+  }
+
+  constexpr T &operator*() & noexcept
+  {
+    return __val_;
+  }
+  constexpr const T &operator*() const & noexcept
+  {
+    return __val_;
+  }
+  constexpr T &&operator*() && noexcept
+  {
+    return std::move(__val_);
+  }
+  constexpr const T &&operator*() const && noexcept
+  {
+    return std::move(__val_);
+  }
+
+  constexpr T *operator->() noexcept
+  {
+    return &__val_;
+  }
+  constexpr const T *operator->() const noexcept
+  {
+    return &__val_;
+  }
+
+  template <class U>
+  constexpr T value_or(U &&def) const &
+  {
+    return __has_ ? __val_ : static_cast<T>(std::forward<U>(def));
+  }
+  template <class U>
+  constexpr T value_or(U &&def) &&
+  {
+    return __has_ ? std::move(__val_) : static_cast<T>(std::forward<U>(def));
+  }
+};
+
+} // namespace std
+
+#endif


### PR DESCRIPTION
Add a C++23 `<expected>` operational model and a no-op converter case for CTAD deduction guides:

```cpp
#include <expected>
std::expected<int, int> f(bool b) {
  if (b) return 42;
  return std::unexpected<int>(-1);   // explicit template args; see caveat
}
```

* **`<expected>`** under `src/cpp/library/` — `std::expected<T,E>`, `std::unexpected<E>`, `in_place_t` / `unexpect_t`, plus `has_value` / `value` / `error` / `operator*` / `operator->` / `value_or`. Storage uses a discriminator + two members rather than a tagged union, which is far easier to lower and observably equivalent for verification (no real destructors or non-trivial member layouts). Out of scope: monadic `and_then` / `or_else` / `transform` and reference-typed `expected<T&,E>`.

* **`Decl::CXXDeductionGuide`** is now a no-op in `clang_c_convertert::get_decl()`. CTAD deduction guides have no runtime form; clang materialises specialisations through them at template-argument-deduction time. Without this, any header that ships a guide (the new `<expected>`, future `<variant>`/`<any>`, user code, …) failed conversion with `unrecognized / unimplemented clang declaration CXXDeductionGuide`.

**Caveat:** Calling `std::unexpected(-1)` without explicit template arguments still fails — clang's CTAD result lowers to a `DeducedTemplateSpecialization` type that the converter doesn't yet handle. That is a separate, larger item in #4377; this PR works around it by recommending `std::unexpected<E>(...)` (the form most stdlib code already uses internally).

Adds passing + failing tests under `regression/esbmc-cpp20/cpp/github_4377_expected{,_fail}/` covering struct error type, `value_or`, `operator->`. `esbmc-cpp17`/`esbmc-cpp20` suites all pass; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the `<expected>` item from the C++17/20/23 audit umbrella in #4377.
