### PR TITLE
[docs] move CWE mapping into Hugo website

### DIFF
--- a/website/content/docs/_index.md
+++ b/website/content/docs/_index.md
@@ -28,6 +28,11 @@ next: /docs/setup
   <li>Memory leak.</li>
 </ul>
 
+<p>Each reported violation is annotated with the matching Common Weakness
+Enumeration identifiers (MITRE CWE 4.20). See the
+<a href="/docs/cwe-mapping/">CWE Mapping</a> page for the full table and the
+SARIF output schema.</p>
+
 <p>Concurrent software (using the pthread API) is verified by explicitly exploring interleavings, thus producing one symbolic execution per interleaving. By default, pointer-safety, array-out-of-bounds, division-by-zero, and user-specified assertions  will be checked for; one can also specify options to check multi-threaded programs for:</p>
 
 <ul>

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -1,4 +1,7 @@
-# CWE Mapping for ESBMC Property Violations
+---
+title: CWE Mapping
+weight: 12
+---
 
 ESBMC annotates every reported property violation with the matching
 Common Weakness Enumeration (CWE) identifiers. The mapping is pinned


### PR DESCRIPTION
Relocates the standalone CWE mapping reference from docs/ into the Hugo content tree at website/content/docs/cwe-mapping.md so it is rendered on the project site instead of living as an unpublished markdown file. Front-matter slots it between Config and the GitHub Action page in the sidebar, and the main docs index now links to it from the ESBMC Features section.