### PR TITLE
[clang-cpp] lazy-register methods missing in cross-TU class views

### DIFF
--- a/regression/esbmc-cpp/vector/github_4416/holder.cpp
+++ b/regression/esbmc-cpp/vector/github_4416/holder.cpp
@@ -1,0 +1,12 @@
+#include "holder.h"
+
+// `tab.at(i).resize(inner)` is the first instantiation of
+// `std::vector<bool>::resize(int)` in this build. The crash in
+// adjust_cpp_member fired here when `main.cpp` was parsed first and
+// completed `vector<bool>` without seeing this method.
+holder::holder(int outer, int inner)
+{
+  tab.resize(outer);
+  for (int i = 0; i < outer; ++i)
+    tab.at(i).resize(inner);
+}

--- a/regression/esbmc-cpp/vector/github_4416/holder.h
+++ b/regression/esbmc-cpp/vector/github_4416/holder.h
@@ -1,0 +1,12 @@
+#ifndef GITHUB_4416_HOLDER_H_
+#define GITHUB_4416_HOLDER_H_
+
+#include <vector>
+
+class holder {
+public:
+  holder(int outer, int inner);
+  std::vector<std::vector<bool> > tab;
+};
+
+#endif

--- a/regression/esbmc-cpp/vector/github_4416/main.cpp
+++ b/regression/esbmc-cpp/vector/github_4416/main.cpp
@@ -1,0 +1,7 @@
+#include "holder.h"
+
+int main()
+{
+  holder h(2, 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/github_4416/test.desc
+++ b/regression/esbmc-cpp/vector/github_4416/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+holder.cpp --unwind 1 --no-pointer-check --no-bounds-check --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -4,6 +4,7 @@
 #include <util/c_types.h>
 #include <util/destructor.h>
 #include <util/expr_util.h>
+#include <util/message.h>
 
 clang_cpp_adjust::clang_cpp_adjust(contextt &_context)
   : clang_c_adjust(_context)
@@ -195,7 +196,18 @@ void clang_cpp_adjust::adjust_cpp_member(member_exprt &expr)
    *      * id: <setX_clang_ID>
    */
   const symbolt *comp_symb = ns.lookup(expr.component_name());
-  assert(comp_symb);
+  if (!comp_symb)
+  {
+    log_error(
+      "{}: unresolved C++ member component `{}` at {} (struct-op type "
+      "id `{}`, member type id `{}`)",
+      __func__,
+      expr.component_name(),
+      expr.location().as_string(),
+      expr.struct_op().type().id_string(),
+      expr.type().id_string());
+    abort();
+  }
   // compoment's type shall be the same as member_exprt's type
   // and both are of the type `code`
   assert(comp_symb->type.is_code());

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2225,6 +2225,44 @@ bool clang_cpp_convertert::get_member_expr(
   if (perform_virtual_dispatch(memb))
     return get_vft_binding_expr(memb, new_expr);
 
+  // Lazy-register a body-less symbol for member calls whose enclosing
+  // class was already completed by an earlier translation unit. Without
+  // this, a template method first instantiated in *this* TU (e.g.
+  // `std::vector<bool>::resize` first used in Solver.cpp after the class
+  // was completed while parsing lista7paa.cpp) would never be added to
+  // the context, and `adjust_cpp_member` would later fail to resolve it
+  // (issue #4416). The signature is enough: the body-less stub is sound
+  // because symex falls back to nondet for the return and havocs pointer
+  // args at call sites with `body_available=false`. Constructors
+  // are unreached here (CXXConstructExpr path); destructors and lambda
+  // `operator()` go through this branch and are handled identically.
+  // See also `get_method` for the canonical full-body version.
+  if (
+    const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(memb.getMemberDecl()))
+  {
+    std::string id, name;
+    get_decl_name(*md, name, id);
+    if (!id.empty() && context.find_symbol(id) == nullptr)
+    {
+      typet sym_type;
+      if (get_type(md->getType(), sym_type))
+        return true;
+      symbolt symbol;
+      locationt loc;
+      get_location_from_decl(*md, loc);
+      get_default_symbol(
+        symbol,
+        get_modulename_from_path(loc.file().as_string()),
+        sym_type,
+        name,
+        id,
+        loc);
+      symbol.lvalue = true;
+      symbol.is_extern = true;
+      context.move_symbol_to_context(symbol);
+    }
+  }
+
   return clang_c_convertert::get_member_expr(memb, new_expr);
 }
 


### PR DESCRIPTION
Fixes #4416. Multi-TU C++ inputs could trip `assert(comp_symb)` in `clang_cpp_adjust::adjust_cpp_member` when one TU finalised a class symbol before another TU first instantiated one of its template methods (e.g. `std::vector<bool>::resize` referenced only from a later .cpp). `get_struct_union_class` returns early for already-complete classes, so the later instantiation never reached the context.

Lazy-register a body-less extern stub at `get_member_expr` whenever the referenced `CXXMethodDecl`'s id is not yet in the symbol table; symex falls back to nondet for body-less callees, so the stub is sound. Also replaces the bare `assert` with a structured `log_error+abort` reporting the unresolved name and source location, and adds `regression/esbmc-cpp/vector/github_4416/` as a positive multi-TU repro.
