### PR TITLE
[python] reject non-literal string args to complex() cleanly

### DIFF
--- a/regression/python/github_4658/main.py
+++ b/regression/python/github_4658/main.py
@@ -1,0 +1,6 @@
+def make(s: str):
+    return complex(s)
+
+
+c = make("1+2j")
+assert c.real == 1.0

--- a/regression/python/github_4658/test.desc
+++ b/regression/python/github_4658/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: complex\(\) does not support non-literal string arguments$

--- a/regression/python/github_4658_const/main.py
+++ b/regression/python/github_4658_const/main.py
@@ -1,0 +1,5 @@
+flag = True
+s = "1+2j" if flag else "3+4j"
+z = complex(s)
+assert z.real == 1.0
+assert z.imag == 2.0

--- a/regression/python/github_4658_const/test.desc
+++ b/regression/python/github_4658_const/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1062,11 +1062,12 @@ exprt function_call_expr::handle_complex() const
              (t.is_unsignedbv() && to_unsignedbv_type(t).get_width() == 8);
     };
     const typet &vt = value.type();
-    const bool is_textual_array = vt.is_array() && is_char_subtype(vt.subtype());
+    const bool is_textual_array =
+      vt.is_array() && is_char_subtype(vt.subtype());
     const bool is_textual_pointer =
       vt.is_pointer() && is_char_subtype(vt.subtype());
-    const bool is_bare_char = is_char_subtype(vt) && !vt.is_array() &&
-                              !vt.is_pointer();
+    const bool is_bare_char =
+      is_char_subtype(vt) && !vt.is_array() && !vt.is_pointer();
 
     if (vt.is_array() && !is_textual_array)
       return raise_type_error(

--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -1049,19 +1049,32 @@ exprt function_call_expr::handle_complex() const
     if (is_unsigned_byte_array(value.type()))
       return raise_type_error(
         "complex() first argument must be a string or a number, not 'bytes'");
-    if (value.type().is_array())
-    {
-      const typet &elem_type = value.type().subtype();
-      const bool is_textual_char_array =
-        elem_type == char_type() ||
-        (elem_type.is_signedbv() &&
-         to_signedbv_type(elem_type).get_width() == 8) ||
-        (elem_type.is_unsignedbv() &&
-         to_unsignedbv_type(elem_type).get_width() == 8);
-      if (!is_textual_char_array)
-        return raise_type_error(
-          "complex() first argument must be a string or a number, not 'bytes'");
-    }
+    // Detect textual string operands (array of char / pointer to char / a
+    // bare char) whose compile-time value could not be extracted above. The
+    // existing constant-folding paths handle literals and constant-folded
+    // conditionals; anything else (function parameters, return values from
+    // calls, etc.) reaches here with a string-typed value but no constant
+    // contents. Typecasting such a value to double generates an ill-typed
+    // SMT expression that aborts the encoder, so reject it explicitly.
+    auto is_char_subtype = [](const typet &t) {
+      return t == char_type() ||
+             (t.is_signedbv() && to_signedbv_type(t).get_width() == 8) ||
+             (t.is_unsignedbv() && to_unsignedbv_type(t).get_width() == 8);
+    };
+    const typet &vt = value.type();
+    const bool is_textual_array = vt.is_array() && is_char_subtype(vt.subtype());
+    const bool is_textual_pointer =
+      vt.is_pointer() && is_char_subtype(vt.subtype());
+    const bool is_bare_char = is_char_subtype(vt) && !vt.is_array() &&
+                              !vt.is_pointer();
+
+    if (vt.is_array() && !is_textual_array)
+      return raise_type_error(
+        "complex() first argument must be a string or a number, not 'bytes'");
+
+    if (is_textual_array || is_textual_pointer || is_bare_char)
+      throw std::runtime_error(
+        "complex() does not support non-literal string arguments");
 
     if (is_complex_type(value.type()))
       return value;


### PR DESCRIPTION
complex(s) where s is a function parameter (or any runtime str value)
crashed ESBMC with an SMT-encoder assertion in get_significand_width
because handle_complex() typecast a char-array/char-pointer to double
and handed the ill-typed expression to bitwuzla. Detect textual string
operands reaching the post-extraction fallback and abort the conversion
with a clear "complex() does not support non-literal string arguments"
error, matching the existing throw-runtime_error idiom used elsewhere
in the Python frontend.

Fixes #4658