### PR TITLE
[docs] document Python threading support and concurrency limitations

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -123,6 +123,25 @@ weight: 4
 
 - Does not analyze return statements inside lambda expressions within the main function body.
 
+## Concurrency
+
+- **`Lock` model is invisible to `--deadlock-check`** ([#4581](https://github.com/esbmc/esbmc/issues/4581)). `threading.Lock.acquire` lowers to `__ESBMC_atomic_begin / __ESBMC_assume / __ESBMC_atomic_end`, mirroring `pthread_mutex_lock_noassert`. The deadlock checker only inspects the pthread mutex wait graph, so reverse-order lock acquisition between two Python threads is *not* reported as a deadlock — ESBMC explores all interleavings and reports `VERIFICATION SUCCESSFUL`.
+- **`Thread(args=(instance,))` value-copies object arguments** ([#4583](https://github.com/esbmc/esbmc/issues/4583)). When a `Thread` target receives a class instance with non-trivial attributes (e.g. a `threading.Lock`), the args-capture struct copies the descriptor by value and breaks attribute dereference inside the trampoline body. Workaround: share state via module-level globals instead of instance attributes passed through `args=`.
+- **Symex does not interleave at Python module-global accesses** ([#4584](https://github.com/esbmc/esbmc/issues/4584)). `--data-races-check` correctly flags W/W races on a module global, but symex's per-statement scheduler does not insert interleaving points at function-internal reads/writes of these globals. A classic split read-modify-write race (`tmp = counter; counter = tmp + 1` from two threads) reports `VERIFICATION SUCCESSFUL` instead of finding the schedule where both threads read `counter == 0` before either writes. The C equivalent of the same program is correctly reported as `VERIFICATION FAILED`.
+- **Thread shapes refused at parse time** with explicit errors:
+  - `Thread` subclassing with `run` override
+  - Lambda or runtime-variable `target=`
+  - Positional argument forms (`Thread(f, (a, b))`)
+  - `args=` bound to a variable instead of a tuple literal (`Thread(target=f, args=payload)`)
+  - `daemon=`, `name=`, `kwargs=`, `group=` keyword arguments
+  - `Thread` construction inside loops or comprehensions
+  - `Thread` reassignment within the same scope
+  - `Thread` as a class attribute (`class C: t = Thread(...)`)
+  - `target` defined after the caller in source order
+  - `from threading import *`
+- **Other `threading` primitives are not supported**: `RLock`, `Semaphore`, `Condition`, `Event`, `Barrier`, `Timer` are refused at parse time. `queue.Queue` is also unsupported and blocks the existing `regression/python/concurrency_fail` example.
+- **The CPython Global Interpreter Lock (GIL) is not modelled** ([#4579](https://github.com/esbmc/esbmc/issues/4579)). Translated programs execute under sequentially-consistent POSIX semantics rather than GIL-serialised bytecode execution, so the analysis over-approximates the set of feasible interleavings compared to actual CPython execution. This preserves safety but may produce spurious concurrency counterexamples.
+
 ## Module System
 
 - Built-in variable support is limited to `__name__`; `__file__`, `__doc__`, `__package__`, and other built-ins are not yet supported.

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -168,6 +168,54 @@ Byte sequences and integer class methods:
 
 Exception instances expose a message attribute and support `__str__()`.
 
+## Concurrency (`threading` module)
+
+ESBMC-Python lowers `threading` primitives onto ESBMC's existing pthread operational model in `src/c2goto/library/pthread_lib.c`, so symex's interleaving exploration, deadlock detection, and data-race detection apply.
+
+### `threading.Lock`
+
+`Lock.acquire()` and `Lock.release()` mirror `pthread_mutex_lock_noassert` via `__ESBMC_atomic_begin / __ESBMC_assume / __ESBMC_atomic_end`. Supported usage:
+
+- `lock = threading.Lock()` at module scope or as a class instance attribute
+- `lock.acquire()` / `lock.release()`
+- Multiple `Lock` instances co-existing on the same object (e.g. paired `mutex` and `lock` fields)
+- `from threading import Lock` aliasing
+
+### `threading.Thread`
+
+For each `Thread(target=f, args=(...))` construction site, the frontend synthesises a per-call-site trampoline `__pythread_trampoline_<N>` plus three helpers in `pthread_lib.c` (`__pyt_init_tid`, `__pyt_terminate`, `__pyt_join`) that mirror `pthread_create` / `pthread_join` bookkeeping. The resulting GOTO program is a direct call (not a function pointer), so symex preserves precision.
+
+Supported `Thread` shapes:
+
+- `target=f` — `f` must be a function statically resolvable at the construction site (a `Name` or attribute chain). Lambdas, runtime-callable values, and `Thread`-subclassing's `run` override are out of scope.
+- `args=(...)` — must be a tuple literal whose elements are expressions evaluable at the construction site. Passing simple values (ints, floats, bools, strings) works end-to-end.
+- `t.start()` and `t.join()` — lower to `pthread_create` and `pthread_join` semantics; `join` establishes happens-before.
+- Multiple construction sites per program, with independent trampolines.
+
+### Data-race detection
+
+Python module-level globals (declared with `x: T = …` or `x = …` at module scope) are flagged in the symbol table so they are visible to ESBMC's race-assertion pass. Two threads writing to the same global without synchronisation are detected under `--data-races-check`:
+
+```python
+import threading
+
+shared: int = 0
+
+def writer_a() -> None:
+    global shared
+    shared = 1
+
+def writer_b() -> None:
+    global shared
+    shared = 2
+
+t1 = threading.Thread(target=writer_a)
+t2 = threading.Thread(target=writer_b)
+t1.start(); t2.start(); t1.join(); t2.join()
+```
+
+`esbmc race.py --incremental-bmc --data-races-check` reports `W/W data race on py:race.py@shared` and `VERIFICATION FAILED`.
+
 ## Cover Properties and Reachability
 
 `__ESBMC_cover(cond)` checks whether a condition is satisfiable at a given program point (inverted assertion semantics: a counterexample means the condition *is* reachable).


### PR DESCRIPTION
Adds Python concurrency coverage to `website/content/docs/python/`:

- `supported-features.md` gains a "Concurrency (`threading` module)" section covering `Lock`, `Thread(target=f, args=(...))`, `start`/`join`, and `--data-races-check` on module-level globals (PRs #4565, #4577, #4580, #4585).
- `limitations.md` gains a "Concurrency" section listing the parse-time refusals and the four open gaps with issue links: Lock vs `--deadlock-check` (#4581), `Thread(args=instance)` value-copy (#4583), symex interleaving on Python globals (#4584), and GIL modelling (#4579).
