### PR TITLE
[python] fold cross-type Eq/NotEq to False/True

### DIFF
--- a/regression/python/cross_type_eq_bytes_int/main.py
+++ b/regression/python/cross_type_eq_bytes_int/main.py
@@ -1,0 +1,10 @@
+b: bytes = b'A'
+# Whole-bytes vs int: distinct categories ("bytes" vs "numeric") → cross-type fold
+assert (b == 65) == False
+assert (b != 65) == True
+# Indexed bytes vs int: in CPython `b[0]` is an int, so this must hold.
+# Locks in that bytes elements are modeled as numerics (long_long_int), not as
+# 8-bit chars — otherwise the 8-bit-int-as-string heuristic in
+# get_python_type_category would wrongly fold this comparison to False.
+assert b[0] == 65
+assert (b[0] != 65) == False

--- a/regression/python/cross_type_eq_bytes_int/test.desc
+++ b/regression/python/cross_type_eq_bytes_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cross_type_eq_dict_int/main.py
+++ b/regression/python/cross_type_eq_dict_int/main.py
@@ -1,0 +1,3 @@
+d = {'a': 1, 'b': 2}
+assert (d == 5) == False
+assert (d != 5) == True

--- a/regression/python/cross_type_eq_dict_int/test.desc
+++ b/regression/python/cross_type_eq_dict_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cross_type_eq_float_bytes/main.py
+++ b/regression/python/cross_type_eq_float_bytes/main.py
@@ -1,0 +1,4 @@
+a: float = 65.0
+b: bytes = b'A'
+assert (a == b) == False
+assert (a != b) == True

--- a/regression/python/cross_type_eq_float_bytes/test.desc
+++ b/regression/python/cross_type_eq_float_bytes/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cross_type_eq_int_str/main.py
+++ b/regression/python/cross_type_eq_int_str/main.py
@@ -1,0 +1,3 @@
+a: int = 65
+assert (a == 'A') == False
+assert (a != 'A') == True

--- a/regression/python/cross_type_eq_int_str/test.desc
+++ b/regression/python/cross_type_eq_int_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cross_type_eq_list_int/main.py
+++ b/regression/python/cross_type_eq_list_int/main.py
@@ -1,0 +1,3 @@
+a = [1, 2, 3]
+assert (a == 5) == False
+assert (a != 5) == True

--- a/regression/python/cross_type_eq_list_int/test.desc
+++ b/regression/python/cross_type_eq_list_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cross_type_eq_numeric_tower/main.py
+++ b/regression/python/cross_type_eq_numeric_tower/main.py
@@ -1,0 +1,5 @@
+assert 1 == 1.0
+assert True == 1
+assert 1.0 == True
+assert (1 + 0j) == 1
+assert (1 + 1j) != 1

--- a/regression/python/cross_type_eq_numeric_tower/test.desc
+++ b/regression/python/cross_type_eq_numeric_tower/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/cross_type_eq_tuple_str/main.py
+++ b/regression/python/cross_type_eq_tuple_str/main.py
@@ -1,0 +1,3 @@
+t = (1, 2, 3)
+assert (t == 'a') == False
+assert (t != 'a') == True

--- a/regression/python/cross_type_eq_tuple_str/test.desc
+++ b/regression/python/cross_type_eq_tuple_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -138,16 +138,14 @@ std::string python_converter::get_python_type_category(const typet &t) const
     return "";
 
   // Python has no `char`: single-character results from `chr()` and string
-  // indexing are 1-char strings. ESBMC models them as 8-bit integers (with or
-  // without the `#cpp_type==char` marker — string indexing in particular
-  // drops the marker), so bucket any 8-bit int with the string category
-  // before the generic numeric check below would otherwise pull them in.
-  // Python's own `int` is `long_long_int_type` (64-bit), so a width-8 int can
-  // only originate from char-level handling here.
-  if (
-    type_utils::is_string_type(t) ||
-    (type_utils::is_integer_type(t) &&
-     static_cast<const bv_typet &>(t).get_width() == 8))
+  // indexing are 1-char strings. ESBMC models them as 8-bit integers tagged
+  // with `#cpp_type==char` (set explicitly in type_handler::get_typet for
+  // `chr()` and in python_list::index for string subscript). A bare width-8
+  // int *without* the marker is something else (e.g. `dtype=np.int8`,
+  // 8-bit user int annotation) and must remain in the numeric tower —
+  // misclassifying it as "string" turns `np.add(127, 1, dtype=np.int8) ==
+  // -128` into a spurious cross-type fold to False.
+  if (type_utils::is_string_type(t) || type_utils::is_char_type(t))
     return "string";
 
   // Python's numeric tower coerces within itself; complex is checked first

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -131,6 +131,51 @@ static void attach_symbol_location(exprt &expr, contextt &symbol_table)
     expr.location() = sym->location;
 }
 
+std::string python_converter::get_python_type_category(const typet &t) const
+{
+  // Unannotated any_type (void*) — caller keeps the existing coercion path.
+  if (t.is_pointer() && t.subtype().id() == "empty")
+    return "";
+
+  // Python has no `char`: single-character results from `chr()` and string
+  // indexing are 1-char strings. ESBMC models them as 8-bit integers (with or
+  // without the `#cpp_type==char` marker — string indexing in particular
+  // drops the marker), so bucket any 8-bit int with the string category
+  // before the generic numeric check below would otherwise pull them in.
+  // Python's own `int` is `long_long_int_type` (64-bit), so a width-8 int can
+  // only originate from char-level handling here.
+  if (
+    type_utils::is_string_type(t) ||
+    (type_utils::is_integer_type(t) &&
+     static_cast<const bv_typet &>(t).get_width() == 8))
+    return "string";
+
+  // Python's numeric tower coerces within itself; complex is checked first
+  // because it is a struct and would otherwise fall through to class_inst.
+  if (
+    is_complex_type(t) || t.is_bool() || t.is_floatbv() ||
+    type_utils::is_integer_type(t))
+    return "numeric";
+
+  // Any remaining non-string array (e.g. bytes literal `b'A'`).
+  if (t.is_array())
+    return "bytes";
+
+  if (t == type_handler_.get_list_type())
+    return "list";
+
+  if (dict_handler_->is_dict_type(t))
+    return "dict";
+
+  if (tuple_handler_->is_tuple_type(t))
+    return "tuple";
+
+  // User-defined class instances are deliberately reported as unknown so the
+  // caller falls through to `dispatch_dunder_operator`, which honours a
+  // user-defined `__eq__`. A cross-type fold here would silently bypass it.
+  return "";
+}
+
 exprt handle_float_vs_string(exprt &bin_expr, const std::string &op)
 {
   if (op == "Eq")
@@ -377,6 +422,18 @@ exprt python_converter::get_binary_operator_expr(const nlohmann::json &element)
 
   attach_symbol_location(lhs, symbol_table());
   attach_symbol_location(rhs, symbol_table());
+
+  // Python rule: cross-type `==`/`!=` returns False/True without coercion,
+  // except within the numeric tower (bool/int/float/complex). Fold here, before
+  // the dict/list/tuple/SMT-encoding paths that otherwise crash on mismatched
+  // operands (e.g. float vs bytes, dict vs int, list vs int — issue #4628).
+  if (op == "Eq" || op == "NotEq")
+  {
+    const std::string lc = get_python_type_category(lhs.type());
+    const std::string rc = get_python_type_category(rhs.type());
+    if (!lc.empty() && !rc.empty() && lc != rc)
+      return gen_boolean(op == "NotEq");
+  }
 
   // Handle set operations (difference, intersection, union)
   typet list_type = type_handler_.get_list_type();

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -295,6 +295,18 @@ private:
 
   exprt get_binary_operator_expr(const nlohmann::json &element);
 
+  /// Coarse Python-level type category used to decide whether two operands
+  /// in an `Eq`/`NotEq` comparison are cross-type (Python's rule: different
+  /// types compare unequal without coercion, except within the numeric
+  /// tower of `bool`/`int`/`float`/`complex`).
+  ///
+  /// Returns one of `"numeric"`, `"string"`, `"bytes"`, `"list"`, `"dict"`,
+  /// `"tuple"`, or `""` when the category cannot be determined (unannotated
+  /// `any_type` void*, or a user-defined class instance whose `__eq__` must
+  /// still be dispatched). The caller MUST fall through to the existing
+  /// handling on the empty result.
+  std::string get_python_type_category(const typet &t) const;
+
   bool is_bytes_literal(const nlohmann::json &element);
 
   exprt get_binary_operator_expr_for_is(const exprt &lhs, const exprt &rhs);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2294,7 +2294,13 @@ exprt python_list::handle_index_access(
     guard.then_case() = throw_code;
     converter_.add_instruction(guard);
 
-    return index_exprt(array, idx, char_type());
+    // Tag with #cpp_type==char so downstream consumers (notably
+    // python_converter::get_python_type_category) can distinguish a 1-char
+    // string element from an arbitrary 8-bit int (e.g. dtype=np.int8) without
+    // resorting to a fragile width-only heuristic.
+    typet char_t = char_type();
+    char_t.set("#cpp_type", "char");
+    return index_exprt(array, idx, char_t);
   }
 
   // For char* (string function parameter), implement Python single-index


### PR DESCRIPTION
CPython compares mismatched types as unequal without coercion (except
within the numeric tower). ESBMC previously crashed or threw on several
mismatched pairs (float vs bytes, dict vs int, list vs int) because the
operands reached the SMT layer with incompatible representations. Fold
cross-type equality early in `get_binary_operator_expr`, before the
dict/list/tuple/SMT-encoding paths, while letting numeric coercion and
user `__eq__` dispatch keep working.

Fixes #4628