### PR TITLE
[docs] Python limitations: round-3 audit findings

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -26,7 +26,7 @@ weight: 4
 
 ## Tuples
 
-- Tuple repetition (`*`) is not yet supported and currently aborts the frontend.
+- Tuple repetition (`*`) is not yet supported and currently aborts the frontend ([#4661](https://github.com/esbmc/esbmc/issues/4661)).
 
 ## Complex Numbers
 
@@ -40,8 +40,8 @@ weight: 4
 - `sum()` supports `int` and `float` element types only.
 - `sorted()` supports `int`, `float`, and `str` element types only; the `key` keyword argument is not supported (`reverse` is supported).
 - `input()` is modelled as a nondeterministic string with a maximum length of 256 characters (under-approximation).
-- `print()` evaluates all arguments for side effects but does not produce actual output during verification.
-- `enumerate()` supports standard usage patterns but may have limitations with complex nested iterables or advanced parameter combinations.
+- `print()` evaluates each argument expression once (so safety checks and call side effects reach the GOTO program) but produces no actual output during verification.
+- `enumerate()` supports the iterable + `start` keyword forms; nested or unusually-shaped iterables are not exercised by the regression suite and may surface edge cases.
 
 ## Lambda Expressions
 
@@ -76,7 +76,8 @@ weight: 4
 ## Collections Module
 
 - `defaultdict`: subscript access/assignment and the common type-factory form (`defaultdict(list)`, with `.append()` on the materialised list) are supported. The `__missing__` hook and other methods are not.
-- `Counter`: only `__getitem__`, `__setitem__`, `values()`, and truthiness are supported. `most_common()` accepts the call but its result is unusable in any subsequent expression (frontend error on comparison); `elements()`, `subtract()`, `update()`, and arithmetic operators are not supported.
+- `Counter`: only `__getitem__`, `__setitem__`, `values()`, and truthiness are supported. `most_common()` accepts the call but its result is unusable in any subsequent expression — comparisons trip a frontend "Unsupported comparison" error ([#4665](https://github.com/esbmc/esbmc/issues/4665)). `elements()`, `subtract()`, and arithmetic operators are not supported.
+- `Counter.update(...)` / `dict.update(...)` accept only the single-positional-argument form; the keyword-argument form (`c.update(a=1)`) is rejected at parse time even though it is valid CPython.
 - `OrderedDict` and `deque` support construction and basic indexing / append / `__setitem__`. `namedtuple`, `ChainMap`, and other `collections` types are not supported.
 
 ## Datetime Module
@@ -101,7 +102,8 @@ weight: 4
 
 ## NumPy Module
 
-- Arrays are modelled as plain Python lists; array shapes, dtypes, multi-dimensional indexing (`a[i, j]`), and broadcasting are not supported.
+- Arrays are modelled as plain Python lists; array shapes, dtypes, multi-dimensional indexing (`a[i, j]`), and broadcasting are not supported. Reading `.shape` reports the misleading frontend error `Class "" not found`, and using the result of `a[i, j]` triggers `Unexpected type in int/ptr typecast` — these surface as opaque frontend errors rather than clean `Unsupported …` rejections ([#4666](https://github.com/esbmc/esbmc/issues/4666)).
+- Adding a scalar to a 1D array (`a + n`) currently aborts the SMT encoder with a sort-width assertion in `mk_store` ([#4668](https://github.com/esbmc/esbmc/issues/4668)).
 - Most NumPy functions beyond those listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) are not available.
 - Several math stub functions (e.g., `np.sin`, `np.sqrt`) return constant placeholder values rather than computing the real result; these are suitable only for type-inference testing, not numerical verification.
 - `numpy.linalg.det` is a 2-scalar stub; general matrix operations are not supported.
@@ -109,6 +111,7 @@ weight: 4
 ## Exception Handling
 
 - Core built-in exception types are supported, but not all Python standard library exceptions; custom exception hierarchies with complex inheritance patterns may not be fully handled.
+- A user-defined exception subclass caught by its parent class (e.g. `class B(A): pass; raise B(); except A:`) currently aborts conversion with `_init_undefined` / `migrate expr failed` rather than matching the parent ([#4670](https://github.com/esbmc/esbmc/issues/4670)).
 
 ## Class Attributes
 


### PR DESCRIPTION
[docs] Python limitations: round-3 audit findings

Add tracker links and new audit findings:

- Tuple `*` abort linked to #4661.
- `print()` claim sharpened to match the actual implementation: each
  argument is evaluated once for its side effects.
- enumerate(start=N) confirmed supported (the previous "advanced
  parameter combinations" caveat was misleading once #4673 landed).
- Counter.most_common() limitation tied to #4665.
- Counter.update/dict.update kwargs form now documented as rejected.
- Numpy `.shape`, 2D indexing, and `a + n` broadcasting failure modes
  documented with #4666 / #4668 trackers (broadcasting actually
  aborts the SMT encoder; not just "unsupported").
- Exception parent-class catch abort documented with #4670 tracker.

(Doc updates for the still-open #4675 print fix and #4676 cmath fix
will follow once those PRs land.)
