### PR TITLE
[python] pool all module ASTs for cross-module __getitem__ inference

### DIFF
--- a/regression/python/github_4554/main.py
+++ b/regression/python/github_4554/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from tensor_add_kernel import nki_tensor_add
+
+t: Tile = Tile(256, 256)
+r: Tile = nki_tensor_add(t)
+assert r.d0 == 128

--- a/regression/python/github_4554/stubs.py
+++ b/regression/python/github_4554/stubs.py
@@ -1,0 +1,8 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        return Tile(sl0.stop - sl0.start, sl1.stop - sl1.start)

--- a/regression/python/github_4554/tensor_add_kernel.py
+++ b/regression/python/github_4554/tensor_add_kernel.py
@@ -1,0 +1,4 @@
+from stubs import *
+
+def nki_tensor_add(a: Tile) -> Tile:
+    return a[0:128, 0:128]

--- a/regression/python/github_4554/test.desc
+++ b/regression/python/github_4554/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4554_chain/inner_kernel.py
+++ b/regression/python/github_4554_chain/inner_kernel.py
@@ -1,0 +1,4 @@
+from stubs import *
+
+def inner(a: Tile) -> Tile:
+    return a[0:64, 0:64]

--- a/regression/python/github_4554_chain/main.py
+++ b/regression/python/github_4554_chain/main.py
@@ -1,0 +1,6 @@
+from stubs import Tile
+from outer_kernel import outer
+
+t: Tile = Tile(128, 128)
+r: Tile = outer(t)
+assert r.d0 == 64

--- a/regression/python/github_4554_chain/outer_kernel.py
+++ b/regression/python/github_4554_chain/outer_kernel.py
@@ -1,0 +1,5 @@
+from inner_kernel import inner
+from stubs import Tile
+
+def outer(a: Tile) -> Tile:
+    return inner(a)

--- a/regression/python/github_4554_chain/stubs.py
+++ b/regression/python/github_4554_chain/stubs.py
@@ -1,0 +1,8 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        return Tile(sl0.stop - sl0.start, sl1.stop - sl1.start)

--- a/regression/python/github_4554_chain/test.desc
+++ b/regression/python/github_4554_chain/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4554_fail/main.py
+++ b/regression/python/github_4554_fail/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from tensor_add_kernel import nki_tensor_add
+
+t: Tile = Tile(256, 256)
+r: Tile = nki_tensor_add(t)
+assert r.d0 == 999

--- a/regression/python/github_4554_fail/stubs.py
+++ b/regression/python/github_4554_fail/stubs.py
@@ -1,0 +1,8 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+    def __getitem__(self, key) -> "Tile":
+        sl0: slice = key[0]
+        sl1: slice = key[1]
+        return Tile(sl0.stop - sl0.start, sl1.stop - sl1.start)

--- a/regression/python/github_4554_fail/tensor_add_kernel.py
+++ b/regression/python/github_4554_fail/tensor_add_kernel.py
@@ -1,0 +1,4 @@
+from stubs import *
+
+def nki_tensor_add(a: Tile) -> Tile:
+    return a[0:128, 0:128]

--- a/regression/python/github_4554_fail/test.desc
+++ b/regression/python/github_4554_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -236,12 +236,12 @@ bool python_converter::import_module_into_block(
   if (imported_modules.find(module_name) != imported_modules.end())
     return true;
 
-  std::ifstream imported_file = locator.open_module_file(module_name);
-  if (!imported_file.is_open())
+  // pre_collect_module_asts populates the pool before any import runs.
+  // A miss here means the same module_locator could not open the file.
+  auto pooled = module_ast_pool_.find(module_name);
+  if (pooled == module_ast_pool_.end())
     return false;
-
-  nlohmann::json nested_module_json;
-  imported_file >> nested_module_json;
+  nlohmann::json &nested_module_json = pooled->second;
 
   current_python_file = nested_module_json["filename"].get<std::string>();
   imported_modules.emplace(module_name, current_python_file);
@@ -253,11 +253,16 @@ bool python_converter::import_module_into_block(
   create_builtin_symbols();
   python_annotation<nlohmann::json> imported_annotator(
     nested_module_json, const_cast<global_scope &>(global_scope_));
-  // Expose the importing module's AST so that multi-axis subscript usages
-  // on imported-class instances (e.g. `t[i:j, k:l]` where `Tile` comes from
-  // this imported module) are visible when inferring tuple-key annotations
-  // for __getitem__/__setitem__ (GitHub #4545).
+  // Expose every other reachable module's AST as an extra subscript
+  // inference source so that multi-axis subscript usages on instances of
+  // this module's classes (e.g. `t[i:j, k:l]` where `Tile` is defined
+  // here) are visible no matter which module they appear in. The
+  // entry-point AST closes the 2-file form (GitHub #4545); intermediate
+  // modules close the 3+-file transitive form (GitHub #4554).
   imported_annotator.add_extra_subscript_inference_source(*ast_json);
+  for (auto &entry : module_ast_pool_)
+    if (&entry.second != &nested_module_json)
+      imported_annotator.add_extra_subscript_inference_source(entry.second);
   imported_annotator.add_type_annotation();
 
   exprt imported_code = with_ast(&nested_module_json, [&]() {
@@ -285,6 +290,52 @@ void python_converter::process_module_imports(
       import_module_into_block(elem, locator, block);
       current_python_file = saved_file;
     }
+  }
+}
+
+void python_converter::pre_collect_module_asts(
+  const nlohmann::json &module_ast,
+  module_locator &locator)
+{
+  auto try_collect = [&](const nlohmann::json &node) {
+    if (node["_type"] != "ImportFrom" && node["_type"] != "Import")
+      return;
+    if (node.value("module_not_found", false))
+      return;
+    const std::string module_name = (node["_type"] == "ImportFrom")
+                                      ? node["module"]
+                                      : node["names"][0]["name"];
+    if (module_ast_pool_.count(module_name))
+      return;
+    std::ifstream f = locator.open_module_file(module_name);
+    if (!f.is_open())
+      return;
+    nlohmann::json parsed;
+    try
+    {
+      f >> parsed;
+    }
+    catch (const nlohmann::json::exception &)
+    {
+      // Treat a malformed AST as an unresolvable import; the subsequent
+      // import_module_into_block lookup will return false the same way.
+      return;
+    }
+    auto [it, _] = module_ast_pool_.emplace(module_name, std::move(parsed));
+    pre_collect_module_asts(it->second, locator);
+  };
+
+  if (!module_ast.contains("body") || !module_ast["body"].is_array())
+    return;
+
+  for (const auto &elem : module_ast["body"])
+  {
+    try_collect(elem);
+    if (
+      elem["_type"] == "FunctionDef" && elem.contains("body") &&
+      elem["body"].is_array())
+      for (const auto &stmt : elem["body"])
+        try_collect(stmt);
   }
 }
 
@@ -464,6 +515,10 @@ void python_converter::convert()
   {
     // Convert imported modules
     module_locator locator((*ast_json)["ast_output_dir"].get<std::string>());
+
+    // Pre-walk the import graph so each annotator can see subscript usages
+    // from any other module (GitHub #4554).
+    pre_collect_module_asts(*ast_json, locator);
 
     // Accumulate all imports
     code_blockt all_imports_block;

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -514,6 +514,17 @@ private:
     module_locator &locator,
     code_blockt &accumulated_code);
 
+  /// Walk the import graph rooted at @p module_ast (without annotating or
+  /// generating code) and parse each reachable module's JSON AST into
+  /// @ref module_ast_pool_. Mirrors @ref process_module_imports's reach:
+  /// top-level imports plus imports directly inside top-level
+  /// FunctionDef bodies. Idempotent on names already pooled. Used so that
+  /// annotators for any one module can see subscript usages from any
+  /// other module in the graph (GitHub #4554).
+  void pre_collect_module_asts(
+    const nlohmann::json &module_ast,
+    module_locator &locator);
+
   symbolt *find_function_in_base_classes(
     const std::string &class_name,
     const std::string &symbol_id,
@@ -998,6 +1009,14 @@ private:
   std::map<std::string, std::set<std::string>> instance_attr_map;
   /// Map imported modules to their corresponding paths
   std::unordered_map<std::string, std::string> imported_modules;
+
+  /// Pool of every reachable imported module's parsed JSON AST, keyed by
+  /// module name. Populated by @ref pre_collect_module_asts before any
+  /// annotation runs so that @ref import_module_into_block can expose the
+  /// full pool to each module's annotator as extra subscript inference
+  /// sources (GitHub #4554). Owns the JSONs to keep their addresses stable
+  /// across annotator calls.
+  std::map<std::string, nlohmann::json> module_ast_pool_;
   /// Maps any symbol currently known to refer to an input() string
   /// (e.g. $input_str$N or a variable aliasing it) to its $input_len$N symbol ID
   std::unordered_map<std::string, std::string> input_str_to_len_sym_;


### PR DESCRIPTION
PR #4553 closed the 2-file form of cross-module `__getitem__` on a parameter, but the 3-file chain (`main → kernel → stubs`) where the natural-form subscript lives in the intermediate kernel still crashed BMC with `type2t::symbolic_type_excp`: `stubs` was annotated as soon as `main` imported it, before `kernel` was even parsed, so the kernel's subscript site never reached `stubs`'s annotator. Pre-walk the whole import graph into a module-AST pool before any annotation runs, and pass every other pool entry as an extra subscript inference source.

Fixes #4554.