### PR TITLE
[python] infer top-level function param types from call sites

### DIFF
--- a/regression/python/github_4570/main.py
+++ b/regression/python/github_4570/main.py
@@ -1,0 +1,15 @@
+import threading
+
+
+class SharedResource:
+    def __init__(self):
+        self.mutex = threading.Lock()
+
+
+def use_lock(resource):
+    resource.mutex.acquire()
+    resource.mutex.release()
+
+
+resource = SharedResource()
+use_lock(resource)

--- a/regression/python/github_4570/test.desc
+++ b/regression/python/github_4570/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4570_fail/main.py
+++ b/regression/python/github_4570_fail/main.py
@@ -1,0 +1,18 @@
+import threading
+
+
+class SharedResource:
+    def __init__(self):
+        self.mutex = threading.Lock()
+        self.flag: int = 0
+
+
+def set_flag(resource):
+    resource.mutex.acquire()
+    resource.flag = 1
+    resource.mutex.release()
+
+
+resource = SharedResource()
+set_flag(resource)
+assert resource.flag == 2

--- a/regression/python/github_4570_fail/test.desc
+++ b/regression/python/github_4570_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call_builder.cpp
+++ b/src/python-frontend/function_call_builder.cpp
@@ -502,7 +502,21 @@ symbol_id function_call_builder::build_function_id() const
       symbolt *var_symbol = converter_.find_symbol(var_sid.to_string());
 
       if (!var_symbol)
-        throw std::runtime_error("Variable " + obj_name + " not found");
+      {
+        // Reaching here means the attribute-chain resolver above could not
+        // determine a struct type for the receiver (most commonly because a
+        // function parameter is unannotated and python_annotation could not
+        // infer it from any call site), and `obj_name` ended up as the
+        // trailing attribute name rather than a real variable. Surface a
+        // diagnostic that names the unresolved member call and points at
+        // the likely missing annotation, instead of the cryptic
+        // "Variable <attr> not found" the call previously emitted.
+        throw std::runtime_error(
+          "Could not resolve type of receiver in member call '." + obj_name +
+          "." + func_name +
+          "()'. Add a type annotation to the function parameter or local "
+          "variable so the attribute chain can be typed.");
+      }
 
       // Extract class name from the type, following symbol references
       typet var_type = var_symbol->type.is_pointer()

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -7,9 +7,12 @@
 #include <python-frontend/type_utils.h>
 #include <util/message.h>
 
+#include <map>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 enum class InferResult
 {
@@ -266,12 +269,161 @@ public:
     }
   }
 
+  /// Infer unannotated parameter types of top-level functions from the
+  /// argument types at every plain `f(arg1, arg2)` call site (i.e.
+  /// `Call.func._type == "Name"`). Method calls on instances and class
+  /// constructors are out of scope — they are handled by
+  /// `preprocess_method_calls` and `preprocess_constructor_calls`.
+  ///
+  /// Conflict policy: a parameter is annotated only when every call site
+  /// that yields a non-empty inferred type agrees on the same type. Calls
+  /// passing different concrete classes (e.g. polymorphic dispatch over a
+  /// shared base) leave the parameter unannotated, preserving the
+  /// pre-existing behaviour where the symex layer handles the dispatch.
+  /// Explicit annotations are always preserved.
+  ///
+  /// Scope tracking: when descending into a `FunctionDef`, the current
+  /// function name context is updated so `get_argument_type` can resolve
+  /// `Name` arguments by looking them up in the enclosing function's
+  /// scope (parameters, local assignments). Without this, calls nested
+  /// inside `def main(): ... f(local_var)` would fail to type-infer
+  /// `local_var`, since `find_var_decl` searches by function name.
+  void preprocess_function_calls(Json &root)
+  {
+    // First pass: gather inferred argument types for every top-level
+    // function call. Recurse into FunctionDef bodies so scope-dependent
+    // type inference resolves correctly. Self-recursive calls are
+    // skipped so the function's own internal use of its parameter does
+    // not poison the inference.
+    std::set<std::string> top_level_funcs;
+    for (const Json &top_node : ast_["body"])
+    {
+      if (
+        top_node["_type"] == "FunctionDef" && top_node.contains("name") &&
+        top_node["name"].is_string())
+        top_level_funcs.insert(
+          top_node["name"].template get<std::string>());
+    }
+
+    std::map<std::pair<std::string, size_t>, std::set<std::string>>
+      param_types;
+    collect_function_call_arg_types(root, param_types, top_level_funcs);
+
+    // Second pass: for each top-level FunctionDef, if all observed call
+    // sites agreed on a single type for a parameter, write the annotation.
+    for (Json &top_node : ast_["body"])
+    {
+      if (
+        top_node["_type"] != "FunctionDef" || !top_node.contains("args") ||
+        !top_node["args"].contains("args"))
+        continue;
+
+      const std::string fname = top_node["name"].template get<std::string>();
+      Json &params = top_node["args"]["args"];
+      for (size_t i = 0; i < params.size(); ++i)
+      {
+        Json &param = params[i];
+        if (param.contains("annotation") && !param["annotation"].is_null())
+          continue;
+        auto it = param_types.find({fname, i});
+        if (it == param_types.end() || it->second.size() != 1)
+          continue;
+        add_parameter_annotation(param, *it->second.begin());
+      }
+    }
+  }
+
+  void collect_function_call_arg_types(
+    Json &node,
+    std::map<std::pair<std::string, size_t>, std::set<std::string>>
+      &param_types,
+    const std::set<std::string> &top_level_funcs)
+  {
+    if (node.is_object())
+    {
+      if (
+        node.contains("_type") && node["_type"] == "Call" &&
+        node.contains("func") && node["func"].is_object() &&
+        node["func"].contains("_type") && node["func"]["_type"] == "Name" &&
+        node["func"].contains("id") && node["func"]["id"].is_string())
+      {
+        const std::string func_name =
+          node["func"]["id"].template get<std::string>();
+        // Only record calls targeting a top-level FunctionDef (the only
+        // shape this pass annotates). Filtering up front also keeps
+        // nested-def shadows from polluting the per-name type set. Skip
+        // self-recursive calls so the function's own internal use of its
+        // parameter does not poison inference.
+        if (
+          top_level_funcs.count(func_name) != 0 &&
+          func_name != current_func_name_context_)
+        {
+          const Json &call_args =
+            node.contains("args") ? node["args"] : Json::array();
+          for (size_t i = 0; i < call_args.size(); ++i)
+          {
+            std::string arg_type = get_argument_type(call_args[i]);
+            // Skip ambiguous / under-specified types: NoneType is `bool*`
+            // in the operational model (issue #3796) and Any leaves the
+            // type uninformative; both would lock in a misleading
+            // annotation for callers that pass a real value.
+            if (arg_type.empty() || arg_type == "NoneType" ||
+                arg_type == "Any")
+              continue;
+            param_types[{func_name, i}].insert(arg_type);
+          }
+        }
+      }
+
+      const bool is_function_def = node.contains("_type") &&
+                                   node["_type"] == "FunctionDef" &&
+                                   node.contains("name") &&
+                                   node["name"].is_string();
+      std::string saved_ctx = current_func_name_context_;
+      Json *saved_current = current_func;
+      Json *saved_parent = parent_func;
+      if (is_function_def)
+      {
+        // Set up parent/current scope so get_argument_type's nested-scope
+        // fallback (parent_func body lookup) can resolve closure variables
+        // captured by trampolines (e.g. threading.Thread-desugared bodies).
+        current_func_name_context_ = node["name"].template get<std::string>();
+        parent_func = saved_current;
+        current_func = &node;
+      }
+
+      for (auto &kv : node.items())
+        collect_function_call_arg_types(
+          kv.value(), param_types, top_level_funcs);
+
+      if (is_function_def)
+      {
+        current_func_name_context_ = saved_ctx;
+        current_func = saved_current;
+        parent_func = saved_parent;
+      }
+    }
+    else if (node.is_array())
+    {
+      for (auto &element : node)
+        collect_function_call_arg_types(
+          element, param_types, top_level_funcs);
+    }
+  }
+
   void add_type_annotation()
   {
     // First pass: preprocess all constructor calls to infer parameter types
     preprocess_constructor_calls(ast_);
     // Also preprocess method calls on temporary instances: A().method(args)
     preprocess_method_calls(ast_);
+    // Preprocess top-level function calls f(arg) so unannotated parameters of
+    // top-level functions inherit a type from their callers. Runs after the
+    // constructor pass so `f(SharedResource())` resolves through the
+    // inferred return type. Without this, attribute-chain lookups on
+    // unannotated parameters (e.g. `resource.mutex.acquire()`) fail with a
+    // cryptic "Variable mutex not found" — GitHub #4570.
+    preprocess_function_calls(ast_);
 
     // Second pass: add type annotations to global scope variables
     annotate_global_scope();

--- a/src/python-frontend/python_annotation.h
+++ b/src/python-frontend/python_annotation.h
@@ -301,12 +301,10 @@ public:
       if (
         top_node["_type"] == "FunctionDef" && top_node.contains("name") &&
         top_node["name"].is_string())
-        top_level_funcs.insert(
-          top_node["name"].template get<std::string>());
+        top_level_funcs.insert(top_node["name"].template get<std::string>());
     }
 
-    std::map<std::pair<std::string, size_t>, std::set<std::string>>
-      param_types;
+    std::map<std::pair<std::string, size_t>, std::set<std::string>> param_types;
     collect_function_call_arg_types(root, param_types, top_level_funcs);
 
     // Second pass: for each top-level FunctionDef, if all observed call
@@ -367,18 +365,16 @@ public:
             // in the operational model (issue #3796) and Any leaves the
             // type uninformative; both would lock in a misleading
             // annotation for callers that pass a real value.
-            if (arg_type.empty() || arg_type == "NoneType" ||
-                arg_type == "Any")
+            if (arg_type.empty() || arg_type == "NoneType" || arg_type == "Any")
               continue;
             param_types[{func_name, i}].insert(arg_type);
           }
         }
       }
 
-      const bool is_function_def = node.contains("_type") &&
-                                   node["_type"] == "FunctionDef" &&
-                                   node.contains("name") &&
-                                   node["name"].is_string();
+      const bool is_function_def =
+        node.contains("_type") && node["_type"] == "FunctionDef" &&
+        node.contains("name") && node["name"].is_string();
       std::string saved_ctx = current_func_name_context_;
       Json *saved_current = current_func;
       Json *saved_parent = parent_func;
@@ -406,8 +402,7 @@ public:
     else if (node.is_array())
     {
       for (auto &element : node)
-        collect_function_call_arg_types(
-          element, param_types, top_level_funcs);
+        collect_function_call_arg_types(element, param_types, top_level_funcs);
     }
   }
 


### PR DESCRIPTION
Walking `param.attr.method()` inside `def f(param):` previously crashed
the frontend with `[ERROR] Variable mutex not found` when `param` was an
unannotated function parameter — the attribute-chain resolver fell
through to treating the intermediate attribute as a local variable. Add
a `preprocess_function_calls` pass that mirrors the existing constructor
and method preprocessors for plain `f(arg)` calls, with a conflict-aware
policy that preserves polymorphic dispatch. Replaces the cryptic throw
at `function_call_builder.cpp:505` with an actionable diagnostic for
cases inference cannot resolve.