### PR TITLE
[python] fix vacuous nondet3 assertion and re-enable test

### DIFF
--- a/regression/python/esbmc-module-nondet3/main.py
+++ b/regression/python/esbmc-module-nondet3/main.py
@@ -1,17 +1,21 @@
-from esbmc import nondet_dict, __ESBMC_assume, __ESBMC_assert
+from esbmc import (
+    nondet_dict, nondet_str, nondet_int,
+    __ESBMC_assume, __ESBMC_assert,
+)
 
 def test_symbolic_dict() -> None:
-    d = nondet_dict()
+    d = nondet_dict(key_type=nondet_str(), value_type=nondet_int())
     __ESBMC_assume(len(d) <= 3)  # constrain size
 
-    # If key exists, check type of value
-    if "key1" in d:
-        v = d["key1"]
-        __ESBMC_assert(isinstance(v, int) or isinstance(v, str),
-                       "Dict value type valid")
+    # Property: size constraint holds
+    __ESBMC_assert(len(d) <= 3, "Dict size respects constraint")
 
     # Property: all keys are strings
     for k in d.keys():
         __ESBMC_assert(isinstance(k, str), "All keys are strings")
+
+    # Property: all values are ints
+    for v in d.values():
+        __ESBMC_assert(isinstance(v, int), "All values are ints")
 
 test_symbolic_dict()

--- a/regression/python/esbmc-module-nondet3/test.desc
+++ b/regression/python/esbmc-module-nondet3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+THOROUGH
 main.py
---unwind 9 --bitwuzla --no-standard-checks
+--unwind 9 --no-standard-checks
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The `regression/python/esbmc-module-nondet3` test asserted `isinstance(k, str)` for every key of `nondet_dict()`, but the default preprocessor expansion is `int -> int` — so the property was logically false. It had been passing vacuously since the test was added in #3485 because `__ESBMC_assert` was a no-op Python stub until #4597 wired the real `code_assertt` lowering, at which point the assertion finally fired and the test was demoted to `KNOWNBUG` in 21672959e9.

Parameterise the dict to `nondet_str()` keys and `nondet_int()` values so the size, key, and value assertions are now semantically correct and provable. Both `--unwind 9` and `--incremental-bmc` agree on the patched property. Restore `THOROUGH` and drop the redundant `--bitwuzla` flag.

Refs #4629 for the separate `--incremental-bmc` soundness divergence #4597 also unmasked, tracked independently.