### PR TITLE
[om] add const begin()/end() overloads to std::list

### DIFF
--- a/regression/esbmc-cpp/cpp/ch21_4/test.desc
+++ b/regression/esbmc-cpp/cpp/ch21_4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -1168,6 +1168,9 @@ public:
     this->_size = 0;
   }
 
+  typedef iterator const_iterator;
+  typedef reverse_iterator const_reverse_iterator;
+
   iterator begin()
   {
     iterator it;
@@ -1180,6 +1183,20 @@ public:
     iterator it;
     this->_list[this->_size] = value_type();
     it.it = &(this->_list[this->_size]);
+    it.pos = this->_size;
+    return it;
+  }
+  const_iterator begin() const
+  {
+    const_iterator it;
+    it.it = const_cast<value_type *>(&(this->_list[0]));
+    it.pos = 0;
+    return it;
+  }
+  const_iterator end() const
+  {
+    const_iterator it;
+    it.it = const_cast<value_type *>(&(this->_list[this->_size]));
     it.pos = this->_size;
     return it;
   }


### PR DESCRIPTION
The array-backed `std::list` operational model in `src/cpp/library/list`
exposes only non-const `begin()`/`end()`, so any call through a
`const std::list<T>&` fails to parse:

```
error: 'this' argument to member function 'begin' has type
'const std::list<int>', but function is not marked const
```

`cpp/ch21_4` (Deitel Fig. 21.17) hits this via its `printList`
template, which takes the list by const reference and iterates it with
`std::copy`.

Adds const overloads returning a `const_iterator` (typedef of `iterator`
for now, matching the OM's existing iterator-value semantics) plus a
parallel `const_reverse_iterator` typedef. Purely additive — non-const
callers see no behavioural change.

Flips `regression/esbmc-cpp/cpp/ch21_4` from `KNOWNBUG` to `CORE`
(`VERIFICATION SUCCESSFUL` in ~28s).

Refs #4397
