### PR TITLE
[python] materialise function-call list elements as values (fixes #4699)

### DIFF
--- a/regression/python/github_4699/main.py
+++ b/regression/python/github_4699/main.py
@@ -1,0 +1,17 @@
+def g(x: int) -> int:
+    if x > 0:
+        return x + 1
+    return 0
+
+
+def main() -> None:
+    a: int = 5
+    # List literal whose elements are non-constant-foldable function calls.
+    # Previously this leaked a code_function_call into the SSA and crashed
+    # the SMT backend with a SIGSEGV (issue #4699).
+    w: list[int] = [g(a), g(a)]
+    assert w[0] == 6
+    assert w[1] == 6
+
+
+main()

--- a/regression/python/github_4699/test.desc
+++ b/regression/python/github_4699/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_4699_fail/main.py
+++ b/regression/python/github_4699_fail/main.py
@@ -1,0 +1,14 @@
+def g(x: int) -> int:
+    if x > 0:
+        return x + 1
+    return 0
+
+
+def main() -> None:
+    a: int = 5
+    w: list[int] = [g(a), g(a)]
+    # g(5) == 6, so this assertion is false.
+    assert w[0] == 99
+
+
+main()

--- a/regression/python/github_4699_fail/test.desc
+++ b/regression/python/github_4699_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^VERIFICATION FAILED$

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2,6 +2,7 @@
 #include <python-frontend/python_converter.h>
 #include <util/c_types.h>
 #include <python-frontend/python_exception_handler.h>
+#include <python-frontend/function_call/expr.h>
 #include <python-frontend/type_handler.h>
 #include <python-frontend/json_utils.h>
 #include <python-frontend/symbol_id.h>
@@ -751,13 +752,22 @@ exprt python_list::get()
     if (elem.is_symbol())
       return elem;
 
+    // A list element that is itself a function call (e.g. ``[nd(), nd()]``)
+    // comes back from get_expr as a code_function_callt (a code statement).
+    // Assigning that directly to the temp produces a malformed assignment
+    // whose RHS is a call statement; it leaks into the SSA and crashes the
+    // SMT backend on a null operand (issue #4699). Normalise it to a
+    // side-effect call expression so create_tmp_symbol/code_assignt lower it
+    // to a proper function call, exactly as a statement-level ``x = nd()``.
+    const exprt value_elem = to_value_expr(elem, converter_.name_space());
+
     symbolt &tmp = converter_.create_tmp_symbol(
-      list_value_, "$list_elem$", elem.type(), elem);
+      list_value_, "$list_elem$", value_elem.type(), value_elem);
     code_declt decl(symbol_expr(tmp));
     decl.location() = location;
     converter_.add_instruction(decl);
 
-    code_assignt assign(symbol_expr(tmp), elem);
+    code_assignt assign(symbol_expr(tmp), value_elem);
     assign.location() = location;
     converter_.add_instruction(assign);
     return symbol_expr(tmp);

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -2108,8 +2108,7 @@ exprt python_list::handle_index_access(
       size_t subscript_depth = 0;
       const nlohmann::json *cur = &list_value_;
       while (cur->is_object() && cur->contains("value") &&
-             (*cur)["value"].is_object() &&
-             (*cur)["value"].contains("_type") &&
+             (*cur)["value"].is_object() && (*cur)["value"].contains("_type") &&
              (*cur)["value"]["_type"] == "Subscript")
       {
         ++subscript_depth;


### PR DESCRIPTION
A list literal whose elements are non-constant-foldable function calls (`[nd(), nd()]`) came back from `get_expr` as `code_function_callt` *statements*. `python_list::get()` assigned them straight to a temp with `code_assignt`, producing a malformed assignment whose RHS is a call statement. It leaked into the SSA and crashed the SMT backend with a SIGSEGV (null `expr2t` in `irep_container<expr2t>::crc`) during VCC encoding.

This is #4699, and also the remaining nondet-float symptom of #4697 after #4701 fixed the `list[list[T]]` typing — both reproducers now return a clean verdict.

Fix: normalise each list element with `to_value_expr` (the helper the ternary path already uses) so a call element becomes a `side_effect_expr_function_call` and lowers to a proper function call. Constant-foldable calls were already inlined and never reached this path. Regressions `github_4699` / `github_4699_fail` added (CPython-runnable, non-foldable branchy callee).

Fixes #4699
