### PR TITLE
[ir-ieee] fix infinity predicates without simplification

### DIFF
--- a/src/solvers/smt/smt_conv.cpp
+++ b/src/solvers/smt/smt_conv.cpp
@@ -1304,6 +1304,23 @@ smt_astt smt_convt::get_single_max_normal()
   return mk_smt_real(val);
 }
 
+smt_astt smt_convt::get_double_inf_sentinel()
+{
+  // One above double max_normal: used to represent ±∞ in integer encoding.
+  // This value satisfies |x| > max_normal, so isinf/isfinite predicates fire.
+  static const std::string val =
+    integer2string((power(2, 53) - 1) * power(2, 971) + 1);
+  return mk_smt_real(val);
+}
+
+smt_astt smt_convt::get_single_inf_sentinel()
+{
+  // One above single max_normal: used to represent ±∞ in integer encoding.
+  static const std::string val =
+    integer2string((power(2, 24) - 1) * power(2, 104) + 1);
+  return mk_smt_real(val);
+}
+
 smt_astt smt_convt::get_double_eps_rel()
 {
   // Relative error bound for IEEE 754 double under round-to-nearest:
@@ -1930,10 +1947,12 @@ smt_astt smt_convt::convert_ast(const expr2tc &expr)
         break;
       }
 
-      smt_astt max_val =
-        is_single ? get_single_max_normal() : get_double_max_normal();
+      // Use double_inf_sentinel for all precisions so that div-by-zero results
+      // are consistent with infinity constants (C's INFINITY is a float that
+      // gets cast to double, both must map to the same sentinel value).
+      smt_astt sentinel = get_double_inf_sentinel();
       smt_astt inf_result =
-        mk_ite(mk_lt(side1, zero), mk_sub(zero, max_val), max_val);
+        mk_ite(mk_lt(side1, zero), mk_sub(zero, sentinel), sentinel);
       smt_astt real_result = mk_div(side1, side2);
       const expr2tc &rounding_mode = to_ieee_div2t(expr).rounding_mode;
 
@@ -2997,10 +3016,22 @@ smt_astt smt_convt::convert_terminal(const expr2tc &expr)
     const constant_floatbv2t &thereal = to_constant_floatbv2t(expr);
     if (int_encoding)
     {
-      if (
-        thereal.value.is_zero() || thereal.value.is_NaN() ||
-        thereal.value.is_infinity())
+      if (thereal.value.is_zero() || thereal.value.is_NaN())
         return mk_smt_real("0");
+      if (thereal.value.is_infinity())
+      {
+        // Encode ±∞ as ±double_inf_sentinel (one above double max_normal) for
+        // all float widths. Using the double sentinel universally ensures that
+        // a float INFINITY constant typecast to double (C's INFINITY macro is
+        // float) produces the same value as a double IEEE_DIV(x,0) result.
+        // The double sentinel exceeds both single and double max_normal, so
+        // isinf/isfinite predicates work correctly for both precisions.
+        // NaN handling is deferred to the IEEE corner-case phase.
+        smt_astt sentinel = get_double_inf_sentinel();
+        if (thereal.value.get_sign())
+          return mk_sub(get_zero_real(), sentinel);
+        return sentinel;
+      }
       BigInt frac, exp;
       thereal.value.extract_base2(frac, exp);
       std::string result;

--- a/src/solvers/smt/smt_conv.h
+++ b/src/solvers/smt/smt_conv.h
@@ -433,6 +433,10 @@ public:
   smt_astt get_single_min_subnormal();
   // Returns SMT AST representing single precision maximum normal value (~3.4028234663852886e+38)
   smt_astt get_single_max_normal();
+  // Returns SMT AST for the integer-encoding sentinel for double +∞: max_normal+1
+  smt_astt get_double_inf_sentinel();
+  // Returns SMT AST for the integer-encoding sentinel for single +∞: max_normal+1
+  smt_astt get_single_inf_sentinel();
   // Returns SMT AST for the double precision relative error bound under
   // round-to-nearest: half machine epsilon = 2^-53 ~ 1.11e-16
   smt_astt get_double_eps_rel();


### PR DESCRIPTION
## Description

This PR fixes the handling of infinity predicates under `--ir-ieee` integer encoding when simplification is disabled.

Previously, under integer encoding, `constant_floatbv(+INFINITY)` and `constant_floatbv(-INFINITY)` were encoded as `0`. This caused predicates such as `isfinite(INFINITY)` and `isinf(INFINITY)` to produce incorrect results in the `--no-simplify` path.

This PR introduces an infinity sentinel value above `double` max normal and uses it consistently for:

- infinity constants
- div-by-zero infinity results under `IEEE_DIV`

This ensures that `isinf` and `isfinite` can correctly identify infinity values even when simplification is disabled.

## Scope

This is a targeted fix for the current `--ir-ieee` integer-encoding path.

It does **not** attempt to implement full IEEE corner-case support. 

## Validation

Tested locally with:

```bash
ESBMC_OPTS="--ir-ieee --z3" ctest -R "infty-finite" --output-on-failure --timeout 120