### PR TITLE
[docs] add IREP2 goto-program migration plan

### DIFF
--- a/docs/irep2-goto-migration-phase2-rwset.md
+++ b/docs/irep2-goto-migration-phase2-rwset.md
@@ -1,0 +1,200 @@
+---
+title: "Phase 2 work breakdown — rw_set / data-race migration to IREP2"
+status: draft
+date: 2026-05-22
+parent: docs/irep2-goto-migration-plan.md
+tracking-issue: esbmc/esbmc#4715
+---
+
+# Phase 2 expanded: migrate `rw_set` (data-race detection) to IREP2
+
+Phase 2 from the roadmap, broken into four PR-sized, independently reviewable
+and revertible units. Each PR has an explicit scope, the exact edits, the
+behaviour-preservation argument, and its own gate.
+
+**Why this phase is the template.** `rw_set` is the most self-contained legacy
+island (B5) — but it still has a B2-coupled tail (symbol *creation* in
+`w_guardst`). So it demonstrates the general pattern for the whole migration:
+*migrate the computation cleanly, then stop at the symbol-table boundary and
+defer that tail to Phase 4.* Do not let PR 2.4 below tempt you into starting B2
+early.
+
+## Current data flow (ground truth)
+
+```
+add_race_assertions (per instruction)
+  instruction.code / .guard  : expr2tc                      ← already IREP2
+    └─ migrate_expr_back  →  exprt  ────────┐  (round-trip #1, add_race:130-136)
+                                            ▼
+  rw_sett::compute(const exprt&)            ← LEGACY island (rw_set.cpp:8)
+    └─ read_write_rec(... guard2tc ...)     ← guard already IREP2 internally
+         └─ entryt{ exprt guard;            ← stored back as exprt via
+                    exprt original_expr }     migrate_expr_back (rw_set.cpp:125)
+                                            │
+  w_guardst::get_guard_symbol_expr(exprt&)  ← builds exprt("races_check") …
+    └─ migrate_expr  →  expr2tc  ───────────┘  (round-trips #2/#3, add_race:174,191,239)
+                                               then symex consumes races_check2t
+```
+
+`races_check2t` is already a first-class IREP2 node (`src/irep2/irep2_expr.h:180,984`)
+and symex already consumes it as `expr2tc` (`src/goto-symex/builtin_functions/misc.cpp:24-30`).
+So every `migrate_expr`/`migrate_expr_back` above is a pure round-trip — except
+the symbol-table writes in `w_guardst` (`migrate_type_back` at
+`add_race_assertions.cpp:35,85`), which are forced by B2.
+
+---
+
+## PR 2.1 — Migrate `rw_sett` internals + `entryt` storage to IREP2
+
+**Scope:** `src/goto-programs/rw_set.h`, `rw_set.cpp`, and the minimal
+consumption changes in `add_race_assertions.cpp` needed to keep it compiling.
+Leave `w_guardst`'s legacy expr building intact (adapt at its boundary).
+
+**Edits:**
+1. `rw_set.h:17-18` — change `entryt`:
+   - `exprt guard;` → `guard2tc guard;` (it is *already* produced from a
+     `guard2tc` at `rw_set.cpp:125`; just store it directly).
+   - `exprt original_expr;` → `expr2tc original_expr;`
+   - `entryt()` initialiser `guard(true_exprt())` → default `guard2tc()`.
+   - `get_guard()` returns `const guard2tc &`.
+2. `rw_set.h:46,56,62-71,77,79-86` — retype signatures from `const exprt &` to
+   `const expr2tc &`: `compute`, the convenience ctor, `read_rec` (both),
+   `assign`, `read_write_rec`. The `guard2tc guard` parameter already exists.
+3. `rw_set.cpp:8-58` `compute` — replace the stringy
+   `expr.is_code()` / `code.get_statement()` dispatch with an IREP2 node switch:
+   - `"assign"` → `is_code_assign2t` → `assign(asn.target, asn.source)`
+   - `"printf"` → `code_printf2t` / `code_expression2t` operand walk
+   - `"return"` → `code_return2t` → `read_rec(ret.operand)`
+   - `"function_call"` → `code_function_call2t` (`.function`, `.operands`,
+     symbol-body check via `ns.lookup`). Preserve the
+     `symbol->value.is_nil() || name == "__VERIFIER_assert"` guard exactly
+     (`rw_set.cpp:44`).
+   - the `is_goto()/is_assert()/is_assume()` branch (`:55-57`) is unchanged.
+4. `rw_set.cpp:66-183` `read_write_rec` — replace the `is_symbol/is_member/
+   is_index/is_dereference/is_address_of/"if"` chain with
+   `symbol2t/member2t/index2t/dereference2t/address_of2t/if2t`. The internal
+   guard handling at `:165-176` already uses `guard2tc`; **delete** the
+   `migrate_expr` calls at `:166-173` (build the if-condition guard directly in
+   IREP2 — `true_guard.add(if_expr.cond)`, `false_guard.add(not2tc(if_expr.cond))`).
+   - **Preserve the symbol filters verbatim** (`:87-115`): the Python-global
+     `mode == "Python" && !file_local` rule, the `__ESBMC_alloc`/`stdin`/… name
+     list, CUDA `indexOfThread`/`indexOfBlock`, and the `#atomic` C11 filter.
+     These read `symbolt` fields (`mode`, `file_local`, `static_lifetime`,
+     `is_thread_local`, `type.get_bool("#atomic")`) which are unaffected by this
+     PR (B2 is untouched).
+   - **delete** `entry.guard = migrate_expr_back(guard.as_expr())` → `entry.guard = guard;`
+5. `add_race_assertions.cpp:130-136` — drop the `migrate_expr_back` of
+   `instruction.guard`/`instruction.code`; pass them directly:
+   `rw_sett rw_set(ns, i_it, instruction.is_goto()||instruction.is_assert() ? instruction.guard : instruction.code);`
+6. `w_guardst` boundary adaptation (kept legacy in this PR): where it reads
+   `entry.original_expr` (now `expr2tc`) it back-migrates locally —
+   `get_guard_symbol_expr(migrate_expr_back(entry.original_expr))` — and
+   `entry.get_guard()` (now `guard2tc`) is back-migrated at
+   `add_race_assertions.cpp:189`. These two local back-migrations are removed in
+   PR 2.2.
+
+**Behaviour-preservation argument:** every transformation is a structural
+1:1 re-expression; the guard was already `guard2tc` internally, so dropping the
+back-migration at `:125` removes a lossy round-trip, not a computation. The
+symbol filters and the `original_expr` nil-fallback logic (`:126,132,146,152`)
+are preserved exactly (`is_nil()` → `is_nil(expr2tc)`).
+
+**Gate:** zero goto-binary diff on the concurrency corpus
+(`ctest -L concurrency`, `--data-races-check` tests), dual-solver Bitwuzla+Z3
+agreement, ASan/UBSan clean (lifetime risk — `expr2tc` COW now in play).
+
+---
+
+## PR 2.2 — Migrate `w_guardst` expression *building* to IREP2
+
+**Scope:** `add_race_assertions.cpp:44-64` (`get_guard_symbol_expr`,
+`get_w_guard_expr`, `get_assertion`) and the three `migrate_expr` call sites that
+consume their results (`:174,191,239`). Symbol *creation* stays legacy (PR 2.4).
+
+**Edits:**
+1. `get_guard_symbol_expr` — build IREP2 directly:
+   `races_check2tc(address_of2tc(orig->type, orig))` instead of
+   `exprt("races_check")` + `move_to_operands`. Return `expr2tc`.
+   (`races_check2t` exists: `irep2_expr.h:180,984`; symex consumes it at
+   `builtin_functions/misc.cpp:24`.)
+2. `get_assertion` returns `not2tc(get_guard_symbol_expr(...))`.
+3. `add_race_assertions.cpp:173-175` — `t->make_assertion(w_guards.get_assertion(...))`
+   directly (drop `migrate_expr`).
+4. `:188-191` and `:237-239` — build `code_assign2tc(w_guards.get_w_guard_expr(...),
+   entry.get_guard())` / `code_assign2tc(..., gen_false_expr())` directly (drop
+   the legacy `code_assignt` + `migrate_expr`). Note `entry.get_guard()` is now
+   `guard2tc` (PR 2.1) → use `.as_expr()`.
+5. Remove the two local back-migrations introduced in PR 2.1 step 6.
+
+**Behaviour-preservation argument:** `migrate_expr(exprt("races_check", bool, addr))`
+produces exactly `races_check2tc(addr)` (`migrate.cpp:1688-1692`); constructing
+it directly is byte-identical post-migration. The assertion `gen_not` → `not2tc`
+and `code_assignt` → `code_assign2tc` are the same nodes the migrator emits.
+
+**Gate:** zero goto-binary diff (this is the strongest check here — the inserted
+instruction stream must be identical); dual-solver agreement on the concurrency
+corpus.
+
+---
+
+## PR 2.3 — Tests: differential + targeted regression
+
+**Scope:** `regression/esbmc/` (or `regression/concurrency/`) and `unit/`.
+
+**Edits:**
+1. Add a focused regression pair under `regression/esbmc/github_4715_rwset/`
+   (one CORE pass, one `*_fail` race-positive) exercising: array-index race
+   (`original_expr.is_index()` path), member race, `if`-guarded race
+   (the `if2t` guard split), and a `__VERIFIER_assert` function-call read.
+   These pin the branches PR 2.1/2.2 rewrote.
+2. Unit test in `unit/goto-programs/` constructing a small `goto_programt`,
+   running `rw_sett::compute` on hand-built `expr2tc`, and asserting the
+   `entries` map (objects, r/w flags, deref) matches a golden — no migration in
+   the test, proving the IREP2 path standalone.
+3. Wire the **differential goto-binary harness** (Phase 0) target for the
+   concurrency corpus into CI as a non-blocking report initially.
+
+**Gate:** new tests pass on the PR 2.1+2.2 build and *fail* if reverted to
+master (proving they discriminate).
+
+---
+
+## PR 2.4 — DEFERRED to Phase 4 (do not implement now)
+
+The symbol creation in `w_guardst::get_guard_symbol` (`add_race_assertions.cpp:31-41`)
+and `add_initialization` (`:82-88`) writes `new_symbol.type = migrate_type_back(...)`
+and `new_symbol.value.make_false()` into the `contextt`. This is forced by B2
+(`symbolt` stores `typet`/`exprt`). **Leave it legacy.** When Phase 4 migrates
+the symbol table, these two `migrate_type_back` calls and the `.make_false()`
+become `symbolt::type2 = array_type2tc(...)` / `value2 = gen_false_expr()` and
+this PR is folded into the Phase-4 writer switch (step 4c). Tracking note only;
+no code in Phase 2.
+
+---
+
+## Phase 2 exit criteria (all required)
+
+- `rw_set.{h,cpp}` contain **zero** `exprt`/`typet`/`migrate_*` (except the
+  documented symbol-filter `symbolt` field reads, which are not expressions).
+- `add_race_assertions.cpp` contains `migrate_*` calls **only** in the
+  symbol-creation tail (PR 2.4 scope) — the per-instruction hot path is
+  migrate-free.
+- Concurrency corpus: **zero goto-binary diff** vs. the Phase-0 baseline.
+- Dual-solver (Bitwuzla + Z3) verdict **and** counterexample-digest agreement.
+- ASan/UBSan build of the concurrency regression subset is clean.
+- `migrate_*` census (Phase 0 scoreboard) strictly decreases in
+  `src/goto-programs/{rw_set.cpp,add_race_assertions.cpp}` and increases nowhere.
+
+## Suggested PR order & rollback
+
+```
+PR 2.1  rw_set internals + entryt        ← revertible alone (w_guardst still legacy)
+PR 2.2  w_guardst expr building          ← depends on 2.1; revert restores 2.1 state
+PR 2.3  tests                            ← can merge before or after 2.2
+PR 2.4  (none — folded into Phase 4)
+```
+
+Each PR is green-before-merge (no broken commits, no squashing). If PR 2.2's
+goto-binary diff is non-zero and the cause is not an obvious justified
+improvement, revert 2.2 only — 2.1 already removed round-trip #1 and stands on
+its own.

--- a/docs/irep2-goto-migration-phase4-symboltable.md
+++ b/docs/irep2-goto-migration-phase4-symboltable.md
@@ -1,0 +1,264 @@
+---
+title: "Phase 4 work breakdown — symbol table (symbolt) migration to IREP2"
+status: draft
+date: 2026-05-22
+parent: docs/irep2-goto-migration-plan.md
+tracking-issue: esbmc/esbmc#4715
+---
+
+# Phase 4 expanded: migrate `symbolt::value`/`type` to IREP2
+
+Phase 4 is the **linchpin** (B2): it stores `typet type` and `exprt value`
+(`src/util/symbol.h:15-16`), which every frontend writes and the whole goto
+pipeline reads. Migrating it unblocks the forced B6 round-trips
+(`contracts.cpp:1730,1896,…`; `add_race_assertions.cpp:35,85` — deferred PR 2.4).
+
+It is also the **highest-risk** phase, so it gets the most sub-PRs and the
+slowest, most defensive sequencing. The guiding principle: **the legacy fields
+remain the source of truth until the very end; IREP2 fields are derived and
+continuously cross-checked against them.** No frontend behaviour changes until
+correctness on the read side is proven.
+
+## Why the ordering is forced (ground truth)
+
+1. **Writes cannot be intercepted today.** `contextt::find_symbol` returns a
+   mutable `symbolt*` (`src/util/context.cpp:47-52`) and callers mutate
+   `sym->value = …` / `sym->type = …` directly. There is no setter chokepoint.
+   → **We must encapsulate before we can shadow-sync.** (PR 4.1 precedes 4.2.)
+2. **The dual-role of `value` is keyed off `type`, not `value`.** A symbol's
+   `value` is a function body iff `type.is_code()` (`goto_convert_functions.cpp:107,113`),
+   otherwise it is a constant initializer (`python_converter.cpp:703`:
+   `static_lifetime && !value.is_nil() && !type.is_code()`). Nothing checks
+   `value.type() == type`. → preserve the `is_code` discriminator **exactly**;
+   it becomes `is_code_type2t` under IREP2. This is the known
+   `static_lifetime` + `symbol.value` hazard — guard it with a regression.
+3. **Serialization is opaque and couples to Phase 5.** `to_irep` does
+   `dest.type() = type; dest.symvalue(value)` (`symbol.cpp:98-99`); `from_irep`
+   casts back (`:135-136`). `reference_convert` dedup
+   (`irep_serialization.cpp:31-90`) is purely structural. → leave (de)serialization
+   on legacy `irept` until Phase 5; the IREP2 fields are non-persistent and
+   rebuilt from legacy on load. (PR 4.6 is the only one touching serialization,
+   and it is the Phase-4/Phase-5 seam.)
+
+## Shadow-field model
+
+```
+            ┌──────────────── symbolt ────────────────┐
+ frontends  │  typet  type   (source of truth)  ◄──────┼── written by ~56 sites
+   write ──►│  exprt  value  (source of truth)  ◄──────┼── written by ~31 sites
+            │                                           │
+            │  type2tc  type2  (DERIVED, synced) ───────┼─► read by goto pipeline
+            │  expr2tc  value2 (DERIVED, synced) ───────┼─►   after PR 4.3
+            └───────────────────────────────────────────┘
+   sync point: a single setter (PR 4.1) recomputes type2/value2 via migrate_*.
+   debug builds assert  migrate_back(type2) ≡ type  on every read (PR 4.2).
+```
+
+The legacy field stays authoritative through PR 4.5. PR 4.6 flips the source of
+truth; PR 4.7 deletes the legacy fields (gated on Phase 5 owning serialization).
+
+---
+
+## PR 4.0 — `migrate_symbol` helper + invariant assertions (no behaviour change)
+
+**Scope:** `src/util/migrate.{h,cpp}`, `src/util/symbol.{h,cpp}`.
+
+**Edits:**
+1. Add `void migrate_symbol(const symbolt &, /*out*/ type2tc &, expr2tc &)`
+   centralising the field-by-field `migrate_type`/`migrate_expr` that callers
+   currently open-code. Single tested conversion path.
+2. Add a debug-only `symbolt::check_invariants()` documenting+asserting the
+   discriminator: if `type.is_code()` then `value.is_nil() || value.is_code()`;
+   if `static_lifetime && !type.is_code()` then `value` is a value-expr not a
+   `codet`. Call it from `symbolt::show`/in unit tests only (no hot-path cost).
+3. Unit test in `unit/util/`: round-trip a representative symbol set
+   (function body, struct global initializer, scalar initializer, nil value,
+   Python static-lifetime global) through `migrate_symbol` and assert
+   `migrate_*_back` recovers a structurally-equal legacy field.
+
+**Behaviour:** none — pure addition. **Gate:** unit test green; full build green.
+
+---
+
+## PR 4.1 — Encapsulate `symbolt::type`/`value` behind accessors (mechanical)
+
+**Scope:** rename `symbolt::type`→`type_` / `value`→`value_` (private-by-convention)
+and add `type()`/`value()` (const + mutable-set) accessors; mechanically update
+all ~193 referencing files. **No shadow field yet** — accessors just return the
+field. Purely mechanical, uniform diff = easy review.
+
+**Split into reviewable sub-PRs by tree** (each independently compiles & passes):
+- 4.1a `src/util/`, `src/goto-programs/`, `src/goto-symex/`, `src/pointer-analysis/`
+- 4.1b `src/clang-c-frontend/`, `src/clang-cpp-frontend/`
+- 4.1c `src/python-frontend/` (~290 access sites — largest)
+- 4.1d `src/solidity-frontend/` (~187 sites; 24 value-writes in
+  `solidity_convert_{decl,call,contract}.cpp`)
+- 4.1e `src/jimple-frontend/`, remaining `unit/` and `src/esbmc/`
+
+**Mechanics:** the mutable setter must be a method (`set_value(exprt)`,
+`set_type(typet)`), *not* a returned reference, so PR 4.2 can hook it. Reads
+keep returning `const typet&`/`const exprt&`. In-place edits like
+`sym->value.operands()...` get rewritten to read-modify-`set` (these are rare;
+flag each in review).
+
+**Behaviour:** none. **Gate per sub-PR:** zero goto-binary diff on full corpus;
+full regression green; clang-format clean.
+
+---
+
+## PR 4.2 — Add shadow fields + sync in setter + read-side assertions
+
+**Scope:** `src/util/symbol.{h,cpp}`.
+
+**Edits:**
+1. Add `type2tc type2_; expr2tc value2_;`.
+2. `set_type`/`set_value` recompute the shadow via `migrate_type`/`migrate_expr`
+   (and clear to `type2tc()`/`expr2tc()` on nil, mirroring `value.make_nil()`).
+3. `swap`/`clear`/`from_irep` keep both in sync (`from_irep` recomputes shadow
+   after setting legacy — `symbol.cpp:135-136`).
+4. Add `type2()`/`value2()` const accessors (IREP2 view) — not yet used by
+   readers.
+5. **Debug-build cross-check:** on every `type2()`/`value2()` read, assert the
+   shadow round-trips to the legacy field (`migrate_type_back(type2_) ≡ type_`).
+   This is the differential self-check (§5.3 of the master plan).
+
+**Behaviour:** none (shadow is write-only-derived, read by nobody yet).
+**Gate:** the cross-check assertion **never fires** across the full corpus +
+SV-COMP subset; zero goto-binary diff; dual-solver agreement. *This is the
+phase's central evidence gate* — it proves migrate is lossless on every symbol
+ESBMC actually constructs.
+
+---
+
+## PR 4.3 — Switch goto-pipeline readers to the IREP2 view
+
+**Scope:** `src/goto-programs/`, `src/goto-symex/` reader sites; frontends
+untouched (still write legacy, synced).
+
+**Edits:** migrate the consumers identified in the impact analysis to read
+`value2()`/`type2()`:
+- `goto_convert_functions.cpp:102,107,113,117` — `body_available`,
+  `is_code_type2t` discriminator, `to_code_*2t(value2())` instead of
+  `to_code(symbol.value)`.
+- `goto_convert_functions.cpp:288,301` — argument `code_type2t` introspection
+  (overlaps Phase 3 B3 work; coordinate).
+- `namespace.cpp:39-43` value-following (read `value2()` when not code-typed).
+- `context.cpp:128-141` merge logic — keep deciding on legacy `is_nil` for now
+  (writes still legacy); only the *reads that feed the goto pipeline* move.
+- the deferred PR 2.4 symbol-*reads* in `add_race_assertions`/contracts.
+
+**Behaviour-preservation:** identical because shadow ≡ legacy (proven in 4.2).
+The `is_code` → `is_code_type2t` swap is the one semantic-looking change;
+back it with a focused regression on a function symbol and a same-named global.
+**Gate:** zero goto-binary diff; dual-solver; the 4.2 cross-check still silent.
+
+---
+
+## PR 4.4 — Switch B6 writers to set IREP2 directly (kills the round-trips)
+
+**Scope:** the passes that currently build `type2tc`/`expr2tc`, back-migrate,
+then store legacy. With the setter syncing both ways we add an IREP2 setter
+overload so they store natively.
+
+**Edits:**
+1. Add `set_type(type2tc)` / `set_value(expr2tc)` overloads that set the shadow
+   directly and back-migrate to keep the legacy field valid for serialization.
+2. Remove the round-trips:
+   - `contracts.cpp:1730,1896,2145,2331,2369,2501,2540` (`migrate_type_back`).
+   - `goto_atomicity_check.cpp:42`.
+   - **Folds in deferred PR 2.4**: `add_race_assertions.cpp:35,85`
+     (`new_symbol.set_type(array_type2tc(...))`, `set_value(gen_false_expr())`).
+   - `assign_params_as_non_det.cpp` symbol writes.
+
+**Behaviour-preservation:** `set_type(t2)` stores `t2` and derives
+`migrate_type_back(t2)`; previously the code did `migrate_type_back(t2)` and the
+setter (4.2) would derive `migrate_type(that)`. Net identity holds iff
+`migrate_type ∘ migrate_type_back = id` on these nodes — **add a unit test
+asserting that** for the specific node kinds these passes produce (array of
+bool, snapshot struct/pointer types). **Gate:** zero goto-binary diff on
+contracts + concurrency + data-race corpora; dual-solver.
+
+---
+
+## PR 4.5 — Tests: differential corpus + dual-role regression
+
+**Scope:** `regression/`, `unit/`.
+
+**Edits:**
+1. Regression pinning the **dual-role discriminator**: a translation unit with
+   (a) a function symbol, (b) a `static_lifetime` non-code global with a
+   non-nil initializer, (c) a same-named local — assert ESBMC still emits the
+   static initializer assignment and does *not* treat the body as data. This is
+   the `gotcha_python_symbol_value_static_lifetime` guard, lifted to a test.
+2. Python frontend: a `regression/python/` case exercising module-level globals
+   (`static_lifetime=false`, `file_local=false`) to pin the interaction with
+   the rw_set Python-global filter and const-prop snapshot behaviour. Run
+   `scripts/check_python_tests.sh` on it.
+3. Promote the 4.2 shadow cross-check to a CI THOROUGH/Linux job over the
+   SV-COMP subset.
+
+**Gate:** all green; tests fail if reverted to master (discriminating).
+
+---
+
+## PR 4.6 — Flip source of truth to IREP2 (Phase 4 / Phase 5 seam)
+
+**Scope:** frontends (write IREP2 via the setter); `symbol.cpp` serialization.
+
+**Edits:**
+1. Migrate frontend write sites (PR 4.1 setters already in place) to call the
+   IREP2 overloads; legacy field becomes the *derived* one.
+   Sequence by cluster, smallest first: jimple → clang-cpp → clang-c → python →
+   solidity (largest last, by then the pattern is proven).
+2. `to_irep`/`from_irep`: until Phase 5 ships an IREP2-native goto-binary
+   format, serialize from the derived legacy field (no on-disk format change).
+   **This is the explicit hand-off point to Phase 5** — do not change the
+   binary format here.
+
+**Behaviour-preservation:** still gated on the (now-inverted) shadow cross-check
+and zero goto-binary diff. **Gate:** full corpus diff = 0; dual-solver;
+old goto-binaries still load (legacy reader unchanged).
+
+---
+
+## PR 4.7 — Cleanup (gated on Phase 5)
+
+Remove the legacy `type_`/`value_` fields, the back-derivation in setters, and
+the cross-check assertions — **only after Phase 5 owns IREP2-native
+serialization** (otherwise `to_irep` still needs the legacy field). Until then,
+PR 4.7 is blocked; record the dependency in #4715.
+
+---
+
+## Phase 4 exit criteria (all required)
+
+- Shadow cross-check assertion silent across full corpus + SV-COMP subset
+  (the lossless-migration proof).
+- Zero goto-binary diff vs. Phase-0 baseline at every sub-PR.
+- Dual-solver Bitwuzla + Z3 verdict **and** counterexample-digest agreement.
+- The dual-role / `static_lifetime` regression (PR 4.5) passes and discriminates.
+- `migrate_type_back`/`migrate_expr_back` call count in `src/goto-programs/`
+  strictly decreased (the B6 round-trips from `contracts.cpp`,
+  `goto_atomicity_check.cpp`, `add_race_assertions.cpp` are gone).
+- `scripts/check_python_tests.sh` green (Python frontend touched).
+
+## Suggested order & rollback
+
+```
+PR 4.0  migrate_symbol helper + invariant asserts   ← pure addition
+PR 4.1  encapsulate type/value behind accessors      ← mechanical, split a–e by tree
+PR 4.2  shadow fields + setter sync + read asserts    ← CENTRAL EVIDENCE GATE
+PR 4.3  switch goto-pipeline readers to IREP2 view    ← revert restores legacy reads
+PR 4.4  switch B6 writers to IREP2 (kills round-trips, folds in PR 2.4)
+PR 4.5  tests (dual-role + Python globals)
+PR 4.6  flip source of truth (Phase 4/5 seam — no format change)
+PR 4.7  cleanup  ── BLOCKED on Phase 5
+```
+
+Rollback insurance: through PR 4.5 the legacy fields are authoritative, so any
+sub-PR reverts cleanly to a working legacy state. PR 4.2's cross-check is the
+trip-wire — if it ever fires, stop and fix `migrate_*` before proceeding rather
+than weakening the assertion. PR 4.6 is the only irreversible-feeling step;
+keep it behind the cross-check (now inverted) and a clean full-corpus diff
+before merge, and do not let it touch the on-disk format — that is Phase 5's
+deliberate, versioned decision.

--- a/docs/irep2-goto-migration-plan.md
+++ b/docs/irep2-goto-migration-plan.md
@@ -1,0 +1,314 @@
+---
+title: "Migration Plan: Legacy IREP → IREP2 in the goto-program pipeline"
+status: draft
+date: 2026-05-22
+owner: goto-programs
+---
+
+# Migrating the goto-program pipeline from legacy `irept` to IREP2
+
+## 0. TL;DR for reviewers
+
+The premise "goto-programs still depend on legacy IREP in several classes" is
+correct, but the dependency is **narrower and more structured than a rewrite**.
+The *core* instruction representation is already IREP2:
+
+- `goto_programt::instructiont::code` is `expr2tc` (`src/goto-programs/goto_program.h:93`)
+- `goto_programt::instructiont::guard` is `expr2tc` (`goto_program.h:105`)
+- loop invariants / assigns targets are `std::list<expr2tc>` (`goto_program.h:108,111`)
+
+Legacy `irept`/`exprt`/`typet`/`codet` survives only at **six boundaries**.
+The migration is therefore "drain each boundary, in dependency order, behind an
+adaptor, with differential validation" — not a big-bang core rewrite. This is
+inherently friendlier to incremental review and rollback, which is exactly what
+the constraints ask for.
+
+The single most important sequencing fact: **do not touch serialization or the
+symbol table until everything that consumes them is already IREP2-clean**. They
+are the foundation; they are also the highest-risk subsystems (hashing,
+structural sharing, on-disk format compatibility).
+
+---
+
+## 1. Dependency and impact analysis
+
+### 1.1 The six surviving legacy boundaries
+
+| # | Boundary | Where | Legacy type | Why it persists | Risk |
+|---|----------|-------|-------------|-----------------|------|
+| B1 | **Frontend → goto lowering input** | `goto_convert*` consume `codet` (`goto_convert_class.h:18,37,131-167`; `goto_convert.cpp:117`) | `codet`/`exprt` | The clang/python/etc. frontends emit `symbolt::value` as `codet`; `goto_convert` migrates per-instruction (`goto_convert.cpp:136` `migrate_expr`) | Medium |
+| B2 | **Symbol table** | `symbolt::value` (`exprt`), `symbolt::type` (`typet`) (`src/util/symbol.h:15-16`) | `exprt`/`typet` | Shared by *all* frontends and serialization; the lowering target | **High (foundational)** |
+| B3 | **`goto_functiont::type`** | `code_typet type` (`src/goto-programs/goto_functions.h:24`) | `code_typet` (irept) | Function signature still stored stringy | Medium |
+| B4 | **Goto-binary serialization** | `goto_program_irep.cpp:4-57`, `goto_program_serialization.cpp`, `goto_function_serialization.cpp`, `read_bin_goto_object.cpp`, `write_goto_binary.cpp`, `src/util/irep_serialization.{h,cpp}` | `irept` | On-disk format is `irept`; converted via `migrate_expr_back`/`migrate_expr` on each I/O | **High (format compat + hashing)** |
+| B5 | **`rw_set` data-race pass** | `rw_set.h:17-18` stores `exprt original_expr`, `exprt guard`; `rw_set.cpp:8-72` operates in `exprt` | `exprt` | Pass never migrated; still computes over legacy expressions | Medium |
+| B6 | **Analysis passes that build `exprt` then migrate** | `goto_check.cpp:116-565`, `add_race_assertions.cpp:19-238`, `contracts/contracts.cpp` (round-trips `migrate_type_back` at `:1730,1896,2145,2331,2369,2501,2540`), `goto_atomicity_check.cpp:42`, `goto_sideeffects.cpp:13-104`, `destructor.cpp:5-34`, `format_strings.cpp:179`, `assign_params_as_non_det.cpp` | `exprt`/`typet` (transient) | These *produce* IREP2 (they `migrate_expr` before insertion) but *build* in legacy IREP and round-trip through `symbolt` | Medium |
+
+Note B6 round-trips (`expr2tc → exprt → expr2tc`) are *forced* by B2: when a pass
+creates a new symbol it must store `exprt`/`typet` into the symbol table, so it
+back-migrates. **B6 cannot be fully eliminated until B2 is done.** This is the
+core ordering constraint.
+
+### 1.2 Already-migrated (do not touch except to delete adaptors later)
+
+- Instruction `code`/`guard`, loop contracts — `expr2tc` (`goto_program.h`).
+- Loop analysis: `loopst.h:14`, `goto_loops.h:14` use `std::unordered_set<expr2tc, irep2_hash>`.
+- k-induction: `goto_k_induction.h` uses `guard2tc`.
+- Abstract interpretation: `ai.h`, `interval_domain.*`, `gcse.*`, `wrapped_interval.h` operate over `expr2tc`.
+
+### 1.3 The conversion layer (the seam we lean on)
+
+`src/util/migrate.{h,cpp}`: `migrate_expr`, `migrate_type`, `migrate_expr_back`,
+`migrate_type_back`. Every boundary above already routes through these. **The
+migration strategy is to push these calls outward toward B2/B4 and shrink the
+legacy region they bound, rather than to invent new machinery.** When B2 and B4
+are migrated, large parts of `migrate.cpp` become dead and can be deleted last.
+
+---
+
+## 2. High-risk areas (call out explicitly)
+
+These are the properties that, if broken, produce *silent unsoundness or
+nondeterminism* — the worst failure mode for a verifier. Each gets dedicated
+validation in §5.
+
+1. **Serialization / on-disk goto-binary format (B4).** Changing how
+   instructions serialize can silently change byte layout, breaking cached
+   goto-binaries and cross-version reads. The `irep_serialization` string-pool
+   and `reference_convert` sharing logic (`goto_program_serialization.cpp:17`)
+   are subtle. Treat the binary format as a *frozen external contract* until a
+   deliberate, versioned format bump.
+2. **Hashing & structural sharing.** Legacy `irept` and `irep2` have *different*
+   hash functions and sharing semantics (`irep2_hash` vs irept's hashing). Sets
+   keyed on expressions (`loop_varst`, AI domains) must not change iteration
+   order — order changes propagate into SMT formula construction and can flip
+   results or timings nondeterministically.
+3. **Equality semantics.** `irept` equality is structural-string; `expr2tc`
+   equality is typed and considers the type node. Code that compared `exprt`
+   for identity may get *different* answers after migration (e.g. two ints of
+   different bit-width that stringified equal). Audit every `==`/`operator<`.
+4. **Symbol handling (B2).** `symbolt::value` doubles as "code body" and "const
+   value"; the Python frontend already has a known dual-role hazard
+   (`gotcha_python_symbol_value_static_lifetime`). Migrating B2 must preserve
+   the static-initializer vs function-body distinction exactly.
+5. **Expression canonicalization.** `simplify`/typecheck behaviour differs
+   between the two reps. Migrating a pass must not silently insert/skip a
+   simplification step that changes the VC set.
+6. **Goto-program transformations producing different instruction sequences.**
+   Any pass (B5, B6) whose output instruction list changes — even reordered —
+   changes symex paths. Differential goto-binary diffing is the guard here (§5).
+7. **Ownership/lifetime.** `expr2tc` is reference-counted copy-on-write; `exprt`
+   is value-copied. A pass that mutated an `exprt` in place and relied on the
+   copy being independent may, after migration, mutate shared state via COW
+   aliasing. Audit in-place mutation sites.
+
+---
+
+## 3. Assumptions in the current code that may break under IREP2
+
+- **In-place mutation independence** (lifetime risk #7). `exprt` subexpression
+  edits are local; `expr2tc` edits trigger COW — patterns that grab `exprt &`
+  and mutate operands (e.g. `goto_sideeffects.cpp`, `add_race_assertions.cpp`)
+  need `expr2tc` rewrite via the visitor / `Forall_operands` analogue.
+- **String-keyed lookups.** Code using `.id()`/`.get("…")` string tags assumes
+  the stringy schema. IREP2 nodes are typed enums — every `irep_idt` tag access
+  must map to an `expr2t::expr_ids` case.
+- **`code_typet` introspection** (B3). Passes reading argument types off
+  `goto_functiont::type` (`goto_convert_functions.cpp:288,301`,
+  `assign_params_as_non_det.cpp:57,115-120`,
+  `destructor.cpp`) assume legacy `code_typet`. IREP2's `code_type2t` exposes a
+  different accessor surface.
+- **Serialization round-trip identity.** Code may assume "write then read"
+  yields a byte-identical / pointer-shared graph. IREP2 deserialization rebuilds
+  fresh nodes; any reliance on post-read sharing breaks.
+- **Symbol value emptiness sentinels.** `symbolt::value.is_nil()` vs an empty
+  `expr2tc()` — the nil/none distinction differs and is load-bearing in
+  `instructiont::clear` (`goto_program.h:167-168`).
+
+---
+
+## 4. Phased migration roadmap
+
+Each phase is independently shippable, independently revertible, and gated on
+the validation in §5 passing **with dual-solver agreement (Bitwuzla + Z3)** and
+zero goto-binary diff on the corpus.
+
+### Phase 0 — Instrumentation & safety net (no behaviour change)
+- Build the **differential harness** (§5.1): a script that runs ESBMC on a fixed
+  corpus, emits goto-binary + counterexample digests, and diffs against a golden
+  baseline captured from `master` HEAD *before* any change.
+- Add a `migrate_*` **call-site census** as a checked-in report so each later
+  phase can show the legacy region shrinking (a measurable checkpoint, §6).
+- Capture baselines: full regression corpus, SV-COMP subset digests, goto-binary
+  hashes.
+- **Exit criterion:** harness reproduces identical digests on two clean builds.
+
+### Phase 1 — Drain pure-analysis legacy (B6 leaf passes, no symbol creation)
+Target passes that *build* `exprt` transiently but neither persist symbols nor
+touch serialization. Lowest risk, no B2 dependency.
+- `format_strings.cpp` (`:179`), `goto_sideeffects.cpp` (`:13-104`),
+  `destructor.cpp` analysis (`:5-34`).
+- Rewrite to construct `expr2tc` directly (drop the build-then-`migrate_expr`).
+- **Exit:** zero goto-binary diff on corpus; these files contain no
+  `exprt`/`typet` locals.
+
+### Phase 2 — Migrate `rw_set` (B5)
+- `rw_set` is self-contained (race detection). Rewrite `rw_sett::compute/assign`
+  to take `const expr2tc &` and store `expr2tc original_expr/guard`
+  (`rw_set.h:17-18`). Update its sole caller `add_race_assertions.cpp`.
+- This removes one whole legacy island without symbol-table coupling.
+- **Exit:** `--data-races-check` corpus shows zero goto-binary diff;
+  `rw_set.{h,cpp}` free of `exprt`.
+
+### Phase 3 — Migrate `goto_functiont::type` (B3)
+- Introduce IREP2 `code_type2t` storage on `goto_functiont` *behind an accessor*
+  that still exposes a legacy view (adaptor) so callers compile unchanged.
+- Migrate readers one at a time (`goto_convert_functions.cpp:288,301`,
+  `assign_params_as_non_det.cpp`, `destructor.cpp`, contracts) to the IREP2
+  accessor.
+- Remove the legacy adaptor once no caller uses it.
+- **Exit:** `goto_functiont` stores only IREP2 type; corpus diff clean.
+
+### Phase 4 — Symbol table (B2) — the foundational, highest-risk step
+This is the linchpin (it unblocks the rest of B6). Do it *most carefully*.
+- 4a. Add `expr2tc value2`/`type2tc type2` *alongside* the legacy fields, kept in
+  sync by the existing `migrate_*` calls (shadow fields). Assert equality of the
+  two views on every access in debug builds (differential self-check).
+- 4b. Switch *readers* in the goto pipeline to the IREP2 fields, leaving
+  frontends writing legacy (still synced).
+- 4c. Switch *writers* (the B6 contract/atomicity passes that currently
+  `migrate_type_back`) to write IREP2 directly, dropping the round-trips at
+  `contracts.cpp:1730,1896,2145,2331,2369,2501,2540` and `goto_atomicity_check.cpp:42`.
+- 4d. Migrate `symbolt::to_irep/from_irep` (`symbol.h:42-43`) — **this couples to
+  B4; sequence 4d with Phase 5.**
+- **Exit per sub-step:** shadow-field equality assertions never fire across the
+  full corpus; zero goto-binary diff.
+
+### Phase 5 — Serialization / goto-binary format (B4)
+Do **last**, deliberately, and behind an explicit format version.
+- 5a. Keep reading the legacy `irept` format (back-compat) but add an IREP2-native
+  writer behind a version byte bump in the goto-binary header.
+- 5b. Differential test: write legacy + IREP2 formats, read both, assert digest
+  equality of resulting goto-functions.
+- 5c. Flip the default writer to IREP2 only after a full corpus round-trips
+  identically. Retain the legacy reader indefinitely for old binaries (or gate
+  removal on a separate, later deprecation decision).
+- **Exit:** new binaries IREP2-native; old binaries still load; corpus digests
+  identical across the format boundary.
+
+### Phase 6 — Frontend lowering input (B1) — optional / longest-horizon
+- `goto_convert` consuming `codet` is the deepest boundary (touches every
+  frontend). Migrate only after Phases 1–5 prove the approach. May be deferred
+  indefinitely — `goto_convert.cpp:136` migrating once per instruction is cheap
+  and correct.
+- **Decision gate:** evaluate whether B1 removal is worth the cross-frontend
+  churn, or whether the `migrate_expr` seam at goto-convert is the permanent,
+  acceptable boundary.
+
+### Phase 7 — Cleanup
+- Delete now-dead `migrate_*_back` paths, adaptors, shadow fields, legacy
+  accessors. Only after correctness is proven (§ workflow rule: "cleanup after
+  correctness").
+
+---
+
+## 5. Validation & testing strategy
+
+### 5.1 Differential goto-binary diffing (primary guard)
+- For every corpus input, dump the goto program (`--goto-functions-only`) and the
+  goto-binary; canonicalize and hash. **Any diff between baseline and patched is
+  a hard failure** unless explicitly justified (the "deviation must be justified"
+  constraint). This catches transformation-order and canonicalization drift
+  (risks #5, #6) that pass/fail verdicts alone would miss.
+
+### 5.2 Differential verdict + counterexample testing
+- Run the full `regression/` suite (cap 5 min per CLAUDE.md; narrow per phase).
+- Compare not just SAT/UNSAT verdict but **counterexample trace digests** —
+  a changed trace at an unchanged verdict signals a semantic shift.
+- **Dual-solver:** every phase gate requires Bitwuzla *and* Z3 agreement (matches
+  the repo's Mode-C dual-solver rule).
+
+### 5.3 Shadow-field equality assertions (Phase 4)
+- Debug-build assertions that the legacy and IREP2 views of every symbol are
+  semantically equal at each access. Run across the corpus; zero firings is the
+  gate.
+
+### 5.4 Serialization round-trip (Phase 5)
+- Property test: `read(write(g)) ≡ g` for both formats, and
+  `read_legacy(write_legacy(g)) ≡ read_irep2(write_irep2(g))`.
+- Cross-version: old binaries from a tagged release must still load.
+
+### 5.5 Hashing/ordering invariants (risk #2, #3)
+- Add a targeted test that iterates the expr-keyed sets (`loop_varst`, AI worklists)
+  and asserts deterministic order across two runs and across reps.
+
+### 5.6 ESBMC self-verification & sanitizers
+- Per repo workflow: `esbmc-verifier` agent on touched C/C++; ASan/UBSan build
+  of the unit + regression harness for any pointer/lifetime-touching phase
+  (risk #7).
+- Unit tests under `unit/` (Catch2) for `migrate.*` invariants.
+
+---
+
+## 6. Measurable checkpoints / milestones
+
+| Milestone | Metric | Gate |
+|-----------|--------|------|
+| M0 baseline | Golden digests captured; harness reproducible | 2 clean builds identical |
+| M1 (Phase 1) | `exprt` locals in 3 analysis files → 0 | Corpus diff = 0 |
+| M2 (Phase 2) | `rw_set` `exprt` count → 0 | Race corpus diff = 0 |
+| M3 (Phase 3) | `goto_functiont` legacy type readers → 0 | Corpus diff = 0 |
+| M4 (Phase 4) | Symbol shadow-field assertions firings | 0 firings, corpus diff = 0 |
+| M5 (Phase 5) | Format round-trip + old-binary load | Digests identical; back-compat read OK |
+| M6 (Phase 6, opt) | `migrate_expr` calls in goto_convert | Decision recorded |
+| M7 (cleanup) | Dead `migrate_*_back` LOC removed | Build green, full regression green |
+
+The **`migrate_*` call-site census** (Phase 0) is the running scoreboard: each
+phase must show the count strictly decreasing in its target region and *not*
+increasing anywhere else.
+
+---
+
+## 7. Rollback & compatibility considerations
+
+- **Per-phase revert points.** Each phase is a small, self-contained PR set; a
+  failed gate reverts that PR without disturbing earlier phases. No phase is
+  merged until its gate is green — preserving the no-broken-commits rule.
+- **Adaptor layers as rollback insurance.** Phases 3 and 4 keep legacy views
+  alive behind adaptors/shadow fields, so a regression discovered downstream can
+  be diagnosed by toggling reads back to the legacy view without a full revert.
+- **Serialization back-compat is permanent for reads** (Phase 5a): the legacy
+  `irept` goto-binary reader is retained even after the writer flips, so existing
+  cached binaries and CI artifacts keep loading. Removal of the legacy reader is
+  a *separate, later, explicitly-approved* deprecation — not part of this
+  migration.
+- **Format version byte** gates Phase 5; an IREP2-written binary is unambiguously
+  distinguishable from a legacy one, so a misread fails loudly instead of
+  silently mis-deserializing.
+- **Never squash** (repo rule): each incremental step stays in history for
+  bisection if a regression surfaces months later.
+
+---
+
+## 8. Recommended implementation order (summary)
+
+```
+Phase 0  Instrumentation + baselines        (no behaviour change)
+Phase 1  Pure-analysis leaf passes (B6')     ── lowest risk, no coupling
+Phase 2  rw_set / data-race (B5)             ── self-contained island
+Phase 3  goto_functiont::type (B3)           ── behind adaptor
+Phase 4  Symbol table (B2)                   ── FOUNDATION, shadow-field method
+           ├ 4a shadow fields + assertions
+           ├ 4b switch readers
+           ├ 4c switch writers (kills B6 round-trips)
+           └ 4d symbol (de)serialization  ── couples to Phase 5
+Phase 5  Goto-binary serialization (B4)      ── versioned, back-compat reader kept
+Phase 6  Frontend lowering input (B1)        ── OPTIONAL / deferrable
+Phase 7  Cleanup: delete dead migrate paths  ── only after correctness proven
+```
+
+Rationale: passes with no symbol-table or serialization coupling go first (cheap
+confidence). The symbol table (B2) is the foundation that unblocks the forced B6
+round-trips, so it precedes serialization. Serialization (B4) is last because it
+is the highest-risk and the only one with an external (on-disk) compatibility
+contract. B1 is genuinely optional — the `migrate_expr` seam at goto-convert may
+be the right permanent boundary.


### PR DESCRIPTION
Adds a conservative, phased plan to migrate the goto-program pipeline from legacy `irept` to IREP2, plus a PR-sized breakdown of Phase 2 (`rw_set`). Documents the six surviving legacy boundaries, the phase ordering, validation strategy (differential goto-binary diffing + dual-solver), and rollback considerations.

Planning docs only — no code changes. Tracking issue #4715.