### PR TITLE
[python] honour re.match's at-the-start semantics for \d+ / [x-y]+

### DIFF
--- a/regression/python/github_4664_charclass/main.py
+++ b/regression/python/github_4664_charclass/main.py
@@ -1,0 +1,9 @@
+import re
+
+# CPython: [a-z]+ matches the leading "abc" of "abc123" -> truthy Match.
+m = re.match(r"[a-z]+", "abc123")
+assert m
+
+# Non-match: "123" has no leading lowercase.
+m2 = re.match(r"[a-z]+", "123")
+assert not m2

--- a/regression/python/github_4664_charclass/test.desc
+++ b/regression/python/github_4664_charclass/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4664_digit/main.py
+++ b/regression/python/github_4664_digit/main.py
@@ -1,0 +1,5 @@
+import re
+
+# CPython: \d+ matches the leading "123" of "123abc" -> truthy Match.
+m = re.match(r"\d+", "123abc")
+assert m

--- a/regression/python/github_4664_digit/test.desc
+++ b/regression/python/github_4664_digit/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4664_fullmatch/main.py
+++ b/regression/python/github_4664_fullmatch/main.py
@@ -1,0 +1,7 @@
+import re
+
+# fullmatch is unchanged: still requires the WHOLE string to match.
+assert not re.fullmatch(r"\d+", "123abc")
+assert re.fullmatch(r"\d+", "123")
+assert not re.fullmatch(r"[a-z]+", "abc123")
+assert re.fullmatch(r"[a-z]+", "abc")

--- a/regression/python/github_4664_fullmatch/test.desc
+++ b/regression/python/github_4664_fullmatch/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -24,7 +24,9 @@
 # 3) String constraint solving can be expensive; we may need further strategies for handling large string programs.
 
 
-def try_match_char_class_range(pattern: str, pattern_len: int, string: str,
+def try_match_char_class_range(pattern: str,
+                               pattern_len: int,
+                               string: str,
                                prefix_only: bool = False) -> int:
     """Match [x-y]+ or [x-y]* patterns.
 
@@ -75,7 +77,9 @@ def try_match_char_class_range(pattern: str, pattern_len: int, string: str,
     return 1
 
 
-def try_match_digit_sequence(pattern: str, pattern_len: int, string: str,
+def try_match_digit_sequence(pattern: str,
+                             pattern_len: int,
+                             string: str,
                              prefix_only: bool = False) -> int:
     r"""Match \d+ or \d* patterns.
 

--- a/src/python-frontend/models/re.py
+++ b/src/python-frontend/models/re.py
@@ -24,8 +24,16 @@
 # 3) String constraint solving can be expensive; we may need further strategies for handling large string programs.
 
 
-def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> int:
-    """Match [x-y]+ or [x-y]* patterns"""
+def try_match_char_class_range(pattern: str, pattern_len: int, string: str,
+                               prefix_only: bool = False) -> int:
+    """Match [x-y]+ or [x-y]* patterns.
+
+    When ``prefix_only`` is False (default, used by ``fullmatch``), every
+    character of ``string`` must lie in [x-y]. When True (used by ``match``),
+    only the leading run of in-range characters is required: ``+`` needs at
+    least one such character, ``*`` always matches at the start of the
+    string. This mirrors CPython's at-the-start semantics for ``re.match``.
+    """
     if pattern_len != 6:
         return -1
 
@@ -47,6 +55,15 @@ def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> i
     if string_len == 0:
         return 1 if quantifier == '*' else 0
 
+    if prefix_only:
+        # `*` matches the empty prefix always; `+` requires one leading char.
+        if quantifier == '*':
+            return 1
+        c0: str = string[0]
+        if c0 < start_char or c0 > end_char:
+            return 0
+        return 1
+
     i: int = 0
     while i < string_len:
         c: str = string[i]
@@ -58,8 +75,13 @@ def try_match_char_class_range(pattern: str, pattern_len: int, string: str) -> i
     return 1
 
 
-def try_match_digit_sequence(pattern: str, pattern_len: int, string: str) -> int:
-    r"""Match \d+ or \d* patterns"""
+def try_match_digit_sequence(pattern: str, pattern_len: int, string: str,
+                             prefix_only: bool = False) -> int:
+    r"""Match \d+ or \d* patterns.
+
+    See ``try_match_char_class_range`` for the ``prefix_only`` semantics:
+    full-string when False, at-the-start when True.
+    """
     if pattern_len != 3:
         return -1
 
@@ -77,6 +99,14 @@ def try_match_digit_sequence(pattern: str, pattern_len: int, string: str) -> int
 
     if string_len == 0:
         return 1 if quantifier == '*' else 0
+
+    if prefix_only:
+        if quantifier == '*':
+            return 1
+        c0: str = string[0]
+        if c0 < '0' or c0 > '9':
+            return 0
+        return 1
 
     i: int = 0
     while i < string_len:
@@ -204,12 +234,15 @@ def match(pattern: str, string: str) -> bool:
         if ch0 == '.' and ch1 == '*':
             return True
 
-    # Try each pattern recognizer
-    result: int = try_match_char_class_range(pattern, pattern_len, string)
+    # Try each pattern recognizer. ``re.match`` matches at the START of the
+    # string, so the quantified recognizers run in prefix mode -- a non-
+    # matching suffix is fine, as long as the leading run satisfies the
+    # quantifier (one-or-more for ``+``, zero-or-more for ``*``).
+    result: int = try_match_char_class_range(pattern, pattern_len, string, True)
     if result >= 0:
         return result == 1
 
-    result = try_match_digit_sequence(pattern, pattern_len, string)
+    result = try_match_digit_sequence(pattern, pattern_len, string, True)
     if result >= 0:
         return result == 1
 


### PR DESCRIPTION
[python] honour re.match's at-the-start semantics for \d+ / [x-y]+

re.match should match the pattern at the START of the string in
CPython, but the model's try_match_digit_sequence and
try_match_char_class_range insisted that every character of the input
satisfy the pattern. The result: re.match(r"\d+", "123abc") returned
False even though CPython returns a Match for the leading "123".

Add a prefix_only parameter to both recognisers. When True (passed by
match()), only the leading run is checked: "+" needs at least one
matching character, "*" matches the empty prefix. When False
(default, used by fullmatch()), the existing full-string semantics
are preserved.

The other recognisers (alternation, two_char_class_range, dot_literal)
were either already prefix-style or anchored (^...$), so the same
quantified prefix vs. full distinction does not apply to them.

Fixes #4664
