### PR TITLE
[esbmc-cpp] regression: --uninitialised-vars-check on C++ arrays

### DIFF
--- a/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp/main.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+
+int compute_index(int x)
+{
+  volatile int y = x * 17 + 3;
+  return (y ^ (y >> 2)) & 7;
+}
+
+int main()
+{
+  int table[8];
+
+  for (int i = 0; i < 8; ++i)
+    if ((i % 3) == 0)
+      table[i] = i * 11;
+
+  int total = 0;
+  for (int i = 0; i < 8; ++i)
+    total += table[compute_index(i)];
+
+  std::cout << total << "\n";
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp/test.desc
+++ b/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.cpp
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION FAILED$
+^  use of uninitialized variable: table$
+^  CWE: CWE-457$

--- a/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp_pass/main.cpp
+++ b/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp_pass/main.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+
+int compute_index(int x)
+{
+  volatile int y = x * 17 + 3;
+  return (y ^ (y >> 2)) & 7;
+}
+
+int main()
+{
+  int table[8];
+
+  for (int i = 0; i < 8; ++i)
+    table[i] = i * 11;
+
+  int total = 0;
+  for (int i = 0; i < 8; ++i)
+    total += table[compute_index(i)];
+
+  std::cout << total << "\n";
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp_pass/test.desc
+++ b/regression/esbmc-cpp/cpp/cwe_uninit_array_cpp_pass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--uninitialised-vars-check --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Summary

Issue #4504 reported a false negative for `--uninitialised-vars-check` on a C++ program. The underlying analysis was already fixed in master by:

- #4501 — detect uninitialised local scalar reads as CWE-457
- #4507 — extend the pass to scalar arrays (CWE-457)

This PR closes the remaining gap: there was no C++-frontend regression entry guarding that behaviour. The existing coverage under `regression/esbmc/cwe_uninit_*` exercises only the clang-c frontend.

Two minimal C++ tests are added under `regression/esbmc-cpp/cpp/`:

- `cwe_uninit_array_cpp` — partially initialised `int table[8]` read via a `volatile`-tainted symbolic index; expects `VERIFICATION FAILED` with the CWE-457 message.
- `cwe_uninit_array_cpp_pass` — same shape but fully initialised; expects `VERIFICATION SUCCESSFUL`.

Verified against ESBMC 8.3.0 (master):

```
test_cwe_uninit_array_cpp        ... ok
test_cwe_uninit_array_cpp_pass   ... ok
```

The full `cwe_uninit_*` C-language suite continues to pass.

Fixes #4504.

## Test plan

- [x] `testing_tool.py` on the two new tests (CORE mode) — both pass
- [x] Existing `regression/esbmc/cwe_uninit_*` suite — all 12 pass
- [x] Manual reproduction of the issue program — now reports `VERIFICATION FAILED` with `use of uninitialized variable: table`
