### PR TITLE
[build] add Phase 0 differential harness for IREP2 migration

### DIFF
--- a/scripts/irep2-migration/README.md
+++ b/scripts/irep2-migration/README.md
@@ -1,0 +1,90 @@
+# IREP2 goto-program migration — differential harness (Phase 0)
+
+Tooling for the legacy-IREP → IREP2 migration of the goto-program pipeline.
+This is **Phase 0** of the plan in
+[`docs/irep2-goto-migration-plan.md`](../../docs/irep2-goto-migration-plan.md);
+tracking issue [esbmc/esbmc#4715](https://github.com/esbmc/esbmc/issues/4715).
+
+Phase 0 changes **no** ESBMC behaviour — it adds the safety net that every later
+migration PR is gated on: a way to prove a patch leaves the generated goto
+program **bit-for-bit identical** (after canonicalisation), plus a scoreboard
+that measures the legacy region shrinking.
+
+## Why
+
+The migration's hard constraint is behavioural equivalence. Pass/fail verdicts
+alone miss silent drift (reordered instructions, changed canonicalisation, lost
+guards). The strongest cheap guard is to diff the **canonical goto dump**
+(`esbmc --goto-functions-only`) before and after a change: any difference is a
+hard failure unless explicitly justified.
+
+## Contents
+
+| Script | Purpose |
+|--------|---------|
+| `lib.sh` | Shared helpers (canonicalisation, test.desc-faithful argument construction). Sourced by the others. |
+| `capture_goto_baseline.sh` | Capture golden canonical dumps for a corpus. Run on a **clean pre-migration build**. |
+| `diff_goto_baseline.sh` | Re-derive dumps and diff against the baseline. Exit 0 = identical, 1 = drift. |
+| `migrate_census.sh` | Count `migrate_expr`/`migrate_type`(`_back`) calls per file — the migration scoreboard. |
+
+## Usage
+
+Build a clean `esbmc` first (the binary lives at `build/src/esbmc/esbmc`).
+Corpus arguments are directories searched recursively for `test.desc`; paths are
+interpreted relative to the repository root.
+
+```sh
+# 1. Capture the golden baseline on the current (pre-migration) build.
+#    Scope it to the subsystems an upcoming PR touches (here: concurrency).
+scripts/irep2-migration/capture_goto_baseline.sh \
+    build/src/esbmc/esbmc /tmp/irep2-baseline \
+    regression/parallel-solving regression/esbmc-unix
+
+# 2. Apply a migration PR, rebuild, then check for drift.
+scripts/irep2-migration/diff_goto_baseline.sh \
+    build/src/esbmc/esbmc /tmp/irep2-baseline \
+    regression/parallel-solving regression/esbmc-unix
+#    exit 0 => goto program unchanged (the gate passes)
+#    exit 1 => drift; the per-test unified diff is printed
+
+# 3. Track the legacy region shrinking (default scope: src/goto-programs).
+scripts/irep2-migration/migrate_census.sh
+scripts/irep2-migration/migrate_census.sh src/goto-programs/rw_set.cpp
+```
+
+A migration PR's checklist (per the plan):
+1. `migrate_census.sh <target>` strictly decreases in the target region, nowhere increases.
+2. `diff_goto_baseline.sh` exits 0 on the relevant corpus.
+3. Regression verdicts + counterexamples agree under both Bitwuzla and Z3.
+
+## Canonicalisation
+
+`irep2_canon` (in `lib.sh`) strips only non-deterministic / environment-specific
+noise, preserving everything semantically meaningful (instruction kinds,
+operands, guards, goto targets, file/line/column locations):
+
+- the `ESBMC version …` banner;
+- timing lines (`GOTO program creation time: …s`, etc.);
+- the program-global instruction index in `// N file …` comments (a change
+  anywhere renumbers everything downstream, so the bare index is dropped while
+  the `file/line/column/function` location is kept);
+- the build-tree absolute path → `REPO_ROOT`;
+- the per-run temporary header directory (`/tmp/esbmc-…` on Linux,
+  `/var/folders/…/T/esbmc[._-]…` on macOS, including occurrences embedded inside
+  generated type names) → `HDR`.
+
+If a future ESBMC change introduces a new non-deterministic line, add a rule to
+`irep2_canon` (and note it here) rather than weakening the diff.
+
+## Notes
+
+- Argument construction mirrors `regression/testing_tool.py` exactly, so each
+  test is driven with the same flags the real suite uses (including
+  goto-affecting ones like `--data-races-check`, `--k-induction`).
+- esbmc's exit status is intentionally ignored; the deterministic dumped text is
+  what is compared, so descriptors with no flags line (whose regex line is
+  mis-parsed as bogus args, exactly as the real suite does) still yield a stable,
+  comparable digest.
+- Both scripts clean up `/tmp/esbmc-headers-*` on exit (per the repo's /tmp
+  hygiene rule).
+- macOS `bash` 3.2 compatible (no associative arrays / `mapfile`).

--- a/scripts/irep2-migration/capture_goto_baseline.sh
+++ b/scripts/irep2-migration/capture_goto_baseline.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Capture a golden baseline of canonicalised goto-program dumps for a corpus of
+# regression tests. Run this on a clean (pre-migration) build; later migration
+# PRs re-run diff_goto_baseline.sh and must produce ZERO diff.
+#
+# Usage:
+#   capture_goto_baseline.sh <esbmc-binary> <baseline-out-dir> <corpus-dir>...
+#
+# Each <corpus-dir> is searched recursively for `test.desc` files; the source
+# and flags from each are used to drive `esbmc --goto-functions-only`.
+#
+# Example (concurrency + data-race subset, the early-phase scope):
+#   scripts/irep2-migration/capture_goto_baseline.sh \
+#       build/src/esbmc/esbmc /tmp/irep2-baseline \
+#       regression/esbmc/concurrency regression/esbmc-cpp/concurrency
+#
+# Tracking issue: esbmc/esbmc#4715
+set -euo pipefail
+
+# shellcheck source=scripts/irep2-migration/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ "$#" -lt 3 ]; then
+  sed -n '2,20p' "$0"; exit 2
+fi
+
+ESBMC="$(irep2_abspath "$1")"; OUT="$2"; shift 2
+REPO="$(irep2_repo_root)"
+# Absolutise OUT before we cd, then interpret corpus args relative to repo root.
+mkdir -p "$OUT"; OUT="$(cd "$OUT" && pwd)"
+cd "$REPO"
+
+[ -x "$ESBMC" ] || { echo "error: esbmc binary not executable: $ESBMC" >&2; exit 2; }
+
+manifest="$OUT/MANIFEST.sha256"
+: > "$manifest"
+count=0
+
+for corpus in "$@"; do
+  [ -d "$corpus" ] || { echo "warning: skipping missing corpus dir: $corpus" >&2; continue; }
+  while IFS= read -r desc; do
+    dir="$(dirname "$desc")"
+    # Stable per-test key: repo-relative dir, slashes -> _.
+    key="$(printf '%s' "$dir" | tr '/' '_')"
+    dump="$OUT/$key.goto.txt"
+
+    irep2_goto_dump "$ESBMC" "$desc" "$REPO" > "$dump" || { rm -f "$dump"; continue; }
+    ( cd "$OUT" && shasum -a 256 "$key.goto.txt" ) >> "$manifest"
+    count=$((count + 1))
+  done < <(find "$corpus" -name test.desc | sort)
+done
+
+irep2_cleanup_tmp
+sort -o "$manifest" "$manifest"
+echo "captured $count goto dumps into $OUT"
+echo "manifest: $manifest"

--- a/scripts/irep2-migration/diff_goto_baseline.sh
+++ b/scripts/irep2-migration/diff_goto_baseline.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Re-derive canonical goto dumps for a corpus and diff them against a baseline
+# captured by capture_goto_baseline.sh. The migration gate: a behaviour-
+# preserving PR must produce ZERO diff. Any difference is reported per-test and
+# the script exits non-zero.
+#
+# Usage:
+#   diff_goto_baseline.sh <esbmc-binary> <baseline-dir> <corpus-dir>...
+#
+# Exit codes: 0 = identical to baseline, 1 = differences found, 2 = usage error.
+#
+# Tracking issue: esbmc/esbmc#4715
+set -euo pipefail
+
+# shellcheck source=scripts/irep2-migration/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ "$#" -lt 3 ]; then
+  sed -n '2,16p' "$0"; exit 2
+fi
+
+ESBMC="$(irep2_abspath "$1")"; BASE="$2"; shift 2
+REPO="$(irep2_repo_root)"
+[ -d "$BASE" ] && BASE="$(cd "$BASE" && pwd)"
+cd "$REPO"
+
+[ -x "$ESBMC" ] || { echo "error: esbmc binary not executable: $ESBMC" >&2; exit 2; }
+[ -d "$BASE" ]  || { echo "error: baseline dir not found: $BASE" >&2; exit 2; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"; irep2_cleanup_tmp' EXIT
+
+differing=0; checked=0; missing=0
+
+for corpus in "$@"; do
+  [ -d "$corpus" ] || { echo "warning: skipping missing corpus dir: $corpus" >&2; continue; }
+  while IFS= read -r desc; do
+    dir="$(dirname "$desc")"
+    key="$(printf '%s' "$dir" | tr '/' '_')"
+    golden="$BASE/$key.goto.txt"
+
+    irep2_goto_dump "$ESBMC" "$desc" "$REPO" > "$work/cur.txt" || continue
+    if [ ! -f "$golden" ]; then
+      echo "MISSING-BASELINE  $dir"; missing=$((missing + 1)); continue
+    fi
+    if ! diff -u "$golden" "$work/cur.txt" > "$work/d.txt"; then
+      echo "DIFF              $dir"
+      sed 's/^/    /' "$work/d.txt"
+      differing=$((differing + 1))
+    fi
+    checked=$((checked + 1))
+  done < <(find "$corpus" -name test.desc | sort)
+done
+
+echo "checked=$checked  differing=$differing  missing-baseline=$missing"
+[ "$differing" -eq 0 ] && [ "$missing" -eq 0 ]

--- a/scripts/irep2-migration/lib.sh
+++ b/scripts/irep2-migration/lib.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash
+# Shared helpers for the IREP2 goto-program migration differential harness.
+# Sourced by capture_goto_baseline.sh and diff_goto_baseline.sh.
+# See README.md for the rationale (tracking issue: esbmc/esbmc#4715).
+
+# Resolve the repository root from this script's location.
+irep2_repo_root() {
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  printf '%s\n' "$here"
+}
+
+# Absolutise a path that contains a slash (so it survives a later `cd`).
+# A bare command name (no slash) is left untouched to be resolved via PATH.
+irep2_abspath() {
+  case "$1" in
+    */*) printf '%s\n' "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")" ;;
+    *)   printf '%s\n' "$1" ;;
+  esac
+}
+
+# Canonicalise `esbmc --goto-functions-only` output read from stdin.
+# Strips environment-specific and program-global noise while preserving
+# instruction kinds, operands, guards, goto targets and file/line locations.
+# $1 = repository root (collapsed to the literal token REPO_ROOT).
+irep2_canon() {
+  local repo="$1"
+  sed \
+    -e '/^ESBMC version /d' \
+    -e '/^GOTO program creation time:/d' \
+    -e '/^GOTO program processing time:/d' \
+    -e '/ time: [0-9.]*s$/d' \
+    -e 's|^\([[:space:]]*//\) [0-9][0-9]* file |\1 file |' \
+    -e "s|${repo}|REPO_ROOT|g" \
+    -e 's|/var/folders/[^/ ]*/[^/ ]*/T/esbmc[._-][0-9A-Za-z-]*|HDR|g' \
+    -e 's|/tmp/esbmc[._-][0-9A-Za-z-]*|HDR|g'
+}
+
+# Produce the canonical goto dump for one test.desc into stdout. Returns 1 if
+# the descriptor is unusable (no source / missing file).
+# $1 = esbmc binary  $2 = path to a test.desc  $3 = repo root
+#
+# Argument construction mirrors regression/testing_tool.py exactly
+# (generate_run_argument_list): line 3 is word-split, each token resolved to
+# <test_dir>/<token> when that names an existing file else passed verbatim, then
+# the source is appended. We add --goto-functions-only so esbmc stops after
+# building the goto program. Goto-affecting flags (--data-races-check,
+# --k-induction, --no-pointer-check, ...) are thus honoured exactly as the
+# real suite passes them.
+irep2_goto_dump() {
+  local esbmc="$1" desc="$2" repo="$3"
+  local dir src args tok
+  dir="$(dirname "$desc")"
+  src="$(sed -n '2p' "$desc" | tr -d '[:space:]')"
+  args="$(sed -n '3p' "$desc")"
+  [ -n "$src" ] && [ -f "$dir/$src" ] || return 1
+
+  local argv=()
+  for tok in $args; do
+    if [ -f "$dir/$tok" ]; then argv+=("$dir/$tok"); else argv+=("$tok"); fi
+  done
+
+  # esbmc's exit status is intentionally ignored: --goto-functions-only can exit
+  # non-zero on some inputs, but the (deterministic) dumped text is what we diff.
+  ( "$esbmc" "${argv[@]}" --goto-functions-only "$dir/$src" 2>&1 || true ) \
+    | irep2_canon "$repo"
+}
+
+# Remove per-run header temp dirs (CLAUDE.md hygiene rule).
+irep2_cleanup_tmp() {
+  rm -rf /tmp/esbmc-headers-* 2>/dev/null || true
+}

--- a/scripts/irep2-migration/migrate_census.sh
+++ b/scripts/irep2-migration/migrate_census.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Count legacy<->IREP2 conversion calls (migrate_expr, migrate_type,
+# migrate_expr_back, migrate_type_back) per file. This is the migration
+# "scoreboard": each migration PR must show the count strictly DECREASING in the
+# region it targets and increasing nowhere else (the Phase-0 measurable
+# checkpoint from docs/irep2-goto-migration-plan.md §6).
+#
+# Usage:
+#   migrate_census.sh [path ...]      # default: src/goto-programs
+#
+# Output: per-file counts (forward / back / total) sorted by total descending,
+# then a grand total. Stable and greppable, suitable for checking a snapshot
+# into the tree and diffing across PRs.
+#
+# Tracking issue: esbmc/esbmc#4715
+set -u
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo" || exit 1
+
+paths=("$@")
+[ "${#paths[@]}" -gt 0 ] || paths=("src/goto-programs")
+
+# Forward = into IREP2 (migrate_expr / migrate_type). The _back variants also
+# match this pattern, so we subtract them out below.
+fwd_re='migrate_(expr|type)\b'
+back_re='migrate_(expr|type)_back\b'
+
+# Count occurrences of an ERE in a file (0 on no match; never fails the script).
+count() { grep -E -o "$1" "$2" 2>/dev/null | wc -l | tr -d ' '; }
+
+rows=""
+tot_fwd=0; tot_back=0
+
+while IFS= read -r f; do
+  back=$(count "$back_re" "$f")
+  all=$(count "$fwd_re" "$f")
+  fwd=$(( all - back ))
+  total=$(( fwd + back ))
+  [ "$total" -gt 0 ] || continue
+  rows+="$(printf '%6d\t%6d\t%6d\t%s\n' "$total" "$fwd" "$back" "${f#"$repo"/}")"$'\n'
+  tot_fwd=$(( tot_fwd + fwd )); tot_back=$(( tot_back + back ))
+done < <(
+  for p in "${paths[@]}"; do
+    find "$p" -type f \( -name '*.cpp' -o -name '*.h' \) 2>/dev/null
+  done | sort
+)
+
+printf '%-58s %6s %6s %6s\n' "FILE" "FWD" "BACK" "TOTAL"
+printf '%-58s %6s %6s %6s\n' "----" "---" "----" "-----"
+# Sort rows by total (col 1) descending, then re-layout as FILE FWD BACK TOTAL.
+printf '%s' "$rows" | sort -t$'\t' -k1,1nr -k4,4 | while IFS=$'\t' read -r total fwd back file; do
+  [ -n "$file" ] || continue
+  printf '%-58s %6d %6d %6d\n' "$file" "$fwd" "$back" "$total"
+done
+printf '%-58s %6s %6s %6s\n' "----" "---" "----" "-----"
+printf '%-58s %6d %6d %6d\n' "TOTAL" "$tot_fwd" "$tot_back" "$(( tot_fwd + tot_back ))"


### PR DESCRIPTION
Phase 0 of the goto-program legacy-IREP → IREP2 migration (#4715). Adds the safety net every later migration PR is gated on, with no change to ESBMC behaviour.

`scripts/irep2-migration/`:
- `capture_goto_baseline.sh` / `diff_goto_baseline.sh` — capture a canonicalised `--goto-functions-only` baseline over a corpus and diff later builds against it (exit 1 on any drift). Argument construction mirrors `regression/testing_tool.py`; canonicalisation strips only non-deterministic noise (version banner, timing lines, global instruction index, build path, per-run temp header dir on Linux + macOS) while preserving instructions, operands, guards, targets and locations.
- `migrate_census.sh` — per-file `migrate_*` scoreboard so each PR can show the legacy region shrinking.
- `lib.sh` / `README.md`.

Validated: deterministic (zero diff on the same build), fires (exit 1) on an injected change, exits 0 when clean; shellcheck `-x` clean.