### PR TITLE
[build] Support Boost 1.88+ where boost/process/v1.hpp umbrella was removed

### DIFF
--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -13,10 +13,26 @@
 
 #include <boost/filesystem.hpp>
 
-// Use boost::process v1 on macOS or when Boost >= 1.87
+// Use boost::process v1 on macOS or when Boost >= 1.87. The umbrella
+// header layout differs between Boost releases:
+//
+//   - Boost <= 1.86: `boost/process.hpp` IS v1 (v2 not yet shipped),
+//                    namespace `boost::process`.
+//   - Boost == 1.87: `boost/process/v1.hpp` umbrella exists; the
+//                    default `boost/process.hpp` switched to v2.
+//                    Use the umbrella, namespace `boost::process::v1`.
+//   - Boost >= 1.88: the `boost/process/v1.hpp` umbrella was removed;
+//                    v1 is still shipped under `boost/process/v1/*.hpp`
+//                    subheaders. Include the ones we use.
+//
 // We use Boost.Process to run the Python interpreter in a separate process.
-#if defined(__APPLE__) || (BOOST_VERSION >= 108700)
+#if defined(__APPLE__) || (BOOST_VERSION == 108700)
 #  include <boost/process/v1.hpp>
+namespace bp = boost::process::v1;
+#elif BOOST_VERSION >= 108800
+#  include <boost/process/v1/child.hpp>
+#  include <boost/process/v1/io.hpp>
+#  include <boost/process/v1/search_path.hpp>
 namespace bp = boost::process::v1;
 #else
 #  include <boost/process.hpp>

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -25,9 +25,25 @@ CC_DIAGNOSTIC_POP()
 #include <cstdlib>
 #include <regex>
 
-// Use boost::process v1 on macOS or when Boost >= 1.87
-#if defined(__APPLE__) || (BOOST_VERSION >= 108700)
+// Use boost::process v1 on macOS or when Boost >= 1.87. The umbrella
+// header layout differs between Boost releases:
+//
+//   - Boost <= 1.86: `boost/process.hpp` IS v1 (v2 not yet shipped),
+//                    namespace `boost::process`.
+//   - Boost == 1.87: `boost/process/v1.hpp` umbrella exists; the
+//                    default `boost/process.hpp` switched to v2.
+//                    Use the umbrella, namespace `boost::process::v1`.
+//   - Boost >= 1.88: the `boost/process/v1.hpp` umbrella was removed;
+//                    v1 is still shipped under `boost/process/v1/*.hpp`
+//                    subheaders. Include the ones we use.
+#if defined(__APPLE__) || (BOOST_VERSION == 108700)
 #  include <boost/process/v1.hpp>
+namespace bp = boost::process::v1;
+#elif BOOST_VERSION >= 108800
+#  include <boost/process/v1/child.hpp>
+#  include <boost/process/v1/io.hpp>
+#  include <boost/process/v1/pipe.hpp>
+#  include <boost/process/v1/search_path.hpp>
 namespace bp = boost::process::v1;
 #else
 #  include <boost/process.hpp>


### PR DESCRIPTION
## Summary

Boost 1.88 removed the `boost/process/v1.hpp` umbrella header that 1.87 introduced, but still ships v1 under `boost/process/v1/*.hpp` subheaders. The current `BOOST_VERSION >= 108700` branch breaks on 1.88+ because the umbrella include no longer resolves.

Split the preprocessor branches:

- `BOOST_VERSION == 108700` (or `__APPLE__`): keep using the `boost/process/v1.hpp` umbrella.
- `BOOST_VERSION >= 108800`: include the specific v1 subheaders we actually use (`child.hpp`, `io.hpp`, `pipe.hpp` for solidity, `search_path.hpp`).
- Otherwise: fall back to the pre-1.87 `boost/process.hpp` (which *is* v1).

A comment documenting the umbrella-header layout across Boost releases is added next to each `#if` block.