### PR TITLE
[CI] add witness validation workflow and improve compare-runs script

### DIFF
--- a/.github/workflows/witness-validation.yml
+++ b/.github/workflows/witness-validation.yml
@@ -237,10 +237,13 @@ jobs:
       - name: Extract witness results
         run: unzip witness-output.zip || true
 
-      - name: Generate combined table
+      - name: Generate html table
         run: ./scripts/competitions/compare-runs.sh esbmc-output witness-output
 
       - uses: actions/upload-artifact@v7
         with:
-          name: combined-table
-          path: diff-esbmc-output-witness-output/
+          name: html-table
+          path: |
+            diff-esbmc-output-witness-output/
+            esbmc-output/
+            witness-output/

--- a/.github/workflows/witness-validation.yml
+++ b/.github/workflows/witness-validation.yml
@@ -124,25 +124,26 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Download benchexec results
-        env:
-          GH_TOKEN: ${{ github.token }}
+        uses: actions/download-artifact@v4
+        with:
+          name: esbmc-result
+          path: ${{ runner.temp }}
+          run-id: ${{ steps.parse.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract benchexec results
         run: |
-          gh run download "${{ steps.parse.outputs.run_id }}" \
-            --repo esbmc/esbmc \
-            --name esbmc-result \
-            --dir ./
-          unzip output.zip
-          mv esbmc-output $HOME/esbmc-output
+          rm -rf $HOME/esbmc-output
+          unzip -q ${{ runner.temp }}/output.zip -d $HOME
 
       - name: Download ESBMC binary (from benchexec run)
         if: ${{ inputs.esbmc_source == 'Download from benchexec run' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh run download "${{ steps.parse.outputs.run_id }}" \
-            --repo esbmc/esbmc \
-            --name 'release-ubuntu-24.04--b Release -e OFF -C' \
-            --dir ./
+        uses: actions/download-artifact@v4
+        with:
+          name: 'release-ubuntu-24.04--b Release -e OFF -C'
+          path: ./
+          run-id: ${{ steps.parse.outputs.run_id }}
+          github-token: ${{ github.token }}
 
       - name: Download ESBMC binary (rebuilt)
         if: ${{ inputs.esbmc_source == 'Rebuild' }}

--- a/.github/workflows/witness-validation.yml
+++ b/.github/workflows/witness-validation.yml
@@ -98,7 +98,7 @@ on:
 
 jobs:
   build-esbmc:
-    if: ${{ inputs.esbmc_source == 'Rebuild' }}
+    if: ${{ inputs.validator == 'ESBMC' && inputs.esbmc_source == 'Rebuild' }}
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ubuntu-24.04
@@ -112,7 +112,7 @@ jobs:
     if: ${{ always() && !cancelled() && (needs.build-esbmc.result == 'success' || needs.build-esbmc.result == 'skipped') }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: esbmc-src
 
@@ -124,21 +124,22 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Download benchexec results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: esbmc-result
-          path: ${{ runner.temp }}
+          path: ./
           run-id: ${{ steps.parse.outputs.run_id }}
           github-token: ${{ github.token }}
 
       - name: Extract benchexec results
         run: |
-          rm -rf $HOME/esbmc-output
-          unzip -q ${{ runner.temp }}/output.zip -d $HOME
+          rm -rf ./esbmc-output $HOME/esbmc-output
+          unzip -q output.zip
+          mv esbmc-output $HOME/esbmc-output
 
       - name: Download ESBMC binary (from benchexec run)
-        if: ${{ inputs.esbmc_source == 'Download from benchexec run' }}
-        uses: actions/download-artifact@v4
+        if: ${{ inputs.validator == 'ESBMC' && inputs.esbmc_source == 'Download from benchexec run' }}
+        uses: actions/download-artifact@v8
         with:
           name: 'release-ubuntu-24.04--b Release -e OFF -C'
           path: ./
@@ -146,13 +147,14 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Download ESBMC binary (rebuilt)
-        if: ${{ inputs.esbmc_source == 'Rebuild' }}
-        uses: actions/download-artifact@v4
+        if: ${{ inputs.validator == 'ESBMC' && inputs.esbmc_source == 'Rebuild' }}
+        uses: actions/download-artifact@v8
         with:
           name: 'release-ubuntu-24.04--b Release -e OFF -C'
           path: ./
 
       - name: Install ESBMC binary
+        if: ${{ inputs.validator == 'ESBMC' }}
         run: |
           mkdir -p $HOME/output-action
           cp bin/esbmc $HOME/output-action/esbmc
@@ -186,7 +188,7 @@ jobs:
       - name: Move validation output
         run: mv $HOME/witness-output.zip ./witness-output.zip
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: witness-result
           path: witness-output.zip
@@ -194,9 +196,10 @@ jobs:
   generate-table:
     runs-on: ubuntu-slim
     needs: run-validation
+    if: ${{ always() && needs.run-validation.result == 'success' }}
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -205,7 +208,7 @@ jobs:
           pip install --user benchexec
           echo "$(python -m site --user-base)/bin" >> "$GITHUB_PATH"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract run ID from URL
         id: parse
@@ -215,28 +218,29 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Download benchexec results
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh run download "${{ steps.parse.outputs.run_id }}" \
-            --repo esbmc/esbmc \
-            --name esbmc-result \
-            --dir ./
-          unzip output.zip
+        uses: actions/download-artifact@v8
+        with:
+          name: esbmc-result
+          path: ./
+          run-id: ${{ steps.parse.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract benchexec results
+        run: unzip output.zip || true
 
       - name: Download witness results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: witness-result
           path: ./
 
       - name: Extract witness results
-        run: unzip witness-output.zip
+        run: unzip witness-output.zip || true
 
       - name: Generate combined table
         run: ./scripts/competitions/compare-runs.sh esbmc-output witness-output
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: combined-table
           path: diff-esbmc-output-witness-output/

--- a/scripts/benchexec.sh
+++ b/scripts/benchexec.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 BENCHEXEC_BIN=/usr/bin/benchexec
-BENCHEXEC_COMMON_FLAGS="-o ../esbmc-output/ -N 30 ./esbmc.xml --read-only-dir / --overlay-dir /home/benchexec  -T $TIMEOUT --container"
+BENCHEXEC_COMMON_FLAGS="-o $HOME/esbmc-output/ -N 30 ./esbmc.xml --read-only-dir / --overlay-dir /home/benchexec  -T $TIMEOUT --container"
 
 # Prepare Environment to run benchexec
 setup_folder () {
@@ -37,8 +37,8 @@ benchexec_run_task () {
 }
 
 save_files () {
-    zip -r run-output.zip ../esbmc-output
-    cp run-output.zip $HOME/output.zip
+    cd $HOME
+    zip -r output.zip esbmc-output
 }
 
 setup_folder

--- a/scripts/competitions/compare-runs.sh
+++ b/scripts/competitions/compare-runs.sh
@@ -8,16 +8,31 @@ fi
 
 echo "Generating diff between runs"
 
-shopt -s failglob
+shopt -s nullglob
 
 old=$1
 new=$2
 out=diff-$1-$2
 
-res=()
-mkdir -p $out &&
-    for c in no-overflow termination unreach-call valid-memcleanup valid-memsafety; do
-	table-generator -f html -d -o $out/$c {$old,$new}/esbmc.*.results.SV-COMP26_$c.xml.bz2
-    done
+mkdir -p "$out"
+
+# Collect unique result identifiers (runset.task) from both directories,
+# regardless of tool name or date prefix.
+declare -A seen
+for f in "$old"/*.results.*.xml.bz2 "$new"/*.results.*.xml.bz2; do
+    base=$(basename "$f")
+    id="${base#*.results.}"   # strip <tool>.<date>.results.
+    id="${id%.xml.bz2}"       # strip .xml.bz2
+    seen["$id"]=1
+done
+
+if [ ${#seen[@]} -eq 0 ]; then
+    echo "No result files found in $old or $new"
+    exit 1
+fi
+
+for id in "${!seen[@]}"; do
+    files=( "$old"/*.results."$id".xml.bz2 "$new"/*.results."$id".xml.bz2 )
+    [ ${#files[@]} -gt 0 ] && table-generator -f html -d -o "$out/$id" "${files[@]}"
+done
 echo
-printf "%s\n" "${res[@]}"


### PR DESCRIPTION
Add a new GitHub Actions workflow (`witness-validation.yml`) that validates SV-COMP witnesses produced by ESBMC or CPAChecker against a given benchexec run. The workflow supports three validation modes (Full / RunSet / Task) and generates an HTML comparison table via `compare-runs.sh`.