### PR TITLE
[k-induction] perf: contains_rec early-exit + memoize callee summaries

### DIFF
--- a/src/goto-programs/goto_k_induction.cpp
+++ b/src/goto-programs/goto_k_induction.cpp
@@ -260,17 +260,18 @@ void goto_k_inductiont::make_nondet_assign(
 
 static bool contains_rec(const expr2tc &expr, const loopst::loop_varst &vars)
 {
+  // Check this node first: if it's a tracked symbol, we're done.
+  if (is_symbol2t(expr) && vars.find(expr) != vars.end())
+    return true;
+
+  // Otherwise recurse into operands and stop at the first match.
   bool res = false;
   expr->foreach_operand([&vars, &res](const expr2tc &e) {
-    if (!is_nil_expr(e))
-      res = contains_rec(e, vars) || res;
-    return res;
+    if (res || is_nil_expr(e))
+      return;
+    res = contains_rec(e, vars);
   });
-
-  if (!is_symbol2t(expr))
-    return res;
-
-  return (vars.find(expr) != vars.end()) || res;
+  return res;
 }
 
 void goto_k_inductiont::remove_unrelated_loop_cond(

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -101,6 +101,99 @@ void goto_loopst::create_function_loop(
   it1->set_size(size + 1);
 }
 
+void goto_loopst::collect_loop_symbols(
+  const expr2tc &expr,
+  loopst::loop_varst &out) const
+{
+  if (is_nil_expr(expr))
+    return;
+
+  expr->foreach_operand(
+    [this, &out](const expr2tc &e) { collect_loop_symbols(e, out); });
+
+  if (is_symbol2t(expr) && check_var_name(expr))
+    out.insert(expr);
+}
+
+bool goto_loopst::compute_function_summary(
+  const irep_idt &fname,
+  std::vector<irep_idt> &in_progress,
+  function_summaryt &out)
+{
+  auto cached = function_summary_cache.find(fname);
+  if (cached != function_summary_cache.end())
+  {
+    // Union the cached summary into out.
+    out.modified.insert(
+      cached->second.modified.begin(), cached->second.modified.end());
+    out.unmodified.insert(
+      cached->second.unmodified.begin(), cached->second.unmodified.end());
+    return true;
+  }
+
+  auto it = goto_functions.function_map.find(fname);
+  if (it == goto_functions.function_map.end())
+  {
+    log_error("failed to find `{}' in function_map", id2string(fname));
+    abort();
+  }
+  if (!it->second.body_available)
+  {
+    function_summary_cache[fname] = function_summaryt{};
+    return true;
+  }
+
+  in_progress.push_back(fname);
+  bool complete = true;
+  function_summaryt local;
+
+  for (const auto &instr : it->second.body.instructions)
+  {
+    if (instr.is_assign())
+    {
+      collect_loop_symbols(to_code_assign2t(instr.code).target, local.modified);
+    }
+    else if (instr.is_function_call())
+    {
+      const code_function_call2t &call = to_code_function_call2t(instr.code);
+      if (is_dereference2t(call.function))
+        continue;
+
+      collect_loop_symbols(call.ret, local.modified);
+
+      const irep_idt &callee = to_symbol2t(call.function).thename;
+      if (
+        std::find(in_progress.begin(), in_progress.end(), callee) !=
+        in_progress.end())
+      {
+        // Cycle cut: matches the legacy "do nothing on recursion" behaviour.
+        // Mark the result incomplete so we don't cache this summary — the
+        // missing recursive contributions are call-site dependent.
+        complete = false;
+        continue;
+      }
+
+      if (!compute_function_summary(callee, in_progress, local))
+        complete = false;
+    }
+    else if (
+      instr.is_goto() || instr.is_assert() || instr.is_assume())
+    {
+      collect_loop_symbols(instr.guard, local.unmodified);
+    }
+  }
+
+  in_progress.pop_back();
+
+  // Fold local into out regardless of completeness.
+  out.modified.insert(local.modified.begin(), local.modified.end());
+  out.unmodified.insert(local.unmodified.begin(), local.unmodified.end());
+
+  if (complete)
+    function_summary_cache[fname] = std::move(local);
+  return complete;
+}
+
 void goto_loopst::get_modified_variables(
   goto_programt::instructionst::iterator instruction,
   function_loopst::iterator loop,
@@ -113,7 +206,6 @@ void goto_loopst::get_modified_variables(
   }
   else if (instruction->is_function_call())
   {
-    // Functions are a bit tricky
     code_function_call2t &function_call =
       to_code_function_call2t(instruction->code);
 
@@ -124,49 +216,29 @@ void goto_loopst::get_modified_variables(
     // First, add its return
     add_loop_var(*loop, function_call.ret, true);
 
-    // The run over the function body and get the modified variables there
-    irep_idt &identifier = to_symbol2t(function_call.function).thename;
+    const irep_idt &identifier = to_symbol2t(function_call.function).thename;
 
-    // This means recursion, do nothing
+    // This means recursion, do nothing — matches legacy behaviour.
     if (
       std::find(function_names.begin(), function_names.end(), identifier) !=
       function_names.end())
       return;
 
-    // We didn't entered this function yet, so add it to the list
-    function_names.push_back(identifier);
-
-    // find code in function map
-    goto_functionst::function_mapt::iterator it =
-      goto_functions.function_map.find(identifier);
-
-    if (it == goto_functions.function_map.end())
-    {
-      log_error("failed to find `{}' in function_map", id2string(identifier));
-      abort();
-    }
-
-    // Avoid iterating over functions that don't have a body
-    if (!it->second.body_available)
-      return;
-
-    for (goto_programt::instructionst::iterator head =
-           it->second.body.instructions.begin();
-         head != it->second.body.instructions.end();
-         ++head)
-    {
-      get_modified_variables(head, loop, function_names);
-    }
+    // Compute (or fetch the cached) summary of the callee. Two loops that
+    // both call the same helper now share the helper's per-symbol set
+    // instead of re-walking the helper from scratch.
+    function_summaryt summary;
+    compute_function_summary(identifier, function_names, summary);
+    for (const auto &v : summary.modified)
+      loop->add_modified_var_to_loop(v);
+    for (const auto &v : summary.unmodified)
+      loop->add_unmodified_var_to_loop(v);
   }
   else if (
     instruction->is_goto() || instruction->is_assert() ||
     instruction->is_assume())
   {
     add_loop_var(*loop, instruction->guard, false);
-  }
-  else if (instruction->is_end_function())
-  {
-    function_names.pop_back();
   }
 }
 

--- a/src/goto-programs/goto_loops.h
+++ b/src/goto-programs/goto_loops.h
@@ -4,6 +4,7 @@
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/loopst.h>
 #include <util/std_types.h>
+#include <unordered_map>
 
 class goto_loopst
 {
@@ -15,6 +16,24 @@ protected:
   typedef std::list<loopst> function_loopst;
   function_loopst function_loops;
 
+  /// Per-callee summary: the leaf symbols (post check_var_name filtering)
+  /// that walking the callee's body would contribute to the current loop.
+  /// Cached across loops in the same goto_loopst instance so two loops
+  /// in the *same* outer function don't re-walk a shared helper.
+  ///
+  /// Scope is intentionally per-instance (one goto_loopst per analysed
+  /// function), not per-program: goto_k_induction constructs a fresh
+  /// instance per outer function, and promoting the cache to a static
+  /// would need invalidation across the goto-program rewrites that
+  /// happen between functions.
+  struct function_summaryt
+  {
+    loopst::loop_varst modified;
+    loopst::loop_varst unmodified;
+  };
+  std::unordered_map<irep_idt, function_summaryt, irep_id_hash>
+    function_summary_cache;
+
   void create_function_loop(
     goto_programt::instructionst::iterator loop_head,
     goto_programt::instructionst::iterator loop_exit);
@@ -23,6 +42,21 @@ protected:
     goto_programt::instructionst::iterator instruction,
     function_loopst::iterator loop,
     std::vector<irep_idt> &function_name);
+
+  /// Compute (or fetch the cached) summary of `fname`. `in_progress` is the
+  /// stack of callees currently being expanded; if a re-entry is detected
+  /// the walk is cut (matches the legacy in-place behaviour). Returns true
+  /// when the resulting summary is complete (no cycle-cut along the way);
+  /// only complete summaries are cached.
+  bool compute_function_summary(
+    const irep_idt &fname,
+    std::vector<irep_idt> &in_progress,
+    function_summaryt &out);
+
+  /// Collect the leaf symbols of `expr` into `out`, applying check_var_name.
+  void collect_loop_symbols(
+    const expr2tc &expr,
+    loopst::loop_varst &out) const;
 
   void add_modified_var(loopst &loop, const expr2tc &expr);
   void add_unmodified_var(loopst &loop, const expr2tc &expr);


### PR DESCRIPTION
## Summary

Two small, independent perf fixes in the k-induction preprocessing pass:

1. **`contains_rec` early-exit** (`src/goto-programs/goto_k_induction.cpp`): the recursion previously walked every operand even after a match (`res = recurse() || res`). Now: check the node first (immediate return if it's a tracked symbol), then short-circuit the operand walk as soon as a sibling matches. Equivalent result (`loop_varst` is unordered, operands are read-only) but skips work on every match. Hot during `remove_unrelated_loop_cond`.

2. **Memoize callee summaries** (`src/goto-programs/goto_loops.cpp` + `.h`): `get_modified_variables` previously descended into every callee body on every loop. Two loops in the same outer function calling the same helper re-walked the helper from scratch. Add a per-instance summary cache keyed by callee identifier, holding `(modified_loop_vars, unmodified_loop_vars)`. Each callee body is walked at most once per `goto_loopst` instance; subsequent calls fold the cached set in. Mutual recursion is detected via an `in_progress` stack and falls back to the legacy "do nothing on cycle" behaviour — partial summaries along a cycle-cut path are call-site dependent and are not cached.

This is item #2 from the broader k-induction deep-dive.

## Test plan

- [x] All 176 `-L k-induction` tests pass.
- [x] All 142 `-R interval` tests pass.
- [x] Reviewed by code-reviewer agent (two minor follow-ups applied: preserved the legacy `abort()` for unknown-callee lookups, documented the per-instance cache scope).
- [ ] CI runs the full suite.