### PR TITLE
[python] guard JSON parse sites against truncated AST input (fixes #2012)

### DIFF
--- a/regression/python/github_2012_unresolvable_import_fail/main.py
+++ b/regression/python/github_2012_unresolvable_import_fail/main.py
@@ -1,0 +1,9 @@
+from jira_unavailable_pkg import JIRA
+
+
+def connect() -> int:
+    client = JIRA()
+    return 0
+
+
+connect()

--- a/regression/python/github_2012_unresolvable_import_fail/test.desc
+++ b/regression/python/github_2012_unresolvable_import_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^ERROR: Module 'jira_unavailable_pkg' not found\.$

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -379,7 +379,33 @@ void python_converter::convert()
 
       std::ifstream model_file(model_path.str());
       nlohmann::json model_json;
-      model_file >> model_json;
+      if (!model_file.is_open())
+      {
+        // parser.py exited before producing this model — the user's
+        // program almost certainly hit an unresolvable import that
+        // aborted the AST generation pipeline (issue #2012). Surface
+        // a structured error instead of letting the downstream
+        // ``>> model_json`` throw an uncaught nlohmann parse_error.
+        log_error(
+          "Python frontend: missing operational-model AST '{}'. "
+          "This usually means parser.py exited before generating it; "
+          "check the parser output above for the underlying error.",
+          model_path.str());
+        exit(1);
+      }
+      try
+      {
+        model_file >> model_json;
+      }
+      catch (const nlohmann::json::exception &e)
+      {
+        log_error(
+          "Python frontend: failed to parse operational-model AST "
+          "'{}': {}.",
+          model_path.str(),
+          e.what());
+        exit(1);
+      }
       model_file.close();
 
       size_t pos = file.rfind("/");

--- a/src/python-frontend/python_language.cpp
+++ b/src/python-frontend/python_language.cpp
@@ -141,7 +141,21 @@ bool python_languaget::parse(const std::string &path)
     exit(1);
   }
 
-  ast = nlohmann::json::parse(ast_json);
+  try
+  {
+    ast = nlohmann::json::parse(ast_json);
+  }
+  catch (const nlohmann::json::exception &e)
+  {
+    // parser.py exited 0 but left a truncated or empty AST file. Report
+    // it instead of aborting via an uncaught nlohmann parse_error
+    // (issue #2012).
+    log_error(
+      "<python-parser> failed to parse generated AST {}: {}\n",
+      script_path.str(),
+      e.what());
+    exit(1);
+  }
 
   if (config.options.get_bool_option("parse-tree-only"))
     return false;


### PR DESCRIPTION
The Python frontend parsed the main program AST (`python_language.cpp`) and each operational-model AST (`python_converter.cpp`) with no exception handling. A truncated or empty JSON file aborted ESBMC with an uncaught `nlohmann::detail::parse_error` ("terminate called ... Aborted") — the failure reported in #2012, seen when a model AST failed to materialise after an unresolvable third-party import.

Both parse sites now catch `nlohmann::json::exception`, report a structured error naming the offending file, and exit cleanly. A regression (`github_2012_unresolvable_import_fail/`) covers the unresolvable-import scenario; the two pre-existing #2012 tests sidestepped the bug by replacing the missing import with a local class.

Fixes #2012
