### PR TITLE
[docs] remove tuple repetition limitation now that #4661 is fixed

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -24,10 +24,6 @@ weight: 4
 
 - Supported operations are: literals, subscript access/assignment, `del`, `in`/`not in`, equality, iteration over `keys()`/`values()`/`items()`, `update()`, `get()`, `setdefault()`, `pop()`, and `popitem()`. Other methods (e.g., `copy()`) are not yet implemented.
 
-## Tuples
-
-- Tuple repetition (`*`) is not yet supported and currently aborts the frontend ([#4661](https://github.com/esbmc/esbmc/issues/4661)).
-
 ## Complex Numbers
 
 - The `complex()` constructor accepts string arguments only when the string is a compile-time constant (e.g., `complex("1+2j")` is folded by the frontend). Constructing from a runtime string is rejected with the error `complex() does not support non-literal string arguments`.


### PR DESCRIPTION
[docs] remove tuple repetition limitation now that #4661 is fixed

PR #4678 added the missing Tuple branch to get_type_from_binary_expr,
so ``t = (1, 2) * 3`` no longer aborts the frontend and now produces
the expected (1, 2, 1, 2, 1, 2) result. The Tuples section had only
this one entry, so the whole section is removed -- tuple semantics
are otherwise documented under Control Flow (iteration) and the
Supported Features page.
