### PR TITLE
[ci] add clang sanitizer CI workflow (ASan + UBSan)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,80 @@
+name: Sanitizers
+
+# Builds ESBMC under clang's AddressSanitizer and UndefinedBehaviorSanitizer
+# and runs the CORE regression suite, capturing every sanitizer diagnostic
+# to per-PID log files. The deduplicated findings are written to the job
+# summary; the raw logs upload as artifacts for triage.
+#
+# This workflow tracks https://github.com/esbmc/esbmc/issues/223.
+#
+# Bring-up note: `continue-on-error: true` is set so a finding does not
+# block master while the suppression files are still being populated.
+# Once the steady-state suppressions are in place a follow-up PR will
+# drop the flag and promote this workflow to a required check.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'regression/CMakeLists.txt'
+      - 'scripts/build.sh'
+      - 'scripts/cmake/Sanitizers.cmake'
+      - 'scripts/sanitizers/**'
+      - '.github/workflows/sanitizers.yml'
+
+jobs:
+  sanitizer:
+    name: ${{ matrix.sanitizer }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [asan, ubsan]
+    env:
+      ESBMC_SANITIZER_LOG_DIR: ${{ github.workspace }}/sanitizer-logs
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare log directory
+        run: mkdir -p "$ESBMC_SANITIZER_LOG_DIR"
+
+      - name: Build ESBMC (${{ matrix.sanitizer }})
+        run: |
+          case "${{ matrix.sanitizer }}" in
+            asan)  STYPE=ASAN ;;
+            ubsan) STYPE=UBSAN ;;
+            *) echo "unknown sanitizer ${{ matrix.sanitizer }}"; exit 1 ;;
+          esac
+          ./scripts/build.sh -b Sanitizer -s "$STYPE"
+
+      - name: Run CORE regression under ${{ matrix.sanitizer }}
+        run: |
+          source scripts/sanitizers/common-options.sh
+          cd build
+          # ESBMC_REGRESS_TIMEOUT defaults to 1200s but is overridden to 120s
+          # by the standard PR workflow; restore 600s explicitly so we are not
+          # at the mercy of a stale cache. -DENABLE_SANITIZER_CI=ON forces
+          # MODES=CORE inside regression/CMakeLists.txt.
+          cmake -DESBMC_REGRESS_TIMEOUT=600 -DENABLE_SANITIZER_CI=ON .
+          # -j2 keeps memory pressure manageable — ASan inflates RSS several
+          # fold and the ubuntu-24.04 runner has 16 GB.
+          # `|| true` lets a failing test still feed collect_findings.py;
+          # the script's own exit code drives the step's success bit.
+          ctest -j2 --output-on-failure -L '^esbmc/$' || true
+
+      - name: Collect findings
+        if: always()
+        run: python3 scripts/sanitizers/collect_findings.py
+
+      - name: Upload sanitizer logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitizer-${{ matrix.sanitizer }}-logs
+          path: ${{ env.ESBMC_SANITIZER_LOG_DIR }}
+          retention-days: 30
+          if-no-files-found: warn

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -21,6 +21,9 @@ set(ESBMC_REGRESS_TIMEOUT 1200 CACHE STRING
 set(ESBMC_REGRESS_MEMORY_LIMIT 8192 CACHE STRING
     "Per-test virtual memory limit")
 
+option(ENABLE_SANITIZER_CI
+    "Restrict regression to CORE mode for sanitizer-instrumented CI runs" OFF)
+
 if(BENCHBRINGUP)
   # To run a specific benchmark in Github workflow and download the log archive when completed
   #   - BENCHMARK_TO_RUN: user-specified benchmark to run
@@ -300,7 +303,11 @@ foreach(regression IN LISTS REGRESSIONS)
     else()
         set(MODES CORE KNOWNBUG FUTURE THOROUGH)
     endif()
-    if(CORE_REGRESSION_ONLY)
+    # ENABLE_SANITIZER_CI mirrors CORE_REGRESSION_ONLY but is keyed on the
+    # sanitizer workflow rather than benchmark bring-up. Sanitizer-instrumented
+    # builds run 3-5x slower; restricting to CORE keeps each leg of the matrix
+    # inside the workflow's 90-minute budget.
+    if(CORE_REGRESSION_ONLY OR ENABLE_SANITIZER_CI)
       set(MODES CORE)
     endif()
     add_esbmc_regression("${regression}" "${MODES}")

--- a/scripts/sanitizers/asan-suppressions.txt
+++ b/scripts/sanitizers/asan-suppressions.txt
@@ -1,0 +1,10 @@
+# AddressSanitizer interceptor suppressions for ESBMC.
+#
+# Format: one rule per line, comments start with '#'.
+#   interceptor_via_fun:<function name substring>
+#   interceptor_via_lib:<library path substring>
+#
+# Keep each rule paired with the issue that tracks the underlying bug.
+# See: https://clang.llvm.org/docs/AddressSanitizer.html#suppressing-issues
+#
+# (empty — populated as the bring-up CI run surfaces findings)

--- a/scripts/sanitizers/collect_findings.py
+++ b/scripts/sanitizers/collect_findings.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Aggregate clang sanitizer log files into a deduplicated report.
+
+Reads every ``sanitizer.<pid>`` file in ``$ESBMC_SANITIZER_LOG_DIR`` (or the
+directory passed on the command line), groups findings by ``(sanitizer,
+kind, first-source-frame)`` and writes a Markdown summary. When the
+environment variable ``GITHUB_STEP_SUMMARY`` is set, the summary is
+appended to that file as well so it shows up on the GitHub Actions job
+page.
+
+Exit status:
+    0 — no findings, or all findings are silenced by their respective
+        suppression files.
+    1 — at least one un-suppressed finding remains.
+
+The runtime suppressions wired by ``common-options.sh`` already filter
+matched entries out of the log files; this script's exit status reflects
+what survived that filter. It is therefore safe to mark the CI step as
+``continue-on-error: true`` during bring-up and let the artifact upload
+carry the raw logs forward for triage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+
+# UBSan emits one line per finding. The location's column suffix is
+# optional on some runtimes, and the line is not always anchored to a
+# line start (CTest can interleave stderr with the test runner's own
+# output), so we re.search the discriminator anywhere on the line.
+#   src/util/foo.cpp:42:7: runtime error: signed integer overflow: ...
+_UBSAN_RE = re.compile(
+    r"(?P<loc>[^:\s]+:\d+(?::\d+)?): runtime error: (?P<msg>.+)$")
+
+# ASan/LSan reports begin with a header line containing the tool and a
+# kind identifier. The kind is the first token after the colon; ASan
+# sometimes appends parenthesised qualifiers (e.g.
+# "alloc-dealloc-mismatch (operator new vs free) on ...") which we discard.
+#   ==1234==ERROR: AddressSanitizer: heap-buffer-overflow on address ...
+_HEADER_RE = re.compile(
+    r"==\d+==ERROR: (?P<tool>AddressSanitizer|LeakSanitizer): (?P<kind>\S+)")
+
+# Stack frames look like:
+#   #0 0xdeadbeef in symbol_name path/to/file.cc:42:3
+_FRAME_RE = re.compile(
+    r"^\s*#\d+\s+0x[0-9a-fA-F]+\s+in\s+(?P<sym>\S+)"
+    r"(?:\s+(?P<loc>\S+:\d+(?::\d+)?))?")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """Single sanitizer finding (already comparable; used as dedup key)."""
+    tool: str
+    kind: str
+    location: str
+
+
+_ALLOCATOR_SYM_PREFIXES = (
+    "malloc",
+    "calloc",
+    "realloc",
+    "operator",  # operator new / operator delete
+    "__interceptor_",
+)
+
+
+def _is_allocator(sym: str) -> bool:
+    """True if ``sym`` names a libc / libstdc++ allocator interceptor
+    that should be skipped when picking the user-frame for dedup."""
+    return any(sym.startswith(p) for p in _ALLOCATOR_SYM_PREFIXES)
+
+
+def _first_user_frame(line_iter: Iterator[str]) -> str:
+    """Consume frames from ``line_iter`` until the first one outside
+    an allocator interceptor is found.
+
+    Tolerates blank lines that precede the first frame (LSan inserts
+    one between the header and the leak block) and stops at the first
+    blank line *after* at least one frame has been seen. Returns the
+    location (``file:line[:col]``) when available, else the symbol,
+    else the literal ``"<no frame>"`` when the iterator runs dry.
+    """
+    fallback = ""
+    saw_frame = False
+    for line in line_iter:
+        if not line.strip():
+            if saw_frame:
+                break
+            continue
+        m = _FRAME_RE.match(line)
+        if not m:
+            continue
+        saw_frame = True
+        loc = m.group("loc") or ""
+        sym = m.group("sym")
+        if not fallback:
+            fallback = loc or sym
+        if _is_allocator(sym):
+            continue
+        return loc or sym
+    return fallback or "<no frame>"
+
+
+# Skip log files larger than this — sanitizer dumps with no suppressions
+# can run to hundreds of MB on hot loops; pulling such a file into memory
+# would OOM the runner before the report is written.
+_MAX_LOG_BYTES = 64 * 1024 * 1024
+
+
+def parse_log(path: Path) -> List[Finding]:
+    """Stream a single sanitizer log file, returning every finding."""
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        print(f"warning: cannot stat {path}: {exc}", file=sys.stderr)
+        return []
+    if size > _MAX_LOG_BYTES:
+        print(f"warning: skipping {path} ({size} bytes > "
+              f"{_MAX_LOG_BYTES} cap)",
+              file=sys.stderr)
+        return []
+    try:
+        fh = path.open("r", encoding="utf-8", errors="replace")
+    except OSError as exc:
+        print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
+        return []
+    out: List[Finding] = []
+    with fh:
+        line_iter = iter(fh)
+        for line in line_iter:
+            ubsan = _UBSAN_RE.search(line)
+            if ubsan:
+                kind = ubsan.group("msg").split(":", 1)[0].strip()
+                out.append(Finding("UBSan", kind, ubsan.group("loc")))
+                continue
+            header = _HEADER_RE.search(line)
+            if header:
+                tool = "ASan" if header.group(
+                    "tool") == "AddressSanitizer" else "LSan"
+                out.append(
+                    Finding(tool, header.group("kind"),
+                            _first_user_frame(line_iter)))
+    return out
+
+
+def collect(log_dir: Path) -> List[Finding]:
+    """Return every finding in every ``sanitizer.*`` file under log_dir."""
+    if not log_dir.is_dir():
+        return []
+    findings: List[Finding] = []
+    for entry in sorted(log_dir.iterdir()):
+        if entry.is_file() and entry.name.startswith("sanitizer."):
+            findings.extend(parse_log(entry))
+    return findings
+
+
+def render_markdown(findings: Iterable[Finding]) -> str:
+    """Render a Markdown table summarising the (deduplicated) findings."""
+    counts: Counter = Counter(findings)
+    if not counts:
+        return "## Sanitizer findings\n\nNo findings.\n"
+    rows = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    lines = [
+        "## Sanitizer findings",
+        "",
+        f"{len(counts)} unique finding(s); {sum(counts.values())} total occurrence(s).",
+        "",
+        "| Count | Tool | Kind | Location |",
+        "| ----: | :--- | :--- | :------- |",
+    ]
+    for finding, count in rows:
+        lines.append(
+            f"| {count} | {finding.tool} | {finding.kind} | `{finding.location}` |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(report: str) -> None:
+    """Write report to stdout and, when running under GitHub Actions, to
+    the job-summary file pointed at by ``$GITHUB_STEP_SUMMARY``."""
+    sys.stdout.write(report)
+    if not report.endswith("\n"):
+        sys.stdout.write("\n")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(report)
+            if not report.endswith("\n"):
+                fh.write("\n")
+
+
+def main(argv: List[str] | None = None) -> int:
+    """CLI entry point. See module docstring for exit-status semantics."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "log_dir",
+        nargs="?",
+        default=os.environ.get("ESBMC_SANITIZER_LOG_DIR"),
+        help="directory of sanitizer.<pid> log files "
+        "(defaults to $ESBMC_SANITIZER_LOG_DIR)",
+    )
+    args = parser.parse_args(argv)
+    if not args.log_dir:
+        parser.error(
+            "log_dir is required (positional or via $ESBMC_SANITIZER_LOG_DIR)")
+    findings = collect(Path(args.log_dir))
+    write_summary(render_markdown(findings))
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sanitizers/common-options.sh
+++ b/scripts/sanitizers/common-options.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+# Sourced by sanitizer CI and by local reproduction runs.
+#
+# Configures ASAN_OPTIONS / UBSAN_OPTIONS / LSAN_OPTIONS so that sanitizer
+# diagnostics are written to per-process log files under
+# $ESBMC_SANITIZER_LOG_DIR/sanitizer.<pid> instead of stderr.
+#
+# Why log files?  CTest discards stderr from passing tests, and many
+# sanitizer findings live in tests that ESBMC reports as PASSED (the
+# instrumentation fires but ESBMC's exit code stays 0).  Logging to files
+# survives CTest's filtering and lets collect-findings.sh deduplicate
+# across the whole run.
+#
+# Usage (sourced, not executed):
+#     export ESBMC_SANITIZER_LOG_DIR=/path/to/log/dir
+#     source scripts/sanitizers/common-options.sh
+#
+# Resolves $ESBMC_SANITIZER_REPO_ROOT from BASH_SOURCE so callers don't
+# have to set it explicitly.
+
+if [ -z "${ESBMC_SANITIZER_LOG_DIR:-}" ]; then
+    echo "common-options.sh: ESBMC_SANITIZER_LOG_DIR is unset; defaulting to /tmp" >&2
+    ESBMC_SANITIZER_LOG_DIR="/tmp"
+fi
+mkdir -p "$ESBMC_SANITIZER_LOG_DIR"
+
+# Resolve repo root from this file's location: <repo>/scripts/sanitizers/common-options.sh
+_esbmc_san_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ESBMC_SANITIZER_REPO_ROOT="$(cd "$_esbmc_san_dir/../.." && pwd)"
+unset _esbmc_san_dir
+
+_log_prefix="$ESBMC_SANITIZER_LOG_DIR/sanitizer"
+
+# Shared across ASan/LSan/UBSan: do not abort the process; do not stop at
+# the first error; symbolize stack frames inline; write to log files;
+# emit "Suppression: ..." lines so the artifact records which rules
+# fired (the collector ignores those lines when ranking findings).
+_common="log_path=$_log_prefix:halt_on_error=0:abort_on_error=0:symbolize=1:print_suppressions=1"
+
+ASAN_OPTIONS="$_common:detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+UBSAN_OPTIONS="$_common:print_stacktrace=1:report_error_type=1:suppressions=$ESBMC_SANITIZER_REPO_ROOT/scripts/sanitizers/ubsan-suppressions.txt"
+LSAN_OPTIONS="$_common:suppressions=$ESBMC_SANITIZER_REPO_ROOT/scripts/sanitizers/lsan-suppressions.txt"
+
+export ASAN_OPTIONS UBSAN_OPTIONS LSAN_OPTIONS ESBMC_SANITIZER_LOG_DIR ESBMC_SANITIZER_REPO_ROOT
+unset _log_prefix _common

--- a/scripts/sanitizers/lsan-suppressions.txt
+++ b/scripts/sanitizers/lsan-suppressions.txt
@@ -1,0 +1,9 @@
+# LeakSanitizer suppressions for ESBMC.
+#
+# Format: one rule per line, comments start with '#'.
+#   leak:<function or source-path substring>
+#
+# Keep each rule paired with the issue that tracks the underlying leak.
+# See: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
+#
+# (empty — populated as the bring-up CI run surfaces findings)

--- a/scripts/sanitizers/test_collect_findings.py
+++ b/scripts/sanitizers/test_collect_findings.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Unit tests for collect_findings.py.
+
+Exercises every branch with real fixture logs (no mocks).
+
+Run from this directory:
+    python3 -m unittest test_collect_findings.py
+"""
+# Standard unittest patterns trip several pylint checks: setUp/tearDown owns
+# the temp dir lifecycle (consider-using-with), tests legitimately exercise
+# the module's private frame helper (protected-access), and the sys.path
+# bootstrap precedes the local import (wrong-import-position).
+# pylint: disable=consider-using-with,protected-access,wrong-import-position
+# pylint: disable=missing-function-docstring,missing-class-docstring
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import collect_findings as cf  # noqa: E402  # pyright: ignore[reportMissingImports]
+
+
+def _write(dir_path: Path, name: str, content: str) -> Path:
+    """Helper: write a sanitizer log fixture and return its path."""
+    p = dir_path / name
+    p.write_text(content)
+    return p
+
+
+# Realistic UBSan one-liner (the column part is optional in the wild).
+UBSAN_LINE = (
+    "src/util/foo.cpp:42:7: runtime error: signed integer overflow: "
+    "2147483647 + 1 cannot be represented in type 'int'\n")
+
+# Realistic multi-line ASan report.
+ASAN_REPORT = """\
+==12345==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xdeadbeef at pc 0xabc
+READ of size 4 at 0xdeadbeef thread T0
+    #0 0x123456 in foo() src/foo.cc:42:3
+    #1 0x789abc in main src/main.cc:10:5
+"""
+
+# Realistic LSan report. First #0 is an interceptor (malloc), must be skipped.
+LSAN_REPORT = """\
+==99999==ERROR: LeakSanitizer: detected memory leaks
+
+Direct leak of 16 byte(s) in 1 object(s) allocated from:
+    #0 0xaaaa in malloc /usr/lib/llvm/asan_interceptors.cpp:707:3
+    #1 0xbbbb in build_payload() src/payload.cc:88:13
+    #2 0xcccc in main src/main.cc:3:5
+"""
+
+
+def _tail_iter(text: str):
+    """Yield every line of ``text`` after the first (which is the
+    sanitizer header) — matching what parse_log feeds to
+    _first_user_frame in production."""
+    lines = text.splitlines()
+    return iter(lines[1:])
+
+
+class FrameParsing(unittest.TestCase):
+    """_first_user_frame walks past allocator interceptors."""
+
+    def test_skips_allocator_interceptor(self):
+        loc = cf._first_user_frame(_tail_iter(LSAN_REPORT))
+        self.assertEqual(loc, "src/payload.cc:88:13")
+
+    def test_returns_first_frame_when_no_interceptor(self):
+        loc = cf._first_user_frame(_tail_iter(ASAN_REPORT))
+        self.assertEqual(loc, "src/foo.cc:42:3")
+
+    def test_returns_symbol_when_location_missing(self):
+        # Synthesised: a frame with no file:line suffix.
+        loc = cf._first_user_frame(iter(["    #0 0xa in mystery_symbol", ""]))
+        self.assertEqual(loc, "mystery_symbol")
+
+    def test_falls_back_when_no_frame_at_all(self):
+        loc = cf._first_user_frame(iter(["", ""]))
+        self.assertEqual(loc, "<no frame>")
+
+    def test_allocator_prefix_matching(self):
+        # Reviewer's case: `operator new(unsigned long)` symbolises with
+        # `sym == "operator"` because of the \S+ capture; the prefix
+        # check must still treat it as an allocator.
+        self.assertTrue(cf._is_allocator("operator"))
+        self.assertTrue(cf._is_allocator("__interceptor_malloc"))
+        self.assertTrue(cf._is_allocator("malloc"))
+        self.assertFalse(cf._is_allocator("my_function"))
+
+
+class ParseLog(unittest.TestCase):
+    """parse_log extracts UBSan, ASan, and LSan findings from a file."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_ubsan_oneliner(self):
+        f = _write(self.dir, "sanitizer.100", UBSAN_LINE)
+        findings = cf.parse_log(f)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].tool, "UBSan")
+        self.assertEqual(findings[0].kind, "signed integer overflow")
+        self.assertEqual(findings[0].location, "src/util/foo.cpp:42:7")
+
+    def test_asan_report(self):
+        f = _write(self.dir, "sanitizer.101", ASAN_REPORT)
+        findings = cf.parse_log(f)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].tool, "ASan")
+        self.assertEqual(findings[0].kind, "heap-buffer-overflow")
+        self.assertEqual(findings[0].location, "src/foo.cc:42:3")
+
+    def test_lsan_report(self):
+        f = _write(self.dir, "sanitizer.102", LSAN_REPORT)
+        findings = cf.parse_log(f)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].tool, "LSan")
+        # LSan headers have no quantitative tail; the regex grabs everything
+        # after the tool name.
+        self.assertIn("detected", findings[0].kind.lower() + " memory leaks")
+        self.assertEqual(findings[0].location, "src/payload.cc:88:13")
+
+    def test_mixed_file(self):
+        f = _write(self.dir, "sanitizer.103", UBSAN_LINE + ASAN_REPORT)
+        findings = cf.parse_log(f)
+        tools = sorted(f.tool for f in findings)
+        self.assertEqual(tools, ["ASan", "UBSan"])
+
+    def test_unreadable_file_returns_empty(self):
+        # Point parse_log at a directory rather than a file; open raises.
+        findings = cf.parse_log(self.dir)
+        self.assertEqual(findings, [])
+
+    def test_asan_header_with_parenthesised_qualifier(self):
+        # Regression: alloc-dealloc-mismatch headers carry a parenthesised
+        # qualifier between the kind and the address. The previous regex
+        # required ` on ` or ` detected` directly after the kind, dropping
+        # this entire class of findings — the silent-miss the design was
+        # meant to prevent.
+        report = ("==1==ERROR: AddressSanitizer: alloc-dealloc-mismatch "
+                  "(operator new vs free) on 0xdeadbeef\n"
+                  "    #0 0x1 in operator new(unsigned long) /lib/new.cc:9\n"
+                  "    #1 0x2 in user_fn() src/code.cc:55:1\n")
+        f = _write(self.dir, "sanitizer.200", report)
+        findings = cf.parse_log(f)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].kind, "alloc-dealloc-mismatch")
+        self.assertEqual(findings[0].location, "src/code.cc:55:1")
+
+    def test_ubsan_line_with_leading_prefix(self):
+        # CTest can prefix lines with the test name; the parser must
+        # still pick the finding up.
+        line = "[123/456] " + UBSAN_LINE
+        f = _write(self.dir, "sanitizer.201", line)
+        findings = cf.parse_log(f)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].tool, "UBSan")
+
+    def test_oversized_log_is_skipped(self):
+        big = self.dir / "sanitizer.300"
+        # Cap is 64 MiB; produce a file just over it cheaply via seek.
+        with big.open("wb") as fh:
+            fh.seek(cf._MAX_LOG_BYTES + 1)
+            fh.write(b"\0")
+        findings = cf.parse_log(big)
+        self.assertEqual(findings, [])
+
+    def test_duplicates_within_one_log(self):
+        # Two identical UBSan lines in one log must yield two Findings
+        # (Counter then collapses them); pin the parser contract.
+        f = _write(self.dir, "sanitizer.301", UBSAN_LINE + UBSAN_LINE)
+        findings = cf.parse_log(f)
+        self.assertEqual(len(findings), 2)
+        self.assertEqual(findings[0], findings[1])
+
+
+class Collect(unittest.TestCase):
+    """collect walks the directory in sorted order, ignores other files."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_missing_directory(self):
+        self.assertEqual(cf.collect(Path("/no/such/path/xyz")), [])
+
+    def test_skips_non_sanitizer_files(self):
+        _write(self.dir, "unrelated.log", UBSAN_LINE)
+        self.assertEqual(cf.collect(self.dir), [])
+
+    def test_picks_up_sanitizer_prefix_only(self):
+        _write(self.dir, "sanitizer.100", UBSAN_LINE)
+        _write(self.dir, "sanitizer.200", ASAN_REPORT)
+        findings = cf.collect(self.dir)
+        self.assertEqual(len(findings), 2)
+
+
+class Render(unittest.TestCase):
+    """render_markdown dedups and sorts by descending count."""
+
+    def test_empty(self):
+        out = cf.render_markdown([])
+        self.assertIn("No findings", out)
+
+    def test_dedup_counts(self):
+        f = cf.Finding("UBSan", "shift", "src/a.cc:1")
+        out = cf.render_markdown([f, f, f])
+        self.assertIn("| 3 | UBSan | shift | `src/a.cc:1` |", out)
+        self.assertIn("1 unique finding(s); 3 total occurrence(s).", out)
+
+    def test_sort_descending_then_lex(self):
+        many = cf.Finding("UBSan", "shift", "src/a.cc:1")
+        once = cf.Finding("ASan", "heap-buffer-overflow", "src/b.cc:1")
+        out = cf.render_markdown([many, many, once])
+        # The "many" row appears before the "once" row in the table body.
+        many_pos = out.index("| 2 | UBSan |")
+        once_pos = out.index("| 1 | ASan |")
+        self.assertLess(many_pos, once_pos)
+
+
+class WriteSummary(unittest.TestCase):
+    """write_summary appends to $GITHUB_STEP_SUMMARY when set."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self._prior = os.environ.get("GITHUB_STEP_SUMMARY")
+
+    def tearDown(self):
+        if self._prior is None:
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
+        else:
+            os.environ["GITHUB_STEP_SUMMARY"] = self._prior
+        self.tmp.cleanup()
+
+    def test_appends_when_env_set(self):
+        summary_file = self.dir / "summary.md"
+        os.environ["GITHUB_STEP_SUMMARY"] = str(summary_file)
+        cf.write_summary("hello world")
+        self.assertEqual(summary_file.read_text(), "hello world\n")
+        # Second call appends rather than overwrites.
+        cf.write_summary("again\n")
+        self.assertEqual(summary_file.read_text(), "hello world\nagain\n")
+
+    def test_no_env_means_stdout_only(self):
+        os.environ.pop("GITHUB_STEP_SUMMARY", None)
+        # Should not raise.
+        cf.write_summary("stdout-only\n")
+
+
+class Main(unittest.TestCase):
+    """CLI: positional arg, env-var fallback, exit codes."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self._prior_env = os.environ.get("ESBMC_SANITIZER_LOG_DIR")
+        self._prior_sum = os.environ.get("GITHUB_STEP_SUMMARY")
+        os.environ.pop("ESBMC_SANITIZER_LOG_DIR", None)
+        os.environ.pop("GITHUB_STEP_SUMMARY", None)
+
+    def tearDown(self):
+        for k, v in (
+            ("ESBMC_SANITIZER_LOG_DIR", self._prior_env),
+            ("GITHUB_STEP_SUMMARY", self._prior_sum),
+        ):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self.tmp.cleanup()
+
+    def test_exit_zero_when_clean(self):
+        # Empty directory → exit 0.
+        rc = cf.main([str(self.dir)])
+        self.assertEqual(rc, 0)
+
+    def test_exit_one_when_findings(self):
+        _write(self.dir, "sanitizer.500", UBSAN_LINE)
+        rc = cf.main([str(self.dir)])
+        self.assertEqual(rc, 1)
+
+    def test_env_fallback(self):
+        _write(self.dir, "sanitizer.501", UBSAN_LINE)
+        os.environ["ESBMC_SANITIZER_LOG_DIR"] = str(self.dir)
+        rc = cf.main([])
+        self.assertEqual(rc, 1)
+
+    def test_missing_arg_errors(self):
+        with self.assertRaises(SystemExit) as ctx:
+            cf.main([])
+        # argparse calls parser.error → SystemExit(2)
+        self.assertEqual(ctx.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sanitizers/ubsan-suppressions.txt
+++ b/scripts/sanitizers/ubsan-suppressions.txt
@@ -1,0 +1,14 @@
+# UndefinedBehaviorSanitizer suppressions for ESBMC.
+#
+# Format: one rule per line, comments start with '#'.
+#   <check-name>:<source-path-substring>
+# Common check names: signed-integer-overflow, unsigned-integer-overflow,
+# alignment, null, vla-bound, shift, integer-divide-by-zero, bool, enum,
+# float-cast-overflow, float-divide-by-zero, function, return,
+# vptr, implicit-conversion, nullability-arg, nullability-assign,
+# nullability-return.
+#
+# Keep each rule paired with the issue that tracks the underlying bug.
+# See: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#runtime-suppressions
+#
+# (empty — populated as the bring-up CI run surfaces findings)


### PR DESCRIPTION
Add a GitHub Actions workflow that builds ESBMC under clang's ASan and
UBSan, runs the CORE regression suite under each, deduplicates the
diagnostics into a job-summary table, and uploads the raw logs as a
30-day artifact. Bring-up uses continue-on-error while the suppression
files are populated.

Fixes #223
