### PR TITLE
[python] support re.Match.group/groups/span

### DIFF
--- a/regression/python/github_4354/main.py
+++ b/regression/python/github_4354/main.py
@@ -1,0 +1,10 @@
+import re
+
+
+def main() -> None:
+    m = re.match(r"(\d+)", "123abc")
+    assert m is not None
+    assert m.group(1) == "123"
+
+
+main()

--- a/regression/python/github_4354/test.desc
+++ b/regression/python/github_4354/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 7 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4354_fail/main.py
+++ b/regression/python/github_4354_fail/main.py
@@ -1,0 +1,11 @@
+import re
+
+
+def main() -> None:
+    m = re.match(r"(\d+)", "123abc")
+    assert m is not None
+    # group(1) is "123", not "456" — must FAIL.
+    assert m.group(1) == "456"
+
+
+main()

--- a/regression/python/github_4354_fail/test.desc
+++ b/regression/python/github_4354_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 7 --no-unwinding-assertions
+^VERIFICATION FAILED$

--- a/regression/python/github_4354_groups/main.py
+++ b/regression/python/github_4354_groups/main.py
@@ -1,0 +1,11 @@
+import re
+
+
+def main() -> None:
+    m = re.match(r"(\d+)", "42x")
+    g = m.groups()
+    assert g[0] == "42"
+    assert m.group(0) == "42"
+
+
+main()

--- a/regression/python/github_4354_groups/test.desc
+++ b/regression/python/github_4354_groups/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4354_span/main.py
+++ b/regression/python/github_4354_span/main.py
@@ -1,0 +1,11 @@
+import re
+
+
+def main() -> None:
+    m = re.match(r"(\d+)", "42x")
+    s = m.span(0)
+    assert s[0] == 0
+    assert s[1] == 2
+
+
+main()

--- a/regression/python/github_4354_span/test.desc
+++ b/regression/python/github_4354_span/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6 --no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -361,8 +361,8 @@ def _is_paren_digit_plus(pattern: str, pattern_len: int) -> bool:
     r"""Return True iff ``pattern`` is exactly ``(\d+)``."""
     if pattern_len != 5:
         return False
-    return (pattern[0] == '(' and pattern[1] == '\\' and pattern[2] == 'd'
-            and pattern[3] == '+' and pattern[4] == ')')
+    return (pattern[0] == '(' and pattern[1] == '\\' and pattern[2] == 'd' and pattern[3] == '+'
+            and pattern[4] == ')')
 
 
 def _group(pattern: str, string: str, n: int) -> str:

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -1,6 +1,6 @@
 # pylint: disable=undefined-variable
-# `__VERIFIER_nondet_bool` is an ESBMC intrinsic matched by name by
-# the Python converter; it has no Python binding.
+# `__VERIFIER_nondet_bool`, `nondet_str`, `nondet_int` are ESBMC intrinsics
+# matched by name by the Python converter; they have no Python binding.
 #
 # pylint: disable=too-many-locals,too-many-branches,too-many-boolean-expressions,line-too-long
 # This module hosts a hand-rolled regex matcher whose control-flow shape
@@ -330,6 +330,85 @@ def search(pattern: str, string: str) -> bool:
     # For patterns with metacharacters, use nondeterministic behavior
     has_match: bool = __VERIFIER_nondet_bool()
     return has_match
+
+
+# Match-object accessors
+# ----------------------
+# CPython exposes captured groups, the tuple of groups, and span via methods
+# on a Match object returned from re.match/search/fullmatch. ESBMC's Python
+# frontend cannot soundly model an Optional[Match] return without breaking
+# truthiness assertions on every existing re* regression test, so the
+# parser rewrites ``m.group(N)`` / ``m.groups()`` / ``m.span(N)`` into
+# direct calls to the helpers below when ``m`` was bound by
+# re.match/search/fullmatch. The helpers recompute the matched substring
+# from the original (pattern, string) pair the parser captured at the
+# binding site; for patterns the recognisers below do not understand they
+# return a nondeterministic value (sound for verification).
+
+
+def _digit_prefix_len(string: str, string_len: int) -> int:
+    """Return the length of the leading digit run in ``string``."""
+    i: int = 0
+    while i < string_len:
+        c: str = string[i]
+        if c < '0' or c > '9':
+            return i
+        i = i + 1
+    return string_len
+
+
+def _is_paren_digit_plus(pattern: str, pattern_len: int) -> bool:
+    r"""Return True iff ``pattern`` is exactly ``(\d+)``."""
+    if pattern_len != 5:
+        return False
+    return (pattern[0] == '(' and pattern[1] == '\\' and pattern[2] == 'd'
+            and pattern[3] == '+' and pattern[4] == ')')
+
+
+def _group(pattern: str, string: str, n: int) -> str:
+    """Return the n-th captured group when re.match(pattern, string) succeeded.
+
+    Group 0 is the full match. For supported patterns the recognised
+    substring is returned exactly; for everything else a symbolic string
+    is returned so downstream assertions remain sound.
+    """
+    pattern_len: int = len(pattern)
+    string_len: int = len(string)
+
+    if _is_paren_digit_plus(pattern, pattern_len):
+        if n == 0 or n == 1:
+            return string[0:_digit_prefix_len(string, string_len)]
+
+    return nondet_str()
+
+
+def _groups(pattern: str, string: str) -> tuple:
+    """Return the tuple of capturing groups (group 1, group 2, ...)."""
+    pattern_len: int = len(pattern)
+    string_len: int = len(string)
+
+    if _is_paren_digit_plus(pattern, pattern_len):
+        return (string[0:_digit_prefix_len(string, string_len)], )
+
+    return (nondet_str(), )
+
+
+def _span(pattern: str, string: str, n: int) -> tuple:
+    """Return the ``(start, end)`` tuple for the n-th group.
+
+    For group 0 this is the span of the full match. For supported patterns
+    the exact bounds are returned; for everything else a symbolic pair is
+    returned so downstream assertions remain sound.
+    """
+    pattern_len: int = len(pattern)
+    string_len: int = len(string)
+    end: int = _digit_prefix_len(string, string_len)
+
+    if _is_paren_digit_plus(pattern, pattern_len):
+        if n == 0 or n == 1:
+            return (0, end)
+
+    return (nondet_int(), nondet_int())
 
 
 def fullmatch(pattern: str, string: str) -> bool:

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -2312,6 +2312,307 @@ def select_threading_model(output_dir: str, deadlock_check: bool) -> None:
         shutil.copyfile(src, dst)
 
 
+_RE_ENTRY_FUNCS = frozenset({"match", "search", "fullmatch"})
+_RE_MATCH_METHODS = frozenset({"group", "groups", "span"})
+
+
+def _is_re_match_call(node: ast.AST) -> bool:
+    """Return True iff ``node`` is ``re.match/search/fullmatch(pat, str)``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    return (isinstance(func.value, ast.Name)
+            and func.value.id == "re"
+            and func.attr in _RE_ENTRY_FUNCS
+            and len(node.args) >= 2)
+
+
+def _build_re_helper_call(
+    helper: str, pat: ast.expr, string: ast.expr, extra_args: list[ast.expr]
+) -> ast.Call:
+    """Build ``re.<helper>(pat, string, *extra_args)``."""
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="re", ctx=ast.Load()),
+            attr=helper,
+            ctx=ast.Load(),
+        ),
+        args=[copy.deepcopy(pat), copy.deepcopy(string), *extra_args],
+        keywords=[],
+    )
+
+
+_NESTED_BODY_FIELDS = frozenset({
+    "body", "orelse", "handlers", "finalbody", "cases",
+})
+
+
+def _iter_same_scope(node: ast.AST):
+    """Yield ``node`` and every descendant in the same lexical scope.
+
+    Stops at nested ``FunctionDef`` / ``AsyncFunctionDef`` / ``Lambda``
+    boundaries (variables there are local) and at compound-statement body
+    fields (``If.body``, ``For.body``, ...): those nested statement lists
+    are processed by :func:`_rewrite_re_calls_in_body` with the bindings
+    visible at their entry, so visiting them here would use stale
+    outer-scope bindings and silently rewrite an inner-scope ``m.group``
+    against the wrong ``(pat, str)`` pair.
+    """
+    yield node
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        return
+    for field, value in ast.iter_fields(node):
+        if field in _NESTED_BODY_FIELDS:
+            continue
+        if isinstance(value, ast.AST):
+            yield from _iter_same_scope(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, ast.AST):
+                    yield from _iter_same_scope(item)
+
+
+def _rewrite_re_calls_in_node(
+    node: ast.AST,
+    bindings: dict[str, tuple[ast.expr, ast.expr]],
+) -> None:
+    """In-place rewrite of ``m.group/groups/span(...)`` inside ``node``.
+
+    Walks every same-scope Call descendant; when the receiver name is in
+    ``bindings`` and the attribute is one of group/groups/span, replaces
+    the Call in place with a direct call to the corresponding re._<method>
+    helper. Nested functions/lambdas are not visited here — they are
+    enrolled separately by :func:`rewrite_re_match_attribute_calls`.
+    """
+    for child in _iter_same_scope(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in _RE_MATCH_METHODS:
+            continue
+        if not isinstance(func.value, ast.Name):
+            continue
+        binding = bindings.get(func.value.id)
+        if binding is None:
+            continue
+        pat, string = binding
+        helper = "_" + func.attr
+        # Preserve any optional integer argument (group index / span index).
+        extra = list(child.args)
+        replacement = _build_re_helper_call(helper, pat, string, extra)
+        ast.copy_location(replacement, child)
+        child.func = replacement.func
+        child.args = replacement.args
+        child.keywords = replacement.keywords
+
+
+def _nested_statement_bodies(stmt: ast.stmt) -> list[list[ast.stmt]]:
+    """Return the lists of nested statements inside ``stmt`` for recursion."""
+    bodies: list[list[ast.stmt]] = []
+    if isinstance(stmt, (ast.For, ast.AsyncFor, ast.While, ast.If)):
+        bodies.append(stmt.body)
+        bodies.append(stmt.orelse)
+    elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+        bodies.append(stmt.body)
+    elif isinstance(stmt, ast.Try):
+        bodies.append(stmt.body)
+        for handler in stmt.handlers:
+            bodies.append(handler.body)
+        bodies.append(stmt.orelse)
+        bodies.append(stmt.finalbody)
+    elif isinstance(stmt, ast.Match):
+        for case in stmt.cases:
+            bodies.append(case.body)
+    return bodies
+
+
+def _re_call_from_assignment(stmt: ast.stmt) -> ast.Call | None:
+    """Return the ``re.<entry>(...)`` Call node bound by ``stmt``, or None.
+
+    Recognises plain assignments (``m = re.match(...)``) and annotated
+    assignments with a value (``m: ... = re.search(...)``).
+    """
+    if isinstance(stmt, ast.AnnAssign):
+        value = stmt.value
+    elif isinstance(stmt, ast.Assign):
+        value = stmt.value
+    else:
+        return None
+    return value if _is_re_match_call(value) else None
+
+
+def _collect_walrus_re_bindings(
+    node: ast.AST,
+) -> list[tuple[str, ast.Call]]:
+    """Find every ``NamedExpr`` whose value is an ``re.match`` call.
+
+    Returns ``[(target_name, re_call), ...]`` for ``(m := re.match(p, s))``
+    occurrences anywhere inside ``node`` (same lexical scope only).
+    """
+    found: list[tuple[str, ast.Call]] = []
+    for child in _iter_same_scope(node):
+        if not isinstance(child, ast.NamedExpr):
+            continue
+        if not isinstance(child.target, ast.Name):
+            continue
+        if _is_re_match_call(child.value):
+            found.append((child.target.id, child.value))
+    return found
+
+
+def _names_from(target: ast.expr) -> list[str]:
+    """Return every ``Name`` id bound by ``target`` (including nested tuples)."""
+    out: list[str] = []
+    _walk_target_names(target, out)
+    return out
+
+
+def _iter_same_function_scope(node: ast.AST):
+    """Yield ``node`` and every descendant inside the same function scope.
+
+    Like :func:`_iter_same_scope` but does *not* stop at compound-statement
+    body fields, so the visitor sees every assignment in every nested
+    branch. Still stops at nested function/lambda boundaries.
+    """
+    yield node
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        return
+    for child in ast.iter_child_nodes(node):
+        yield from _iter_same_function_scope(child)
+
+
+def _collect_assigned_names_anywhere(body: list[ast.stmt]) -> set[str]:
+    """Return every ``Name`` id bound anywhere within ``body``.
+
+    Used to invalidate parent-scope bindings after recursing into a
+    nested branch (if/for/while/with/try/match): a name reassigned
+    inside the branch must not retain its pre-branch ``re.match`` cache
+    once control re-joins the outer scope.
+    """
+    names: set[str] = set()
+    for stmt in body:
+        for sub in _iter_same_function_scope(stmt):
+            if isinstance(sub, ast.Assign):
+                for tgt in sub.targets:
+                    names.update(_names_from(tgt))
+            elif isinstance(sub, ast.AnnAssign) and sub.value is not None:
+                names.update(_names_from(sub.target))
+            elif isinstance(sub, (ast.AugAssign, ast.For, ast.AsyncFor)):
+                names.update(_names_from(sub.target))
+            elif (isinstance(sub, ast.NamedExpr)
+                  and isinstance(sub.target, ast.Name)):
+                names.add(sub.target.id)
+            elif isinstance(sub, (ast.With, ast.AsyncWith)):
+                for item in sub.items:
+                    if item.optional_vars is not None:
+                        names.update(_names_from(item.optional_vars))
+            elif isinstance(sub, ast.ExceptHandler) and sub.name is not None:
+                names.add(sub.name)
+    return names
+
+
+def _walk_target_names(target: ast.expr, into: list[str]) -> None:
+    """Collect every ``Name`` id bound by ``target`` (handles nested tuples)."""
+    if isinstance(target, ast.Name):
+        into.append(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            _walk_target_names(elt, into)
+    elif isinstance(target, ast.Starred):
+        _walk_target_names(target.value, into)
+
+
+def _assigned_names_for_re_binding(stmt: ast.stmt) -> tuple[list[str], list[str]]:
+    """Return ``(top_level_names, all_names)`` bound by ``stmt``.
+
+    Only ``top_level_names`` (single-Name targets) can hold the result of
+    an ``re.match`` call directly; ``all_names`` are every Name reassigned
+    (including tuple-destructure elements) — used to invalidate stale
+    bindings on a reassignment that does not point at an ``re.match`` call.
+    """
+    top: list[str] = []
+    every: list[str] = []
+    if isinstance(stmt, ast.Assign):
+        for tgt in stmt.targets:
+            if isinstance(tgt, ast.Name):
+                top.append(tgt.id)
+            _walk_target_names(tgt, every)
+    elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+        if isinstance(stmt.target, ast.Name):
+            top.append(stmt.target.id)
+        _walk_target_names(stmt.target, every)
+    return top, every
+
+
+def _rewrite_re_calls_in_body(
+    body: list[ast.stmt],
+    parent_bindings: dict[str, tuple[ast.expr, ast.expr]],
+) -> None:
+    """Rewrite re-match attribute calls inside ``body``.
+
+    Walks statements in order, maintaining a {var: (pat, str)} map of
+    variables bound to an ``re.match/search/fullmatch(pat, str)`` call.
+    On each statement: first rewrite descendant ``m.group/groups/span``
+    calls using the bindings visible *before* the statement executes,
+    then update the bindings based on this statement's assignment, then
+    recurse into nested bodies with the updated map.
+    """
+    bindings: dict[str, tuple[ast.expr, ast.expr]] = dict(parent_bindings)
+    for stmt in body:
+        _rewrite_re_calls_in_node(stmt, bindings)
+
+        # Statement-level assignment to a Name.
+        re_call = _re_call_from_assignment(stmt)
+        top, every = _assigned_names_for_re_binding(stmt)
+        bound: set[str] = set()
+        if re_call is not None:
+            for name in top:
+                bindings[name] = (re_call.args[0], re_call.args[1])
+                bound.add(name)
+        for name in every:
+            if name not in bound:
+                bindings.pop(name, None)
+
+        # Walrus assignments (``m := re.match(...)``) anywhere in the stmt.
+        for name, call in _collect_walrus_re_bindings(stmt):
+            bindings[name] = (call.args[0], call.args[1])
+
+        # Recurse into nested branches with the (now-current) bindings, then
+        # invalidate any name reassigned inside any branch so the join below
+        # cannot retain a stale (pat, str) pair.
+        for nested_body in _nested_statement_bodies(stmt):
+            _rewrite_re_calls_in_body(nested_body, bindings)
+            for name in _collect_assigned_names_anywhere(nested_body):
+                bindings.pop(name, None)
+
+
+def rewrite_re_match_attribute_calls(tree: ast.Module) -> None:
+    """Rewrite ``m.group(N)`` / ``m.groups()`` / ``m.span(N)`` into direct
+    calls to ``re._group/_groups/_span(pat, string, ...)`` when ``m`` was
+    bound by ``re.match/search/fullmatch(pat, string)``.
+
+    CPython returns a Match-or-None object from these entry points; the
+    ESBMC Python frontend cannot soundly model that without breaking
+    existing truthiness assertions, so we keep the model boolean and
+    redirect the Match accessor methods to side-channel helpers in
+    ``models/re.py`` that recompute the result from the original
+    ``(pattern, string)`` pair.
+
+    Limitations: the rewriter tracks direct bindings only — aliasing via
+    ``m2 = m`` does not propagate the cached ``(pat, string)``, so
+    ``m2.group(...)`` is left as an unmodelled attribute call. The
+    converter's existing ``Unsupported function`` diagnostic surfaces this.
+    """
+    _rewrite_re_calls_in_body(tree.body, {})
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            _rewrite_re_calls_in_body(node.body, {})
+
+
 def main():
     check_usage()
     check_dependencies()
@@ -2380,6 +2681,8 @@ def main():
     reject_unsupported_threading_usage(tree, filename)
     validate_threading_thread_usage(tree, filename)
     lower_threading_thread_usage(tree, filename)
+
+    rewrite_re_match_attribute_calls(tree)
 
     # Generate JSON from AST for the main file.
     generate_ast_json(tree, filename, None, output_dir)


### PR DESCRIPTION
Closes #4354.

Adds parser-level rewriting of `m.group(N)` / `m.groups()` / `m.span(N)` to side-channel helpers `re._group/_groups/_span(pat, string, ...)` when `m` was bound by `re.match/search/fullmatch(pat, string)`. The match-entry functions keep returning `bool`; an Optional-Match return is blocked by frontend bugs (narrowing through `is not None`, class-instance truthiness in `if obj:`), so changing it would break every existing `re*` regression test.

The rewriter handles AnnAssign, chained `a = b = re.match(...)`, tuple destructure (invalidate-only), walrus, and joins on conditional rebinding. Helpers recognise `(\d+)` exactly and fall back to nondet for other patterns (sound, incomplete). Four new regression tests cover the issue reproducer, the failing variant, `.groups()`, and `.span()`.