### PR TITLE
[symex] gate end-of-program leak check on all-threads-terminal

### DIFF
--- a/regression/esbmc/github_4634/main.c
+++ b/regression/esbmc/github_4634/main.c
@@ -1,0 +1,68 @@
+// Regression for #4634.
+//
+// Two-element linked list `A -> p`. A spawned thread inserts a new
+// node between them by saving the old `A->next` in a stack local `t`,
+// then overwriting `A->next`. Until the thread completes, the global
+// head `A` no longer reaches the original `p` directly, but `t` does —
+// at every schedule the program is memory-safe (the join pulls the
+// thread to completion before main returns).
+//
+// Before #4634, `add_memory_leak_checks()` rooted its reachability
+// constraint at globals only, so the intermediate schedule where the
+// thread is suspended between `A->next = new_node` and the splice
+// back-link was reported as a forgotten-memory violation whenever the
+// `main_thread_ended` throttle was bypassed (e.g. `--data-races-check`).
+
+#include <pthread.h>
+#include <stdlib.h>
+
+struct s
+{
+  int datum;
+  struct s *next;
+};
+
+static struct s *A;
+static pthread_mutex_t A_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void init(struct s *p, int x)
+{
+  p->datum = x;
+  p->next = NULL;
+}
+
+static void *t_fun(void *arg)
+{
+  (void)arg;
+  struct s *p = malloc(sizeof(struct s));
+  if (!p)
+    return NULL;
+  struct s *t;
+  init(p, 7);
+
+  pthread_mutex_lock(&A_mutex);
+  t = A->next;
+  A->next = p;
+  p->next = t;
+  pthread_mutex_unlock(&A_mutex);
+  return NULL;
+}
+
+int main(void)
+{
+  pthread_t t1;
+  struct s *p = malloc(sizeof(struct s));
+  if (!p)
+    return 0;
+  init(p, 9);
+
+  A = malloc(sizeof(struct s));
+  if (!A)
+    return 0;
+  init(A, 3);
+  A->next = p;
+
+  pthread_create(&t1, NULL, t_fun, NULL);
+  pthread_join(t1, NULL);
+  return 0;
+}

--- a/regression/esbmc/github_4634/test.desc
+++ b/regression/esbmc/github_4634/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --no-assertions --data-races-check --incremental-bmc --k-step 2 --state-hashing --no-por --unlimited-k-steps
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_4634_fail/main.c
+++ b/regression/esbmc/github_4634_fail/main.c
@@ -1,0 +1,27 @@
+// Companion-fail for #4634.
+//
+// Confirms that gating `add_memory_leak_checks()` on the
+// all-threads-terminal predicate does not suppress real leaks. The
+// thread mallocs a block, stores the pointer only in a stack local,
+// returns without freeing or exporting it. At the all-threads-terminal
+// schedule the block is unreachable from any live pointer — a genuine
+// `valid-memcleanup` violation.
+
+#include <pthread.h>
+#include <stdlib.h>
+
+static void *t_fun(void *arg)
+{
+  (void)arg;
+  void *p = malloc(16);
+  (void)p;
+  return NULL;
+}
+
+int main(void)
+{
+  pthread_t t1;
+  pthread_create(&t1, NULL, t_fun, NULL);
+  pthread_join(t1, NULL);
+  return 0;
+}

--- a/regression/esbmc/github_4634_fail/test.desc
+++ b/regression/esbmc/github_4634_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--memory-leak-check --no-reachable-memory-leak --no-abnormal-memory-leak --no-assertions --incremental-bmc --k-step 2
+^VERIFICATION FAILED$
+^.*forgotten memory.*$

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -455,6 +455,14 @@ bool execution_statet::check_if_ileaves_blocked()
   return false;
 }
 
+bool execution_statet::all_threads_terminal() const
+{
+  for (const auto &ts : threads_state)
+    if (!ts.thread_ended && !ts.call_stack.empty())
+      return false;
+  return true;
+}
+
 void execution_statet::end_thread()
 {
   get_active_state().thread_ended = true;

--- a/src/goto-symex/execution_state.h
+++ b/src/goto-symex/execution_state.h
@@ -337,6 +337,16 @@ public:
   bool check_if_ileaves_blocked();
 
   /**
+   *  True iff every thread in this schedule has reached a terminal state,
+   *  i.e. has either ended or has an empty call stack. This is the precondition
+   *  for treating the schedule's tail as program termination — only then is it
+   *  sound to fire end-of-program checks such as the memory-leak walker, since
+   *  a still-running thread may hold the only live reference to a dynamic
+   *  object via its stack frames.
+   */
+  bool all_threads_terminal() const;
+
+  /**
    *  Create a new thread.
    *  Creates and initializes a new thread, running at the start of the GOTO
    *  program prog.

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -291,8 +291,12 @@ void reachability_treet::go_next_state()
       it = cur_state_it;
       cur_state_it--;
 
-      // For the last one:
-      if (execution_states.size() == 1)
+      // For the last one. Only fire the leak walker when every thread has
+      // reached a terminal state — otherwise a still-running spawned thread
+      // may hold the only live reference to a dynamic object via its stack
+      // frame, which the globals-rooted reachability constraint will miss
+      // and spuriously report as a forgotten-memory violation. See #4634.
+      if (execution_states.size() == 1 && (*it)->all_threads_terminal())
         (*it)->add_memory_leak_checks();
 
       execution_states.erase(it);
@@ -573,7 +577,15 @@ goto_symext::symex_resultt reachability_treet::get_next_formula()
     switch_to_next_execution_state();
   }
 
-  (*cur_state_it)->add_memory_leak_checks();
+  // Only fire the leak walker on schedules whose tail is a genuine program
+  // termination — every thread terminal. Otherwise a still-running spawned
+  // thread may hold the only live reference to a dynamic object via its
+  // stack frame; the leak walker's reachability constraint is rooted at
+  // globals only, so it would spuriously report that object forgotten. The
+  // DFS will produce the all-threads-terminal sibling schedule separately,
+  // and the check fires correctly there. See #4634.
+  if ((*cur_state_it)->all_threads_terminal())
+    (*cur_state_it)->add_memory_leak_checks();
 
   has_complete_formula = false;
 


### PR DESCRIPTION
`add_memory_leak_checks()` roots its globals-only reachability constraint
at `value_set_analysist::get_globals()`, so a thread still mid-execution
that holds the only live pointer to a dynamic object via its stack frame
is misread as a forgotten-memory violation. Fire the check only when every
thread in the schedule has reached a terminal state.

Recovers the seven `false(valid-memtrack)` sv-comp regressions surfaced by
#4599 (now: 2 correct-true + 5 unknown, zero incorrect-false). Regression
test `github_4634` reproduces the spurious failure on master under
`--data-races-check` and now passes; `github_4634_fail` confirms genuine
leaks still fire.

Fixes #4634.
