### PR TITLE
[esbmc-cpp] bump ch16_3 unwind so strchr terminates

### DIFF
--- a/regression/esbmc-cpp/cpp/ch16_3/test.desc
+++ b/regression/esbmc-cpp/cpp/ch16_3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
---unwind 10 --no-unwinding-assertions --timeout 900
+--unwind 15 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$


### PR DESCRIPTION
`ch16_3` verifies that `std::string(getenv("QUERY_STRING"))` traps when `getenv` returns NULL. The `getenv` OM does return NULL on a nondet branch — but at `--unwind 10`, the `strchr('=')` loop inside `getenv` can't terminate on the 12-char `"QUERY_STRING"`. With `--no-unwinding-assertions`, ESBMC then assumes the loop exited within the bound, making the NULL-return path infeasible — so the `basic_string` NULL-pointer assertion is never reached and ESBMC silently reports SUCCESSFUL. Bumping to `--unwind 15` lets `strchr` finish and the expected `VERIFICATION FAILED` is produced.

Refs #4397
