### PR TITLE
[irep2] reduce scope of tmp in do_type_lt loop

### DIFF
--- a/src/irep2/templates/irep2_template_utils.cpp
+++ b/src/irep2/templates/irep2_template_utils.cpp
@@ -215,11 +215,10 @@ int do_type_lt(
   if (side1.size() != side2.size())
     return side1.size() < side2.size() ? -1 : 1;
 
-  int tmp = 0;
   std::vector<expr2tc>::const_iterator it2 = side2.begin();
   for (auto const &it : side1)
   {
-    tmp = it->ltchecked(**it2);
+    int tmp = it->ltchecked(**it2);
     if (tmp != 0)
       return tmp;
     ++it2;


### PR DESCRIPTION
Codacy flagged the loop-local result of `ltchecked()` as having unnecessarily broad scope. Declare it inside the loop body so its lifetime matches its single use.

Pure scope reduction — no behavioural change.