### PR TITLE
[python] pass explicit zero to Decimal in _maybe_rewrite_decimal_call

### DIFF
--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -449,7 +449,7 @@ class CoreVisitorsMixin:
         import decimal as _decimal_mod
 
         if len(node.args) == 0:
-            dec = _decimal_mod.Decimal()
+            dec = _decimal_mod.Decimal("0")
         elif len(node.args) == 1:
             dec = self._decimal_from_single_arg(node.args[0], _decimal_mod)
         else:


### PR DESCRIPTION
Codacy/pylint flagged `Decimal()` with no arguments as missing the required value parameter (`no-value-for-parameter`). `Decimal("0")` is semantically identical — same `as_tuple()` result — and satisfies the static analyser.