### PR TITLE
[python] honour key= on list.sort() and sorted() on tracked literals

### DIFF
--- a/regression/python/github_4364/main.py
+++ b/regression/python/github_4364/main.py
@@ -1,0 +1,17 @@
+def main() -> None:
+    pairs = [(1, "b"), (3, "a"), (2, "c")]
+
+    # sorted(key=) on a list-of-tuples literal.
+    out = sorted(pairs, key=lambda p: p[1])
+    assert out[0][1] == "a"
+
+    # list.sort(key=) — mutate in place; rewrites to `pairs = sorted(...)`.
+    pairs.sort(key=lambda p: p[1])
+    assert pairs[0][1] == "a"
+    assert pairs[2][1] == "c"
+
+    # Numeric sort key.
+    nums = [(5, "x"), (1, "y"), (3, "z")]
+    nums.sort(key=lambda p: p[0])
+    assert nums[0][0] == 1
+main()

--- a/regression/python/github_4364/test.desc
+++ b/regression/python/github_4364/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4364_fail/main.py
+++ b/regression/python/github_4364_fail/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    # Negative: sort by p[1] selects "a" first, not "b".
+    pairs = [(1, "b"), (3, "a"), (2, "c")]
+    pairs.sort(key=lambda p: p[1])
+    assert pairs[0][1] == "b"
+main()

--- a/regression/python/github_4364_fail/test.desc
+++ b/regression/python/github_4364_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -1982,6 +1982,16 @@ class Preprocessor(ast.NodeTransformer):
         return node
 
     def visit_Expr(self, node):
+        # Lower `xs.sort(key=...)` to `xs = sorted(xs, key=...)` BEFORE
+        # generic_visit, since visit_Call invalidates the
+        # `list_literal_values[xs]` entry on `xs.sort()` (sort is a
+        # mutating list method). The existing sorted-with-key folding
+        # depends on that entry, so the rewrite has to fire while it's
+        # still tracked.
+        rewritten = self._maybe_rewrite_list_sort_with_key(node)
+        if rewritten is not None:
+            return rewritten
+
         node = self.generic_visit(node)
 
         # Handle standalone next(g)
@@ -2002,6 +2012,37 @@ class Preprocessor(ast.NodeTransformer):
         if prefix:
             return prefix + [node]
         return node
+
+    def _maybe_rewrite_list_sort_with_key(self, expr_node):
+        """If expr_node is `name.sort(key=lambda ...)` (with optional reverse=),
+        rewrite to `name = sorted(name, key=..., reverse=...)`. Returns the
+        replacement Assign, or None when the pattern does not apply."""
+        call = expr_node.value
+        if not (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "sort"
+            and isinstance(call.func.value, ast.Name)
+            and not call.args
+        ):
+            return None
+        has_key = any(kw.arg == "key" for kw in call.keywords)
+        if not has_key:
+            return None  # plain reverse= keeps today's path
+        target_name = call.func.value.id
+        sorted_call = ast.Call(
+            func=ast.Name(id="sorted", ctx=ast.Load()),
+            args=[ast.Name(id=target_name, ctx=ast.Load())],
+            keywords=[copy.deepcopy(kw) for kw in call.keywords],
+        )
+        assign = ast.Assign(
+            targets=[ast.Name(id=target_name, ctx=ast.Store())],
+            value=sorted_call,
+        )
+        ast.copy_location(sorted_call, expr_node)
+        ast.copy_location(assign, expr_node)
+        ast.fix_missing_locations(assign)
+        return self.visit(assign)
 
     def visit_If(self, node):
         node = self.generic_visit(node)


### PR DESCRIPTION
`list.sort(key=lambda p: p[K])` and `sorted(xs, key=...)` for the literal-list-of-tuples + constant-subscript pattern (already handled for `sorted` via `_lower_sorted_with_key_call`) now work for the in-place `list.sort` path too.

The preprocessor's `visit_Expr` rewrites `name.sort(key=lambda)` to `name = sorted(name, key=lambda)` BEFORE `generic_visit` runs, so the mutating-method pass (which pops the name out of `list_literal_values` when it sees `.sort()`) doesn't fire first. The rewrite then drops into the existing sorted-key folding pipeline.

Non-lambda callables, non-tuple-subscript bodies, and runtime-typed iterables continue to fall through to `handle_list_sort` and get the same 'key= not supported' error as before; those remain follow-ups under #4296.

Fixes #4364. Refs #4296.