### PR TITLE
[symex] recognise Python module globals as shared at interleaving points

### DIFF
--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -929,8 +929,7 @@ void execution_statet::get_expr_globals(
     // Necessary but not sufficient on its own: the scheduler-side DFS /
     // MPOR limiters tracked in #4584 also need to be loosened before
     // assertion-based race tests like increment_race flip to FAILED.
-    const bool python_global =
-      symbol->mode == "Python" && !symbol->file_local;
+    const bool python_global = symbol->mode == "Python" && !symbol->file_local;
     if (
       symbol->static_lifetime || symbol->type.is_dynamic_set() ||
       point_to_global || python_global)

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -919,9 +919,21 @@ void execution_statet::get_expr_globals(
 
     // Rename to level1 to avoid shared varible mismatch in mpor.
     cur_state->top().level1.rename(p);
+    // Python module-level globals carry static_lifetime=false (their
+    // symbol.value field doubles as a const-prop snapshot in the Python
+    // frontend), but the frontend marks them with file_local=false to
+    // signal "shared module state". Recognise them here so symex inserts
+    // interleaving points at their reads/writes, matching the
+    // race-eligible bypass added to rw_set.cpp.
+    //
+    // Necessary but not sufficient on its own: the scheduler-side DFS /
+    // MPOR limiters tracked in #4584 also need to be loosened before
+    // assertion-based race tests like increment_race flip to FAILED.
+    const bool python_global =
+      symbol->mode == "Python" && !symbol->file_local;
     if (
       symbol->static_lifetime || symbol->type.is_dynamic_set() ||
-      point_to_global)
+      point_to_global || python_global)
     {
       std::list<unsigned int> threadId_list;
       auto it_find = art1->vars_map.find(p);


### PR DESCRIPTION
Extends `execution_statet::get_expr_globals` at `src/goto-symex/execution_state.cpp:922` to recognise Python module-level globals (`mode == "Python" && !file_local`) as shared state. Mirrors the `rw_set.cpp` bypass landed in #4585 — the two predicates now match verbatim so the analysis stays coherent across `goto-programs` and `goto-symex`.

**This is a partial fix for #4584.** With it:
- `get_expr_globals` correctly classifies Python globals as shared.
- `has_cswitch_point_occured` returns true at their reads/writes.
- Interleavings explored on the canonical `increment_race.py` reproducer grow from 7 (baseline) to 13.

The race verdict **still reports `VERIFICATION SUCCESSFUL`** because the scheduler-side DFS/MPOR limiters under-explore the bad schedule despite the cswitch points firing. The equivalent C program reports `VERIFICATION FAILED` after 2604 interleavings. #4584 stays open for the remaining scheduler work. The inline comment names #4584 as the tracking issue so the fix isn't read as dead code in future cleanup passes.

Triage: 26/26 threading tests pass; 830/833 on the focused `(global|lock|nondet|github_3xxx)` subset (2 boolector infrastructure pre-existing, 1 parallel-execution flake).

References #4584.
