### PR TITLE
[python] add issubset / update / symmetric_difference / frozenset

### DIFF
--- a/regression/python/github_4366/main.py
+++ b/regression/python/github_4366/main.py
@@ -1,14 +1,6 @@
 def main() -> None:
-    # issubset
     a = {1, 2}
     b = {1, 2, 3}
     assert a.issubset(b)
     assert not b.issubset(a)
-    # update mutates self
-    s = {1, 2}
-    s.update({3})
-    assert 3 in s and 1 in s
-    # frozenset constructor
-    fs = frozenset([1, 2])
-    assert 1 in fs and 2 in fs
 main()

--- a/regression/python/github_4366/main.py
+++ b/regression/python/github_4366/main.py
@@ -1,0 +1,14 @@
+def main() -> None:
+    # issubset
+    a = {1, 2}
+    b = {1, 2, 3}
+    assert a.issubset(b)
+    assert not b.issubset(a)
+    # update mutates self
+    s = {1, 2}
+    s.update({3})
+    assert 3 in s and 1 in s
+    # frozenset constructor
+    fs = frozenset([1, 2])
+    assert 1 in fs and 2 in fs
+main()

--- a/regression/python/github_4366/test.desc
+++ b/regression/python/github_4366/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4366_fail/main.py
+++ b/regression/python/github_4366_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # Negative: a is a strict subset of b, so b is NOT a subset of a.
+    a = {1, 2}
+    b = {1, 2, 3}
+    assert b.issubset(a)
+main()

--- a/regression/python/github_4366_fail/test.desc
+++ b/regression/python/github_4366_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4366_frozenset/main.py
+++ b/regression/python/github_4366_frozenset/main.py
@@ -1,0 +1,4 @@
+def main() -> None:
+    fs = frozenset([1, 2])
+    assert 1 in fs and 2 in fs
+main()

--- a/regression/python/github_4366_frozenset/test.desc
+++ b/regression/python/github_4366_frozenset/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4366_update/main.py
+++ b/regression/python/github_4366_update/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    s = {1, 2}
+    s.update({3})
+    assert 3 in s and 1 in s
+main()

--- a/regression/python/github_4366_update/test.desc
+++ b/regression/python/github_4366_update/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -8,6 +8,7 @@
 #include <python-frontend/string_handler_utils.h>
 #include <python-frontend/python_exception_handler.h>
 #include <python-frontend/python_list.h>
+#include <python-frontend/python_set.h>
 #include <python-frontend/string_builder.h>
 #include <python-frontend/symbol_id.h>
 #include <python-frontend/tuple_handler.h>
@@ -3319,7 +3320,10 @@ bool function_call_expr::is_set_method_call() const
     return false;
 
   const std::string &method_name = function_id_.get_function();
-  if (method_name != "add" && method_name != "discard")
+  if (
+    method_name != "add" && method_name != "discard" &&
+    method_name != "issubset" && method_name != "update" &&
+    method_name != "symmetric_difference")
     return false;
 
   std::string dummy;
@@ -3341,11 +3345,20 @@ exprt function_call_expr::handle_set_method() const
   if (!set_symbol)
     throw std::runtime_error("Set variable not found: " + set_display_name);
 
-  exprt elem = converter_.get_expr(args[0]);
+  // add/discard take a single element value.
+  if (method_name == "add" || method_name == "discard")
+  {
+    exprt elem = converter_.get_expr(args[0]);
+    python_list helper(converter_, call_);
+    return helper.build_set_membership_call(
+      *set_symbol, call_, elem, method_name);
+  }
 
-  python_list helper(converter_, call_);
-  return helper.build_set_membership_call(
-    *set_symbol, call_, elem, method_name);
+  // issubset / update / symmetric_difference take another set/iterable.
+  exprt other = converter_.get_expr(args[0]);
+  python_set set_helper(converter_, call_);
+  return set_helper.build_set_method_call(
+    *set_symbol, other, call_, method_name);
 }
 
 bool function_call_expr::is_list_method_call() const

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -2887,14 +2887,29 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     return python_list::build_list_from_range(*this, range_args, element);
   }
 
-  // Handle set(iterable) calls
+  // Handle set(iterable) and frozenset(iterable) calls. frozenset is
+  // modelled as a regular set: the verifier doesn't reason about
+  // immutability, so the only divergence (rejecting mutation methods)
+  // is academic for the safety properties we check.
   if (
-    element["func"]["_type"] == "Name" && element["func"]["id"] == "set" &&
+    element["func"]["_type"] == "Name" &&
+    (element["func"]["id"] == "set" ||
+     element["func"]["id"] == "frozenset") &&
     element.contains("args") && element["args"].size() == 1)
   {
     exprt iterable_expr = get_expr(element["args"][0]);
     python_set set_handler(*this, element);
     return set_handler.get_from_iterable(iterable_expr, element);
+  }
+
+  // frozenset() with no args — empty frozenset.
+  if (
+    element["func"]["_type"] == "Name" &&
+    element["func"]["id"] == "frozenset" &&
+    (!element.contains("args") || element["args"].empty()))
+  {
+    python_set set_handler(*this, element);
+    return set_handler.get_empty_set();
   }
 
   // Handle list(...) calls

--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -889,6 +889,269 @@ exprt python_set::build_set_union_call(
   return symbol_expr(result_set);
 }
 
+// Walk @p source_expr, push every element into @p sink whose membership
+// in @p ref_expr matches @p want_in_ref. Used by update /
+// symmetric_difference to express "elements not in X" filters with a
+// single helper. Static member of python_set so it inherits the friend
+// access python_set already has on python_converter's privates.
+void python_set::emit_filtered_extend(
+  python_converter &converter,
+  const exprt &source_expr,
+  const exprt &ref_expr,
+  const symbolt &sink,
+  bool want_in_ref,
+  const nlohmann::json &element)
+{
+  contextt &symtab = converter.symbol_table();
+  const symbolt *size_func = symtab.find_symbol("c:@F@__ESBMC_list_size");
+  const symbolt *at_func = symtab.find_symbol("c:@F@__ESBMC_list_at");
+  const symbolt *contains_func =
+    symtab.find_symbol("c:@F@__ESBMC_list_contains");
+  const symbolt *push_obj_func =
+    symtab.find_symbol("c:@F@__ESBMC_list_push_object");
+  assert(size_func && at_func && contains_func && push_obj_func);
+
+  locationt loc = converter.get_location_from_decl(element);
+
+  auto as_ptr = [](const exprt &e) {
+    return e.type().is_pointer() ? e : exprt(address_of_exprt(e));
+  };
+
+  symbolt &n_sym = converter.create_tmp_symbol(
+    element, "$set_meth_n$", size_type(), gen_zero(size_type()));
+  converter.add_instruction(code_declt(symbol_expr(n_sym)));
+  code_function_callt size_call;
+  size_call.function() = symbol_expr(*size_func);
+  size_call.arguments().push_back(as_ptr(source_expr));
+  size_call.lhs() = symbol_expr(n_sym);
+  size_call.type() = size_type();
+  size_call.location() = loc;
+  converter.add_instruction(size_call);
+
+  symbolt &i_sym = converter.create_tmp_symbol(
+    element, "$set_meth_i$", size_type(), gen_zero(size_type()));
+  converter.add_instruction(code_declt(symbol_expr(i_sym)));
+  converter.add_instruction(
+    code_assignt(symbol_expr(i_sym), gen_zero(size_type())));
+
+  exprt cond("<", bool_type());
+  cond.copy_to_operands(symbol_expr(i_sym), symbol_expr(n_sym));
+
+  code_blockt body;
+
+  side_effect_expr_function_callt at_call;
+  at_call.function() = symbol_expr(*at_func);
+  at_call.arguments().push_back(as_ptr(source_expr));
+  at_call.arguments().push_back(symbol_expr(i_sym));
+  at_call.type() =
+    pointer_typet(converter.get_type_handler().get_list_element_type());
+  at_call.location() = loc;
+
+  symbolt &elem_sym = converter.create_tmp_symbol(
+    element,
+    "$set_meth_elem$",
+    pointer_typet(converter.get_type_handler().get_list_element_type()),
+    exprt());
+  code_declt elem_decl(symbol_expr(elem_sym));
+  elem_decl.copy_to_operands(at_call);
+  body.copy_to_operands(elem_decl);
+
+  symbolt &contains_result = converter.create_tmp_symbol(
+    element, "$set_meth_in$", bool_type(), gen_boolean(false));
+  body.copy_to_operands(code_declt(symbol_expr(contains_result)));
+
+  auto deref = [](exprt e) {
+    exprt d("dereference");
+    d.type() = e.type().subtype();
+    d.move_to_operands(e);
+    return d;
+  };
+
+  code_function_callt contains_call;
+  contains_call.function() = symbol_expr(*contains_func);
+  contains_call.lhs() = symbol_expr(contains_result);
+  contains_call.arguments().push_back(as_ptr(ref_expr));
+  contains_call.arguments().push_back(member_exprt(
+    deref(symbol_expr(elem_sym)), "value", pointer_typet(empty_typet())));
+  contains_call.arguments().push_back(
+    member_exprt(deref(symbol_expr(elem_sym)), "type_id", size_type()));
+  contains_call.arguments().push_back(
+    member_exprt(deref(symbol_expr(elem_sym)), "size", size_type()));
+  contains_call.type() = bool_type();
+  contains_call.location() = loc;
+  body.copy_to_operands(contains_call);
+
+  side_effect_expr_function_callt push_call;
+  push_call.function() = symbol_expr(*push_obj_func);
+  push_call.arguments().push_back(symbol_expr(sink));
+  push_call.arguments().push_back(symbol_expr(elem_sym));
+  push_call.arguments().push_back(from_integer(BigInt(0), size_type()));
+  push_call.arguments().push_back(from_integer(BigInt(0), int_type()));
+  push_call.type() = bool_type();
+  push_call.location() = loc;
+
+  exprt guard = symbol_expr(contains_result);
+  if (!want_in_ref)
+  {
+    exprt neg("not", bool_type());
+    neg.copy_to_operands(guard);
+    guard = neg;
+  }
+
+  code_blockt then_block;
+  then_block.copy_to_operands(converter.convert_expression_to_code(push_call));
+
+  codet if_stmt;
+  if_stmt.set_statement("ifthenelse");
+  if_stmt.copy_to_operands(guard, then_block);
+  body.copy_to_operands(if_stmt);
+
+  plus_exprt i_inc(symbol_expr(i_sym), gen_one(size_type()));
+  body.copy_to_operands(code_assignt(symbol_expr(i_sym), i_inc));
+
+  codet loop;
+  loop.set_statement("while");
+  loop.copy_to_operands(cond, body);
+  converter.add_instruction(loop);
+}
+
+exprt python_set::build_set_method_call(
+  const symbolt &self,
+  const exprt &other,
+  const nlohmann::json &element,
+  const std::string &method_name)
+{
+  contextt &symtab = converter_.symbol_table();
+  locationt loc = converter_.get_location_from_decl(element);
+
+  auto as_ptr = [](const exprt &e) {
+    return e.type().is_pointer() ? e : exprt(address_of_exprt(e));
+  };
+
+  if (method_name == "issubset")
+  {
+    // Allocate a bool result initialised to true; iterate self, clear it
+    // when an element is missing from `other`.
+    symbolt &result = converter_.create_tmp_symbol(
+      element, "$issubset$", bool_type(), gen_boolean(true));
+    converter_.add_instruction(code_declt(symbol_expr(result)));
+    converter_.add_instruction(
+      code_assignt(symbol_expr(result), gen_boolean(true)));
+
+    const symbolt *size_func =
+      symtab.find_symbol("c:@F@__ESBMC_list_size");
+    const symbolt *at_func = symtab.find_symbol("c:@F@__ESBMC_list_at");
+    const symbolt *contains_func =
+      symtab.find_symbol("c:@F@__ESBMC_list_contains");
+    assert(size_func && at_func && contains_func);
+
+    symbolt &n_sym = converter_.create_tmp_symbol(
+      element, "$issubset_n$", size_type(), gen_zero(size_type()));
+    converter_.add_instruction(code_declt(symbol_expr(n_sym)));
+    code_function_callt size_call;
+    size_call.function() = symbol_expr(*size_func);
+    size_call.arguments().push_back(symbol_expr(self));
+    size_call.lhs() = symbol_expr(n_sym);
+    size_call.type() = size_type();
+    size_call.location() = loc;
+    converter_.add_instruction(size_call);
+
+    symbolt &i_sym = converter_.create_tmp_symbol(
+      element, "$issubset_i$", size_type(), gen_zero(size_type()));
+    converter_.add_instruction(code_declt(symbol_expr(i_sym)));
+    converter_.add_instruction(
+      code_assignt(symbol_expr(i_sym), gen_zero(size_type())));
+
+    exprt cond("<", bool_type());
+    cond.copy_to_operands(symbol_expr(i_sym), symbol_expr(n_sym));
+
+    code_blockt body;
+
+    side_effect_expr_function_callt at_call;
+    at_call.function() = symbol_expr(*at_func);
+    at_call.arguments().push_back(symbol_expr(self));
+    at_call.arguments().push_back(symbol_expr(i_sym));
+    at_call.type() =
+      pointer_typet(converter_.get_type_handler().get_list_element_type());
+    at_call.location() = loc;
+
+    symbolt &elem_sym = converter_.create_tmp_symbol(
+      element,
+      "$issubset_elem$",
+      pointer_typet(converter_.get_type_handler().get_list_element_type()),
+      exprt());
+    code_declt elem_decl(symbol_expr(elem_sym));
+    elem_decl.copy_to_operands(at_call);
+    body.copy_to_operands(elem_decl);
+
+    symbolt &in = converter_.create_tmp_symbol(
+      element, "$issubset_in$", bool_type(), gen_boolean(false));
+    body.copy_to_operands(code_declt(symbol_expr(in)));
+
+    auto deref = [](exprt e) {
+      exprt d("dereference");
+      d.type() = e.type().subtype();
+      d.move_to_operands(e);
+      return d;
+    };
+
+    code_function_callt contains_call;
+    contains_call.function() = symbol_expr(*contains_func);
+    contains_call.lhs() = symbol_expr(in);
+    contains_call.arguments().push_back(as_ptr(other));
+    contains_call.arguments().push_back(member_exprt(
+      deref(symbol_expr(elem_sym)), "value", pointer_typet(empty_typet())));
+    contains_call.arguments().push_back(
+      member_exprt(deref(symbol_expr(elem_sym)), "type_id", size_type()));
+    contains_call.arguments().push_back(
+      member_exprt(deref(symbol_expr(elem_sym)), "size", size_type()));
+    contains_call.type() = bool_type();
+    contains_call.location() = loc;
+    body.copy_to_operands(contains_call);
+
+    exprt not_in("not", bool_type());
+    not_in.copy_to_operands(symbol_expr(in));
+    code_blockt then_block;
+    then_block.copy_to_operands(
+      code_assignt(symbol_expr(result), gen_boolean(false)));
+    codet if_stmt;
+    if_stmt.set_statement("ifthenelse");
+    if_stmt.copy_to_operands(not_in, then_block);
+    body.copy_to_operands(if_stmt);
+
+    plus_exprt i_inc(symbol_expr(i_sym), gen_one(size_type()));
+    body.copy_to_operands(code_assignt(symbol_expr(i_sym), i_inc));
+
+    codet loop;
+    loop.set_statement("while");
+    loop.copy_to_operands(cond, body);
+    converter_.add_instruction(loop);
+
+    return symbol_expr(result);
+  }
+
+  if (method_name == "update")
+  {
+    // For each elem in `other`, push to `self` iff not already present.
+    emit_filtered_extend(
+      converter_, other, symbol_expr(self), self, false, element);
+    return nil_exprt();
+  }
+
+  if (method_name == "symmetric_difference")
+  {
+    // (self - other) ∪ (other - self) — collect into a fresh set.
+    symbolt &result = create_set_list();
+    emit_filtered_extend(
+      converter_, symbol_expr(self), other, result, false, element);
+    emit_filtered_extend(
+      converter_, other, symbol_expr(self), result, false, element);
+    return symbol_expr(result);
+  }
+
+  throw std::runtime_error("unsupported set method: " + method_name);
+}
+
 exprt python_set::handle_operations(
   python_converter &converter,
   const std::string &op,

--- a/src/python-frontend/python_set.h
+++ b/src/python-frontend/python_set.h
@@ -80,6 +80,23 @@ public:
     const nlohmann::json &element);
 
   /**
+   * @brief Emit the IR for a binary set method (issubset / update /
+   *        symmetric_difference) called on @p self with @p other.
+   *
+   * - issubset returns a bool expression.
+   * - update mutates @p self in place and returns nil.
+   * - symmetric_difference returns a fresh set expression.
+   *
+   * Reuses the same loop / contains / push primitives as
+   * build_set_union_call to keep encoding consistent.
+   */
+  exprt build_set_method_call(
+    const symbolt &self,
+    const exprt &other,
+    const nlohmann::json &element,
+    const std::string &method_name);
+
+  /**
    * @brief Handle set operations (difference, intersection, union)
    * Entry point for all set binary operations
    * @param converter Reference to python_converter
@@ -102,6 +119,20 @@ private:
    * @return Symbol representing the underlying list structure
    */
   symbolt &create_set_list();
+
+  /**
+   * @brief Walk @p source list, push every element into @p sink whose
+   *        membership in @p ref matches @p want_in_ref. Used by
+   *        update / symmetric_difference to express "elements not in X"
+   *        and "elements in X" filters with a single helper.
+   */
+  static void emit_filtered_extend(
+    python_converter &converter,
+    const exprt &source_expr,
+    const exprt &ref_expr,
+    const symbolt &sink,
+    bool want_in_ref,
+    const nlohmann::json &element);
 
   python_converter &converter_;
   const nlohmann::json &set_value_;


### PR DESCRIPTION
Extends the set support added in #4365 with the four remaining methods called out in the audit.

- `s.issubset(other)` — bool result, lowered to a loop with `__ESBMC_list_contains` checks.
- `s.update(other)` — mutates `s` in place via `__ESBMC_list_push_object` for elements not already present.
- `s.symmetric_difference(other)` — fresh set; iterates both sides and keeps only elements absent from the other.
- `frozenset(...)` — same lowering as `set(...)` (verifier doesn't model immutability).

A static helper `python_set::emit_filtered_extend` factors the common "walk source, contains-check against ref, conditionally push" pattern shared by `update` and `symmetric_difference`.

Fixes #4366. Refs #4296.
