### PR TITLE
[python] reduce scope of symbol_created in get_assign

### DIFF
--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1437,7 +1437,6 @@ void python_converter::get_var_assign(
       lhs_symbol = symbol_table_.find_symbol(sid.global_to_string().c_str());
 
     // Symbol creation
-    bool symbol_created = false;
     if (!lhs_symbol || !is_global)
     {
       std::string module_name = location_begin.get_file().as_string();
@@ -1455,7 +1454,7 @@ void python_converter::get_var_assign(
       symbol.file_local = !current_func_name_.empty();
       symbol.is_extern = false;
 
-      symbol_created = (lhs_symbol == nullptr);
+      bool symbol_created = (lhs_symbol == nullptr);
       lhs_symbol = symbol_table_.move_symbol_to_context(symbol);
 
       // Add declaration statement ONLY for newly created local variables


### PR DESCRIPTION
Codacy flagged the `symbol_created` flag as having unnecessarily broad scope. It is only read inside the `!lhs_symbol || !is_global` branch that writes it, so move the declaration into that branch.

Pure scope reduction — no behavioural change.