### PR TITLE
[docs] drop exception parent-class catch limitation (#4670 fixed)

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -111,7 +111,6 @@ weight: 4
 ## Exception Handling
 
 - Core built-in exception types are supported, but not all Python standard library exceptions; custom exception hierarchies with complex inheritance patterns may not be fully handled.
-- A user-defined exception subclass caught by its parent class (e.g. `class B(A): pass; raise B(); except A:`) currently aborts conversion with `_init_undefined` / `migrate expr failed` rather than matching the parent ([#4670](https://github.com/esbmc/esbmc/issues/4670)).
 
 ## Class Attributes
 


### PR DESCRIPTION
[docs] drop exception parent-class catch limitation now that #4670 is fixed

PR #4680 made get_raise_statement recognise the _init_undefined
sentinel from constructors of exception classes that have no
__init__, so ``raise B()`` caught by ``except A:`` (where B subclasses
A) now matches the parent instead of aborting. Remove the bullet
that called out the abort; the generic "complex inheritance patterns
may not be fully handled" caveat above it still applies.
