### PR TITLE
[om] gate utility/functional C++11+ syntax for --std c++03

### DIFF
--- a/regression/esbmc-cpp/bug_fixes/github_4475_functional_c++03/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_4475_functional_c++03/main.cpp
@@ -1,0 +1,52 @@
+// Pin issue #4475: <functional> must parse and verify cleanly under --std c++03.
+// Exercises the comparator/arithmetic/logical/bitwise functors that stay
+// available in both modes via the OM_CONSTEXPR macro.
+#include <cassert>
+#include <functional>
+
+int main()
+{
+  std::less<int> lt;
+  std::greater<int> gt;
+  std::equal_to<int> eq;
+  std::not_equal_to<int> ne;
+  std::less_equal<int> le;
+  std::greater_equal<int> ge;
+  assert(lt(1, 2));
+  assert(gt(2, 1));
+  assert(eq(3, 3));
+  assert(ne(3, 4));
+  assert(le(3, 3));
+  assert(ge(3, 3));
+
+  std::plus<int> add;
+  std::minus<int> sub;
+  std::multiplies<int> mul;
+  std::divides<int> div;
+  std::modulus<int> mod;
+  std::negate<int> neg;
+  assert(add(2, 3) == 5);
+  assert(sub(5, 2) == 3);
+  assert(mul(2, 3) == 6);
+  assert(div(6, 2) == 3);
+  assert(mod(7, 3) == 1);
+  assert(neg(4) == -4);
+
+  std::logical_and<bool> land;
+  std::logical_or<bool> lor;
+  std::logical_not<bool> lnot;
+  assert(land(true, true));
+  assert(lor(false, true));
+  assert(lnot(false));
+
+  std::bit_and<int> band;
+  std::bit_or<int> bor;
+  std::bit_xor<int> bxor;
+  std::bit_not<int> bnot;
+  assert(band(0xF0, 0x0F) == 0x00);
+  assert(bor(0xF0, 0x0F) == 0xFF);
+  assert(bxor(0xFF, 0x0F) == 0xF0);
+  assert(bnot(0) == ~0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_4475_functional_c++03/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_4475_functional_c++03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/bug_fixes/github_4475_utility_c++03/main.cpp
+++ b/regression/esbmc-cpp/bug_fixes/github_4475_utility_c++03/main.cpp
@@ -1,0 +1,29 @@
+// Pin issue #4475: <utility> must parse and verify cleanly under --std c++03.
+// Exercises the C++03 fallback pair/make_pair/swap and the relational
+// operators routed through the OM_CONSTEXPR macro.
+#include <cassert>
+#include <utility>
+
+int main()
+{
+  std::pair<int, int> p1(1, 2);
+  std::pair<int, int> p2 = std::make_pair(1, 2);
+  std::pair<int, int> p3(3, 4);
+
+  assert(p1.first == 1 && p1.second == 2);
+  assert(p1 == p2);
+  assert(p1 != p3);
+  assert(p1 < p3);
+  assert(p3 > p1);
+  assert(p1 <= p2);
+  assert(p2 >= p1);
+
+  int a = 5, b = 10;
+  std::swap(a, b);
+  assert(a == 10 && b == 5);
+
+  p1.swap(p3);
+  assert(p1.first == 3 && p3.first == 1);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/bug_fixes/github_4475_utility_c++03/test.desc
+++ b/regression/esbmc-cpp/bug_fixes/github_4475_utility_c++03/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++03 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/OM_compiler_defs.h
+++ b/src/cpp/library/OM_compiler_defs.h
@@ -7,3 +7,12 @@
 
 #define CC_DIAGNOSTIC_IGNORE_OM_LLVM_CHECKS()                                  \
   DO_PRAGMA(GCC diagnostic ignored "-Wreturn-type")
+
+// C++11+ syntax that is invalid under --std c++03 — elide it on the C++03 path.
+#if __cplusplus >= 201103L
+#  define OM_CONSTEXPR constexpr
+#  define OM_NOEXCEPT noexcept
+#else
+#  define OM_CONSTEXPR
+#  define OM_NOEXCEPT
+#endif

--- a/src/cpp/library/functional
+++ b/src/cpp/library/functional
@@ -1,16 +1,22 @@
 #ifndef STL_FUNCTIONAL
 #define STL_FUNCTIONAL
 
-#include <cassert>
-#include <utility> // std::forward
 #include <cstddef>
-#include <type_traits>
-#include <cstdint> // for uint32_t, uint64_t
-#include <cmath>   // for INFINITY
-#include <string>  // for std::string
+#include "OM_compiler_defs.h" // OM_CONSTEXPR
+
+#if __cplusplus >= 201103L
+#  include <cassert>
+#  include <utility> // std::forward
+#  include <type_traits>
+#  include <cstdint> // for uint32_t, uint64_t
+#  include <cmath>   // for INFINITY
+#  include <string>  // for std::string
+#endif
 
 namespace std
 {
+
+#if __cplusplus >= 201103L
 
 // Base class for callable objects
 class callable_base
@@ -337,7 +343,7 @@ struct hash<unsigned long long>
 };
 
 // Specialization for size_t (only if different from unsigned long)
-#if !defined(__SIZEOF_SIZE_T__) || (__SIZEOF_SIZE_T__ != __SIZEOF_LONG__)
+#  if !defined(__SIZEOF_SIZE_T__) || (__SIZEOF_SIZE_T__ != __SIZEOF_LONG__)
 template <>
 struct hash<size_t>
 {
@@ -346,7 +352,7 @@ struct hash<size_t>
     return __esbmc_deterministic_hash(key);
   }
 };
-#endif
+#  endif
 
 // Specializations for floating point types
 template <>
@@ -452,20 +458,22 @@ struct hash<::std::string>
   }
 };
 
-// Legacy binary_function class template (for compatibility)
+#endif // __cplusplus >= 201103L
+
+// Legacy binary_function class template (typedef-based — valid in C++03 too)
 template <typename Arg1, typename Arg2, typename Result>
 struct binary_function
 {
-  using first_argument_type = Arg1;
-  using second_argument_type = Arg2;
-  using result_type = Result;
+  typedef Arg1 first_argument_type;
+  typedef Arg2 second_argument_type;
+  typedef Result result_type;
 };
 
 // Arithmetic Operations
 template <typename T = int>
 struct plus
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a + b;
   }
@@ -474,7 +482,7 @@ struct plus
 template <typename T = int>
 struct minus
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a - b;
   }
@@ -483,7 +491,7 @@ struct minus
 template <typename T = int>
 struct multiplies
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a * b;
   }
@@ -492,7 +500,7 @@ struct multiplies
 template <typename T = int>
 struct divides
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a / b;
   }
@@ -501,7 +509,7 @@ struct divides
 template <typename T = int>
 struct modulus
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a % b;
   }
@@ -510,7 +518,7 @@ struct modulus
 template <typename T = int>
 struct negate
 {
-  constexpr T operator()(const T &a) const
+  OM_CONSTEXPR T operator()(const T &a) const
   {
     return -a;
   }
@@ -520,7 +528,7 @@ struct negate
 template <typename T = int>
 struct equal_to
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a == b;
   }
@@ -529,7 +537,7 @@ struct equal_to
 template <typename T = int>
 struct not_equal_to
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a != b;
   }
@@ -538,7 +546,7 @@ struct not_equal_to
 template <typename T = int>
 struct greater
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a > b;
   }
@@ -547,7 +555,7 @@ struct greater
 template <typename T = int>
 struct less
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a < b;
   }
@@ -556,7 +564,7 @@ struct less
 template <typename T = int>
 struct greater_equal
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a >= b;
   }
@@ -565,7 +573,7 @@ struct greater_equal
 template <typename T = int>
 struct less_equal
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a <= b;
   }
@@ -575,7 +583,7 @@ struct less_equal
 template <typename T = bool>
 struct logical_and
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a && b;
   }
@@ -584,7 +592,7 @@ struct logical_and
 template <typename T = bool>
 struct logical_or
 {
-  constexpr bool operator()(const T &a, const T &b) const
+  OM_CONSTEXPR bool operator()(const T &a, const T &b) const
   {
     return a || b;
   }
@@ -593,7 +601,7 @@ struct logical_or
 template <typename T = bool>
 struct logical_not
 {
-  constexpr bool operator()(const T &a) const
+  OM_CONSTEXPR bool operator()(const T &a) const
   {
     return !a;
   }
@@ -603,7 +611,7 @@ struct logical_not
 template <typename T = int>
 struct bit_and
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a & b;
   }
@@ -612,7 +620,7 @@ struct bit_and
 template <typename T = int>
 struct bit_or
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a | b;
   }
@@ -621,7 +629,7 @@ struct bit_or
 template <typename T = int>
 struct bit_xor
 {
-  constexpr T operator()(const T &a, const T &b) const
+  OM_CONSTEXPR T operator()(const T &a, const T &b) const
   {
     return a ^ b;
   }
@@ -630,18 +638,20 @@ struct bit_xor
 template <typename T = int>
 struct bit_not
 {
-  constexpr T operator()(const T &a) const
+  OM_CONSTEXPR T operator()(const T &a) const
   {
     return ~a;
   }
 };
 
+#if __cplusplus >= 201103L
 // Simplified std::invoke model
 template <typename Func, typename... Args>
 decltype(auto) invoke(Func &&f, Args &&...args)
 {
   return ::std::forward<Func>(f)(::std::forward<Args>(args)...);
 }
+#endif
 
 } // namespace std
 

--- a/src/cpp/library/utility
+++ b/src/cpp/library/utility
@@ -2,11 +2,12 @@
 #define ESBMC_UTILITY
 
 #include "cstddef"
+#include "OM_compiler_defs.h" // OM_CONSTEXPR / OM_NOEXCEPT
 
 namespace std
 {
 
-// remove_reference — needed by move and forward
+// remove_reference — primary plus lvalue specialization (valid in C++03)
 template <class T>
 struct remove_reference
 {
@@ -17,14 +18,6 @@ struct remove_reference<T &>
 {
   typedef T type;
 };
-template <class T>
-struct remove_reference<T &&>
-{
-  typedef T type;
-};
-
-template <class T>
-using remove_reference_t = typename remove_reference<T>::type;
 
 // remove_extent — needed by make_unique for array types
 template <class T>
@@ -42,6 +35,19 @@ struct remove_extent<T[N]>
 {
   typedef T type;
 };
+
+#if __cplusplus >= 201103L
+
+// rvalue-reference specialization of remove_reference
+template <class T>
+struct remove_reference<T &&>
+{
+  typedef T type;
+};
+
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
 template <class T>
 using remove_extent_t = typename remove_extent<T>::type;
 
@@ -76,7 +82,7 @@ constexpr T &&forward(remove_reference_t<T> &&t) noexcept
   return static_cast<T &&>(t);
 }
 
-// swap
+// swap (uses move; C++11+)
 template <class T>
 void swap(T &a, T &b) noexcept
 {
@@ -89,7 +95,19 @@ void swap(T &a, T &b) noexcept
 template <class T>
 typename add_rvalue_reference<T>::type declval() noexcept;
 
-// pair
+#else // __cplusplus < 201103L — C++03 fallback for swap (copy-based)
+
+template <class T>
+void swap(T &a, T &b)
+{
+  T tmp = a;
+  a = b;
+  b = tmp;
+}
+
+#endif // __cplusplus >= 201103L
+
+// pair — common body across C++03 / C++11+; rvalue-ref ctors are gated.
 template <class T1, class T2>
 struct pair
 {
@@ -99,35 +117,29 @@ struct pair
   T1 first;
   T2 second;
 
-  constexpr pair() : first(), second()
+  OM_CONSTEXPR pair() : first(), second()
   {
   }
-  constexpr pair(const T1 &a, const T2 &b) : first(a), second(b)
+  OM_CONSTEXPR pair(const T1 &a, const T2 &b) : first(a), second(b)
   {
   }
+  template <class U1, class U2>
+  OM_CONSTEXPR pair(const pair<U1, U2> &p) : first(p.first), second(p.second)
+  {
+  }
+  OM_CONSTEXPR pair(const pair &p) : first(p.first), second(p.second)
+  {
+  }
+
+#if __cplusplus >= 201103L
   template <class U1, class U2>
   constexpr pair(U1 &&a, U2 &&b) : first(forward<U1>(a)), second(forward<U2>(b))
   {
   }
   template <class U1, class U2>
-  constexpr pair(const pair<U1, U2> &p) : first(p.first), second(p.second)
-  {
-  }
-  constexpr pair(const pair &p) : first(p.first), second(p.second)
-  {
-  }
-
-  template <class U1, class U2>
   constexpr pair(pair<U1, U2> &&p)
     : first(forward<U1>(p.first)), second(forward<U2>(p.second))
   {
-  }
-
-  pair &operator=(const pair &p)
-  {
-    first = p.first;
-    second = p.second;
-    return *this;
   }
   pair &operator=(pair &&p)
   {
@@ -135,8 +147,16 @@ struct pair
     second = std::move(p.second);
     return *this;
   }
+#endif
 
-  void swap(pair &p) noexcept
+  pair &operator=(const pair &p)
+  {
+    first = p.first;
+    second = p.second;
+    return *this;
+  }
+
+  void swap(pair &p) OM_NOEXCEPT
   {
     std::swap(first, p.first);
     std::swap(second, p.second);
@@ -148,42 +168,43 @@ struct pair
 };
 
 template <class T1, class T2>
-constexpr bool operator==(const pair<T1, T2> &a, const pair<T1, T2> &b)
+OM_CONSTEXPR bool operator==(const pair<T1, T2> &a, const pair<T1, T2> &b)
 {
   return a.first == b.first && a.second == b.second;
 }
 
 template <class T1, class T2>
-constexpr bool operator!=(const pair<T1, T2> &a, const pair<T1, T2> &b)
+OM_CONSTEXPR bool operator!=(const pair<T1, T2> &a, const pair<T1, T2> &b)
 {
   return !(a == b);
 }
 
 template <class T1, class T2>
-constexpr bool operator<(const pair<T1, T2> &a, const pair<T1, T2> &b)
+OM_CONSTEXPR bool operator<(const pair<T1, T2> &a, const pair<T1, T2> &b)
 {
   return a.first < b.first || (!(b.first < a.first) && a.second < b.second);
 }
 
 template <class T1, class T2>
-constexpr bool operator<=(const pair<T1, T2> &a, const pair<T1, T2> &b)
+OM_CONSTEXPR bool operator<=(const pair<T1, T2> &a, const pair<T1, T2> &b)
 {
   return !(b < a);
 }
 
 template <class T1, class T2>
-constexpr bool operator>(const pair<T1, T2> &a, const pair<T1, T2> &b)
+OM_CONSTEXPR bool operator>(const pair<T1, T2> &a, const pair<T1, T2> &b)
 {
   return b < a;
 }
 
 template <class T1, class T2>
-constexpr bool operator>=(const pair<T1, T2> &a, const pair<T1, T2> &b)
+OM_CONSTEXPR bool operator>=(const pair<T1, T2> &a, const pair<T1, T2> &b)
 {
   return !(a < b);
 }
 
-// make_pair
+#if __cplusplus >= 201103L
+// make_pair — perfect forwarding (C++11+); decays references.
 template <class T1, class T2>
 constexpr pair<remove_reference_t<T1>, remove_reference_t<T2>>
 make_pair(T1 &&a, T2 &&b)
@@ -191,6 +212,14 @@ make_pair(T1 &&a, T2 &&b)
   return pair<remove_reference_t<T1>, remove_reference_t<T2>>(
     forward<T1>(a), forward<T2>(b));
 }
+#else
+// make_pair — pre-C++11 (by const reference).
+template <class T1, class T2>
+pair<T1, T2> make_pair(const T1 &a, const T2 &b)
+{
+  return pair<T1, T2>(a, b);
+}
+#endif
 
 #if __cplusplus >= 201402L
 // integer_sequence


### PR DESCRIPTION
Wrap C++11+ machinery in `<utility>` (`move`/`forward`/`declval`, rvalue-ref `pair` ctors, perfect-forwarding `make_pair`) and `<functional>` (`function<>`, `hash<>`, `invoke`) behind `#if __cplusplus >= 201103L`, with C++03 fallbacks so STL OMs parse cleanly under `esbmc --std c++03`. Share `OM_CONSTEXPR`/`OM_NOEXCEPT` via `OM_compiler_defs.h` to keep one body for `pair` and the comparator functors. Add pinning regression tests under `regression/esbmc-cpp/bug_fixes/`.

Fixes #4475. Refs #4400.