### PR TITLE
[clang-c-frontend] lower BinaryOperator::BO_Cmp (C++20 spaceship)

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship/main.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+
+// Minimal in-source <compare> equivalent — exercises BinaryOperator's
+// BO_Cmp lowering without depending on a separate <compare> OM.
+namespace std
+{
+struct strong_ordering
+{
+  signed char __value_;
+  static const strong_ordering less;
+  static const strong_ordering equal;
+  static const strong_ordering greater;
+};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::greater{1};
+} // namespace std
+
+int main()
+{
+  std::strong_ordering lt = 1 <=> 2;
+  assert(lt.__value_ < 0);
+
+  std::strong_ordering eq = 5 <=> 5;
+  assert(eq.__value_ == 0);
+
+  std::strong_ordering gt = 9 <=> 3;
+  assert(gt.__value_ > 0);
+
+  // Pointer spaceship is also strong_ordering for ordered pointers.
+  int arr[3] = {0, 1, 2};
+  int *p = &arr[0];
+  int *q = &arr[2];
+  std::strong_ordering po = p <=> q;
+  assert(po.__value_ < 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/main.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+
+namespace std
+{
+struct strong_ordering
+{
+  signed char __value_;
+  static const strong_ordering less;
+  static const strong_ordering equal;
+  static const strong_ordering greater;
+};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::greater{1};
+} // namespace std
+
+int main()
+{
+  std::strong_ordering gt = 9 <=> 3;
+  // gt is greater (.__value_ == 1); the assertion below must fail.
+  assert(gt.__value_ < 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3854,6 +3854,54 @@ bool clang_c_convertert::get_binary_operator_expr(
     new_expr = exprt("ptr_mem", t);
     break;
 
+  // C++20 three-way comparison `a <=> b`. Lower to a conditional that
+  // produces a comparison-category struct value:
+  //   lhs <  rhs  ->  T{-1}    (less)
+  //   lhs == rhs  ->  T{ 0}    (equivalent / equal)
+  //   else        ->  T{ 1}    (greater)
+  // Per [expr.spaceship] in N4861. The std::strong_ordering /
+  // weak_ordering / partial_ordering types in <compare> all share a
+  // single signed-char first field; t has already been resolved to that
+  // struct type by get_type(). For floating-point operands the standard
+  // also requires a partial_ordering::unordered case for NaN, which
+  // this lowering does not yet model — direct float spaceship will
+  // miss that branch but otherwise behave correctly for ordered values.
+  case clang::BO_Cmp:
+  {
+    typet ct = get_complete_type(t, ns);
+    if (!ct.is_struct())
+    {
+      log_error("BO_Cmp: result type is not a struct");
+      return true;
+    }
+    auto make_value = [&](int v) -> exprt
+    {
+      exprt s = gen_zero(ct);
+      if (!s.operands().empty())
+      {
+        typet field_t = to_struct_type(ct).components().front().type();
+        s.operands().at(0) = constant_exprt(
+          integer2binary(v, config.ansi_c.char_width),
+          integer2string(v),
+          field_t);
+      }
+      return s;
+    };
+
+    exprt eq_cond("=", bool_type());
+    eq_cond.copy_to_operands(lhs, rhs);
+    exprt eq_branch("if", ct);
+    eq_branch.copy_to_operands(eq_cond, make_value(0), make_value(1));
+
+    exprt lt_cond("<", bool_type());
+    lt_cond.copy_to_operands(lhs, rhs);
+    exprt outer("if", ct);
+    outer.copy_to_operands(lt_cond, make_value(-1), eq_branch);
+
+    new_expr = outer;
+    return false;
+  }
+
   default:
   {
     const clang::CompoundAssignOperator &compop =


### PR DESCRIPTION
Lower the C++20 three-way comparison `a <=> b` for integer / pointer operands. Until now, any direct use of `<=>` failed conversion with `Conversion of unsupported clang binary operator: "<=>" to expression`.

```cpp
namespace std {
struct strong_ordering {
  signed char __value_;
  static const strong_ordering less, equal, greater;
};
inline constexpr strong_ordering strong_ordering::less{-1};
inline constexpr strong_ordering strong_ordering::equal{0};
inline constexpr strong_ordering strong_ordering::greater{1};
}

std::strong_ordering o = 5 <=> 3;   // .__value_ == 1 (greater)
std::strong_ordering p = 1 <=> 1;   // .__value_ == 0 (equal)
std::strong_ordering q = 1 <=> 5;   // .__value_ == -1 (less)
```

Lowering follows [expr.spaceship] in N4861: emit a nested conditional that produces the comparison-category struct value with the right signed-char tag (`-1`/`0`/`1`). `std::strong_ordering` / `weak_ordering` / `partial_ordering` all share a single signed-char first field, so the same construction works for all three; `t` is already resolved to the struct by `get_type()` by the time `BO_Cmp` is hit.

**Out of scope:**

- Floating-point spaceship. IEEE-754 NaN requires `partial_ordering::unordered`, which this lowering does not model yet. Direct float spaceship will miss the unordered case but otherwise behave correctly for ordered values.
- Defaulted `auto operator<=>(const T&) const = default;` on a user struct. Clang synthesises a body that compares members via literal-zero overloads (`CXXRewrittenBinaryOperator` + a `_CmpUnspecifiedParam` helper), which today trips a deeper symex assertion separate from this lowering. Pairs with #4386 (`<compare>` OM) — together they unblock the language feature; the symex follow-up is a separate piece of work.

Adds passing + failing regression tests under `regression/esbmc-cpp20/cpp/github_4377_spaceship{,_fail}/` covering less / equal / greater on integers and pointer ordering. `esbmc-cpp17` (27) and `esbmc-cpp20` (35+2) suites pass; `esbmc-cpp/cpp` baseline failures unchanged.

Picks off the `BO_Cmp` converter prerequisite from the C++17/20/23 audit umbrella in #4377.
