### PR TITLE
[docs] drop re.match prefix-match limitation (#4664 fixed)

### DIFF
--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -65,7 +65,7 @@ weight: 4
 
 - Only `re.match()`, `re.search()`, and `re.fullmatch()` are supported.
 - Group-capture methods (`.group()`, `.groups()`, `.span()`) are rewritten by the parser into direct calls to internal helpers, and only the `(\d+)` pattern is recognised precisely; everything else returns a nondeterministic value.
-- The result of `re.match` / `re.search` / `re.fullmatch` is a `bool`, not an `Optional[Match]`. `if m:` works; `if m is None:` does not. The pattern recognisers also enforce full-string match for the supported patterns, so `re.match` does not match a prefix of a longer string (tracked in [#4664](https://github.com/esbmc/esbmc/issues/4664)).
+- The result of `re.match` / `re.search` / `re.fullmatch` is a `bool`, not an `Optional[Match]`: `if m:` works, `if m is None:` does not.
 - Complex patterns beyond the explicitly supported constructs exhibit nondeterministic behavior.
 - Not supported: lookahead/lookbehind assertions, backreferences, named groups, conditional patterns, Unicode property escapes.
 


### PR DESCRIPTION
[docs] drop re.match prefix-match limitation now that #4664 is fixed

PR #4687 threaded a prefix_only flag through the digit-sequence and
char-class-range recognisers so re.match honours CPython's at-the-
start semantics for those patterns. The remaining
bool-vs-Optional[Match] caveat still applies (separate concern),
so keep that sentence and only drop the prefix-match clause and the
#4664 reference.
