### PR TITLE
[python] make module-level globals visible to --data-races-check

### DIFF
--- a/regression/python/threading_thread_race_fail/main.py
+++ b/regression/python/threading_thread_race_fail/main.py
@@ -1,0 +1,24 @@
+import threading
+
+# Two concurrent threads write to the same module-level global with no
+# synchronisation. Under --data-races-check ESBMC must report a W/W
+# data race on `shared`.
+shared: int = 0
+
+
+def writer_a() -> None:
+    global shared
+    shared = 1
+
+
+def writer_b() -> None:
+    global shared
+    shared = 2
+
+
+t1 = threading.Thread(target=writer_a)
+t2 = threading.Thread(target=writer_b)
+t1.start()
+t2.start()
+t1.join()
+t2.join()

--- a/regression/python/threading_thread_race_fail/test.desc
+++ b/regression/python/threading_thread_race_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc --data-races-check
+^VERIFICATION FAILED$
+^.*data race.*$

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -79,8 +79,16 @@ void rw_sett::read_write_rec(
     const symbolt *symbol = ns.lookup(symbol_expr.get_identifier());
     if (symbol)
     {
+      // Python module-level globals carry static_lifetime=false to keep
+      // them out of the C-side static-init pass (their values double as
+      // const-prop snapshots in the Python frontend). The Python frontend
+      // sets file_local=false on them so this filter recognises them
+      // as race-eligible shared state.
+      const bool python_global =
+        symbol->mode == "Python" && !symbol->file_local;
       if (
-        (!symbol->static_lifetime && !dereferenced) || symbol->is_thread_local)
+        (!symbol->static_lifetime && !dereferenced && !python_global) ||
+        symbol->is_thread_local)
       {
         return; // ignore for now
       }

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1285,7 +1285,12 @@ void python_converter::preregister_global_variables(
     symbolt symbol =
       create_symbol(module_name, var_name, sid.to_string(), location, var_type);
     symbol.lvalue = true;
-    symbol.file_local = true;
+    // Module-level Python globals are not file-local: they are visible
+    // across the entire program. rw_set.cpp uses (mode == "Python" &&
+    // !file_local) to recognise them as race-eligible shared state,
+    // since the Python frontend leaves static_lifetime=false to avoid
+    // the C-side static-init pass picking up its const-prop snapshot.
+    symbol.file_local = false;
     symbol.is_extern = false;
 
     symbol_table_.move_symbol_to_context(symbol);
@@ -1444,7 +1449,10 @@ void python_converter::get_var_assign(
         location_begin,
         current_element_type);
       symbol.lvalue = true;
-      symbol.file_local = true;
+      // Module-level Python globals are not file-local (see
+      // preregister_global_variables). Function-local annotated assigns
+      // stay file-local.
+      symbol.file_local = !current_func_name_.empty();
       symbol.is_extern = false;
 
       symbol_created = (lhs_symbol == nullptr);
@@ -1549,7 +1557,9 @@ void python_converter::get_var_assign(
           location_begin,
           current_element_type);
         symbol.lvalue = true;
-        symbol.file_local = true;
+        // Inferred-annotation Assign: module-scope symbols are not
+        // file-local (so rw_set recognises them); function-locals are.
+        symbol.file_local = !current_func_name_.empty();
         symbol.is_extern = false;
         lhs_symbol = symbol_table_.move_symbol_to_context(symbol);
       }

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -228,7 +228,11 @@ void python_exception_handler::get_except_handler_statement(
     symbol.name = name;
     symbol.lvalue = true;
     symbol.is_extern = false;
-    symbol.file_local = false;
+    // Exception-bind variables (`except E as v:`) are function-local in
+    // Python semantics; keeping file_local=true matches the convention
+    // used by other Python frontend temp symbols and prevents rw_set's
+    // race-eligible-Python-symbol filter from picking them up.
+    symbol.file_local = true;
     exception_symbol = converter_.symbol_table().move_symbol_to_context(symbol);
   }
 


### PR DESCRIPTION
Flips `file_local=false` on module-level Python globals in `converter_stmt.cpp`'s three creation sites and extends `rw_set.cpp` to recognise `(mode == "Python" && !file_local)` as race-eligible. `static_lifetime` stays `false`: the Python frontend repurposes `symbol.value` as a const-prop snapshot, and flipping it leaks function-local RHS expressions into `__ESBMC_main` via the C-side static-init pass (breaks tests like `github_3553_reverse`). Also tightens exception-bind variables to `file_local=true` so they don't accidentally pass the new rw_set bypass.

New `regression/python/threading_thread_race_fail/` exercises two concurrent threads writing to a shared module-level int; expects `VERIFICATION FAILED` with a `data race` witness under `--data-races-check`.

Fixes the `--data-races-check` half of #4582. Symex-side interleaving-point exploration on Python globals is a separate gap tracked as #4584.
