### PR TITLE
[python] resolve foreign-scope Name elts in __getitem__ key inference

### DIFF
--- a/regression/python/github_4558/kernel.py
+++ b/regression/python/github_4558/kernel.py
@@ -1,0 +1,5 @@
+from stubs import *
+
+
+def f(t3: Tile3D, src: Tile, i: int) -> None:
+    copy(t3[i, :, :], src)

--- a/regression/python/github_4558/main.py
+++ b/regression/python/github_4558/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from kernel import f
+
+t3: Tile3D = Tile3D(5, 50, 100)
+src: Tile = Tile(50, 100)
+f(t3, src, 2)

--- a/regression/python/github_4558/stubs.py
+++ b/regression/python/github_4558/stubs.py
@@ -1,0 +1,21 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+class Tile3D:
+    def __init__(self, d0: int, d1: int, d2: int):
+        self.d0: int = d0
+        self.d1: int = d1
+        self.d2: int = d2
+
+    def __getitem__(self, key) -> "Tile":
+        k: int = key[0]
+        sl1: slice = key[1]
+        sl2: slice = key[2]
+        return Tile(self.d1, self.d2)
+
+
+def copy(dst: Tile, src: Tile) -> None:
+    assert dst.d0 == src.d0

--- a/regression/python/github_4558/test.desc
+++ b/regression/python/github_4558/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4558_fail/kernel.py
+++ b/regression/python/github_4558_fail/kernel.py
@@ -1,0 +1,5 @@
+from stubs import *
+
+
+def f(t3: Tile3D, src: Tile, i: int) -> None:
+    copy(t3[i, :, :], src)

--- a/regression/python/github_4558_fail/main.py
+++ b/regression/python/github_4558_fail/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from kernel import f
+
+t3: Tile3D = Tile3D(5, 50, 100)
+src: Tile = Tile(50, 100)
+f(t3, src, 2)

--- a/regression/python/github_4558_fail/stubs.py
+++ b/regression/python/github_4558_fail/stubs.py
@@ -1,0 +1,21 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+class Tile3D:
+    def __init__(self, d0: int, d1: int, d2: int):
+        self.d0: int = d0
+        self.d1: int = d1
+        self.d2: int = d2
+
+    def __getitem__(self, key) -> "Tile":
+        k: int = key[0]
+        sl1: slice = key[1]
+        sl2: slice = key[2]
+        return Tile(self.d1, self.d2)
+
+
+def copy(dst: Tile, src: Tile) -> None:
+    assert dst.d0 != src.d0

--- a/regression/python/github_4558_fail/test.desc
+++ b/regression/python/github_4558_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4558_loop/kernel.py
+++ b/regression/python/github_4558_loop/kernel.py
@@ -1,0 +1,6 @@
+from stubs import *
+
+
+def f(t4: Tile4D, src: Tile) -> None:
+    for i in range(2):
+        copy(t4[i, 0, :, :], src)

--- a/regression/python/github_4558_loop/main.py
+++ b/regression/python/github_4558_loop/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from kernel import f
+
+t4: Tile4D = Tile4D(5, 4, 50, 100)
+src: Tile = Tile(50, 100)
+f(t4, src)

--- a/regression/python/github_4558_loop/stubs.py
+++ b/regression/python/github_4558_loop/stubs.py
@@ -1,0 +1,23 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+class Tile4D:
+    def __init__(self, d0: int, d1: int, d2: int, d3: int):
+        self.d0: int = d0
+        self.d1: int = d1
+        self.d2: int = d2
+        self.d3: int = d3
+
+    def __getitem__(self, key) -> "Tile":
+        i: int = key[0]
+        j: int = key[1]
+        sl1: slice = key[2]
+        sl2: slice = key[3]
+        return Tile(self.d2, self.d3)
+
+
+def copy(dst: Tile, src: Tile) -> None:
+    assert dst.d0 == src.d0

--- a/regression/python/github_4558_loop/test.desc
+++ b/regression/python/github_4558_loop/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -750,10 +750,11 @@ private:
     // void* default keeps working for those call sites.
     bool any_reject = false;
     std::vector<std::string> expected;
-    auto reducer = [&](const Json &elts) {
+    auto reducer = [&](const Json &elts, const Json *enclosing_func) {
       if (any_reject)
         return;
-      std::vector<std::string> types = infer_tuple_element_types(elts);
+      std::vector<std::string> types =
+        infer_tuple_element_types(elts, enclosing_func);
       if (types.empty())
       {
         any_reject = true;
@@ -839,18 +840,32 @@ private:
       walk(ast["body"]);
   }
 
-  // Walk @p node and invoke @p visit(elts) for every Subscript whose value
-  // is a Name resolving to @p class_name and whose slice is a Tuple. @p
-  // visit receives the tuple's `elts` JSON array.
+  // Walk @p node and invoke @p visit(elts, enclosing_func) for every
+  // Subscript whose value is a Name resolving to @p class_name and whose
+  // slice is a Tuple. @p visit receives the tuple's `elts` JSON array along
+  // with a pointer to the enclosing FunctionDef/AsyncFunctionDef (or nullptr
+  // at module scope). The enclosing function lets the reducer resolve
+  // `Name` elts against arguments and local annotations of the AST being
+  // scanned — essential when scanning a foreign module's AST whose locals
+  // are not visible to this annotator's own `ast_`-scoped lookup (GitHub
+  // #4558).
   template <typename Visitor>
   void visit_class_tuple_subscripts(
     const Json &node,
     const std::string &class_name,
     const std::unordered_map<std::string, std::string> &var_to_class,
-    Visitor &&visit)
+    Visitor &&visit,
+    const Json *enclosing_func = nullptr)
   {
     if (node.is_object())
     {
+      const Json *next_enclosing = enclosing_func;
+      if (
+        node.contains("_type") &&
+        (node["_type"] == "FunctionDef" ||
+         node["_type"] == "AsyncFunctionDef"))
+        next_enclosing = &node;
+
       if (
         node.contains("_type") && node["_type"] == "Subscript" &&
         node.contains("value") && node["value"].is_object() &&
@@ -863,26 +878,61 @@ private:
         auto it =
           var_to_class.find(node["value"]["id"].template get<std::string>());
         if (it != var_to_class.end() && it->second == class_name)
-          visit(node["slice"]["elts"]);
+          visit(node["slice"]["elts"], next_enclosing);
       }
       for (auto it = node.begin(); it != node.end(); ++it)
         visit_class_tuple_subscripts(
-          it.value(), class_name, var_to_class, visit);
+          it.value(), class_name, var_to_class, visit, next_enclosing);
     }
     else if (node.is_array())
     {
       for (const auto &elem : node)
-        visit_class_tuple_subscripts(elem, class_name, var_to_class, visit);
+        visit_class_tuple_subscripts(
+          elem, class_name, var_to_class, visit, enclosing_func);
     }
+  }
+
+  // Resolve a `Name` elt against @p enclosing_func's parameters and local
+  // annotated assigns. Returns the annotation type name on success, or "" if
+  // the name is not declared in that scope. Used as a foreign-scope fallback
+  // when @p elts come from an AST other than `ast_` — `get_argument_type`'s
+  // own `find_var_node_for_inference` only searches `ast_` (GitHub #4558).
+  std::string resolve_name_in_enclosing_func(
+    const std::string &name,
+    const Json &enclosing_func)
+  {
+    auto lookup = [&](const Json &scope) -> std::string {
+      Json node = find_annotated_assign(name, scope);
+      if (has_annotation(node))
+        return json_utils::get_annotation_type_name(node["annotation"]);
+      return "";
+    };
+
+    if (enclosing_func.contains("args"))
+    {
+      const Json &arg_spec = enclosing_func["args"];
+      for (const char *key : {"args", "kwonlyargs"})
+        if (arg_spec.contains(key))
+          if (std::string t = lookup(arg_spec[key]); !t.empty())
+            return t;
+    }
+    if (enclosing_func.contains("body"))
+      return lookup(enclosing_func["body"]);
+    return "";
   }
 
   // Resolve each element of @p elts to a Python type name suitable for a
   // synthesised `tuple[...]` annotation. Slice literals and `slice(...)`
   // calls map to "slice"; scalars and other expressions are routed through
-  // get_argument_type(). Returns an empty vector when any element resolves
-  // to "" or "Any" — bailing keeps the synthesised callee struct consistent
-  // with whatever the caller actually builds at the subscript site.
-  std::vector<std::string> infer_tuple_element_types(const Json &elts)
+  // get_argument_type(). `Name` elts are first looked up in @p
+  // enclosing_func (when non-null) so foreign-AST scans can resolve
+  // variables defined outside this annotator's `ast_` (GitHub #4558).
+  // Returns an empty vector when any element resolves to "" or "Any" —
+  // bailing keeps the synthesised callee struct consistent with whatever
+  // the caller actually builds at the subscript site.
+  std::vector<std::string> infer_tuple_element_types(
+    const Json &elts,
+    const Json *enclosing_func = nullptr)
   {
     std::vector<std::string> types;
     types.reserve(elts.size());
@@ -904,7 +954,11 @@ private:
         types.emplace_back("slice");
         continue;
       }
-      std::string resolved = get_argument_type(elt);
+      std::string resolved;
+      if (t == "Name" && enclosing_func != nullptr && elt.contains("id"))
+        resolved = resolve_name_in_enclosing_func(elt["id"], *enclosing_func);
+      if (resolved.empty())
+        resolved = get_argument_type(elt);
       if (resolved.empty() || resolved == "Any")
         return {};
       types.push_back(std::move(resolved));

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -862,8 +862,7 @@ private:
       const Json *next_enclosing = enclosing_func;
       if (
         node.contains("_type") &&
-        (node["_type"] == "FunctionDef" ||
-         node["_type"] == "AsyncFunctionDef"))
+        (node["_type"] == "FunctionDef" || node["_type"] == "AsyncFunctionDef"))
         next_enclosing = &node;
 
       if (

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -11,10 +11,6 @@ weight: 4
 - List comprehensions and generator expressions are supported. Set comprehensions are not supported (`Unsupported expression SetComp`). Dictionary comprehensions are accepted by the parser but produce a dictionary whose subsequent key lookups raise `KeyError`.
 - Iteration over dictionaries via `d.keys()`, `d.values()`, and `d.items()` is supported inside `for` loops (see [Supported Features — Dictionaries](./supported-features#dictionaries)).
 
-## Context Managers
-
-- `__enter__` is invoked before the body and `__exit__` after. Exceptions raised inside the `with` block propagate, but `__exit__`'s return value is ignored: returning `True` does not suppress the exception.
-
 ## Lists
 
 - `list.sort()` does not support the `key` or `reverse` keyword arguments.

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -18,6 +18,7 @@ This page is a reference of all Python language constructs, data structures, and
   - `with EXPR: BODY` — context manager used without variable binding
   - `with A as a, B as b: BODY` — multiple context managers in one statement; expanded left-to-right, `__exit__` called in reverse order
   - `async with` is handled identically to `with`
+  - Exception suppression: when the body raises, `__exit__(type, value, traceback)` is called and the exception is re-raised iff the return value is falsy, matching CPython semantics. This covers static `return True`, conditional returns (`return self.flag`, `return et is ValueError`), implicit-`None` bodies (propagate by default), and single-level base-class inheritance of `__exit__`.
 
 ## Functions and Methods
 
@@ -156,7 +157,7 @@ Byte sequences and integer class methods:
 ## Error Handling
 
 - **`try`/`except`** blocks with multiple handlers and `except ExceptionType as var` binding
-- **`raise`** statements with exception instantiation and custom messages
+- **`raise`** statements with exception instantiation and custom messages; bare `raise` re-raises the active exception inside an `except` handler
 - **`assert`** statements for property verification
 - **`__ESBMC_assume`** for constraining non-deterministic inputs
 - **`ImportError` guards**: Imports inside `try/except ImportError` are handled statically


### PR DESCRIPTION
PR #4555 pooled module ASTs so the annotator scanning `Tile3D.__getitem__` in `stubs.py` can see call sites like `t3[i, :, :]` in `kernel.py`. The variable-scalar case still crashed BMC with `type2t::symbolic_type_excp` (or `Incorrect alignment` for higher arity) because `get_argument_type` routes `Name` elts through `find_var_node_for_inference`, which only searches the annotator's own `ast_` — `kernel.py`'s parameter `i` was invisible, so synthesis of `tuple[int, slice, slice]` silently bailed.

Thread the enclosing `FunctionDef`/`AsyncFunctionDef` through `visit_class_tuple_subscripts` and consult it for `Name` elts before falling through. Three regression tests added (`github_4558`, `github_4558_loop`, `github_4558_fail`).

Fixes #4558.