### PR TITLE
[python] materialize return temp for __getitem__ in return stmt

### DIFF
--- a/regression/python/github_4541-fail/main.py
+++ b/regression/python/github_4541-fail/main.py
@@ -1,0 +1,15 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        return Tile(sl0.stop - sl0.start, sl1.stop - sl1.start)
+
+def f(t: Tile) -> Tile:
+    return t[2:5, 3:8]
+
+t: Tile = Tile(100, 200)
+r: Tile = f(t)
+assert r.d0 == 4

--- a/regression/python/github_4541-fail/test.desc
+++ b/regression/python/github_4541-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4541/main.py
+++ b/regression/python/github_4541/main.py
@@ -1,0 +1,15 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        return Tile(sl0.stop - sl0.start, sl1.stop - sl1.start)
+
+def f(t: Tile) -> Tile:
+    return t[2:5, 3:8]
+
+t: Tile = Tile(100, 200)
+r: Tile = f(t)
+assert r.d0 == 3

--- a/regression/python/github_4541/test.desc
+++ b/regression/python/github_4541/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4541_parametric/main.py
+++ b/regression/python/github_4541_parametric/main.py
@@ -1,0 +1,15 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        return Tile(sl0.stop - sl0.start, sl1.stop - sl1.start)
+
+def f(t: Tile, n: int) -> Tile:
+    return t[n*4:(n+1)*4, n*8:(n+1)*8]
+
+t: Tile = Tile(100, 200)
+r: Tile = f(t, 2)
+assert r.d0 == 4

--- a/regression/python/github_4541_parametric/test.desc
+++ b/regression/python/github_4541_parametric/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4541_three_axis/main.py
+++ b/regression/python/github_4541_three_axis/main.py
@@ -1,0 +1,21 @@
+class Tile:
+    def __init__(self, d0: int, d1: int, d2: int):
+        self.d0: int = d0
+        self.d1: int = d1
+        self.d2: int = d2
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        sl2: slice = key[2]
+        return Tile(sl0.stop - sl0.start,
+                    sl1.stop - sl1.start,
+                    sl2.stop - sl2.start)
+
+def f(t: Tile) -> Tile:
+    return t[1:4, 2:7, 3:9]
+
+t: Tile = Tile(10, 20, 30)
+r: Tile = f(t)
+assert r.d0 == 3
+assert r.d1 == 5
+assert r.d2 == 6

--- a/regression/python/github_4541_three_axis/test.desc
+++ b/regression/python/github_4541_three_axis/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9869,8 +9869,7 @@ void python_converter::get_return_statements(
     // materialisation, otherwise the call expression ends up embedded
     // directly in the GOTO RETURN and trips value-set's make_member
     // assertion at value_set.cpp:1543.
-    const std::string ast_type =
-      ast_node["value"]["_type"].get<std::string>();
+    const std::string ast_type = ast_node["value"]["_type"].get<std::string>();
     std::string func_name = "func";
     if (ast_type == "Call")
     {

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -9859,16 +9859,28 @@ void python_converter::get_return_statements(
   bool is_func_call =
     return_value.is_code() && return_value.get("statement") == "function_call";
 
-  if (is_func_call && ast_node["value"]["_type"] == "Call")
+  if (is_func_call)
   {
-    // Extract function name for temporary variable naming
-    std::string func_name;
-    if (ast_node["value"]["func"]["_type"] == "Name")
-      func_name = ast_node["value"]["func"]["id"].get<std::string>();
-    else if (ast_node["value"]["func"]["_type"] == "Attribute")
-      func_name = ast_node["value"]["func"]["attr"].get<std::string>();
-    else
-      func_name = "func"; // fallback
+    // Extract function name for temporary variable naming.
+    // get_expr() also returns a function-call expression when a Subscript
+    // dispatches to a user-defined __getitem__ (see GitHub #4541); in that
+    // case the AST node type is "Subscript" rather than "Call", but the
+    // returned code is still a function_call that needs the same temp-LHS
+    // materialisation, otherwise the call expression ends up embedded
+    // directly in the GOTO RETURN and trips value-set's make_member
+    // assertion at value_set.cpp:1543.
+    const std::string ast_type =
+      ast_node["value"]["_type"].get<std::string>();
+    std::string func_name = "func";
+    if (ast_type == "Call")
+    {
+      if (ast_node["value"]["func"]["_type"] == "Name")
+        func_name = ast_node["value"]["func"]["id"].get<std::string>();
+      else if (ast_node["value"]["func"]["_type"] == "Attribute")
+        func_name = ast_node["value"]["func"]["attr"].get<std::string>();
+    }
+    else if (ast_type == "Subscript")
+      func_name = "__getitem__";
 
     // Determine return type: check if it's empty (forward reference)
     typet return_type = return_value.type();


### PR DESCRIPTION
Widen the return-statement converter so it materialises a temp for any
function-call return expression, not just AST `Call` nodes. A Subscript
that dispatches to a user-defined `__getitem__` also yields a
`code_function_callt` from `get_expr()`; without the temp it ended up
embedded directly in the GOTO `RETURN` and tripped value-set's
`make_member` assertion (`value_set.cpp:1543`) on parameter-instance
receivers.

Fixes #4541.