### PR TITLE
[om] propagate it_str through string iterator copies; NUL temp in append<T>

### DIFF
--- a/regression/esbmc-cpp/string/string_append_6/test.desc
+++ b/regression/esbmc-cpp/string/string_append_6/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 25 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_append_final/test.desc
+++ b/regression/esbmc-cpp/string/string_append_final/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 55 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_assign_final/test.desc
+++ b/regression/esbmc-cpp/string/string_assign_final/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 45 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_iterator_propagation/main.cpp
+++ b/regression/esbmc-cpp/string/string_iterator_propagation/main.cpp
@@ -1,0 +1,32 @@
+// std::string iterator copies must propagate `it_str` (the underlying
+// buffer pointer) so that range-based append/assign can read the source.
+// Before the fix, `iterator(const iterator &)` copied only `pointer` and
+// `pos`, so `s.begin()+k` returned an iterator with an uninitialised
+// `it_str`, and `str.append(s.begin()+k, s.end())` read garbage.
+#include <string>
+#include <cassert>
+
+int main()
+{
+  // Templated append<int>(n, c): tests the integer-iterator overload that
+  // must NUL-terminate its scratch buffer (the `*this = temp` follow-up
+  // strcpy's into a buffer whose terminator was previously not written).
+  std::string a;
+  a.append<int>(5, '*');
+  assert(a == "*****");
+
+  // Range append from a non-default-iterator (begin()+k, end()): exercises
+  // the iterator copy-ctor it_str propagation.
+  std::string b;
+  std::string src = "hello world";
+  b.append(src.begin() + 6, src.end());
+  assert(b == "world");
+
+  // Range assign from (begin()+k, end()-k): exercises both endpoints
+  // moving away from the trivial begin()/end() positions.
+  std::string c;
+  c.assign(src.begin() + 6, src.end() - 1);
+  assert(c == "worl");
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/string_iterator_propagation/test.desc
+++ b/regression/esbmc-cpp/string/string_iterator_propagation/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--unwind 25 --no-unwinding-assertions --timeout 120
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -131,16 +131,21 @@ public:
     {
       pointer = i.pointer;
       pos = i.pos;
+      it_str = i.it_str;
     }
 
     iterator()
     {
       pointer = NULL;
+      pos = 0;
+      it_str = NULL;
     }
 
     iterator(char *p_pointer)
     {
       pointer = p_pointer;
+      pos = 0;
+      it_str = p_pointer;
     }
 
     iterator &operator=(const const_iterator &right)
@@ -154,6 +159,7 @@ public:
     {
       this->pointer = right.pointer;
       this->pos = right.pos;
+      this->it_str = right.it_str;
       return *this;
     }
 
@@ -175,7 +181,8 @@ public:
       iterator buffer;
       buffer.pointer = pointer - sizeof(char) * n;
       buffer.pos = pos - n;
-      __ESBMC_assert(buffer.pos > 0, "underflow");
+      buffer.it_str = it_str;
+      __ESBMC_assert(buffer.pos >= 0, "underflow");
       return buffer;
     }
 
@@ -1031,11 +1038,7 @@ public:
 
   basic_string<CharT, Traits, Alloc>::iterator begin() const
   {
-    int i;
-    basic_string<CharT, Traits, Alloc>::iterator first(this->str);
-    first.pos = 0;
-    first.it_str = this->str;
-    return first;
+    return basic_string<CharT, Traits, Alloc>::iterator(this->str);
   }
 
   basic_string<CharT, Traits, Alloc>::iterator end() const
@@ -1068,21 +1071,18 @@ public:
   basic_string<CharT, Traits, Alloc> &
   append(InputIterator first, InputIterator last)
   {
-    __ESBMC_assert(
-      first != NULL, "The first parameter must be different than NULL");
-    __ESBMC_assert(
-      last != NULL, "The second parameter must be different than NULL");
     __ESBMC_assert(first >= 0, "The first parameter must be greater than zero");
     __ESBMC_assert(last >= 0, "The second parameter must be greater than zero");
     int rhsLen = first;
     char c = last;
     int totalLen = this->_size + rhsLen;
     basic_string<CharT, Traits, Alloc> temp(totalLen);
-    int i, j, k;
+    int i, j;
     for (i = 0; i < this->_size; i++)
-      temp[i] = this->str[i];
-    for (j = i, k = 0; j < temp._size; j++, k++)
+      temp.str[i] = this->str[i];
+    for (j = i; j < totalLen; j++)
       temp.str[j] = c;
+    temp.str[totalLen] = '\0';
     *this = temp;
     return *this;
   }


### PR DESCRIPTION
Fourth slice of #4401. Two bugs in `src/cpp/library/string`:

- The iterator class has three members (`pointer`, `pos`, `it_str`),
  but every constructor / copy-assignment except `operator+` set only
  `pointer`/`pos`. `s.begin() + k` propagated `it_str` into a buffer
  iterator, but the by-value return invoked the copy constructor, which
  dropped `it_str`. Range `append`/`assign` then read `one.it_str` as
  uninitialised. Propagate `it_str` everywhere.
- The templated `append<T>(T first, T last)` (used by the integer
  overload `s.append<int>(5, '.')`) filled `temp.str[0..totalLen)` but
  never wrote `temp.str[totalLen] = '\0'`. The follow-up
  `*this = temp` calls `operator=` which `strcpy`s from `temp.str` —
  walking past the end. Write the terminator. Also drop two
  `first/last != NULL` preconditions that misfire for integral `T`.

Re-enables `string_append_6`, `string_append_final`,
`string_assign_final` (KNOWNBUG → CORE) and adds
`string_iterator_propagation` covering `append<int>(n,c)`, range
`append(begin+k, end)`, and range `assign(begin+k, end-k)`.

Out of scope and left for follow-up: `assign(basic_string&, pos, n)`
doesn't NUL-terminate; `assign(const char*, n)` allocates `n` bytes
(no NUL) with a wrong precondition; `end()` returns `length()-1`
instead of `length()`. Refs #4401.
