### PR TITLE
[python] register cmath as an imported model

### DIFF
--- a/regression/python/github_4671/main.py
+++ b/regression/python/github_4671/main.py
@@ -1,0 +1,7 @@
+import cmath
+
+r, phi = cmath.polar(complex(0.0, 0.0))
+assert r == 0.0
+
+z = cmath.rect(1.0, 0.0)
+assert z.real == 1.0

--- a/regression/python/github_4671/test.desc
+++ b/regression/python/github_4671/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4671_fail/main.py
+++ b/regression/python/github_4671_fail/main.py
@@ -1,0 +1,4 @@
+import cmath
+
+z = cmath.rect(2.0, 0.0)
+assert z.real == 999.0

--- a/regression/python/github_4671_fail/test.desc
+++ b/regression/python/github_4671_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/parser.py
+++ b/src/python-frontend/parser.py
@@ -119,6 +119,7 @@ def check_usage():
 def is_imported_model(module_name):
     models = [
         "math",
+        "cmath",
         "os",
         "numpy",
         "esbmc",


### PR DESCRIPTION
[python] register cmath as an imported model

The parser's is_imported_model() list omitted "cmath", so
`import cmath` fell through to importlib's real cmath module
rather than loading models/cmath.py. Downstream attribute lookups
on the (unmodelled) cmath symbol then reported the puzzling
`Object "math" not found.` even though the user imported cmath
and the cmath model file already exists with polar()/rect() and
the full trig surface. Add "cmath" to is_imported_model so the
existing model is picked up.

Fixes #4671
