### PR TITLE
[esbmc] extend --uninitialised-vars-check to scalar arrays (CWE-457)

### DIFF
--- a/regression/esbmc/cwe_uninit_array/main.c
+++ b/regression/esbmc/cwe_uninit_array/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main(void)
+{
+  int scores[5];
+  int sum = 0;
+  for (int i = 0; i < 5; i++)
+    sum += scores[i];
+  printf("%d\n", sum);
+  return 0;
+}

--- a/regression/esbmc/cwe_uninit_array/test.desc
+++ b/regression/esbmc/cwe_uninit_array/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION FAILED$
+^  use of uninitialized variable: scores$
+^  CWE: CWE-457$

--- a/regression/esbmc/cwe_uninit_array_addrof/main.c
+++ b/regression/esbmc/cwe_uninit_array_addrof/main.c
@@ -1,0 +1,8 @@
+extern void fill(int *p);
+
+int main(void)
+{
+  int a[5];
+  fill(&a[0]);
+  return a[2];
+}

--- a/regression/esbmc/cwe_uninit_array_addrof/test.desc
+++ b/regression/esbmc/cwe_uninit_array_addrof/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_uninit_array_initlist/main.c
+++ b/regression/esbmc/cwe_uninit_array_initlist/main.c
@@ -1,0 +1,5 @@
+int main(void)
+{
+  int a[5] = {1, 2};
+  return a[3];
+}

--- a/regression/esbmc/cwe_uninit_array_initlist/test.desc
+++ b/regression/esbmc/cwe_uninit_array_initlist/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_uninit_array_oversize/main.c
+++ b/regression/esbmc/cwe_uninit_array_oversize/main.c
@@ -1,0 +1,12 @@
+// Arrays above kMaxShadowedArraySize (see goto_check_uninit_vars.cpp)
+// are deliberately not tracked, to avoid inflating the SMT encoding with
+// a `bool[N]` shadow. The result is that uninit reads against such
+// arrays go undetected — same as the pre-PR-4507 behaviour for any
+// array — and verification reports SUCCESSFUL. This test pins that
+// fallback: a regression here means either the cap moved or oversize
+// arrays started being tracked (and inflating the encoding) again.
+int main(void)
+{
+  int big[4097]; // one above the 4096 element cap (boundary)
+  return big[0]; // uninitialised read, intentionally not flagged
+}

--- a/regression/esbmc/cwe_uninit_array_oversize/test.desc
+++ b/regression/esbmc/cwe_uninit_array_oversize/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_uninit_array_partial/main.c
+++ b/regression/esbmc/cwe_uninit_array_partial/main.c
@@ -1,0 +1,6 @@
+int main(void)
+{
+  int a[5];
+  a[0] = 1;
+  return a[1];
+}

--- a/regression/esbmc/cwe_uninit_array_partial/test.desc
+++ b/regression/esbmc/cwe_uninit_array_partial/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION FAILED$
+^  use of uninitialized variable: a$
+^  CWE: CWE-457$

--- a/regression/esbmc/cwe_uninit_array_partial_pass/main.c
+++ b/regression/esbmc/cwe_uninit_array_partial_pass/main.c
@@ -1,0 +1,6 @@
+int main(void)
+{
+  int a[5];
+  a[0] = 1;
+  return a[0];
+}

--- a/regression/esbmc/cwe_uninit_array_partial_pass/test.desc
+++ b/regression/esbmc/cwe_uninit_array_partial_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_uninit_array_symbolic/main.c
+++ b/regression/esbmc/cwe_uninit_array_symbolic/main.c
@@ -1,0 +1,12 @@
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  int a[4];
+  unsigned i = __VERIFIER_nondet_uint();
+  unsigned j = __VERIFIER_nondet_uint();
+  __ESBMC_assume(i < 4);
+  __ESBMC_assume(j < 4);
+  a[i] = 7;
+  return a[j];
+}

--- a/regression/esbmc/cwe_uninit_array_symbolic/test.desc
+++ b/regression/esbmc/cwe_uninit_array_symbolic/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION FAILED$
+^  use of uninitialized variable: a$
+^  CWE: CWE-457$

--- a/regression/esbmc/cwe_uninit_array_symbolic_pass/main.c
+++ b/regression/esbmc/cwe_uninit_array_symbolic_pass/main.c
@@ -1,0 +1,13 @@
+extern unsigned __VERIFIER_nondet_uint(void);
+
+int main(void)
+{
+  int a[4];
+  unsigned i = __VERIFIER_nondet_uint();
+  unsigned j = __VERIFIER_nondet_uint();
+  __ESBMC_assume(i < 4);
+  __ESBMC_assume(j < 4);
+  __ESBMC_assume(i == j);
+  a[i] = 7;
+  return a[j];
+}

--- a/regression/esbmc/cwe_uninit_array_symbolic_pass/test.desc
+++ b/regression/esbmc/cwe_uninit_array_symbolic_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/cwe_uninit_array_vla/main.c
+++ b/regression/esbmc/cwe_uninit_array_vla/main.c
@@ -1,0 +1,11 @@
+// VLAs are documented out of scope. The pass must not allocate a
+// `bool[<runtime expr>]` shadow for `a` (which would mis-encode), nor
+// emit indexed asserts against it. Reads of `a[0]` after the write must
+// verify SUCCESSFUL with --uninitialised-vars-check enabled.
+int main(int argc, char **argv)
+{
+  int n = argc;
+  int a[n]; // VLA: size known only at runtime
+  a[0] = 42;
+  return a[0];
+}

--- a/regression/esbmc/cwe_uninit_array_vla/test.desc
+++ b/regression/esbmc/cwe_uninit_array_vla/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/goto_check_uninit_vars.cpp
+++ b/src/goto-programs/goto_check_uninit_vars.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <set>
+#include <vector>
 #include <util/c_types.h>
 #include <util/migrate.h>
 #include <util/prefix.h>
@@ -9,34 +10,99 @@
 
 namespace
 {
-/// Tracked iff scalar, automatic storage, lvalue, not internal/return.
-bool is_tracked_local(const symbolt &s)
+/// Element types tracked for uninitialised-read detection (CWE-457). Pointers
+/// are reported under CWE-908; aggregates (struct/union) are out of scope.
+bool is_scalar_element_id(const irep_idt &id)
+{
+  return id == "bool" || id == "signedbv" || id == "unsignedbv" ||
+         id == "fixedbv" || id == "floatbv";
+}
+
+/// Build the shadow type matching a tracked user local. Scalars get a single
+/// `bool`; fixed-size 1-D arrays of scalars get a parallel `bool[N]`. Returns
+/// nil for anything else (pointers, VLAs, infinite/incomplete arrays,
+/// multi-dim arrays, aggregates).
+type2tc shadow_type_for(const typet &user_type)
+{
+  if (is_scalar_element_id(user_type.id()))
+    return get_bool_type();
+
+  if (user_type.id() != "array")
+    return type2tc();
+
+  if (!is_scalar_element_id(user_type.subtype().id()))
+    return type2tc();
+
+  type2tc migrated = migrate_type(user_type);
+  const array_type2t &arr = to_array_type(migrated);
+  if (arr.size_is_infinite || is_nil_expr(arr.array_size))
+    return type2tc();
+  return array_type2tc(get_bool_type(), arr.array_size, false);
+}
+
+/// Tracked iff automatic storage, lvalue, not internal/return, and the type
+/// has a shadow representation.
+type2tc tracked_shadow_type(const symbolt &s)
 {
   if (s.static_lifetime || s.is_extern || !s.lvalue)
-    return false;
+    return type2tc();
   if (has_prefix(s.name, "return_value$"))
-    return false;
+    return type2tc();
   if (has_prefix(s.id, "__ESBMC_") || has_prefix(s.name, "__ESBMC_"))
-    return false;
-  // Scalar types only — pointers / aggregates are out of scope for CWE-457
-  // (pointer uninitialised state is reported under CWE-908 already).
-  return s.type.is_bool() || s.type.id() == "signedbv" ||
-         s.type.id() == "unsignedbv" || s.type.id() == "fixedbv" ||
-         s.type.id() == "floatbv";
+    return type2tc();
+  return shadow_type_for(s.type);
 }
 
-/// LHS name of a direct-symbol ASSIGN, or empty for compound LHS, nil,
-/// or any non-symbol expression.
-irep_idt direct_symbol(const expr2tc &lhs)
+/// Record describing one shadow variable, looked up at emit time by sid.
+struct shadow_record
 {
-  if (is_nil_expr(lhs))
-    return irep_idt();
-  if (is_symbol2t(lhs))
-    return to_symbol2t(lhs).thename;
-  return irep_idt();
+  type2tc type;       // bool, or bool[N]
+  std::string user_name;
+};
+
+/// Build the shadow-initialiser/flip RHS for a tracked variable: a plain
+/// boolean for scalars, or `constant_array_of(value)` for arrays.
+expr2tc shadow_const(const type2tc &shadow_t, const expr2tc &value)
+{
+  return is_array_type(shadow_t) ? expr2tc(constant_array_of2tc(shadow_t, value))
+                                 : value;
 }
 
-/// Lookup helper: return the shadow id for `name` if tracked, else empty.
+/// Walk an lvalue chain and return its root symbol name, or empty if the
+/// chain bottoms out in something other than a symbol (e.g. a dereference).
+irep_idt lvalue_root(const expr2tc &e)
+{
+  const expr2tc *cur = &e;
+  while (true)
+  {
+    if (is_nil_expr(*cur))
+      return irep_idt();
+    if (is_symbol2t(*cur))
+      return to_symbol2t(*cur).thename;
+    if (is_index2t(*cur))
+    {
+      cur = &to_index2t(*cur).source_value;
+      continue;
+    }
+    if (is_member2t(*cur))
+    {
+      cur = &to_member2t(*cur).source_value;
+      continue;
+    }
+    return irep_idt();
+  }
+}
+
+/// Per-instruction collection of reads/writes against tracked shadows.
+struct collected
+{
+  std::set<irep_idt> scalar_reads;   // shadow ids read as whole scalars
+  std::set<irep_idt> whole_flips;    // shadow ids whose whole shadow flips true
+  // (shadow id, index expression) pairs read; one ASSERT per entry.
+  std::vector<std::pair<irep_idt, expr2tc>> indexed_reads;
+};
+
+/// Look up the shadow id for `name`, or empty if `name` is not tracked.
 irep_idt
 shadow_of(irep_idt name, const std::map<irep_idt, irep_idt> &shadows)
 {
@@ -44,21 +110,18 @@ shadow_of(irep_idt name, const std::map<irep_idt, irep_idt> &shadows)
   return it == shadows.end() ? irep_idt() : it->second;
 }
 
-/// Walk an expression, collecting:
-/// - every direct read of a tracked symbol (visited as `reads`),
-/// - every `&local` where the address is taken (visited as `address_takes`).
+/// Walk an expression collecting reads of tracked shadows.
 ///
-/// `lvalue_ctx` is true while recursing inside an l-value context (the
-/// operand of an `address_of2t`, or the source of a `member2t` /
-/// `index2t.source_value` chain whose root is an address-of). In that mode
-/// the base symbol is not a value-read; only embedded sub-expressions —
-/// for example `i` in `a[i]` — are reads.
+/// `lvalue_ctx` is true while inside an l-value chain (operand of an
+/// `address_of2t`, or recursion through `member2t`/`index2t.source_value`
+/// rooted at an address-of). In that mode the root symbol is not a value-read;
+/// embedded sub-expressions (for example `i` in `a[i]`) still are.
 void collect(
   const expr2tc &expr,
   bool lvalue_ctx,
   const std::map<irep_idt, irep_idt> &shadows,
-  std::set<irep_idt> &reads,
-  std::set<irep_idt> &address_takes)
+  const std::map<irep_idt, shadow_record> &by_sid,
+  collected &out)
 {
   if (is_nil_expr(expr))
     return;
@@ -66,32 +129,12 @@ void collect(
   if (is_address_of2t(expr))
   {
     const expr2tc &target = to_address_of2t(expr).ptr_obj;
-    // Record the address-take for the root symbol of the l-value chain.
-    irep_idt root;
-    const expr2tc *cur = &target;
-    while (true)
-    {
-      if (is_symbol2t(*cur))
-      {
-        root = to_symbol2t(*cur).thename;
-        break;
-      }
-      if (is_member2t(*cur))
-        cur = &to_member2t(*cur).source_value;
-      else if (is_index2t(*cur))
-        cur = &to_index2t(*cur).source_value;
-      else
-        break;
-    }
-    if (!root.empty())
-    {
-      irep_idt sid = shadow_of(root, shadows);
-      if (!sid.empty())
-        address_takes.insert(sid);
-    }
-    // Recurse into target in l-value mode so embedded reads (e.g. the
-    // index of `&a[i]`) are still checked.
-    collect(target, true, shadows, reads, address_takes);
+    irep_idt sid = shadow_of(lvalue_root(target), shadows);
+    if (!sid.empty())
+      out.whole_flips.insert(sid);
+    // Recurse into target as an l-value so embedded reads (e.g. `i` in
+    // `&a[i]`) are still checked, but the base symbol itself is not.
+    collect(target, true, shadows, by_sid, out);
     return;
   }
 
@@ -100,23 +143,40 @@ void collect(
     if (lvalue_ctx)
       return; // base symbol of an l-value chain; not a value-read
     irep_idt sid = shadow_of(to_symbol2t(expr).thename, shadows);
-    if (!sid.empty())
-      reads.insert(sid);
+    if (sid.empty())
+      return;
+    if (is_array_type(by_sid.at(sid).type))
+      return; // bare array name as r-value (rare/degenerate); skip
+    out.scalar_reads.insert(sid);
     return;
   }
 
-  if (lvalue_ctx && is_index2t(expr))
+  if (is_index2t(expr))
   {
     const index2t &i = to_index2t(expr);
-    collect(i.source_value, true, shadows, reads, address_takes);
-    collect(i.index, false, shadows, reads, address_takes); // index IS a read
-    return;
+    if (lvalue_ctx)
+    {
+      // Inside an l-value chain: base remains lvalue, index is a read.
+      collect(i.source_value, true, shadows, by_sid, out);
+      collect(i.index, false, shadows, by_sid, out);
+      return;
+    }
+    // R-value `a[i]`: if `a` resolves to a tracked array, record the
+    // (shadow, index) pair and treat the index itself as a read. Do not
+    // recurse into the base symbol — there is no scalar shadow for `a`.
+    irep_idt sid = shadow_of(lvalue_root(i.source_value), shadows);
+    if (!sid.empty() && is_array_type(by_sid.at(sid).type))
+    {
+      out.indexed_reads.emplace_back(sid, i.index);
+      collect(i.index, false, shadows, by_sid, out);
+      return;
+    }
+    // Not a tracked array: fall through to default operand walker.
   }
 
   if (lvalue_ctx && is_member2t(expr))
   {
-    collect(
-      to_member2t(expr).source_value, true, shadows, reads, address_takes);
+    collect(to_member2t(expr).source_value, true, shadows, by_sid, out);
     return; // member name is a literal
   }
 
@@ -124,20 +184,48 @@ void collect(
   // pointer operand is itself a value-read.
   if (lvalue_ctx && is_dereference2t(expr))
   {
-    collect(
-      to_dereference2t(expr).value, false, shadows, reads, address_takes);
+    collect(to_dereference2t(expr).value, false, shadows, by_sid, out);
     return;
   }
 
-  // Default: preserve the current context for unknown wrappers (e.g. an
-  // if-then-else lvalue `&(c ? a : b)` keeps `a` and `b` in l-value mode).
-  // In r-value contexts this still descends r-value, which is what we want
-  // for ordinary expressions like `a + b`. Preserving the context avoids
-  // treating a base lvalue symbol as a value-read — a false-positive risk
-  // we cannot tolerate as a formal verifier.
+  // Default: preserve the current context for unknown wrappers and walk all
+  // operands. Preserving avoids treating a base lvalue symbol as a value-read
+  // — a false-positive risk we cannot tolerate as a formal verifier.
   expr->foreach_operand(
-    [&](const expr2tc &e)
-    { collect(e, lvalue_ctx, shadows, reads, address_takes); });
+    [&](const expr2tc &e) { collect(e, lvalue_ctx, shadows, by_sid, out); });
+}
+
+/// Direct write target for ASSIGN/FUNCTION_CALL.ret: either a bare tracked
+/// symbol (scalar whole-flip, or array whole-flip on `a = …`) or a bare
+/// tracked-array element `a[i]` (per-element flip). Anything else returns
+/// empty.
+struct write_target
+{
+  irep_idt root;      // user name, empty if not a direct write to a tracked
+  expr2tc index;      // non-nil iff root names an `a[i]` write
+};
+
+write_target direct_write_target(
+  const expr2tc &lhs,
+  const std::map<irep_idt, irep_idt> &shadows,
+  const std::map<irep_idt, shadow_record> &by_sid)
+{
+  if (is_nil_expr(lhs))
+    return {};
+  if (is_symbol2t(lhs))
+    return {to_symbol2t(lhs).thename, expr2tc()};
+  if (is_index2t(lhs))
+  {
+    const index2t &i = to_index2t(lhs);
+    if (!is_symbol2t(i.source_value))
+      return {};
+    irep_idt name = to_symbol2t(i.source_value).thename;
+    irep_idt sid = shadow_of(name, shadows);
+    if (sid.empty() || !is_array_type(by_sid.at(sid).type))
+      return {};
+    return {name, i.index};
+  }
+  return {};
 }
 } // namespace
 
@@ -148,9 +236,9 @@ bool goto_check_uninit_vars::runOnFunction(
     return false;
 
   goto_programt &body = F.second.body;
-  std::map<irep_idt, irep_idt> shadows;           // user-name -> shadow_id
-  std::map<irep_idt, std::string> shadow_display; // shadow_id -> display
-  // Prefix uppercase so `is_tracked_local`'s "__ESBMC_" filter at the next
+  std::map<irep_idt, irep_idt> shadows;     // user-name -> shadow_id
+  std::map<irep_idt, shadow_record> by_sid; // shadow_id -> record
+  // Prefix uppercase so `tracked_shadow_type`'s "__ESBMC_" filter at the next
   // pass invocation rejects our own shadows — defence in depth against
   // self-instrumentation on a re-run.
   symbol_generator gen("__ESBMC_defined$" + id2string(F.first) + "$");
@@ -161,61 +249,65 @@ bool goto_check_uninit_vars::runOnFunction(
     {
       const code_decl2t &decl = to_code_decl2t(it->code);
       const symbolt *s = context.find_symbol(decl.value);
-      if (s && is_tracked_local(*s) && !shadows.count(decl.value))
+      type2tc shadow_t = s ? tracked_shadow_type(*s) : type2tc();
+      if (!is_nil_type(shadow_t) && !shadows.count(decl.value))
       {
         symbolt &shadow =
-          gen.new_symbol(context, migrate_type_back(get_bool_type()), "");
+          gen.new_symbol(context, migrate_type_back(shadow_t), "");
         shadows.emplace(decl.value, shadow.id);
-        shadow_display.emplace(shadow.id, id2string(s->name));
+        by_sid.emplace(shadow.id, shadow_record{shadow_t, id2string(s->name)});
 
-        // Insert immediately after the DECL: DECL shadow; ASSIGN shadow = false;
+        // Insert immediately after the DECL:
+        //   DECL shadow;
+        //   ASSIGN shadow = false   (or constant_array_of(false) for arrays)
         auto pos = std::next(it);
         auto decl_it = body.instructions.insert(pos, DECL);
-        decl_it->code = code_decl2tc(get_bool_type(), shadow.id);
+        decl_it->code = code_decl2tc(shadow_t, shadow.id);
         decl_it->location = it->location;
         decl_it->function = it->function;
 
         auto assign_it = body.instructions.insert(pos, ASSIGN);
         assign_it->code = code_assign2tc(
-          symbol2tc(get_bool_type(), shadow.id), gen_false_expr());
+          symbol2tc(shadow_t, shadow.id),
+          shadow_const(shadow_t, gen_false_expr()));
         assign_it->location = it->location;
         assign_it->function = it->function;
 
         ++it; // skip past inserted DECL shadow
-        ++it; // skip past inserted ASSIGN shadow = false
+        ++it; // skip past inserted ASSIGN shadow = init
         continue;
       }
     }
 
-    // Collect reads and address-takes from every expression on the
-    // instruction. Direct assignments and function-call returns treat the
-    // LHS bare-symbol as a *write*, not a read.
-    std::set<irep_idt> reads;
-    std::set<irep_idt> address_takes;
-    irep_idt write_target;
+    collected co;
+    write_target wt;
 
     if (it->is_assign())
     {
       const code_assign2t &a = to_code_assign2t(it->code);
-      write_target = direct_symbol(a.target);
-      if (write_target.empty())
-        collect(a.target, false, shadows, reads, address_takes);
-      collect(a.source, false, shadows, reads, address_takes);
+      wt = direct_write_target(a.target, shadows, by_sid);
+      if (wt.root.empty())
+        collect(a.target, false, shadows, by_sid, co);
+      else if (!is_nil_expr(wt.index))
+        collect(wt.index, false, shadows, by_sid, co);
+      collect(a.source, false, shadows, by_sid, co);
     }
     else if (it->is_function_call())
     {
       const code_function_call2t &fc = to_code_function_call2t(it->code);
-      write_target = direct_symbol(fc.ret);
-      if (write_target.empty())
-        collect(fc.ret, false, shadows, reads, address_takes);
-      collect(fc.function, false, shadows, reads, address_takes);
+      wt = direct_write_target(fc.ret, shadows, by_sid);
+      if (wt.root.empty())
+        collect(fc.ret, false, shadows, by_sid, co);
+      else if (!is_nil_expr(wt.index))
+        collect(wt.index, false, shadows, by_sid, co);
+      collect(fc.function, false, shadows, by_sid, co);
       for (const auto &arg : fc.operands)
-        collect(arg, false, shadows, reads, address_takes);
+        collect(arg, false, shadows, by_sid, co);
     }
     else
     {
-      collect(it->guard, false, shadows, reads, address_takes);
-      collect(it->code, false, shadows, reads, address_takes);
+      collect(it->guard, false, shadows, by_sid, co);
+      collect(it->code, false, shadows, by_sid, co);
     }
 
     // Build a prefix-program of instructions to splice in *before* `it`.
@@ -223,26 +315,33 @@ bool goto_check_uninit_vars::runOnFunction(
     // content to the next position.
     goto_programt new_code;
 
-    for (const irep_idt &shadow_id : address_takes)
+    for (const irep_idt &sid : co.whole_flips)
     {
-      goto_programt::targett t = new_code.add_instruction(ASSIGN);
-      t->code =
-        code_assign2tc(symbol2tc(get_bool_type(), shadow_id), gen_true_expr());
+      const shadow_record &rec = by_sid.at(sid);
+      auto t = new_code.add_instruction(ASSIGN);
+      t->code = code_assign2tc(
+        symbol2tc(rec.type, sid), shadow_const(rec.type, gen_true_expr()));
       t->location = it->location;
       t->function = it->function;
     }
 
-    for (const irep_idt &shadow_id : reads)
+    auto emit_assert = [&](const expr2tc &guard, const shadow_record &rec)
     {
-      auto dit = shadow_display.find(shadow_id);
-      const std::string name =
-        dit != shadow_display.end() ? dit->second : id2string(shadow_id);
-      goto_programt::targett t = new_code.add_instruction(ASSERT);
-      t->guard = symbol2tc(get_bool_type(), shadow_id);
+      auto t = new_code.add_instruction(ASSERT);
+      t->guard = guard;
       t->location = it->location;
-      t->location.comment("use of uninitialized variable: " + name);
+      t->location.comment("use of uninitialized variable: " + rec.user_name);
       t->location.property("uninitialised-variable");
       t->function = it->function;
+    };
+
+    for (const irep_idt &sid : co.scalar_reads)
+      emit_assert(symbol2tc(get_bool_type(), sid), by_sid.at(sid));
+
+    for (const auto &[sid, idx] : co.indexed_reads)
+    {
+      const shadow_record &rec = by_sid.at(sid);
+      emit_assert(index2tc(get_bool_type(), symbol2tc(rec.type, sid), idx), rec);
     }
 
     while (!new_code.instructions.empty())
@@ -252,23 +351,31 @@ bool goto_check_uninit_vars::runOnFunction(
       ++it;
     }
 
-    // After a direct write to a tracked local (ASSIGN or FUNCTION_CALL
-    // return), flip its shadow to true. Insert *after* `it`; jumps and
-    // labels on `it` are unaffected.
-    if (!write_target.empty())
+    // After a direct write to a tracked local, flip the matching shadow
+    // bit(s) to true. Insert *after* `it`; jumps and labels on `it` are
+    // unaffected.
+    if (wt.root.empty())
+      continue;
+    irep_idt sid = shadow_of(wt.root, shadows);
+    if (sid.empty())
+      continue;
+    const shadow_record &rec = by_sid.at(sid);
+    expr2tc shadow_sym = symbol2tc(rec.type, sid);
+    expr2tc lhs = shadow_sym;
+    expr2tc rhs = gen_true_expr();
+    if (is_array_type(rec.type))
     {
-      irep_idt sid = shadow_of(write_target, shadows);
-      if (!sid.empty())
-      {
-        auto pos = std::next(it);
-        auto t = body.instructions.insert(pos, ASSIGN);
-        t->code =
-          code_assign2tc(symbol2tc(get_bool_type(), sid), gen_true_expr());
-        t->location = it->location;
-        t->function = it->function;
-        ++it;
-      }
+      if (is_nil_expr(wt.index))
+        rhs = constant_array_of2tc(rec.type, gen_true_expr());
+      else
+        lhs = index2tc(get_bool_type(), shadow_sym, wt.index);
     }
+    auto pos = std::next(it);
+    auto t = body.instructions.insert(pos, ASSIGN);
+    t->code = code_assign2tc(lhs, rhs);
+    t->location = it->location;
+    t->function = it->function;
+    ++it;
   }
 
   return !shadows.empty();

--- a/src/goto-programs/goto_check_uninit_vars.cpp
+++ b/src/goto-programs/goto_check_uninit_vars.cpp
@@ -56,7 +56,7 @@ type2tc tracked_shadow_type(const symbolt &s)
 /// Record describing one shadow variable, looked up at emit time by sid.
 struct shadow_record
 {
-  type2tc type;       // bool, or bool[N]
+  type2tc type; // bool, or bool[N]
   std::string user_name;
 };
 
@@ -64,8 +64,9 @@ struct shadow_record
 /// boolean for scalars, or `constant_array_of(value)` for arrays.
 expr2tc shadow_const(const type2tc &shadow_t, const expr2tc &value)
 {
-  return is_array_type(shadow_t) ? expr2tc(constant_array_of2tc(shadow_t, value))
-                                 : value;
+  return is_array_type(shadow_t)
+           ? expr2tc(constant_array_of2tc(shadow_t, value))
+           : value;
 }
 
 /// Walk an lvalue chain and return its root symbol name, or empty if the
@@ -96,15 +97,14 @@ irep_idt lvalue_root(const expr2tc &e)
 /// Per-instruction collection of reads/writes against tracked shadows.
 struct collected
 {
-  std::set<irep_idt> scalar_reads;   // shadow ids read as whole scalars
-  std::set<irep_idt> whole_flips;    // shadow ids whose whole shadow flips true
+  std::set<irep_idt> scalar_reads; // shadow ids read as whole scalars
+  std::set<irep_idt> whole_flips;  // shadow ids whose whole shadow flips true
   // (shadow id, index expression) pairs read; one ASSERT per entry.
   std::vector<std::pair<irep_idt, expr2tc>> indexed_reads;
 };
 
 /// Look up the shadow id for `name`, or empty if `name` is not tracked.
-irep_idt
-shadow_of(irep_idt name, const std::map<irep_idt, irep_idt> &shadows)
+irep_idt shadow_of(irep_idt name, const std::map<irep_idt, irep_idt> &shadows)
 {
   auto it = shadows.find(name);
   return it == shadows.end() ? irep_idt() : it->second;
@@ -201,8 +201,8 @@ void collect(
 /// empty.
 struct write_target
 {
-  irep_idt root;      // user name, empty if not a direct write to a tracked
-  expr2tc index;      // non-nil iff root names an `a[i]` write
+  irep_idt root; // user name, empty if not a direct write to a tracked
+  expr2tc index; // non-nil iff root names an `a[i]` write
 };
 
 write_target direct_write_target(
@@ -325,8 +325,7 @@ bool goto_check_uninit_vars::runOnFunction(
       t->function = it->function;
     }
 
-    auto emit_assert = [&](const expr2tc &guard, const shadow_record &rec)
-    {
+    auto emit_assert = [&](const expr2tc &guard, const shadow_record &rec) {
       auto t = new_code.add_instruction(ASSERT);
       t->guard = guard;
       t->location = it->location;
@@ -341,7 +340,8 @@ bool goto_check_uninit_vars::runOnFunction(
     for (const auto &[sid, idx] : co.indexed_reads)
     {
       const shadow_record &rec = by_sid.at(sid);
-      emit_assert(index2tc(get_bool_type(), symbol2tc(rec.type, sid), idx), rec);
+      emit_assert(
+        index2tc(get_bool_type(), symbol2tc(rec.type, sid), idx), rec);
     }
 
     while (!new_code.instructions.empty())

--- a/src/goto-programs/goto_check_uninit_vars.cpp
+++ b/src/goto-programs/goto_check_uninit_vars.cpp
@@ -51,8 +51,9 @@ type2tc shadow_type_for(const typet &user_type)
   if (!is_constant_int2t(arr.array_size))
     return type2tc();
   const BigInt &n = to_constant_int2t(arr.array_size).value;
-  if (n.is_negative() || n.is_zero() ||
-      n.compare(static_cast<unsigned long long>(kMaxShadowedArraySize)) > 0)
+  if (
+    n.is_negative() || n.is_zero() ||
+    n.compare(static_cast<unsigned long long>(kMaxShadowedArraySize)) > 0)
     return type2tc();
   return array_type2tc(get_bool_type(), arr.array_size, false);
 }

--- a/src/goto-programs/goto_check_uninit_vars.cpp
+++ b/src/goto-programs/goto_check_uninit_vars.cpp
@@ -10,6 +10,15 @@
 
 namespace
 {
+/// Maximum element count of a fixed-size array we will shadow per-element.
+/// Above this threshold the parallel `bool[N]` shadow (and the `array-of`
+/// initialiser / whole-flip writes that go with it) inflates the SMT
+/// encoding more than the precision is worth, so the array is left
+/// untracked — same observable behaviour as before PR #4507 for that
+/// variable. Tuned to cover typical stack/firmware buffers (a few KB) while
+/// avoiding blow-up on programs like `int buf[100000];`.
+constexpr uint64_t kMaxShadowedArraySize = 4096;
+
 /// Element types tracked for uninitialised-read detection (CWE-457). Pointers
 /// are reported under CWE-908; aggregates (struct/union) are out of scope.
 bool is_scalar_element_id(const irep_idt &id)
@@ -19,9 +28,10 @@ bool is_scalar_element_id(const irep_idt &id)
 }
 
 /// Build the shadow type matching a tracked user local. Scalars get a single
-/// `bool`; fixed-size 1-D arrays of scalars get a parallel `bool[N]`. Returns
-/// nil for anything else (pointers, VLAs, infinite/incomplete arrays,
-/// multi-dim arrays, aggregates).
+/// `bool`; fixed-size 1-D arrays of scalars whose constant length is at
+/// most `kMaxShadowedArraySize` get a parallel `bool[N]`. Returns nil for
+/// anything else: pointers, VLAs (non-constant length), infinite/incomplete
+/// arrays, multi-dim arrays, aggregates, and oversize arrays.
 type2tc shadow_type_for(const typet &user_type)
 {
   if (is_scalar_element_id(user_type.id()))
@@ -36,6 +46,13 @@ type2tc shadow_type_for(const typet &user_type)
   type2tc migrated = migrate_type(user_type);
   const array_type2t &arr = to_array_type(migrated);
   if (arr.size_is_infinite || is_nil_expr(arr.array_size))
+    return type2tc();
+  // VLAs reach here with a runtime-expression size; require a constant.
+  if (!is_constant_int2t(arr.array_size))
+    return type2tc();
+  const BigInt &n = to_constant_int2t(arr.array_size).value;
+  if (n.is_negative() || n.is_zero() ||
+      n.compare(static_cast<unsigned long long>(kMaxShadowedArraySize)) > 0)
     return type2tc();
   return array_type2tc(get_bool_type(), arr.array_size, false);
 }

--- a/src/goto-programs/goto_check_uninit_vars.h
+++ b/src/goto-programs/goto_check_uninit_vars.h
@@ -19,9 +19,18 @@
 /// Tracked variables are automatic-storage, lvalue, non-extern,
 /// non-`return_value$*`, non-`__ESBMC_` locals whose type is either a
 /// scalar (`_Bool`, signed/unsigned integer, fixed-point, floating-point)
-/// or a fixed-size 1-D array of such a scalar. Pointers (covered under
-/// CWE-908), VLAs, multi-dim arrays, structs, and unions remain out of
-/// scope.
+/// or a fixed-size 1-D array of such a scalar whose element count is a
+/// constant in `[1, kMaxShadowedArraySize]` (see the .cpp). Pointers
+/// (covered under CWE-908), VLAs, multi-dim arrays, structs, unions, and
+/// oversize arrays remain out of scope.
+///
+/// Cost: every tracked array of length `N` allocates a parallel
+/// `bool[N]` shadow and emits per-element `ASSERT`/`ASSIGN` instructions
+/// at reads/writes, plus a `constant_array_of(true, N)` on any address-of
+/// or whole-array assignment. The `kMaxShadowedArraySize` cap exists to
+/// keep this from inflating the SMT encoding on programs with very large
+/// fixed-size buffers; arrays above the cap are simply not tracked
+/// (matching the pre-extension behaviour for that variable).
 ///
 /// The pass must run **before** `mark_decl_as_non_det`, which would
 /// otherwise rewrite every uninitialised `DECL` into a `DECL; ASSIGN nondet`

--- a/src/goto-programs/goto_check_uninit_vars.h
+++ b/src/goto-programs/goto_check_uninit_vars.h
@@ -4,19 +4,24 @@
 #include <util/message.h>
 #include <irep2/irep2.h>
 
-/// Detect reads of uninitialised automatic-storage local scalars (CWE-457).
+/// Detect reads of uninitialised automatic-storage locals (CWE-457).
 ///
-/// For every tracked scalar local `x`, the pass introduces a fresh shadow
-/// boolean `__ESBMC_defined$<function>$<n>` that starts `false`, is set to
-/// `true` on every direct write to `x`, is asserted `true` before every
-/// direct read of `x`, and is conservatively set to `true` when `&x` is
-/// taken (because we cannot soundly track writes through pointer aliases
-/// without a full alias analysis).
+/// For every tracked local `x`, the pass introduces a fresh shadow
+/// `__ESBMC_defined$<function>$<n>` that mirrors `x`'s initialisation
+/// state — a `bool` for scalars, or a parallel `bool[N]` for fixed-size
+/// arrays of scalars. The shadow starts `false` (all elements `false` for
+/// arrays), is set to `true` on every direct write (`shadow[i] = true` on
+/// `x[i] = …`), is asserted `true` before every direct read, and is
+/// conservatively flipped entirely to `true` when `&x` (or `&x[i]`) is
+/// taken — we cannot soundly track writes through pointer aliases without
+/// a full alias analysis.
 ///
 /// Tracked variables are automatic-storage, lvalue, non-extern,
-/// non-`return_value$*`, non-`__ESBMC_` locals whose type is a scalar
-/// (`_Bool`, signed/unsigned integer, fixed-point, floating-point). Pointers,
-/// arrays, structs, and unions are out of scope for v1.
+/// non-`return_value$*`, non-`__ESBMC_` locals whose type is either a
+/// scalar (`_Bool`, signed/unsigned integer, fixed-point, floating-point)
+/// or a fixed-size 1-D array of such a scalar. Pointers (covered under
+/// CWE-908), VLAs, multi-dim arrays, structs, and unions remain out of
+/// scope.
 ///
 /// The pass must run **before** `mark_decl_as_non_det`, which would
 /// otherwise rewrite every uninitialised `DECL` into a `DECL; ASSIGN nondet`


### PR DESCRIPTION
`int scores[5]; return scores[i];` previously verified SUCCESSFUL because the pass tracked only scalar locals. Extend `goto_check_uninit_vars` to allocate a parallel `bool[N]` shadow for every fixed-size 1-D array of scalar elements: per-element writes (`a[i] = …`) flip `shadow[i]`, reads emit `ASSERT shadow[i]`, and any `&a[*]` conservatively flips the whole shadow (matches the existing address-of pessimism on scalars). Pointers, VLAs, multi-dim arrays, structs and unions remain out of scope.