### PR TITLE
[python] fall back to Any for d.get/setdefault/pop with no default

### DIFF
--- a/regression/python/github_4682/main.py
+++ b/regression/python/github_4682/main.py
@@ -1,0 +1,9 @@
+def f(d):
+    v = d.get("a")
+    if isinstance(v, int):
+        return v
+    return None
+
+
+data = {"a": 10}
+r = f(data)

--- a/regression/python/github_4682/test.desc
+++ b/regression/python/github_4682/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -2110,6 +2110,13 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
       return "list";
     // setdefault/get/pop return the value, not the dict — recover its
     // container shape from the default arg when the dict is untyped.
+    // When that fails (no default arg supplied, e.g. ``d.get(key)``),
+    // fall back to "Any" rather than the receiver's "dict" type: the
+    // returned value is an element, never the container itself, and
+    // letting "dict" propagate up causes the assignment-LHS symbol to
+    // be created as __python_dict__ — the dict-handler then emits a
+    // d.keys/d.values access whose member type later trips a member2t
+    // assertion at symex time (tracked in #4682).
     if (
       obj_type == "dict" && call["func"].contains("attr") &&
       (call["func"]["attr"] == "setdefault" ||
@@ -2118,6 +2125,7 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
       std::string t = infer_type_from_default_arg_shape(call["args"]);
       if (!t.empty())
         return t;
+      return "Any";
     }
     type = obj_type;
   }


### PR DESCRIPTION
[python] fall back to Any for d.get/setdefault/pop with no default

The annotation pass let the dict's receiver type "dict" propagate as
the return type of get/setdefault/pop when no default arg was supplied
and infer_type_from_default_arg_shape returned empty. Downstream this
caused the LHS of ``v = d.get(key)`` to be created as
__python_dict__: the dict handler then emitted ``d.keys`` /
``d.values`` member accesses against a parameter whose actual symex-
time type lost its struct tag, tripping the member2t assertion in
irep2_expr.h.

Return "Any" instead so the LHS symbol falls back to any_type() and
the dict-handler emits a generic Optional-typed result rather than
re-projecting the dict container shape.

Fixes #4682
