### PR TITLE
[python] model bare slice `:` as None-bounded, not slice(0,0)

### DIFF
--- a/regression/python/github_4543_bare_start_fail/main.py
+++ b/regression/python/github_4543_bare_start_fail/main.py
@@ -1,0 +1,9 @@
+class T:
+    def __getitem__(self, key) -> int:
+        sl0: slice = key[0]
+        return sl0.start
+
+
+t: T = T()
+x: int = t[:, 3:8]
+assert x == 0

--- a/regression/python/github_4543_bare_start_fail/test.desc
+++ b/regression/python/github_4543_bare_start_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4543_bare_stop_fail/main.py
+++ b/regression/python/github_4543_bare_stop_fail/main.py
@@ -1,0 +1,9 @@
+class T:
+    def __getitem__(self, key) -> int:
+        sl0: slice = key[0]
+        return sl0.stop
+
+
+t: T = T()
+y: int = t[:, 3:8]
+assert y == 0

--- a/regression/python/github_4543_bare_stop_fail/test.desc
+++ b/regression/python/github_4543_bare_stop_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4543_bare_vs_explicit_fail/main.py
+++ b/regression/python/github_4543_bare_vs_explicit_fail/main.py
@@ -1,0 +1,10 @@
+class T:
+    def __getitem__(self, key) -> int:
+        sl0: slice = key[0]
+        return sl0.stop - sl0.start
+
+
+t: T = T()
+empty: int = t[0:0, 3:8]
+full: int = t[:, 3:8]
+assert empty == full

--- a/regression/python/github_4543_bare_vs_explicit_fail/test.desc
+++ b/regression/python/github_4543_bare_vs_explicit_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4543_is_none/main.py
+++ b/regression/python/github_4543_is_none/main.py
@@ -1,0 +1,13 @@
+class T:
+    def __init__(self) -> None:
+        pass
+
+    def __getitem__(self, key) -> int:
+        sl0: slice = key[0]
+        assert sl0.start is None
+        assert sl0.stop is None
+        return 0
+
+
+t: T = T()
+_: int = t[:, 3:8]

--- a/regression/python/github_4543_is_none/test.desc
+++ b/regression/python/github_4543_is_none/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4543_is_not_none/main.py
+++ b/regression/python/github_4543_is_not_none/main.py
@@ -1,0 +1,13 @@
+class T:
+    def __init__(self) -> None:
+        pass
+
+    def __getitem__(self, key) -> int:
+        sl0: slice = key[0]
+        assert sl0.start is not None
+        assert sl0.stop is not None
+        return 0
+
+
+t: T = T()
+_: int = t[0:8, 3:8]

--- a/regression/python/github_4543_is_not_none/test.desc
+++ b/regression/python/github_4543_is_not_none/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -66,6 +66,8 @@ ignored_dirs=(
   "github_3563_3"
   "github_3769"
   "github_4149"
+  "github_4548_floordiv_call_arg"
+  "github_4548_floordiv_negative"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -371,7 +371,10 @@ exprt python_converter::try_lower_slice_member_is_none(
   const exprt &lhs,
   const exprt &rhs)
 {
-  if (op != "Is" && op != "IsNot" && op != "Eq" && op != "NotEq")
+  // Restrict to identity comparisons. Value comparisons (`sl.start == None`)
+  // fall through to the existing int-vs-None handling, which preserves
+  // Python value-equality semantics if the field ever holds a real integer.
+  if (op != "Is" && op != "IsNot")
     return nil_exprt();
 
   // One operand must be the None literal; the other must be a member access
@@ -391,31 +394,20 @@ exprt python_converter::try_lower_slice_member_is_none(
   if (base_type != ns.follow(type_handler_.get_slice_type()))
     return nil_exprt();
 
-  const irep_idt component = member_side->component_name();
-  irep_idt flag_name;
-  if (component == "start")
-    flag_name = "has_start";
-  else if (component == "stop")
-    flag_name = "has_stop";
-  else if (component == "step")
-    flag_name = "has_step";
-  else
-    return nil_exprt();
-
   const struct_typet &slice_struct = to_struct_type(base_type);
+  const std::string flag_name =
+    "has_" + member_side->component_name().as_string();
+  if (!slice_struct.has_component(flag_name))
+    return nil_exprt();
   const typet flag_type = slice_struct.get_component(flag_name).type();
 
-  member_exprt flag_access(
-    member_side->op0(), flag_name.as_string(), flag_type);
-  // "is None" / "== None" → flag is zero (bound was absent).
-  // "is not None" / "!= None" → flag is non-zero (bound was supplied).
-  const bool is_eq = (op == "Eq" || op == "Is");
+  member_exprt flag_access(member_side->op0(), flag_name, flag_type);
+  // `sl.start is None` ⇔ flag is zero (bound was absent).
+  // `sl.start is not None` ⇔ flag is non-zero (bound was supplied).
   equality_exprt eq(flag_access, gen_zero(flag_type));
-  if (is_eq)
+  if (op == "Is")
     return eq;
-  exprt neg("not", bool_type());
-  neg.copy_to_operands(eq);
-  return neg;
+  return not_exprt(eq);
 }
 
 exprt python_converter::handle_none_comparison(

--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -366,6 +366,58 @@ exprt python_converter::handle_string_comparison(
   return nil_exprt(); // continue with lhs OP rhs
 }
 
+exprt python_converter::try_lower_slice_member_is_none(
+  const std::string &op,
+  const exprt &lhs,
+  const exprt &rhs)
+{
+  if (op != "Is" && op != "IsNot" && op != "Eq" && op != "NotEq")
+    return nil_exprt();
+
+  // One operand must be the None literal; the other must be a member access
+  // on a __ESBMC_PySliceObj struct.
+  const exprt *member_side = nullptr;
+  if (lhs.type() == none_type() && rhs.id() == "member")
+    member_side = &rhs;
+  else if (rhs.type() == none_type() && lhs.id() == "member")
+    member_side = &lhs;
+  else
+    return nil_exprt();
+
+  const namespacet ns(symbol_table_);
+  const typet base_type = ns.follow(member_side->op0().type());
+  if (!base_type.is_struct())
+    return nil_exprt();
+  if (base_type != ns.follow(type_handler_.get_slice_type()))
+    return nil_exprt();
+
+  const irep_idt component = member_side->component_name();
+  irep_idt flag_name;
+  if (component == "start")
+    flag_name = "has_start";
+  else if (component == "stop")
+    flag_name = "has_stop";
+  else if (component == "step")
+    flag_name = "has_step";
+  else
+    return nil_exprt();
+
+  const struct_typet &slice_struct = to_struct_type(base_type);
+  const typet flag_type = slice_struct.get_component(flag_name).type();
+
+  member_exprt flag_access(
+    member_side->op0(), flag_name.as_string(), flag_type);
+  // "is None" / "== None" → flag is zero (bound was absent).
+  // "is not None" / "!= None" → flag is non-zero (bound was supplied).
+  const bool is_eq = (op == "Eq" || op == "Is");
+  equality_exprt eq(flag_access, gen_zero(flag_type));
+  if (is_eq)
+    return eq;
+  exprt neg("not", bool_type());
+  neg.copy_to_operands(eq);
+  return neg;
+}
+
 exprt python_converter::handle_none_comparison(
   const std::string &op,
   const exprt &lhs,
@@ -378,6 +430,16 @@ exprt python_converter::handle_none_comparison(
   // Only handle actual None comparisons
   if (!lhs_is_none && !rhs_is_none)
     return exprt();
+
+  // Bare slice components (`sl.start`, `sl.stop`, `sl.step`) hold
+  // nondeterministic values when the user did not supply a bound. The
+  // authoritative "was the bound supplied?" signal lives in the companion
+  // `has_start` / `has_stop` / `has_step` flags of __ESBMC_PySliceObj.
+  // Lower `sl.<field> is None` to `sl.has_<field> == 0` so that user code can
+  // distinguish a bare `:` from an explicit `0:0` (github #4543).
+  if (exprt rewrite = try_lower_slice_member_is_none(op, lhs, rhs);
+      !rewrite.is_nil())
+    return rewrite;
 
   // If one side is None and the other is a different type (e.g., int, str)
   // Handle type mismatch comparison

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1022,10 +1022,17 @@ static exprt make_slice_struct_expr(
   const struct_typet &struct_type =
     to_struct_type(ns.follow(conv.get_type_handler().get_slice_type()));
 
+  // Unspecified bounds (`:`) are modelled as nondeterministic values rather
+  // than literal zeros so that user code reading `sl.start` / `sl.stop` /
+  // `sl.step` cannot mistake a bare slice for an explicit `0:0`. The
+  // companion `has_start` / `has_stop` / `has_step` flags remain the
+  // authoritative "was a bound supplied?" signal; `sl.start is None` is
+  // lowered to a check of those flags in converter_compare.cpp
+  // (try_lower_slice_member_is_none). See github #4543.
   auto lower_int =
     [&](const nlohmann::json *node, const typet &field_type) -> exprt {
     if (!node || node->is_null())
-      return gen_zero(field_type);
+      return side_effect_expr_nondett(field_type);
     exprt value = conv.get_expr(*node);
     if (value.type() != field_type)
       value = typecast_exprt(value, field_type);

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -351,6 +351,16 @@ private:
     const exprt &lhs,
     const exprt &rhs);
 
+  /// Rewrites `sl.start/stop/step is/is not None` to a check of the
+  /// corresponding `has_start/has_stop/has_step` flag on __ESBMC_PySliceObj.
+  /// Returns `nil_exprt()` when the operands are not a slice-member access
+  /// paired with a None literal, so the caller continues with default
+  /// None-comparison handling.
+  exprt try_lower_slice_member_is_none(
+    const std::string &op,
+    const exprt &lhs,
+    const exprt &rhs);
+
   symbolt &create_tmp_symbol(
     const nlohmann::json &element,
     const std::string var_name,


### PR DESCRIPTION
Unspecified slice bounds were materialised as literal zeros, making
`t[:, c0:c1]` indistinguishable from `t[0:0, c0:c1]` and breaking the
`sl.start is None` idiom. Use nondet for unspecified bounds and lower
`sl.<start|stop|step> is/is not None` to the existing `has_*` flag in
`__ESBMC_PySliceObj`.

Fixes #4543