### PR TITLE
[python] defer visit_For until cross-module range aliases resolve

### DIFF
--- a/regression/python/github_4533/lib.py
+++ b/regression/python/github_4533/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4533/main.py
+++ b/regression/python/github_4533/main.py
@@ -1,0 +1,7 @@
+from lib import nl_affine_range
+
+count: int = 0
+for i in nl_affine_range(3):
+    count = count + 1
+
+assert count == 3

--- a/regression/python/github_4533/test.desc
+++ b/regression/python/github_4533/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4533_fail/lib.py
+++ b/regression/python/github_4533_fail/lib.py
@@ -1,0 +1,1 @@
+nl_affine_range = range

--- a/regression/python/github_4533_fail/main.py
+++ b/regression/python/github_4533_fail/main.py
@@ -1,0 +1,7 @@
+from lib import nl_affine_range
+
+count: int = 0
+for i in nl_affine_range(3):
+    count = count + 1
+
+assert count == 4

--- a/regression/python/github_4533_fail/test.desc
+++ b/regression/python/github_4533_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -355,6 +355,23 @@ def parse_file(filename: str) -> tuple[ast.AST, Preprocessor]:
     return tree, preprocessor
 
 
+def parse_file_canonicalised(filename: str) -> tuple[ast.AST, Preprocessor]:
+    """Parse a file and run only the alias-canonicalisation pre-pass.
+
+    Returns the raw tree (with ``apply_range_rewrites`` already applied for
+    in-module aliases) plus the Preprocessor instance so the caller can
+    later (a) feed it cross-module seeds via ``apply_range_rewrites`` and
+    (b) call ``finalize_module`` once propagation has converged. This split
+    is the key to #4533: ``visit_For`` must run after every alias known to
+    the import graph has been rewritten to ``range``.
+    """
+    with open(filename, "r", encoding="utf-8") as src:
+        tree = ast.parse(src.read())
+    preprocessor = Preprocessor(filename)
+    preprocessor.prepare_module(tree)
+    return tree, preprocessor
+
+
 def emit_file_as_json(
     filename: str,
     output_dir: str,
@@ -463,8 +480,10 @@ def process_collected_imports(output_dir):
     JSON the C++ backend reads.
     """
     # Phase 1 — discovery: harvest imports from every reachable module until
-    # module_imports stops growing. Cache parsed trees so emission in Phase 2
-    # does not re-run the (expensive) Preprocessor.
+    # module_imports stops growing. Each module is parsed and only the
+    # alias-canonicalisation pre-pass is run; the full visit (which lowers
+    # for-range to a bounded while via visit_For) is deferred to Phase 1c
+    # so it sees aliases resolved by cross-module propagation (#4533).
     parsed_trees = {}  # module_name -> (tree, filename, preprocessor)
     visited = set()
 
@@ -477,7 +496,7 @@ def process_collected_imports(output_dir):
             filename = resolve_module_file(module_name, output_dir)
             if not filename:
                 continue
-            tree, preprocessor = parse_file(filename)
+            tree, preprocessor = parse_file_canonicalised(filename)
             parsed_trees[module_name] = (tree, filename, preprocessor)
             module_exports[module_name] = _snapshot_exports(preprocessor)
             for subnode in ast.walk(tree):
@@ -487,6 +506,10 @@ def process_collected_imports(output_dir):
 
     # Phase 1b — cross-module range alias / wrapper propagation (#4525).
     _propagate_range_aliases_across_modules(parsed_trees)
+
+    # Phase 1c — finalize each module now that aliases are canonical (#4533).
+    for _module_name, (tree, _filename, preprocessor) in parsed_trees.items():
+        preprocessor.finalize_module(tree)
 
     # Phase 2 — emission: module_imports is now stable, so every emitted JSON
     # contains the full set of names any importer ever asked for.
@@ -725,41 +748,47 @@ def main():
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    # Process and convert AST for main file
+    # Process and convert AST for main file. The entry script is canonicalised
+    # before import discovery and finalised only after cross-module alias /
+    # wrapper propagation, so visit_For sees ``range(...)`` everywhere an
+    # alias resolves to it (#4533).
     with open(filename, "r", encoding="utf-8") as source:
         tree = ast.parse(source.read())
 
-    # Apply AST transformations
     preprocessor = Preprocessor(filename)
-    tree = preprocessor.visit(tree)
+    preprocessor.prepare_module(tree)
     module_exports["__main__"] = _snapshot_exports(preprocessor)
 
-    # Tracking of imported modules and aliases
-    processed_submodules = set()
-
+    # Discover imports first (their nodes are not rewritten by visit_*), so
+    # process_collected_imports can build the cross-module export tables that
+    # the deferred seed-aware re-rewrite below depends on (#4533).
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
-            # Collect import information
             process_imports(node, output_dir)
-        elif isinstance(node, ast.Assign):
-            # Keep assignment-specific annotation behavior.
-            add_type_annotation(node)
-        elif isinstance(node, ast.Constant):
-            # Ensure constants are annotated in all contexts (e.g., call args).
-            annotate_constant_node(node)
-        elif isinstance(node, ast.Attribute):
-            # Detect and process submodule usage
-            detect_and_process_submodules(node, processed_submodules, output_dir)
 
-    # Now process all collected imports once
     process_collected_imports(output_dir)
 
     # Re-apply range-alias / wrapper rewrites on the entry script using the
-    # cross-module export tables built during import processing (#4525).
+    # cross-module export tables built during import processing (#4525), then
+    # run the deferred visitor pass so visit_For lowers for-range with the
+    # bound it now has access to (#4533).
     alias_seed, wrapper_seed = _compute_range_seed(tree)
     preprocessor.apply_range_rewrites(tree,
                                       alias_seed=alias_seed,
                                       wrapper_seed=wrapper_seed)
+    tree = preprocessor.finalize_module(tree)
+
+    # Tag assignments / constants / attribute accesses on the fully-lowered
+    # tree so constants introduced by visit_* (e.g. range-loop helpers,
+    # dataclass synthesis) receive their esbmc_type_annotation.
+    processed_submodules = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            add_type_annotation(node)
+        elif isinstance(node, ast.Constant):
+            annotate_constant_node(node)
+        elif isinstance(node, ast.Attribute):
+            detect_and_process_submodules(node, processed_submodules, output_dir)
 
     # Generate JSON from AST for the main file.
     generate_ast_json(tree, filename, None, output_dir)

--- a/src/python-frontend/preprocessor.py
+++ b/src/python-frontend/preprocessor.py
@@ -411,18 +411,23 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
 
         return [range_next_func, range_has_next_func, reversed_range_start_func]
 
-    def visit_Module(self, node):
-        """Visit the module and inject helper functions if needed"""
-        # Pre-pass: collect all names used as callees so we can distinguish
-        # bound method assignments (g = obj.method; g()) from plain attribute
-        # reads (res = a.x) which must not be removed.
+    def prepare_module(self, node, alias_seed=frozenset(), wrapper_seed=None):
+        """Run pre-visit analyses and the range-alias / wrapper canonicalisation.
+
+        Collects callee names and global-scope variable annotations, captures
+        ``__all__``, and runs ``apply_range_rewrites`` with the supplied
+        cross-module seeds (empty by default). This must complete on every
+        module *before* any module's ``finalize_module`` runs so that
+        ``visit_For`` sees canonical ``range(...)`` calls produced by
+        cross-module alias propagation (#4533).
+
+        Idempotent: re-running with a fresh seed after the in-module aliases
+        have been canonicalised only adds the new (cross-module) names.
+        """
         for n in ast.walk(node):
             if isinstance(n, ast.Call) and isinstance(n.func, ast.Name):
                 self.called_names.add(n.func.id)
 
-        # Pre-pass: collect global-scope variable annotations so that
-        # unannotated function parameters can be inferred from call-site types
-        # (e.g. `def f(d): for k,v in d.items()` called with a dict literal).
         for stmt in node.body:
             if isinstance(stmt, ast.Assign):
                 for target in stmt.targets:
@@ -433,26 +438,25 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
             elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
                 self.variable_annotations[stmt.target.id] = stmt.annotation
 
-        # Pre-pass: canonicalise `alias = range` aliases at module scope and
-        # rewrite call sites of trivial `def f(...): return range(...)` wrappers
-        # back to literal `range(...)` calls. After these rewrites,
-        # `for i in alias_or_wrapper(...)` reaches visit_For as a plain range
-        # call and uses the existing range-for transformation.
-        # Capture `__all__` (if statically a list/tuple of string literals) so
-        # cross-module propagation (#4525) can honour it for `from X import *`.
         self.module_dunder_all = self._capture_dunder_all(node)
-        self.apply_range_rewrites(node)
+        self.apply_range_rewrites(node,
+                                  alias_seed=alias_seed,
+                                  wrapper_seed=wrapper_seed)
 
-        # Transform the module as usual
+    def finalize_module(self, node):
+        """Run ``generic_visit`` and inject any helpers requested during it.
+
+        Must be called after ``prepare_module`` has completed for every module
+        in the import graph, so that visit_For sees canonical ``range(...)``
+        calls produced by cross-module propagation (#4533).
+        """
         node = self.generic_visit(node)
 
         if self._needs_dataclass_initvar_import:
             self._ensure_dataclass_initvar_import(node)
 
-        # If we used range loops, inject helper functions at the beginning
         if self.helper_functions_added:
             helper_functions = self._create_helper_functions()
-            # Ensure all helper functions have proper location info
             for func in helper_functions:
                 self.ensure_all_locations(func)
                 ast.fix_missing_locations(func)
@@ -471,6 +475,18 @@ class Preprocessor(DataclassMixin, ast.NodeTransformer):
             node.body = [helper_fn] + node.body
 
         return node
+
+    def visit_Module(self, node):
+        """Visit the module: prepare, then finalize.
+
+        Back-compat entry point for callers (``emit_file_as_json``, tests,
+        memory models) that don't participate in cross-module range-alias
+        propagation. The parser's main import-aware pipeline calls
+        ``prepare_module`` / ``finalize_module`` directly with the right
+        seeds (#4533).
+        """
+        self.prepare_module(node)
+        return self.finalize_module(node)
 
     @staticmethod
     def _target_names(target):

--- a/unit/python-frontend/test_preprocessor_regressions.py
+++ b/unit/python-frontend/test_preprocessor_regressions.py
@@ -547,6 +547,56 @@ def test_capture_dunder_all_absent_returns_none():
     assert preprocessor_mod.Preprocessor._capture_dunder_all(module) is None
 
 
+def _walk_calls(tree, name):
+    return [n for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == name]
+
+
+def test_prepare_then_finalize_lowers_cross_module_alias_to_bounded_range():
+    # Reproduces #4533: when the alias is only visible via a cross-module
+    # seed, prepare_module must canonicalise the call site to range(N)
+    # before finalize_module runs visit_For, otherwise the for-loop drops to
+    # the generic iterator path and the bound is lost (unbounded unwinding).
+    module = ast.parse(
+        """
+from lib import nl_affine_range
+
+count: int = 0
+for i in nl_affine_range(3):
+    count = count + 1
+""")
+
+    pre = preprocessor_mod.Preprocessor("main")
+    pre.prepare_module(module, alias_seed={"nl_affine_range"})
+    pre.finalize_module(module)
+
+    # The call site is now range(...), and the for-range path was taken
+    # (it injects helper functions for bounded iteration).
+    assert _walk_calls(module, "nl_affine_range") == []
+    assert _walk_calls(module, "ESBMC_range_next_") != []
+    assert pre.helper_functions_added is True
+
+
+def test_visit_module_back_compat_runs_prepare_and_finalize():
+    # The legacy single-call entry point must still produce the same
+    # in-file behaviour: range-alias rewrite + bounded for-range lowering.
+    module = ast.parse(
+        """
+nl_affine_range = range
+
+count: int = 0
+for i in nl_affine_range(3):
+    count = count + 1
+""")
+
+    pre = preprocessor_mod.Preprocessor("main")
+    pre.visit(module)
+
+    assert _walk_calls(module, "nl_affine_range") == []
+    assert _walk_calls(module, "ESBMC_range_next_") != []
+
+
 def test_visit_module_records_export_tables():
     # The Preprocessor pre-passes already ran by the time visit_Module
     # finishes, so the exported tables should reflect the in-file aliases.


### PR DESCRIPTION
PR #4529 propagated `nl_affine_range = range` aliases across modules but ran `Preprocessor.visit()` per file before the cross-module seed was known, so `visit_For` saw `nl_affine_range(N)` and dropped to the generic iterator path, losing the bounded-iteration signal and causing unbounded unwinding. Split `visit_Module` into `prepare_module` (pre-analyses + alias canonicalisation, accepts seeds) and `finalize_module` (generic_visit + helper injection), and reorder the pipeline so cross-module propagation runs between the two phases for both the entry script and every imported module.

Fixes #4533.