### PR TITLE
[irep2] remove dead code_init2t expression kind

### DIFF
--- a/src/irep2/README.md
+++ b/src/irep2/README.md
@@ -324,7 +324,6 @@ ordinary expression tree. Their type is `empty` unless noted.
 |------|-------------|
 | `code_block` | Sequence of statements. |
 | `code_assign` | `target = source`. |
-| `code_init` | Initialisation assignment (specialised `code_assign` — relevant for object lifetime). |
 | `code_decl` | Declaration of a local with a given type and name (starts its lifetime). |
 | `code_dead` | End of a local's lifetime — symex stops trusting reads through it. |
 | `code_return` | `return expr;` (or `return;` if operand is nil). |

--- a/src/irep2/irep2.h
+++ b/src/irep2/irep2.h
@@ -103,7 +103,6 @@
   BOOST_PP_LIST_CONS(sideeffect,                                               \
   BOOST_PP_LIST_CONS(code_block,                                               \
   BOOST_PP_LIST_CONS(code_assign,                                              \
-  BOOST_PP_LIST_CONS(code_init,                                                \
   BOOST_PP_LIST_CONS(code_decl,                                                \
   BOOST_PP_LIST_CONS(code_dead,                                                \
   BOOST_PP_LIST_CONS(code_printf,                                              \
@@ -136,7 +135,7 @@
   BOOST_PP_LIST_CONS(isinstance,                                               \
   BOOST_PP_LIST_CONS(hasattr,                                                  \
   BOOST_PP_LIST_CONS(isnone,                                                   \
-  BOOST_PP_LIST_NIL))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  BOOST_PP_LIST_NIL)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 // clang-format on
 
 // Even crazier forward decls,

--- a/src/irep2/irep2_expr.cpp
+++ b/src/irep2/irep2_expr.cpp
@@ -89,7 +89,6 @@ static const char *expr_names[] = {
   "sideeffect",
   "code_block",
   "code_assign",
-  "code_init",
   "code_decl",
   "code_dead",
   "code_printf",

--- a/src/irep2/irep2_expr.h
+++ b/src/irep2/irep2_expr.h
@@ -1550,7 +1550,6 @@ irep_typedefs(dynamic_size, object_ops);
 irep_typedefs(sideeffect, sideeffect_data);
 irep_typedefs(code_block, code_block_data);
 irep_typedefs(code_assign, code_assign_data);
-irep_typedefs(code_init, code_assign_data);
 irep_typedefs(code_decl, code_decl_data);
 irep_typedefs(code_dead, code_decl_data);
 irep_typedefs(code_printf, code_printf_data);
@@ -3363,19 +3362,6 @@ public:
   {
   }
   code_assign2t(const code_assign2t &ref) = default;
-
-  static std::string field_names[esbmct::num_type_fields];
-};
-
-// NB: code_init2t is a specialization of code_assign2t
-class code_init2t : public code_init_expr_methods
-{
-public:
-  code_init2t(const expr2tc &target, const expr2tc &source)
-    : code_init_expr_methods(get_empty_type(), code_init_id, target, source)
-  {
-  }
-  code_init2t(const code_init2t &ref) = default;
 
   static std::string field_names[esbmct::num_type_fields];
 };

--- a/src/irep2/templates/irep2_templates.cpp
+++ b/src/irep2/templates/irep2_templates.cpp
@@ -192,8 +192,6 @@ std::string code_block2t::field_names[esbmct::num_type_fields] =
   {"operands", "", "", "", ""};
 std::string code_assign2t::field_names[esbmct::num_type_fields] =
   {"target", "source", "", "", ""};
-std::string code_init2t::field_names[esbmct::num_type_fields] =
-  {"target", "source", "", "", ""};
 std::string code_decl2t::field_names[esbmct::num_type_fields] =
   {"value", "", "", "", ""};
 std::string code_dead2t::field_names[esbmct::num_type_fields] =

--- a/src/irep2/templates/irep2_templates_expr_data.cpp
+++ b/src/irep2/templates/irep2_templates_expr_data.cpp
@@ -36,7 +36,6 @@ expr_typedefs2(dereference, dereference_data);
 expr_typedefs5(sideeffect, sideeffect_data);
 expr_typedefs1(code_block, code_block_data);
 expr_typedefs2(code_assign, code_assign_data);
-expr_typedefs2(code_init, code_assign_data);
 expr_typedefs1(code_decl, code_decl_data);
 expr_typedefs1(code_dead, code_decl_data);
 expr_typedefs1(code_printf, code_printf_data);

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1491,11 +1491,6 @@ void value_sett::apply_code(const expr2tc &code)
     const code_assign2t &ref = to_code_assign2t(code);
     assign(ref.target, ref.source);
   }
-  else if (is_code_init2t(code))
-  {
-    const code_init2t &ref = to_code_init2t(code);
-    assign(ref.target, ref.source);
-  }
   else if (is_code_decl2t(code))
   {
     const code_decl2t &ref = to_code_decl2t(code);


### PR DESCRIPTION
Removes the `code_init2t` expression kind. The class was commented as
"a specialization of code_assign2t" but had zero producers anywhere in
the tree (no frontend, no `migrate.cpp` path, no constructor call), and
its single consumer in `value_set::apply_code` was a dead `else if`
that forwarded to `assign()` — identical to the `code_assign2t` arm
above it.

No functional change. Confirmed locally that the three `esbmc-cpp/`
test failures during my run reproduce on clean master at the same SHA,
so they are pre-existing and unrelated to this change.

Surfaced by the per-node README audit on PR #4458.
