### PR TITLE
[python] infer tuple element types for bare 'tuple' annotations

### DIFF
--- a/regression/python/github_4515_attr/main.py
+++ b/regression/python/github_4515_attr/main.py
@@ -1,0 +1,7 @@
+class T:
+    def __init__(self, d0: int, d1: int):
+        self.shape: tuple = (d0, d1)
+
+t: T = T(10, 20)
+M, N = t.shape
+assert M == 10 and N == 20

--- a/regression/python/github_4515_attr/test.desc
+++ b/regression/python/github_4515_attr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4515_attr_fail/main.py
+++ b/regression/python/github_4515_attr_fail/main.py
@@ -1,0 +1,7 @@
+class T:
+    def __init__(self, d0: int, d1: int):
+        self.shape: tuple = (d0, d1)
+
+t: T = T(10, 20)
+M, N = t.shape
+assert M == 99

--- a/regression/python/github_4515_attr_fail/test.desc
+++ b/regression/python/github_4515_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4515_param/main.py
+++ b/regression/python/github_4515_param/main.py
@@ -1,0 +1,5 @@
+def f(t: tuple) -> int:
+    a, b = t
+    return a + b
+
+assert f((3, 4)) == 7

--- a/regression/python/github_4515_param/test.desc
+++ b/regression/python/github_4515_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -553,6 +553,27 @@ private:
             has_partial_annotation = true;
             needs_inference = true; // Try to refine with element type
           }
+          else if (current_type == "tuple")
+          {
+            // Bare `tuple` annotation: try to specialise to
+            // `tuple[T0, T1, ...]` by inspecting call sites so the unpacker
+            // can recover the struct shape (GitHub #4515).
+            if (!function_calls.empty())
+            {
+              std::vector<std::string> elem_types =
+                infer_tuple_param_types_from_calls(i, function_calls);
+              if (!elem_types.empty())
+              {
+                int lineno = param.value("lineno", 0);
+                int col_offset =
+                  param.value("col_offset", 0) +
+                  param["arg"].template get<std::string>().size() + 1;
+                param["annotation"] = create_tuple_subscript_annotation(
+                  elem_types, lineno, col_offset, lineno);
+              }
+            }
+            continue;
+          }
           else
             continue; // Fully annotated, skip
         }
@@ -731,6 +752,62 @@ private:
     }
 
     return types;
+  }
+
+  // For a parameter annotated bare `tuple`, recover the element types by
+  // intersecting all call sites that pass a Tuple literal at position
+  // @p param_index. Returns empty when arity disagrees, any caller passes a
+  // non-Tuple-literal argument, or no usable call sites exist; element types
+  // that disagree across calls fall back to "Any". Used to specialise bare
+  // `tuple` parameter annotations to `tuple[T0, T1, ...]` so tuple-unpacking
+  // sees the struct shape (GitHub #4515).
+  std::vector<std::string> infer_tuple_param_types_from_calls(
+    size_t param_index,
+    const std::vector<Json> &function_calls)
+  {
+    std::vector<std::string> result;
+    bool initialized = false;
+
+    for (const Json &call : function_calls)
+    {
+      if (!call.contains("args") || param_index >= call["args"].size())
+        continue;
+
+      const Json &arg = call["args"][param_index];
+      if (
+        !arg.contains("_type") || arg["_type"] != "Tuple" ||
+        !arg.contains("elts"))
+        return {};
+
+      std::vector<std::string> shape;
+      shape.reserve(arg["elts"].size());
+      for (const Json &elt : arg["elts"])
+      {
+        std::string t = get_argument_type(elt);
+        // Empty result and bare container kinds without parameters all
+        // resolve to incomplete/empty types downstream. Clamp them to "Any"
+        // so the synthesised struct never carries an empty_typet() component.
+        if (t.empty() || t == "tuple" || t == "list" || t == "dict")
+          t = "Any";
+        shape.push_back(std::move(t));
+      }
+
+      if (!initialized)
+      {
+        result = std::move(shape);
+        initialized = true;
+      }
+      else
+      {
+        if (shape.size() != result.size())
+          return {};
+        for (size_t k = 0; k < result.size(); ++k)
+          if (result[k] != shape[k])
+            result[k] = "Any";
+      }
+    }
+
+    return result;
   }
 
   bool are_all_user_classes(const std::vector<std::string> &types) const
@@ -3856,6 +3933,53 @@ private:
       {"slice",
        create_name_annotation(
          element_type, lineno, slice_col, end_lineno, slice_end_col)},
+      {"ctx", {{"_type", "Load"}}},
+      {"lineno", lineno},
+      {"col_offset", col_offset},
+      {"end_lineno", end_lineno},
+      {"end_col_offset", total_end_col}};
+  }
+
+  // Build a `tuple[t0, t1, ...]` Subscript annotation node. Used by the
+  // parameter-inference pass to specialise bare `tuple` annotations once
+  // the element types have been recovered from call sites (GitHub #4515).
+  Json create_tuple_subscript_annotation(
+    const std::vector<std::string> &elem_types,
+    int lineno,
+    int col_offset,
+    int end_lineno)
+  {
+    static const std::string base_type = "tuple";
+    int base_end_col = col_offset + base_type.size();
+    int slice_col = base_end_col + 1;
+
+    Json elts = Json::array();
+    int cur = slice_col;
+    for (const std::string &t : elem_types)
+    {
+      int end_col = cur + t.size();
+      elts.push_back(
+        create_name_annotation(t, lineno, cur, end_lineno, end_col));
+      cur = end_col + 2; // ", "
+    }
+    int slice_end_col = cur - 2;
+    int total_end_col = slice_end_col + 1;
+
+    Json slice = {
+      {"_type", "Tuple"},
+      {"elts", elts},
+      {"ctx", {{"_type", "Load"}}},
+      {"lineno", lineno},
+      {"col_offset", slice_col},
+      {"end_lineno", end_lineno},
+      {"end_col_offset", slice_end_col}};
+
+    return {
+      {"_type", "Subscript"},
+      {"value",
+       create_name_annotation(
+         base_type, lineno, col_offset, end_lineno, base_end_col)},
+      {"slice", slice},
       {"ctx", {{"_type", "Load"}}},
       {"lineno", lineno},
       {"col_offset", col_offset},

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9576,7 +9576,8 @@ void python_converter::get_attributes_from_self(
         // value when it is a Tuple literal so later `obj.attr` reads carry the
         // struct shape needed for unpacking (GitHub #4515).
         if (stmt.contains("value"))
-          type = infer_tuple_struct_from_value(stmt["value"], param_annotations);
+          type =
+            infer_tuple_struct_from_value(stmt["value"], param_annotations);
         if (type.is_nil() || type.is_empty())
           type = type_handler_.get_typet(annotated_type);
       }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9217,6 +9217,53 @@ void python_converter::get_function_definition(
   current_func_name_ = caller_func_name;
 }
 
+typet python_converter::infer_tuple_struct_from_value(
+  const nlohmann::json &value_node,
+  const std::unordered_map<std::string, nlohmann::json> &param_annotations)
+{
+  if (!value_node.is_object() || !value_node.contains("_type"))
+    return empty_typet();
+
+  if (value_node["_type"] != "Tuple" || !value_node.contains("elts"))
+    return empty_typet();
+
+  std::vector<typet> elem_types;
+  elem_types.reserve(value_node["elts"].size());
+
+  for (const auto &elt : value_node["elts"])
+  {
+    typet elem_type;
+    const std::string elt_kind = elt.value("_type", "");
+
+    if (elt_kind == "Constant" && elt.contains("value"))
+    {
+      const auto &v = elt["value"];
+      if (v.is_boolean())
+        elem_type = bool_type();
+      else if (v.is_number_integer())
+        elem_type = long_long_int_type();
+      else if (v.is_number_float())
+        elem_type = double_type();
+      else if (v.is_string())
+        elem_type = gen_pointer_type(char_type());
+    }
+    else if (elt_kind == "Name" && elt.contains("id"))
+    {
+      const std::string name = elt["id"].get<std::string>();
+      auto it = param_annotations.find(name);
+      if (it != param_annotations.end())
+        elem_type = get_type_from_annotation(it->second, elt);
+    }
+
+    if (elem_type.is_nil() || elem_type.id().as_string().empty())
+      elem_type = any_type();
+
+    elem_types.push_back(elem_type);
+  }
+
+  return tuple_handler_->create_tuple_struct_type(elem_types);
+}
+
 typet python_converter::infer_attr_type_from_usage(
   const std::string &class_name,
   const std::string &attr_name)
@@ -9522,6 +9569,16 @@ void python_converter::get_attributes_from_self(
         if (unset(resolved))
           resolved = infer_attr_type_from_usage(current_class_name_, attr_name);
         type = unset(resolved) ? any_type() : resolved;
+      }
+      else if (annotated_type == "tuple" || annotated_type == "Tuple")
+      {
+        // Bare `tuple` annotation: recover element types from the assigned
+        // value when it is a Tuple literal so later `obj.attr` reads carry the
+        // struct shape needed for unpacking (GitHub #4515).
+        if (stmt.contains("value"))
+          type = infer_tuple_struct_from_value(stmt["value"], param_annotations);
+        if (type.is_nil() || type.is_empty())
+          type = type_handler_.get_typet(annotated_type);
       }
       else
         type = type_handler_.get_typet(annotated_type);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -16,6 +16,7 @@
 #include <util/symbol_generator.h>
 #include <map>
 #include <set>
+#include <unordered_map>
 #include <utility>
 
 class codet;
@@ -437,6 +438,26 @@ private:
   typet infer_attr_type_from_usage(
     const std::string &class_name,
     const std::string &attr_name);
+
+  /**
+   * @brief Build a tuple struct type from an AST value node when the annotation
+   *        is bare `tuple`.
+   *
+   * Walks a `Tuple` literal's elements and synthesises a struct_typet whose
+   * components mirror the element types. Constants are typed by their JSON
+   * kind; `Name` elements are resolved through @p param_annotations (used to
+   * recover types of parameters referenced inside `__init__`-style bodies);
+   * everything else falls back to `any_type()`. Returns `empty_typet()` when
+   * the node is not a Tuple literal.
+   *
+   * @param value_node       AST node holding the RHS of `attr: tuple = <rhs>`.
+   * @param param_annotations Parameter-name → annotation AST map for the
+   *                          enclosing function (may be empty).
+   * @return A struct_typet tagged as a tuple, or empty_typet on failure.
+   */
+  typet infer_tuple_struct_from_value(
+    const nlohmann::json &value_node,
+    const std::unordered_map<std::string, nlohmann::json> &param_annotations);
 
   exprt get_return_from_func(const char *func_symbol_id);
 


### PR DESCRIPTION
Bare `tuple` annotations on class attributes (`self.shape: tuple = (d0, d1)`)
and function parameters (`def f(t: tuple)`) crashed tuple unpacking with
`ERROR: Cannot unpack empty` because `get_typet("tuple")` returns
`empty_typet()`. For class attributes, recover element types from a Tuple
literal RHS via the surrounding method's parameter annotations. For
parameters, the annotation pass rewrites bare `tuple` to `tuple[T0, T1, ...]`
when every visible call site passes a Tuple literal of consistent arity.

Fixes #4515.
