### PR TITLE
[python] pin unwinding assertion on truncated __ESBMC_unreachable loop

### DIFF
--- a/regression/python/esbmc-unreachable-truncated-loop/main.py
+++ b/regression/python/esbmc-unreachable-truncated-loop/main.py
@@ -1,0 +1,17 @@
+# Pins Mode-C soundness gate G2 for Python: when a reachability proof is
+# truncated by --unwind below the iteration at which __ESBMC_unreachable() is
+# reachable, ESBMC must surface the truncation via an unwinding assertion
+# rather than silently report SUCCESSFUL. The site below is reachable only
+# at i == 9 (the 10th iteration); --unwind 5 truncates the loop before that
+# point, so the unwinding assertion must fire.
+#
+# Pairing with --no-unwinding-assertions would silently turn this case
+# SUCCESSFUL (false positive on a provably-reachable site); that flag is
+# therefore banned for Python reachability proofs.
+
+i: int = 0
+N: int = 10
+while i < N:
+    if i == 9:
+        __ESBMC_unreachable()
+    i = i + 1

--- a/regression/python/esbmc-unreachable-truncated-loop/test.desc
+++ b/regression/python/esbmc-unreachable-truncated-loop/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--enable-unreachability-intrinsic --unwind 5
+^VERIFICATION FAILED$
+\bunwinding assertion\b

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -48,6 +48,7 @@ ignored_dirs=(
   "esbmc-unreachable-dead"
   "esbmc-unreachable-flag-off"
   "esbmc-unreachable-reachable"
+  "esbmc-unreachable-truncated-loop"
   "enumerate15"
   "enumerate15_fail"
   "func-no-params-types-fail"


### PR DESCRIPTION
## Summary

Adds a single regression test (`regression/python/esbmc-unreachable-truncated-loop/`) that pins the safe-mode behavior for the Python Mode-C reachability methodology: when `--unwind N` truncates a Python loop where `__ESBMC_unreachable()` is reachable only at iteration > N, ESBMC must surface the truncation as an unwinding assertion (`VERIFICATION FAILED`) rather than silently returning `VERIFICATION SUCCESSFUL`.

This protects against a regression that would re-introduce the unsound configuration documented as Mode C soundness gate G2.

## Background — G2 pitfall, confirmed on Python

Pairing `--no-unwinding-assertions` with a reachability proof on a truncated loop returns `VERIFICATION SUCCESSFUL` even though the `__ESBMC_unreachable()` site is provably reachable. Verified on 2026-05-21 against the binary built from #4683 (commit c028951), with dual-solver agreement (Bitwuzla default + Z3 v4.15.4):

| Configuration | Verdict |
|---|---|
| `--unwind 11 --enable-unreachability-intrinsic` (full unwind, ground truth) | `VERIFICATION FAILED` — `reachability: unreachable code reached` at i=9 |
| `--unwind 5 --enable-unreachability-intrinsic` (truncated, assertions on — **this PR pins this row**) | `VERIFICATION FAILED` — `unwinding assertion loop 133` |
| `--unwind 5 --enable-unreachability-intrinsic --no-unwinding-assertions` (pitfall) | `VERIFICATION SUCCESSFUL` (false positive) |

The C/C++ pitfall reproduces identically on Python — same downstream GOTO machinery. `--no-unwinding-assertions` is therefore banned for Python reachability proofs, mirroring the existing C/C++ prohibition; this PR only encodes the *safe* middle row as a CI gate, not the unsound bottom row.

## Files

- `regression/python/esbmc-unreachable-truncated-loop/main.py` — 10-iteration loop with `__ESBMC_unreachable()` reachable only at `i == 9`. Comment block explains the context.
- `regression/python/esbmc-unreachable-truncated-loop/test.desc` — CORE mode, expects `VERIFICATION FAILED` with `\bunwinding assertion\b`.
- `scripts/check_python_tests.sh` — adds the new directory to the ignore list (CPython cannot resolve `__ESBMC_unreachable`).

## Verification

Driver run:

```
$ cd regression && python3 testing_tool.py --tool .../esbmc --regression python     --modes CORE --file esbmc-unreachable-truncated-loop
test_esbmc-unreachable-truncated-loop ... ok
Ran 1 test in 2.594s
OK
```

## Test plan

- [x] Direct ESBMC invocation produces both `VERIFICATION FAILED` and `unwinding assertion` (verified locally).
- [x] `testing_tool.py` exits OK on the new test in CORE mode.
- [ ] Full Python regression suite remains green in CI.