### PR TITLE
[ci] add macOS to nightly release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,17 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-latest]
+        include:
+          - os: ubuntu-24.04
+            flags: '-b RelWithDebInfo -e OFF'
+          - os: windows-latest
+            flags: '-b RelWithDebInfo -e OFF'
+          - os: macos-latest
+            flags: '-b RelWithDebInfo -e OFF -c 21'
     uses: ./.github/workflows/build.yml
     with:
       operating-system: ${{ matrix.os }}
-      build-flags: '-b RelWithDebInfo -e OFF'
+      build-flags: ${{ matrix.flags }}
       testing: false
 
   build-info:
@@ -39,6 +45,13 @@ jobs:
           path: ./windows-release
       - name: Create Windows Release file
         run: zip -r esbmc-windows.zip ./windows-release
+      - name: Download macOS Build
+        uses: actions/download-artifact@v4
+        with:
+          name: 'release-macos-latest--b RelWithDebInfo -e OFF -c 21'
+          path: ./macos-release
+      - name: Create macOS Release file
+        run: zip -r esbmc-macos.zip ./macos-release
       - name: Download Info Manual
         uses: actions/download-artifact@v4
         with:
@@ -57,4 +70,5 @@ jobs:
           files: |
             esbmc-linux.zip
             esbmc-windows.zip
+            esbmc-macos.zip
             esbmc.info


### PR DESCRIPTION
## Summary

- Build ESBMC on `macos-latest` alongside Ubuntu and Windows in the nightly release workflow.
- Bundle the resulting `./release` tree as `esbmc-macos.zip` and attach it to the nightly GitHub release.
- The macOS matrix entry uses `-b RelWithDebInfo -e OFF -c 21`, matching the clang version already used by the PR-time `build-macos-arm` job (`.github/workflows/pull_request.yml`).

## Rationale

`scripts/build.sh` already has full Darwin support and the PR workflow has been building successfully on `macos-latest` for some time, but the release workflow only ships Linux and Windows zips. This bridges that gap so nightly releases include a macOS arm64 binary as well.

The change is isolated to `release.yml` — no changes to `build-unix.yml`, `build.sh`, or any other workflow.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` (or wait for the Monday cron) and confirm all three OS builds succeed.
- [ ] Confirm `esbmc-linux.zip`, `esbmc-windows.zip`, `esbmc-macos.zip`, and `esbmc.info` are attached to the resulting nightly release.
- [ ] Download and run `esbmc --version` from the macOS zip on a real arm64 macOS host.