### PR TITLE
[python] propagate range aliases / wrappers across module imports

### DIFF
--- a/regression/python/github_4525_alias/lib.py
+++ b/regression/python/github_4525_alias/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias/main.py
+++ b/regression/python/github_4525_alias/main.py
@@ -1,0 +1,7 @@
+from lib import nl_affine_range
+
+count: int = 0
+for i in nl_affine_range(5):
+    count = count + 1
+
+assert count == 5

--- a/regression/python/github_4525_alias/test.desc
+++ b/regression/python/github_4525_alias/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4525_alias_as/lib.py
+++ b/regression/python/github_4525_alias_as/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias_as/main.py
+++ b/regression/python/github_4525_alias_as/main.py
@@ -1,0 +1,7 @@
+from lib import nl_affine_range as aff
+
+count: int = 0
+for i in aff(5):
+    count = count + 1
+
+assert count == 5

--- a/regression/python/github_4525_alias_as/test.desc
+++ b/regression/python/github_4525_alias_as/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4525_alias_chain/lib_a.py
+++ b/regression/python/github_4525_alias_chain/lib_a.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias_chain/lib_b.py
+++ b/regression/python/github_4525_alias_chain/lib_b.py
@@ -1,0 +1,3 @@
+from lib_a import nl_affine_range
+
+aff = nl_affine_range

--- a/regression/python/github_4525_alias_chain/main.py
+++ b/regression/python/github_4525_alias_chain/main.py
@@ -1,0 +1,7 @@
+from lib_b import aff
+
+count: int = 0
+for i in aff(3):
+    count = count + 1
+
+assert count == 3

--- a/regression/python/github_4525_alias_chain/test.desc
+++ b/regression/python/github_4525_alias_chain/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4525_alias_fail/lib.py
+++ b/regression/python/github_4525_alias_fail/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias_fail/main.py
+++ b/regression/python/github_4525_alias_fail/main.py
@@ -1,0 +1,7 @@
+from lib import nl_affine_range
+
+count: int = 0
+for i in nl_affine_range(5):
+    count = count + 1
+
+assert count == 4

--- a/regression/python/github_4525_alias_fail/test.desc
+++ b/regression/python/github_4525_alias_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION FAILED$

--- a/regression/python/github_4525_alias_reexport/lib_a.py
+++ b/regression/python/github_4525_alias_reexport/lib_a.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias_reexport/lib_b.py
+++ b/regression/python/github_4525_alias_reexport/lib_b.py
@@ -1,0 +1,1 @@
+from lib_a import nl_affine_range

--- a/regression/python/github_4525_alias_reexport/main.py
+++ b/regression/python/github_4525_alias_reexport/main.py
@@ -1,0 +1,7 @@
+from lib_b import nl_affine_range
+
+count: int = 0
+for i in nl_affine_range(4):
+    count = count + 1
+
+assert count == 4

--- a/regression/python/github_4525_alias_reexport/test.desc
+++ b/regression/python/github_4525_alias_reexport/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4525_alias_shadow/lib.py
+++ b/regression/python/github_4525_alias_shadow/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias_shadow/main.py
+++ b/regression/python/github_4525_alias_shadow/main.py
@@ -1,0 +1,12 @@
+from lib import nl_affine_range
+
+
+def nl_affine_range(n):
+    return [0, 1]
+
+
+count: int = 0
+for i in nl_affine_range(5):
+    count = count + 1
+
+assert count == 2

--- a/regression/python/github_4525_alias_shadow/test.desc
+++ b/regression/python/github_4525_alias_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4525_alias_star/lib.py
+++ b/regression/python/github_4525_alias_star/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4525_alias_star/main.py
+++ b/regression/python/github_4525_alias_star/main.py
@@ -1,0 +1,7 @@
+from lib import *
+
+count: int = 0
+for i in nl_affine_range(4):
+    count = count + 1
+
+assert count == 4

--- a/regression/python/github_4525_alias_star/test.desc
+++ b/regression/python/github_4525_alias_star/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4525_wrapper/lib.py
+++ b/regression/python/github_4525_wrapper/lib.py
@@ -1,0 +1,2 @@
+def affine_range(n):
+    return range(n)

--- a/regression/python/github_4525_wrapper/main.py
+++ b/regression/python/github_4525_wrapper/main.py
@@ -1,0 +1,7 @@
+from lib import affine_range
+
+count: int = 0
+for i in affine_range(5):
+    count = count + 1
+
+assert count == 5

--- a/regression/python/github_4525_wrapper/test.desc
+++ b/regression/python/github_4525_wrapper/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -216,6 +216,10 @@ def get_referenced_names(node):
 import_aliases = {}
 # Track all imports per module to combine them
 module_imports = {}
+# Per-module export tables collected after Preprocessor runs (#4525). Each
+# entry is (range_aliases, range_wrappers, dunder_all_or_None) and is keyed
+# by qualified module name. The entry script is keyed by ``__main__``.
+module_exports = {}
 
 
 # pylint: disable-next=too-many-locals,too-many-branches
@@ -338,11 +342,17 @@ def filter_imports(tree: ast.AST) -> ast.AST:
     return tree
 
 
-def parse_file(filename: str) -> ast.AST:
-    """Open, parse, and run Preprocessor on a Python source file."""
+def parse_file(filename: str) -> tuple[ast.AST, Preprocessor]:
+    """Open, parse, and run Preprocessor on a Python source file.
+
+    Returns the transformed tree alongside the Preprocessor instance so
+    callers can read its cross-module export tables (#4525).
+    """
     with open(filename, "r", encoding="utf-8") as src:
         tree = ast.parse(src.read())
-    return Preprocessor(filename).visit(tree)
+    preprocessor = Preprocessor(filename)
+    tree = preprocessor.visit(tree)
+    return tree, preprocessor
 
 
 def emit_file_as_json(
@@ -352,7 +362,7 @@ def emit_file_as_json(
     elements_to_import=None,
 ) -> None:
     """Generate AST JSON for a file."""
-    tree = parse_file(filename)
+    tree, _preprocessor = parse_file(filename)
     generate_ast_json(
         tree,
         filename,
@@ -373,6 +383,72 @@ def emit_module_json(
         emit_file_as_json(filename, output_dir, module_qualname, elements_to_import)
 
 
+def _snapshot_exports(preprocessor):
+    """Snapshot a Preprocessor's range-alias / wrapper export tables (#4525)."""
+    return (
+        set(preprocessor.exported_range_aliases),
+        dict(preprocessor.exported_range_wrappers),
+        preprocessor.module_dunder_all,
+    )
+
+
+def _compute_range_seed(module_node):
+    """Build a (alias_seed, wrapper_seed) pair for *module_node* (#4525).
+
+    Walks top-level ``ImportFrom`` statements and projects exported aliases
+    and wrappers from each source module (looked up in ``module_exports``)
+    into the consumer's seed. Honours ``as`` rebinds and ``__all__`` for
+    star imports. Bare ``import X`` (qualified attribute access) is out of
+    scope.
+    """
+    alias_seed = set()
+    wrapper_seed = {}
+    for stmt in module_node.body:
+        if not (isinstance(stmt, ast.ImportFrom) and stmt.module):
+            continue
+        src_exports = module_exports.get(stmt.module)
+        if not src_exports:
+            continue
+        src_aliases, src_wrappers, src_all = src_exports
+        if any(a.name == '*' for a in stmt.names):
+            visible = (set(src_all) if src_all is not None
+                       else {n for n in (set(src_aliases) | set(src_wrappers))
+                             if not n.startswith('_')})
+            alias_seed |= (set(src_aliases) & visible)
+            for w in src_wrappers:
+                if w in visible:
+                    wrapper_seed[w] = src_wrappers[w]
+            continue
+        for a in stmt.names:
+            bind_name = a.asname or a.name
+            if a.name in src_aliases:
+                alias_seed.add(bind_name)
+            if a.name in src_wrappers:
+                wrapper_seed[bind_name] = src_wrappers[a.name]
+    return alias_seed, wrapper_seed
+
+
+def _propagate_range_aliases_across_modules(parsed_trees):
+    """Re-apply alias / wrapper rewrites with cross-module seeds (#4525).
+
+    Iterates to a fixed point so chained re-exports (``lib_b`` re-imports
+    aliases from ``lib_a``, which its own consumers then inherit) converge.
+    """
+    while True:
+        changed = False
+        for module_name, (tree, _filename, preprocessor) in parsed_trees.items():
+            alias_seed, wrapper_seed = _compute_range_seed(tree)
+            before = _snapshot_exports(preprocessor)
+            preprocessor._rewrite_range_aliases(tree, seed=alias_seed)
+            preprocessor._inline_range_wrappers(tree, seed=wrapper_seed)
+            after = _snapshot_exports(preprocessor)
+            if after != before:
+                module_exports[module_name] = after
+                changed = True
+        if not changed:
+            return
+
+
 def process_collected_imports(output_dir):
     """
     Emit AST JSON for every transitively-imported module.
@@ -388,7 +464,7 @@ def process_collected_imports(output_dir):
     # Phase 1 — discovery: harvest imports from every reachable module until
     # module_imports stops growing. Cache parsed trees so emission in Phase 2
     # does not re-run the (expensive) Preprocessor.
-    parsed_trees = {}  # module_name -> (tree, filename)
+    parsed_trees = {}  # module_name -> (tree, filename, preprocessor)
     visited = set()
 
     while True:
@@ -400,12 +476,16 @@ def process_collected_imports(output_dir):
             filename = resolve_module_file(module_name, output_dir)
             if not filename:
                 continue
-            tree = parse_file(filename)
-            parsed_trees[module_name] = (tree, filename)
+            tree, preprocessor = parse_file(filename)
+            parsed_trees[module_name] = (tree, filename, preprocessor)
+            module_exports[module_name] = _snapshot_exports(preprocessor)
             for subnode in ast.walk(tree):
                 if isinstance(subnode, (ast.Import, ast.ImportFrom)):
                     rewrite_relative_import(subnode, module_name)
                     process_imports(subnode, output_dir)
+
+    # Phase 1b — cross-module range alias / wrapper propagation (#4525).
+    _propagate_range_aliases_across_modules(parsed_trees)
 
     # Phase 2 — emission: module_imports is now stable, so every emitted JSON
     # contains the full set of names any importer ever asked for.
@@ -420,7 +500,7 @@ def process_collected_imports(output_dir):
 
         if module_name not in parsed_trees:
             continue
-        tree, filename = parsed_trees[module_name]
+        tree, filename, _preprocessor = parsed_trees[module_name]
         generate_ast_json(tree,
                           filename,
                           imported_elements,
@@ -651,6 +731,7 @@ def main():
     # Apply AST transformations
     preprocessor = Preprocessor(filename)
     tree = preprocessor.visit(tree)
+    module_exports["__main__"] = _snapshot_exports(preprocessor)
 
     # Tracking of imported modules and aliases
     processed_submodules = set()
@@ -671,6 +752,12 @@ def main():
 
     # Now process all collected imports once
     process_collected_imports(output_dir)
+
+    # Re-apply range-alias / wrapper rewrites on the entry script using the
+    # cross-module export tables built during import processing (#4525).
+    alias_seed, wrapper_seed = _compute_range_seed(tree)
+    preprocessor._rewrite_range_aliases(tree, seed=alias_seed)
+    preprocessor._inline_range_wrappers(tree, seed=wrapper_seed)
 
     # Generate JSON from AST for the main file.
     generate_ast_json(tree, filename, None, output_dir)

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -439,8 +439,9 @@ def _propagate_range_aliases_across_modules(parsed_trees):
         for module_name, (tree, _filename, preprocessor) in parsed_trees.items():
             alias_seed, wrapper_seed = _compute_range_seed(tree)
             before = _snapshot_exports(preprocessor)
-            preprocessor._rewrite_range_aliases(tree, seed=alias_seed)
-            preprocessor._inline_range_wrappers(tree, seed=wrapper_seed)
+            preprocessor.apply_range_rewrites(tree,
+                                              alias_seed=alias_seed,
+                                              wrapper_seed=wrapper_seed)
             after = _snapshot_exports(preprocessor)
             if after != before:
                 module_exports[module_name] = after
@@ -756,8 +757,9 @@ def main():
     # Re-apply range-alias / wrapper rewrites on the entry script using the
     # cross-module export tables built during import processing (#4525).
     alias_seed, wrapper_seed = _compute_range_seed(tree)
-    preprocessor._rewrite_range_aliases(tree, seed=alias_seed)
-    preprocessor._inline_range_wrappers(tree, seed=wrapper_seed)
+    preprocessor.apply_range_rewrites(tree,
+                                      alias_seed=alias_seed,
+                                      wrapper_seed=wrapper_seed)
 
     # Generate JSON from AST for the main file.
     generate_ast_json(tree, filename, None, output_dir)

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -441,8 +441,7 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
         # Capture `__all__` (if statically a list/tuple of string literals) so
         # cross-module propagation (#4525) can honour it for `from X import *`.
         self.module_dunder_all = self._capture_dunder_all(node)
-        self._rewrite_range_aliases(node)
-        self._inline_range_wrappers(node)
+        self.apply_range_rewrites(node)
 
         # Transform the module as usual
         node = self.generic_visit(node)
@@ -708,6 +707,20 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
                     local.add(lhs)
                     changed = True
         return local, all_aliases
+
+    def apply_range_rewrites(self,
+                             module_node,
+                             alias_seed=frozenset(),
+                             wrapper_seed=None):
+        """Run the range-alias and range-wrapper rewrites on *module_node*.
+
+        Public entry point for both per-module and cross-module (#4525)
+        invocations. *alias_seed* and *wrapper_seed* carry aliases /
+        wrappers inherited from imported modules; pass empty defaults for
+        a single-file pre-pass.
+        """
+        self._rewrite_range_aliases(module_node, seed=alias_seed)
+        self._inline_range_wrappers(module_node, seed=wrapper_seed)
 
     def _rewrite_range_aliases(self, module_node, seed=frozenset()):
         """Rewrite module-scope ``alias = range`` (and chains) to canonical ``range``.

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -84,6 +84,12 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
         self._assert_eq_counter = 0
         self._known_literal_values = {}
         self._identity_functions = set()
+        # Cross-module range-alias / wrapper propagation (#4525). Populated
+        # by visit_Module so parser.py can project these into consumers'
+        # imported-seed sets.
+        self.exported_range_aliases = set()
+        self.exported_range_wrappers = {}
+        self.module_dunder_all = None
 
     # Names treated as typing-style generic constructors (subscript = type alias).
     _TYPING_GENERIC_NAMES = (
@@ -432,6 +438,9 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
         # back to literal `range(...)` calls. After these rewrites,
         # `for i in alias_or_wrapper(...)` reaches visit_For as a plain range
         # call and uses the existing range-for transformation.
+        # Capture `__all__` (if statically a list/tuple of string literals) so
+        # cross-module propagation (#4525) can honour it for `from X import *`.
+        self.module_dunder_all = self._capture_dunder_all(node)
         self._rewrite_range_aliases(node)
         self._inline_range_wrappers(node)
 
@@ -665,19 +674,23 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
             yield child
             yield from cls._iter_module_scope(child, shadow_names)
 
-    def _rewrite_range_aliases(self, module_node):
-        """Rewrite module-scope ``alias = range`` (and chains) to canonical ``range``.
+    @staticmethod
+    def collect_range_aliases(module_node, seed=frozenset()):
+        """Collect module-scope canonical-range aliases.
 
-        Collects every top-level assignment of the form ``X = range`` (and
-        transitively ``Y = X`` where ``X`` is already a known alias), rewrites
-        every ``Call(Name(alias), ...)`` that resolves to the module-scope
-        binding to ``Call(Name("range"), ...)``, and removes the original
-        alias statements so the C++ annotator never sees ``range`` as a bare
-        RHS. Names that are rebound elsewhere are excluded, and rewrites are
-        skipped inside nested scopes that locally shadow the alias.
+        Returns a pair ``(local, all)`` where:
+
+        * ``local`` is the set of names bound *in this module* via ``X = range``
+          or ``X = Y`` for a previously known alias ``Y``.
+        * ``all`` is ``local`` unioned with *seed* (intended to be aliases
+          inherited from imported modules), minus any locally rebound names.
+
+        Names rebound elsewhere (per :meth:`_rebound_module_names`) are
+        excluded from both sets.
         """
-        rebound = self._rebound_module_names(module_node)
-        aliases = set()
+        rebound = Preprocessor._rebound_module_names(module_node)
+        all_aliases = set(seed) - rebound
+        local = set()
         changed = True
         while changed:
             changed = False
@@ -688,47 +701,69 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
                     continue
                 lhs = stmt.targets[0].id
                 rhs = stmt.value.id
-                if lhs in aliases or lhs in rebound:
+                if lhs in all_aliases or lhs in rebound:
                     continue
-                if rhs == "range" or rhs in aliases:
-                    aliases.add(lhs)
+                if rhs == "range" or rhs in all_aliases:
+                    all_aliases.add(lhs)
+                    local.add(lhs)
                     changed = True
+        return local, all_aliases
 
-        if not aliases:
+    def _rewrite_range_aliases(self, module_node, seed=frozenset()):
+        """Rewrite module-scope ``alias = range`` (and chains) to canonical ``range``.
+
+        Collects every top-level assignment of the form ``X = range`` (and
+        transitively ``Y = X`` where ``X`` is already a known alias),
+        rewrites every ``Call(Name(alias), ...)`` that resolves to the
+        module-scope binding to ``Call(Name("range"), ...)``, and removes the
+        original alias statements so the C++ annotator never sees ``range``
+        as a bare RHS. Names that are rebound elsewhere are excluded, and
+        rewrites are skipped inside nested scopes that locally shadow the
+        alias.
+
+        *seed* is a set of alias names inherited from imported modules
+        (#4525). They are added to the alias set used to rewrite call sites
+        but never removed from this module's body — they were never declared
+        here to begin with.
+        """
+        local, all_aliases = self.collect_range_aliases(module_node, seed)
+        # Track exports for cross-module propagation (#4525): both
+        # locally-defined aliases and any seeded names that survived
+        # (i.e. aren't shadowed by a local rebind) are part of this
+        # module's export surface, so downstream consumers can pick them
+        # up via plain ``from this_module import name`` re-imports.
+        self.exported_range_aliases |= local
+        self.exported_range_aliases |= (set(seed) & all_aliases)
+
+        if not all_aliases:
             return
 
-        for n in self._iter_module_scope(module_node, aliases):
+        for n in self._iter_module_scope(module_node, all_aliases):
             if (isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
-                    and n.func.id in aliases):
+                    and n.func.id in all_aliases):
                 n.func.id = "range"
+
+        if not local:
+            return
 
         module_node.body = [
             stmt for stmt in module_node.body
             if not (isinstance(stmt, ast.Assign) and len(stmt.targets) == 1
                     and isinstance(stmt.targets[0], ast.Name)
-                    and stmt.targets[0].id in aliases
+                    and stmt.targets[0].id in local
                     and isinstance(stmt.value, ast.Name)
-                    and (stmt.value.id == "range" or stmt.value.id in aliases))
+                    and (stmt.value.id == "range" or stmt.value.id in all_aliases))
         ]
 
-    def _inline_range_wrappers(self, module_node):
-        """Inline trivial ``def f(p): return range(p_or_const, ...)`` wrappers.
+    @staticmethod
+    def collect_range_wrappers(module_node):
+        """Collect trivial ``def f(p): return range(...)`` wrappers at module scope.
 
-        A wrapper qualifies when it lives at module scope, is not rebound
-        elsewhere, takes only positional parameters with no defaults or
-        ``*args``/``**kwargs``, and its body is exactly one
-        ``return range(...)`` where every argument is either a reference to
-        one of the function's parameters or an integer ``Constant``. Every
-        call ``f(actuals)`` whose arity matches the wrapper's parameter list
-        and that uses only plain positional arguments (no ``*xs``, no
-        keyword args) is rewritten to a fresh ``range(actuals')`` call.
-
-        The wrapper ``def`` is intentionally retained: call sites with
-        mismatched arity, keyword args, or ``*xs`` still need to resolve to
-        it. Nested scopes that locally rebind the wrapper name are skipped
-        so the rewrite respects Python's lexical-scope semantics.
+        Returns ``{name: (params, template_args)}`` for every qualifying
+        wrapper defined directly in *module_node*. Wrappers rebound elsewhere
+        are excluded.
         """
-        rebound = self._rebound_module_names(module_node)
+        rebound = Preprocessor._rebound_module_names(module_node)
         wrappers = {}
         for stmt in module_node.body:
             if not (isinstance(stmt, ast.FunctionDef)
@@ -757,11 +792,46 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
                 for a in call.args):
                 continue
             wrappers[stmt.name] = (params, call.args)
+        return wrappers
+
+    def _inline_range_wrappers(self, module_node, seed=None):
+        """Inline trivial ``def f(p): return range(p_or_const, ...)`` wrappers.
+
+        A wrapper qualifies when it lives at module scope, is not rebound
+        elsewhere, takes only positional parameters with no defaults or
+        ``*args``/``**kwargs``, and its body is exactly one
+        ``return range(...)`` where every argument is either a reference to
+        one of the function's parameters or an integer ``Constant``. Every
+        call ``f(actuals)`` whose arity matches the wrapper's parameter list
+        and that uses only plain positional arguments (no ``*xs``, no
+        keyword args) is rewritten to a fresh ``range(actuals')`` call.
+
+        The wrapper ``def`` is intentionally retained: call sites with
+        mismatched arity, keyword args, or ``*xs`` still need to resolve to
+        it. Nested scopes that locally rebind the wrapper name are skipped
+        so the rewrite respects Python's lexical-scope semantics.
+
+        *seed* maps wrapper-name → ``(params, template_args)`` for wrappers
+        inherited from imported modules (#4525). Entries shadowed by a
+        local rebind are dropped, so the importer's lexical scope still wins.
+        """
+        local = self.collect_range_wrappers(module_node)
+        self.exported_range_wrappers.update(local)
+
+        wrappers = dict(seed) if seed else {}
+        rebound = self._rebound_module_names(module_node)
+        for name in list(wrappers):
+            if name in rebound and name not in local:
+                del wrappers[name]
+        # Surviving seeded wrappers (i.e. those not locally shadowed) are
+        # re-exported so chained importers can resolve them too (#4525).
+        self.exported_range_wrappers.update(wrappers)
+        wrappers.update(local)
 
         if not wrappers:
             return
 
-        wrapper_names = set(wrappers.keys())
+        wrapper_names = set(wrappers)
         for n in self._iter_module_scope(module_node, wrapper_names):
             if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
                     and n.func.id in wrappers):
@@ -779,6 +849,31 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
             ]
             n.func.id = "range"
             ast.fix_missing_locations(n)
+
+    @staticmethod
+    def _capture_dunder_all(module_node):
+        """Return the literal list/tuple of names assigned to ``__all__``.
+
+        Returns ``None`` when ``__all__`` is absent, dynamically constructed,
+        or contains anything other than string literals — in which case the
+        importer cannot statically project a star import.
+        """
+        for stmt in module_node.body:
+            if not (isinstance(stmt, ast.Assign) and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)
+                    and stmt.targets[0].id == "__all__"):
+                continue
+            value = stmt.value
+            if not isinstance(value, (ast.List, ast.Tuple)):
+                return None
+            names = []
+            for el in value.elts:
+                if isinstance(el, ast.Constant) and isinstance(el.value, str):
+                    names.append(el.value)
+                else:
+                    return None
+            return names
+        return None
 
     def ensure_all_locations(self, node, source_node=None, line=1, col=0):
         """Recursively ensure all nodes in an AST tree have location information"""

--- a/unit/python-frontend/test_preprocessor_regressions.py
+++ b/unit/python-frontend/test_preprocessor_regressions.py
@@ -362,3 +362,207 @@ for i in my_range(5):
 
     assert _find_call(module, "my_range") is not None
     assert _find_call(module, "range") is None
+
+
+# ---- Cross-module range-alias / wrapper propagation (#4525) ----
+
+
+def test_collect_range_aliases_returns_local_set():
+    module = ast.parse("a = range\nb = a\n")
+    local, all_aliases = preprocessor_mod.Preprocessor.collect_range_aliases(module)
+    assert local == {"a", "b"}
+    assert all_aliases == {"a", "b"}
+
+
+def test_collect_range_aliases_grows_chain_from_seed():
+    # `a` lives in another module; this one chains `b = a`.
+    module = ast.parse("b = a\n")
+    local, all_aliases = preprocessor_mod.Preprocessor.collect_range_aliases(
+        module, seed={"a"})
+    assert local == {"b"}
+    assert all_aliases == {"a", "b"}
+
+
+def test_collect_range_aliases_seed_dropped_when_rebound_locally():
+    # Real parser flow puts the imported name into the seed because of the
+    # `from lib import a` line. A subsequent rebind shadows the import.
+    module = ast.parse(
+        """
+from lib import a
+a = something_else
+""")
+    local, all_aliases = preprocessor_mod.Preprocessor.collect_range_aliases(
+        module, seed={"a"})
+    assert local == set()
+    assert "a" not in all_aliases
+
+
+def test_rewrite_with_seed_canonicalises_imported_alias_call():
+    module = ast.parse(
+        """
+from lib import nl_affine_range
+for i in nl_affine_range(5):
+    pass
+""")
+
+    pre = preprocessor_mod.Preprocessor("test_module")
+    pre._rewrite_range_aliases(module, seed={"nl_affine_range"})
+
+    assert _find_call(module, "nl_affine_range") is None
+    assert _find_call(module, "range") is not None
+    # Bare re-imports re-export the surviving alias so consumers of *this*
+    # module can resolve it transitively (#4525).
+    assert pre.exported_range_aliases == {"nl_affine_range"}
+
+
+def test_rewrite_with_seed_exports_chained_local_alias():
+    # Importer adds its own chain on top of the imported alias and must
+    # re-export both the local chain target and the surviving seed name.
+    module = ast.parse(
+        """
+from lib_a import nl_affine_range
+aff = nl_affine_range
+""")
+
+    pre = preprocessor_mod.Preprocessor("test_module")
+    pre._rewrite_range_aliases(module, seed={"nl_affine_range"})
+
+    assert pre.exported_range_aliases == {"aff", "nl_affine_range"}
+
+
+def test_rewrite_with_seed_does_not_remove_imported_alias_statement():
+    # The seeded name lives in another module; we must never drop the
+    # importer's own `from lib import ...` statement or any local binding
+    # that didn't come from our own `X = range` rewriter.
+    module = ast.parse(
+        """
+from lib import nl_affine_range
+for i in nl_affine_range(5):
+    pass
+""")
+
+    pre = preprocessor_mod.Preprocessor("test_module")
+    pre._rewrite_range_aliases(module, seed={"nl_affine_range"})
+
+    assert any(isinstance(s, ast.ImportFrom) for s in module.body)
+
+
+def test_rewrite_with_seed_skipped_when_local_rebind_shadows():
+    # Local function definition shadows the imported alias — rewriter
+    # must leave the call site alone.
+    module = ast.parse(
+        """
+from lib import nl_affine_range
+
+def nl_affine_range(n):
+    return [0, 1]
+
+for i in nl_affine_range(5):
+    pass
+""")
+
+    pre = preprocessor_mod.Preprocessor("test_module")
+    pre._rewrite_range_aliases(module, seed={"nl_affine_range"})
+
+    assert _find_call(module, "range") is None
+    assert _find_call(module, "nl_affine_range") is not None
+
+
+def test_collect_range_wrappers_returns_local_definitions():
+    module = ast.parse(
+        """
+def my_range(n):
+    return range(n)
+
+def not_a_wrapper(n):
+    return n + 1
+""")
+
+    wrappers = preprocessor_mod.Preprocessor.collect_range_wrappers(module)
+    assert set(wrappers) == {"my_range"}
+    params, template = wrappers["my_range"]
+    assert params == ["n"]
+    assert isinstance(template[0], ast.Name) and template[0].id == "n"
+
+
+def test_inline_with_seed_rewrites_imported_wrapper_call_site():
+    module = ast.parse(
+        """
+from lib import affine_range
+for i in affine_range(7):
+    pass
+""")
+
+    pre = preprocessor_mod.Preprocessor("test_module")
+    # Seed mimics a wrapper imported from another module:
+    # def affine_range(n): return range(n)
+    seed = {"affine_range": (["n"], [ast.Name(id="n", ctx=ast.Load())])}
+    pre._inline_range_wrappers(module, seed=seed)
+
+    call = _find_call(module, "range")
+    assert call is not None
+    assert isinstance(call.args[0], ast.Constant) and call.args[0].value == 7
+    # The original wrapper call (Name == "affine_range") should be gone.
+    assert _find_call(module, "affine_range") is None
+
+
+def test_inline_with_seed_skipped_when_local_rebind_shadows():
+    module = ast.parse(
+        """
+from lib import affine_range
+
+def affine_range(n):
+    return [n]
+
+for i in affine_range(7):
+    pass
+""")
+
+    pre = preprocessor_mod.Preprocessor("test_module")
+    seed = {"affine_range": (["n"], [ast.Name(id="n", ctx=ast.Load())])}
+    pre._inline_range_wrappers(module, seed=seed)
+
+    assert _find_call(module, "range") is None
+    assert _find_call(module, "affine_range") is not None
+
+
+def test_capture_dunder_all_returns_string_list():
+    module = ast.parse("__all__ = ['nl_affine_range', 'foo']\n")
+    names = preprocessor_mod.Preprocessor._capture_dunder_all(module)
+    assert names == ["nl_affine_range", "foo"]
+
+
+def test_capture_dunder_all_returns_none_for_dynamic_assignment():
+    module = ast.parse("__all__ = some_helper()\n")
+    assert preprocessor_mod.Preprocessor._capture_dunder_all(module) is None
+
+
+def test_capture_dunder_all_returns_none_for_non_string_element():
+    module = ast.parse("__all__ = ['ok', 42]\n")
+    assert preprocessor_mod.Preprocessor._capture_dunder_all(module) is None
+
+
+def test_capture_dunder_all_absent_returns_none():
+    module = ast.parse("x = 1\n")
+    assert preprocessor_mod.Preprocessor._capture_dunder_all(module) is None
+
+
+def test_visit_module_records_export_tables():
+    # The Preprocessor pre-passes already ran by the time visit_Module
+    # finishes, so the exported tables should reflect the in-file aliases.
+    module = ast.parse(
+        """
+__all__ = ['nl_affine_range', 'affine_range']
+
+nl_affine_range = range
+
+def affine_range(n):
+    return range(n)
+""")
+
+    pre = preprocessor_mod.Preprocessor("lib")
+    pre.visit(module)
+
+    assert pre.exported_range_aliases == {"nl_affine_range"}
+    assert set(pre.exported_range_wrappers) == {"affine_range"}
+    assert pre.module_dunder_all == ["nl_affine_range", "affine_range"]


### PR DESCRIPTION
PR #4521's per-module pre-passes only rewrote `X = range` aliases and `def f(p): return range(p)` wrappers when defined in the same module as the call site. Imported aliases (`from lib import nl_affine_range`) hit the BMC with `Unsupported function`. Split the rewriters into seed-aware collect/apply pairs and drive a fixed-point cross-module propagation in parser.py that projects each module's exported aliases / wrappers through `from ... import ...` (honouring `as` rebinds and `__all__` for star imports). Bare re-imports also re-export the surviving alias so chained consumers resolve transitively.

Fixes #4525.
