### PR TITLE
[goto-programs] migrate rw_set data-race analysis to IREP2

### DIFF
--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -55,12 +55,13 @@ public:
 
   const exprt get_w_guard_expr(const rw_sett::entryt &entry)
   {
-    return get_guard_symbol_expr(entry.original_expr);
+    return get_guard_symbol_expr(migrate_expr_back(entry.original_expr));
   }
 
   const exprt get_assertion(const rw_sett::entryt &entry)
   {
-    return gen_not(get_guard_symbol_expr(entry.original_expr));
+    return gen_not(
+      get_guard_symbol_expr(migrate_expr_back(entry.original_expr)));
   }
 
   void add_initialization(goto_programt &goto_program);
@@ -127,13 +128,11 @@ void add_race_assertions(
        instruction.is_assume()) &&
       !is_atomic)
     {
-      exprt tmp_expr;
-      if (instruction.is_goto() || instruction.is_assert())
-        tmp_expr = migrate_expr_back(instruction.guard);
-      else
-        tmp_expr = migrate_expr_back(instruction.code);
+      const expr2tc &rw_expr =
+        (instruction.is_goto() || instruction.is_assert()) ? instruction.guard
+                                                           : instruction.code;
 
-      rw_sett rw_set(ns, i_it, tmp_expr);
+      rw_sett rw_set(ns, i_it, rw_expr);
 
       if (rw_set.entries.empty())
         continue;
@@ -186,7 +185,8 @@ void add_race_assertions(
 
         t->type = ASSIGN;
         code_assignt theassign(
-          w_guards.get_w_guard_expr(e_it->second), e_it->second.get_guard());
+          w_guards.get_w_guard_expr(e_it->second),
+          migrate_expr_back(e_it->second.get_guard().as_expr()));
 
         migrate_expr(theassign, t->code);
 

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -5,51 +5,45 @@
 #include <util/namespace.h>
 #include <util/std_expr.h>
 
-void rw_sett::compute(const exprt &expr)
+void rw_sett::compute(const expr2tc &expr)
 {
+  if (is_nil_expr(expr))
+    return;
+
   const goto_programt::instructiont &instruction = *target;
 
-  if (expr.is_code())
+  if (is_code_assign2t(expr))
   {
-    codet code = to_code(expr);
-    const irep_idt &statement = code.get_statement();
-
-    if (statement == "assign")
+    const code_assign2t &code = to_code_assign2t(expr);
+    assign(code.target, code.source);
+  }
+  else if (is_code_printf2t(expr))
+  {
+    for (const expr2tc &op : to_code_printf2t(expr).operands)
+      read_rec(op);
+  }
+  else if (is_code_return2t(expr))
+  {
+    read_rec(to_code_return2t(expr).operand);
+  }
+  else if (is_code_function_call2t(expr))
+  {
+    const code_function_call2t &code = to_code_function_call2t(expr);
+    read_write_rec(code.ret, false, true, "", guard2tc(), expr2tc());
+    // For function calls, we first check to see if the function has a body
+    // available, and if so, we skip it because we also check inside the
+    // function. If not, we need to check these args.
+    if (is_symbol2t(code.function))
     {
-      assert(code.operands().size() == 2);
-      assign(code.op0(), code.op1());
-    }
-    else if (statement == "printf")
-    {
-      exprt expr = code;
-      Forall_operands (it, expr)
-        read_rec(*it);
-    }
-    else if (statement == "return")
-    {
-      assert(code.operands().size() == 1);
-      read_rec(code.op0());
-    }
-    else if (statement == "function_call")
-    {
-      assert(code.operands().size());
-      read_write_rec(code.op0(), false, true, "", guard2tc(), nil_exprt());
-      // For function calls, we first check to see if the function has a body available,
-      // and if so, we skip it because we also check inside the function
-      // If not, we need check these args
-      if (code.op1().is_symbol())
-      {
-        const symbol_exprt &symbol_expr = to_symbol_expr(code.op1());
-        const symbolt *symbol = ns.lookup(symbol_expr.get_identifier());
-        if (symbol->value.is_nil() || symbol->name == "__VERIFIER_assert")
-          Forall_operands (it, code.op2())
-          {
-            if (it->is_address_of())
-              read_rec(it->op0());
-            else
-              read_rec(*it);
-          }
-      }
+      const symbolt *symbol = ns.lookup(to_symbol2t(code.function).thename);
+      if (symbol->value.is_nil() || symbol->name == "__VERIFIER_assert")
+        for (const expr2tc &arg : code.operands)
+        {
+          if (is_address_of2t(arg))
+            read_rec(to_address_of2t(arg).ptr_obj);
+          else
+            read_rec(arg);
+        }
     }
   }
   else if (
@@ -57,127 +51,180 @@ void rw_sett::compute(const exprt &expr)
     read_rec(expr);
 }
 
-void rw_sett::assign(const exprt &lhs, const exprt &rhs)
+void rw_sett::assign(const expr2tc &lhs, const expr2tc &rhs)
 {
   read_rec(rhs);
-  read_write_rec(lhs, false, true, "", guard2tc(), nil_exprt());
+  read_write_rec(lhs, false, true, "", guard2tc(), expr2tc());
 }
 
 void rw_sett::read_write_rec(
-  const exprt &expr,
+  const expr2tc &expr,
   bool r,
   bool w,
   const std::string &suffix,
   const guard2tc &guard,
-  const exprt &original_expr,
+  const expr2tc &original_expr,
   bool dereferenced)
 {
-  if (expr.is_symbol() && !expr.has_operands())
+  if (is_nil_expr(expr))
+    return;
+
+  if (is_symbol2t(expr))
   {
-    const symbol_exprt &symbol_expr = to_symbol_expr(expr);
+    const symbol2t &symbol_expr = to_symbol2t(expr);
 
-    const symbolt *symbol = ns.lookup(symbol_expr.get_identifier());
-    if (symbol)
+    const symbolt *symbol = ns.lookup(symbol_expr.thename);
+    // irep2 represents synthetic pointer constants (notably the NULL pointer)
+    // as a symbol2t with no namespace entry; the legacy exprt form was a
+    // constant_exprt, which never reached this symbol path. Skip them so we do
+    // not register a bogus race object (and later take its address).
+    if (!symbol)
+      return;
+
+    // Python module-level globals carry static_lifetime=false to keep
+    // them out of the C-side static-init pass (their values double as
+    // const-prop snapshots in the Python frontend). The Python frontend
+    // sets file_local=false on them so this filter recognises them
+    // as race-eligible shared state.
+    const bool python_global = symbol->mode == "Python" && !symbol->file_local;
+    if (
+      (!symbol->static_lifetime && !dereferenced && !python_global) ||
+      symbol->is_thread_local)
     {
-      // Python module-level globals carry static_lifetime=false to keep
-      // them out of the C-side static-init pass (their values double as
-      // const-prop snapshots in the Python frontend). The Python frontend
-      // sets file_local=false on them so this filter recognises them
-      // as race-eligible shared state.
-      const bool python_global =
-        symbol->mode == "Python" && !symbol->file_local;
-      if (
-        (!symbol->static_lifetime && !dereferenced && !python_global) ||
-        symbol->is_thread_local)
-      {
-        return; // ignore for now
-      }
-
-      if (
-        symbol->name == "__ESBMC_alloc" ||
-        symbol->name == "__ESBMC_alloc_size" || symbol->name == "stdin" ||
-        symbol->name == "stdout" || symbol->name == "stderr" ||
-        symbol->name == "sys_nerr" || symbol->name == "operator=::ref" ||
-        symbol->name == "this" || symbol->name == "__ESBMC_atexits")
-      {
-        return; // ignore for now
-      }
-
-      // Improvements for CUDA features
-      if (symbol->name == "indexOfThread" || symbol->name == "indexOfBlock")
-      {
-        return; // ignore for now
-      }
-
-      // C11 _Atomic variables are never involved in data races
-      // (§5.1.2.4p4: concurrent accesses to atomic objects are not races).
-      if (symbol->type.get_bool("#atomic"))
-        return;
+      return; // ignore for now
     }
 
-    irep_idt object = id2string(symbol_expr.get_identifier()) + suffix;
+    if (
+      symbol->name == "__ESBMC_alloc" || symbol->name == "__ESBMC_alloc_size" ||
+      symbol->name == "stdin" || symbol->name == "stdout" ||
+      symbol->name == "stderr" || symbol->name == "sys_nerr" ||
+      symbol->name == "operator=::ref" || symbol->name == "this" ||
+      symbol->name == "__ESBMC_atexits")
+    {
+      return; // ignore for now
+    }
+
+    // Improvements for CUDA features
+    if (symbol->name == "indexOfThread" || symbol->name == "indexOfBlock")
+    {
+      return; // ignore for now
+    }
+
+    // C11 _Atomic variables are never involved in data races
+    // (§5.1.2.4p4: concurrent accesses to atomic objects are not races).
+    if (symbol->type.get_bool("#atomic"))
+      return;
+
+    irep_idt object = id2string(symbol_expr.thename) + suffix;
 
     entryt &entry = entries[object];
     entry.object = object;
     entry.r = entry.r || r;
     entry.w = entry.w || w;
     entry.deref = dereferenced;
-    entry.guard = migrate_expr_back(guard.as_expr());
-    entry.original_expr = original_expr.is_nil() ? expr : original_expr;
+    entry.guard = guard;
+    entry.original_expr = is_nil_expr(original_expr) ? expr : original_expr;
   }
-  else if (expr.is_member())
+  else if (is_member2t(expr))
   {
-    assert(expr.operands().size() == 1);
-    const std::string &component_name = expr.component_name().as_string();
-    exprt tmp = original_expr.is_nil() ? expr : original_expr;
+    const member2t &member = to_member2t(expr);
+    expr2tc tmp = is_nil_expr(original_expr) ? expr : original_expr;
 
     read_write_rec(
-      expr.op0(),
+      member.source_value,
       r,
       w,
-      "." + component_name + suffix,
+      "." + id2string(member.member) + suffix,
       guard,
       tmp,
       dereferenced);
   }
-  else if (expr.is_index())
+  else if (is_index2t(expr))
   {
-    assert(expr.operands().size() == 2);
-    exprt tmp = original_expr.is_nil() ? expr : original_expr;
-    read_write_rec(expr.op0(), r, w, suffix, guard, tmp, dereferenced);
+    expr2tc tmp = is_nil_expr(original_expr) ? expr : original_expr;
+    read_write_rec(
+      to_index2t(expr).source_value, r, w, suffix, guard, tmp, dereferenced);
   }
-  else if (expr.is_dereference())
+  else if (is_dereference2t(expr))
   {
-    assert(expr.operands().size() == 1);
-    exprt tmp = original_expr.is_nil() ? expr : original_expr;
-
-    read_write_rec(expr.op0(), r, w, suffix, guard, tmp, true);
+    expr2tc tmp = is_nil_expr(original_expr) ? expr : original_expr;
+    read_write_rec(
+      to_dereference2t(expr).value, r, w, suffix, guard, tmp, true);
   }
-  else if (expr.is_address_of() || expr.id() == "implicit_address_of")
+  else if (is_address_of2t(expr))
   {
-    assert(expr.operands().size() == 1);
+    // Taking an address neither reads nor writes the pointee.
   }
-  else if (expr.id() == "if")
+  else if (is_if2t(expr))
   {
-    assert(expr.operands().size() == 3);
-    read_rec(expr.op0(), guard, original_expr);
+    const if2t &if_expr = to_if2t(expr);
+    read_rec(if_expr.cond, guard, original_expr);
 
     guard2tc true_guard(guard);
-    expr2tc tmp_expr;
-    migrate_expr(expr.op0(), tmp_expr);
-    true_guard.add(tmp_expr);
+    true_guard.add(if_expr.cond);
     read_write_rec(
-      expr.op1(), r, w, suffix, true_guard, original_expr, dereferenced);
+      if_expr.true_value,
+      r,
+      w,
+      suffix,
+      true_guard,
+      original_expr,
+      dereferenced);
 
     guard2tc false_guard(guard);
-    migrate_expr(gen_not(expr.op0()), tmp_expr);
-    false_guard.add(tmp_expr);
+    false_guard.add(not2tc(if_expr.cond));
     read_write_rec(
-      expr.op2(), r, w, suffix, false_guard, original_expr, dereferenced);
+      if_expr.false_value,
+      r,
+      w,
+      suffix,
+      false_guard,
+      original_expr,
+      dereferenced);
+  }
+  else if (is_typecast2t(expr) || is_nearbyint2t(expr))
+  {
+    // Floating-point typecast/nearbyint carry __ESBMC_rounding_mode as an
+    // extra operand that the legacy exprt form does not expose positionally.
+    // Recurse only into the value operand so the operand walk matches the
+    // pre-migration behaviour (and does not register the rounding mode as a
+    // shared object). A genuine read/write of the rounding-mode global still
+    // reaches the symbol path via assign()/read_rec().
+    const expr2tc &from = is_typecast2t(expr) ? to_typecast2t(expr).from
+                                              : to_nearbyint2t(expr).from;
+    read_write_rec(from, r, w, suffix, guard, original_expr, dereferenced);
+  }
+  else if (
+    is_ieee_add2t(expr) || is_ieee_sub2t(expr) || is_ieee_mul2t(expr) ||
+    is_ieee_div2t(expr) || is_ieee_fma2t(expr) || is_ieee_sqrt2t(expr))
+  {
+    // Same rationale: recurse into the FP value operands, never the rounding
+    // mode. foreach_operand would also visit rounding_mode, so list the value
+    // operands explicitly.
+    std::vector<expr2tc> values;
+    if (is_ieee_add2t(expr))
+      values = {to_ieee_add2t(expr).side_1, to_ieee_add2t(expr).side_2};
+    else if (is_ieee_sub2t(expr))
+      values = {to_ieee_sub2t(expr).side_1, to_ieee_sub2t(expr).side_2};
+    else if (is_ieee_mul2t(expr))
+      values = {to_ieee_mul2t(expr).side_1, to_ieee_mul2t(expr).side_2};
+    else if (is_ieee_div2t(expr))
+      values = {to_ieee_div2t(expr).side_1, to_ieee_div2t(expr).side_2};
+    else if (is_ieee_fma2t(expr))
+      values = {
+        to_ieee_fma2t(expr).value_1,
+        to_ieee_fma2t(expr).value_2,
+        to_ieee_fma2t(expr).value_3};
+    else
+      values = {to_ieee_sqrt2t(expr).value};
+
+    for (const expr2tc &v : values)
+      read_write_rec(v, r, w, suffix, guard, original_expr, dereferenced);
   }
   else
   {
-    forall_operands (it, expr)
-      read_write_rec(*it, r, w, suffix, guard, original_expr, dereferenced);
+    expr->foreach_operand([&](const expr2tc &op) {
+      read_write_rec(op, r, w, suffix, guard, original_expr, dereferenced);
+    });
   }
 }

--- a/src/goto-programs/rw_set.h
+++ b/src/goto-programs/rw_set.h
@@ -14,14 +14,14 @@ public:
   {
     irep_idt object;
     bool r, w, deref;
-    exprt guard;
-    exprt original_expr;
+    guard2tc guard;
+    expr2tc original_expr;
 
-    entryt() : r(false), w(false), guard(true_exprt())
+    entryt() : r(false), w(false), deref(false)
     {
     }
 
-    const exprt &get_guard() const
+    const guard2tc &get_guard() const
     {
       return guard;
     }
@@ -43,7 +43,7 @@ public:
   typedef std::unordered_map<irep_idt, entryt, irep_id_hash> entriest;
   entriest entries;
 
-  void compute(const exprt &expr);
+  void compute(const expr2tc &expr);
 
   rw_sett(const namespacet &_ns, goto_programt::const_targett _target)
     : ns(_ns), target(_target)
@@ -53,19 +53,21 @@ public:
   rw_sett(
     const namespacet &_ns,
     goto_programt::const_targett _target,
-    const exprt &expr)
+    const expr2tc &expr)
     : ns(_ns), target(_target)
   {
     compute(expr);
   }
 
-  void read_rec(const exprt &expr)
+  void read_rec(const expr2tc &expr)
   {
-    read_write_rec(expr, true, false, "", guard2tc(), nil_exprt());
+    read_write_rec(expr, true, false, "", guard2tc(), expr2tc());
   }
 
-  void
-  read_rec(const exprt &expr, const guard2tc &guard, const exprt &original_expr)
+  void read_rec(
+    const expr2tc &expr,
+    const guard2tc &guard,
+    const expr2tc &original_expr)
   {
     read_write_rec(expr, true, false, "", guard, original_expr);
   }
@@ -74,15 +76,15 @@ protected:
   const namespacet &ns;
   const goto_programt::const_targett target;
 
-  void assign(const exprt &lhs, const exprt &rhs);
+  void assign(const expr2tc &lhs, const expr2tc &rhs);
 
   void read_write_rec(
-    const exprt &expr,
+    const expr2tc &expr,
     bool r,
     bool w,
     const std::string &suffix,
     const guard2tc &guard,
-    const exprt &original_expr,
+    const expr2tc &original_expr,
     bool dereferenced = false);
 };
 


### PR DESCRIPTION
Phase 2.1 of the goto-program legacy-IREP → IREP2 migration (#4715), and the first code migration validated against the Phase 0 differential harness.

Retypes `rw_sett`/`entryt` to `expr2tc`/`guard2tc` and rewrites the read/write recursion over typed IREP2 nodes (`code_assign2t`, `code_function_call2t`, `symbol2t`, `member2t`, `index2t`, `dereference2t`, `if2t`, …), replacing the legacy `exprt` string dispatch. `add_race_assertions` now passes `instruction.code`/`guard` directly — no `migrate_expr_back` round-trip on the per-instruction hot path. `w_guardst` stays on legacy `exprt` for now (its symbol creation is deferred to Phase 4).

Two IREP2-vs-legacy representation differences are handled so the instrumented goto program stays byte-identical to the pre-migration output:
- the NULL pointer is a namespace-less `symbol2t` in IREP2 (legacy saw a `constant_exprt`) — skip symbols absent from the namespace;
- FP nodes (`typecast`/`nearbyint`/`ieee_*`) carry `__ESBMC_rounding_mode` as an operand the legacy `exprt` did not expose positionally — recurse only into value operands. Genuine reads/writes of the rounding-mode global still register via the symbol path.

**Validation:** zero goto-program diff across the 85-test data-race regression corpus (3 Python tests differ only in the `__file__` astgen-temp-path byte array — proven build-independent pre-existing non-determinism). The `race`/CUDA/`pthread`/`threading` ctest suites pass.