### PR TITLE
[python] materialise __file__ as a module-level string built-in

### DIFF
--- a/regression/python/github_4662/main.py
+++ b/regression/python/github_4662/main.py
@@ -1,0 +1,1 @@
+assert __file__ is not None

--- a/regression/python/github_4662/test.desc
+++ b/regression/python/github_4662/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4662_fail/main.py
+++ b/regression/python/github_4662_fail/main.py
@@ -1,0 +1,1 @@
+assert __file__ is None

--- a/regression/python/github_4662_fail/test.desc
+++ b/regression/python/github_4662_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -148,28 +148,59 @@ void python_converter::load_c_intrisics(code_blockt &)
   add_global_static_variable(symbol_table_, type2, "__ESBMC_alloc_size");
 }
 
-///  Only addresses __name__; other Python built-ins such as
-/// __file__, __doc__, __package__ are unsupported
+///  Creates ``__name__`` and ``__file__``; ``__doc__`` / ``__package__``
+///  remain unsupported.
 void python_converter::create_builtin_symbols()
 {
-  // Create __name__ symbol
-  symbol_id name_sid(current_python_file, "", "");
-  name_sid.set_object("__name__");
+  const std::string module_name =
+    current_python_file.substr(0, current_python_file.find_last_of("."));
 
   locationt location;
   location.set_file(current_python_file.c_str());
   location.set_line(1);
 
-  std::string module_name =
-    current_python_file.substr(0, current_python_file.find_last_of("."));
+  auto add_string_builtin =
+    [&](const std::string &builtin_name, const std::string &value) {
+      symbol_id sid(current_python_file, "", "");
+      sid.set_object(builtin_name);
 
-  // Determine the value of __name__ based on whether this is the main module or imported
+      typet string_type =
+        type_handler_.build_array(char_type(), value.size() + 1);
+
+      symbolt sym = create_symbol(
+        module_name, builtin_name, sid.to_string(), location, string_type);
+
+      sym.lvalue = true;
+      sym.static_lifetime = true;
+      sym.is_extern = false;
+      sym.file_local = false;
+
+      exprt value_expr = gen_zero(string_type);
+      const typet &char_type_ref = string_type.subtype();
+      for (size_t i = 0; i < value.size(); ++i)
+      {
+        uint8_t ch = value[i];
+        value_expr.operands().at(i) = constant_exprt(
+          integer2binary(BigInt(ch), bv_width(char_type_ref)),
+          integer2string(BigInt(ch)),
+          char_type_ref);
+      }
+      value_expr.operands().at(value.size()) = constant_exprt(
+        integer2binary(BigInt(0), bv_width(char_type_ref)),
+        integer2string(BigInt(0)),
+        char_type_ref);
+      sym.value = value_expr;
+
+      symbol_table_.add(sym);
+    };
+
+  // Determine the value of __name__: "__main__" for the main module, else the
+  // module's basename without extension.
   std::string name_value;
   if (current_python_file == main_python_file)
     name_value = "__main__";
   else
   {
-    // Extract module name from filename (e.g., "/path/to/other.py" -> "other")
     size_t last_slash = current_python_file.find_last_of("/\\");
     size_t last_dot = current_python_file.find_last_of(".");
     if (
@@ -185,43 +216,11 @@ void python_converter::create_builtin_symbols()
       name_value = current_python_file;
   }
 
-  typet string_type =
-    type_handler_.build_array(char_type(), name_value.size() + 1);
+  add_string_builtin("__name__", name_value);
 
-  // Create the symbol
-  symbolt name_symbol = create_symbol(
-    module_name, "__name__", name_sid.to_string(), location, string_type);
-
-  name_symbol.lvalue = true;
-  name_symbol.static_lifetime = true;
-  name_symbol.is_extern = false;
-  name_symbol.file_local = false;
-
-  // Set the value
-  exprt name_expr = gen_zero(string_type);
-  const typet &char_type_ref = string_type.subtype();
-
-  for (size_t i = 0; i < name_value.size(); ++i)
-  {
-    uint8_t ch = name_value[i];
-    exprt char_value = constant_exprt(
-      integer2binary(BigInt(ch), bv_width(char_type_ref)),
-      integer2string(BigInt(ch)),
-      char_type_ref);
-    name_expr.operands().at(i) = char_value;
-  }
-
-  // Add null terminator
-  exprt null_char = constant_exprt(
-    integer2binary(BigInt(0), bv_width(char_type_ref)),
-    integer2string(BigInt(0)),
-    char_type_ref);
-  name_expr.operands().at(name_value.size()) = null_char;
-
-  name_symbol.value = name_expr;
-
-  // Add to symbol table
-  symbol_table_.add(name_symbol);
+  // __file__ mirrors CPython: the (absolute) path of the source file. We use
+  // the canonical path the frontend already tracks via current_python_file.
+  add_string_builtin("__file__", current_python_file);
 }
 
 bool python_converter::import_module_into_block(


### PR DESCRIPTION
[python] materialise __file__ as a module-level string built-in

CPython sets __file__ on every module to the absolute path of the
source file. ESBMC's Python frontend previously only created
__name__ and rejected reads of __file__ with
"Variable '__file__' is not defined". Extend
create_builtin_symbols() to add __file__ alongside __name__,
reusing the existing current_python_file tracking. The bytewise
string-symbol construction is factored into an
add_string_builtin lambda so adding the remaining built-ins later
(__doc__, __package__) is mechanical.

Fixes #4662
