### PR TITLE
[docs] Python limitations: random/collections/re round-2 audit findings

### DIFF
--- a/src/python-frontend/README.md
+++ b/src/python-frontend/README.md
@@ -424,9 +424,7 @@ The current version of ESBMC-Python has the following limitations:
   - Parameter types are assumed to be double for simplicity
 - F-String Limitations:
   - Complex expressions within f-strings may have limited support
-  - Advanced format specifications beyond basic integer `(:d, :i)` and float `(:.Nf)` formatting may not be fully supported
   - Nested f-strings are not supported
-  - String alignment and padding format specifications (e.g., `:>10`, `:<5`) are not supported
   - Custom format specifications for user-defined types are not supported
 - Missing Return Statement Detection Limitations:
   - Does not analyze return statements inside lambda expressions within the main function body.
@@ -450,12 +448,7 @@ The current version of ESBMC-Python has the following limitations:
   - Other types (`objects`, `arrays`, `null`) are not supported as return values for Any-typed functions.
   - Type inference defaults to `double (float)` when no specific type can be determined from return statements.
 - Tuple Limitations:
-  - Tuple indexing requires constant indices; variable indices are not supported (e.g., `t[i]` where `i` is a variable will fail).
-  - Tuple iteration (e.g., `for item in my_tuple:`) is not yet supported.
-  - Tuple methods such as `.count()` and `.index()` are not yet supported.
-  - Tuple concatenation with `+` operator is not yet supported.
-  - Tuple repetition with `*` operator is not yet supported.
-  - Tuple slicing is not yet supported.
+  - Tuple repetition with `*` operator is not yet supported (currently aborts the frontend).
 
 ### Example 1: Division by Zero in Python
 

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -7,19 +7,18 @@ weight: 4
 
 ## Control Flow and Loops
 
-- `for` loops support direct iteration over `range()`, lists, strings, and generators (functions using `yield` and generator expressions). Iteration over tuples is not yet supported.
-- List comprehensions and generator expressions are supported. Set comprehensions are not supported (`Unsupported expression SetComp`). Dictionary comprehensions are accepted by the parser but produce a dictionary whose subsequent key lookups raise `KeyError`.
+- `for` loops support direct iteration over `range()`, lists, strings, tuples, and generators (functions using `yield` and generator expressions).
+- List, set, and generator comprehensions are supported. Dictionary comprehensions are accepted by the parser but produce a dictionary whose subsequent key lookups raise `KeyError`.
 - Iteration over dictionaries via `d.keys()`, `d.values()`, and `d.items()` is supported inside `for` loops (see [Supported Features — Dictionaries](./supported-features#dictionaries)).
 
 ## Lists
 
-- `list.sort()` does not support the `key` or `reverse` keyword arguments.
-- `sorted()` does not support the `key` or `reverse` keyword arguments.
+- `list.sort()` does not support the `key` keyword argument; `reverse` is supported.
+- `sorted()` does not support the `key` keyword argument; `reverse` is supported.
 
 ## Sets
 
-- Set methods `.add()`, `.discard()`, `.update()`, `.issubset()`, `.issuperset()`, and `.symmetric_difference()` are not supported; use binary operators (`-`, `&`, `|`) instead. (`.remove()` happens to work because sets share the underlying list model.)
-- `frozenset` is not supported.
+- Set methods `.issubset()`, `.issuperset()`, and `.symmetric_difference()` are not supported; use the equivalent binary operators (`<=`, `>=`, `^`) instead.
 
 ## Dictionaries
 
@@ -27,23 +26,19 @@ weight: 4
 
 ## Tuples
 
-- Tuple indexing requires constant indices; variable indices (e.g., `t[i]` where `i` is a variable) are not supported.
-- Tuple iteration (`for item in my_tuple:`) is not yet supported.
-- Tuple methods `.count()` and `.index()` are not yet supported.
-- Tuple concatenation (`+`) and repetition (`*`) are not yet supported.
-- Tuple slicing is not yet supported.
+- Tuple repetition (`*`) is not yet supported and currently aborts the frontend.
 
 ## Complex Numbers
 
-- The `complex()` constructor accepts string arguments only when the string is a compile-time constant (e.g., `complex("1+2j")` is folded by the frontend). Constructing from a runtime string fails with "Unhandled symbol format in string extraction".
+- The `complex()` constructor accepts string arguments only when the string is a compile-time constant (e.g., `complex("1+2j")` is folded by the frontend). Constructing from a runtime string is rejected with the error `complex() does not support non-literal string arguments`.
 - `cmath.polar()` and `cmath.rect()` rely on the `atan2` model; results may differ from CPython in edge cases involving signed zeros and NaN.
 
 ## Built-in Functions
 
-- `min()` and `max()` support two-argument form and single-list form only; the `key` and `default` keyword arguments are not supported.
+- `min()` and `max()` support two-argument form and single-list form only; the `key` keyword argument is not supported (`default` is supported).
 - `any()` and `all()` currently support only list literals as arguments. `any()` rejects other iterables with a parse-time error; `all()` may trigger a dereference failure on non-list iterables.
-- `sum()` supports `int` and `float` element types only; the optional `start` argument is not supported.
-- `sorted()` supports `int`, `float`, and `str` element types only; `key` and `reverse` keyword arguments are not supported.
+- `sum()` supports `int` and `float` element types only.
+- `sorted()` supports `int`, `float`, and `str` element types only; the `key` keyword argument is not supported (`reverse` is supported).
 - `input()` is modelled as a nondeterministic string with a maximum length of 256 characters (under-approximation).
 - `print()` evaluates all arguments for side effects but does not produce actual output during verification.
 - `enumerate()` supports standard usage patterns but may have limitations with complex nested iterables or advanced parameter combinations.
@@ -56,7 +51,6 @@ weight: 4
 ## F-Strings
 
 - Complex expressions inside f-strings may have limited support.
-- Only basic integer (`:d`, `:i`) and float (`:.Nf`) format specs are supported; advanced format specs (e.g., string alignment `:>10`, `:<5`) are not.
 - Custom format specifications for user-defined types are not supported.
 
 ## Union and Any Types

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -64,19 +64,20 @@ weight: 4
 ## Regular Expressions (`re` module)
 
 - Only `re.match()`, `re.search()`, and `re.fullmatch()` are supported.
-- Match objects do not expose group-capture methods (`.group()`, `.groups()`, `.span()`).
+- Group-capture methods (`.group()`, `.groups()`, `.span()`) are rewritten by the parser into direct calls to internal helpers, and only the `(\d+)` pattern is recognised precisely; everything else returns a nondeterministic value.
+- The result of `re.match` / `re.search` / `re.fullmatch` is a `bool`, not an `Optional[Match]`. `if m:` works; `if m is None:` does not. The pattern recognisers also enforce full-string match for the supported patterns, so `re.match` does not match a prefix of a longer string (tracked in [#4664](https://github.com/esbmc/esbmc/issues/4664)).
 - Complex patterns beyond the explicitly supported constructs exhibit nondeterministic behavior.
 - Not supported: lookahead/lookbehind assertions, backreferences, named groups, conditional patterns, Unicode property escapes.
 
 ## Random Module
 
-- `random.choice()`, `random.shuffle()`, `random.sample()`, `random.seed()`, and other functions beyond `random()`, `uniform()`, `randint()`, `getrandbits()`, and `randrange()` are not yet supported.
+- Functions beyond `random()`, `uniform()`, `randint()`, `getrandbits()`, `randrange()`, `choice()`, `shuffle()`, `sample()`, and `seed()` are not yet supported.
 
 ## Collections Module
 
-- `defaultdict`: Only basic subscript access/assignment is supported. The `__missing__` hook, type-factory calls (e.g., `defaultdict(list)`), and methods beyond `__getitem__`/`__setitem__` are not supported.
-- `Counter`: Only `__getitem__`, `__setitem__`, `values()`, and truthiness are supported. `most_common()`, `elements()`, `subtract()`, `update()`, and arithmetic operators on `Counter` are not supported.
-- `OrderedDict`, `deque`, `namedtuple`, `ChainMap`, and other `collections` types are not supported.
+- `defaultdict`: subscript access/assignment and the common type-factory form (`defaultdict(list)`, with `.append()` on the materialised list) are supported. The `__missing__` hook and other methods are not.
+- `Counter`: only `__getitem__`, `__setitem__`, `values()`, and truthiness are supported. `most_common()` accepts the call but its result is unusable in any subsequent expression (frontend error on comparison); `elements()`, `subtract()`, `update()`, and arithmetic operators are not supported.
+- `OrderedDict` and `deque` support construction and basic indexing / append / `__setitem__`. `namedtuple`, `ChainMap`, and other `collections` types are not supported.
 
 ## Datetime Module
 
@@ -138,4 +139,4 @@ weight: 4
 
 ## Module System
 
-- Built-in variable support is limited to `__name__`; `__file__`, `__doc__`, `__package__`, and other built-ins are not yet supported.
+- Built-in variable support is limited to `__name__` and `__file__`; `__doc__`, `__package__`, and other built-ins are not yet supported.


### PR DESCRIPTION

Round-2 probing surfaced more obsolete or under-scoped entries:

- random: choice/shuffle/sample/seed all work (verified with assertions).
- collections: defaultdict(list) with .append() works; OrderedDict and
  deque support construction + basic indexing; Counter.most_common
  accepts the call but its result triggers an "Unsupported comparison"
  error downstream (now tracked in #4665).
- re: parser rewrites .group()/.groups()/.span() into internal helpers,
  so they do work — only the (\d+) pattern is recognised precisely.
  Documented that the bool return prevents the `is None` idiom and that
  the recognisers enforce full-string match (tracked in #4664).
- Module System: __file__ now supported (added in #4663).