### PR TITLE
[om] fix sstream operator<< for char and floating-point

### DIFF
--- a/regression/esbmc-cpp/stream/sstream_str_char/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_char/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_double/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_double/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_double_carry/main.cpp
+++ b/regression/esbmc-cpp/stream/sstream_str_double_carry/main.cpp
@@ -1,0 +1,17 @@
+// Half-up rounding in operator<<(double) can produce a fractional integer
+// equal to the precision multiplier (e.g. 0.999999 * 1e6 + 0.5 -> 1e6),
+// which would silently drop the leading carry digit if the model only
+// reserved `prec` characters for the fractional buffer. The carry must be
+// promoted into the integer part instead.
+#include <sstream>
+#include <cassert>
+using namespace std;
+
+int main()
+{
+  stringstream oss;
+  double v = 1.999999;
+  oss << v;
+  assert(oss.str() == "2");
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/sstream_str_double_carry/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_double_carry/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_float/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_float/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_long_double/main.cpp
+++ b/regression/esbmc-cpp/stream/sstream_str_long_double/main.cpp
@@ -1,0 +1,15 @@
+// stringstream::operator<<(long double) must not be silently dropped by
+// the free overload in <ostream>; without a member overload, the call is
+// ambiguous between every integer overload at parse time.
+#include <sstream>
+#include <cassert>
+using namespace std;
+
+int main()
+{
+  stringstream oss;
+  long double d = 45.543L;
+  oss << d;
+  assert(oss.str() == "45.543");
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/sstream_str_long_double/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_long_double/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 10 --no-unwinding-assertions --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/stream/sstream_str_signed_char/main.cpp
+++ b/regression/esbmc-cpp/stream/sstream_str_signed_char/main.cpp
@@ -1,0 +1,15 @@
+// stringstream::operator<<(signed char) must emit the character itself,
+// not its decimal value. Without an explicit overload, signed char would
+// promote to int and print as a number.
+#include <sstream>
+#include <cassert>
+using namespace std;
+
+int main()
+{
+  stringstream oss;
+  signed char val = 'Y';
+  oss << val;
+  assert(oss.str() == "Y");
+  return 0;
+}

--- a/regression/esbmc-cpp/stream/sstream_str_signed_char/test.desc
+++ b/regression/esbmc-cpp/stream/sstream_str_signed_char/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 5 --no-unwinding-assertions --timeout 60
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/sstream
+++ b/src/cpp/library/sstream
@@ -144,47 +144,89 @@ public:
     return *this;
   }
 
-  ostream &operator<<(float val)
+  // Default-precision (6 significant digits) %g-like formatting, with trailing
+  // zeros and a trailing '.' stripped to match iostream defaults. Negative
+  // values get a leading '-'; the integer part fits in `int` (sufficient for
+  // the regression tests). Long double maps to double under ESBMC.
+  ostream &operator<<(double val)
   {
-    char temp[NUM_SIZE];
-    char temp2[2];
-    int n = (int)val;
-    itoa(n, temp, DEC);
-    strcat(temp, ".");
-    val = val - (float)n;
-    for (int i = 0; i < NUM_SIZE && val != 0; i++)
+    char buf[NUM_SIZE];
+    if (val < 0)
     {
-      val = val * DEC;
-      n = (int)val;
-      itoa(n, temp2, DEC);
-      strcat(temp, temp2);
+      _string.append("-");
+      val = -val;
     }
-    _string.append(temp);
+    int ipart = (int)val;
+    itoa(ipart, buf, DEC);
+    int len = strlen(buf);
+
+    // Ternary, not `if (prec < 0) prec = 0;`. With `--unwind 10`
+    // (no `--incremental-bmc`) ESBMC's interval domain widens `prec`
+    // through the if-clamp and produces a false positive on a later
+    // `len` invariant; the ternary is opaque to that widening. Verified
+    // against regression/esbmc-cpp/stream/sstream_str_{char,double,float}
+    // (issue #4401).
+    int prec = (len < 6) ? (6 - len) : 0;
+    if (prec > 0)
+    {
+      double fpart = val - (double)ipart;
+      long mult = 1;
+      for (int i = 0; i < prec; i++)
+        mult *= DEC;
+      long fint = (long)(fpart * (double)mult + 0.5);
+
+      // Half-up rounding can produce fint == mult (e.g. fpart = 0.999999,
+      // mult = 1e6). Promote the carry into ipart and re-emit so the
+      // leading digit is not silently dropped from the fractional buffer.
+      if (fint >= mult)
+      {
+        ipart++;
+        itoa(ipart, buf, DEC);
+        len = strlen(buf);
+        fint = 0;
+      }
+
+      char fbuf[NUM_SIZE];
+      int j = prec;
+      fbuf[j] = '\0';
+      while (j > 0)
+      {
+        fbuf[--j] = '0' + (int)(fint % 10);
+        fint /= 10;
+      }
+      int flen = prec;
+      while (flen > 0 && fbuf[flen - 1] == '0')
+        fbuf[--flen] = '\0';
+      if (flen > 0)
+      {
+        buf[len++] = '.';
+        buf[len] = '\0';
+        strcat(buf, fbuf);
+      }
+    }
+    _string.append(buf);
     return *this;
   }
 
-  ostream &operator<<(double val)
+  ostream &operator<<(float val)
   {
-    char temp[NUM_SIZE];
-    char temp2[2];
-    int n = (int)val;
-    itoa(n, temp, DEC);
-    strcat(temp, ".");
-    val = val - (double)n;
-    for (int i = 0; i < NUM_SIZE && val != 0; i++)
-    {
-      val = val * DEC;
-      n = (int)val;
-      itoa(n, temp2, DEC);
-      strcat(temp, temp2);
-    }
-    _string.append(temp);
-    return *this;
+    return *this << (double)val;
+  }
+
+  ostream &operator<<(long double val)
+  {
+    return *this << (double)val;
   }
 
   ostream &operator<<(char val)
   {
     _string.append(&val, 1);
+    return *this;
+  }
+
+  ostream &operator<<(signed char val)
+  {
+    _string.append(reinterpret_cast<const char *>(&val), 1);
     return *this;
   }
 


### PR DESCRIPTION
Third slice of #4401. Fixes three independent bugs in
`std::stringstream::operator<<`:

- `signed char` had no overload — promoted to int and emitted the
  decimal value instead of the character.
- `long double` had no member overload — parse-time ambiguous, and the
  free overload in `<ostream>` silently dropped the value.
- The float/double formatters never subtracted the integer part between
  digit-extraction iterations, so the digit `n` grew past 9 and
  `itoa(n, temp2[2], 10)` overflowed `temp2`.

Replaces the float/double bodies with a default-precision (6 sig.
digits) `%g`-like formatter that strips trailing zeros and handles
the half-up rounding carry (`fpart=0.999999` → bump `ipart`). `float`
and `long double` delegate to `double`.

Re-enables `sstream_str_char`, `sstream_str_double`,
`sstream_str_float` (KNOWNBUG → CORE) and adds three new tests
covering `signed char`, `long double`, and the carry edge case.

The `prec` clamp is written as a ternary because the equivalent
`if (prec < 0) prec = 0;` form triggers an interval-domain false
positive under `--unwind 10` without `--incremental-bmc`. Comment
in source records the repro for future maintainers. Refs #4401.
