### PR TITLE
[python] expose threading.Lock blocking to --deadlock-check

### DIFF
--- a/regression/python/github_4581/main.py
+++ b/regression/python/github_4581/main.py
@@ -1,0 +1,26 @@
+import threading
+
+lock_a = threading.Lock()
+lock_b = threading.Lock()
+
+
+def thread_a() -> None:
+    lock_a.acquire()
+    lock_b.acquire()
+    lock_b.release()
+    lock_a.release()
+
+
+def thread_b() -> None:
+    lock_b.acquire()
+    lock_a.acquire()
+    lock_a.release()
+    lock_b.release()
+
+
+t1 = threading.Thread(target=thread_a)
+t2 = threading.Thread(target=thread_b)
+t1.start()
+t2.start()
+t1.join()
+t2.join()

--- a/regression/python/github_4581/test.desc
+++ b/regression/python/github_4581/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 3 --deadlock-check --context-bound 6
+^VERIFICATION FAILED$
+^.*Deadlocked state.*$

--- a/regression/python/github_4581_safe/main.py
+++ b/regression/python/github_4581_safe/main.py
@@ -1,0 +1,23 @@
+import threading
+
+# Single-threaded Lock acquire/release under --deadlock-check.
+# Exercises both the if-branch (lock free → take it) and the
+# unlock-with-held assertion of the deadlock-aware model without
+# introducing thread contention, so the verdict is SUCCESSFUL by
+# construction of the model alone.
+lock = threading.Lock()
+counter: int = 0
+
+
+def bump() -> None:
+    global counter
+    lock.acquire()
+    counter = counter + 1
+    lock.release()
+
+
+bump()
+bump()
+bump()
+
+assert counter == 3

--- a/regression/python/github_4581_safe/test.desc
+++ b/regression/python/github_4581_safe/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc --deadlock-check
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4581_unlock_unheld_fail/main.py
+++ b/regression/python/github_4581_unlock_unheld_fail/main.py
@@ -1,0 +1,4 @@
+import threading
+
+lock = threading.Lock()
+lock.release()

--- a/regression/python/github_4581_unlock_unheld_fail/test.desc
+++ b/regression/python/github_4581_unlock_unheld_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--incremental-bmc --deadlock-check
+^VERIFICATION FAILED$
+^.*must hold lock upon unlock.*$

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -69,6 +69,7 @@ ignored_dirs=(
   "github_4149"
   "github_4548_floordiv_call_arg"
   "github_4548_floordiv_negative"
+  "github_4581"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -265,7 +265,11 @@ const static std::vector<std::string> python_c_models = {
   // num_threads_running counts the main thread (deadlock-detector
   // invariant in __pyt_join / pthread_join_switch).
   "__ESBMC_pthread_start_main_hook",
-  "__ESBMC_pthread_end_main_hook"};
+  "__ESBMC_pthread_end_main_hook",
+  // threading.Lock deadlock-aware acquire bookkeeping. Called from the
+  // ``--deadlock-check`` variant of the Python ``Lock`` model
+  // (models/threading_deadlock.py). Mirrors pthread_mutex_lock_check.
+  "__ESBMC_pylock_block_and_check"};
 
 // Solidity operational model functions
 const static std::vector<std::string> solidity_c_models = {

--- a/src/c2goto/library/pthread_lib.c
+++ b/src/c2goto/library/pthread_lib.c
@@ -1023,3 +1023,30 @@ __ESBMC_HIDE:;
   // Block this thread until the target has ended.
   __ESBMC_assume(ended);
 }
+
+/* threading.Lock deadlock-aware bookkeeping.
+ *
+ * Called from ``Lock.acquire`` in the deadlock-aware variant of the
+ * Python operational model (``models/threading_deadlock.py``) on the
+ * branch where the lock is already held by another thread. Mirrors the
+ * else-branch of ``pthread_mutex_lock_check``: bump the global blocked
+ * counter and assert that not every running thread is now blocked. The
+ * Python caller wraps this call in its own ``__ESBMC_atomic_begin`` /
+ * ``__ESBMC_atomic_end`` pair, so the bump-and-assert is atomic with
+ * the lock-field read that decided to block.
+ *
+ * The counter bump persists on a path that the caller then kills with
+ * ``__ESBMC_assume(unlocked)``; symex's interleaving search observes
+ * the bumped value on alternative schedules where two or more threads
+ * have all reached this point, which is where the global deadlock
+ * predicate (``blocked_threads_count == num_threads_running``) becomes
+ * true.
+ */
+void __ESBMC_pylock_block_and_check(void)
+{
+__ESBMC_HIDE:;
+  __ESBMC_blocked_threads_count++;
+  __ESBMC_assert(
+    __ESBMC_blocked_threads_count != __ESBMC_num_threads_running,
+    "Deadlocked state in threading.Lock.acquire");
+}

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -1022,7 +1022,8 @@ void goto_symext::run_intrinsic(
   if (
     has_prefix(symname, "c:@F@__ESBMC_pthread_start_main_hook") ||
     has_prefix(symname, "c:@F@__ESBMC_pthread_end_main_hook") ||
-    has_prefix(symname, "c:@F@__ESBMC_atexit_handler"))
+    has_prefix(symname, "c:@F@__ESBMC_atexit_handler") ||
+    has_prefix(symname, "c:@F@__ESBMC_pylock_block_and_check"))
   {
     bump_call(func_call, symname);
     return;

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -56,6 +56,7 @@ const std::string kEsbmcSpawnThread = "__ESBMC_spawn_thread";
 const std::string kPytInitTid = "__pyt_init_tid";
 const std::string kPytJoin = "__pyt_join";
 const std::string kPytTerminate = "__pyt_terminate";
+const std::string kPyLockBlockAndCheck = "__ESBMC_pylock_block_and_check";
 
 function_call_builder::function_call_builder(
   python_converter &converter,
@@ -830,9 +831,9 @@ exprt function_call_builder::build() const
     }
   }
 
-  // __pyt_init_tid / __pyt_join / __pyt_terminate: the C-side bookkeeping
-  // helpers for the Python threading.Thread lowering (defined in
-  // pthread_lib.c, pulled into the GOTO program via the python_c_models
+  // __pyt_init_tid / __pyt_join / __pyt_terminate / __ESBMC_pylock_block_and_check:
+  // C-side bookkeeping helpers for the Python threading lowering (defined
+  // in pthread_lib.c, pulled into the GOTO program via the python_c_models
   // whitelist in cprover_library.cpp). Register the matching C-style
   // symbol id so the call resolves to the linked body rather than a
   // freshly-created Python-frontend symbol with no implementation.
@@ -841,14 +842,17 @@ exprt function_call_builder::build() const
     const bool is_init_tid = func_name == kPytInitTid;
     const bool is_join = func_name == kPytJoin;
     const bool is_terminate = func_name == kPytTerminate;
-    if (is_init_tid || is_join || is_terminate)
+    const bool is_lock_block = func_name == kPyLockBlockAndCheck;
+    if (is_init_tid || is_join || is_terminate || is_lock_block)
     {
       auto &symbol_table = converter_.symbol_table();
       locationt location = converter_.get_location_from_decl(call_);
 
+      const bool takes_uint_arg = is_init_tid || is_join;
+
       code_typet fn_type;
       fn_type.return_type() = empty_typet();
-      if (!is_terminate)
+      if (takes_uint_arg)
         fn_type.arguments().push_back(code_typet::argumentt(uint_type()));
 
       const std::string symbol_id = "c:@F@" + func_name;
@@ -864,7 +868,7 @@ exprt function_call_builder::build() const
       call.type() = empty_typet();
       call.location() = location;
 
-      if (!is_terminate)
+      if (takes_uint_arg)
       {
         if (call_["args"].size() != 1)
           throw std::runtime_error(func_name + " takes exactly one argument");
@@ -872,6 +876,10 @@ exprt function_call_builder::build() const
         if (arg.type() != uint_type())
           arg = typecast_exprt(arg, uint_type());
         call.arguments().push_back(arg);
+      }
+      else if (!call_["args"].empty())
+      {
+        throw std::runtime_error(func_name + " takes no arguments");
       }
 
       return call;

--- a/src/python-frontend/models/threading_deadlock.py
+++ b/src/python-frontend/models/threading_deadlock.py
@@ -49,13 +49,15 @@ class Lock:
         __ESBMC_assume(unlocked)
 
     def release(self) -> None:
-        """Mark the lock free; assert it was held."""
+        """Mark the lock free; assert it was held.
+
+        The assert is consumed by ESBMC's parser.py via ast.parse() and
+        lowered to a verification claim, so `python -O` byte-code
+        stripping never applies — the nosec marker silences Bandit's
+        generic B101 finding, which does not model that pipeline.
+        """
         __ESBMC_atomic_begin()
-        # nosec B101: ESBMC's parser.py consumes this assert via
-        # ast.parse() and lowers it to a verification claim, so the
-        # bandit/Codacy concern about `python -O` byte-code stripping
-        # does not apply to the ESBMC pipeline.
-        assert self._locked == 1, "must hold lock upon unlock"
+        assert self._locked == 1, "must hold lock upon unlock"  # nosec B101
         self._locked = 0
         __ESBMC_atomic_end()
 

--- a/src/python-frontend/models/threading_deadlock.py
+++ b/src/python-frontend/models/threading_deadlock.py
@@ -1,0 +1,87 @@
+"""Deadlock-aware operational model for the standard ``threading`` module.
+
+Loaded in place of ``threading.py`` when ESBMC is invoked with
+``--deadlock-check``. The Python frontend's ``parser.py`` performs the
+swap, mirroring the C preprocessor swap of ``pthread_mutex_lock`` to
+``pthread_mutex_lock_check`` in ``src/clang-c-frontend/c_preprocess.cpp``.
+
+The acquire path mirrors ``pthread_mutex_lock_check`` in
+``src/c2goto/library/pthread_lib.c``: read the lock field inside an
+atomic block, take the lock on the unlocked branch, or bump
+``__ESBMC_blocked_threads_count`` and assert the global deadlock
+predicate on the locked branch. The ``__ESBMC_assume(unlocked)`` after
+the atomic-end kills the locked branch on this thread, but symex's
+interleaving search observes the bumped counter on alternative
+schedules where every running thread reaches the locked branch — that
+is where the predicate fires.
+
+The release path mirrors ``pthread_mutex_unlock_check``: assert the
+lock was held before clearing the field, so a release-without-acquire
+bug is caught under the same flag whose job it is to find concurrency
+errors.
+"""
+# pylint: disable=unused-argument,unnecessary-pass,undefined-variable,function-redefined
+
+
+class Lock:
+    """Non-recursive mutex; mirrors ``threading.Lock`` with deadlock detection."""
+
+    def __init__(self) -> None:
+        self._locked: int = 0
+
+    def acquire(self) -> None:
+        """Block until the lock is free, then mark it held.
+
+        On the blocked branch, register the thread as blocked and assert
+        that not every running thread is now blocked. Symex's
+        interleaving search lifts the bumped counter into schedules
+        where the deadlock predicate becomes true and the assertion
+        fires; on this thread's own path, ``__ESBMC_assume(unlocked)``
+        kills the blocked branch after the predicate has been checked.
+        """
+        __ESBMC_atomic_begin()
+        unlocked: bool = (self._locked == 0)
+        if unlocked:
+            self._locked = 1
+        else:
+            __ESBMC_pylock_block_and_check()
+        __ESBMC_atomic_end()
+        __ESBMC_assume(unlocked)
+
+    def release(self) -> None:
+        """Mark the lock free; assert it was held."""
+        __ESBMC_atomic_begin()
+        assert self._locked == 1, "must hold lock upon unlock"
+        self._locked = 0
+        __ESBMC_atomic_end()
+
+
+class Thread:
+    """Skeleton matching ``threading.Thread``; identical to the assume-only variant.
+
+    Every ``Thread(target=...)`` construction, ``.start()`` call, and
+    ``.join()`` call is rewritten by ``lower_threading_thread_usage``
+    in ``parser.py`` before this class is ever instantiated. The
+    skeleton's only purpose is to satisfy the Python frontend's
+    class-instantiation machinery when the rewritten construction
+    lowers to ``Thread()`` (no args).
+    """
+
+    def __init__(self) -> None:
+        self._tid: int = 0
+
+    def start(self) -> None:
+        """Reached only when the AST rewrite failed to lower a Thread."""
+        __ESBMC_assert(
+            False,
+            "threading.Thread.start() reached without AST lowering "
+            "(dynamic Thread lookup?)",
+        )
+
+    def join(self) -> None:
+        """Reached only when the AST rewrite failed to lower a Thread."""
+        __ESBMC_assert(
+            False,
+            "threading.Thread.join() reached without AST lowering "
+            "(dynamic Thread lookup?)",
+        )

--- a/src/python-frontend/models/threading_deadlock.py
+++ b/src/python-frontend/models/threading_deadlock.py
@@ -51,6 +51,10 @@ class Lock:
     def release(self) -> None:
         """Mark the lock free; assert it was held."""
         __ESBMC_atomic_begin()
+        # nosec B101: ESBMC's parser.py consumes this assert via
+        # ast.parse() and lowers it to a verification claim, so the
+        # bandit/Codacy concern about `python -O` byte-code stripping
+        # does not apply to the ESBMC pipeline.
         assert self._locked == 1, "must hold lock upon unlock"
         self._locked = 0
         __ESBMC_atomic_end()

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -56,8 +56,14 @@ def run_mypy_strict(filename):
 
 
 def check_usage():
-    if len(sys.argv) != 3:
-        print("Usage: python astgen.py <file path> <output directory>")
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print(
+            "Usage: python astgen.py <file path> <output directory> "
+            "[--deadlock-check]"
+        )
+        sys.exit(2)
+    if len(sys.argv) == 4 and sys.argv[3] != "--deadlock-check":
+        print(f"Unknown flag: {sys.argv[3]}")
         sys.exit(2)
 
 
@@ -2269,11 +2275,31 @@ def check_dependencies():
         print("  Install with: pip install mypy  or  pipx install mypy")
 
 
+def select_threading_model(output_dir: str, deadlock_check: bool) -> None:
+    """Swap ``models/threading.py`` for the deadlock-aware variant.
+
+    Mirrors the C preprocessor swap of ``pthread_mutex_lock`` to
+    ``pthread_mutex_lock_check`` (``clang-c-frontend/c_preprocess.cpp``).
+    When ``deadlock_check`` is true, overwrite ``threading.py`` with
+    the contents of ``threading_deadlock.py``. The variant file stays
+    on disk; the model-JSON loop in ``main`` skips it explicitly by
+    name so it does not emit a stray ``Lock``/``Thread`` module.
+    """
+    if not deadlock_check:
+        return
+    models_dir = os.path.join(output_dir, "models")
+    src = os.path.join(models_dir, "threading_deadlock.py")
+    dst = os.path.join(models_dir, "threading.py")
+    if os.path.exists(src):
+        shutil.copyfile(src, dst)
+
+
 def main():
     check_usage()
     check_dependencies()
     filename = sys.argv[1]
     output_dir = sys.argv[2]
+    deadlock_check = len(sys.argv) == 4 and sys.argv[3] == "--deadlock-check"
 
     # Type checking input program with mypy.
     returncode, mypy_output = run_mypy_strict(filename)
@@ -2288,6 +2314,8 @@ def main():
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
+
+    select_threading_model(output_dir, deadlock_check)
 
     # Process and convert AST for main file. The entry script is canonicalised
     # before import discovery and finalised only after cross-module alias /
@@ -2345,6 +2373,12 @@ def main():
     for python_file in glob.glob(os.path.join(models_dir, "*.py")):
         filename = os.path.basename(python_file)
         module_name = filename[:-3]
+
+        # Variant of threading.py; select_threading_model copies it into
+        # place under --deadlock-check, so skip it as a separate module
+        # to avoid emitting a duplicate Lock/Thread JSON.
+        if module_name == "threading_deadlock":
+            continue
 
         if is_imported_model(module_name) and module_name != "typing":
             continue

--- a/src/python-frontend/python_annotation/annotation_intrinsics.cpp
+++ b/src/python-frontend/python_annotation/annotation_intrinsics.cpp
@@ -81,6 +81,7 @@ const std::map<std::string, std::string> &builtin_functions()
     {"__pyt_init_tid", "NoneType"},
     {"__pyt_join", "NoneType"},
     {"__pyt_terminate", "NoneType"},
+    {"__ESBMC_pylock_block_and_check", "NoneType"},
 
     // Execution functions
     {"eval", "Any"},

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -730,6 +730,12 @@ void python_converter::convert()
   // function_call_builder does for atomic_begin in user code.
   ensure_void_void_intrinsic("__ESBMC_yield", hook_location);
 
+  // The threading.Lock deadlock-aware acquire (models/threading_deadlock.py,
+  // loaded when ``--deadlock-check`` is set) calls this intrinsic on the
+  // blocked branch. Register unconditionally: under the assume-only Lock
+  // variant the symbol is unreferenced and contributes no GOTO code.
+  ensure_void_void_intrinsic("__ESBMC_pylock_block_and_check", hook_location);
+
   main_body.copy_to_operands(make_hook_call("__ESBMC_pthread_start_main_hook"));
 
   // 4. Call python_user_main

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -92,6 +92,13 @@ bool python_languaget::parse(const std::string &path)
   // Execute Python script to generate JSON file from AST
   std::vector<std::string> args = {parser_path.string(), path, ast_output_dir};
 
+  // Propagate ``--deadlock-check`` to the parser so it loads the
+  // deadlock-aware threading model (models/threading_deadlock.py). The
+  // C frontend handles the analogous swap via preprocessor #defines
+  // (clang-c-frontend/c_preprocess.cpp).
+  if (config.options.get_bool_option("deadlock-check"))
+    args.push_back("--deadlock-check");
+
   // Get Python interpreter path informed by the user
   std::string python_exec = config.options.get_option("python");
   auto python_exec_path = bp::search_path(python_exec);


### PR DESCRIPTION
## Summary

Lock.acquire used `__ESBMC_assume(self._locked == 0)` to block, which is sound for mutual exclusion but invisible to `--deadlock-check` — the detector inspects `__ESBMC_blocked_threads_count`, which the assume-only model never touches. This adds a deadlock-aware variant (`models/threading_deadlock.py`) that mirrors `pthread_mutex_lock_check` and `pthread_mutex_unlock_check`, swapped in by `parser.py` when `--deadlock-check` is set — analogous to the C frontend's preprocessor swap in `clang-c-frontend/c_preprocess.cpp`.

Fixes #4581
