### PR TITLE
[style] prefer prefix ++ on non-primitive iterators

### DIFF
--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -134,7 +134,7 @@ execution_statet::execution_statet(const execution_statet &ex)
   // Regenerate threads state using new objects state_level2 ref
   threads_state.clear();
   std::vector<goto_symex_statet>::const_iterator it;
-  for (it = ex.threads_state.begin(); it != ex.threads_state.end(); it++)
+  for (it = ex.threads_state.begin(); it != ex.threads_state.end(); ++it)
   {
     goto_symex_statet state(*it, *state_level2, global_value_set);
     threads_state.push_back(state);
@@ -194,14 +194,14 @@ execution_statet &execution_statet::operator=(const execution_statet &ex)
   {
     for (goto_symex_statet::call_stackt::iterator it2 = it.call_stack.begin();
          it2 != it.call_stack.end();
-         it2++)
+         ++it2)
     {
       for (auto &it3 : it2->goto_state_map)
       {
         for (goto_symex_statet::goto_state_listt::iterator it4 =
                it3.second.begin();
              it4 != it3.second.begin();
-             it4++)
+             ++it4)
         {
           ex_state_level2t &l2 = dynamic_cast<ex_state_level2t &>(it4->level2);
           l2.owner = this;
@@ -1000,21 +1000,21 @@ bool execution_statet::check_mpor_dependency(unsigned int j, unsigned int l)
   // Double write intersection
   for (std::set<expr2tc>::const_iterator it = thread_last_writes[j].begin();
        it != thread_last_writes[j].end();
-       it++)
+       ++it)
     if (thread_last_writes[l].find(*it) != thread_last_writes[l].end())
       return true;
 
   // This read what that wrote intersection
   for (std::set<expr2tc>::const_iterator it = thread_last_reads[j].begin();
        it != thread_last_reads[j].end();
-       it++)
+       ++it)
     if (thread_last_writes[l].find(*it) != thread_last_writes[l].end())
       return true;
 
   // We wrote what that reads intersection
   for (std::set<expr2tc>::const_iterator it = thread_last_writes[j].begin();
        it != thread_last_writes[j].end();
-       it++)
+       ++it)
     if (thread_last_reads[l].find(*it) != thread_last_reads[l].end())
       return true;
 
@@ -1194,7 +1194,7 @@ void execution_statet::print_stack_traces(unsigned int indent) const
     spaces += " ";
 
   i = 0;
-  for (it = threads_state.begin(); it != threads_state.end(); it++)
+  for (it = threads_state.begin(); it != threads_state.end(); ++it)
   {
     std::ostringstream oss;
     oss << spaces << "Thread " << i++ << ":"

--- a/src/irep2/templates/irep2_template_utils.cpp
+++ b/src/irep2/templates/irep2_template_utils.cpp
@@ -222,7 +222,7 @@ int do_type_lt(
     tmp = it->ltchecked(**it2);
     if (tmp != 0)
       return tmp;
-    it2++;
+    ++it2;
   }
   return 0;
 }
@@ -243,7 +243,7 @@ int do_type_lt(
     tmp = it->ltchecked(**it2);
     if (tmp != 0)
       return tmp;
-    it2++;
+    ++it2;
   }
   return 0;
 }


### PR DESCRIPTION
Convert postfix `it++` to prefix `++it` on STL iterators in symex and irep2 template helpers, addressing the Codacy MEDIUM "prefer prefix ++/-- for non-primitive types" warnings. The increment result is discarded at every site, so the change is purely a micro-optimisation with no behavioural impact. Two sibling sites not flagged by Codacy (execution_state.cpp:1010/1017 and irep2_template_utils.cpp:246) are included for consistency with the surrounding code.