### PR TITLE
[goto-programs] build race-check exprs in IREP2 (Phase 2.2)

### DIFF
--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -41,27 +41,22 @@ public:
     return *symbol_ptr;
   }
 
-  const exprt get_guard_symbol_expr(const exprt &original_expr)
+  expr2tc get_guard_symbol_expr(const expr2tc &original_expr)
   {
     // introduce a new expression: RACE_CHECK(&x)
     // its operand is the address of the variable
     // which we will replace during symbolic execution.
-    exprt address = address_of_exprt(original_expr);
-    exprt check("races_check", typet("bool"));
-    check.move_to_operands(address);
-
-    return check;
+    return races_check2tc(address_of2tc(original_expr->type, original_expr));
   }
 
-  const exprt get_w_guard_expr(const rw_sett::entryt &entry)
+  expr2tc get_w_guard_expr(const rw_sett::entryt &entry)
   {
-    return get_guard_symbol_expr(migrate_expr_back(entry.original_expr));
+    return get_guard_symbol_expr(entry.original_expr);
   }
 
-  const exprt get_assertion(const rw_sett::entryt &entry)
+  expr2tc get_assertion(const rw_sett::entryt &entry)
   {
-    return gen_not(
-      get_guard_symbol_expr(migrate_expr_back(entry.original_expr)));
+    return not2tc(get_guard_symbol_expr(entry.original_expr));
   }
 
   void add_initialization(goto_programt &goto_program);
@@ -169,9 +164,7 @@ void add_race_assertions(
       {
         goto_programt::targett t = goto_program.insert(i_it);
 
-        expr2tc assert;
-        migrate_expr(w_guards.get_assertion(e_it->second), assert);
-        t->make_assertion(assert);
+        t->make_assertion(w_guards.get_assertion(e_it->second));
         t->location = original_instruction.location;
         t->location.user_provided(false);
         t->location.comment(e_it->second.get_comment());
@@ -184,11 +177,9 @@ void add_race_assertions(
         goto_programt::targett t = goto_program.insert(i_it);
 
         t->type = ASSIGN;
-        code_assignt theassign(
+        t->code = code_assign2tc(
           w_guards.get_w_guard_expr(e_it->second),
-          migrate_expr_back(e_it->second.get_guard().as_expr()));
-
-        migrate_expr(theassign, t->code);
+          e_it->second.get_guard().as_expr());
 
         t->location = original_instruction.location;
         i_it = ++t;
@@ -234,9 +225,8 @@ void add_race_assertions(
         goto_programt::targett t = goto_program.insert(i_it);
 
         t->type = ASSIGN;
-        code_assignt theassign(
-          w_guards.get_w_guard_expr(e_it->second), false_exprt());
-        migrate_expr(theassign, t->code);
+        t->code = code_assign2tc(
+          w_guards.get_w_guard_expr(e_it->second), gen_false_expr());
 
         t->location = original_instruction.location;
         i_it = ++t;


### PR DESCRIPTION
Phase 2.2 of the goto-program legacy-IREP → IREP2 migration (#4715). **Stacked on #4718 (Phase 2.1)** — review/merge that first; this PR targets the 2.1 branch and will be rebased to master once 2.1 lands.

Moves `w_guardst`'s race-check expression *building* to IREP2, removing the remaining per-instruction round-trips:
- `get_guard_symbol_expr` → `races_check2tc(address_of2tc(orig->type, orig))`
- `get_assertion` → `not2tc(...)`; sources now consume `entry.original_expr` (`expr2tc` since #4718) directly
- the three instrumentation sites set `t->code = code_assign2tc(...)` / `t->make_assertion(...)` directly (no `migrate_expr`/`code_assignt`/`false_exprt`)

Symbol *creation* (the `migrate_type_back` tail) stays on legacy `exprt` — that is Phase 4 (symbol table).

**Validation:** zero goto-program diff across the C/CUDA data-race corpus; the 3 Python tests are set-identical (differ only in pre-existing astgen map-order / `__file__` non-determinism, proven build-independent). race/cuda/pthread/threading ctest suites pass. `code-reviewer` confirmed each construction is byte-equivalent to the migrated legacy form (incl. the `address_of2tc` subtype, `gen_false_expr`, `not2tc`).