### PR TITLE
[esbmc] reject --bitwuzla / --boolector when --ir is set

### DIFF
--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -340,6 +340,29 @@ void esbmc_parseoptionst::get_command_line_options(optionst &options)
     options.set_option("int-encoding", true);
     options.set_option("ir-ieee", true);
   }
+
+  // --ir requests integer/real arithmetic encoding via the SMT Int sort.
+  // Bitwuzla and Boolector are bit-vector-only backends; pairing them with
+  // --ir silently produces wrong-answer behaviour at solve time. cvc4, cvc5,
+  // yices, and mathsat all support Int and are left alone.
+  if (cmdline.isset("ir") || cmdline.isset("ir-ieee"))
+  {
+    for (const char *s : {"bitwuzla", "boolector"})
+    {
+      if (cmdline.isset(s))
+      {
+        log_error(
+          "--{} requires a solver that supports integer/real arithmetic. "
+          "--{} only supports bit-vector arithmetic. Re-run without --{}, "
+          "or drop --{} (--ir defaults to Z3).",
+          cmdline.isset("ir-ieee") ? "ir-ieee" : "ir",
+          s,
+          s,
+          s);
+        exit(1);
+      }
+    }
+  }
   if (cmdline.isset("fixedbv"))
     options.set_option("fixedbv", true);
   else


### PR DESCRIPTION
Refuse `--ir` with bit-vector-only solvers (`--bitwuzla`, `--boolector`) at the CLI. The combination silently produces wrong-answer behaviour because the SMT layer encodes formulas over the `Int` sort, which those backends cannot interpret. `cvc4`, `cvc5`, `yices`, and `mathsat` are left alone — they support `Int`, and existing tests under `regression/cvc/` and `regression/yices/` already use them with `--ir`.

The `python_int_typet` helper that originally rode in this PR is now part of #4656 (where it is used by the `bit_length` fix); only the solver guard remains here.
