### PR TITLE
[python] fall back to enclosing function for closure type inference

### DIFF
--- a/regression/python/github_4572/main.py
+++ b/regression/python/github_4572/main.py
@@ -1,0 +1,20 @@
+class Tile3D:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+
+    def __setitem__(self, key: int, value: "Tile3D") -> None:
+        assert 0 <= key
+        assert key < self.d0
+
+
+def outer(slot: int) -> None:
+    buf: Tile3D = Tile3D(2)
+    src: Tile3D = Tile3D(1)
+
+    def closure(s: int) -> None:
+        buf[s] = src
+
+    closure(slot)
+
+
+outer(0)

--- a/regression/python/github_4572/test.desc
+++ b/regression/python/github_4572/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4572_cross_module/main.py
+++ b/regression/python/github_4572_cross_module/main.py
@@ -1,0 +1,14 @@
+from stubs import Tile3D
+
+
+def outer(slot: int) -> None:
+    buf: Tile3D = Tile3D(2)
+    src: Tile3D = Tile3D(1)
+
+    def closure(s: int) -> None:
+        buf[s] = src
+
+    closure(slot)
+
+
+outer(0)

--- a/regression/python/github_4572_cross_module/stubs.py
+++ b/regression/python/github_4572_cross_module/stubs.py
@@ -1,0 +1,7 @@
+class Tile3D:
+    def __init__(self, d0: int):
+        self.d0: int = d0
+
+    def __setitem__(self, key: int, value: "Tile3D") -> None:
+        assert 0 <= key
+        assert key < self.d0

--- a/regression/python/github_4572_cross_module/test.desc
+++ b/regression/python/github_4572_cross_module/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4572_fail/main.py
+++ b/regression/python/github_4572_fail/main.py
@@ -1,0 +1,13 @@
+def outer(x: int) -> None:
+    cap: int = 5
+
+    def closure() -> None:
+        # y has no explicit annotation -> annotator must infer the type
+        # of `cap` via the closure RHS lookup (the patched path).
+        y = cap
+        assert y == 99
+
+    closure()
+
+
+outer(0)

--- a/regression/python/github_4572_fail/test.desc
+++ b/regression/python/github_4572_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$

--- a/regression/python/github_4572_param_capture/main.py
+++ b/regression/python/github_4572_param_capture/main.py
@@ -1,0 +1,12 @@
+def outer(cap: int) -> None:
+    # Closure captures `cap`, which is a *parameter* of `outer`.
+    # `y = cap` has no explicit annotation, so the annotator must infer
+    # the type by looking up `cap` in the enclosing function's args list.
+    def closure() -> None:
+        y = cap
+        assert y == 0
+
+    closure()
+
+
+outer(0)

--- a/regression/python/github_4572_param_capture/test.desc
+++ b/regression/python/github_4572_param_capture/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -53,6 +53,11 @@ std::string python_annotation<Json>::get_type_from_lhs(
   if (node.empty() && current_func != nullptr)
     node = find_annotated_assign(id, (*current_func)["body"]);
 
+  // Closure capture: fall back to the enclosing function before the
+  // global scope. See find_var_node_for_inference for an analogous pattern.
+  if (node.empty() && parent_func != nullptr)
+    node = find_annotated_assign(id, (*parent_func)["body"]);
+
   // Fall back to variables in the global scope
   if (node.empty())
     node = find_annotated_assign(id, ast_["body"]);
@@ -1341,6 +1346,26 @@ std::string python_annotation<Json>::get_type_from_rhs_variable(
     if (rhs_node.empty() && body["args"].contains("kwonlyargs"))
       rhs_node =
         find_annotated_assign(rhs_var_name, body["args"]["kwonlyargs"]);
+  }
+
+  // Closure capture: fall back to the enclosing function before the
+  // global scope. Matches the args-then-body order used in
+  // find_var_node_for_inference.
+  if (rhs_node.empty() && parent_func != nullptr)
+  {
+    if (
+      (*parent_func).contains("args") &&
+      (*parent_func)["args"].contains("args"))
+    {
+      rhs_node =
+        find_annotated_assign(rhs_var_name, (*parent_func)["args"]["args"]);
+      if (rhs_node.empty() && (*parent_func)["args"].contains("kwonlyargs"))
+        rhs_node = find_annotated_assign(
+          rhs_var_name, (*parent_func)["args"]["kwonlyargs"]);
+    }
+
+    if (rhs_node.empty())
+      rhs_node = find_annotated_assign(rhs_var_name, (*parent_func)["body"]);
   }
 
   // Find RHS variable node in the global scope


### PR DESCRIPTION
A nested function that referenced a variable defined in the enclosing function failed type inference with "Variable X not found", particularly when the captured value was an instance of a class imported from another module (the exact pattern from #4572). The annotator's LHS and RHS variable lookups skipped from the closure's own scope straight to module globals, violating Python's LEGB resolution order.

Add the missing E step in get_type_from_lhs and get_type_from_rhs_variable, mirroring the existing parent-scope fallback in find_var_node_for_inference. Cover the body-local capture, parameter capture, cross-module class capture, and an explicit negative case.

Fixes #4572