### PR TITLE
[python] add threading.Lock; reject other threading names at parse

### DIFF
--- a/regression/python/threading_lock_from_import/main.py
+++ b/regression/python/threading_lock_from_import/main.py
@@ -1,0 +1,9 @@
+from threading import Lock
+
+held = Lock()
+held.acquire()
+held.release()
+held.acquire()
+held.release()
+
+assert True

--- a/regression/python/threading_lock_from_import/test.desc
+++ b/regression/python/threading_lock_from_import/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/threading_lock_safe/main.py
+++ b/regression/python/threading_lock_safe/main.py
@@ -1,0 +1,18 @@
+import threading
+
+counter: int = 0
+lock = threading.Lock()
+
+
+def bump() -> None:
+    global counter
+    lock.acquire()
+    counter = counter + 1
+    lock.release()
+
+
+bump()
+bump()
+bump()
+
+assert counter == 3

--- a/regression/python/threading_lock_safe/test.desc
+++ b/regression/python/threading_lock_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/threading_rlock_unsupported/main.py
+++ b/regression/python/threading_rlock_unsupported/main.py
@@ -1,0 +1,3 @@
+import threading
+
+rlock = threading.RLock()

--- a/regression/python/threading_rlock_unsupported/test.desc
+++ b/regression/python/threading_rlock_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR:.*threading\.RLock is not yet supported by ESBMC

--- a/regression/python/threading_star_import_unsupported/main.py
+++ b/regression/python/threading_star_import_unsupported/main.py
@@ -1,0 +1,8 @@
+from threading import *
+
+
+def worker() -> None:
+    pass
+
+
+t = Thread(target=worker)

--- a/regression/python/threading_star_import_unsupported/test.desc
+++ b/regression/python/threading_star_import_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR:.*'from threading import \*' is not supported

--- a/regression/python/threading_thread_aliased_module/main.py
+++ b/regression/python/threading_thread_aliased_module/main.py
@@ -1,0 +1,8 @@
+import threading as t
+
+
+def worker() -> None:
+    pass
+
+
+x = t.Thread(target=worker)

--- a/regression/python/threading_thread_aliased_module/test.desc
+++ b/regression/python/threading_thread_aliased_module/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR:.*threading\.Thread is not yet supported by ESBMC

--- a/regression/python/threading_thread_unsupported/main.py
+++ b/regression/python/threading_thread_unsupported/main.py
@@ -1,0 +1,8 @@
+import threading
+
+
+def worker() -> None:
+    pass
+
+
+t = threading.Thread(target=worker)

--- a/regression/python/threading_thread_unsupported/test.desc
+++ b/regression/python/threading_thread_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR:.*threading\.Thread is not yet supported by ESBMC

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -48,6 +48,8 @@ const std::string kVerifierAssume = "__VERIFIER_assume";
 const std::string kLoopInvariant = "__loop_invariant";
 const std::string kEsbmcLoopInvariant = "__ESBMC_loop_invariant";
 const std::string kEsbmcCover = "__ESBMC_cover";
+const std::string kEsbmcAtomicBegin = "__ESBMC_atomic_begin";
+const std::string kEsbmcAtomicEnd = "__ESBMC_atomic_end";
 
 function_call_builder::function_call_builder(
   python_converter &converter,
@@ -714,6 +716,51 @@ exprt function_call_builder::build() const
     cover_code.location() = loc;
 
     return cover_code;
+  }
+
+  // __ESBMC_atomic_begin / __ESBMC_atomic_end: thin wrappers around the C
+  // intrinsics with the same names. Emitting a call to a symbol whose
+  // base name matches is enough; goto-symex lowers it to the atomic-section
+  // builtins in src/goto-programs/builtin_functions.cpp.
+  {
+    const std::string &func_name = function_id.get_function();
+    const bool is_atomic_begin = func_name == kEsbmcAtomicBegin;
+    const bool is_atomic_end = func_name == kEsbmcAtomicEnd;
+    if (is_atomic_begin || is_atomic_end)
+    {
+      if (!call_["args"].empty())
+        throw std::runtime_error(func_name + " takes no arguments");
+
+      code_typet atomic_type;
+      atomic_type.return_type() = empty_typet();
+
+      auto &symbol_table = converter_.symbol_table();
+      locationt location = converter_.get_location_from_decl(call_);
+
+      auto declare_zero_arg_void = [&](const std::string &name) {
+        const std::string id = "c:@F@" + name;
+        if (symbol_table.find_symbol(id.c_str()) != nullptr)
+          return;
+        symbolt symbol = converter_.create_symbol(
+          converter_.python_file(), name, id, location, atomic_type);
+        converter_.add_symbol(symbol);
+      };
+
+      declare_zero_arg_void(func_name);
+      // do_atomic_begin emits a call to __ESBMC_yield to force a context
+      // switch before entering the atomic section, dereferencing the symbol
+      // unconditionally; the Python frontend does not pull in the C
+      // intrinsics header, so register the yield symbol here too. Only
+      // atomic_begin needs it; atomic_end does not call yield.
+      if (is_atomic_begin)
+        declare_zero_arg_void("__ESBMC_yield");
+
+      code_function_callt atomic_call;
+      atomic_call.function() = symbol_exprt("c:@F@" + func_name, atomic_type);
+      atomic_call.type() = empty_typet();
+      atomic_call.location() = location;
+      return atomic_call;
+    }
   }
 
   // Add len function to symbol table

--- a/src/python-frontend/models/threading.py
+++ b/src/python-frontend/models/threading.py
@@ -1,0 +1,33 @@
+"""Operational model for the standard ``threading`` module."""
+# pylint: disable=unused-argument,unnecessary-pass,undefined-variable,function-redefined
+# Stub for the ``threading`` module. ESBMC currently models only the
+# non-recursive mutex (``threading.Lock``). Any other name from the
+# ``threading`` namespace is rejected at parse time by
+# ``reject_unsupported_threading_usage`` in ``parser.py``.
+#
+# ``Lock.acquire`` / ``Lock.release`` are implemented in pure Python on
+# top of ESBMC's atomic-section and assume intrinsics; the assume on
+# ``self._locked == 0`` forces ESBMC's interleaving search to schedule
+# the calling thread only on states where the lock is free, which is
+# the same semantics ``pthread_mutex_lock_noassert`` uses in the C
+# operational model.
+
+
+class Lock:
+    """Non-recursive mutex; mirrors ``threading.Lock``."""
+
+    def __init__(self) -> None:
+        self._locked: int = 0
+
+    def acquire(self) -> None:
+        """Block until the lock is free, then mark it held."""
+        __ESBMC_atomic_begin()
+        __ESBMC_assume(self._locked == 0)
+        self._locked = 1
+        __ESBMC_atomic_end()
+
+    def release(self) -> None:
+        """Mark the lock free."""
+        __ESBMC_atomic_begin()
+        self._locked = 0
+        __ESBMC_atomic_end()

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -71,6 +71,7 @@ def is_imported_model(module_name):
         "dataclasses",
         "typing",
         "time",
+        "threading",
     ]
     return module_name in models
 
@@ -78,6 +79,79 @@ def is_imported_model(module_name):
 def is_unsupported_module(module_name):
     unsuported_modules = ["blah"]
     return module_name in unsuported_modules
+
+
+# Names from the ``threading`` module that ESBMC currently models. Anything
+# else (Thread, RLock, Semaphore, Condition, Event, Barrier, Timer, ...) is
+# rejected at parse time by ``reject_unsupported_threading_usage`` so we
+# never emit a half-modelled concurrency construct that could yield a
+# silently wrong verification verdict.
+SUPPORTED_THREADING_SYMBOLS = frozenset({"Lock"})
+
+
+def reject_unsupported_threading_usage(tree: ast.AST, source_filename: str) -> None:
+    """Refuse to compile programs using unsupported ``threading`` names.
+
+    Walks the AST for usages of names from the ``threading`` module that
+    ESBMC does not yet model and exits with a clear error rather than
+    silently emitting a weaker abstraction. The supported set is
+    ``SUPPORTED_THREADING_SYMBOLS``. Detects three import shapes:
+
+      ``import threading``         → ``threading.<X>`` attribute access
+      ``import threading as t``    → ``t.<X>`` attribute access
+      ``from threading import X``  → bare ``X`` reference
+
+    ``from threading import *`` is refused outright because static name
+    resolution would require importing the real ``threading`` module.
+    """
+    def fail(line, message: str) -> None:
+        print(f"ERROR: {source_filename}:{line}: {message}")
+        sys.exit(4)
+
+    unsupported_message = (
+        "is not yet supported by ESBMC. Only threading.Lock is "
+        "currently modelled; Thread/RLock/Semaphore/Condition/Event/"
+        "Barrier/Timer are tracked as follow-ups to the initial "
+        "threading support."
+    )
+
+    module_aliases: set[str] = set()
+    name_aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "threading":
+                    module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "threading":
+            for alias in node.names:
+                if alias.name == "*":
+                    fail(
+                        node.lineno,
+                        "'from threading import *' is not supported; "
+                        "import names explicitly so ESBMC can verify "
+                        "each one is modelled.",
+                    )
+                name_aliases[alias.asname or alias.name] = alias.name
+
+    for node in ast.walk(tree):
+        offending: str | None = None
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in module_aliases
+            and node.attr not in SUPPORTED_THREADING_SYMBOLS
+        ):
+            offending = node.attr
+        elif isinstance(node, ast.Name) and node.id in name_aliases:
+            original = name_aliases[node.id]
+            if original not in SUPPORTED_THREADING_SYMBOLS:
+                offending = original
+
+        if offending is not None:
+            fail(
+                getattr(node, "lineno", "?"),
+                f"threading.{offending} {unsupported_message}",
+            )
 
 
 def is_testing_framework(module_name):
@@ -789,6 +863,8 @@ def main():
             annotate_constant_node(node)
         elif isinstance(node, ast.Attribute):
             detect_and_process_submodules(node, processed_submodules, output_dir)
+
+    reject_unsupported_threading_usage(tree, filename)
 
     # Generate JSON from AST for the main file.
     generate_ast_json(tree, filename, None, output_dir)


### PR DESCRIPTION
Maps `threading.Lock` to `__ESBMC_atomic_begin / __ESBMC_assume / __ESBMC_atomic_end`, mirroring `pthread_mutex_lock_noassert` in the C operational model. Other `threading` names (`Thread`, `RLock`, `Semaphore`, `Condition`, `Event`, `Barrier`, `Timer`, `from threading import *`) are refused at parse time so ESBMC never silently weakens a concurrency model to a shape that could produce a wrong verdict.

Closes the `Object "threading" not found.` error from the issue. The Lock model is exercised sequentially by six new regression tests; `Thread` support — and end-to-end interleaving exercise of the Lock model — is a deliberate follow-up.
