### PR TITLE
[python] use bool xor (not bitxor) in floor-div sign correction

### DIFF
--- a/regression/python/github_4548_floordiv_call_arg-fail/main.py
+++ b/regression/python/github_4548_floordiv_call_arg-fail/main.py
@@ -1,0 +1,6 @@
+def check(c: int) -> None:
+    assert c >= 0
+
+a: int = nondet_int()
+__ESBMC_assume(a >= -3)
+check(a // 2)

--- a/regression/python/github_4548_floordiv_call_arg-fail/test.desc
+++ b/regression/python/github_4548_floordiv_call_arg-fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4548_floordiv_call_arg/main.py
+++ b/regression/python/github_4548_floordiv_call_arg/main.py
@@ -1,0 +1,6 @@
+def check(c: int) -> None:
+    assert c >= 0
+
+a: int = nondet_int()
+__ESBMC_assume(a >= 0)
+check(a // 2)

--- a/regression/python/github_4548_floordiv_call_arg/test.desc
+++ b/regression/python/github_4548_floordiv_call_arg/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4548_floordiv_negative/main.py
+++ b/regression/python/github_4548_floordiv_negative/main.py
@@ -1,0 +1,6 @@
+def check(c: int) -> None:
+    assert c == -3
+
+a: int = nondet_int()
+__ESBMC_assume(a == -5)
+check(a // 2)

--- a/regression/python/github_4548_floordiv_negative/test.desc
+++ b/regression/python/github_4548_floordiv_negative/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -581,7 +581,9 @@ exprt python_math::handle_floor_division(
   pos_remainder.copy_to_operands(remainder, gen_zero(div_type));
 
   // diff_signals = is_num_neg ^ is_den_neg;
-  exprt diff_signals("bitxor", bool_type());
+  // Boolean XOR — `bitxor` over bool-typed operands is malformed and
+  // crashes Bitwuzla's BV encoder ("term with unexpected sort"); GitHub #4548.
+  exprt diff_signals("xor", bool_type());
   diff_signals.copy_to_operands(is_num_neg, is_den_neg);
 
   exprt cond("and", bool_type());


### PR DESCRIPTION
The Python floor-division lowering in `python_math::handle_floor_division` built the sign-difference correction `(a<0) ^ (b<0)` as `bitxor` over `bool_type()` operands. `bitxor` migrates to `bitxor2tc(type, side1, side2)` which carries the bool type into a BV-shaped term — Bitwuzla's encoder rejects it ("term with unexpected sort"). Z3 happens to be lenient and masked the bug, so the issue only surfaced when the floor-div result was materialised at a function-call argument site under default Bitwuzla. Switching the operator to `xor` (the canonical boolean op, asserted bool in `migrate.cpp`) matches the operand types and encodes cleanly on both solvers without changing semantics.

Fixes #4548
