### PR TITLE
[python] cleaner errors for numpy .shape and a[i,j] 2D indexing

### DIFF
--- a/regression/python/github_4666_2d/main.py
+++ b/regression/python/github_4666_2d/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+a = np.array([[1, 2], [3, 4]])
+x = a[0, 1]

--- a/regression/python/github_4666_2d/test.desc
+++ b/regression/python/github_4666_2d/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: TypeError: multi-dimensional indexing

--- a/regression/python/github_4666_shape/main.py
+++ b/regression/python/github_4666_shape/main.py
@@ -1,0 +1,3 @@
+import numpy as np
+a = np.array([1, 2, 3])
+s = a.shape

--- a/regression/python/github_4666_shape/test.desc
+++ b/regression/python/github_4666_shape/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: AttributeError: 'a' has no attribute 'shape'

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -74,6 +74,8 @@ ignored_dirs=(
   "github_4548_floordiv_call_arg"
   "github_4548_floordiv_negative"
   "github_4581"
+  "github_4666_2d"
+  "github_4666_shape"
   "global"
   "infer-func-no-return_fail"
   "integer_squareroot_fail"

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -751,7 +751,27 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       }
       if (!class_symbol)
       {
-        throw std::runtime_error("Class \"" + obj_type_name + "\" not found");
+        // Surface a Python-level AttributeError naming the attribute and the
+        // location of the access. The previous "Class '' not found" message
+        // leaked an internal lookup vocabulary and was emitted whenever an
+        // attribute was read on a value whose symbol type is not a class
+        // struct -- e.g. ``a.shape`` on a numpy array (which the frontend
+        // models as a plain list), or any other non-class object.
+        const std::string base_name = element.contains("value") &&
+                                          element["value"].contains("id")
+                                        ? element["value"]["id"].get<std::string>()
+                                        : std::string();
+        std::ostringstream msg;
+        msg << "AttributeError: '";
+        if (!base_name.empty())
+          msg << base_name;
+        else
+          msg << "object";
+        msg << "' has no attribute '" << attr_name << "'";
+        const locationt loc = get_location_from_decl(element);
+        if (!loc.is_nil())
+          msg << " at " << loc.get_file() << ":" << loc.get_line();
+        throw std::runtime_error(msg.str());
       }
 
       struct_typet &class_type =
@@ -988,6 +1008,23 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         build_dunder_call(element["value"], "__getitem__", args, element);
       expr = get_function_call(call_node);
       break;
+    }
+
+    // Multi-dimensional indexing ``a[i, j]`` -- the slice AST is a Tuple of
+    // index expressions. This is the canonical numpy 2D-indexing form. The
+    // frontend models numpy arrays as plain 1D Python lists, so the operation
+    // is unsupported; rejecting it explicitly produces a clean Python-level
+    // error rather than tripping `Unexpected type in int/ptr typecast` deep
+    // inside the SMT encoder when the resulting expression is consumed.
+    if (slice.contains("_type") && slice["_type"] == "Tuple")
+    {
+      std::ostringstream msg;
+      msg << "TypeError: multi-dimensional indexing (a[i, j, ...]) is not "
+             "supported; numpy arrays are modelled as 1D lists";
+      const locationt loc = get_location_from_decl(element);
+      if (!loc.is_nil())
+        msg << " at " << loc.get_file() << ":" << loc.get_line();
+      throw std::runtime_error(msg.str());
     }
 
     // Handle regular array/list subscripting

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -757,10 +757,10 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         // attribute was read on a value whose symbol type is not a class
         // struct -- e.g. ``a.shape`` on a numpy array (which the frontend
         // models as a plain list), or any other non-class object.
-        const std::string base_name = element.contains("value") &&
-                                          element["value"].contains("id")
-                                        ? element["value"]["id"].get<std::string>()
-                                        : std::string();
+        const std::string base_name =
+          element.contains("value") && element["value"].contains("id")
+            ? element["value"]["id"].get<std::string>()
+            : std::string();
         std::ostringstream msg;
         msg << "AttributeError: '";
         if (!base_name.empty())


### PR DESCRIPTION
[python] cleaner errors for numpy .shape and a[i,j] 2D indexing

Two unsupported numpy patterns surfaced as opaque internal errors:

- ``a.shape`` (and any attribute on a non-class value) raised
  ``Class "" not found`` from the class-lookup path of attribute
  access. Replace with a Python-level ``AttributeError`` naming the
  receiver, the attribute, and the source location.

- ``a[i, j]`` lowered the Tuple slice to ``python_list::index`` which
  silently produced a malformed expression that hit the bitwuzla
  ``Unexpected type in int/ptr typecast`` deep in the SMT encoder.
  Reject multi-dimensional indexing at the Subscript site with a
  clear ``TypeError`` and note that numpy arrays are modelled as 1D
  lists.

Both messages are emitted at the conversion site (with file:line)
rather than from internal IR lookup, so users can map the error
straight to the offending source line.

Fixes #4666
