### PR TITLE
[python] preserve object identity on Thread(args=instance,) capture

### DIFF
--- a/regression/python/threading_thread_args_instance_safe/main.py
+++ b/regression/python/threading_thread_args_instance_safe/main.py
@@ -1,0 +1,30 @@
+import threading
+
+
+class SharedResource:
+    def __init__(self) -> None:
+        self.mutex = threading.Lock()
+        self.value: int = 0
+
+
+def worker(resource: SharedResource) -> None:
+    resource.mutex.acquire()
+    resource.value = resource.value + 1
+    resource.mutex.release()
+
+
+# Canonical SharedResource pattern from the issue body of #4568 / #4583:
+# two threads share a class instance carrying both a Lock and an int.
+# Before #4583's fix, the args-struct field for the instance was
+# declared as int (degraded from the construction-site rebind) and the
+# trampoline's call to worker(arg) dereferenced an int as a pointer,
+# producing "Access to object out of bounds" inside Lock's __init__.
+resource = SharedResource()
+t1 = threading.Thread(target=worker, args=(resource,))
+t2 = threading.Thread(target=worker, args=(resource,))
+t1.start()
+t2.start()
+t1.join()
+t2.join()
+
+assert resource.value == 2

--- a/regression/python/threading_thread_args_instance_safe/test.desc
+++ b/regression/python/threading_thread_args_instance_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/threading_thread_args_mixed_safe/main.py
+++ b/regression/python/threading_thread_args_mixed_safe/main.py
@@ -1,0 +1,22 @@
+import threading
+
+
+class Counter:
+    def __init__(self) -> None:
+        self.value: int = 0
+
+
+# Mixed args tuple: (int literal, class instance). Each tuple element
+# drives its own typed prelude declaration independently — int args
+# stay int-typed (= 0), instance args take the object-typed fallback
+# (`: object = None`).
+def worker(n: int, c: Counter) -> None:
+    c.value = n
+
+
+counter = Counter()
+t = threading.Thread(target=worker, args=(7, counter))
+t.start()
+t.join()
+
+assert counter.value == 7

--- a/regression/python/threading_thread_args_mixed_safe/test.desc
+++ b/regression/python/threading_thread_args_mixed_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -759,27 +759,59 @@ def _build_trampoline(site_id: int, target_expr: ast.expr, n_args: int) -> ast.F
     return fn
 
 
-def _build_arg_declaration(site_id: int, arg_index: int) -> ast.Assign:
-    """Return ``__pythread_arg_<N>_<i> = 0`` as a module-top assignment.
+def _build_arg_declaration(
+    site_id: int,
+    arg_index: int,
+    arg_value: ast.expr,
+) -> ast.stmt:
+    """Return a module-top declaration for ``__pythread_arg_<N>_<i>``.
 
-    A plain ``Assign`` is required (rather than ``AnnAssign``-without-
-    value) so the ESBMC Python frontend creates a *module-level*
+    A plain ``Assign`` or an ``AnnAssign`` with a non-null ``value`` is
+    required so the ESBMC Python frontend creates a *module-level*
     binding: an annotation-only declaration silently degrades to a
     function-local at the first construction-site write, and the
     spawned trampoline would then read an uninitialised global rather
     than the user-supplied argument.
 
-    The integer default is acceptable for ``args=`` tuples whose
-    elements are integers; class-instance arguments will hit a type
-    mismatch at the construction-site rebind — an MVP limitation
-    documented in the validator's docstring and tracked in #4568 as a
-    follow-up.
+    The declared shape is chosen by ``arg_value`` (the construction-
+    site expression, treated read-only):
+
+      * Numeric / string constants — emit ``= <zero-of-that-kind>`` so
+        the symbol's inferred type matches the construction-site rebind
+        and the trampoline call site type-checks against the target's
+        parameter.
+      * Anything else (Name references, attribute chains, calls,
+        list/dict/set literals, ``None``) — emit ``: object = None``.
+        ``object`` lowers to ``any_type()`` (``void *``) in the Python
+        frontend, so a class-instance arg carrying a struct pointer is
+        forwarded to the trampoline call site without the
+        int-degradation that ``= 0`` would force.
     """
-    return ast.Assign(
-        targets=[
-            ast.Name(id=f"__pythread_arg_{site_id}_{arg_index}", ctx=ast.Store())
-        ],
-        value=ast.Constant(value=0),
+    target = ast.Name(
+        id=f"__pythread_arg_{site_id}_{arg_index}", ctx=ast.Store()
+    )
+
+    if isinstance(arg_value, ast.Constant):
+        v = arg_value.value
+        # bool must be checked before int: isinstance(True, int) is True.
+        if isinstance(v, bool):
+            return ast.Assign(targets=[target], value=ast.Constant(value=False))
+        if isinstance(v, int):
+            return ast.Assign(targets=[target], value=ast.Constant(value=0))
+        if isinstance(v, float):
+            return ast.Assign(targets=[target], value=ast.Constant(value=0.0))
+        if isinstance(v, str):
+            return ast.Assign(targets=[target], value=ast.Constant(value=""))
+        if isinstance(v, bytes):
+            return ast.Assign(targets=[target], value=ast.Constant(value=b""))
+        # ``None`` and other constant kinds (Ellipsis, complex) fall
+        # through to the object-typed declaration below.
+
+    return ast.AnnAssign(
+        target=target,
+        annotation=ast.Name(id="object", ctx=ast.Load()),
+        value=ast.Constant(value=None),
+        simple=1,
     )
 
 
@@ -964,8 +996,10 @@ def lower_threading_thread_usage(
     for scope_sites in sites_by_scope.values():
         for _, (site_id, call_node) in scope_sites.items():
             target_expr, args_values = _thread_call_keywords(call_node)
-            for i in range(len(args_values)):
-                prelude.append(_build_arg_declaration(site_id, i))
+            for i, arg_value in enumerate(args_values):
+                prelude.append(
+                    _build_arg_declaration(site_id, i, arg_value)
+                )
             prelude.append(
                 ast.Assign(
                     targets=[


### PR DESCRIPTION
`Thread(target=f, args=(...))` lowering bundles each construction-site arg into a module-level global `__pythread_arg_<N>_<i>` that the trampoline reads back. The prelude initialised every slot with `= 0`, fixing the symbol's inferred type to `int`. A class-instance rebind kept the int type, so the trampoline's `f(arg)` passed an int where the target expected a struct pointer — dereferenced on the first attribute access as `Access to object out of bounds`.

`parser.py` now inspects the construction-site arg expression and emits a typed declaration:
- Numeric/string constants (`bool`/`int`/`float`/`str`/`bytes`) → `= <zero-of-that-kind>` (matches prior behaviour for int args).
- Anything else (Names, attribute chains, calls, container literals, `None`) → `: object = None`. `object` lowers to `any_type()` (`void *`) so a class-instance pointer is forwarded to the trampoline call site without degradation.

Two new CORE regression tests:
- `threading_thread_args_instance_safe/` — canonical SharedResource pattern from #4583's issue body (two threads, shared Lock + counter, mutual exclusion).
- `threading_thread_args_mixed_safe/` — `args=(7, counter)` exercises that each tuple element drives its own typed prelude independently.

Triage: 28/28 threading tests pass; 855/857 focused triage (`global|lock|nondet|github_3xxx|threading_`) — 2 pre-existing `--boolector` infrastructure failures, independent of this patch.

Fixes #4583.
