### PR TITLE
[esbmc] map deadlock-check assertions to CWE-833

### DIFF
--- a/docs/cwe-mapping.md
+++ b/docs/cwe-mapping.md
@@ -6,10 +6,10 @@ to **MITRE CWE 4.20** (published 2024-11-19,
 <https://cwe.mitre.org/data/index.html>) and only retains ids whose
 Vulnerability Mapping Usage is `ALLOWED` or `ALLOWED-WITH-REVIEW`.
 
-ESBMC currently distinguishes **28 unique CWE identifiers** across
-**23 violation kinds**: CWE-120, 121, 125, 129, 131, 190, 191, 193,
+ESBMC currently distinguishes **29 unique CWE identifiers** across
+**24 violation kinds**: CWE-120, 121, 125, 129, 131, 190, 191, 193,
 362, 366, 369, 401, 415, 416, 469, 476, 562, 590, 617, 681, 761,
-787, 822, 823, 824, 825, 908, 1335.
+787, 822, 823, 824, 825, 833, 908, 1335.
 
 The CWE ids appear in:
 
@@ -51,6 +51,7 @@ first-match-wins substring table ordered longest-substring-first.
 | `undefined behavior on shift operation`                        | 1335                              |
 | `atomicity violation`                                          | 362, 366                          |
 | `data race on`                                                 | 362, 366                          |
+| `Deadlocked state`                                             | 833                               |
 | `unreachable code reached`                                     | 617                               |
 | `recursion unwinding assertion` / `unwinding assertion loop`   | *(none — k-bound exceeded, not a weakness)* |
 

--- a/regression/esbmc-unix/cwe_deadlock/main.c
+++ b/regression/esbmc-unix/cwe_deadlock/main.c
@@ -1,0 +1,34 @@
+#include <pthread.h>
+
+static pthread_mutex_t a = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t b = PTHREAD_MUTEX_INITIALIZER;
+
+static void *t1(void *_)
+{
+  (void)_;
+  pthread_mutex_lock(&a);
+  pthread_mutex_lock(&b);
+  pthread_mutex_unlock(&b);
+  pthread_mutex_unlock(&a);
+  return 0;
+}
+
+static void *t2(void *_)
+{
+  (void)_;
+  pthread_mutex_lock(&b);
+  pthread_mutex_lock(&a);
+  pthread_mutex_unlock(&a);
+  pthread_mutex_unlock(&b);
+  return 0;
+}
+
+int main(void)
+{
+  pthread_t p1, p2;
+  pthread_create(&p1, 0, t1, 0);
+  pthread_create(&p2, 0, t2, 0);
+  pthread_join(p1, 0);
+  pthread_join(p2, 0);
+  return 0;
+}

--- a/regression/esbmc-unix/cwe_deadlock/test.desc
+++ b/regression/esbmc-unix/cwe_deadlock/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--unwind 3 --context-bound 3 --deadlock-check
+^VERIFICATION FAILED$
+^  Deadlocked state in pthread_mutex_lock$
+^  CWE: CWE-833$

--- a/src/util/cwe_mapping.cpp
+++ b/src/util/cwe_mapping.cpp
@@ -95,6 +95,7 @@ const std::vector<entry_t> &rules_table()
       {"atomicity violation",
        {"atomicity-violation", "Atomicity violation", {362, 366}}},
       {"data race on", {"data-race", "Data race", {362, 366}}},
+      {"Deadlocked state", {"deadlock", "Deadlock", {833}}},
       // Reachability.
       {"unreachable code reached",
        {"reachable-error", "Reachable error/assertion", {617}}},
@@ -146,6 +147,7 @@ const std::map<unsigned, std::string_view> &names_map()
     {823, "Use of Out-of-range Pointer Offset"},
     {824, "Access of Uninitialized Pointer"},
     {825, "Expired Pointer Dereference"},
+    {833, "Deadlock"},
     {908, "Use of Uninitialized Resource"},
     {1335, "Incorrect Bitwise Shift of Integer"},
   };

--- a/unit/util/cwe_mapping.test.cpp
+++ b/unit/util/cwe_mapping.test.cpp
@@ -73,6 +73,15 @@ TEST_CASE("cwe_for matches data race", "[util][cwe_mapping]")
   REQUIRE(cwe_for("data race on x") == std::vector<unsigned>{362, 366});
 }
 
+TEST_CASE("cwe_for matches deadlock", "[util][cwe_mapping]")
+{
+  REQUIRE(
+    cwe_for("Deadlocked state in pthread_mutex_lock") ==
+    std::vector<unsigned>{833});
+  REQUIRE(
+    cwe_for("Deadlocked state in pthread_join") == std::vector<unsigned>{833});
+}
+
 TEST_CASE("cwe_for returns empty on unknown comment", "[util][cwe_mapping]")
 {
   REQUIRE(cwe_for("").empty());
@@ -95,6 +104,7 @@ TEST_CASE("cwe_name resolves known ids", "[util][cwe_mapping]")
   REQUIRE(cwe_name(190) == "Integer Overflow or Wraparound");
   REQUIRE(cwe_name(369) == "Divide By Zero");
   REQUIRE(cwe_name(617) == "Reachable Assertion");
+  REQUIRE(cwe_name(833) == "Deadlock");
   // Unknown id returns empty view.
   REQUIRE(cwe_name(0).empty());
   REQUIRE(cwe_name(99999).empty());
@@ -156,6 +166,7 @@ TEST_CASE(
         "undefined behavior on shift operation",
         "atomicity violation",
         "data race on x",
+        "Deadlocked state in pthread_mutex_lock",
         "unreachable code reached",
         ""})
   {
@@ -187,6 +198,7 @@ TEST_CASE(
         "division by zero",
         "atomicity violation",
         "data race on x",
+        "Deadlocked state in pthread_mutex_lock",
         "Access to object out of bounds",
         "dereference failure: memset of memory segment of size 4",
         "undefined behavior on shift operation"})


### PR DESCRIPTION
## Summary
Maps ESBMC's existing `--deadlock-check` assertions to **CWE-833** (Deadlock, `ALLOWED` in CWE 4.20). The pthread / semaphore operational models already emit four `Deadlocked state ...` assertions; adding one substring rule plus one taxonomy entry to `util/cwe_mapping` now surfaces them as CWE-833 in textual / JSON / GraphML / SARIF output. No OM changes required.

Fixes #4489

## Test plan
- [x] New unit test cases — `cwe_for` returns `{833}` for the deadlock comment family; `cwe_name(833) == "Deadlock"`; the simpleName-validity and id-coverage matrices both gain the deadlock comment. 15 cases / 551 assertions pass.
- [x] New regression test `regression/esbmc-unix/cwe_deadlock` — minimal AB-BA two-thread mutex deadlock with `--unwind 3 --context-bound 3 --deadlock-check`; expects `VERIFICATION FAILED`, the comment, and the `CWE: CWE-833` line.
- [x] Existing `regression/esbmc-unix/01_cond_0{2,5,6}` pthread tests still pass — the extra `CWE:` line is purely additive and their `^VERIFICATION FAILED$` anchor is unaffected.
- [x] Existing `regression/esbmc/cwe_{null_deref,overflow,sarif}` tests still pass.
- [x] SARIF smoke confirmed: `ruleId: "deadlock"`, `result.taxa.id: "833"`, taxonomy lists CWE-833 with `helpUri`.
