### PR TITLE
[om] fix multiset::insert return type (2 of #4400)

### DIFF
--- a/regression/esbmc-cpp/multiset/multiset-insert-bug/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-insert-bug/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/multiset/multiset-insert/test.desc
+++ b/regression/esbmc-cpp/multiset/multiset-insert/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 --unwind 10 --no-unwinding-assertions --timeout 900
 ^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/set
+++ b/src/cpp/library/set
@@ -520,7 +520,7 @@ public:
   }
 
   template <class Iterator>
-  iterator insert(Iterator first, Iterator last)
+  void insert(Iterator first, Iterator last)
   {
     __ESBMC_assert(
       last > first,
@@ -531,8 +531,10 @@ public:
   }
 
   // modifiers:
-  // multiset insert should maintain sorted order and allow duplicates
-  std::pair<iterator, bool> insert(const value_type &x)
+  // multiset insert should maintain sorted order and allow duplicates.
+  // Returns iterator (not pair<iterator,bool>): the bool would be meaningless
+  // for multiset since duplicates are always inserted (C++ standard).
+  iterator insert(const value_type &x)
   {
     // Find the correct position to insert while maintaining sorted order
     int insert_pos = 0;
@@ -551,15 +553,13 @@ public:
     buf[insert_pos] = x;
     _size++;
 
-    // For multiset, always return true (duplicates allowed)
-    return make_pair(iterator(buf, insert_pos), true);
+    return iterator(buf, insert_pos);
   }
 
   iterator insert(iterator position, const value_type &x)
   {
     // For multiset, we ignore position hint and maintain sorted order
-    auto result = insert(x);
-    return result.first;
+    return insert(x);
   }
 
   void erase(iterator position)
@@ -1230,7 +1230,7 @@ public:
   }
 
   template <class Iterator>
-  iterator insert(Iterator first, Iterator last)
+  void insert(Iterator first, Iterator last)
   {
     __ESBMC_assert(
       last > first,


### PR DESCRIPTION
Fixes multiset::insert overloads in ESBMC's C++ operational model to
match the standard. multiset::insert(value) returned pair<iterator,bool>
(the set signature), which is wrong since multiset always inserts
duplicates, and broke `it = m.insert(v)` for users. Both set's and
multiset's range-insert overloads also declared iterator with no
return statement (UB) — both are void per the standard.

Flips multiset-insert and multiset-insert-bug from KNOWNBUG to CORE.
Refs #4400.
