### PR TITLE
[python] infer class type for methods returning self

### DIFF
--- a/regression/python/github_4514/main.py
+++ b/regression/python/github_4514/main.py
@@ -1,0 +1,12 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+    def __getitem__(self, key):
+        return self
+
+
+t: Tile = Tile(10, 20)
+sub = t[5]
+assert sub.d0 == 10

--- a/regression/python/github_4514/test.desc
+++ b/regression/python/github_4514/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4514_fail/main.py
+++ b/regression/python/github_4514_fail/main.py
@@ -1,0 +1,12 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+    def __getitem__(self, key):
+        return self
+
+
+t: Tile = Tile(10, 20)
+sub = t[5]
+assert sub.d0 == 11

--- a/regression/python/github_4514_fail/test.desc
+++ b/regression/python/github_4514_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -8884,6 +8884,16 @@ typet python_converter::infer_return_type_from_body(const nlohmann::json &body)
     {
       const auto &ret_val = stmt["value"];
 
+      // `return self` in a method: surface the class's struct value type so
+      // callers can assign to a `Class`-typed local. Without this, fallback
+      // inference picks up `Class *` from `self` and the call-site assignment
+      // becomes a pointer-to-struct mismatch that trips an assertion in
+      // value_set::make_member on later member access. See GitHub #4514.
+      if (
+        ret_val["_type"] == "Name" && ret_val.contains("id") &&
+        ret_val["id"] == "self" && !current_class_name_.empty())
+        return type_handler_.get_typet(current_class_name_);
+
       // If returning a tuple, infer its type
       if (ret_val["_type"] == "Tuple")
         return tuple_handler_->get_tuple_expr(ret_val).type();


### PR DESCRIPTION
A class method that returns `self` and has no explicit return annotation
had its return type inferred as `Class *` (from the GOTO-body scan), while
the caller's subscript-lvalue was typed as the class struct value. The
resulting pointer-to-struct mismatch tripped an assertion in
`value_sett::make_member` on later member access through `t[k]`. Catch
`return self` at AST-level inference so the existing auto-dereference path
produces a struct return.

Fixes #4514
