### PR TITLE
[irep2] add cmp_three_way for the C++20 spaceship operator

### DIFF
--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship/main.cpp
@@ -1,0 +1,41 @@
+#include <cassert>
+
+// In-source comparison-category type — exercises the IREP2
+// cmp_three_way2t lowering without depending on the external <compare>
+// OM.  All three category types share a signed-char first field, which
+// is what the SMT layer writes when it expands cmp_three_way to the
+// less / equivalent / greater ITE chain.
+namespace std
+{
+struct strong_ordering
+{
+  signed char __value_;
+  static const strong_ordering less;
+  static const strong_ordering equal;
+  static const strong_ordering greater;
+};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::greater{1};
+} // namespace std
+
+int main()
+{
+  std::strong_ordering lt = 1 <=> 2;
+  assert(lt.__value_ < 0);
+
+  std::strong_ordering eq = 5 <=> 5;
+  assert(eq.__value_ == 0);
+
+  std::strong_ordering gt = 9 <=> 3;
+  assert(gt.__value_ > 0);
+
+  // Pointer spaceship is also strong_ordering for ordered pointers.
+  int arr[3] = {0, 1, 2};
+  int *p = &arr[0];
+  int *q = &arr[2];
+  std::strong_ordering po = p <=> q;
+  assert(po.__value_ < 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/main.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+
+namespace std
+{
+struct strong_ordering
+{
+  signed char __value_;
+  static const strong_ordering less;
+  static const strong_ordering equal;
+  static const strong_ordering greater;
+};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::greater{1};
+} // namespace std
+
+int main()
+{
+  std::strong_ordering gt = 9 <=> 3;
+  // gt is greater (.__value_ == 1); the assertion below must fail.
+  assert(gt.__value_ < 0);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship_sideeffect/main.cpp
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship_sideeffect/main.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+namespace std
+{
+struct strong_ordering
+{
+  signed char __value_;
+  static const strong_ordering less;
+  static const strong_ordering equal;
+  static const strong_ordering greater;
+};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::greater{1};
+} // namespace std
+
+int counter = 0;
+int next()
+{
+  return ++counter;
+}
+
+int main()
+{
+  // Each operand of <=> must be evaluated exactly once.  A converter-
+  // side if/else lowering would call next() in both the < arm and the
+  // == arm, producing counter == 4.  The IREP2 cmp_three_way node
+  // captures each side in a single SSA name, so counter == 2.
+  std::strong_ordering o = next() <=> next();
+  assert(o.__value_ < 0);
+  assert(counter == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp20/cpp/github_4377_spaceship_sideeffect/test.desc
+++ b/regression/esbmc-cpp20/cpp/github_4377_spaceship_sideeffect/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++20 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3854,6 +3854,14 @@ bool clang_c_convertert::get_binary_operator_expr(
     new_expr = exprt("ptr_mem", t);
     break;
 
+  // C++20 three-way comparison `a <=> b`. Build a dedicated irep node
+  // with id "<=>"; migrate.cpp lowers it to cmp_three_way2t, and the
+  // SMT backend expands it to the ITE chain (less/equivalent/greater)
+  // with the operands captured once.  Per [expr.spaceship] in N4861.
+  case clang::BO_Cmp:
+    new_expr = exprt(exprt::i_cmp_three_way, t);
+    break;
+
   default:
   {
     const clang::CompoundAssignOperator &compop =

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -45,6 +45,7 @@
   BOOST_PP_LIST_CONS(greaterthan,                                              \
   BOOST_PP_LIST_CONS(lessthanequal,                                            \
   BOOST_PP_LIST_CONS(greaterthanequal,                                         \
+  BOOST_PP_LIST_CONS(cmp_three_way,                                            \
   BOOST_PP_LIST_CONS(not,                                                      \
   BOOST_PP_LIST_CONS(and,                                                      \
   BOOST_PP_LIST_CONS(or,                                                       \
@@ -135,7 +136,7 @@
   BOOST_PP_LIST_CONS(isinstance,                                               \
   BOOST_PP_LIST_CONS(hasattr,                                                  \
   BOOST_PP_LIST_CONS(isnone,                                                   \
-  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -31,6 +31,7 @@ static const char *expr_names[] = {
   "greaterthan",
   "lessthanequal",
   "greaterthanequal",
+  "cmp_three_way",
   "not",
   "and",
   "or",

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1494,6 +1494,7 @@ irep_typedefs(lessthan, relation_data);
 irep_typedefs(greaterthan, relation_data);
 irep_typedefs(lessthanequal, relation_data);
 irep_typedefs(greaterthanequal, relation_data);
+irep_typedefs(cmp_three_way, relation_data);
 irep_typedefs(not, bool_1op);
 irep_typedefs(and, logic_2ops);
 irep_typedefs(or, logic_2ops);
@@ -2145,6 +2146,33 @@ public:
   {
   }
   greaterthanequal2t(const greaterthanequal2t &ref) = default;
+
+  expr2tc do_simplify() const override;
+
+  static std::string field_names[esbmct::num_type_fields];
+};
+
+/** C++20 three-way comparison `a <=> b`. Result type is the
+ * comparison-category struct (`std::strong_ordering` /
+ * `std::weak_ordering` / `std::partial_ordering`); the discriminating
+ * signed-char member sits at the start of the struct. The expansion to
+ *
+ *   side_1 <  side_2  ->  T{-1}    (less)
+ *   side_1 == side_2  ->  T{ 0}    (equivalent / equal)
+ *   else              ->  T{ 1}    (greater)
+ *
+ * is performed at the SMT layer rather than the AST level so the
+ * semantic node survives through symex / value_set / interval analysis,
+ * and operands are captured once.  Per [expr.spaceship] in N4861.
+ * @extends relation_data */
+class cmp_three_way2t : public cmp_three_way_expr_methods
+{
+public:
+  cmp_three_way2t(const type2tc &t, const expr2tc &v1, const expr2tc &v2)
+    : cmp_three_way_expr_methods(t, cmp_three_way_id, v1, v2)
+  {
+  }
+  cmp_three_way2t(const cmp_three_way2t &ref) = default;
 
   expr2tc do_simplify() const override;
 

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -80,6 +80,8 @@ std::string lessthanequal2t::field_names[esbmct::num_type_fields] =
   {"side_1", "side_2", "", "", ""};
 std::string greaterthanequal2t::field_names[esbmct::num_type_fields] =
   {"side_1", "side_2", "", "", ""};
+std::string cmp_three_way2t::field_names[esbmct::num_type_fields] =
+  {"side_1", "side_2", "", "", ""};
 std::string not2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
 std::string and2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates_expr_data.cpp
+++ b/src/irep2/templates/irep2_templates_expr_data.cpp
@@ -21,6 +21,7 @@ expr_typedefs2(lessthan, relation_data);
 expr_typedefs2(greaterthan, relation_data);
 expr_typedefs2(lessthanequal, relation_data);
 expr_typedefs2(greaterthanequal, relation_data);
+expr_typedefs2(cmp_three_way, relation_data);
 expr_typedefs2(same_object, same_object_data);
 expr_typedefs3(byte_extract, byte_extract_data);
 expr_typedefs4(byte_update, byte_update_data);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2434,6 +2434,39 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
     }
     break;
   }
+  case expr2t::cmp_three_way_id:
+  {
+    // C++20 spaceship `a <=> b`. Lower to the equivalent ITE chain
+    // producing a comparison-category struct value:
+    //   side_1 <  side_2  ->  T{-1}    (less)
+    //   side_1 == side_2  ->  T{ 0}    (equivalent / equal)
+    //   else              ->  T{ 1}    (greater)
+    // Operands are captured once via the recursive convert_ast on the
+    // children — preserving the IR-level cmp_three_way2t up to here.
+    const cmp_three_way2t &cw = to_cmp_three_way2t(expr);
+
+    auto make_value = [&](int v) -> expr2tc {
+      const struct_type2t &st = to_struct_type(cw.type);
+      std::vector<expr2tc> ops;
+      ops.reserve(st.members.size());
+      for (size_t i = 0; i < st.members.size(); ++i)
+      {
+        if (i == 0)
+          ops.push_back(constant_int2tc(st.members[0], BigInt(v)));
+        else
+          ops.push_back(gen_zero(st.members[i]));
+      }
+      return constant_struct2tc(cw.type, std::move(ops));
+    };
+
+    expr2tc lt = lessthan2tc(cw.side_1, cw.side_2);
+    expr2tc eq = equality2tc(cw.side_1, cw.side_2);
+    expr2tc inner =
+      if2tc(cw.type, eq, make_value(0), make_value(1));
+    expr2tc outer = if2tc(cw.type, lt, make_value(-1), inner);
+    a = convert_ast(outer);
+    break;
+  }
   case expr2t::lessthan_id:
   {
     const lessthan2t &lt = to_lessthan2t(expr);

--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -2461,8 +2461,7 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
 
     expr2tc lt = lessthan2tc(cw.side_1, cw.side_2);
     expr2tc eq = equality2tc(cw.side_1, cw.side_2);
-    expr2tc inner =
-      if2tc(cw.type, eq, make_value(0), make_value(1));
+    expr2tc inner = if2tc(cw.type, eq, make_value(0), make_value(1));
     expr2tc outer = if2tc(cw.type, lt, make_value(-1), inner);
     a = convert_ast(outer);
     break;

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -381,6 +381,7 @@ irep_idt exprt::i_lt = dstring("<");
 irep_idt exprt::i_gt = dstring(">");
 irep_idt exprt::i_le = dstring("<=");
 irep_idt exprt::i_ge = dstring(">=");
+irep_idt exprt::i_cmp_three_way = dstring("<=>");
 irep_idt exprt::i_bitand = dstring("bitand");
 irep_idt exprt::i_bitor = dstring("bitor");
 irep_idt exprt::i_bitxor = dstring("bitxor");

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -250,6 +250,7 @@ public:
   static irep_idt i_gt;
   static irep_idt i_le;
   static irep_idt i_ge;
+  static irep_idt i_cmp_three_way;
   static irep_idt i_bitand;
   static irep_idt i_bitor;
   static irep_idt i_bitxor;

--- a/src/util/expr_simplifier.cpp
+++ b/src/util/expr_simplifier.cpp
@@ -3308,6 +3308,47 @@ expr2tc greaterthanequal2t::do_simplify() const
     type, side_1, side_2);
 }
 
+// Build a comparison-category struct value with the discriminant set to v.
+// All three categories (strong/weak/partial) layout the discriminant as the
+// first field, so writing operand[0] is enough.
+static expr2tc make_cmp_value(const type2tc &t, int v)
+{
+  if (!is_struct_type(t))
+    return expr2tc();
+  const struct_type2t &st = to_struct_type(t);
+  if (st.members.empty())
+    return expr2tc();
+  std::vector<expr2tc> ops;
+  ops.reserve(st.members.size());
+  for (size_t i = 0; i < st.members.size(); ++i)
+  {
+    if (i == 0)
+      ops.push_back(constant_int2tc(st.members[0], BigInt(v)));
+    else
+      ops.push_back(gen_zero(st.members[i]));
+  }
+  return constant_struct2tc(t, std::move(ops));
+}
+
+expr2tc cmp_three_way2t::do_simplify() const
+{
+  // Self-comparison on a non-float type is always equivalent. (Floats need
+  // partial_ordering::unordered for NaN; leave that case alone.)
+  if (side_1 == side_2 && !is_floatbv_type(side_1) && !is_floatbv_type(side_2))
+    return make_cmp_value(type, 0);
+
+  // Both sides constant integers: fold to the appropriate value.
+  if (is_constant_int2t(side_1) && is_constant_int2t(side_2))
+  {
+    const BigInt &a = to_constant_int2t(side_1).value;
+    const BigInt &b = to_constant_int2t(side_2).value;
+    int v = (a < b) ? -1 : (a == b ? 0 : 1);
+    return make_cmp_value(type, v);
+  }
+
+  return expr2tc();
+}
+
 // Check if two conditions are equivalent (accounting for casts)
 static bool conditions_equivalent(const expr2tc &a, const expr2tc &b)
 {

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -932,6 +932,15 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr_ref)
     return;
   }
 
+  if (expr.id() == exprt::i_cmp_three_way)
+  {
+    expr2tc side1, side2;
+    convert_operand_pair(expr, side1, side2);
+    type2tc t = migrate_type(expr.type());
+    new_expr_ref = cmp_three_way2tc(t, side1, side2);
+    return;
+  }
+
   if (expr.id() == exprt::i_ge)
   {
     expr2tc side1, side2;
@@ -2694,6 +2703,14 @@ exprt migrate_expr_back(const expr2tc &ref)
     greaterthanequal.copy_to_operands(
       migrate_expr_back(ref2.side_1), migrate_expr_back(ref2.side_2));
     return greaterthanequal;
+  }
+  case expr2t::cmp_three_way_id:
+  {
+    const cmp_three_way2t &ref2 = to_cmp_three_way2t(ref);
+    exprt cmp(exprt::i_cmp_three_way, migrate_type_back(ref2.type));
+    cmp.copy_to_operands(
+      migrate_expr_back(ref2.side_1), migrate_expr_back(ref2.side_2));
+    return cmp;
   }
   case expr2t::not_id:
   {


### PR DESCRIPTION
Replaces the converter-side if/else shim from #4405 with a proper IREP2 node for `a <=> b`. The node preserves the semantic anchor through symex / value_set / interval analysis, captures each operand in a single SSA name, and centralises the expansion in the SMT layer.

```cpp
namespace std {
struct strong_ordering {
  signed char __value_;
  static const strong_ordering less, equal, greater;
};
inline constexpr strong_ordering strong_ordering::less{-1};
inline constexpr strong_ordering strong_ordering::equal{0};
inline constexpr strong_ordering strong_ordering::greater{1};
}

std::strong_ordering o = 5 <=> 3;   // .__value_ == 1
std::strong_ordering p = 1 <=> 1;   // .__value_ == 0
std::strong_ordering q = 1 <=> 5;   // .__value_ == -1

int counter = 0;
int next() { return ++counter; }
auto r = next() <=> next();          // counter == 2 (single evaluation)
```

**Why an IR node, not a converter shim:** the if/else lowering would re-instantiate each operand in both the `<` and `==` arms, so `next() <=> next()` would bump `counter` to 4. The IR node holds the operands once and lets the SMT layer do the ITE expansion against the already-converted children — `counter == 2` end-to-end. The added `github_4377_spaceship_sideeffect` regression test pins this down.

**Pieces:**

- `src/irep2/irep2.h` — `cmp_three_way` joins the expr list.
- `src/irep2/irep2_expr.{h,cpp}`, `templates/irep2_templates*.cpp` — `cmp_three_way2t` defined as two-operand over an arbitrary result type (the comparison-category struct), same shape as `relation_data`.
- `src/util/migrate.cpp`, `src/util/expr.{h,cpp}` — irep1 expr id `"<=>"` (`exprt::i_cmp_three_way`) migrates to `cmp_three_way2tc` forward, and back to an `exprt` of the same id for goto2c / printers.
- `src/solvers/smt/smt_conv.cpp` — at SMT time, expand to `(side_1 < side_2) ? T{-1} : ((side_1 == side_2) ? T{0} : T{1})` by building the equivalent IR (`lessthan2tc` + `equality2tc` + `if2tc` + `constant_struct2tc`) and recursing `convert_ast`. All three category types share a signed-char first field; remaining members are zero-initialised.
- `src/util/expr_simplifier.cpp` — `do_simplify`: `x <=> x` (non-float) folds to `T{0}`; two integer-constant sides fold to `T{-1/0/1}`.
- `src/clang-c-frontend/clang_c_convert.cpp` — `BO_Cmp` becomes a single-line build of `exprt(i_cmp_three_way, t)`. Migration handles the rest.

Per [expr.spaceship] in N4861.

**Out of scope:**

- Floating-point `<=>`. Produces `partial_ordering` correctly for ordered values but the NaN → `partial_ordering::unordered` branch isn't modelled. Documented inline in the IR class.
- Defaulted `auto operator<=>(const T&) const = default;` on a user struct. Clang synthesises a body that compares members through literal-zero overloads (`CXXRewrittenBinaryOperator` + a `_CmpUnspecifiedParam` helper) — that path trips a separate symex assertion orthogonal to this PR. Tracked in #4377.

Adds 3 regression tests under `regression/esbmc-cpp20/cpp/github_4377_spaceship{,_fail,_sideeffect}/` covering less/equal/greater on integers + pointer ordering, a wrong-value negative, and the single-evaluation property. `esbmc-cpp17` (30) and `esbmc-cpp20` (35+3) suites all pass; `esbmc-cpp/cpp` baseline failures unchanged.

Supersedes #4405. Picks off the spaceship lowering item from the C++17/20/23 audit umbrella in #4377.
