### PR TITLE
[esbmc-cpp] fix <algorithm> heap/sort/partition operations and 6 KNOWNBUG tests

### DIFF
--- a/regression/esbmc-cpp/algorithm/algorithm32/main.cpp
+++ b/regression/esbmc-cpp/algorithm/algorithm32/main.cpp
@@ -1,4 +1,12 @@
 // unique_copy example
+//
+// Note: vector::assign() invalidates all iterators per the C++ standard
+// ([sequence.reqmts] / [vector.modifiers]).  The original cplusplus.com
+// example here reused a pre-assign iterator across an assign() call, which
+// is undefined behaviour.  The test was marked KNOWNBUG because ESBMC
+// (correctly) flagged the resulting dangling deref as an array-bounds
+// violation.  Updated to recompute the iterator after assign so the test
+// exercises unique_copy(..., pred) on a well-defined input range.
 #include <iostream>
 #include <algorithm>
 #include <vector>
@@ -12,31 +20,30 @@ bool myfunction (int i, int j) {
 int main () {
   int myints[] = {10,20,20,20,30,30,20,20,10};
   int myints1[] = {10,10,20,20,30,0,0,0,0};
-  vector<int> myvector (9);                            // 0  0  0  0  0  0  0  0  0
+  vector<int> myvector (9);
   vector<int>::iterator it;
 
-  // using default comparison:
-  it=unique_copy (myints,myints+9,myvector.begin());   // 10 20 30 20 10 0  0  0  0
-                                                       //                ^
+  // using default comparison: 5 unique consecutive values written.
+  it = unique_copy (myints, myints+9, myvector.begin());   // 10 20 30 20 10
+  assert(it - myvector.begin() == 5);
 
-  myvector.assign(myints1, myints1+9);                          // 10 10 20 20 30 0  0  0  0
-                                                       //                ^
+  // assign() invalidates iterators; recompute the input range below.
+  myvector.assign(myints1, myints1+9);                     // 10 10 20 20 30 0 0 0 0
 
-  // using predicate comparison:
-  it=unique_copy (myvector.begin(), it, myvector.begin(), myfunction);
-                                                       // 10 20 30 20 30 0  0  0  0
-                                                       //          ^
+  // using predicate comparison on the first 5 elements: {10,10,20,20,30}
+  // yields {10,20,30}; positions 3 and 4 are left untouched.
+  it = unique_copy (myvector.begin(), myvector.begin()+5,
+                    myvector.begin(), myfunction);         // 10 20 30 20 30
+  assert(it - myvector.begin() == 3);
+
   assert(myvector[0] == 10);
   assert(myvector[1] == 20);
   assert(myvector[2] == 30);
   assert(myvector[3] == 20);
   assert(myvector[4] == 30);
 
- // myvector.resize( it - myvector.begin() );            // 10 20 30
-
-//   print out content:
   cout << "myvector contains:";
-  for (it=myvector.begin(); it!=myvector.end(); it++)
+  for (it=myvector.begin(); it!=myvector.end(); ++it)
     cout << " " << *it;
 
   cout << endl;

--- a/regression/esbmc-cpp/algorithm/algorithm32/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm32/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm43_partial_sort_copy1/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm43_partial_sort_copy1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm44/main.cpp
+++ b/regression/esbmc-cpp/algorithm/algorithm44/main.cpp
@@ -1,4 +1,12 @@
 // nth_element example
+//
+// std::nth_element only guarantees that the element at the nth position is
+// the one that would be there in a fully sorted sequence, with elements
+// before it <= it and elements after it >= it.  It does NOT guarantee any
+// specific permutation of the surrounding elements.  The original assertions
+// here checked an implementation-specific permutation, which is why this
+// test was marked KNOWNBUG.  Updated to assert only what the C++ standard
+// guarantees ([alg.nth.element]).
 #include <iostream>
 #include <algorithm>
 #include <vector>
@@ -10,26 +18,25 @@ bool myfunction (int i,int j) { return (i<j); }
 int main () {
   vector<int> myvector;
   vector<int>::iterator it;
-//5 2 3 4 1 6 7 8 9
 
   // set some values:
   for (int i=1; i<10; i++) myvector.push_back(i);   // 1 2 3 4 5 6 7 8 9
 
   // using default comparison (operator <):
   nth_element (myvector.begin(), myvector.begin()+5, myvector.end());
-  
-  assert(myvector[0] == 5);
-  assert(myvector[1] == 2);
-  assert(myvector[2] == 3);
-  assert(myvector[3] == 4);
-  assert(myvector[4] == 1);
+
+  // The element at position 5 must be the 6th-smallest, i.e. 6.
   assert(myvector[5] == 6);
-  assert(myvector[6] == 7);
-  assert(myvector[7] == 8);
-  assert(myvector[8] == 9);
+  // Elements before the partition point are <= the pivot.
+  for (int i = 0; i < 5; ++i)
+    assert(myvector[i] <= myvector[5]);
+  // Elements after the partition point are >= the pivot.
+  for (int i = 6; i < 9; ++i)
+    assert(myvector[i] >= myvector[5]);
 
   // using function as comp
-  nth_element (myvector.begin(), myvector.begin()+5, myvector.end(),myfunction);
+  nth_element (myvector.begin(), myvector.begin()+5, myvector.end(), myfunction);
+  assert(myvector[5] == 6);
 
   // print out content:
   cout << "myvector contains:";

--- a/regression/esbmc-cpp/algorithm/algorithm44/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm44/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm57/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm57/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 6 --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm58/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm58/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 6 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/algorithm/algorithm98/test.desc
+++ b/regression/esbmc-cpp/algorithm/algorithm98/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/src/cpp/library/algorithm
+++ b/src/cpp/library/algorithm
@@ -922,17 +922,33 @@ BidIt partition(BidIt first, BidIt last, Pr pred)
 template <class BidIt, class Pr>
 BidIt stable_partition(BidIt first, BidIt last, Pr pred)
 {
-  while (first <= last)
+  // Skip leading elements that already satisfy pred.
+  while (first != last && pred(*first))
+    ++first;
+  if (first == last)
+    return first;
+
+  // For each subsequent element that satisfies pred, rotate it into place
+  // at *first by shifting [first, next) one position to the right.
+  // O(n^2) worst case but stable, which std::stable_partition requires.
+  BidIt next = first;
+  ++next;
+  for (; next != last; ++next)
   {
-    while (first != last && pred(*first))
+    if (pred(*next))
+    {
+      auto tmp = *next;
+      BidIt i = next;
+      while (i != first)
+      {
+        BidIt prev = i;
+        --prev;
+        *i = *prev;
+        i = prev;
+      }
+      *first = tmp;
       ++first;
-    if (first == last--)
-      break;
-    while (first != last && !pred(*last))
-      --last;
-    if (first == last)
-      break;
-    swap(*first++, *last);
+    }
   }
   return first;
 }
@@ -1084,7 +1100,7 @@ void stable_sort(BidIt begin, BidIt end, Pr pred)
   for (i = begin; i != end; i++)
   {
     j = i;
-    while (pred(*j, *(j - 1)) && (j != begin))
+    while ((j != begin) && pred(*j, *(j - 1)))
     {
       swap(*j, *(j - 1));
       j--;
@@ -1185,7 +1201,7 @@ RanIt partial_sort_copy(InIt first1, InIt last1, RanIt first2, RanIt last2)
   for (i = first2; i != last2; i++)
   {
     j = i;
-    while ((*j < *(j - 1)) && (j != first2))
+    while ((j != first2) && (*j < *(j - 1)))
     {
       std::swap(*j, *(j - 1));
       j--;
@@ -1199,7 +1215,7 @@ RanIt partial_sort_copy(InIt first1, InIt last1, RanIt first2, RanIt last2)
       for (i = first2; i != last2; i++)
       {
         j = i;
-        while ((*j < *(j - 1)) && (j != first2))
+        while ((j != first2) && (*j < *(j - 1)))
         {
           std::swap(*j, *(j - 1));
           j--;
@@ -1221,7 +1237,7 @@ RanIt partial_sort_copy(InIt *first1, InIt *last1, RanIt first2, RanIt last2)
   for (i = first2; i != last2; i++)
   {
     j = i;
-    while ((*j < *(j - 1)) && (j != first2))
+    while ((j != first2) && (*j < *(j - 1)))
     {
       std::swap(*j, *(j - 1));
       j--;
@@ -1235,7 +1251,7 @@ RanIt partial_sort_copy(InIt *first1, InIt *last1, RanIt first2, RanIt last2)
       for (i = first2; i != last2; i++)
       {
         j = i;
-        while ((*j < *(j - 1)) && (j != first2))
+        while ((j != first2) && (*j < *(j - 1)))
         {
           std::swap(*j, *(j - 1));
           j--;
@@ -1262,7 +1278,7 @@ RanIt partial_sort_copy(
   for (i = first2; i != last2; i++)
   {
     j = i;
-    while (pred(*j, *(j - 1)) && (j != first2))
+    while ((j != first2) && pred(*j, *(j - 1)))
     {
       std::swap(*j, *(j - 1));
       j--;
@@ -1276,7 +1292,7 @@ RanIt partial_sort_copy(
       for (i = first2; i != last2; i++)
       {
         j = i;
-        while (pred(*j, *(j - 1)) && (j != first2))
+        while ((j != first2) && pred(*j, *(j - 1)))
         {
           std::swap(*j, *(j - 1));
           j--;
@@ -1303,7 +1319,7 @@ RanIt partial_sort_copy(
   for (i = first2; i != last2; i++)
   {
     j = i;
-    while (pred(*j, *(j - 1)) && (j != first2))
+    while ((j != first2) && pred(*j, *(j - 1)))
     {
       std::swap(*j, *(j - 1));
       j--;
@@ -1317,7 +1333,7 @@ RanIt partial_sort_copy(
       for (i = first2; i != last2; i++)
       {
         j = i;
-        while (pred(*j, *(j - 1)) && (j != first2))
+        while ((j != first2) && pred(*j, *(j - 1)))
         {
           std::swap(*j, *(j - 1));
           j--;
@@ -1340,12 +1356,13 @@ void nth_element(RanIt first, RanIt nth, RanIt last)
     {
       swap(*pilgrim, *nth);
       nth = pilgrim;
-      pos = nth - 1;
-      while (*nth < *pos)
+      while (nth != first)
       {
+        pos = nth - 1;
+        if (!(*nth < *pos))
+          break;
         swap(*nth, *pos);
         nth = pos;
-        pos--;
       }
     }
   }
@@ -1363,12 +1380,13 @@ void nth_element(RanIt first, RanIt nth, RanIt last, Pr pred)
     {
       swap(*pilgrim, *nth);
       nth = pilgrim;
-      pos = nth - 1;
-      while (pred(*nth, *pos))
+      while (nth != first)
       {
+        pos = nth - 1;
+        if (!pred(*nth, *pos))
+          break;
         swap(*nth, *pos);
         nth = pos;
-        pos--;
       }
     }
   }
@@ -2123,191 +2141,106 @@ OutIt set_symmetric_difference(
 template <class RanIt>
 void push_heap(RanIt first, RanIt last)
 {
-  int n = 0;
-  RanIt t = first;
-  while (t++ != last)
-    n++;
-  int i = n / 2;
-  int pai, filho;
-  t = last;
-  for (int j = 0; j < n / 2; j++)
+  // Sift up the element at *(last - 1) within the max-heap [first, last).
+  auto n = last - first;
+  if (n <= 1)
+    return;
+  auto child = n - 1;
+  while (child > 0)
   {
-    if (i > 0)
+    auto parent = (child - 1) / 2;
+    if (*(first + parent) < *(first + child))
     {
-      i--;
-      *t = *(first + i);
+      auto tmp = *(first + parent);
+      *(first + parent) = *(first + child);
+      *(first + child) = tmp;
+      child = parent;
     }
     else
-    {
-      n--;
-      if (n == 0)
-      {
-        return;
-      }
-      *t = *(first + n);
-      *(first + n) = *first;
-    }
-    pai = i;
-    filho = i * 2 + 1;
-    while (filho < n)
-    {
-      if ((filho + 1 < n) && (*(first + filho + 1) > *(first + filho)))
-        filho++;
-      if (*(first + filho) > *t)
-      {
-        *(first + pai) = *(first + filho);
-        pai = filho;
-        filho = pai * 2 + 1;
-      }
-      else
-        break;
-    }
-    *(first + pai) = *t;
+      break;
   }
 }
 
 template <class RanIt, class Pr>
 void push_heap(RanIt first, RanIt last, Pr pred)
 {
-  int n = 0;
-  RanIt t = first;
-  while (t++ != last)
-    n++;
-  int i = n / 2;
-  int pai, filho;
-  t = last;
-  for (int j = 0; j < n / 2; j++)
+  auto n = last - first;
+  if (n <= 1)
+    return;
+  auto child = n - 1;
+  while (child > 0)
   {
-    if (i > 0)
+    auto parent = (child - 1) / 2;
+    if (pred(*(first + parent), *(first + child)))
     {
-      i--;
-      *t = *(first + i);
+      auto tmp = *(first + parent);
+      *(first + parent) = *(first + child);
+      *(first + child) = tmp;
+      child = parent;
     }
     else
-    {
-      n--;
-      if (n == 0)
-      {
-        return;
-      }
-      *t = *(first + n);
-      *(first + n) = *first;
-    }
-    int aux = i * 2 + 1;
-    pai = i;
-    filho = aux;
-    while (filho < n)
-    {
-      if ((filho + 1 < n) && (pred(*(first + filho), *(first + filho + 1))))
-        filho++;
-      if (pred(*(first + filho), *t))
-      {
-        *(first + pai) = *(first + filho);
-        pai = filho;
-        filho = pai * 2 + 1;
-      }
-      else
-        break;
-    }
-    *(first + pai) = *t;
+      break;
   }
 }
 
 template <class RanIt>
 void pop_heap(RanIt first, RanIt last)
 {
-  swap(*first, *(last - 1));
-  last = last - 1;
-  int n = 0;
-  RanIt t = first;
-  while (t++ != last)
-    n++;
-  int i = n / 2;
-  int pai, filho;
-  t = last;
-  for (int j = 0; j < n / 2; j++)
+  // Move max to end, then sift down [first, last - 1).
+  auto n = last - first;
+  if (n <= 1)
+    return;
+  auto tmp = *first;
+  *first = *(last - 1);
+  *(last - 1) = tmp;
+  --n;
+  decltype(n) parent = 0;
+  while (true)
   {
-    if (i > 0)
+    auto child = 2 * parent + 1;
+    if (child >= n)
+      break;
+    if (child + 1 < n && *(first + child) < *(first + child + 1))
+      ++child;
+    if (*(first + parent) < *(first + child))
     {
-      i--;
-      *t = *(first + i);
+      auto t = *(first + parent);
+      *(first + parent) = *(first + child);
+      *(first + child) = t;
+      parent = child;
     }
     else
-    {
-      n--;
-      if (n == 0)
-      {
-        return;
-      }
-      *t = *(first + n);
-      *(first + n) = *first;
-    }
-    int aux = i * 2 + 1;
-    pai = i;
-    filho = aux;
-    while (filho < n)
-    {
-      if ((filho + 1 < n) && (*(first + filho) < *(first + filho + 1)))
-        filho++;
-      if (*(first + filho) < *t)
-      {
-        *(first + pai) = *(first + filho);
-        pai = filho;
-        filho = pai * 2 + 1;
-      }
-      else
-        break;
-    }
-    *(first + pai) = *t;
+      break;
   }
 }
 
 template <class RanIt, class Pr>
 void pop_heap(RanIt first, RanIt last, Pr pred)
 {
-  swap(*first, *(last - 1));
-  last = last - 1;
-  int n = 0;
-  RanIt t = first;
-  while (t++ != last)
-    n++;
-  int i = n / 2;
-  int pai, filho;
-  t = last;
-  for (int j = 0; j < n / 2; j++)
+  auto n = last - first;
+  if (n <= 1)
+    return;
+  auto tmp = *first;
+  *first = *(last - 1);
+  *(last - 1) = tmp;
+  --n;
+  decltype(n) parent = 0;
+  while (true)
   {
-    if (i > 0)
+    auto child = 2 * parent + 1;
+    if (child >= n)
+      break;
+    if (child + 1 < n && pred(*(first + child), *(first + child + 1)))
+      ++child;
+    if (pred(*(first + parent), *(first + child)))
     {
-      i--;
-      *t = *(first + i);
+      auto t = *(first + parent);
+      *(first + parent) = *(first + child);
+      *(first + child) = t;
+      parent = child;
     }
     else
-    {
-      n--;
-      if (n == 0)
-      {
-        return;
-      }
-      *t = *(first + n);
-      *(first + n) = *first;
-    }
-    int aux = i * 2 + 1;
-    pai = i;
-    filho = aux;
-    while (filho < n)
-    {
-      if ((filho + 1 < n) && (pred(*(first + filho), *(first + filho + 1))))
-        filho++;
-      if (pred(*(first + filho), *t))
-      {
-        *(first + pai) = *(first + filho);
-        pai = filho;
-        filho = pai * 2 + 1;
-      }
-      else
-        break;
-    }
-    *(first + pai) = *t;
+      break;
   }
 }
 
@@ -2344,47 +2277,27 @@ void make_heap(RanIt first, RanIt last)
 template <class RanIt, class Pr>
 void make_heap(RanIt first, RanIt last, Pr pred)
 {
-  int n = 0;
-  RanIt t = first;
-  while (t++ != last)
-    n++;
-  int i = n / 2;
-  int pai, filho;
-  t = last;
-  for (int j = 0; j < n / 2; j++)
+  auto n = last - first;
+  for (int i = (n / 2) - 1; i >= 0; --i)
   {
-    if (i > 0)
+    int parent = i;
+    auto value = *(first + parent);
+    while (true)
     {
-      i--;
-      *t = *(first + i);
-    }
-    else
-    {
-      n--;
-      if (n == 0)
+      int child = 2 * parent + 1;
+      if (child >= n)
+        break;
+      if (child + 1 < n && pred(*(first + child), *(first + child + 1)))
+        ++child;
+      if (pred(value, *(first + child)))
       {
-        return;
-      }
-      *t = *(first + n);
-      *(first + n) = *first;
-    }
-    int aux = i * 2 + 1;
-    pai = i;
-    filho = aux;
-    while (filho < n)
-    {
-      if ((filho + 1 < n) && (pred(*(first + filho), *(first + filho + 1))))
-        filho++;
-      if (pred(*(first + filho), *t))
-      {
-        *(first + pai) = *(first + filho);
-        pai = filho;
-        filho = pai * 2 + 1;
+        *(first + parent) = *(first + child);
+        parent = child;
       }
       else
         break;
     }
-    *(first + pai) = *t;
+    *(first + parent) = value;
   }
 }
 


### PR DESCRIPTION
Fixes #4394.

Resurrects the six `regression/esbmc-cpp/algorithm/` tests that were marked `KNOWNBUG`. Two issues were operational-model bugs in `src/cpp/library/algorithm`, the other two were latent UB / impl-specific assertions in the test sources themselves:

- `push_heap` / `pop_heap` / `make_heap(Pr)` had a half-baked heap-sort that wrote past `last`. Replaced with textbook sift-up and swap-then-sift-down.
- `stable_partition` was a Lomuto-style swap loop, not actually stable. Replaced with a rotate-into-place variant ([alg.stable.partition]).
- `nth_element`'s inner sift loop could underflow `pos` below `first`. Recompute `pos` inside the loop with a `nth != first` guard.
- `partial_sort_copy` had nine `pred(*j, *(j-1)) && (j != first2)` short-circuits across four overloads (plus one analogous helper) that dereferenced `*(j-1)` before checking the bound. Reordered.
- `algorithm32` reused a `vector::iterator` across a `vector::assign()`, which invalidates iterators per [sequence.reqmts] / [vector.modifiers] — recompute after assign.
- `algorithm44` asserted a specific permutation `nth_element` does not guarantee per [alg.nth.element]. Updated to assert only the standard's actual contract (`*nth` is sorted-position n; `[first, nth)` ≤ `*nth` ≤ `(nth, last)`).

Test plan: all six tests flipped to `CORE` and pass; the surrounding `algorithm/`, `vector/`, `list/`, `deque/`, `set/`, `multiset/`, `map/`, `multimap/`, `template/` suites (642 tests on Darwin) remain green.
