### PR TITLE
[python] add concurrent Thread/Lock acceptance tests for #4568

### DIFF
--- a/regression/python/threading_thread_shared_resource_safe/main.py
+++ b/regression/python/threading_thread_shared_resource_safe/main.py
@@ -1,0 +1,44 @@
+import threading
+
+# End-to-end exercise of threading.Lock + threading.Thread lowering: two
+# threads acquire (mutex, lock) in the SAME order before incrementing the
+# shared `counter`, and the final value is exactly 2.
+#
+# NOTE: ESBMC currently marks module-level Python globals with
+# static_lifetime=false, so rw_set/execution_state under-approximate
+# races on `counter`. The SUCCESSFUL verdict here validates the
+# threading.Thread + Lock lowering and the join-happens-before semantics
+# — it does NOT prove the locks enforce mutual exclusion in the model.
+# Follow-up issues track the static_lifetime gap and the parallel
+# Lock-vs--deadlock-check gap.
+mutex = threading.Lock()
+lock = threading.Lock()
+counter: int = 0
+
+
+def thread_a() -> None:
+    global counter
+    mutex.acquire()
+    lock.acquire()
+    counter = counter + 1
+    lock.release()
+    mutex.release()
+
+
+def thread_b() -> None:
+    global counter
+    mutex.acquire()
+    lock.acquire()
+    counter = counter + 1
+    lock.release()
+    mutex.release()
+
+
+t1 = threading.Thread(target=thread_a)
+t2 = threading.Thread(target=thread_b)
+t1.start()
+t2.start()
+t1.join()
+t2.join()
+
+assert counter == 2

--- a/regression/python/threading_thread_shared_resource_safe/test.desc
+++ b/regression/python/threading_thread_shared_resource_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/threading_thread_skip_join_fail/main.py
+++ b/regression/python/threading_thread_skip_join_fail/main.py
@@ -1,0 +1,18 @@
+import threading
+
+flag: int = 0
+
+
+def setter() -> None:
+    global flag
+    flag = 1
+
+
+t = threading.Thread(target=setter)
+t.start()
+# Read BEFORE join: an interleaving in which `setter` has not yet
+# executed must be feasible, so the assertion is violated. This is the
+# negative counterpart to threading_thread_join_orders_writes_safe and
+# confirms that ESBMC actually explores the spawn-vs-main interleaving.
+assert flag == 1
+t.join()

--- a/regression/python/threading_thread_skip_join_fail/test.desc
+++ b/regression/python/threading_thread_skip_join_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -26,6 +26,7 @@ ignored_dirs=(
   "cover4"
   "cover5"
   "concurrency_fail"
+  "threading_thread_skip_join_fail"
   "convert-byte-update2"
   "constants"
   "decimal"


### PR DESCRIPTION
Adds two concurrent Thread+Lock regression tests against #4577's end-to-end lowering, dischargeable subset of the #4568 acceptance criteria.

- `threading_thread_shared_resource_safe` — two threads, two ordered locks, shared counter; expects `VERIFICATION SUCCESSFUL`.
- `threading_thread_skip_join_fail` — assert before join; expects `VERIFICATION FAILED`, pinning that ESBMC explores the spawn-vs-main interleaving.

Two further #4568 acceptance criteria (deadlock under `--deadlock-check`, race under `--data-races-check`) are blocked on Lock-model and Python-global `static_lifetime` gaps in #4577. Filed as follow-ups rather than papered over with `KNOWNBUG`:

- #4581 — `threading.Lock` model invisible to `--deadlock-check`
- #4582 — Python module-level globals are `static_lifetime=false`, dropped by `rw_set` and symex interleaving
- #4583 — `Thread(args=(instance,))` value-copies the object

References #4568.
