### PR TITLE
[python] scope entry-script skip to top-level module load

### DIFF
--- a/regression/python/github_4513/kernels/tensor_add.py
+++ b/regression/python/github_4513/kernels/tensor_add.py
@@ -1,0 +1,5 @@
+from stubs import Tile, make_tile
+
+def nki_tensor_add(a: Tile, b: Tile) -> Tile:
+    assert a.d0 == b.d0
+    return make_tile(a.d0, a.d1)

--- a/regression/python/github_4513/stubs.py
+++ b/regression/python/github_4513/stubs.py
@@ -1,0 +1,9 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+def make_tile(d0: int, d1: int) -> Tile:
+    assert d0 > 0
+    assert d1 > 0
+    return Tile(d0, d1)

--- a/regression/python/github_4513/tensor_add.py
+++ b/regression/python/github_4513/tensor_add.py
@@ -1,0 +1,6 @@
+from stubs import make_tile
+from kernels.tensor_add import nki_tensor_add
+
+a = make_tile(4, 8)
+c = nki_tensor_add(a, a)
+assert c.d0 == 4

--- a/regression/python/github_4513/test.desc
+++ b/regression/python/github_4513/test.desc
@@ -1,0 +1,4 @@
+CORE
+tensor_add.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4513_fail/kernels/tensor_add.py
+++ b/regression/python/github_4513_fail/kernels/tensor_add.py
@@ -1,0 +1,5 @@
+from stubs import Tile, make_tile
+
+def nki_tensor_add(a: Tile, b: Tile) -> Tile:
+    assert a.d0 == b.d0
+    return make_tile(a.d0, a.d1)

--- a/regression/python/github_4513_fail/stubs.py
+++ b/regression/python/github_4513_fail/stubs.py
@@ -1,0 +1,9 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+def make_tile(d0: int, d1: int) -> Tile:
+    assert d0 > 0
+    assert d1 > 0
+    return Tile(d0, d1)

--- a/regression/python/github_4513_fail/tensor_add.py
+++ b/regression/python/github_4513_fail/tensor_add.py
@@ -1,0 +1,6 @@
+from stubs import make_tile
+from kernels.tensor_add import nki_tensor_add
+
+a = make_tile(4, 8)
+c = nki_tensor_add(a, a)
+assert c.d0 == 5

--- a/regression/python/github_4513_fail/test.desc
+++ b/regression/python/github_4513_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+tensor_add.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/module_manager.cpp
+++ b/src/python-frontend/module_manager.cpp
@@ -204,7 +204,10 @@ void module_manager::load_directory(
       auto submodule = create_module(entry.path());
       if (submodule)
       {
-        if (main_module_ == submodule->name())
+        // The entry-script JSON is only at the top level; a submodule whose
+        // basename happens to match (e.g. kernels/<main>.py) is a distinct
+        // module and must be loaded.
+        if (!parent_module && main_module_ == submodule->name())
         {
           continue;
         }

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -1948,6 +1948,9 @@ private:
           json_utils::find_imported_function(ast_, func_name);
         auto module = module_manager_->get_module(import_node["module"]);
 
+        if (!module)
+          throw std::runtime_error("module not found");
+
         // Try to get it as a function first
         try
         {


### PR DESCRIPTION
`load_directory` was suppressing every submodule whose basename matched
the entry-script stem, not only the top-level entry-script JSON. With
`entry.py` plus `pkg/entry.py`, the submodule was dropped and a later
`get_module("pkg.entry")` returned nullptr, segfaulting in the
import-resolution path of `python_annotation.h`. Gate the skip on
`!parent_module` and add the missing null-check before dereferencing
the lookup result so unregistered modules raise instead of crashing.

Fixes #4513