### PR TITLE
[goto-programs] migrate goto_functiont::type to IREP2 (Phase 3)

### DIFF
--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -916,7 +916,7 @@ void code_contractst::enforce_contracts(
     goto_functiont new_func;
     new_func.body = wrapper;
     if (func_sym->type.is_code())
-      new_func.type = to_code_type(func_sym->type);
+      new_func.type = migrate_type(func_sym->type);
     new_func.body_available = true;
     new_func.update_instructions_function(original_id);
 

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -67,9 +67,8 @@ void goto_convert_functionst::add_return(
   t->make_return();
   t->location = location;
 
-  const typet &thetype = (f.type.return_type().id() == "symbol")
-                           ? ns.follow(f.type.return_type())
-                           : f.type.return_type();
+  const typet rt = migrate_type_back(to_code_type(f.type).ret_type);
+  const typet &thetype = (rt.id() == "symbol") ? ns.follow(rt) : rt;
   exprt rhs = exprt("sideeffect", thetype);
   rhs.statement("nondet");
 
@@ -98,7 +97,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
     functions.function_map.emplace(identifier, goto_functiont());
 
   goto_functiont &f = functions.function_map.at(identifier);
-  f.type = to_code_type(symbol.type);
+  f.type = migrate_type(symbol.type);
   f.body_available = symbol.value.is_not_nil();
 
   if (!f.body_available)
@@ -128,9 +127,10 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
 
   targets = targetst();
   targets.set_return(end_function);
-  targets.has_return_value = f.type.return_type().id() != "empty" &&
-                             f.type.return_type().id() != "constructor" &&
-                             f.type.return_type().id() != "destructor";
+  // constructor/destructor return types migrate to empty_type (see
+  // util/migrate.cpp), so the legacy three-way id check collapses to this.
+  targets.has_return_value =
+    to_code_type(f.type).ret_type->type_id != type2t::empty_id;
 
   goto_convert_rec(code, f.body);
 

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -210,13 +210,9 @@ void get_local_identifiers(
 {
   goto_function.body.get_decl_identifiers(dest);
 
-  const code_typet::argumentst &arguments = goto_function.type.arguments();
-
   // add parameters
-  for (const auto &param : arguments)
-  {
-    const irep_idt &identifier = param.get_identifier();
+  for (const irep_idt &identifier :
+       to_code_type(goto_function.type).argument_names)
     if (identifier != "")
       dest.insert(identifier);
-  }
 }

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -21,7 +21,11 @@ class goto_functiont
 {
 public:
   goto_programt body;
-  code_typet type;
+  // The function signature (a code_type2t). Unlike the legacy code_typet this
+  // replaced, a default-constructed type2tc is nil rather than an empty code
+  // type, so it must be assigned (migrate_type(symbol.type)) before any read:
+  // to_code_type() dereferences it. All construction paths set it before use.
+  type2tc type;
   bool body_available = false;
 
   // The set of functions that have been inlined into this one. Necessary to

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -238,8 +238,13 @@ void goto_inlinet::expand_function_call(
     replace_return(tmp2, lhs);
 
     goto_programt tmp;
+    // parameter_assignments still consumes the legacy code_typet; recover it
+    // from the IREP2 goto-function type at this single call site.
     parameter_assignments(
-      tmp2.instructions.front().location, f.type, arguments, tmp);
+      tmp2.instructions.front().location,
+      to_code_type(migrate_type_back(f.type)),
+      arguments,
+      tmp);
     tmp.destructive_append(tmp2);
 
     if (f.body.hide)

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -80,7 +80,7 @@ bool read_bin_goto_object(
       if (it == goto_functions.function_map.end())
         goto_functions.function_map.emplace(symbol.id, goto_functiont());
       goto_functions.function_map.at(symbol.id).type =
-        to_code_type(symbol.type);
+        migrate_type(symbol.type);
     }
 
     // Add functions only from the list if there is a whitelist

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -387,11 +387,9 @@ void goto_symext::symex_function_call_code(const expr2tc &expr)
   frame.calling_location = cur_state->source;
   frame.entry_guard = cur_state->guard;
 
-  // assign arguments
-  type2tc tmp_type = migrate_type(goto_function.type);
-
-  frame.va_index =
-    argument_assignments(identifier, to_code_type(tmp_type), arguments);
+  // assign arguments (goto_function.type is already IREP2)
+  frame.va_index = argument_assignments(
+    identifier, to_code_type(goto_function.type), arguments);
 
   frame.end_of_function = --goto_function.body.instructions.end();
   frame.return_value = ret_value;

--- a/src/goto2c/goto2c_translate.cpp
+++ b/src/goto2c/goto2c_translate.cpp
@@ -92,7 +92,7 @@ goto2ct::translate(std::string function_id, goto_functiont &goto_function)
   // Creating a function symbol
   symbolt fun_sym;
   fun_sym.id = function_id;
-  fun_sym.type = goto_function.type;
+  fun_sym.type = migrate_type_back(goto_function.type);
   // Translating the function declaration
   out << expr2c(code_declt(symbol_expr(fun_sym)), ns) << "\n";
   // Translating the function body


### PR DESCRIPTION
Phase 3 of the goto-program legacy-IREP → IREP2 migration (#4715). Independent of the rw_set PRs (#4718/#4719); branches off master.

Changes `goto_functiont::type` from the legacy `code_typet` to `type2tc` (a `code_type2t`) across 10 sites in 8 files:
- writes use `migrate_type(symbol.type)` (goto_convert, read_bin, contracts);
- symex drops its now-redundant `migrate_type` of the field (one round-trip removed);
- `has_return_value` becomes `ret_type->type_id != empty_id` — `migrate_type` collapses `constructor`/`destructor` return types to `empty_type` (migrate.cpp:331-341), so the legacy three-way id check is exactly equivalent;
- `get_local_identifiers` reads `code_type2t::argument_names`;
- `add_return`, goto_inline `parameter_assignments`, and goto2c keep their legacy `code_typet` logic via a boundary `migrate_type_back` (those consumers migrate later).

`goto_functiont::type` is **never serialized** (rebuilt from the symbol table on read), so there is no goto-binary format coupling.

**Validation:** zero goto-program diff *attributable to this change* across 499 `esbmc-cpp/cpp` tests + the 85-test data-race corpus. The only flagged diffs were a `__TIME__` timestamp (`ch19_1`) and a build-nondeterministic global zero-init reorder — both pre-existing and provably upstream of this change (the init order is fixed in `clang_c_maint::static_lifetime_init` before goto-convert runs). All affected tests pass verdicts; the only ctest failures in the sweep were pre-existing macOS SDK header parse errors. `code-reviewer` verified each mapping against `migrate.cpp` and found no material correctness defects.