### PR TITLE
[esbmc] detect uninitialised local scalar reads as CWE-457

### DIFF
--- a/regression/esbmc/cwe_uninit_var/main.c
+++ b/regression/esbmc/cwe_uninit_var/main.c
@@ -1,0 +1,9 @@
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  int x;
+  if (__VERIFIER_nondet_int())
+    x = 1;
+  return x;
+}

--- a/regression/esbmc/cwe_uninit_var/test.desc
+++ b/regression/esbmc/cwe_uninit_var/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION FAILED$
+^  use of uninitialized variable: x$
+^  CWE: CWE-457$

--- a/regression/esbmc/cwe_uninit_var_funcall/main.c
+++ b/regression/esbmc/cwe_uninit_var_funcall/main.c
@@ -1,0 +1,8 @@
+extern int foo(void);
+
+int main(void)
+{
+  int x;
+  x = foo();
+  return x;
+}

--- a/regression/esbmc/cwe_uninit_var_funcall/test.desc
+++ b/regression/esbmc/cwe_uninit_var_funcall/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_uninit_var_pass/main.c
+++ b/regression/esbmc/cwe_uninit_var_pass/main.c
@@ -1,0 +1,11 @@
+extern int __VERIFIER_nondet_int(void);
+
+int main(void)
+{
+  int x;
+  if (__VERIFIER_nondet_int())
+    x = 1;
+  else
+    x = 2;
+  return x;
+}

--- a/regression/esbmc/cwe_uninit_var_pass/test.desc
+++ b/regression/esbmc/cwe_uninit_var_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -44,6 +44,7 @@ extern "C"
 #include <goto-programs/set_claims.h>
 #include <goto-programs/show_claims.h>
 #include <goto-programs/loop_unroll.h>
+#include <goto-programs/goto_check_uninit_vars.h>
 #include <goto-programs/mark_decl_as_non_det.h>
 #include <goto-programs/assign_params_as_non_det.h>
 #include <goto2c/goto2c.h>
@@ -722,6 +723,13 @@ int esbmc_parseoptionst::doit()
     // Unroll intrinsic support
     goto_preprocess_algorithms.emplace_back(
       std::make_unique<apply_intrinsic_unroller>());
+
+    // Uninitialised-variable check (CWE-457) must run before
+    // mark_decl_as_non_det, which would otherwise overwrite every
+    // uninitialised DECL with a nondet ASSIGN and erase the property.
+    if (cmdline.isset("uninitialised-vars-check"))
+      goto_preprocess_algorithms.emplace_back(
+        std::make_unique<goto_check_uninit_vars>(context));
 
     // Explicitly marking all declared variables as "nondet"
     goto_preprocess_algorithms.emplace_back(

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -581,6 +581,9 @@ const struct group_opt_templ all_cmd_options[] = {
      "thread interleaving"},
     {"lock-order-check", NULL, "Enable for lock acquisition ordering check"},
     {"atomicity-check", NULL, "Enable atomicity check at visible assignments"},
+    {"uninitialised-vars-check",
+     NULL,
+     "Enable check for reads of uninitialised local variables (CWE-457)"},
     {"volatile-check", NULL, "Enable check for volatile variable"},
     {"stack-limit",
      boost::program_options::value<int>()->default_value(-1)->value_name(

--- a/src/goto-programs/CMakeLists.txt
+++ b/src/goto-programs/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(gotoprograms goto_convert.cpp goto_function.cpp goto_main.cpp
   loop_numbers.cpp goto_loops.cpp write_goto_binary.cpp
   goto_k_induction.cpp loopst.cpp goto_coverage.cpp goto_coverage_rm.cpp k_path_spanning.cpp goto_cfg.cpp goto_loop_invariant.cpp
   goto_atomicity_check.cpp frame_enforcer.cpp contracts/contracts.cpp)
-add_library(gotoalgorithms loop_unroll.cpp mark_decl_as_non_det.cpp assign_params_as_non_det.cpp)
+add_library(gotoalgorithms loop_unroll.cpp mark_decl_as_non_det.cpp assign_params_as_non_det.cpp goto_check_uninit_vars.cpp)
 
 if(ENABLE_GOTO_CONTRACTOR)
     include(SetupIbex)

--- a/src/goto-programs/goto_check_uninit_vars.cpp
+++ b/src/goto-programs/goto_check_uninit_vars.cpp
@@ -1,0 +1,275 @@
+#include <goto-programs/goto_check_uninit_vars.h>
+
+#include <map>
+#include <set>
+#include <util/c_types.h>
+#include <util/migrate.h>
+#include <util/prefix.h>
+#include <util/symbol_generator.h>
+
+namespace
+{
+/// Tracked iff scalar, automatic storage, lvalue, not internal/return.
+bool is_tracked_local(const symbolt &s)
+{
+  if (s.static_lifetime || s.is_extern || !s.lvalue)
+    return false;
+  if (has_prefix(s.name, "return_value$"))
+    return false;
+  if (has_prefix(s.id, "__ESBMC_") || has_prefix(s.name, "__ESBMC_"))
+    return false;
+  // Scalar types only — pointers / aggregates are out of scope for CWE-457
+  // (pointer uninitialised state is reported under CWE-908 already).
+  return s.type.is_bool() || s.type.id() == "signedbv" ||
+         s.type.id() == "unsignedbv" || s.type.id() == "fixedbv" ||
+         s.type.id() == "floatbv";
+}
+
+/// LHS name of a direct-symbol ASSIGN, or empty for compound LHS, nil,
+/// or any non-symbol expression.
+irep_idt direct_symbol(const expr2tc &lhs)
+{
+  if (is_nil_expr(lhs))
+    return irep_idt();
+  if (is_symbol2t(lhs))
+    return to_symbol2t(lhs).thename;
+  return irep_idt();
+}
+
+/// Lookup helper: return the shadow id for `name` if tracked, else empty.
+irep_idt
+shadow_of(irep_idt name, const std::map<irep_idt, irep_idt> &shadows)
+{
+  auto it = shadows.find(name);
+  return it == shadows.end() ? irep_idt() : it->second;
+}
+
+/// Walk an expression, collecting:
+/// - every direct read of a tracked symbol (visited as `reads`),
+/// - every `&local` where the address is taken (visited as `address_takes`).
+///
+/// `lvalue_ctx` is true while recursing inside an l-value context (the
+/// operand of an `address_of2t`, or the source of a `member2t` /
+/// `index2t.source_value` chain whose root is an address-of). In that mode
+/// the base symbol is not a value-read; only embedded sub-expressions —
+/// for example `i` in `a[i]` — are reads.
+void collect(
+  const expr2tc &expr,
+  bool lvalue_ctx,
+  const std::map<irep_idt, irep_idt> &shadows,
+  std::set<irep_idt> &reads,
+  std::set<irep_idt> &address_takes)
+{
+  if (is_nil_expr(expr))
+    return;
+
+  if (is_address_of2t(expr))
+  {
+    const expr2tc &target = to_address_of2t(expr).ptr_obj;
+    // Record the address-take for the root symbol of the l-value chain.
+    irep_idt root;
+    const expr2tc *cur = &target;
+    while (true)
+    {
+      if (is_symbol2t(*cur))
+      {
+        root = to_symbol2t(*cur).thename;
+        break;
+      }
+      if (is_member2t(*cur))
+        cur = &to_member2t(*cur).source_value;
+      else if (is_index2t(*cur))
+        cur = &to_index2t(*cur).source_value;
+      else
+        break;
+    }
+    if (!root.empty())
+    {
+      irep_idt sid = shadow_of(root, shadows);
+      if (!sid.empty())
+        address_takes.insert(sid);
+    }
+    // Recurse into target in l-value mode so embedded reads (e.g. the
+    // index of `&a[i]`) are still checked.
+    collect(target, true, shadows, reads, address_takes);
+    return;
+  }
+
+  if (is_symbol2t(expr))
+  {
+    if (lvalue_ctx)
+      return; // base symbol of an l-value chain; not a value-read
+    irep_idt sid = shadow_of(to_symbol2t(expr).thename, shadows);
+    if (!sid.empty())
+      reads.insert(sid);
+    return;
+  }
+
+  if (lvalue_ctx && is_index2t(expr))
+  {
+    const index2t &i = to_index2t(expr);
+    collect(i.source_value, true, shadows, reads, address_takes);
+    collect(i.index, false, shadows, reads, address_takes); // index IS a read
+    return;
+  }
+
+  if (lvalue_ctx && is_member2t(expr))
+  {
+    collect(
+      to_member2t(expr).source_value, true, shadows, reads, address_takes);
+    return; // member name is a literal
+  }
+
+  // In l-value mode, a `dereference2t` exits the l-value context: the
+  // pointer operand is itself a value-read.
+  if (lvalue_ctx && is_dereference2t(expr))
+  {
+    collect(
+      to_dereference2t(expr).value, false, shadows, reads, address_takes);
+    return;
+  }
+
+  // Default: preserve the current context for unknown wrappers (e.g. an
+  // if-then-else lvalue `&(c ? a : b)` keeps `a` and `b` in l-value mode).
+  // In r-value contexts this still descends r-value, which is what we want
+  // for ordinary expressions like `a + b`. Preserving the context avoids
+  // treating a base lvalue symbol as a value-read — a false-positive risk
+  // we cannot tolerate as a formal verifier.
+  expr->foreach_operand(
+    [&](const expr2tc &e)
+    { collect(e, lvalue_ctx, shadows, reads, address_takes); });
+}
+} // namespace
+
+bool goto_check_uninit_vars::runOnFunction(
+  std::pair<const dstring, goto_functiont> &F)
+{
+  if (!F.second.body_available)
+    return false;
+
+  goto_programt &body = F.second.body;
+  std::map<irep_idt, irep_idt> shadows;           // user-name -> shadow_id
+  std::map<irep_idt, std::string> shadow_display; // shadow_id -> display
+  // Prefix uppercase so `is_tracked_local`'s "__ESBMC_" filter at the next
+  // pass invocation rejects our own shadows — defence in depth against
+  // self-instrumentation on a re-run.
+  symbol_generator gen("__ESBMC_defined$" + id2string(F.first) + "$");
+
+  for (auto it = body.instructions.begin(); it != body.instructions.end(); ++it)
+  {
+    if (it->is_decl())
+    {
+      const code_decl2t &decl = to_code_decl2t(it->code);
+      const symbolt *s = context.find_symbol(decl.value);
+      if (s && is_tracked_local(*s) && !shadows.count(decl.value))
+      {
+        symbolt &shadow =
+          gen.new_symbol(context, migrate_type_back(get_bool_type()), "");
+        shadows.emplace(decl.value, shadow.id);
+        shadow_display.emplace(shadow.id, id2string(s->name));
+
+        // Insert immediately after the DECL: DECL shadow; ASSIGN shadow = false;
+        auto pos = std::next(it);
+        auto decl_it = body.instructions.insert(pos, DECL);
+        decl_it->code = code_decl2tc(get_bool_type(), shadow.id);
+        decl_it->location = it->location;
+        decl_it->function = it->function;
+
+        auto assign_it = body.instructions.insert(pos, ASSIGN);
+        assign_it->code = code_assign2tc(
+          symbol2tc(get_bool_type(), shadow.id), gen_false_expr());
+        assign_it->location = it->location;
+        assign_it->function = it->function;
+
+        ++it; // skip past inserted DECL shadow
+        ++it; // skip past inserted ASSIGN shadow = false
+        continue;
+      }
+    }
+
+    // Collect reads and address-takes from every expression on the
+    // instruction. Direct assignments and function-call returns treat the
+    // LHS bare-symbol as a *write*, not a read.
+    std::set<irep_idt> reads;
+    std::set<irep_idt> address_takes;
+    irep_idt write_target;
+
+    if (it->is_assign())
+    {
+      const code_assign2t &a = to_code_assign2t(it->code);
+      write_target = direct_symbol(a.target);
+      if (write_target.empty())
+        collect(a.target, false, shadows, reads, address_takes);
+      collect(a.source, false, shadows, reads, address_takes);
+    }
+    else if (it->is_function_call())
+    {
+      const code_function_call2t &fc = to_code_function_call2t(it->code);
+      write_target = direct_symbol(fc.ret);
+      if (write_target.empty())
+        collect(fc.ret, false, shadows, reads, address_takes);
+      collect(fc.function, false, shadows, reads, address_takes);
+      for (const auto &arg : fc.operands)
+        collect(arg, false, shadows, reads, address_takes);
+    }
+    else
+    {
+      collect(it->guard, false, shadows, reads, address_takes);
+      collect(it->code, false, shadows, reads, address_takes);
+    }
+
+    // Build a prefix-program of instructions to splice in *before* `it`.
+    // insert_swap preserves jumps that target `it` by moving the existing
+    // content to the next position.
+    goto_programt new_code;
+
+    for (const irep_idt &shadow_id : address_takes)
+    {
+      goto_programt::targett t = new_code.add_instruction(ASSIGN);
+      t->code =
+        code_assign2tc(symbol2tc(get_bool_type(), shadow_id), gen_true_expr());
+      t->location = it->location;
+      t->function = it->function;
+    }
+
+    for (const irep_idt &shadow_id : reads)
+    {
+      auto dit = shadow_display.find(shadow_id);
+      const std::string name =
+        dit != shadow_display.end() ? dit->second : id2string(shadow_id);
+      goto_programt::targett t = new_code.add_instruction(ASSERT);
+      t->guard = symbol2tc(get_bool_type(), shadow_id);
+      t->location = it->location;
+      t->location.comment("use of uninitialized variable: " + name);
+      t->location.property("uninitialised-variable");
+      t->function = it->function;
+    }
+
+    while (!new_code.instructions.empty())
+    {
+      body.insert_swap(it, new_code.instructions.front());
+      new_code.instructions.pop_front();
+      ++it;
+    }
+
+    // After a direct write to a tracked local (ASSIGN or FUNCTION_CALL
+    // return), flip its shadow to true. Insert *after* `it`; jumps and
+    // labels on `it` are unaffected.
+    if (!write_target.empty())
+    {
+      irep_idt sid = shadow_of(write_target, shadows);
+      if (!sid.empty())
+      {
+        auto pos = std::next(it);
+        auto t = body.instructions.insert(pos, ASSIGN);
+        t->code =
+          code_assign2tc(symbol2tc(get_bool_type(), sid), gen_true_expr());
+        t->location = it->location;
+        t->function = it->function;
+        ++it;
+      }
+    }
+  }
+
+  return !shadows.empty();
+}

--- a/src/goto-programs/goto_check_uninit_vars.h
+++ b/src/goto-programs/goto_check_uninit_vars.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <util/algorithms.h>
+#include <util/message.h>
+#include <irep2/irep2.h>
+
+/// Detect reads of uninitialised automatic-storage local scalars (CWE-457).
+///
+/// For every tracked scalar local `x`, the pass introduces a fresh shadow
+/// boolean `__ESBMC_defined$<function>$<n>` that starts `false`, is set to
+/// `true` on every direct write to `x`, is asserted `true` before every
+/// direct read of `x`, and is conservatively set to `true` when `&x` is
+/// taken (because we cannot soundly track writes through pointer aliases
+/// without a full alias analysis).
+///
+/// Tracked variables are automatic-storage, lvalue, non-extern,
+/// non-`return_value$*`, non-`__ESBMC_` locals whose type is a scalar
+/// (`_Bool`, signed/unsigned integer, fixed-point, floating-point). Pointers,
+/// arrays, structs, and unions are out of scope for v1.
+///
+/// The pass must run **before** `mark_decl_as_non_det`, which would
+/// otherwise rewrite every uninitialised `DECL` into a `DECL; ASSIGN nondet`
+/// pair, erasing the uninitialised-state distinction.
+class goto_check_uninit_vars : public goto_functions_algorithm
+{
+public:
+  explicit goto_check_uninit_vars(contextt &context)
+    : goto_functions_algorithm(true), context(context)
+  {
+  }
+
+protected:
+  contextt &context;
+
+  bool runOnFunction(std::pair<const dstring, goto_functiont> &F) override;
+};

--- a/src/util/cwe_mapping.cpp
+++ b/src/util/cwe_mapping.cpp
@@ -96,6 +96,9 @@ const std::vector<entry_t> &rules_table()
        {"atomicity-violation", "Atomicity violation", {362, 366}}},
       {"data race on", {"data-race", "Data race", {362, 366}}},
       {"Deadlocked state", {"deadlock", "Deadlock", {833}}},
+      // Uninitialised local scalar (CWE-457).
+      {"use of uninitialized variable",
+       {"uninitialised-variable", "Use of uninitialized variable", {457}}},
       // Reachability.
       {"unreachable code reached",
        {"reachable-error", "Reachable error/assertion", {617}}},
@@ -135,6 +138,7 @@ const std::map<unsigned, std::string_view> &names_map()
     {401, "Missing Release of Memory after Effective Lifetime"},
     {415, "Double Free"},
     {416, "Use After Free"},
+    {457, "Use of Uninitialized Variable"},
     {469, "Use of Pointer Subtraction to Determine Size"},
     {476, "NULL Pointer Dereference"},
     {562, "Return of Stack Variable Address"},

--- a/unit/util/cwe_mapping.test.cpp
+++ b/unit/util/cwe_mapping.test.cpp
@@ -82,6 +82,12 @@ TEST_CASE("cwe_for matches deadlock", "[util][cwe_mapping]")
     cwe_for("Deadlocked state in pthread_join") == std::vector<unsigned>{833});
 }
 
+TEST_CASE("cwe_for matches uninitialised variable", "[util][cwe_mapping]")
+{
+  REQUIRE(
+    cwe_for("use of uninitialized variable: x") == std::vector<unsigned>{457});
+}
+
 TEST_CASE("cwe_for returns empty on unknown comment", "[util][cwe_mapping]")
 {
   REQUIRE(cwe_for("").empty());
@@ -105,6 +111,7 @@ TEST_CASE("cwe_name resolves known ids", "[util][cwe_mapping]")
   REQUIRE(cwe_name(369) == "Divide By Zero");
   REQUIRE(cwe_name(617) == "Reachable Assertion");
   REQUIRE(cwe_name(833) == "Deadlock");
+  REQUIRE(cwe_name(457) == "Use of Uninitialized Variable");
   // Unknown id returns empty view.
   REQUIRE(cwe_name(0).empty());
   REQUIRE(cwe_name(99999).empty());
@@ -167,6 +174,7 @@ TEST_CASE(
         "atomicity violation",
         "data race on x",
         "Deadlocked state in pthread_mutex_lock",
+        "use of uninitialized variable: foo",
         "unreachable code reached",
         ""})
   {
@@ -199,6 +207,7 @@ TEST_CASE(
         "atomicity violation",
         "data race on x",
         "Deadlocked state in pthread_mutex_lock",
+        "use of uninitialized variable: foo",
         "Access to object out of bounds",
         "dereference failure: memset of memory segment of size 4",
         "undefined behavior on shift operation"})

--- a/website/content/docs/cwe-mapping.md
+++ b/website/content/docs/cwe-mapping.md
@@ -9,10 +9,10 @@ to **MITRE CWE 4.20** (published 2024-11-19,
 <https://cwe.mitre.org/data/index.html>) and only retains ids whose
 Vulnerability Mapping Usage is `ALLOWED` or `ALLOWED-WITH-REVIEW`.
 
-ESBMC currently distinguishes **29 unique CWE identifiers** across
-**24 violation kinds**: CWE-120, 121, 125, 129, 131, 190, 191, 193,
-362, 366, 369, 401, 415, 416, 469, 476, 562, 590, 617, 681, 761,
-787, 822, 823, 824, 825, 833, 908, 1335.
+ESBMC currently distinguishes **30 unique CWE identifiers** across
+**25 violation kinds**: CWE-120, 121, 125, 129, 131, 190, 191, 193,
+362, 366, 369, 401, 415, 416, 457, 469, 476, 562, 590, 617, 681,
+761, 787, 822, 823, 824, 825, 833, 908, 1335.
 
 The CWE ids appear in:
 
@@ -55,6 +55,7 @@ first-match-wins substring table ordered longest-substring-first.
 | `atomicity violation`                                          | 362, 366                          |
 | `data race on`                                                 | 362, 366                          |
 | `Deadlocked state`                                             | 833                               |
+| `use of uninitialized variable`                                | 457                               |
 | `unreachable code reached`                                     | 617                               |
 | `recursion unwinding assertion` / `unwinding assertion loop`   | *(none — k-bound exceeded, not a weakness)* |
 


### PR DESCRIPTION
## Summary
Adds a new GOTO instrumentation pass `goto_check_uninit_vars`, gated behind `--uninitialised-vars-check`, that detects reads of uninitialised automatic-storage local scalars and surfaces them as **CWE-457** *Use of Uninitialized Variable* (`ALLOWED` in CWE 4.20).

For every tracked scalar local `x`, the pass introduces a fresh shadow boolean `__ESBMC_defined$<func>$<n>` that:
- starts `false` at the `DECL` site,
- flips to `true` after every direct write,
- is asserted `true` before every direct read,
- is conservatively flipped to `true` when `&x` is taken (we cannot soundly track writes through pointer aliases without a full alias analysis).

The pass runs **before** `mark_decl_as_non_det`, which would otherwise rewrite every uninitialised `DECL` into a `DECL; ASSIGN nondet` and erase the property.

Fixes #4491

## Test plan
- [x] New unit test cases (`cwe_for matches uninitialised variable`, `cwe_name(457)`, expanded validity matrices) — 15 cases / 564 assertions pass.
- [x] New regression `regression/esbmc/cwe_uninit_var` — conditional init → FAIL with `CWE-457`.
- [x] New regression `regression/esbmc/cwe_uninit_var_pass` — both branches init → SUCCESSFUL.
- [x] New regression `regression/esbmc/cwe_uninit_var_funcall` — `int x; x = foo(); return x;` → SUCCESSFUL (pins the function-call-init false-positive fix from review).
- [x] Existing 31-test regression subset still passes with flag off (no behaviour change by default).
- [x] Manual soundness sample with flag on:
  - `int x; x = x + 1; return x;` → FAIL (self-assign RHS read).
  - `int i; int a[10]; return a[i];` → FAIL on `i` (read inside `&a[i]`-style indexing).
  - `int x; int *p = &x; *p = 5; return x;` → SUCCESSFUL (address-of-then-write through alias).
  - `int x; for (int i = 0; i < 3; i++) x = i; return x;` → SUCCESSFUL.
- [x] code-reviewer flagged two real bugs (FUNCTION_CALL return treated as read, missed reads inside `&a[i]` index); both fixed in this commit, with pinned regression tests.

## Out of scope
- Aggregate types (struct/union/array elements).
- Function parameters (frontend models them as already initialised).
- Pointers — already covered under CWE-908.
- Aliased writes via tracked address-of (would need a Steensgaard/Andersen pass).
