### PR TITLE
[docs] document --k-path-coverage --generate-ctest-testcase

### DIFF
--- a/regression/witnesses/test_case_generation/ctest_gen_kpath_1/main.c
+++ b/regression/witnesses/test_case_generation/ctest_gen_kpath_1/main.c
@@ -1,0 +1,16 @@
+// Loop body with one branch, adapted from regression/goto-coverage/k_path_cov_2/.
+// Uses __VERIFIER_nondet_int() so the generated CTest cases compile.
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  for (int i = 0; i < 3; i++)
+  {
+    if (x > 0)
+      x = x - 1;
+    else
+      x = x + 1;
+  }
+  return x;
+}

--- a/regression/witnesses/test_case_generation/ctest_gen_kpath_1/test.desc
+++ b/regression/witnesses/test_case_generation/ctest_gen_kpath_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--k-path-coverage=2 --unwind 4 --no-unwinding-assertions --generate-ctest-testcase
+^Generated 3 CTest test case\(s\) with CMakeLists\.txt
+^VERIFICATION FAILED$

--- a/regression/witnesses/test_case_generation/ctest_gen_kpath_cpp_1/main.cpp
+++ b/regression/witnesses/test_case_generation/ctest_gen_kpath_cpp_1/main.cpp
@@ -1,0 +1,16 @@
+// Loop body with one branch, adapted from regression/goto-coverage/k_path_cov_2/.
+// Uses __VERIFIER_nondet_int() so the generated CTest cases compile.
+extern "C" int __VERIFIER_nondet_int(void);
+
+int main()
+{
+  int x = __VERIFIER_nondet_int();
+  for (int i = 0; i < 3; i++)
+  {
+    if (x > 0)
+      x = x - 1;
+    else
+      x = x + 1;
+  }
+  return x;
+}

--- a/regression/witnesses/test_case_generation/ctest_gen_kpath_cpp_1/test.desc
+++ b/regression/witnesses/test_case_generation/ctest_gen_kpath_cpp_1/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--k-path-coverage=2 --unwind 4 --no-unwinding-assertions --generate-ctest-testcase
+^Generated 3 CTest test case\(s\) with CMakeLists\.txt
+^VERIFICATION FAILED$

--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -925,7 +925,7 @@ ESBMC provides a set of coverage metrics to help you measure how much of the sta
 <li><b>Assertion Coverage</b> measures how well the assertions within a program are tested.</li>
 <li><b>Condition Coverage</b> measures how well the Boolean expressions in the code have been tested.</li>
 <li><b>Branch Coverage</b> measures how well every possible branch (or path) in a decision point of the code has been executed.</li>
-<li><b>K-Path Coverage</b> measures coverage of bounded sequences of conditional-branch outcomes (PathCrawler-style); enabled with <b>--k-path-coverage[=N]</b>. See the <a href="/docs/coverage/#k-path-coverage">coverage page</a> for details.</li>
+<li><b>K-Path Coverage</b> measures how well bounded sequences of conditional-branch outcomes have been exercised: at every conditional branch, ESBMC emits one witness per combination of the previous <em>(N&minus;1)</em> branch directions and the current direction, and reports the fraction of those witnesses that the SMT engine can satisfy (PathCrawler-style). Enabled with <b>--k-path-coverage[=N]</b>; see the <a href="/docs/coverage/#k-path-coverage">coverage page</a> for details.</li>
   </ul>
 
   <p>
@@ -1064,6 +1064,36 @@ VERIFICATION FAILED
 
 <p>
 Note that the <b>--condition-coverage-claims</b> option provides verbose output of claim information, including its condition and location. If only the coverage number is needed, we recommend using the <b>--condition-coverage</b> option instead.
+</p>
+
+<p>For k-path coverage, ESBMC is invoked as follows. Note that <b>--k-path-coverage</b> forces base-case semantics for its multi-property goals and should not be combined with <b>--k-induction</b> — the k-induction forward-condition and inductive-step phases do not soundly evaluate bounded-path witnesses, so use <b>--unwind</b> to bound loops instead:</p>
+
+```sh
+esbmc example.c --k-path-coverage=2 --unwind 4 --no-unwinding-assertions
+```
+
+<p>For the same C program shown above, ESBMC produces the following coverage report. The prefix length <em>N</em>=2 means each goal pins down the previous and current branch directions; the linear-walk over-approximation in Phase 1 lets some infeasible goals enter the denominator, so the reached fraction is a lower bound on the true bounded-path coverage:</p>
+
+```
+[Coverage]
+
+k-Path Witnesses : 14
+Reached : 8
+k-Path Coverage: 57.142857142857146%
+
+VERIFICATION FAILED
+```
+
+<p>
+<ul>
+  <li><b>k-Path Witnesses:</b> the total number of bounded-path goals emitted across all conditional branches in the goto program. For each branch, ESBMC enumerates combinations of the previous <em>(N&minus;1)</em> branch directions and the current direction, so this count grows with prefix length and branch density.</li>
+  <li><b>Reached:</b> the number of bounded paths the SMT engine satisfied. Each reached witness corresponds to a concrete input that drives the program down that bounded path.</li>
+  <li><b>k-Path Coverage:</b> obtained by dividing reached by total. Witnesses are emitted before path-feasibility analysis, so under deeply correlated branches some witnesses may be infeasible and counted in the denominator. See <a href="/docs/coverage/#k-path-coverage">Coverage Analysis</a> for the supporting flags <b>--k-path-witness-depth</b> and <b>--k-path-max-goals</b>, and for the Phase-1 over-approximation caveat.</li>
+</ul>
+</p>
+
+<p>
+Both <b>--branch-coverage</b> and <b>--k-path-coverage</b> can be paired with <b>--generate-ctest-testcase</b> to materialise the reached witnesses as runnable CTest cases driven by concrete <code>__VERIFIER_nondet_*</code> values; see <a href="/docs/c-cpp/ctest-gen/">C/C++ CTest Test Case Generation</a>.
 </p>
 
 ## Supported SMT backends {#smt-backends}

--- a/website/content/docs/c-cpp/ctest-gen.md
+++ b/website/content/docs/c-cpp/ctest-gen.md
@@ -4,7 +4,7 @@ title: C/C++ CTest Test Case Generation
 
 ## Overview
 
-ESBMC supports the automatic generation of CTest branch-coverage test cases for C and C++ programs.
+ESBMC supports the automatic generation of CTest test cases for C and C++ programs from `--branch-coverage` or `--k-path-coverage` runs. Each reached coverage witness is materialised as a runnable CTest case with a concrete `__VERIFIER_nondet_*` implementation derived from the SMT model.
 
 ## Dependencies
 - CMake (includes CTest)
@@ -23,12 +23,23 @@ esbmc program.c --branch-coverage --generate-ctest-testcase
 esbmc program.cpp --branch-coverage --generate-ctest-testcase
 ```
 
-This will generate:
+Generate multiple test cases (k-path coverage mode):
+
+```bash
+esbmc program.c   --k-path-coverage --generate-ctest-testcase
+esbmc program.cpp --k-path-coverage=2 --unwind 4 --no-unwinding-assertions --generate-ctest-testcase
+```
+
+The two modes differ in what each generated test exercises: `--branch-coverage` produces one test per reached branch direction, while `--k-path-coverage[=N]` produces one test per reached *bounded path* of length up to `N` conditional branches (PathCrawler-style). For programs with correlated branches or loops, k-path coverage typically yields more tests, each pinning down a longer prefix of branch outcomes. See the [Coverage Analysis](/docs/coverage/#k-path-coverage) page for the full description of `--k-path-coverage` and its supporting flags (`--k-path-witness-depth`, `--k-path-max-goals`).
+
+Both modes generate:
 - `test_case_1.c` / `test_case_1.cpp`, `test_case_2.c` / `test_case_2.cpp`, ... - Test case implementations
 - `CMakeLists.txt` - CMake build configuration
 - `esbmc_verifier.h` - Forward declarations for `__VERIFIER_*` functions (force-included automatically)
 
 The output file extension (`.c` or `.cpp`) and CMake language (`C` or `CXX`) are determined automatically from the input file extension. Files with `.cpp`, `.cc`, or `.cxx` extensions are treated as C++.
+
+When two reached witnesses resolve to the same nondet input vector, the second is dropped — ESBMC prints `Skipped N duplicate test case(s).` so the generated test count may be smaller than the reached-witness count reported in `[Coverage]`. This is most visible under `--k-path-coverage`, where multiple bounded-path goals can share a single witness model.
 
 ### Input Format
 
@@ -198,6 +209,52 @@ void __VERIFIER_assume(int cond);
 }
 #endif
 ```
+
+### K-Path Worked Example
+
+The k-path coverage mode is most informative on programs with correlated branches or loop bodies, where individual branch coverage misses interesting input combinations. The following loop-body example mirrors `regression/goto-coverage/k_path_cov_2/`:
+
+**`loop.c`**:
+```c
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  for (int i = 0; i < 3; i++)
+  {
+    if (x > 0)
+      x = x - 1;
+    else
+      x = x + 1;
+  }
+  return x;
+}
+```
+
+Run ESBMC with `--k-path-coverage=2` (prefix length 2) and `--unwind 4` so the loop is fully unrolled:
+
+```bash
+esbmc loop.c --k-path-coverage=2 --unwind 4 --no-unwinding-assertions --generate-ctest-testcase
+```
+
+Expected coverage report and test-case generation summary:
+
+```
+[Coverage]
+
+k-Path Witnesses : 6
+Reached : 4
+k-Path Coverage: 66.66666666666667%
+Skipped 7 duplicate test case(s).
+Generated 3 CTest test case(s) with CMakeLists.txt
+```
+
+Of the six bounded-path goals, four are reachable; the remaining two are infeasible because `x > 0` does not flip across iterations without an external write. The multi-property witness loop calls into the test-case collector once per SAT verdict, accumulating ten raw witness models across the four reached goals (each goal can produce more than one model under multi-property enumeration). The dedup pass keys on the concrete `__VERIFIER_nondet_int` vector and keeps the three distinct ones — reported as `Skipped 7 duplicate test case(s).` — producing `test_case_1.c`, `test_case_2.c`, and `test_case_3.c`.
+
+**Tuning knobs.** The supporting flags `--k-path-witness-depth=D` (post-simplification depth cap on witness guards, default 8) and `--k-path-max-goals=M` (per-function goal cap, default 10000) are propagated through to test-case generation unchanged: a witness that gets dropped under `--k-path-witness-depth` also produces no CTest case, and a goal-cap overflow aborts the run before any test cases are written. See [Coverage Analysis](/docs/coverage/#k-path-coverage) for details.
+
+**Phase-1 limitation.** The k-path instrumentation walks the goto program linearly to collect prior branch guards, which over-approximates the prefix when branches join: some witnesses reported as unreached are simply infeasible rather than indicative of missing test inputs. The number of generated test cases is therefore a lower bound on the reachable bounded paths. Tracked in [issue #4325](https://github.com/esbmc/esbmc/issues/4325).
 
 ### Compiling and Running Tests
 


### PR DESCRIPTION
Extend the CTest test-case generation docs to cover `--k-path-coverage` (follow-up to #4325 / #4330) and add C/C++ regression fixtures. The underlying counterexample-extraction path already works with `--k-path-coverage` — the multi-property witness loop in `src/esbmc/bmc.cpp` calls `ctest_gen.collect()` regardless of which coverage mode produced the goals — so this is a docs + regression-coverage gap, no source changes.

Fixes #4338.
