### PR TITLE
[python] honour enumerate(iter, start=N) keyword argument

### DIFF
--- a/regression/python/github_4672/main.py
+++ b/regression/python/github_4672/main.py
@@ -1,0 +1,4 @@
+total = 0
+for i, c in enumerate("abc", start=1):
+    total += i
+assert total == 6

--- a/regression/python/github_4672/test.desc
+++ b/regression/python/github_4672/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4672_fail/main.py
+++ b/regression/python/github_4672_fail/main.py
@@ -1,0 +1,4 @@
+total = 0
+for i, c in enumerate("abc", start=1):
+    total += i
+assert total == 3

--- a/regression/python/github_4672_fail/test.desc
+++ b/regression/python/github_4672_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -586,6 +586,16 @@ class LoopMixin:
         if len(enumerate_call.args) > 2:
             raise TypeError(
                 f"enumerate() takes at most 2 arguments ({len(enumerate_call.args)} given)")
+        for kw in getattr(enumerate_call, "keywords", []) or []:
+            if kw.arg is None:
+                raise TypeError("enumerate() does not accept **kwargs")
+            if kw.arg != "start":
+                raise TypeError(
+                    f"enumerate() got an unexpected keyword argument '{kw.arg}'")
+        if (len(enumerate_call.args) == 2
+                and any(kw.arg == "start" for kw in (enumerate_call.keywords or []))):
+            raise TypeError(
+                "enumerate() got multiple values for argument 'start'")
 
     def _parse_enumerate_target(self, target):
         """Parse and validate the for loop target, return target information."""
@@ -615,11 +625,19 @@ class LoopMixin:
         """Extract and validate iterable and start value from enumerate call."""
         iterable = enumerate_call.args[0]
 
+        start_value = None
         if len(enumerate_call.args) > 1:
             start_value = enumerate_call.args[1]
-            self._validate_start_value(start_value)
         else:
+            for kw in (enumerate_call.keywords or []):
+                if kw.arg == "start":
+                    start_value = kw.value
+                    break
+
+        if start_value is None:
             start_value = self.create_constant_node(0, node)
+        else:
+            self._validate_start_value(start_value)
 
         return iterable, start_value
 

--- a/src/python-frontend/preprocessor/loop_mixin.py
+++ b/src/python-frontend/preprocessor/loop_mixin.py
@@ -590,12 +590,10 @@ class LoopMixin:
             if kw.arg is None:
                 raise TypeError("enumerate() does not accept **kwargs")
             if kw.arg != "start":
-                raise TypeError(
-                    f"enumerate() got an unexpected keyword argument '{kw.arg}'")
+                raise TypeError(f"enumerate() got an unexpected keyword argument '{kw.arg}'")
         if (len(enumerate_call.args) == 2
                 and any(kw.arg == "start" for kw in (enumerate_call.keywords or []))):
-            raise TypeError(
-                "enumerate() got multiple values for argument 'start'")
+            raise TypeError("enumerate() got multiple values for argument 'start'")
 
     def _parse_enumerate_target(self, target):
         """Parse and validate the for loop target, return target information."""


### PR DESCRIPTION
[python] honour the enumerate(iter, start=N) keyword argument

The preprocessor's enumerate-transform inspected only enumerate_call.args
and silently dropped the start kwarg, so enumerate(s, start=1) produced
indices beginning at 0 instead of 1. Look for a start= keyword when no
second positional argument is provided, reject unknown kwargs and
positional/kwarg conflicts with the CPython error messages, and run the
existing _validate_start_value check on the resolved value.

Fixes #4672
