### PR TITLE
[python] guard infer_loop_variable_types against null AnnAssign value

### DIFF
--- a/regression/python/github_4510/main.py
+++ b/regression/python/github_4510/main.py
@@ -1,0 +1,16 @@
+def f(n: int) -> int:
+    h: int = 0
+    result: int = 0
+    while h < 3:
+        x: int
+        if 5 < n:
+            x = 5
+        else:
+            x = n
+        result = result + x
+        h = h + 1
+    return result
+
+
+r = f(10)
+assert r == 15

--- a/regression/python/github_4510/test.desc
+++ b/regression/python/github_4510/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4510_fail/main.py
+++ b/regression/python/github_4510_fail/main.py
@@ -1,0 +1,16 @@
+def f(n: int) -> int:
+    h: int = 0
+    result: int = 0
+    while h < 3:
+        x: int
+        if 5 < n:
+            x = 5
+        else:
+            x = n
+        result = result + x
+        h = h + 1
+    return result
+
+
+r = f(10)
+assert r == 0

--- a/regression/python/github_4510_fail/test.desc
+++ b/regression/python/github_4510_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -3567,9 +3567,13 @@ private:
     for (auto &stmt : while_stmt["body"])
     {
       // Look for pattern: loop_var: Any = iterable[ESBMC_index_N]
+      // A bare annotation like `x: int` has value == null; nlohmann::json's
+      // `contains("value")` returns true for present-but-null members, so an
+      // explicit is_null() guard is required to avoid a type_error on the
+      // subsequent subscript.
       if (
         stmt["_type"] == "AnnAssign" && stmt.contains("value") &&
-        stmt["value"]["_type"] == "Subscript")
+        !stmt["value"].is_null() && stmt["value"]["_type"] == "Subscript")
       {
         if (!stmt["value"]["value"].contains("id"))
           continue;


### PR DESCRIPTION
A bare annotation like `x: int` inside a while-loop body has `"value": null` in the AST. `nlohmann::json::contains("value")` returns true for present-but-null members, so the subsequent `stmt["value"]["_type"]` subscript threw `nlohmann::detail::type_error`, aborting the Python frontend silently at the Converting stage. An explicit `is_null()` guard makes the loop-variable inference pass skip bare annotations cleanly.

Fixes #4510