### PR TITLE
[python] consult __exit__ return value for dynamic suppression

### DIFF
--- a/regression/python/github_4373/main.py
+++ b/regression/python/github_4373/main.py
@@ -1,0 +1,19 @@
+class CMCond:
+    def __init__(self, swallow: bool):
+        self.swallow = swallow
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb) -> bool:
+        return self.swallow
+
+
+def main() -> None:
+    suppressed = False
+    try:
+        with CMCond(True):
+            raise ValueError("x")
+        suppressed = True
+    except ValueError:
+        pass
+    assert suppressed
+main()

--- a/regression/python/github_4373/test.desc
+++ b/regression/python/github_4373/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4373_base/main.py
+++ b/regression/python/github_4373_base/main.py
@@ -1,0 +1,21 @@
+class Base:
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb) -> bool:
+        return True
+
+
+class Child(Base):
+    pass
+
+
+def main() -> None:
+    suppressed = False
+    try:
+        with Child():
+            raise ValueError("x")
+        suppressed = True
+    except ValueError:
+        pass
+    assert suppressed
+main()

--- a/regression/python/github_4373_base/test.desc
+++ b/regression/python/github_4373_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4373_fail/main.py
+++ b/regression/python/github_4373_fail/main.py
@@ -1,0 +1,19 @@
+class CMCond:
+    def __init__(self, swallow: bool):
+        self.swallow = swallow
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb) -> bool:
+        return self.swallow
+
+
+def main() -> None:
+    suppressed = False
+    try:
+        with CMCond(False):
+            raise ValueError("x")
+        suppressed = True
+    except ValueError:
+        pass
+    assert suppressed
+main()

--- a/regression/python/github_4373_fail/test.desc
+++ b/regression/python/github_4373_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4373_nested_def/main.py
+++ b/regression/python/github_4373_nested_def/main.py
@@ -1,0 +1,22 @@
+class CMNested:
+    """__exit__ returns None implicitly. The inner helper returning True
+    must not fool the truthy-Return scan into wrapping this class for
+    dynamic dispatch (which would crash on the void result)."""
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb):
+        def helper():
+            return True
+        helper()
+        return None
+
+
+def main() -> None:
+    caught = False
+    try:
+        with CMNested():
+            raise ValueError("x")
+    except ValueError:
+        caught = True
+    assert caught
+main()

--- a/regression/python/github_4373_nested_def/test.desc
+++ b/regression/python/github_4373_nested_def/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4373_none/main.py
+++ b/regression/python/github_4373_none/main.py
@@ -1,0 +1,16 @@
+class CMNone:
+    def __enter__(self):
+        return self
+    def __exit__(self, et, ev, tb):
+        pass  # implicit None return -> exception must propagate
+
+
+def main() -> None:
+    caught = False
+    try:
+        with CMNone():
+            raise ValueError("x")
+    except ValueError:
+        caught = True
+    assert caught
+main()

--- a/regression/python/github_4373_none/test.desc
+++ b/regression/python/github_4373_none/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/preprocessor/__init__.py
+++ b/src/python-frontend/preprocessor/__init__.py
@@ -2931,24 +2931,55 @@ class Preprocessor(DataclassMixin, GeneratorMixin, LoopMixin, ast.NodeTransforme
 
         node = self.expand_dataclass(node)
         self._collect_class_attr_annotations(node)
-        self._record_exit_suppresses_all(node)
+        self._record_class_with_exit(node)
         self.generic_visit(node)
 
         self.current_class_name = old_class_name
         return node
 
-    def _record_exit_suppresses_all(self, class_node):
-        """Cache classes whose __exit__ unconditionally returns True so
-        visit_With can suppress exceptions from the body."""
-        if not hasattr(self, "_exit_suppresses_all"):
-            self._exit_suppresses_all = set()
-        for member in class_node.body:
-            if (isinstance(member, ast.FunctionDef) and member.name == "__exit__"
-                    and len(member.body) == 1 and isinstance(member.body[0], ast.Return)
-                    and isinstance(member.body[0].value, ast.Constant)
-                    and member.body[0].value.value is True):
-                self._exit_suppresses_all.add(class_node.name)
-                return
+    def _record_class_with_exit(self, class_node):
+        """Cache classes whose __exit__ can potentially suppress.
+
+        visit_With lowers a `with` over such a class to a try/except wrapper
+        that calls __exit__ in the handler and re-raises iff the result is
+        falsy, matching CPython's dynamic suppression semantics.
+
+        A class qualifies if it (or any of its bases) defines __exit__ with at
+        least one Return whose value is neither omitted nor literal None — i.e.
+        a return that could plausibly be truthy.  Bodies that only ``pass``,
+        ``return`` or ``return None`` always evaluate falsy and need no
+        dispatch; the default propagation is already correct for them.
+        """
+        if not hasattr(self, "_classes_with_exit"):
+            self._classes_with_exit = set()
+        defines_truthy_exit = any(
+            isinstance(member, ast.FunctionDef) and member.name == "__exit__"
+            and self._function_may_return_truthy(member) for member in class_node.body)
+        inherits_truthy_exit = any(
+            isinstance(base, ast.Name) and base.id in self._classes_with_exit
+            for base in class_node.bases)
+        if defines_truthy_exit or inherits_truthy_exit:
+            self._classes_with_exit.add(class_node.name)
+
+    @staticmethod
+    def _function_may_return_truthy(func_node):
+        """True if func has any Return (in its own scope) with a non-None value.
+
+        Returns nested inside an inner FunctionDef / AsyncFunctionDef / Lambda /
+        ClassDef belong to a different scope and must not influence the outer
+        function's verdict.
+        """
+        stack = list(func_node.body)
+        skip = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+        while stack:
+            node = stack.pop()
+            if isinstance(node, skip):
+                continue
+            if isinstance(node, ast.Return) and node.value is not None and not (
+                    isinstance(node.value, ast.Constant) and node.value.value is None):
+                return True
+            stack.extend(ast.iter_child_nodes(node))
+        return False
 
     def _collect_class_attr_annotations(self, class_node):
         """Scan __init__ for self.attr: T = ... and cache attribute annotations."""

--- a/src/python-frontend/preprocessor/__init__.py
+++ b/src/python-frontend/preprocessor/__init__.py
@@ -2975,8 +2975,8 @@ class Preprocessor(DataclassMixin, GeneratorMixin, LoopMixin, ast.NodeTransforme
             node = stack.pop()
             if isinstance(node, skip):
                 continue
-            if isinstance(node, ast.Return) and node.value is not None and not (
-                    isinstance(node.value, ast.Constant) and node.value.value is None):
+            if isinstance(node, ast.Return) and node.value is not None and not (isinstance(
+                    node.value, ast.Constant) and node.value.value is None):
                 return True
             stack.extend(ast.iter_child_nodes(node))
         return False

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -459,42 +459,58 @@ class LoopMixin:
             else:
                 result.append(self.ensure_all_locations(ast.Expr(value=enter_call), node))
 
-        # Build the list of __exit__ calls (reverse order, non-exceptional path).
-        exit_calls = []
-        for i in range(len(node.items) - 1, -1, -1):
+        # Build __exit__ calls in reverse order.  The helper is factored out so
+        # the same call shape can be re-instantiated for both the success path
+        # (statement) and the exception handler (operand of `not`); AST nodes
+        # must not be shared across locations because each carries its own
+        # location/parent metadata.
+        def make_exit_call(i):
             mgr_name = f"__esbmc_mgr_{exit_start + i}"
-            exit_call = ast.Call(
+            return ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id=mgr_name, ctx=ast.Load()),
                     attr="__exit__",
                     ctx=ast.Load(),
                 ),
-                args=[
-                    ast.Constant(value=0),
-                    ast.Constant(value=0),
-                    ast.Constant(value=0),
-                ],
+                args=[ast.Constant(value=0)] * 3,
                 keywords=[],
             )
-            exit_calls.append(self.ensure_all_locations(ast.Expr(value=exit_call), node))
 
-        # If every context manager's __exit__ statically returns True, wrap the
-        # body and exit calls in a try/except BaseException: pass so any
-        # exception raised inside the with block is suppressed, matching
-        # CPython semantics. Other __exit__ shapes preserve today's behaviour
-        # (exception propagates without consulting __exit__).
-        suppress = (hasattr(self, "_exit_suppresses_all") and len(node.items) > 0 and all(
+        exit_calls = [
+            self.ensure_all_locations(ast.Expr(value=make_exit_call(i)), node)
+            for i in range(len(node.items) - 1, -1, -1)
+        ]
+
+        # When every manager's class defines (or inherits) __exit__, lower to
+        # CPython's dynamic-suppression form:
+        #   try:
+        #       BODY
+        #       <success-path exit calls>
+        #   except BaseException:
+        #       if not mgr.__exit__(0, 0, 0): raise
+        #       ...                          # one guard per manager, reverse order
+        # __exit__'s return value is consulted at runtime: truthy suppresses,
+        # falsy re-raises via bare `raise`.  Managers without a tracked class
+        # (e.g. `open(...)`) fall back to today's unwrapped lowering.
+        wrap = (hasattr(self, "_classes_with_exit") and len(node.items) > 0 and all(
             isinstance(item.context_expr, ast.Call) and isinstance(item.context_expr.func, ast.Name)
-            and item.context_expr.func.id in self._exit_suppresses_all for item in node.items))
+            and item.context_expr.func.id in self._classes_with_exit for item in node.items))
 
-        if suppress:
+        if wrap:
+            handler_body = [
+                ast.If(
+                    test=ast.UnaryOp(op=ast.Not(), operand=make_exit_call(i)),
+                    body=[ast.Raise(exc=None, cause=None)],
+                    orelse=[],
+                ) for i in range(len(node.items) - 1, -1, -1)
+            ]
             try_node = ast.Try(
                 body=list(node.body) + exit_calls,
                 handlers=[
                     ast.ExceptHandler(
                         type=ast.Name(id="BaseException", ctx=ast.Load()),
                         name=None,
-                        body=[ast.Pass()],
+                        body=handler_body,
                     )
                 ],
                 orelse=[],

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -80,6 +80,22 @@ void python_exception_handler::get_raise_statement(
   const nlohmann::json &element,
   codet &block)
 {
+  locationt location = converter_.get_location_from_decl(element);
+
+  // Bare 'raise' (Raise.exc is null) re-raises the active exception.
+  // Lower it to a cpp-throw with no operand and an empty exception_list;
+  // goto_symext::handle_rethrow replays last_throw at symex time.
+  if (element["exc"].is_null())
+  {
+    side_effect_exprt side("cpp-throw", empty_typet());
+    side.location() = location;
+
+    codet code_expr("expression");
+    code_expr.operands().push_back(side);
+    block.move_to_operands(code_expr);
+    return;
+  }
+
   std::string exc_name;
 
   // Try to extract the exception name from different AST shapes
@@ -92,7 +108,6 @@ void python_exception_handler::get_raise_statement(
   else
     exc_name = ""; // fallback
 
-  locationt location = converter_.get_location_from_decl(element);
   typet type = type_handler_.get_typet(exc_name);
 
   // AssertionError is special-cased to a clean assert(false)


### PR DESCRIPTION
Lower bare `raise` to a nil-operand cpp-throw (`goto_symext::handle_rethrow` already replays `last_throw` at symex time) and replace the static-True special case in `visit_With` with a unified dynamic dispatch that calls `__exit__` in a `BaseException` handler and re-raises iff the result is falsy. Covers conditional returns, implicit-None bodies (left to propagate by default), and single-level base-class inheritance of `__exit__`.

Fixes #4373.