### PR TITLE
[clang-c-frontend] support C++17/20 class template argument deduction

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_ctad/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_ctad/main.cpp
@@ -1,0 +1,44 @@
+#include <cassert>
+
+// Aggregate template (C++20 P1816 implicit aggregate guides).
+template <typename T>
+struct Box
+{
+  T t;
+};
+
+// Template with user-provided constructor.
+template <typename T>
+struct Wrap
+{
+  T t;
+  Wrap(T x) : t(x)
+  {
+  }
+};
+
+// Template with explicit deduction guide.
+template <typename T>
+struct Holder
+{
+  T value;
+};
+template <typename T>
+Holder(T) -> Holder<T>;
+
+int main()
+{
+  // Aggregate CTAD.
+  Box b{42};
+  assert(b.t == 42);
+
+  // Constructor-based CTAD.
+  Wrap w{99};
+  assert(w.t == 99);
+
+  // Explicit guide.
+  Holder h{7};
+  assert(h.value == 7);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_ctad/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_ctad/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_ctad_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_ctad_fail/main.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+template <typename T>
+struct Box
+{
+  T t;
+};
+
+int main()
+{
+  Box b{42};
+  // CTAD-deduced Box<int>; b.t == 42, so the assertion below must fail.
+  assert(b.t == 99);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_ctad_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_ctad_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -268,6 +268,10 @@ bool clang_c_convertert::get_decl(const clang::Decl &decl, exprt &new_expr)
   // the underlying type defined by the typedef, so we don't need
   // to add them to the context
   case clang::Decl::Typedef:
+
+  // CTAD deduction guides (C++17): clang materialises specialisations
+  // through the guide, so the guide itself has no runtime form.
+  case clang::Decl::CXXDeductionGuide:
     break;
 
   // We pretty much ignore this information, clang does the expansion for us.
@@ -1280,6 +1284,20 @@ bool clang_c_convertert::get_type(const clang::Type &the_type, typet &new_type)
     if (get_type(at.desugar(), new_type))
       return true;
 
+    break;
+  }
+
+  // C++17/20 class template argument deduction (CTAD): a class template
+  // name written without explicit args resolves through deduction to a
+  // concrete specialisation; lower to that specialisation.
+  case clang::Type::DeducedTemplateSpecialization:
+  {
+    const clang::DeducedType &dt =
+      static_cast<const clang::DeducedType &>(the_type);
+    if (dt.getDeducedType().isNull())
+      return true;
+    if (get_type(dt.getDeducedType(), new_type))
+      return true;
     break;
   }
 


### PR DESCRIPTION
Add C++17/20 class template argument deduction (CTAD) support to the C frontend:

```cpp
template<typename T> struct Box { T t; };
Box b{42};                        // C++20 aggregate CTAD — was: PARSING ERROR
std::pair p{1, 2.5};              // ctor-based CTAD — was: CONVERSION ERROR
template<typename T> Holder(T) -> Holder<T>;
Holder h{7};                      // explicit guide — was: CONVERSION ERROR
```

Two pieces:

* `Decl::CXXDeductionGuide` handled as a no-op. CTAD deduction guides exist purely for template-argument deduction — clang materialises a concrete specialisation through them and they have no runtime form. The C frontend previously rejected them with `unrecognized / unimplemented clang declaration CXXDeductionGuide`, which broke any header carrying CTAD guides (libstdc++/libc++'s `pair`, the new `<expected>` (#4388), user code, …).

* `Type::DeducedTemplateSpecialization` forwarded to `DeducedType::getDeducedType()`. When a class-template name is written without explicit args, clang resolves it through deduction and stores the result as a `DeducedTemplateSpecialization` whose `getDeducedType()` is the concrete `RecordType`. Forward to that and the rest of `get_type()` handles it normally.

Together these cover aggregate CTAD (C++20 P1816), ctor-based CTAD (C++17), and explicit user-written guides ([over.match.class.deduct] in N4861).

Adds passing + failing tests under `regression/esbmc-cpp20/cpp/github_4377_ctad{,_fail}/`. `esbmc-cpp17`/`esbmc-cpp20` suites all pass; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the CTAD item from the C++17/20/23 audit umbrella in #4377.
