### PR TITLE
[python] resolve transitive imports through intermediate modules

### DIFF
--- a/regression/python/transitive-imports-deep/inner.py
+++ b/regression/python/transitive-imports-deep/inner.py
@@ -1,0 +1,5 @@
+from leaf import deep_value
+
+
+def call_deep() -> int:
+    return deep_value()

--- a/regression/python/transitive-imports-deep/leaf.py
+++ b/regression/python/transitive-imports-deep/leaf.py
@@ -1,0 +1,6 @@
+def direct_value() -> int:
+    return 10
+
+
+def deep_value() -> int:
+    return 20

--- a/regression/python/transitive-imports-deep/main.py
+++ b/regression/python/transitive-imports-deep/main.py
@@ -1,0 +1,15 @@
+# Regression for esbmc/esbmc#4509: deterministic transitive-import case.
+#
+# main directly imports `direct_value` from `leaf`, so `leaf` enters round 1
+# of the parser's import-discovery fixpoint with specific_names = {direct_value}.
+# `mid` is also in round 1; parsing it adds `inner` to module_imports. `inner`
+# is processed in round 2 and only then adds `deep_value` to leaf's
+# specific_names. A single-phase emitter (the pre-fix bug) would have already
+# written leaf.json with only direct_value in round 1, and never re-emit it —
+# so `inner`'s call to `deep_value()` would fail to resolve regardless of set
+# iteration order. The fix's discovery/emission split makes this case pass.
+from leaf import direct_value
+from mid import via_mid
+
+assert direct_value() == 10
+assert via_mid() == 20

--- a/regression/python/transitive-imports-deep/mid.py
+++ b/regression/python/transitive-imports-deep/mid.py
@@ -1,0 +1,5 @@
+from inner import call_deep
+
+
+def via_mid() -> int:
+    return call_deep()

--- a/regression/python/transitive-imports-deep/test.desc
+++ b/regression/python/transitive-imports-deep/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/transitive-imports-fail/kernels/kernel.py
+++ b/regression/python/transitive-imports-fail/kernels/kernel.py
@@ -1,0 +1,6 @@
+from stubs import Tile, make_tile, check_shape
+
+
+def add_kernel(a: Tile, b: Tile) -> Tile:
+    check_shape(a, b)
+    return make_tile(a.d0, a.d1)

--- a/regression/python/transitive-imports-fail/main.py
+++ b/regression/python/transitive-imports-fail/main.py
@@ -1,0 +1,8 @@
+from stubs import make_tile
+from kernels.kernel import add_kernel
+
+# Mismatched shapes — check_shape (imported transitively through kernel)
+# must fire its assertion, proving the transitive import chain is wired up.
+a = make_tile(4, 8)
+b = make_tile(8, 4)
+add_kernel(a, b)

--- a/regression/python/transitive-imports-fail/stubs.py
+++ b/regression/python/transitive-imports-fail/stubs.py
@@ -1,0 +1,15 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+def make_tile(d0: int, d1: int) -> Tile:
+    assert d0 > 0
+    assert d1 > 0
+    return Tile(d0, d1)
+
+
+def check_shape(a: Tile, b: Tile) -> None:
+    assert a.d0 == b.d0
+    assert a.d1 == b.d1

--- a/regression/python/transitive-imports-fail/test.desc
+++ b/regression/python/transitive-imports-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$

--- a/regression/python/transitive-imports/kernels/kernel.py
+++ b/regression/python/transitive-imports/kernels/kernel.py
@@ -1,0 +1,6 @@
+from stubs import Tile, make_tile, check_shape
+
+
+def add_kernel(a: Tile, b: Tile) -> Tile:
+    check_shape(a, b)
+    return make_tile(a.d0, a.d1)

--- a/regression/python/transitive-imports/main.py
+++ b/regression/python/transitive-imports/main.py
@@ -1,0 +1,8 @@
+from stubs import make_tile
+from kernels.kernel import add_kernel
+
+a = make_tile(4, 8)
+b = make_tile(4, 8)
+c = add_kernel(a, b)
+assert c.d0 == 4
+assert c.d1 == 8

--- a/regression/python/transitive-imports/stubs.py
+++ b/regression/python/transitive-imports/stubs.py
@@ -1,0 +1,15 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+def make_tile(d0: int, d1: int) -> Tile:
+    assert d0 > 0
+    assert d1 > 0
+    return Tile(d0, d1)
+
+
+def check_shape(a: Tile, b: Tile) -> None:
+    assert a.d0 == b.d0
+    assert a.d1 == b.d1

--- a/regression/python/transitive-imports/test.desc
+++ b/regression/python/transitive-imports/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -369,45 +369,58 @@ def emit_module_json(
 
 
 def process_collected_imports(output_dir):
-    # Keep processing until no new modules are discovered
-    processed_modules = set()
+    """
+    Emit AST JSON for every transitively-imported module.
+
+    Discovery and emission are split into two phases so that names added to
+    ``module_imports[m]['specific_names']`` by a transitive importer (parsed
+    later in the walk) are seen by the emitter for ``m``. A single-phase loop
+    would emit ``m``'s JSON the first time it appears, before its full
+    specific_names set is known, and later expansions would never be
+    re-emitted — causing transitive symbols to silently disappear from the
+    JSON the C++ backend reads.
+    """
+    # Phase 1 — discovery: harvest imports from every reachable module until
+    # module_imports stops growing. Cache parsed trees so emission in Phase 2
+    # does not re-run the (expensive) Preprocessor.
+    parsed_trees = {}  # module_name -> (tree, filename)
+    visited = set()
 
     while True:
-        # Get modules that haven't been processed yet
-        modules_to_process = set(module_imports.keys()) - processed_modules
-
-        if not modules_to_process:
+        pending = set(module_imports.keys()) - visited
+        if not pending:
             break
-
-        for module_name in modules_to_process:
-            import_info = module_imports[module_name]
-            processed_modules.add(module_name)
-
-            imported_elements = None if import_info['import_all'] \
-                else [ast.alias(name, None) for name in import_info['specific_names']]
-
-            # Attempt to resolve and emit JSON for imported submodules (e.g., "pkg.sub")
-            if import_info['specific_names']:
-                for name in list(import_info['specific_names']):
-                    emit_module_json(f"{module_name}.{name}", output_dir)
-
-            # Emit the module itself
+        for module_name in pending:
+            visited.add(module_name)
             filename = resolve_module_file(module_name, output_dir)
             if not filename:
                 continue
-
-            # Parse once, fix relative imports, collect nested imports
             tree = parse_file(filename)
+            parsed_trees[module_name] = (tree, filename)
             for subnode in ast.walk(tree):
                 if isinstance(subnode, (ast.Import, ast.ImportFrom)):
                     rewrite_relative_import(subnode, module_name)
                     process_imports(subnode, output_dir)
 
-            generate_ast_json(tree,
-                              filename,
-                              imported_elements,
-                              output_dir,
-                              module_qualname=module_name)
+    # Phase 2 — emission: module_imports is now stable, so every emitted JSON
+    # contains the full set of names any importer ever asked for.
+    for module_name, import_info in module_imports.items():
+        imported_elements = None if import_info['import_all'] \
+            else [ast.alias(name, None) for name in import_info['specific_names']]
+
+        # Submodule guess (e.g. "pkg.sub" referenced as "pkg.sub.name")
+        if import_info['specific_names']:
+            for name in list(import_info['specific_names']):
+                emit_module_json(f"{module_name}.{name}", output_dir)
+
+        if module_name not in parsed_trees:
+            continue
+        tree, filename = parsed_trees[module_name]
+        generate_ast_json(tree,
+                          filename,
+                          imported_elements,
+                          output_dir,
+                          module_qualname=module_name)
 
 
 def rewrite_relative_import(node, parent_module: str | None):
@@ -500,9 +513,15 @@ def generate_ast_json(tree, python_filename, elements_to_import, output_dir, mod
                     filtered_nodes.append(node)
 
             # Include annotated assignments (e.g., x: int = 42)
-            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
                 if node.target.id in explicitly_imported:
                     filtered_nodes.append(node)
+
+            # Preserve Import/ImportFrom nodes: the C++ converter needs them
+            # (with the parser-attached ``full_path``/``module_not_found``
+            # attributes) to resolve calls into transitively-imported modules.
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                filtered_nodes.append(node)
 
     # Convert AST to JSON
     ast2json_module = import_module_by_name("ast2json", "")


### PR DESCRIPTION
process_collected_imports emitted each module's AST JSON the first time it was seen, before discovering that a transitively-imported module needed extra names — and generate_ast_json's body filter dropped Import/ImportFrom nodes, so the C++ resolver lost the full_path needed to find symbols across modules. Both bugs combined to surface as "Unsupported function ... is reached" for any call into a transitively- imported symbol.

Split process_collected_imports into a discovery fixpoint (parse each reachable module to harvest its imports until module_imports stabilises) followed by a single emission pass, and preserve Import/ImportFrom nodes through the body filter. Adds regression tests transitive-imports, transitive-imports-fail, and transitive-imports-deep (the last one deterministically fails pre-fix regardless of set iteration order).

Fixes #4509