### PR TITLE
[python] clear current_lhs while evaluating Call arguments

### DIFF
--- a/regression/python/github_4552/main.py
+++ b/regression/python/github_4552/main.py
@@ -1,0 +1,10 @@
+from stubs import *
+
+def f(a: A) -> int:
+    return a[2:5, 10:20]
+
+def g(b: B) -> int:
+    return b[1:2, 2:5, 0:64, 0:128]
+
+x: int = f(A())
+y: int = g(B())

--- a/regression/python/github_4552/stubs.py
+++ b/regression/python/github_4552/stubs.py
@@ -1,0 +1,7 @@
+class A:
+    def __getitem__(self, key) -> int:
+        return key[0]
+
+class B:
+    def __getitem__(self, key) -> int:
+        return key[0]

--- a/regression/python/github_4552/test.desc
+++ b/regression/python/github_4552/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4552_fail/main.py
+++ b/regression/python/github_4552_fail/main.py
@@ -1,0 +1,11 @@
+from stubs import *
+
+def f(a: A) -> int:
+    return a[2:5, 10:20]
+
+def g(b: B) -> int:
+    return b[1:2, 2:5, 0:64, 0:128]
+
+x: int = f(A())
+y: int = g(B())
+assert x == 999

--- a/regression/python/github_4552_fail/stubs.py
+++ b/regression/python/github_4552_fail/stubs.py
@@ -1,0 +1,7 @@
+class A:
+    def __getitem__(self, key) -> int:
+        return key[0].start
+
+class B:
+    def __getitem__(self, key) -> int:
+        return key[0].start

--- a/regression/python/github_4552_fail/test.desc
+++ b/regression/python/github_4552_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4552_single/main.py
+++ b/regression/python/github_4552_single/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+
+def f(a: A) -> int:
+    return a[2:5, 10:20]
+
+x: int = f(A())

--- a/regression/python/github_4552_single/stubs.py
+++ b/regression/python/github_4552_single/stubs.py
@@ -1,0 +1,3 @@
+class A:
+    def __getitem__(self, key) -> int:
+        return key[0]

--- a/regression/python/github_4552_single/test.desc
+++ b/regression/python/github_4552_single/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call_expr.cpp
+++ b/src/python-frontend/function_call_expr.cpp
@@ -5609,7 +5609,15 @@ exprt function_call_expr::handle_general_function_call()
   size_t arg_index = 0;
   for (const auto &arg_node : call_["args"])
   {
+    // An argument expression does not bind to the outer assignment's LHS.
+    // Clearing `current_lhs` while evaluating each argument prevents inner
+    // constructor calls (e.g. `f(A())`) from using an unrelated LHS as their
+    // `self` storage; they will allocate a `$ctor_self$` temp instead
+    // (GitHub #4552).
+    exprt *saved_lhs = converter_.current_lhs;
+    converter_.current_lhs = nullptr;
     exprt arg = converter_.get_expr(arg_node);
+    converter_.current_lhs = saved_lhs;
 
     // A function name passed as an argument decays to a function pointer,
     // mirroring C's implicit function-to-pointer conversion.


### PR DESCRIPTION
Constructor calls used as inner arguments — e.g. `x: int = f(A())` where `A` is a class without `__init__` — were binding the outer assignment's LHS as the constructor's `self`. With `x: int`, the GOTO emitted `A(&x)` (int* cast to A*) and propagated the constructor's `_Bool *` return value as the argument to `f`, crashing BMC with `type mismatch: got pointer, expected struct`. Save/clear/restore `current_lhs` across each argument's `get_expr` so inner constructors fall through to the existing `$ctor_self$` temp path.

Fixes #4552.