### PR TITLE
[docs] update Python context-manager docs after #4559

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -11,10 +11,6 @@ weight: 4
 - List comprehensions and generator expressions are supported. Set comprehensions are not supported (`Unsupported expression SetComp`). Dictionary comprehensions are accepted by the parser but produce a dictionary whose subsequent key lookups raise `KeyError`.
 - Iteration over dictionaries via `d.keys()`, `d.values()`, and `d.items()` is supported inside `for` loops (see [Supported Features — Dictionaries](./supported-features#dictionaries)).
 
-## Context Managers
-
-- `__enter__` is invoked before the body and `__exit__` after. Exceptions raised inside the `with` block propagate, but `__exit__`'s return value is ignored: returning `True` does not suppress the exception.
-
 ## Lists
 
 - `list.sort()` does not support the `key` or `reverse` keyword arguments.

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -18,6 +18,7 @@ This page is a reference of all Python language constructs, data structures, and
   - `with EXPR: BODY` — context manager used without variable binding
   - `with A as a, B as b: BODY` — multiple context managers in one statement; expanded left-to-right, `__exit__` called in reverse order
   - `async with` is handled identically to `with`
+  - Exception suppression: when the body raises, `__exit__(type, value, traceback)` is called and the exception is re-raised iff the return value is falsy, matching CPython semantics. This covers static `return True`, conditional returns (`return self.flag`, `return et is ValueError`), implicit-`None` bodies (propagate by default), and single-level base-class inheritance of `__exit__`.
 
 ## Functions and Methods
 
@@ -156,7 +157,7 @@ Byte sequences and integer class methods:
 ## Error Handling
 
 - **`try`/`except`** blocks with multiple handlers and `except ExceptionType as var` binding
-- **`raise`** statements with exception instantiation and custom messages
+- **`raise`** statements with exception instantiation and custom messages; bare `raise` re-raises the active exception inside an `except` handler
 - **`assert`** statements for property verification
 - **`__ESBMC_assume`** for constraining non-deterministic inputs
 - **`ImportError` guards**: Imports inside `try/except ImportError` are handled statically


### PR DESCRIPTION
## Summary

Documentation follow-up to #4559 (which made `with`/`__exit__`'s return value gate exception suppression, and lowered bare `raise` to a nil-operand cpp-throw):

- **`limitations.md`** — drop the "Context Managers" section. The limitation it described (`__exit__`'s return value is ignored) no longer holds.
- **`supported-features.md`** —
  - Context managers: spell out the suppression rule (truthy return ⇒ swallow, falsy / implicit `None` ⇒ propagate, inherited `__exit__` honoured).
  - Error handling: note that bare `raise` re-raises the active exception inside an `except` handler.

No code changes. Refs #4373.

## Test plan
- [x] Markdown-only diff; no compile/regression sweep required.
- [x] Source claims cross-checked against `regression/python/github_4373*` (static-True, conditional, implicit-`None`, base-class inheritance, dynamic-False) added by #4559.
