### PR TITLE
[k-induction] warn + disable IS for pointer-only loops

### DIFF
--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -2270,7 +2270,7 @@ bool esbmc_parseoptionst::process_goto_program(
       // ASSUME(INV) injected at end of loop body + k-induction (Branch 2).
       remove_no_op(goto_functions);
       goto_loop_invariant_combined(goto_functions);
-      goto_k_induction(goto_functions);
+      goto_k_induction(goto_functions, options);
     }
     else
     {
@@ -2280,7 +2280,7 @@ bool esbmc_parseoptionst::process_goto_program(
         remove_no_op(goto_functions);
 
       if (is_k_induction)
-        goto_k_induction(goto_functions);
+        goto_k_induction(goto_functions, options);
 
       if (cmdline.isset("loop-invariant-check"))
       {

--- a/src/goto-programs/goto_k_induction.cpp
+++ b/src/goto-programs/goto_k_induction.cpp
@@ -5,20 +5,20 @@
 #include <util/i2string.h>
 #include <util/std_expr.h>
 
-void goto_k_induction(goto_functionst &goto_functions)
+void goto_k_induction(goto_functionst &goto_functions, optionst &options)
 {
   Forall_goto_functions (it, goto_functions)
     if (it->second.body_available)
-      goto_k_inductiont(it->first, goto_functions, it->second);
+      goto_k_inductiont(it->first, goto_functions, it->second, options);
 
   goto_functions.update();
 }
 
-void goto_termination(goto_functionst &goto_functions)
+void goto_termination(goto_functionst &goto_functions, optionst &options)
 {
   Forall_goto_functions (it, goto_functions)
     if (it->second.body_available)
-      goto_k_inductiont(it->first, goto_functions, it->second);
+      goto_k_inductiont(it->first, goto_functions, it->second, options);
   goto_functions.update();
 
   auto function = goto_functions.function_map.find("__ESBMC_main");
@@ -64,7 +64,32 @@ void goto_k_inductiont::goto_k_induction()
     if (
       config.options.get_bool_option("add-symex-value-sets") &&
       function_loop.contains_only_pointers())
+    {
+      // The loop's only modified vars are pointers. Under
+      // --add-symex-value-sets the nondet havoc for pointers is suppressed
+      // (make_nondet_assign skips pointer LHSs), so we'd produce a
+      // degenerate inductive step that havocs nothing. Skip the whole
+      // loop transformation and disable IS for the run — matches the
+      // precedent for unsupported constructs (recursion in
+      // symex_function.cpp:43, threads in builtin_functions/threads.cpp:129).
+      // Tell the user once so the missing IS coverage isn't a silent
+      // surprise; if IS was already disabled (or never enabled) by an
+      // earlier construct, the warnings just stack up by loop.
+      const auto &loc = function_loop.get_original_loop_head()->location;
+      log_warning(
+        "k-induction: skipping loop at {} (function {}) — all modified "
+        "variables are pointers and --add-symex-value-sets is enabled.",
+        loc.as_string(),
+        id2string(function_name));
+      if (!options.get_bool_option("disable-inductive-step"))
+      {
+        log_warning(
+          "k-induction: disabling inductive step because a pointer-only "
+          "loop cannot be inductively havoc'd under --add-symex-value-sets.");
+        options.set_option("disable-inductive-step", true);
+      }
       continue;
+    }
     // Start the loop conversion
     convert_finite_loop(function_loop);
   }

--- a/src/goto-programs/goto_k_induction.h
+++ b/src/goto-programs/goto_k_induction.h
@@ -4,11 +4,12 @@
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/goto_loops.h>
 #include <util/guard.h>
+#include <util/options.h>
 #include <irep2/irep2_expr.h>
 
-void goto_k_induction(goto_functionst &goto_functions);
+void goto_k_induction(goto_functionst &goto_functions, optionst &options);
 
-void goto_termination(goto_functionst &goto_functions);
+void goto_termination(goto_functionst &goto_functions, optionst &options);
 
 class goto_k_inductiont : public goto_loopst
 {
@@ -16,14 +17,22 @@ public:
   goto_k_inductiont(
     const irep_idt &_function_name,
     goto_functionst &_goto_functions,
-    goto_functiont &_goto_function)
-    : goto_loopst(_function_name, _goto_functions, _goto_function)
+    goto_functiont &_goto_function,
+    optionst &_options)
+    : goto_loopst(_function_name, _goto_functions, _goto_function),
+      options(_options)
   {
     if (function_loops.size())
       goto_k_induction();
   }
 
 protected:
+  /// Reference to the BMC driver's options so the pass can flip
+  /// `disable-inductive-step` when it encounters a loop that the IS
+  /// cannot soundly cover (today: pointer-only loops under
+  /// --add-symex-value-sets).
+  optionst &options;
+
   typedef std::unordered_map<unsigned, bool> marked_branchst;
   marked_branchst marked_branch;
 


### PR DESCRIPTION
## Summary

- When `--add-symex-value-sets` is enabled and a loop's only modified variables are pointers, `goto_k_induction` silently skips the entire loop transformation (because `make_nondet_assign` suppresses pointer havoc — the inductive step would havoc nothing for that loop).
- Today this is silent and IS still runs for the rest of the program, but with no havoc for the affected loop the IS verdict on it is meaningless.
- This change matches the precedent for unsupported constructs (recursion in `symex_function.cpp:43`, threads in `builtin_functions/threads.cpp:129`): log a warning identifying the loop, then flip `--disable-inductive-step` so the run does only base case + forward condition.
- Plumbs `optionst&` into `goto_k_induction()` and `goto_termination()`.

This is item #4 from the broader k-induction deep-dive analysis.

## Stacking note

This PR is stacked on top of #4484 — the base is `feat/interval-analysis-instrument-before-loop` rather than `master`. Rebase once #4484 lands.

## Test plan

- [x] All 177 `-L k-induction` tests pass.
- [x] All 143 `-R interval` tests pass.
- [x] Manual smoke test: `--k-induction --add-symex-value-sets` on a program with a pointer-only loop now emits two warnings and skips IS.
- [ ] CI runs the full suite.