### PR TITLE
fix: the doftcoin in contract.solast

### DIFF
--- a/regression/esbmc-solidity/doftcoin_1/contract.sol
+++ b/regression/esbmc-solidity/doftcoin_1/contract.sol
@@ -55,7 +55,7 @@ contract BasicToken is ERC20 {
     }
 }
 
-contract Doftcoin is BasicToken {
+contract Doftcoin is BasicToken, owned {
     string public name;
     string public symbol;
     uint256 public decimals;
@@ -97,6 +97,7 @@ contract Doftcoin is BasicToken {
     }
 
     function mintToken(address _target, uint256 _mintedAmount) public {
+        require(msg.sender == owner);
         balanceOf[msg.sender] = _totalSupply;
         uint balanceOf_target = balanceOf[_target];
         balanceOf_target += _mintedAmount;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `regression/esbmc-solidity/doftcoin_1/contract.solast`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `regression/esbmc-solidity/doftcoin_1/contract.solast:1` |

**Description**: The Doftcoin.mintToken(address _target, uint256 _mintedAmount) function is declared public with an empty modifiers array (confirmed via AST). No require(msg.sender == owner) or onlyOwner modifier exists. Any external account can call mintToken() to mint unlimited tokens to any address, completely inflating the token supply. The Reproduction contract in doftcoin_2 explicitly demonstrates this exploit by calling mintToken with type(uint256).max.

## Changes
- `regression/esbmc-solidity/doftcoin_1/contract.sol`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
