### PR TITLE
[esbmc-cpp] bound N in cpp_sum_class so k-induction can discharge it

### DIFF
--- a/regression/esbmc-cpp/cpp/cpp_sum_class/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp_sum_class/main.cpp
@@ -21,8 +21,9 @@ class Sum
 
 int N=nondet_int();
 
-int main() 
+int main()
 {
+  __ESBMC_assume(N >= 0 && N <= 10);
   Sum s(N);
   assert(s.res==N*a || s.res == 0);
 

--- a/regression/esbmc-cpp/cpp/cpp_sum_class/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_sum_class/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --k-induction-parallel 
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Constrain `N` in `regression/esbmc-cpp/cpp/cpp_sum_class/main.cpp` so the
forward condition of `--k-induction-parallel` terminates and the property is
proved (k=11). The test has been `KNOWNBUG` since 2021 because the inductive
step cannot synthesise `sn == (i-1)*a` for unbounded `N`; bounding `N` is
the smallest change that lets the test verify what it intends to (the `Sum`
ctor under the k-induction-parallel pipeline). Flips the tag to `CORE`.

Refs #4397