### PR TITLE
[python] speed up github_3647_11-nondet_fail and restore CORE

### DIFF
--- a/regression/python/github_3647_11-nondet_fail/test.desc
+++ b/regression/python/github_3647_11-nondet_fail/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.py
---no-standard-checks --unwind 9 --smt-symex-guard
+--no-standard-checks --incremental-bmc --smt-symex-guard
 ^VERIFICATION FAILED$


### PR DESCRIPTION
`regression/python/github_3647_11-nondet_fail` was timing out under parallel ctest load (per-test cap 120s). The current flags `--no-standard-checks --unwind 9 --smt-symex-guard` take ~32s sequentially on macOS arm64 (28s in symex alone) — comfortably enough headroom to blow past 120s when CI runs 4 workers in parallel.

Switching the bound from `--unwind 9` to `--incremental-bmc` (while keeping `--smt-symex-guard`) drops wall-clock to ~3s — a ~10× speedup — because incremental-BMC reaches the counterexample after the first feasible k without unrolling the full 8-element `nondet_dict()` expansion.

| Flags | Real time |
|---|---|
| `--unwind 9 --smt-symex-guard` (current) | ~32 s |
| `--unwind 9` (plain) | ~68 s |
| `--incremental-bmc` (plain) | ~25 s |
| `--incremental-bmc --smt-symex-guard` (this PR) | **~3 s** |

Promoted back from `THOROUGH` to `CORE` because the test was originally `CORE` (demoted in 79e69fee7a as a perf workaround) and at 3s comfortably fits the cap on all platforms.

Verified via `ctest -R regression/python/github_3647_11-nondet_fail$` — passes in 3.43s, FAILED verdict matches `^VERIFICATION FAILED$` as before.
