### PR TITLE
[python] handle raise of class without __init__

### DIFF
--- a/regression/python/github_4670/main.py
+++ b/regression/python/github_4670/main.py
@@ -1,0 +1,15 @@
+class A(Exception):
+    pass
+
+
+class B(A):
+    pass
+
+
+caught = False
+try:
+    raise B()
+except A:
+    caught = True
+
+assert caught

--- a/regression/python/github_4670/test.desc
+++ b/regression/python/github_4670/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4670_direct/main.py
+++ b/regression/python/github_4670_direct/main.py
@@ -1,0 +1,15 @@
+class A(Exception):
+    pass
+
+
+class B(A):
+    pass
+
+
+caught = False
+try:
+    raise B()
+except B:
+    caught = True
+
+assert caught

--- a/regression/python/github_4670_direct/test.desc
+++ b/regression/python/github_4670_direct/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -164,7 +164,31 @@ void python_exception_handler::get_raise_statement(
     // FUNCTION_CALL:  MyException(&return_value, &"message");
     // Throw MyException return_value;
     raise = converter_.get_expr(element["exc"]);
-    if (raise.is_code() && raise.get("statement") == "function_call")
+
+    // get_function_call() returns the `_init_undefined` sentinel when the
+    // raised class (and its bases) define no __init__. Constructors emit
+    // this so var-assign can lower `x = MyClass()` to a bare declaration;
+    // the raise path has no such shortcut, so synthesize a zero-initialised
+    // instance of the class instead. Without this, the sentinel propagates
+    // into the cpp-throw operand and migrate aborts with "_init_undefined
+    // ... migrate expr failed". Covers user exception hierarchies whose
+    // subclasses inherit __init__ from `Exception`.
+    if (raise.id() == "_init_undefined")
+    {
+      if (type.is_empty())
+        type = any_type();
+      // type_handler_.get_typet returns a symbol_typet referring to the
+      // class's tag; gen_zero has no symbol-id branch and would yield a nil
+      // expression, which propagates into the cpp-throw operand and makes
+      // symex treat the throw as a bare re-throw. Resolve the symbol to the
+      // underlying struct before zero-initialising.
+      typet resolved = type;
+      if (resolved.id() == "symbol")
+        resolved = converter_.name_space().follow(type);
+      raise = gen_zero(resolved);
+      raise.type() = type;
+    }
+    else if (raise.is_code() && raise.get("statement") == "function_call")
     {
       code_function_callt call =
         to_code_function_call(converter_.convert_expression_to_code(raise));


### PR DESCRIPTION
[python] handle raise of class without __init__

When a user-defined exception class (or any subclass of it) has no
explicit __init__, function_call_expr returns the `_init_undefined`
sentinel so var-assign can lower `x = MyClass()` to a bare declaration.
The raise path had no equivalent shortcut: the sentinel propagated into
the cpp-throw operand and migrate aborted the conversion with
`ERROR: _init_undefined ... migrate expr failed`.

Detect the sentinel in get_raise_statement and synthesise a
zero-initialised instance of the exception class for the throw. The
type returned by type_handler.get_typet is a symbol referring to the
class tag; resolve it through the namespace before gen_zero so we get
an actual struct value rather than a nil expression.

Fixes #4670
