### PR TITLE
[irep2] reduce scope of tmp in do_type_lt

### DIFF
--- a/src/irep2/templates/irep2_template_utils.cpp
+++ b/src/irep2/templates/irep2_template_utils.cpp
@@ -235,11 +235,10 @@ int do_type_lt(
   else if (side1.size() > side2.size())
     return 1;
 
-  int tmp = 0;
   std::vector<type2tc>::const_iterator it2 = side2.begin();
   for (auto const &it : side1)
   {
-    tmp = it->ltchecked(**it2);
+    int tmp = it->ltchecked(**it2);
     if (tmp != 0)
       return tmp;
     ++it2;


### PR DESCRIPTION
The outer `int tmp = 0;` in the `std::vector<type2tc>` overload of `do_type_lt` was dead: the loop body unconditionally overwrites it before reading, and the function returns the literal `0` once the loop completes. Move the declaration into the loop body so this overload matches the sibling `std::vector<expr2tc>` overload just above. Addresses a Codacy MEDIUM "Best practice" scope finding at `src/irep2/templates/irep2_template_utils.cpp:238`.