### PR TITLE
[om] fix std::string::find_last_of overloads

### DIFF
--- a/regression/esbmc-cpp/string/string_find_last_of_1/test.desc
+++ b/regression/esbmc-cpp/string/string_find_last_of_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 26 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_find_last_of_3/main.cpp
+++ b/regression/esbmc-cpp/string/string_find_last_of_3/main.cpp
@@ -1,0 +1,36 @@
+// Edge cases for std::string::find_last_of:
+//   - default pos == npos must not overflow the precondition
+//   - position 0 must be reachable
+//   - pos beyond length() clamps to length()-1
+//   - empty haystack / needle returns npos
+#include <string>
+#include <cassert>
+
+int main()
+{
+  // position 0 must be reachable
+  std::string s1("/abc");
+  assert(s1.find_last_of("/") == 0);
+
+  // not found returns npos
+  std::string s2("abc");
+  assert(s2.find_last_of("xyz") == std::string::npos);
+
+  // explicit pos clamps the search window
+  std::string s3("aXbX");
+  assert(s3.find_last_of("X", 2) == 1);
+
+  // pos beyond length() is clamped, not an overflow
+  std::string s4("ab");
+  assert(s4.find_last_of("a", 100) == 0);
+
+  // single-char overload with large pos
+  std::string s5("xxa.b");
+  assert(s5.find_last_of('.', 100) == 3);
+
+  // empty haystack returns npos
+  std::string s6("");
+  assert(s6.find_last_of("a") == std::string::npos);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/string_find_last_of_3/test.desc
+++ b/regression/esbmc-cpp/string/string_find_last_of_3/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--incremental-bmc --no-unwinding-assertions --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2887,34 +2887,16 @@ size_t basic_string<CharT, Traits, Alloc>::find_last_of(
   size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert((pos < this->length()) && (pos >= 0), "overflow");
   __ESBMC_assert(s.str != NULL, "The parameter must be different than NULL");
-  size_t i, j;
-
-  int len = this->length();
-  int lim = pos;
-  char *s1 = new char[len + 1];
-  strcpy(s1, this->str);
-
-  int slen = s.length();
-  char *s2 = new char[slen + 1];
-  for (i = 0; i < slen; i++)
-  {
-    s2[i] = s.str[i];
-  }
-  s2[i] = '\0';
-
-  for (i = len; i > 0; i--)
-  {
-    for (j = 0; j < slen; j++)
-    {
-      if (s1[i] == s2[j])
-      {
+  size_t len = this->length();
+  size_t slen = s.length();
+  if (len == 0 || slen == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t i = start + 1; i-- > 0;)
+    for (size_t j = 0; j < slen; j++)
+      if (this->str[i] == s.str[j])
         return i;
-      }
-    }
-  }
-  // Return npos if the character is not found
   return npos;
 }
 
@@ -2924,71 +2906,23 @@ size_t basic_string<CharT, Traits, Alloc>::find_last_of(
   size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert((pos < this->length()) && (pos >= 0), "overflow");
   __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
-  size_t i, j;
-
-  int len = this->length();
-  int lim = pos;
-  char *s1 = new char[len + 1];
-  strcpy(s1, this->str);
-
-  int slen = strlen(s);
-  char *s2 = new char[slen + 1];
-  for (i = 0; i < slen; i++)
-  {
-    s2[i] = s[i];
-  }
-  s2[i] = '\0';
-
-  for (i = len; i > 0; i--)
-  {
-    for (j = 0; j < slen; j++)
-    {
-      if (s1[i] == s2[j])
-      {
+  size_t len = this->length();
+  size_t slen = strlen(s);
+  if (len == 0 || slen == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t i = start + 1; i-- > 0;)
+    for (size_t j = 0; j < slen; j++)
+      if (this->str[i] == s[j])
         return i;
-      }
-    }
-  }
-  // Return npos if the character is not found
   return npos;
 }
 
 template <typename CharT, typename Traits, typename Alloc>
 size_t basic_string<CharT, Traits, Alloc>::find_last_of(char *s) const
 {
-  //__ESBMC_HIDE: __ESBMC_assert((pos < this->length()) && (pos >= 0),
-  //"overflow");
-  __ESBMC_assert(s != NULL, "The parameter must be different than NULL");
-  int pos = npos;
-  size_t i, j;
-
-  int len = this->length();
-  int lim = pos;
-  char *s1 = new char[len + 1];
-  strcpy(s1, this->str);
-
-  int slen = strlen(s);
-  char *s2 = new char[slen + 1];
-  for (i = 0; i < slen; i++)
-  {
-    s2[i] = s[i];
-  }
-  s2[i] = '\0';
-
-  for (i = len; i > 0; i--)
-  {
-    for (j = 0; j < slen; j++)
-    {
-      if (s1[i] == s2[j])
-      {
-        return i;
-      }
-    }
-  }
-  // Return npos if the character is not found
-  return npos;
+  return find_last_of(static_cast<const char *>(s), npos);
 }
 
 template <typename CharT, typename Traits, typename Alloc>
@@ -2996,22 +2930,14 @@ size_t
 basic_string<CharT, Traits, Alloc>::find_last_of(char c, size_t pos) const
 {
 __ESBMC_HIDE:
-  __ESBMC_assert((pos < this->length()) && (pos >= 0), "overflow");
-  size_t i, j;
-
-  int len = this->length();
-  int lim = pos;
-  char *s1 = new char[len + 1];
-  strcpy(s1, this->str);
-
-  for (i = len; i > 0; i--)
-  {
-    if (s1[i] == c)
-    {
+  size_t len = this->length();
+  if (len == 0)
+    return npos;
+  size_t start = (pos >= len) ? len - 1 : pos;
+  for (size_t i = start + 1; i-- > 0;)
+    if (this->str[i] == c)
       return i;
-    }
-  }
-  return npos; // Return npos when the character is not found
+  return npos;
 }
 
 template <typename CharT, typename Traits, typename Alloc>


### PR DESCRIPTION
Second slice of #4401. Fixes the four `std::string::find_last_of`
overloads in `src/cpp/library/string`, which had three independent
bugs: a precondition that rejected the standard's default `pos = npos`,
a reverse loop that skipped index 0 and read past the end, and a `pos`
parameter that was never used to bound the search. Each overload also
leaked two heap allocations on early return.

Re-enables `string/string_find_last_of_1` (KNOWNBUG → CORE) and adds
`string/string_find_last_of_3` covering pos=0, default npos, beyond-
length clamp, and empty haystack. `string_find_last_of_2_bug` still
produces VERIFICATION FAILED, so the negative case is preserved.

`find_first_not_of` carries the identical pattern of bugs and is left
for a follow-up. Refs #4401.
