### PR TITLE
[regression] KNOWNBUG: Python increment-race scheduler under-exploration (#4584)

### DIFF
--- a/regression/python/threading_thread_increment_race_fail/main.py
+++ b/regression/python/threading_thread_increment_race_fail/main.py
@@ -1,0 +1,28 @@
+import threading
+
+# Two concurrent threads perform a read-modify-write on the same
+# module-level global with no synchronisation. The classic interleaving
+# where both threads read counter==0 before either writes leaves
+# counter==1, violating the assertion. ESBMC should explore that
+# interleaving and report VERIFICATION FAILED.
+#
+# Tracked as #4584: execution_statet::get_expr_globals already recognises
+# Python module globals as shared (PR #4587), but the scheduler
+# under-explores the bad schedule (13 interleavings vs the equivalent C
+# program's 2604). KNOWNBUG until the scheduler-side fix lands.
+counter: int = 0
+
+
+def bump() -> None:
+    global counter
+    tmp: int = counter
+    counter = tmp + 1
+
+
+t1 = threading.Thread(target=bump)
+t2 = threading.Thread(target=bump)
+t1.start()
+t2.start()
+t1.join()
+t2.join()
+assert counter == 2

--- a/regression/python/threading_thread_increment_race_fail/test.desc
+++ b/regression/python/threading_thread_increment_race_fail/test.desc
@@ -1,0 +1,5 @@
+KNOWNBUG
+main.py
+--incremental-bmc --context-bound 2
+^VERIFICATION FAILED$
+^.*assertion.*$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -111,6 +111,7 @@ ignored_dirs=(
   "random6_fail"
   "range19-fail"
   "ternary_symbolic"
+  "threading_thread_increment_race_fail"
   "threading_thread_race_fail"
   "try-fail"
   "verifier-assume"


### PR DESCRIPTION
Adds `regression/python/threading_thread_increment_race_fail/` — two
threads run an unsynchronised read-modify-write on a module-level int
and the post-join assertion `counter == 2` should be violated by the
classic 0/0 read interleaving.

Currently reports `VERIFICATION SUCCESSFUL`: PR #4587 made
`execution_statet::get_expr_globals` recognise Python module globals as
shared, but the scheduler only explores 13 interleavings (vs 2604 for
the equivalent C program), missing the bad schedule. Marked `KNOWNBUG`
so it flips to `CORE` once #4584's scheduler work lands.

References #4584.
