### PR TITLE
[ir-ieee] add infinity nosimplify regression tests

### DIFF
--- a/regression/floats-regression/infty-finite-1-ir-ieee-nosimp/infty-finite.c
+++ b/regression/floats-regression/infty-finite-1-ir-ieee-nosimp/infty-finite.c
@@ -1,0 +1,7 @@
+#include <math.h>
+#include <assert.h>
+
+int main()
+{
+	assert(!isfinite(INFINITY));
+}

--- a/regression/floats-regression/infty-finite-1-ir-ieee-nosimp/test.desc
+++ b/regression/floats-regression/infty-finite-1-ir-ieee-nosimp/test.desc
@@ -1,0 +1,4 @@
+CORE
+infty-finite.c
+--ir-ieee --z3 --no-simplify
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats-regression/infty-finite-ir-ieee-nosimp/infty-finite.c
+++ b/regression/floats-regression/infty-finite-ir-ieee-nosimp/infty-finite.c
@@ -1,0 +1,9 @@
+#include <math.h>
+#include <assert.h>
+
+int main()
+{
+	double inf = 1.0 / 0.0;
+	assert(inf == INFINITY);
+	assert(!isfinite(inf));
+}

--- a/regression/floats-regression/infty-finite-ir-ieee-nosimp/test.desc
+++ b/regression/floats-regression/infty-finite-ir-ieee-nosimp/test.desc
@@ -1,0 +1,4 @@
+CORE
+infty-finite.c
+--ir-ieee --z3 --no-simplify
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
## Description

This is a follow-up PR to lock the behaviour fixed in the previous `--ir-ieee` infinity predicate PR.

It adds explicit regression tests for the `--ir-ieee --z3 --no-simplify` path, ensuring that infinity constants and division-by-zero infinity results are handled correctly by the SMT integer-encoding path.

## Tests added

- `infty-finite-ir-ieee-nosimp`
  - checks `1.0 / 0.0 == INFINITY`
  - checks `!isfinite(inf)`

- `infty-finite-1-ir-ieee-nosimp`
  - checks `!isfinite(INFINITY)`

Both tests use:

```bash
--ir-ieee --z3 --no-simplify