### PR TITLE
[clang-c-frontend] byte-level __builtin_bit_cast + fix list_reference-3 typo

### DIFF
--- a/regression/esbmc-cpp/cpp/github_4191_nonptr/test.desc
+++ b/regression/esbmc-cpp/cpp/github_4191_nonptr/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --std c++20 --overflow-check --incremental-bmc
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/list_reference-3/main.cpp
+++ b/regression/esbmc-cpp/cpp/list_reference-3/main.cpp
@@ -13,8 +13,12 @@ int main ()
 
   mylist.reverse();
 
+  // After reversing {1,2,3,4}, the head should be 4.  The original test
+  // asserted `*it != 4`, which contradicts std::list::reverse semantics and
+  // is why this case was marked KNOWNBUG.  Match the sibling list_reference-1
+  // / list_reference-2 tests, which assert positive equality.
   it = mylist.begin();
-  assert(*it != 4);
+  assert(*it == 4);
 
   cout << "*it: " << *it << endl;
   return 0;

--- a/regression/esbmc-cpp/cpp/list_reference-3/test.desc
+++ b/regression/esbmc-cpp/cpp/list_reference-3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -3243,7 +3243,6 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     break;
   }
 
-  // Unsupported extensions (optional don't care)
   case clang::Stmt::BuiltinBitCastExprClass:
   {
     const clang::BuiltinBitCastExpr &cast =
@@ -3256,7 +3255,18 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     if (get_expr(*cast.getSubExpr(), new_expr))
       return true;
 
-    gen_typecast(ns, new_expr, t);
+    // __builtin_bit_cast / std::bit_cast must reinterpret the value's
+    // byte-level representation, NOT perform an arithmetic conversion.  Using
+    // gen_typecast here would, e.g., turn `bit_cast<float>(uint32_t{0xFFFFFFFF})`
+    // into the float value 4.29e9 rather than the IEEE-NaN whose bits match
+    // the input.  Use the irep1 "bitcast" node, which migrates to bitcast2tc
+    // and is handled by symex as a byte-level reinterpret.  See #4191.
+    if (new_expr.type() != t)
+    {
+      exprt bc("bitcast", t);
+      bc.copy_to_operands(new_expr);
+      new_expr.swap(bc);
+    }
     break;
   }
 


### PR DESCRIPTION
Partial progress on #4397 — fixes 2 of 13 tests.

**`cpp/github_4191_nonptr`** — `clang_c_convert.cpp::BuiltinBitCastExprClass` was lowering `__builtin_bit_cast` / `std::bit_cast` via `gen_typecast`, which performs an arithmetic value cast. For two arithmetic operands of the same size that gives the wrong answer: `bit_cast<float>(uint32_t{0xFFFFFFFF})` becomes the float `4.29e9` instead of the IEEE-NaN whose object representation is `0xFFFFFFFF`, and the round-trip therefore loses bits. Replaced with the irep1 `bitcast` node, which `migrate.cpp` already lowers to `bitcast2tc` and which symex handles as a byte-level reinterpret (the same machinery used for the existing pointer specialisation under #4191).

**`cpp/list_reference-3`** — assertion typo. After building `{1,2,3,4}` and calling `mylist.reverse()`, the head iterator must point at `4` per `std::list::reverse`. The original test asserted `*it != 4`, which is the inverse of the standard's contract. Sibling tests `list_reference-1` and `-2` assert positive equality after their respective operations.

Both tests flipped from `KNOWNBUG` to `CORE`.

**11 of 13 tests remain `KNOWNBUG`.** They cover diverse C++ language features and each requires non-trivial, separate subsystem work — destructor-order semantics for nested template members (`cbmc/Templates6`), virtual-dispatch modelling through Deitel-style class hierarchies (`cpp/ch10_4`, `cpp/ch8_9`, `cpp/bicycle`, `unix/10_bicycle_03`), `new[]` / `bad_alloc` size-limit handling and `set_new_handler` (`cpp/ch13_6`, `cpp/try-catch_08`), `getenv` returning a NULL `char*` to `std::string` ctor (`cpp/ch16_3`), `std::list` model edge cases (`cpp/ch21_4`), k-induction loop-invariant synthesis (`cpp/cpp_sum_class`), and multi-inheritance delete-via-base detection (`cpp/llbmc_invalid_delete`). Each is a candidate for follow-up issues filed individually rather than a sprawling combined PR.

Test plan: full Darwin `esbmc-cpp` regression sweep — 99% pass, 9 failures all pre-existing on `master` (verified via stash on previous PRs in the same sweep).
