### PR TITLE
[python] thread slice values into user-defined __getitem__ params

### DIFF
--- a/regression/python/github_4537_bare_param-fail/main.py
+++ b/regression/python/github_4537_bare_param-fail/main.py
@@ -1,0 +1,9 @@
+class Tile:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+    def __getitem__(self, sl) -> "Tile":
+        return Tile(sl.stop - sl.start)
+
+t: Tile = Tile(10)
+sub: Tile = t[2:5]
+assert sub.d0 == 99

--- a/regression/python/github_4537_bare_param-fail/test.desc
+++ b/regression/python/github_4537_bare_param-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4537_bare_param/main.py
+++ b/regression/python/github_4537_bare_param/main.py
@@ -1,0 +1,9 @@
+class Tile:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+    def __getitem__(self, sl) -> "Tile":
+        return Tile(sl.stop - sl.start)
+
+t: Tile = Tile(10)
+sub: Tile = t[2:5]
+assert sub.d0 == 3

--- a/regression/python/github_4537_bare_param/test.desc
+++ b/regression/python/github_4537_bare_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4537_slice_annot-fail/main.py
+++ b/regression/python/github_4537_slice_annot-fail/main.py
@@ -1,0 +1,9 @@
+class Tile:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+    def __getitem__(self, sl: slice) -> "Tile":
+        return Tile(sl.stop - sl.start)
+
+t: Tile = Tile(10)
+sub: Tile = t[2:5]
+assert sub.d0 == 99

--- a/regression/python/github_4537_slice_annot-fail/test.desc
+++ b/regression/python/github_4537_slice_annot-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4537_slice_annot/main.py
+++ b/regression/python/github_4537_slice_annot/main.py
@@ -1,0 +1,9 @@
+class Tile:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+    def __getitem__(self, sl: slice) -> "Tile":
+        return Tile(sl.stop - sl.start)
+
+t: Tile = Tile(10)
+sub: Tile = t[2:5]
+assert sub.d0 == 3

--- a/regression/python/github_4537_slice_annot/test.desc
+++ b/regression/python/github_4537_slice_annot/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4537_slice_call/main.py
+++ b/regression/python/github_4537_slice_call/main.py
@@ -1,0 +1,10 @@
+class Tile:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+    def __getitem__(self, sl: slice) -> "Tile":
+        return Tile(sl.stop - sl.start)
+
+t: Tile = Tile(10)
+sl: slice = slice(2, 5)
+sub: Tile = t[sl]
+assert sub.d0 == 3

--- a/regression/python/github_4537_slice_call/test.desc
+++ b/regression/python/github_4537_slice_call/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -3687,7 +3687,30 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           if (
             param_type.is_pointer() && arg_actual_type.is_struct() &&
             !arg.is_address_of() && !arg_actual_type.is_pointer())
+          {
+            // Rvalue structs (e.g. the constant `__ESBMC_PySliceObj` produced
+            // by `a[i:j]`) cannot be the operand of `address_of` at the SMT
+            // level. Materialise them in a temp symbol first so the address
+            // we hand to the callee points at a real lvalue.
+            if (!arg.is_symbol())
+            {
+              assert(
+                current_block &&
+                "rvalue struct argument requires a statement-level block to "
+                "materialise into");
+              locationt loc = get_location_from_decl(element);
+              symbolt &tmp = create_tmp_symbol(
+                element, "$struct_arg$", arg.type(), gen_zero(arg.type()));
+              code_declt tmp_decl(symbol_expr(tmp));
+              tmp_decl.location() = loc;
+              current_block->copy_to_operands(tmp_decl);
+              code_assignt tmp_assign(symbol_expr(tmp), arg);
+              tmp_assign.location() = loc;
+              current_block->copy_to_operands(tmp_assign);
+              arg = symbol_expr(tmp);
+            }
             arg = gen_address_of(arg);
+          }
 
           // Propagate instance attributes set on this parameter back to the
           // caller's argument. This models Python's pass-by-object-reference:

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -437,6 +437,17 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   if (ast_type == "bool")
     return bool_type();
 
+  // slice — Python's slice() builtin, modelled as __ESBMC_PySliceObj.
+  // Only resolve to the slice struct if the operational model is loaded;
+  // otherwise fall through so early type-handler queries don't assert.
+  if (ast_type == "slice")
+  {
+    const symbolt *sym =
+      converter_.symbol_table().find_symbol("tag-struct __ESBMC_PySliceObj");
+    if (sym)
+      return symbol_typet(sym->id);
+  }
+
   if (ast_type == "complex")
   {
     const char *complex_type_id = "tag-complex";


### PR DESCRIPTION
Resolves the `slice` annotation to the `__ESBMC_PySliceObj` operational-model struct so `def __getitem__(self, sl: slice)` types `sl` correctly, and materialises a temp symbol when an rvalue struct (e.g. the constant slice produced by `a[i:j]`) is coerced to a pointer parameter so that the SMT lowering of `address_of` operates on a real lvalue.

Fixes #4537