### PR TITLE
[python] resolve compound tuple-key elts and star-imported callees

### DIFF
--- a/regression/python/github_4564_compound_key/kernel.py
+++ b/regression/python/github_4564_compound_key/kernel.py
@@ -1,0 +1,5 @@
+from stubs import *
+
+
+def f(t3: Tile3D, src: Tile, bm: int, k: int) -> None:
+    copy(t3[bm * k, :, :], src)

--- a/regression/python/github_4564_compound_key/main.py
+++ b/regression/python/github_4564_compound_key/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from kernel import f
+
+t3: Tile3D = Tile3D(5, 50, 100)
+src: Tile = Tile(50, 100)
+f(t3, src, 2, 3)

--- a/regression/python/github_4564_compound_key/stubs.py
+++ b/regression/python/github_4564_compound_key/stubs.py
@@ -1,0 +1,21 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+class Tile3D:
+    def __init__(self, d0: int, d1: int, d2: int):
+        self.d0: int = d0
+        self.d1: int = d1
+        self.d2: int = d2
+
+    def __getitem__(self, key) -> "Tile":
+        k: int = key[0]
+        sl1: slice = key[1]
+        sl2: slice = key[2]
+        return Tile(self.d1, self.d2)
+
+
+def copy(dst: Tile, src: Tile) -> None:
+    assert dst.d0 == src.d0

--- a/regression/python/github_4564_compound_key/test.desc
+++ b/regression/python/github_4564_compound_key/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4564_compound_key_fail/kernel.py
+++ b/regression/python/github_4564_compound_key_fail/kernel.py
@@ -1,0 +1,5 @@
+from stubs import *
+
+
+def f(t3: Tile3D, src: Tile, bm: int, k: int) -> None:
+    copy(t3[bm * k, :, :], src)

--- a/regression/python/github_4564_compound_key_fail/main.py
+++ b/regression/python/github_4564_compound_key_fail/main.py
@@ -1,0 +1,6 @@
+from stubs import *
+from kernel import f
+
+t3: Tile3D = Tile3D(5, 50, 100)
+src: Tile = Tile(50, 100)
+f(t3, src, 2, 3)

--- a/regression/python/github_4564_compound_key_fail/stubs.py
+++ b/regression/python/github_4564_compound_key_fail/stubs.py
@@ -1,0 +1,21 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+class Tile3D:
+    def __init__(self, d0: int, d1: int, d2: int):
+        self.d0: int = d0
+        self.d1: int = d1
+        self.d2: int = d2
+
+    def __getitem__(self, key) -> "Tile":
+        k: int = key[0]
+        sl1: slice = key[1]
+        sl2: slice = key[2]
+        return Tile(self.d1, self.d2)
+
+
+def copy(dst: Tile, src: Tile) -> None:
+    assert dst.d0 != src.d0

--- a/regression/python/github_4564_compound_key_fail/test.desc
+++ b/regression/python/github_4564_compound_key_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_4564_setitem_call/main.py
+++ b/regression/python/github_4564_setitem_call/main.py
@@ -1,0 +1,5 @@
+from stubs import *
+
+t: Container = Container()
+t[0, :, :] = make_tile(3, 4)
+assert t.value.d0 == 3

--- a/regression/python/github_4564_setitem_call/stubs.py
+++ b/regression/python/github_4564_setitem_call/stubs.py
@@ -1,0 +1,16 @@
+class Tile:
+    def __init__(self, d0: int, d1: int):
+        self.d0: int = d0
+        self.d1: int = d1
+
+
+class Container:
+    def __init__(self) -> None:
+        self.value: Tile = Tile(0, 0)
+
+    def __setitem__(self, key, val: Tile) -> None:
+        self.value = val
+
+
+def make_tile(d0: int, d1: int) -> Tile:
+    return Tile(d0, d1)

--- a/regression/python/github_4564_setitem_call/test.desc
+++ b/regression/python/github_4564_setitem_call/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -934,8 +934,9 @@ private:
       return "";
     for (const auto &node : ast_["body"])
     {
-      if (!node.contains("_type") || node["_type"] != "ImportFrom" ||
-          !node.contains("names") || !node.contains("module"))
+      if (
+        !node.contains("_type") || node["_type"] != "ImportFrom" ||
+        !node.contains("names") || !node.contains("module"))
         continue;
       bool is_star = false;
       for (const auto &name : node["names"])
@@ -969,9 +970,8 @@ private:
   /// @c int). Returns "" when any operand is not resolvable in the foreign
   /// scope, signalling the caller to fall through to @c ast_-based
   /// inference. Introduced for GitHub #4564.
-  std::string resolve_expr_in_enclosing_func(
-    const Json &elt,
-    const Json &enclosing_func)
+  std::string
+  resolve_expr_in_enclosing_func(const Json &elt, const Json &enclosing_func)
   {
     if (!elt.contains("_type"))
       return "";
@@ -984,7 +984,8 @@ private:
       return resolve_expr_in_enclosing_func(elt["operand"], enclosing_func);
     if (t == "BinOp" && elt.contains("left") && elt.contains("right"))
     {
-      std::string l = resolve_expr_in_enclosing_func(elt["left"], enclosing_func);
+      std::string l =
+        resolve_expr_in_enclosing_func(elt["left"], enclosing_func);
       std::string r =
         resolve_expr_in_enclosing_func(elt["right"], enclosing_func);
       if (l.empty() || r.empty())

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -920,15 +920,95 @@ private:
     return "";
   }
 
+  /// @brief Resolve @p func_name through any `from X import *` in @c ast_.
+  ///
+  /// Iterates wildcard ImportFrom nodes at module scope and probes each
+  /// module's exported functions via @c module_manager_. Returns the
+  /// function's declared return type if found; "" otherwise. A NoneType /
+  /// missing return type falls back to @p func_name so callers treat it as
+  /// a class-constructor-style call, matching the named-import branch's
+  /// heuristic. Introduced for GitHub #4564.
+  std::string resolve_wildcard_import_func(const std::string &func_name)
+  {
+    if (!module_manager_ || !ast_.contains("body"))
+      return "";
+    for (const auto &node : ast_["body"])
+    {
+      if (!node.contains("_type") || node["_type"] != "ImportFrom" ||
+          !node.contains("names") || !node.contains("module"))
+        continue;
+      bool is_star = false;
+      for (const auto &name : node["names"])
+        if (name.contains("name") && name["name"] == "*")
+        {
+          is_star = true;
+          break;
+        }
+      if (!is_star)
+        continue;
+      auto module = module_manager_->get_module(node["module"]);
+      if (!module)
+        continue;
+      auto func_info = module->get_function(func_name);
+      if (func_info.name_.empty())
+        continue;
+      if (
+        func_info.return_type_.empty() || func_info.return_type_ == "NoneType")
+        return func_name;
+      return func_info.return_type_;
+    }
+    return "";
+  }
+
+  /// @brief Resolve a tuple-key elt against @p enclosing_func's scope.
+  ///
+  /// Generalises @ref resolve_name_in_enclosing_func to expressions whose
+  /// operands are names declared outside this annotator's @c ast_ —
+  /// constants, unary ops, and binary arithmetic. Numeric promotion follows
+  /// Python semantics (any @c float operand → @c float; @c int + @c int →
+  /// @c int). Returns "" when any operand is not resolvable in the foreign
+  /// scope, signalling the caller to fall through to @c ast_-based
+  /// inference. Introduced for GitHub #4564.
+  std::string resolve_expr_in_enclosing_func(
+    const Json &elt,
+    const Json &enclosing_func)
+  {
+    if (!elt.contains("_type"))
+      return "";
+    const std::string &t = elt["_type"];
+    if (t == "Constant")
+      return get_type_from_constant(elt);
+    if (t == "Name" && elt.contains("id"))
+      return resolve_name_in_enclosing_func(elt["id"], enclosing_func);
+    if (t == "UnaryOp" && elt.contains("operand"))
+      return resolve_expr_in_enclosing_func(elt["operand"], enclosing_func);
+    if (t == "BinOp" && elt.contains("left") && elt.contains("right"))
+    {
+      std::string l = resolve_expr_in_enclosing_func(elt["left"], enclosing_func);
+      std::string r =
+        resolve_expr_in_enclosing_func(elt["right"], enclosing_func);
+      if (l.empty() || r.empty())
+        return "";
+      if (l == "float" || r == "float")
+        return "float";
+      if (l == "int" && r == "int")
+        return "int";
+      return "";
+    }
+    return "";
+  }
+
   // Resolve each element of @p elts to a Python type name suitable for a
   // synthesised `tuple[...]` annotation. Slice literals and `slice(...)`
   // calls map to "slice"; scalars and other expressions are routed through
-  // get_argument_type(). `Name` elts are first looked up in @p
-  // enclosing_func (when non-null) so foreign-AST scans can resolve
-  // variables defined outside this annotator's `ast_` (GitHub #4558).
-  // Returns an empty vector when any element resolves to "" or "Any" —
-  // bailing keeps the synthesised callee struct consistent with whatever
-  // the caller actually builds at the subscript site.
+  // get_argument_type(). Non-slice elts are first looked up in @p
+  // enclosing_func (when non-null) via @ref resolve_expr_in_enclosing_func
+  // so foreign-AST scans can resolve variables defined outside this
+  // annotator's `ast_` — including compound arithmetic expressions like
+  // `bm * k` whose operand names are foreign-scope parameters
+  // (GitHub #4558, #4564). Returns an empty vector when any element resolves
+  // to "" or "Any" — bailing keeps the synthesised callee struct consistent
+  // with whatever the caller actually builds at the subscript site.
   std::vector<std::string> infer_tuple_element_types(
     const Json &elts,
     const Json *enclosing_func = nullptr)
@@ -954,8 +1034,8 @@ private:
         continue;
       }
       std::string resolved;
-      if (t == "Name" && enclosing_func != nullptr && elt.contains("id"))
-        resolved = resolve_name_in_enclosing_func(elt["id"], *enclosing_func);
+      if (enclosing_func != nullptr)
+        resolved = resolve_expr_in_enclosing_func(elt, *enclosing_func);
       if (resolved.empty())
         resolved = get_argument_type(elt);
       if (resolved.empty() || resolved == "Any")
@@ -2330,6 +2410,16 @@ private:
     }
     catch (std::runtime_error &)
     {
+    }
+
+    // Probe wildcard imports (`from X import *`) for @p func_name when the
+    // named-import lookup above missed. find_imported_function only matches
+    // explicit aliases, so star-imported functions stay invisible to the
+    // annotator's type inference without this fallback (GitHub #4564).
+    if (std::string t = resolve_wildcard_import_func(func_name); !t.empty())
+    {
+      functions_in_analysis_.erase(func_name);
+      return t;
     }
 
     // Check if the function is a built-in function


### PR DESCRIPTION
Two related #4564 inference gaps in `__getitem__` annotation. (1) `infer_tuple_element_types` only resolved a tuple elt against the enclosing scope when it was a bare `Name`; expressions like `bm * k` (both names foreign-scope parameters) fell back to `get_argument_type` on the annotator's own AST, which has no binding for the operands, and the synthesised tuple type dropped to `Any`. Introduce `resolve_expr_in_enclosing_func` to recurse through Constant / Name / UnaryOp / BinOp against the foreign scope, with int+int -> int and float-on-either-side -> float promotion. (2) When the user-defined `__setitem__` callee was reachable only via `from X import *`, `find_imported_function` returned nothing (it matches explicit aliases) and the call's return type fell through to "Any". Add `resolve_wildcard_import_func` as a fallback that walks wildcard ImportFrom nodes and probes each module via `module_manager_`, mirroring the named-import branch's NoneType -> classname heuristic.

Three CORE regression tests cover the gaps: `github_4564_compound_key` and its `_fail` twin for the tuple-key compound elt path, and `github_4564_setitem_call` for the star-imported `__setitem__` path.

Fixes #4564