### PR TITLE
[interval-analysis] enforce float bounds in k-induction base case

### DIFF
--- a/regression/k-induction/github_4438/main.c
+++ b/regression/k-induction/github_4438/main.c
@@ -1,0 +1,36 @@
+// Smoke test for issue #4438.
+//
+// Mirrors the shape of c/neural-networks/log_6_safe.c-amalgamation
+// (SV-COMP 2026): a nondet float is range-guarded, then passed
+// through a libm call.  Under --k-induction --interval-analysis
+// --floatbv the interval-derived float bound used to be tagged
+// inductive-step-only, so the k-induction base case ignored it and
+// could observe spurious NaN values propagated by libm operational
+// models.  Post-fix the bound is enforced in every k-induction
+// phase.
+//
+// This test exercises the configuration plumbing only: sqrtf is
+// modeled precisely enough that the bug does not fire even pre-fix.
+// The actual false-alarm reproducer is the SV-COMP benchmark
+// itself, whose solve time (Z3 and Bitwuzla both >> 8 min on the
+// fix-validation runs we attempted) makes it unsuitable as a
+// regression test.
+#include <math.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  if (!(__builtin_isgreaterequal(x, 1.0f) &&
+        __builtin_islessequal(x, 10.0f)))
+    return 0;
+
+  float y = sqrtf(x);
+  if (!(__builtin_isgreaterequal(y, 0.0f) &&
+        __builtin_islessequal(y, 10.0f)))
+  {
+  ERROR:;
+  }
+  return 0;
+}

--- a/regression/k-induction/github_4438/test.desc
+++ b/regression/k-induction/github_4438/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --interval-analysis --floatbv --error-label ERROR --k-step 2 --max-inductive-step 3 --32 --z3
+^VERIFICATION SUCCESSFUL$

--- a/regression/k-induction/github_4438_fail/main.c
+++ b/regression/k-induction/github_4438_fail/main.c
@@ -1,0 +1,25 @@
+// Negative companion to github_4438: same shape but the downstream
+// gate is genuinely violable for the bounded input range, so the
+// k-induction base case must still discover the ERROR label even
+// after the issue #4438 fix forced the interval-derived float
+// assume into the base case.  Confirms the fix does not over-
+// constrain the base case into masking real errors.
+#include <math.h>
+
+extern float __VERIFIER_nondet_float(void);
+
+int main(void)
+{
+  float x = __VERIFIER_nondet_float();
+  if (!(__builtin_isgreaterequal(x, 1.0f) &&
+        __builtin_islessequal(x, 100.0f)))
+    return 0;
+
+  float y = sqrtf(x);
+  if (!(__builtin_isgreaterequal(y, 0.0f) &&
+        __builtin_islessequal(y, 5.0f)))
+  {
+  ERROR:;
+  }
+  return 0;
+}

--- a/regression/k-induction/github_4438_fail/test.desc
+++ b/regression/k-induction/github_4438_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--k-induction --interval-analysis --floatbv --error-label ERROR --k-step 2 --max-inductive-step 3 --32 --z3
+^VERIFICATION FAILED$

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -110,43 +110,65 @@ inline void instrument_symbol_constraints(
   goto_programt::instructionst::iterator &it,
   goto_functiont &goto_function)
 {
-  std::vector<expr2tc> symbol_constraints;
   auto state_iterator = interval_analysis.state_map.find(it);
   // We may be trying to instrument an unreachable state
   if (state_iterator == interval_analysis.state_map.end())
     return;
   const interval_domaint &d = state_iterator->second;
-  bool constrains_float = false;
+
+  // Partition by symbol type so the existing k-induction optimization
+  // can still tag non-float assumptions as inductive-step-only, while
+  // float assumptions are emitted in all phases.  Float interval
+  // bounds expand to `lower <= x` and `x <= upper` (or `x == c` in
+  // singleton intervals), all of which evaluate to false when x is
+  // NaN (IEEE 754).  The base case relies on these interval-derived
+  // assumes to propagate range-restricting guards (e.g.
+  // `if (a <= x && x <= b)`) forward to later program points.
+  // Tagging them inductive-step-only loses that propagation and lets
+  // the base case observe spurious NaN traces produced by libm
+  // operational models such as expf/logf — see issue #4438.
+  std::vector<expr2tc> non_float_constraints;
+  std::vector<expr2tc> float_constraints;
   for (const auto &symbol_expr : symbols)
   {
     expr2tc tmp = d.make_expression(symbol_expr);
-    if (!is_true(tmp))
-    {
-      symbol_constraints.push_back(tmp);
-      if (is_floatbv_type(symbol_expr->type))
-        constrains_float = true;
-    }
+    if (is_true(tmp))
+      continue;
+    if (is_floatbv_type(symbol_expr->type))
+      float_constraints.push_back(tmp);
+    else
+      non_float_constraints.push_back(tmp);
   }
 
-  if (!symbol_constraints.empty())
-  {
+  // Both assumes must execute before the original instruction at `it`.
+  // `insert_swap(it, ...)` swaps the assume into `it`'s slot and moves
+  // the previous content into a new slot immediately after.  Calling
+  // it on the same `it` twice (float first, then non-float) yields
+  // source order [non_float] [float] [orig], and jumps to the original
+  // slot now pass through both assumes before reaching the original
+  // instruction.  After N insertions the original instruction lives
+  // N positions past `it`, so we advance `it` by N+1 to match the
+  // original `insert_swap(it++, ...)` post-condition of pointing one
+  // past the original instruction.
+  std::size_t insertion_count = 0;
+  auto insert_at_target = [&](const std::vector<expr2tc> &constraints,
+                              bool inductive_step_only) {
+    if (constraints.empty())
+      return;
     goto_programt::instructiont instruction;
-    instruction.make_assumption(conjunction(symbol_constraints));
-    // Float interval bounds expand to `lower <= x` and `x <= upper`
-    // (or `x == c` in singleton intervals), all of which evaluate
-    // to false when x is NaN (IEEE 754).  The base case relies on
-    // these interval-derived assumes to propagate range-restricting
-    // guards (e.g. `if (a <= x && x <= b)`) forward to later
-    // program points.  Tagging them inductive-step-only loses that
-    // propagation and lets the base case observe spurious NaN
-    // traces produced by libm operational models such as
-    // expf/logf — see issue #4438.
-    instruction.inductive_step_instruction =
-      config.options.is_kind() && !constrains_float;
+    instruction.make_assumption(conjunction(constraints));
+    instruction.inductive_step_instruction = inductive_step_only;
     instruction.location = it->location;
     instruction.function = it->function;
-    goto_function.body.insert_swap(it++, instruction);
-  }
+    goto_function.body.insert_swap(it, instruction);
+    ++insertion_count;
+  };
+
+  insert_at_target(float_constraints, false);
+  insert_at_target(non_float_constraints, config.options.is_kind());
+
+  if (insertion_count > 0)
+    std::advance(it, insertion_count + 1);
 }
 
 /**

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -116,18 +116,33 @@ inline void instrument_symbol_constraints(
   if (state_iterator == interval_analysis.state_map.end())
     return;
   const interval_domaint &d = state_iterator->second;
+  bool constrains_float = false;
   for (const auto &symbol_expr : symbols)
   {
     expr2tc tmp = d.make_expression(symbol_expr);
     if (!is_true(tmp))
+    {
       symbol_constraints.push_back(tmp);
+      if (is_floatbv_type(symbol_expr->type))
+        constrains_float = true;
+    }
   }
 
   if (!symbol_constraints.empty())
   {
     goto_programt::instructiont instruction;
     instruction.make_assumption(conjunction(symbol_constraints));
-    instruction.inductive_step_instruction = config.options.is_kind();
+    // Float interval bounds expand to `lower <= x` and `x <= upper`
+    // (or `x == c` in singleton intervals), all of which evaluate
+    // to false when x is NaN (IEEE 754).  The base case relies on
+    // these interval-derived assumes to propagate range-restricting
+    // guards (e.g. `if (a <= x && x <= b)`) forward to later
+    // program points.  Tagging them inductive-step-only loses that
+    // propagation and lets the base case observe spurious NaN
+    // traces produced by libm operational models such as
+    // expf/logf — see issue #4438.
+    instruction.inductive_step_instruction =
+      config.options.is_kind() && !constrains_float;
     instruction.location = it->location;
     instruction.function = it->function;
     goto_function.body.insert_swap(it++, instruction);

--- a/src/goto-programs/abstract-interpretation/interval_analysis.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_analysis.cpp
@@ -151,18 +151,18 @@ inline void instrument_symbol_constraints(
   // original `insert_swap(it++, ...)` post-condition of pointing one
   // past the original instruction.
   std::size_t insertion_count = 0;
-  auto insert_at_target = [&](const std::vector<expr2tc> &constraints,
-                              bool inductive_step_only) {
-    if (constraints.empty())
-      return;
-    goto_programt::instructiont instruction;
-    instruction.make_assumption(conjunction(constraints));
-    instruction.inductive_step_instruction = inductive_step_only;
-    instruction.location = it->location;
-    instruction.function = it->function;
-    goto_function.body.insert_swap(it, instruction);
-    ++insertion_count;
-  };
+  auto insert_at_target =
+    [&](const std::vector<expr2tc> &constraints, bool inductive_step_only) {
+      if (constraints.empty())
+        return;
+      goto_programt::instructiont instruction;
+      instruction.make_assumption(conjunction(constraints));
+      instruction.inductive_step_instruction = inductive_step_only;
+      instruction.location = it->location;
+      instruction.function = it->function;
+      goto_function.body.insert_swap(it, instruction);
+      ++insertion_count;
+    };
 
   insert_at_target(float_constraints, false);
   insert_at_target(non_float_constraints, config.options.is_kind());


### PR DESCRIPTION
The interval analysis treated pre-guard instructions as inductive-step
only under --k-induction, so the base case skipped them; for IEEE 754
float bounds this is unsound (NaN fails both comparisons), causing
spurious NaN FALSE_REACH on TRUE benchmarks. Restrict the marker to
integer-only constraint sets so float bounds hold in the base case.

Fixes #4438
