### PR TITLE
[util] encapsulate symbolt::type/value behind accessors (B2 S0)

### DIFF
--- a/src/c2goto/cprover_library.cpp
+++ b/src/c2goto/cprover_library.cpp
@@ -586,8 +586,8 @@ void add_cprover_library(contextt &context, const languaget *language)
 
   // Traverse symbols and get dependencies from both their nested types and values
   new_ctx.foreach_operand([&symbol_deps](const symbolt &s) {
-    generate_symbol_deps(s.id, s.value, symbol_deps);
-    generate_symbol_deps(s.id, s.type, symbol_deps);
+    generate_symbol_deps(s.id, s.get_value(), symbol_deps);
+    generate_symbol_deps(s.id, s.get_type(), symbol_deps);
   });
 
   // Add two hacks; we might use either pthread_mutex_lock or the checked
@@ -624,7 +624,7 @@ void add_cprover_library(contextt &context, const languaget *language)
     const symbolt *symbol = context.find_symbol(s.id);
     if (
       (is_solidity || uses_whitelist) ||
-      (symbol != nullptr && symbol->value.is_nil()))
+      (symbol != nullptr && symbol->get_value().is_nil()))
     {
       store_ctx.add(s);
       ingest_symbol(s.id, symbol_deps, to_include);
@@ -662,8 +662,8 @@ void add_cprover_library(contextt &context, const languaget *language)
 
       if (uses_whitelist)
       {
-        generate_symbol_deps(s->id, s->value, symbol_deps);
-        generate_symbol_deps(s->id, s->type, symbol_deps);
+        generate_symbol_deps(s->id, s->get_value(), symbol_deps);
+        generate_symbol_deps(s->id, s->get_type(), symbol_deps);
       }
 
       ingest_symbol(*nameit, symbol_deps, to_include);
@@ -684,7 +684,7 @@ void add_cprover_library(contextt &context, const languaget *language)
   // value is nil) will stay unresolved. A normal linker would reject such files, but we provide some compatibility with
   // those and initialize the extern variables to nondet.
   context.Foreach_operand([&context](symbolt &s) {
-    if (s.is_extern && !s.type.is_code())
+    if (s.is_extern && !s.get_type().is_code())
     {
       log_debug(
         "c2goto",
@@ -692,10 +692,10 @@ void add_cprover_library(contextt &context, const languaget *language)
         "nondet! "
         "This code would not compile with an actual compiler.",
         s.id);
-      exprt value =
-        exprt("sideeffect", get_complete_type(s.type, namespacet{context}));
+      exprt value = exprt(
+        "sideeffect", get_complete_type(s.get_type(), namespacet{context}));
       value.statement("nondet");
-      s.value = value;
+      s.get_value() = value;
     }
   });
 }

--- a/src/clang-c-frontend/clang_c_adjust_expr.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_expr.cpp
@@ -34,7 +34,7 @@ bool clang_c_adjust::adjust()
   {
     symbolt &symbol = **it;
     if (symbol.is_type)
-      adjust_type(symbol.type);
+      adjust_type(symbol.get_type());
   }
 
   Forall_symbol_list(it, symbol_list)
@@ -51,13 +51,15 @@ bool clang_c_adjust::adjust()
 
 void clang_c_adjust::adjust_symbol(symbolt &symbol)
 {
-  if (!symbol.value.is_nil())
-    adjust_expr(symbol.value);
+  if (!symbol.get_value().is_nil())
+    adjust_expr(symbol.get_value());
 
-  if (symbol.type.is_code() && has_prefix(symbol.id.as_string(), "c:@F@main"))
+  if (
+    symbol.get_type().is_code() &&
+    has_prefix(symbol.id.as_string(), "c:@F@main"))
     adjust_argc_argv(symbol);
 
-  adjust_type(symbol.type);
+  adjust_type(symbol.get_type());
 }
 
 void clang_c_adjust::adjust_expr(exprt &expr)
@@ -207,7 +209,7 @@ void clang_c_adjust::adjust_symbol(exprt &expr)
 
   if (symbol.is_macro)
   {
-    expr = symbol.value;
+    expr = symbol.get_value();
 
     // put it back
     expr.location() = location;
@@ -698,7 +700,7 @@ void clang_c_adjust::adjust_type(typet &type)
 
     if (symbol.is_macro)
     {
-      type = symbol.type; // overwrite
+      type = symbol.get_type(); // overwrite
       adjust_type(type);
     }
   }
@@ -825,7 +827,7 @@ void clang_c_adjust::adjust_side_effect_function_call(
           param_symbol.id = id2string(identifier_with_type) + "::" + base_name;
           param_symbol.name = base_name;
           param_symbol.location = f_op.location();
-          param_symbol.type = arguments[i].type();
+          param_symbol.get_type() = arguments[i].type();
           param_symbol.lvalue = true;
           param_symbol.is_parameter = true;
           param_symbol.file_local = true;
@@ -840,10 +842,10 @@ void clang_c_adjust::adjust_side_effect_function_call(
         new_symbol.id = identifier_with_type;
         new_symbol.name = f_op.name();
         new_symbol.location = expr.location();
-        new_symbol.type = poly.type();
+        new_symbol.get_type() = poly.type();
         code_blockt implementation =
           instantiate_gcc_polymorphic_builtin(identifier, to_symbol_expr(poly));
-        new_symbol.value = implementation;
+        new_symbol.get_value() = implementation;
 
         context.add(new_symbol);
       }
@@ -879,11 +881,11 @@ void clang_c_adjust::adjust_side_effect_function_call(
         new_symbol.id = identifier;
         new_symbol.name = f_op.name();
         new_symbol.location = expr.location();
-        new_symbol.type = f_op.type();
+        new_symbol.get_type() = f_op.type();
         new_symbol.mode = "C";
 
         // Adjust type
-        to_code_type(new_symbol.type).make_ellipsis();
+        to_code_type(new_symbol.get_type()).make_ellipsis();
         to_code_type(f_op.type()).make_ellipsis();
         context.add(new_symbol);
       }
@@ -1388,7 +1390,7 @@ void clang_c_adjust::adjust_expr_binary_boolean(exprt &expr)
 void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
 {
   const code_typet::argumentst &arguments =
-    to_code_type(main_symbol.type).arguments();
+    to_code_type(main_symbol.get_type()).arguments();
 
   if (arguments.size() == 0)
     return;
@@ -1402,7 +1404,7 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
   symbolt argc_symbol;
   argc_symbol.name = "argc";
   argc_symbol.id = "argc'";
-  argc_symbol.type = op0.type();
+  argc_symbol.get_type() = op0.type();
   argc_symbol.static_lifetime = true;
   argc_symbol.lvalue = true;
 
@@ -1411,15 +1413,15 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
 
   // need to add one to the size -- the array is terminated
   // with NULL
-  exprt one_expr = from_integer(1, argc_new_symbol->type);
+  exprt one_expr = from_integer(1, argc_new_symbol->get_type());
 
-  exprt size_expr("+", argc_new_symbol->type);
+  exprt size_expr("+", argc_new_symbol->get_type());
   size_expr.copy_to_operands(symbol_expr(*argc_new_symbol), one_expr);
 
   symbolt argv_symbol;
   argv_symbol.name = "argv";
   argv_symbol.id = "argv'";
-  argv_symbol.type = array_typet(op1.type().subtype(), size_expr);
+  argv_symbol.get_type() = array_typet(op1.type().subtype(), size_expr);
   argv_symbol.static_lifetime = true;
   argv_symbol.lvalue = true;
 
@@ -1433,7 +1435,7 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
     symbolt envp_size_symbol;
     envp_size_symbol.name = "envp_size";
     envp_size_symbol.id = "envp_size'";
-    envp_size_symbol.type = op0.type(); // same type as argc!
+    envp_size_symbol.get_type() = op0.type(); // same type as argc!
     envp_size_symbol.static_lifetime = true;
 
     symbolt *envp_new_size_symbol;
@@ -1442,10 +1444,11 @@ void clang_c_adjust::adjust_argc_argv(const symbolt &main_symbol)
     symbolt envp_symbol;
     envp_symbol.name = "envp";
     envp_symbol.id = "envp'";
-    envp_symbol.type = op2.type();
+    envp_symbol.get_type() = op2.type();
     envp_symbol.static_lifetime = true;
     exprt size_expr = symbol_expr(*envp_new_size_symbol);
-    envp_symbol.type = array_typet(envp_symbol.type.subtype(), size_expr);
+    envp_symbol.get_type() =
+      array_typet(envp_symbol.get_type().subtype(), size_expr);
 
     symbolt *envp_new_symbol;
     context.move(envp_symbol, envp_new_symbol);
@@ -1498,7 +1501,7 @@ void clang_c_adjust::adjust_builtin_va_arg(exprt &expr)
   symbolt symbol;
   symbol.name = "__ESBMC_va_arg";
   symbol.id = "__ESBMC_va_arg";
-  symbol.type = symbol_type;
+  symbol.get_type() = symbol_type;
 
   context.move(symbol);
 }

--- a/src/clang-c-frontend/clang_c_adjust_polymorphic_functions.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_polymorphic_functions.cpp
@@ -218,7 +218,7 @@ result_symbol(const irep_idt &identifier, const typet &type, contextt &context)
   symbolt symbol;
   symbol.id = id2string(identifier) + "::1::result";
   symbol.name = "result";
-  symbol.type = type;
+  symbol.get_type() = type;
 
   context.add(symbol);
 

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -369,9 +369,11 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
    * infinite recursion if the type we're defining refers to itself
    * (via pointers): it either is already being defined (up the stack somewhere)
    * or it's already a complete struct or union in the context. */
-  if (!sym->type.incomplete() && sym->type.id() != "incomplete_struct")
+  if (
+    !sym->get_type().incomplete() &&
+    sym->get_type().id() != "incomplete_struct")
     return false;
-  sym->type.remove(irept::a_incomplete);
+  sym->get_type().remove(irept::a_incomplete);
 
   clang::RecordDecl *rd_def = rd.getDefinition();
   assert(rd_def);
@@ -427,10 +429,10 @@ bool clang_c_convertert::get_struct_union_class(const clang::RecordDecl &rd)
   assert(sym && "symbol disappeared from context during field conversion");
   symbolt symbol = *sym;
   context.erase_symbol(symbol.id);
-  symbol.type = t;
+  symbol.get_type() = t;
   sym = context.move_symbol_to_context(symbol);
 
-  if (get_struct_union_class_methods_decls(*rd_def, sym->type))
+  if (get_struct_union_class_methods_decls(*rd_def, sym->get_type()))
     return true;
 
   return false;
@@ -545,8 +547,8 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
     // Initialize with zero value, if the symbol has initial value,
     // it will be added later on in this method
-    symbol.value = gen_zero(get_complete_type(t, ns), true);
-    symbol.value.zero_initializer(true);
+    symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
+    symbol.get_value().zero_initializer(true);
   }
 
   symbolt *added_symbol = nullptr;
@@ -616,7 +618,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
     added_symbol = context.move_symbol_to_context(symbol);
     gen_typecast(ns, val, t);
     if (!aggregate_without_init)
-      added_symbol->value = val;
+      added_symbol->get_value() = val;
 
     code_declt decl(symbol_expr(*added_symbol));
     decl.location() = location_begin;
@@ -643,7 +645,7 @@ bool clang_c_convertert::get_var(const clang::VarDecl &vd, exprt &new_expr)
 
       gen_typecast(ns, val, t);
 
-      added_symbol->value = val;
+      added_symbol->get_value() = val;
       decl.operands().push_back(val);
     }
 
@@ -738,14 +740,14 @@ bool clang_c_convertert::get_function(
     }
   }
 
-  added_symbol.type = type;
+  added_symbol.get_type() = type;
   new_expr.type() = type;
 
   // We need: a type, a name, and an optional body.
   // Always call get_function_body so overrides (e.g. the C++ frontend) can
   // synthesise a body for bodyless declarations such as trivial destructors.
   // The base implementation returns immediately when fd.hasBody() is false.
-  if (get_function_body(fd, added_symbol.value, type))
+  if (get_function_body(fd, added_symbol.get_value(), type))
     return true;
 
   // Restore old functionDecl
@@ -2138,7 +2140,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
     cl.static_lifetime = !current_block || compound.isFileScope();
     cl.is_extern = false;
     cl.file_local = true;
-    cl.value = initializer;
+    cl.get_value() = initializer;
 
     new_expr = symbol_expr(cl);
 
@@ -4243,7 +4245,7 @@ void clang_c_convertert::get_default_symbol(
   symbol.mode = mode;
   symbol.module = module_name;
   symbol.location = std::move(location);
-  symbol.type = std::move(type);
+  symbol.get_type() = std::move(type);
   symbol.name = name;
   symbol.id = id;
 }

--- a/src/clang-c-frontend/clang_c_main.cpp
+++ b/src/clang-c-frontend/clang_c_main.cpp
@@ -11,17 +11,17 @@
 
 void clang_c_maint::init_variable(codet &dest, const symbolt &sym)
 {
-  const exprt &value = sym.value;
+  const exprt &value = sym.get_value();
 
   if (value.is_nil())
     return;
 
   assert(!value.type().is_code());
 
-  exprt symbol("symbol", sym.type);
+  exprt symbol("symbol", sym.get_type());
   symbol.identifier(sym.id);
 
-  code_assignt code(symbol, sym.value);
+  code_assignt code(symbol, sym.get_value());
   code.location() = sym.location;
 
   codet adjusted("decl-block");
@@ -47,7 +47,7 @@ void clang_c_maint::static_lifetime_init(const contextt &context, codet &dest)
 
   // call designated "initialization" functions
   context.foreach_operand_in_order([&dest](const symbolt &s) {
-    if (s.type.initialization() && s.type.is_code())
+    if (s.get_type().initialization() && s.get_type().is_code())
     {
       code_function_callt function_call;
       function_call.function() = symbol_expr(s);
@@ -89,7 +89,7 @@ bool clang_c_maint::clang_main()
       if (is_found_sym)
       {
         symbolt *s = context.find_symbol(it->second);
-        if (s != nullptr && s->type.is_code())
+        if (s != nullptr && s->get_type().is_code())
           matches.push_back(it->second);
         break; // prevent ambiguous
       }
@@ -98,7 +98,7 @@ bool clang_c_maint::clang_main()
     {
       // look it up
       symbolt *s = context.find_symbol(it->second);
-      if (s != nullptr && s->type.is_code())
+      if (s != nullptr && s->get_type().is_code())
         matches.push_back(it->second);
     }
   }
@@ -125,7 +125,7 @@ bool clang_c_maint::clang_main()
   const symbolt &symbol = *s;
 
   // check if it has a body
-  if (symbol.value.is_nil())
+  if (symbol.get_value().is_nil())
     return false; // give up
 
   codet init_code;
@@ -133,7 +133,7 @@ bool clang_c_maint::clang_main()
   static_lifetime_init(context, init_code);
 
   init_code.make_block();
-  init_code.end_location(symbol.value.end_location());
+  init_code.end_location(symbol.get_value().end_location());
 
   // build call to function
 
@@ -142,7 +142,7 @@ bool clang_c_maint::clang_main()
   call.function() = symbol_expr(symbol);
 
   const code_typet::argumentst &arguments =
-    to_code_type(symbol.type).arguments();
+    to_code_type(symbol.get_type()).arguments();
 
   if (symbol.name == "main")
   {
@@ -157,7 +157,7 @@ bool clang_c_maint::clang_main()
       const symbolt &argc_symbol = *ns.lookup("argc'");
       const symbolt &argv_symbol = *ns.lookup("argv'");
 
-      exprt one = from_integer(1, argc_symbol.type);
+      exprt one = from_integer(1, argc_symbol.get_type());
 
       exprt add("+", uint_type());
       add.copy_to_operands(symbol_expr(argc_symbol), one); // argc + 1
@@ -177,17 +177,17 @@ bool clang_c_maint::clang_main()
       // assume argc is at most MAX-1
       BigInt max;
 
-      if (argc_symbol.type.id() == "signedbv")
-        max = power(2, atoi(argc_symbol.type.width().c_str()) - 1) - 1;
-      else if (argc_symbol.type.id() == "unsignedbv")
-        max = power(2, atoi(argc_symbol.type.width().c_str())) - 1;
+      if (argc_symbol.get_type().id() == "signedbv")
+        max = power(2, atoi(argc_symbol.get_type().width().c_str()) - 1) - 1;
+      else if (argc_symbol.get_type().id() == "unsignedbv")
+        max = power(2, atoi(argc_symbol.get_type().width().c_str())) - 1;
       else
         assert(false);
 
       // The argv array of MAX elements of pointer type has to fit
       max /= config.ansi_c.pointer_width() / 8;
 
-      exprt max_minus_one = from_integer(max - 1, argc_symbol.type);
+      exprt max_minus_one = from_integer(max - 1, argc_symbol.get_type());
 
       exprt le("<=", bool_type());
       le.copy_to_operands(symbol_expr(argc_symbol), max_minus_one);
@@ -207,13 +207,13 @@ bool clang_c_maint::clang_main()
       // rather than NULL: this is a bounded under-approximation, raise
       // --argv-max-args for wider coverage at the cost of a larger SMT
       // formula.
-      exprt null = gen_zero(argv_symbol.type.subtype());
+      exprt null = gen_zero(argv_symbol.get_type().subtype());
 
       // argv[argc] == NULL
       index_exprt argv_argc(
         symbol_expr(argv_symbol),
         symbol_expr(argc_symbol),
-        argv_symbol.type.subtype());
+        argv_symbol.get_type().subtype());
       exprt term_eq("=", bool_type());
       term_eq.copy_to_operands(argv_argc, null);
       init_code.copy_to_operands(code_assumet(term_eq));
@@ -253,7 +253,7 @@ bool clang_c_maint::clang_main()
           max_args,
           max_args * 2);
       const int max_strlen = get_int_opt("argv-max-strlen", 256, 1);
-      typet char_t = argv_symbol.type.subtype().subtype();
+      typet char_t = argv_symbol.get_type().subtype().subtype();
 
       for (int ai = 0; ai < max_args; ++ai)
       {
@@ -262,7 +262,7 @@ bool clang_c_maint::clang_main()
         symbolt len_sym;
         len_sym.name = irep_idt(lname);
         len_sym.id = irep_idt("c:@" + lname);
-        len_sym.type = uint_type();
+        len_sym.get_type() = uint_type();
         len_sym.static_lifetime = true;
         len_sym.lvalue = true;
         symbolt *len_ptr = nullptr;
@@ -285,7 +285,7 @@ bool clang_c_maint::clang_main()
         symbolt str_sym;
         str_sym.name = irep_idt(sname);
         str_sym.id = irep_idt("c:@" + sname);
-        str_sym.type = array_typet(char_t, len);
+        str_sym.get_type() = array_typet(char_t, len);
         str_sym.static_lifetime = true;
         str_sym.lvalue = true;
         symbolt *str_ptr = nullptr;
@@ -308,16 +308,16 @@ bool clang_c_maint::clang_main()
 
         exprt cond_lt("<", bool_type());
         cond_lt.copy_to_operands(
-          from_integer(ai, argc_symbol.type), symbol_expr(argc_symbol));
+          from_integer(ai, argc_symbol.get_type()), symbol_expr(argc_symbol));
 
         index_exprt argv_ai(
           symbol_expr(argv_symbol),
           from_integer(ai, index_type()),
-          argv_symbol.type.subtype());
+          argv_symbol.get_type().subtype());
 
         index_exprt str_first(
           symbol_expr(*str_ptr), gen_zero(index_type()), char_t);
-        exprt addr_str("address_of", argv_symbol.type.subtype());
+        exprt addr_str("address_of", argv_symbol.get_type().subtype());
         addr_str.copy_to_operands(str_first);
 
         code_ifthenelset if_assign;
@@ -372,7 +372,7 @@ bool clang_c_maint::clang_main()
         index_exprt envp_index(
           symbol_expr(envp_symbol),
           symbol_expr(envp_size_symbol),
-          envp_symbol.type.subtype());
+          envp_symbol.get_type().subtype());
 
         // disable bounds check on that one
         // Logic to perform this ^ moved into goto_check, rather than load
@@ -433,8 +433,8 @@ bool clang_c_maint::clang_main()
 
   new_symbol.id = "__ESBMC_main";
   new_symbol.name = "__ESBMC_main";
-  new_symbol.type.swap(main_type);
-  new_symbol.value.swap(init_code);
+  new_symbol.get_type().swap(main_type);
+  new_symbol.get_value().swap(init_code);
 
   if (context.move(new_symbol))
   {

--- a/src/clang-c-frontend/padding.cpp
+++ b/src/clang-c-frontend/padding.cpp
@@ -390,7 +390,7 @@ static void add_padding(union_typet &type, const namespacet &ns)
 void add_padding(typet &type, const namespacet &ns)
 {
   if (type.is_symbol())
-    return add_padding(const_cast<typet &>(ns.lookup(type)->type), ns);
+    return add_padding(const_cast<typet &>(ns.lookup(type)->get_type()), ns);
 
   /* Only structs and unions get padded, all other types are fine */
   if (type.is_struct())

--- a/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_code_gen.cpp
@@ -23,7 +23,7 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
    *  copied to the `components` list in its type, which should have been
    *  done in the converter.
    */
-  if (!symbol.value.need_vptr_init() || symbol.value.is_nil())
+  if (!symbol.get_value().need_vptr_init() || symbol.get_value().is_nil())
     return;
 
   /*
@@ -31,8 +31,8 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
    *  - a ctor symbol shall contain a function body modelled by code_blockt
    *  - symbol should be of code type
    */
-  code_typet &ctor_type = to_code_type(symbol.type);
-  code_blockt &ctor_body = to_code_block(to_code(symbol.value));
+  code_typet &ctor_type = to_code_type(symbol.get_type());
+  code_blockt &ctor_body = to_code_block(to_code(symbol.get_value()));
 
   /*
    *  vptr initializations shall be done in ctor
@@ -48,7 +48,7 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
   assert(ctor_class_symb);
   // get the `components` vector from this class' type
   const struct_typet::componentst &components =
-    to_struct_type(ctor_class_symb->type).components();
+    to_struct_type(ctor_class_symb->get_type()).components();
 
   // iterate over the `components` and initialize each virtual pointers
   for (const auto &comp : components)
@@ -63,7 +63,7 @@ void clang_cpp_adjust::gen_vptr_initializations(symbolt &symbol)
     ctor_body.operands().push_back(code_expr);
   }
 
-  symbol.value.need_vptr_init(false);
+  symbol.get_value().need_vptr_init(false);
 }
 
 void clang_cpp_adjust::gen_vptr_init_code(
@@ -111,7 +111,7 @@ exprt clang_cpp_adjust::gen_vptr_init_lhs(
 
   // prepare dereference operand
   exprt deref_operand = symbol_exprt(
-    ctor_type.arguments().at(0).get("#identifier"), this_symb->type);
+    ctor_type.arguments().at(0).get("#identifier"), this_symb->get_type());
 
   // get the reference symbol
   dereference_exprt this_deref(deref_operand.type());
@@ -144,7 +144,8 @@ exprt clang_cpp_adjust::gen_vptr_init_rhs(
   assert(vtable_var_symb);
 
   // get the operand for address_of expr as in `&<vtable_struct_variable>`
-  exprt vtable_var = symbol_exprt(vtable_var_symb->id, vtable_var_symb->type);
+  exprt vtable_var =
+    symbol_exprt(vtable_var_symb->id, vtable_var_symb->get_type());
   vtable_var.name(vtable_var_symb->name);
 
   // now we can get the address_of expr for "&<vtable_struct_variable>"

--- a/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_adjust_expr.cpp
@@ -13,19 +13,19 @@ clang_cpp_adjust::clang_cpp_adjust(contextt &_context)
 
 void clang_cpp_adjust::gen_implicit_union_copy_move_constructor(symbolt &symbol)
 {
-  if (!symbol.type.is_code())
+  if (!symbol.get_type().is_code())
     return;
 
-  code_typet &ctor_type = to_code_type(symbol.type);
+  code_typet &ctor_type = to_code_type(symbol.get_type());
 
   if (
     ctor_type.return_type().id() != "constructor" ||
     !ctor_type.return_type().get_bool("#implicit_union_copy_move_constructor"))
     return;
 
-  if (symbol.value.is_not_nil())
+  if (symbol.get_value().is_not_nil())
   {
-    code_blockt &ctor_body = to_code_block(to_code(symbol.value));
+    code_blockt &ctor_body = to_code_block(to_code(symbol.get_value()));
     assert(
       ctor_body.operands().size() == 1 &&
       ctor_body.op0().statement() ==
@@ -34,9 +34,9 @@ void clang_cpp_adjust::gen_implicit_union_copy_move_constructor(symbolt &symbol)
   else
   {
     code_blockt ctor_body;
-    symbol.value = ctor_body;
+    symbol.get_value() = ctor_body;
   }
-  code_blockt &ctor_body = to_code_block(to_code(symbol.value));
+  code_blockt &ctor_body = to_code_block(to_code(symbol.get_value()));
   /* https://en.cppreference.com/w/cpp/language/copy_constructor#Implicitly-defined_copy_constructor
    * > If the implicitly-declared copy constructor is not deleted, it is defined (that is, a function body is generated and compiled)
    * > by the compiler if odr-used or needed for constant evaluation(since C++11).
@@ -210,7 +210,7 @@ void clang_cpp_adjust::adjust_cpp_member(member_exprt &expr)
   }
   // compoment's type shall be the same as member_exprt's type
   // and both are of the type `code`
-  assert(comp_symb->type.is_code());
+  assert(comp_symb->get_type().is_code());
   exprt method_call = symbol_expr(*comp_symb);
   expr.swap(method_call);
 }
@@ -417,7 +417,7 @@ void clang_cpp_adjust::convert_exception_id(
     irep_idt identifier = type.identifier();
 
     // Check if base class exists
-    typet t = ns.lookup(identifier)->type;
+    typet t = ns.lookup(identifier)->get_type();
 
     // only get the base class when throwing
     if (t.id() == "struct" && !is_catch)

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -1818,7 +1818,7 @@ bool clang_cpp_convertert::get_function_body(
             symbolt new_symbol;
             new_symbol.name = "array_init$";
             new_symbol.id = id2string(this_ptr.identifier()) + "_array_init$";
-            new_symbol.type = this_type;
+            new_symbol.get_type() = this_type;
             if (context.move(new_symbol, array_init_sym))
             {
               log_error(
@@ -2339,12 +2339,12 @@ bool clang_cpp_convertert::annotate_class_method(
     symbolt *fd_symb = get_fd_symbol(cxxmdd);
     if (fd_symb)
     {
-      fd_symb->type = component_type;
+      fd_symb->get_type() = component_type;
       /*
        * we indicate the need for vptr initializations in contructor.
        * vptr initializations will be added in the adjuster.
        */
-      fd_symb->value.need_vptr_init(has_vptr_component);
+      fd_symb->get_value().need_vptr_init(has_vptr_component);
     }
   }
 
@@ -2548,7 +2548,7 @@ void clang_cpp_convertert::get_base_components_methods(
     assert(s);
     base_ids.emplace_back(s->id);
 
-    const struct_typet &base_type = to_struct_type(s->type);
+    const struct_typet &base_type = to_struct_type(s->get_type());
 
     // pull components in
     const struct_typet::componentst &components = base_type.components();

--- a/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert_vft.cpp
@@ -190,9 +190,9 @@ symbolt *clang_cpp_convertert::add_vtable_type_symbol(
   vt_type_symb.id = vt_name;
   vt_type_symb.name = vtable_type_prefix + type.tag().as_string();
   vt_type_symb.mode = mode;
-  vt_type_symb.type = struct_typet();
+  vt_type_symb.get_type() = struct_typet();
   vt_type_symb.is_type = true;
-  vt_type_symb.type.set("name", vt_type_symb.id);
+  vt_type_symb.get_type().set("name", vt_type_symb.id);
   vt_type_symb.location = comp.location();
   vt_type_symb.module =
     get_modulename_from_path(comp.location().file().as_string());
@@ -266,7 +266,7 @@ void clang_cpp_convertert::add_vtable_type_entry(
   vt_entry.location() = comp.location();
   // add an entry to the virtual table
   assert(vtable_type_symbol);
-  struct_typet &vtable_type = to_struct_type(vtable_type_symbol->type);
+  struct_typet &vtable_type = to_struct_type(vtable_type_symbol->get_type());
   vtable_type.components().push_back(vt_entry);
 }
 
@@ -340,7 +340,7 @@ void clang_cpp_convertert::add_thunk_method(
   thunk_func_symb.name = component.base_name();
   thunk_func_symb.mode = mode;
   thunk_func_symb.location = component.location();
-  thunk_func_symb.type = component.type();
+  thunk_func_symb.get_type() = component.type();
   thunk_func_symb.module =
     get_modulename_from_path(component.location().file().as_string());
 
@@ -348,7 +348,7 @@ void clang_cpp_convertert::add_thunk_method(
   set_thunk_name(thunk_func_symb, base_class_id);
 
   // update the type of `this` argument in thunk
-  update_thunk_this_type(thunk_func_symb.type, base_class_id);
+  update_thunk_this_type(thunk_func_symb.get_type(), base_class_id);
 
   // add symbols for arguments of this thunk function
   add_thunk_method_arguments(thunk_func_symb);
@@ -411,7 +411,7 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
    * Each argument symbol's id is of the form - "<thunk_func_symbol_ID>::<argument_base_name>"
    */
 
-  code_typet &code_type = to_code_type(thunk_func_symb.type);
+  code_typet &code_type = to_code_type(thunk_func_symb.get_type());
   code_typet::argumentst &args = code_type.arguments();
   for (unsigned i = 0; i < args.size(); i++)
   {
@@ -423,7 +423,7 @@ void clang_cpp_convertert::add_thunk_method_arguments(symbolt &thunk_func_symb)
     arg_symb.name = base_name;
     arg_symb.mode = mode;
     arg_symb.location = thunk_func_symb.location;
-    arg_symb.type = arg.type();
+    arg_symb.get_type() = arg.type();
 
     // Change argument identifier field to thunk function
     arg.set("#identifier", arg_symb.id);
@@ -448,7 +448,7 @@ void clang_cpp_convertert::add_thunk_method_body(
   const struct_typet::componentt &component,
   uint64_t base_offset)
 {
-  code_typet &code_type = to_code_type(thunk_func_symb.type);
+  code_typet &code_type = to_code_type(thunk_func_symb.get_type());
   code_typet::argumentst &args = code_type.arguments();
 
   // Build the adjusted 'this' to pass to the overriding method.
@@ -493,7 +493,8 @@ void clang_cpp_convertert::add_thunk_method_body_return(
    *  RETURN: return_value;
    * END_FUNCTION
    */
-  code_typet::argumentst &args = to_code_type(thunk_func_symb.type).arguments();
+  code_typet::argumentst &args =
+    to_code_type(thunk_func_symb.get_type()).arguments();
 
   side_effect_expr_function_callt expr_call;
   expr_call.function() = symbol_exprt(component.get_name(), component.type());
@@ -511,7 +512,7 @@ void clang_cpp_convertert::add_thunk_method_body_return(
   code_returnt code_return;
   code_return.return_value() = expr_call;
 
-  thunk_func_symb.value = code_return;
+  thunk_func_symb.get_value() = code_return;
 }
 
 void clang_cpp_convertert::add_thunk_method_body_no_return(
@@ -525,7 +526,8 @@ void clang_cpp_convertert::add_thunk_method_body_no_return(
    *  FUNCTION_CALL: do_something((Derived*)this);
    * END_FUNCTION
    */
-  code_typet::argumentst &args = to_code_type(thunk_func_symb.type).arguments();
+  code_typet::argumentst &args =
+    to_code_type(thunk_func_symb.get_type()).arguments();
 
   code_function_callt code_func;
   code_func.function() = symbol_exprt(component.get_name(), component.type());
@@ -539,7 +541,7 @@ void clang_cpp_convertert::add_thunk_method_body_no_return(
       symbol_expr(*namespacet(context).lookup(args[i].cmt_identifier())));
   }
 
-  thunk_func_symb.value = code_func;
+  thunk_func_symb.get_value() = code_func;
 }
 
 void clang_cpp_convertert::add_thunk_component_to_type(
@@ -548,7 +550,7 @@ void clang_cpp_convertert::add_thunk_component_to_type(
   const struct_typet::componentt &comp)
 {
   struct_typet::componentt new_compo = comp;
-  new_compo.type() = thunk_func_symb.type;
+  new_compo.type() = thunk_func_symb.get_type();
   new_compo.set_name(thunk_func_symb.id);
   type.methods().push_back(new_compo);
 }
@@ -654,12 +656,12 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
     vt_symb_var.module =
       get_modulename_from_path(type.location().file().as_string());
     vt_symb_var.location = vt_symb_type->location;
-    vt_symb_var.type = symbol_typet(vt_symb_type->id);
+    vt_symb_var.get_type() = symbol_typet(vt_symb_type->id);
     vt_symb_var.lvalue = true;
     vt_symb_var.static_lifetime = true;
 
     // add vtable variable symbols
-    const struct_typet &vt_type = to_struct_type(vt_symb_type->type);
+    const struct_typet &vt_type = to_struct_type(vt_symb_type->get_type());
     exprt values("struct", symbol_typet(vt_symb_type->id));
     for (const auto &compo : vt_type.components())
     {
@@ -670,7 +672,7 @@ void clang_cpp_convertert::add_vtable_variable_symbols(
       assert(value.type().id() == compo.type().id());
       values.operands().push_back(value);
     }
-    vt_symb_var.value = values;
+    vt_symb_var.get_value() = values;
 
     if (context.move(vt_symb_var))
     {

--- a/src/esbmc/esbmc_parseoptions.cpp
+++ b/src/esbmc/esbmc_parseoptions.cpp
@@ -3011,7 +3011,7 @@ expr2tc esbmc_parseoptionst::calculate_a_property_monitor(
   const symbolt *fn = context.find_symbol("c:@F@" + name + "_status");
   assert(fn);
 
-  const codet &fn_code = to_code(fn->value);
+  const codet &fn_code = to_code(fn->get_value());
   assert(fn_code.get_statement() == "block");
   assert(fn_code.operands().size() == 1);
 
@@ -3107,7 +3107,7 @@ static unsigned int calc_globals_used(const namespacet &ns, const expr2tc &expr)
 
   const symbolt *sym = ns.lookup(identifier);
   assert(sym);
-  if (sym->static_lifetime || sym->type.is_dynamic_set())
+  if (sym->static_lifetime || sym->get_type().is_dynamic_set())
     return 1;
 
   return 0;

--- a/src/goto-programs/abstract-interpretation/gcse.cpp
+++ b/src/goto-programs/abstract-interpretation/gcse.cpp
@@ -481,7 +481,7 @@ inline symbolt goto_cse::create_cse_symbol(
   const goto_programt::const_targett &to)
 {
   symbolt symbol;
-  symbol.type = migrate_type_back(t);
+  symbol.get_type() = migrate_type_back(t);
   symbol.id = fmt::format("{}${}", prefix, symbol_counter++);
   symbol.name = symbol.id;
   symbol.mode = "C";

--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -949,7 +949,7 @@ void interval_domaint::transform(
   {
     // After a return, all function arguments becomes nondet
     const symbolt *current_function = ns.lookup(instruction.function);
-    type2tc t = migrate_type(current_function->type);
+    type2tc t = migrate_type(current_function->get_type());
     const code_type2t &function = to_code_type(t);
 
     for (size_t i = 0; i < function.arguments.size(); i++)

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -31,10 +31,10 @@ public:
     symbolt new_symbol;
     new_symbol.id = identifier;
     new_symbol.name = identifier;
-    new_symbol.type =
+    new_symbol.get_type() =
       original_expr.is_index() ? migrate_type_back(index) : typet("bool");
     new_symbol.static_lifetime = true;
-    new_symbol.value.make_false();
+    new_symbol.get_value().make_false();
 
     symbolt *symbol_ptr;
     context.move(new_symbol, symbol_ptr);
@@ -78,9 +78,9 @@ void w_guardst::add_initialization(goto_programt &goto_program)
   symbolt new_symbol;
   new_symbol.id = identifier;
   new_symbol.name = identifier;
-  new_symbol.type = migrate_type_back(arrayt);
+  new_symbol.get_type() = migrate_type_back(arrayt);
   new_symbol.static_lifetime = true;
-  new_symbol.value.make_false();
+  new_symbol.get_value().make_false();
   context.move_symbol_to_context(new_symbol);
 
   for (const auto &w_guard : w_guards)
@@ -90,8 +90,9 @@ void w_guardst::add_initialization(goto_programt &goto_program)
     expr2tc new_sym;
     migrate_expr(symbol, new_sym);
 
-    expr2tc falsity = s.type.is_array() ? gen_zero(migrate_type(s.type), true)
-                                        : gen_false_expr();
+    expr2tc falsity = s.get_type().is_array()
+                        ? gen_zero(migrate_type(s.get_type()), true)
+                        : gen_false_expr();
     t = goto_program.insert(t);
     t->type = ASSIGN;
     t->code = code_assign2tc(new_sym, falsity);

--- a/src/goto-programs/assign_params_as_non_det.cpp
+++ b/src/goto-programs/assign_params_as_non_det.cpp
@@ -8,7 +8,7 @@ symbolt *assign_params_as_non_det::get_default_symbol(
 {
   symbolt symbol;
   symbol.location = std::move(location);
-  symbol.type = std::move(type);
+  symbol.get_type() = std::move(type);
   symbol.name = name;
   symbol.id = id;
 
@@ -24,7 +24,7 @@ symbolt *assign_params_as_non_det::get_default_symbol(
 /// Build an irep2 symbol expression referring to @p sym.
 static expr2tc sym_to_expr2tc(const symbolt &sym)
 {
-  return symbol2tc(migrate_type(sym.type), sym.id);
+  return symbol2tc(migrate_type(sym.get_type()), sym.id);
 }
 
 /// Append @p instr (with location and function copied from @p it) before @p it
@@ -52,9 +52,9 @@ bool assign_params_as_non_det::runOnFunction(
   if (fn_sym == nullptr)
     return false; // Not exist
 
-  if (!fn_sym->type.is_code())
+  if (!fn_sym->get_type().is_code())
     return false; // Not expected
-  const code_typet t = to_code_type(fn_sym->type);
+  const code_typet t = to_code_type(fn_sym->get_type());
 
   if (fn_sym->name.as_string() != target_function)
     return false; // Not target function
@@ -112,9 +112,9 @@ bool assign_params_as_non_det::runOnFunction(
       goto_program, it, code_assign2tc(lhs, gen_nondet(l_t)), ASSIGN, l);
 
     // resolve named subtypes for the temp object's symbol
-    typet obj_typet = lhs_sym->type.subtype();
+    typet obj_typet = lhs_sym->get_type().subtype();
     if (obj_typet.is_symbol())
-      obj_typet = context.find_symbol(obj_typet.identifier())->type;
+      obj_typet = context.find_symbol(obj_typet.identifier())->get_type();
 
     symbolt *obj_sym = get_default_symbol(
       obj_typet,
@@ -132,7 +132,7 @@ bool assign_params_as_non_det::runOnFunction(
     insert_before(
       goto_program,
       it,
-      code_decl2tc(migrate_type(flag_sym->type), flag_sym->id),
+      code_decl2tc(migrate_type(flag_sym->get_type()), flag_sym->id),
       DECL,
       l);
 
@@ -149,7 +149,7 @@ bool assign_params_as_non_det::runOnFunction(
     insert_before(
       goto_program,
       it,
-      code_decl2tc(migrate_type(obj_sym->type), obj_sym->id),
+      code_decl2tc(migrate_type(obj_sym->get_type()), obj_sym->id),
       DECL,
       l);
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -568,7 +568,7 @@ void goto_convertt::do_function_call_symbol(
     abort();
   }
 
-  if (!symbol->type.is_code())
+  if (!symbol->get_type().is_code())
   {
     log_error(
       "Function `{}' type mismatch: expected code", id2string(identifier));
@@ -576,7 +576,7 @@ void goto_convertt::do_function_call_symbol(
 
   // If the symbol is not nil, i.e., the user defined the expected behavior of
   // the builtin function, we should honor the user function and call it
-  if (symbol->value.is_not_nil() && symbol->value.has_operands())
+  if (symbol->get_value().is_not_nil() && symbol->get_value().has_operands())
   {
     // insert function call
     code_function_callt function_call;
@@ -1404,9 +1404,9 @@ void goto_convertt::do_function_call_symbol(
   {
     symbolt new_symbol;
     new_symbol.name = "__ESBMC_unexpected";
-    new_symbol.type = arguments[0].type();
+    new_symbol.get_type() = arguments[0].type();
     new_symbol.id = "c:@F@" + id2string(new_symbol.name);
-    new_symbol.value = arguments[0].op0().op0();
+    new_symbol.get_value() = arguments[0].op0().op0();
     new_name(new_symbol);
     return;
   }

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -146,7 +146,7 @@ symbolt *code_contractst::find_function_symbol(const std::string &function_name)
   {
     symbolt *candidate = context.find_symbol(it->first);
     if (
-      candidate && candidate->type.is_code() &&
+      candidate && candidate->get_type().is_code() &&
       id2string(candidate->name) == function_name)
     {
       if (matched == nullptr)
@@ -490,20 +490,20 @@ expr2tc code_contractst::extract_requires_clause(const symbolt &contract_symbol)
 {
   // Extract from contract symbol's value field
   // The value field should contain a struct with requires/ensures expressions
-  if (contract_symbol.value.is_nil())
+  if (contract_symbol.get_value().is_nil())
     return gen_true_expr();
 
   // For now, return the entire value as requires
   // TODO: Parse structured contract data if needed
   expr2tc req;
-  migrate_expr(contract_symbol.value, req);
+  migrate_expr(contract_symbol.get_value(), req);
   return req;
 }
 
 expr2tc code_contractst::extract_ensures_clause(const symbolt &contract_symbol)
 {
   // Extract from contract symbol's value field
-  if (contract_symbol.value.is_nil())
+  if (contract_symbol.get_value().is_nil())
     return gen_true_expr();
 
   // TODO: Implement proper separation of requires and ensures from contract symbol
@@ -652,10 +652,10 @@ void code_contractst::havoc_function_parameters(
   goto_programt &dest,
   const locationt &location)
 {
-  if (!original_func.type.is_code())
+  if (!original_func.get_type().is_code())
     return;
 
-  const code_typet &code_type = to_code_type(original_func.type);
+  const code_typet &code_type = to_code_type(original_func.get_type());
   const code_typet::argumentst &params = code_type.arguments();
 
   for (const auto &param : params)
@@ -686,7 +686,7 @@ void code_contractst::havoc_static_globals(
   // Iterate over all symbols in context to find static lifetime globals
   ns.get_context().foreach_operand([&dest, &location](const symbolt &s) {
     // Skip functions, types, and non-lvalue symbols
-    if (s.type.is_code() || s.is_type || !s.lvalue)
+    if (s.get_type().is_code() || s.is_type || !s.lvalue)
       return;
 
     // Only process static lifetime variables (globals and static locals)
@@ -699,7 +699,7 @@ void code_contractst::havoc_static_globals(
       return;
 
     // Build LHS symbol expression
-    type2tc global_type = migrate_type(s.type);
+    type2tc global_type = migrate_type(s.get_type());
     expr2tc lhs = symbol2tc(global_type, s.id);
 
     // Do not assign nondeterministic values to pointers when value-set based
@@ -915,8 +915,8 @@ void code_contractst::enforce_contracts(
     // Create new function entry
     goto_functiont new_func;
     new_func.body = wrapper;
-    if (func_sym->type.is_code())
-      new_func.type = migrate_type(func_sym->type);
+    if (func_sym->get_type().is_code())
+      new_func.type = migrate_type(func_sym->get_type());
     new_func.body_available = true;
     new_func.update_instructions_function(original_id);
 
@@ -1226,9 +1226,9 @@ goto_programt code_contractst::generate_checking_wrapper(
   // 2. Declare return value variable (if function has return type)
   expr2tc ret_val;
   type2tc ret_type;
-  if (original_func.type.is_code())
+  if (original_func.get_type().is_code())
   {
-    const code_typet &code_type = to_code_type(original_func.type);
+    const code_typet &code_type = to_code_type(original_func.get_type());
     typet return_type_irep1 = code_type.return_type();
     log_debug(
       "contracts",
@@ -1282,7 +1282,7 @@ goto_programt code_contractst::generate_checking_wrapper(
       symbolt ret_val_symbol;
       ret_val_symbol.name = ret_val_id;
       ret_val_symbol.id = ret_val_id;
-      ret_val_symbol.type = return_type_irep1;
+      ret_val_symbol.get_type() = return_type_irep1;
       ret_val_symbol.lvalue = true;
       ret_val_symbol.static_lifetime = false;
       ret_val_symbol.location = location;
@@ -1292,8 +1292,8 @@ goto_programt code_contractst::generate_checking_wrapper(
         "contracts",
         "generate_checking_wrapper: creating return_value symbol with type "
         "id={}, is_symbol={}",
-        ret_val_symbol.type.id().as_string(),
-        ret_val_symbol.type.id() == "symbol");
+        ret_val_symbol.get_type().id().as_string(),
+        ret_val_symbol.get_type().id() == "symbol");
 
       // Add symbol to context
       symbolt *added_symbol = context.move_symbol_to_context(ret_val_symbol);
@@ -1334,11 +1334,11 @@ goto_programt code_contractst::generate_checking_wrapper(
   }
 
   // 3. Call original function
-  if (original_func.type.is_code())
+  if (original_func.get_type().is_code())
   {
-    const code_typet &code_type = to_code_type(original_func.type);
+    const code_typet &code_type = to_code_type(original_func.get_type());
     // Convert function type to irep2
-    type2tc func_type = migrate_type(original_func.type);
+    type2tc func_type = migrate_type(original_func.get_type());
 
     // Build parameter list
     std::vector<expr2tc> arguments;
@@ -1727,7 +1727,7 @@ expr2tc code_contractst::extract_struct_members_to_temps(
         symbolt temp_symbol;
         temp_symbol.name = temp_id;
         temp_symbol.id = temp_id;
-        temp_symbol.type = migrate_type_back(member.type);
+        temp_symbol.get_type() = migrate_type_back(member.type);
         temp_symbol.lvalue = true;
         temp_symbol.static_lifetime = false;
         temp_symbol.location = location;
@@ -1892,7 +1892,7 @@ expr2tc code_contractst::create_snapshot_variable(
   symbolt snapshot_symbol;
   snapshot_symbol.name = snapshot_name;
   snapshot_symbol.id = snapshot_name;
-  snapshot_symbol.type =
+  snapshot_symbol.get_type() =
     migrate_type_back(expr->type); // IRep2 → IRep1 conversion
   snapshot_symbol.lvalue = true;
   snapshot_symbol.static_lifetime = false;
@@ -2097,10 +2097,10 @@ code_contractst::materialize_ptr_field_snapshots(
 
   if (classified.ptr_field_targets.empty())
     return result;
-  if (!original_func.type.is_code())
+  if (!original_func.get_type().is_code())
     return result;
 
-  const code_typet &code_type = to_code_type(original_func.type);
+  const code_typet &code_type = to_code_type(original_func.get_type());
   const code_typet::argumentst &params = code_type.arguments();
 
   for (const auto &[ptr_name, assigned_fields] : classified.ptr_field_targets)
@@ -2142,7 +2142,7 @@ code_contractst::materialize_ptr_field_snapshots(
         symbolt snap_sym_obj;
         snap_sym_obj.name = snap_name;
         snap_sym_obj.id = snap_name;
-        snap_sym_obj.type = migrate_type_back(ftype);
+        snap_sym_obj.get_type() = migrate_type_back(ftype);
         snap_sym_obj.lvalue = true;
         snap_sym_obj.static_lifetime = false;
         snap_sym_obj.file_local = false;
@@ -2218,10 +2218,10 @@ code_contractst::materialize_ptr_deref_snapshots(
   // If assigns_targets is empty there is no clause → function may modify anything.
   if (assigns_targets.empty())
     return result;
-  if (!original_func.type.is_code())
+  if (!original_func.get_type().is_code())
     return result;
 
-  const code_typet &code_type = to_code_type(original_func.type);
+  const code_typet &code_type = to_code_type(original_func.get_type());
   const code_typet::argumentst &params = code_type.arguments();
 
   for (const auto &param : params)
@@ -2328,7 +2328,7 @@ code_contractst::materialize_ptr_deref_snapshots(
         symbolt snap_obj;
         snap_obj.name = snap_name;
         snap_obj.id = snap_name;
-        snap_obj.type = migrate_type_back(ftype);
+        snap_obj.get_type() = migrate_type_back(ftype);
         snap_obj.lvalue = true;
         snap_obj.static_lifetime = false;
         snap_obj.file_local = false;
@@ -2366,7 +2366,7 @@ code_contractst::materialize_ptr_deref_snapshots(
       symbolt snap_obj;
       snap_obj.name = snap_name;
       snap_obj.id = snap_name;
-      snap_obj.type = migrate_type_back(pointee);
+      snap_obj.get_type() = migrate_type_back(pointee);
       snap_obj.lvalue = true;
       snap_obj.static_lifetime = false;
       snap_obj.file_local = false;
@@ -2498,7 +2498,7 @@ code_contractst::materialize_arr_elem_snapshots(
     symbolt j_obj;
     j_obj.name = j_sym_name;
     j_obj.id = j_sym_name;
-    j_obj.type = migrate_type_back(j_type);
+    j_obj.get_type() = migrate_type_back(j_type);
     j_obj.lvalue = true;
     j_obj.static_lifetime = false;
     j_obj.file_local = false;
@@ -2537,7 +2537,7 @@ code_contractst::materialize_arr_elem_snapshots(
     symbolt snap_obj;
     snap_obj.name = snap_sym_name;
     snap_obj.id = snap_sym_name;
-    snap_obj.type = migrate_type_back(elem_type);
+    snap_obj.get_type() = migrate_type_back(elem_type);
     snap_obj.lvalue = true;
     snap_obj.static_lifetime = false;
     snap_obj.file_local = false;
@@ -2688,9 +2688,9 @@ code_contractst::materialize_old_snapshots_at_callsite(
     expr2tc temp_var = old_snapshots[i].snapshot_var; // temp var from body
 
     // Apply the same parameter substitution used for requires/ensures
-    if (function_symbol.type.is_code())
+    if (function_symbol.get_type().is_code())
     {
-      const code_typet &code_type = to_code_type(function_symbol.type);
+      const code_typet &code_type = to_code_type(function_symbol.get_type());
       const code_typet::argumentst &params = code_type.arguments();
 
       for (size_t j = 0; j < params.size() && j < actual_args.size(); ++j)
@@ -3190,7 +3190,7 @@ bool code_contractst::is_annotated_contract_function(
 {
   // Check if function type has #annotated_contract attribute set
   // This is set in clang_c_convert.cpp when parsing __attribute__((annotate("__ESBMC_contract")))
-  return func_sym.type.get_bool("#annotated_contract");
+  return func_sym.get_type().get_bool("#annotated_contract");
 }
 
 void code_contractst::replace_calls(const std::set<std::string> &to_replace)
@@ -3370,9 +3370,9 @@ void code_contractst::generate_replacement_at_call(
   }
 
   // Replace function parameters with actual arguments in contract clauses
-  if (function_symbol.type.is_code())
+  if (function_symbol.get_type().is_code())
   {
-    const code_typet &code_type = to_code_type(function_symbol.type);
+    const code_typet &code_type = to_code_type(function_symbol.get_type());
     const code_typet::argumentst &params = code_type.arguments();
 
     // Build parameter-to-argument mapping
@@ -3451,9 +3451,9 @@ void code_contractst::generate_replacement_at_call(
       // Substitute function parameters with actual call arguments
       expr2tc instantiated_target = target_expr;
 
-      if (function_symbol.type.is_code())
+      if (function_symbol.get_type().is_code())
       {
-        const code_typet &code_type = to_code_type(function_symbol.type);
+        const code_typet &code_type = to_code_type(function_symbol.get_type());
         const code_typet::argumentst &params = code_type.arguments();
 
         for (size_t i = 0; i < params.size() && i < actual_args.size(); ++i)
@@ -3534,9 +3534,9 @@ void code_contractst::generate_replacement_at_call(
   //   call site:  int x = 41;  increment(&x);
   // Without this havoc the ASSUME would be  ASSUME(41 == 41+1 = 42), i.e.
   // FALSE, making all subsequent assertions vacuously VERIFICATION SUCCESSFUL.
-  if (!has_empty_assigns && function_symbol.type.is_code())
+  if (!has_empty_assigns && function_symbol.get_type().is_code())
   {
-    const code_typet &code_type = to_code_type(function_symbol.type);
+    const code_typet &code_type = to_code_type(function_symbol.get_type());
     const code_typet::argumentst &params = code_type.arguments();
 
     for (size_t i = 0; i < params.size() && i < actual_args.size(); ++i)
@@ -3664,10 +3664,10 @@ void code_contractst::add_pointer_validity_assumptions(
   const std::set<irep_idt> &array_params,
   const std::set<irep_idt> &skip_params)
 {
-  if (!func.type.is_code())
+  if (!func.get_type().is_code())
     return;
 
-  const code_typet &code_type = to_code_type(func.type);
+  const code_typet &code_type = to_code_type(func.get_type());
   const code_typet::argumentst &params = code_type.arguments();
 
   for (const auto &param : params)
@@ -3760,7 +3760,7 @@ void code_contractst::add_pointer_validity_assumptions(
         symbolt harness_sym;
         harness_sym.name = harness_var_name;
         harness_sym.id = harness_var_name;
-        harness_sym.type = migrate_type_back(resolved_type);
+        harness_sym.get_type() = migrate_type_back(resolved_type);
         harness_sym.lvalue = true;
         harness_sym.static_lifetime = false;
         harness_sym.location = location;

--- a/src/goto-programs/frame_enforcer.cpp
+++ b/src/goto-programs/frame_enforcer.cpp
@@ -231,7 +231,7 @@ frame_enforcert::collect_global_variables(const contextt &context)
 
   context.foreach_operand([&globals](const symbolt &s) {
     // Skip functions, types, and non-lvalue symbols
-    if (s.type.is_code() || s.is_type || !s.lvalue)
+    if (s.get_type().is_code() || s.is_type || !s.lvalue)
       return;
 
     // Only process static lifetime variables (globals and static locals)
@@ -244,7 +244,7 @@ frame_enforcert::collect_global_variables(const contextt &context)
       return;
 
     // Build symbol expression
-    type2tc global_type = migrate_type(s.type);
+    type2tc global_type = migrate_type(s.get_type());
     expr2tc sym_expr = symbol2tc(global_type, s.id);
 
     // Skip pointer types (consistent with loop frame rule behavior)
@@ -359,7 +359,7 @@ expr2tc frame_enforcert::create_snapshot_symbol(
   symbolt snapshot_symbol;
   snapshot_symbol.name = snapshot_name;
   snapshot_symbol.id = snapshot_name;
-  snapshot_symbol.type = migrate_type_back(original->type);
+  snapshot_symbol.get_type() = migrate_type_back(original->type);
   snapshot_symbol.lvalue = true;
   snapshot_symbol.static_lifetime = false;
   snapshot_symbol.file_local = false;

--- a/src/goto-programs/goto_atomicity_check.cpp
+++ b/src/goto-programs/goto_atomicity_check.cpp
@@ -61,7 +61,7 @@ bool goto_atomicity_checkt::is_global(const irep_idt &id) const
   const symbolt *sym = ns.lookup(id);
   if (!sym)
     return false;
-  return sym->static_lifetime || sym->type.is_dynamic_set();
+  return sym->static_lifetime || sym->get_type().is_dynamic_set();
 }
 
 unsigned goto_atomicity_checkt::count_globals(const expr2tc &expr) const

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -495,7 +495,7 @@ void goto_checkt::input_overflow_check(
       return;
 
     const symbolt &arg = *ns.lookup(arg_names.at(i));
-    const irep_idt type_id = arg.type.id();
+    const irep_idt type_id = arg.get_type().id();
     std::string width;
 
     // if no length limits, then we treat it as a buffer overflow
@@ -510,13 +510,13 @@ void goto_checkt::input_overflow_check(
 
     if (type_id == "array")
     {
-      width = to_array_type(arg.type).size().cformat().as_string();
+      width = to_array_type(arg.get_type()).size().cformat().as_string();
       input_overflow_check_arr(
         string2integer(width), string2integer(limits.at(i)), buf_overflow);
     }
     else if (type_id == "unsignedbv" || type_id == "signedbv")
     {
-      width = arg.type.width().as_string();
+      width = arg.get_type().width().as_string();
       input_overflow_check_int(
         string2integer(width), string2integer(limits.at(i)), buf_overflow);
     }
@@ -528,8 +528,8 @@ void goto_checkt::input_overflow_check(
     else if (type_id == "pointer")
     {
       // remove typecast
-      assert(arg.value.is_typecast());
-      const exprt out_operands = to_typecast_expr(arg.value).op();
+      assert(arg.get_value().is_typecast());
+      const exprt out_operands = to_typecast_expr(arg.get_value()).op();
       const exprt::operandst operands = out_operands.op1().operands();
 
       if (!operands[0].has_operands())
@@ -839,7 +839,7 @@ typet goto_checkt::resolve_python_effective_type(
     {
       const symbolt *type_symbol = ns.lookup(pointed);
       if (type_symbol != nullptr)
-        pointed = type_symbol->type;
+        pointed = type_symbol->get_type();
     }
 
     if (pointed.id() == "struct")
@@ -850,7 +850,7 @@ typet goto_checkt::resolve_python_effective_type(
   {
     const symbolt *type_symbol = ns.lookup(effective);
     if (type_symbol != nullptr)
-      effective = type_symbol->type;
+      effective = type_symbol->get_type();
   }
 
   return effective;
@@ -870,7 +870,7 @@ expr2tc goto_checkt::build_python_type_operand(const typet &type) const
     const symbolt *symbol = ns.lookup(followed);
     if (symbol == nullptr)
       return expr2tc();
-    type2tc symbol_type = migrate_type(symbol->type);
+    type2tc symbol_type = migrate_type(symbol->get_type());
     return symbol2tc(symbol_type, symbol->id);
   }
 

--- a/src/goto-programs/goto_check_uninit_vars.cpp
+++ b/src/goto-programs/goto_check_uninit_vars.cpp
@@ -68,7 +68,7 @@ type2tc tracked_shadow_type(const symbolt &s)
     return type2tc();
   if (has_prefix(s.id, "__ESBMC_") || has_prefix(s.name, "__ESBMC_"))
     return type2tc();
-  return shadow_type_for(s.type);
+  return shadow_type_for(s.get_type());
 }
 
 /// Record describing one shadow variable, looked up at emit time by sid.

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -664,7 +664,7 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
 
   // A static variable will be declared in the global scope and
   // a code type means a function declaration, we ignore both
-  if (s->static_lifetime || s->type.is_code())
+  if (s->static_lifetime || s->get_type().is_code())
     return; // this is a SKIP!
 
   // Check if is an VLA declaration and rewrite the declaration
@@ -673,7 +673,7 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
   {
     // This means that it was a VLA declaration and we need to
     // to rewrite the symbol as well
-    s->type = var.type();
+    s->get_type() = var.type();
   }
 
   exprt initializer = nil_exprt();
@@ -709,7 +709,7 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
   // now create a 'dead' instruction -- will be added after the
   // destructor created below as unwind_destructor_stack pops off the
   // top of the destructor stack
-  const symbol_exprt symbol_expr(s->id, s->type);
+  const symbol_exprt symbol_expr(s->id, s->get_type());
 
   {
     code_deadt code_dead(symbol_expr);
@@ -718,7 +718,7 @@ void goto_convertt::convert_decl(const codet &code, goto_programt &dest)
 
   // do destructor
   code_function_callt destructor;
-  if (get_destructor(ns, s->type, destructor))
+  if (get_destructor(ns, s->get_type(), destructor))
   {
     // add "this"
     address_of_exprt this_expr(symbol_expr);
@@ -741,7 +741,7 @@ bool goto_convertt::is_atomic_symbol(const exprt &expr, const namespacet &ns)
   if (expr.id() != "symbol")
     return false;
   const symbolt *sym = ns.lookup(expr.identifier());
-  return sym && sym->type.get_bool("#atomic");
+  return sym && sym->get_type().get_bool("#atomic");
 }
 
 /// Returns true if @p expr contains a direct read of any C11 _Atomic variable

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -24,7 +24,7 @@ void goto_convert_functionst::goto_convert()
 
   symbol_listt symbol_list;
   context.Foreach_operand_in_order([&symbol_list](symbolt &s) {
-    if (!s.is_type && s.type.is_code())
+    if (!s.is_type && s.get_type().is_code())
       symbol_list.push_back(&s);
   });
 
@@ -85,8 +85,8 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
   // Note: can be removed probably? as the new clang-cpp-frontend should've
   // done a pretty good job at resolving template overloading
   if (
-    symbol.value.get("#speculative_template") == "1" &&
-    symbol.value.get("#template_in_use") != "1")
+    symbol.get_value().get("#speculative_template") == "1" &&
+    symbol.get_value().get("#template_in_use") != "1")
     return;
 
   // make tmp variables local to function
@@ -97,23 +97,23 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
     functions.function_map.emplace(identifier, goto_functiont());
 
   goto_functiont &f = functions.function_map.at(identifier);
-  f.type = migrate_type(symbol.type);
-  f.body_available = symbol.value.is_not_nil();
+  f.type = migrate_type(symbol.get_type());
+  f.body_available = symbol.get_value().is_not_nil();
 
   if (!f.body_available)
     return;
 
-  if (!symbol.value.is_code())
+  if (!symbol.get_value().is_code())
   {
     log_error("got invalid code for function `{}'", id2string(identifier));
     abort();
   }
 
-  const codet &code = to_code(symbol.value);
+  const codet &code = to_code(symbol.get_value());
 
   locationt end_location;
 
-  if (to_code(symbol.value).get_statement() == "block")
+  if (to_code(symbol.get_value()).get_statement() == "block")
     end_location =
       static_cast<const locationt &>(to_code_block(code).end_location());
   else
@@ -395,7 +395,7 @@ void goto_convert_functionst::wallop_type_impl(
   symbolt *s = context.find_symbol(name);
   if (s != nullptr)
   {
-    rename_types(s->type, *s, sname);
+    rename_types(s->get_type(), *s, sname);
   }
 
   deps.clear();
@@ -417,8 +417,8 @@ void goto_convert_functionst::thrash_type_symbols()
   // to decide what name is a type or not.
   typename_sett names;
   context.foreach_operand([this, &names](const symbolt &s) {
-    collect_expr(s.value, names);
-    collect_type(s.type, names);
+    collect_expr(s.get_value(), names);
+    collect_type(s.get_type(), names);
   });
 
   // Try to compute their dependencies.
@@ -428,8 +428,8 @@ void goto_convert_functionst::thrash_type_symbols()
     if (names.find(s.id) != names.end())
     {
       typename_sett list;
-      collect_expr(s.value, list);
-      collect_type(s.type, list);
+      collect_expr(s.get_value(), list);
+      collect_type(s.get_type(), list);
       typenames[s.id] = list;
     }
   });
@@ -447,7 +447,7 @@ void goto_convert_functionst::thrash_type_symbols()
 
   // And now all the types have a fixed form, rename types in all existing code.
   context.Foreach_operand([this](symbolt &s) {
-    rename_types(s.type, s, s.id);
-    rename_exprs(s.value, s, s.id);
+    rename_types(s.get_type(), s, s.id);
+    rename_exprs(s.get_value(), s, s.id);
   });
 }

--- a/src/goto-programs/goto_main.cpp
+++ b/src/goto-programs/goto_main.cpp
@@ -28,5 +28,5 @@ void goto_convert(contextt &context, optionst &options, goto_programt &dest)
     throw "failed to find main symbol";
 
   log_status("goto_convert : start converting symbol table to goto functions ");
-  ::goto_convert(to_code(s->value), context, options, dest);
+  ::goto_convert(to_code(s->get_value()), context, options, dest);
 }

--- a/src/goto-programs/goto_sideeffects.cpp
+++ b/src/goto-programs/goto_sideeffects.cpp
@@ -1009,7 +1009,7 @@ void goto_convertt::remove_function_call(
   symbolt new_symbol;
 
   new_symbol.name = "return_value$";
-  new_symbol.type = expr.type();
+  new_symbol.get_type() = expr.type();
   new_symbol.location = expr.location();
 
   // get name of function, if available
@@ -1122,7 +1122,7 @@ void goto_convertt::remove_cpp_new(
   symbolt new_symbol;
 
   new_symbol.name = "new_ptr$" + std::to_string(++tmp_symbol.counter);
-  new_symbol.type = expr.type();
+  new_symbol.get_type() = expr.type();
   new_symbol.id = tmp_symbol.prefix + id2string(new_symbol.name);
 
   new_name(new_symbol);
@@ -1233,7 +1233,7 @@ void goto_convertt::remove_statement_expression(
   decl.location() = location;
   convert_decl(decl, dest);
 
-  symbol_exprt tmp_symbol_expr(new_symbol.id, new_symbol.type);
+  symbol_exprt tmp_symbol_expr(new_symbol.id, new_symbol.get_type());
   tmp_symbol_expr.location() = location;
 
   if (last.statement() == "expression")

--- a/src/goto-programs/mark_decl_as_non_det.cpp
+++ b/src/goto-programs/mark_decl_as_non_det.cpp
@@ -19,7 +19,7 @@ bool mark_decl_as_non_det::runOnFunction(
     // find_symbol should always work here
     assert(s);
     // Global variables and function declaration shouldn't reach here
-    assert(!s->static_lifetime || !s->type.is_code());
+    assert(!s->static_lifetime || !s->get_type().is_code());
 
     // Explicit initialization of return_values is not needed as it will always be
     // later initialized (e.g. return_value$foo = FOO()).
@@ -29,7 +29,7 @@ bool mark_decl_as_non_det::runOnFunction(
     if (has_prefix(s->name, "return_value$"))
       continue;
     // Is the value initialized?
-    if (s->value.is_nil())
+    if (s->get_value().is_nil())
     {
       // Initialize it with nondet then
       expr2tc new_value =

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -71,7 +71,7 @@ bool read_bin_goto_object(
     symbolt symbol;
     symbol.from_irep(t);
 
-    if (!symbol.is_type && symbol.type.is_code())
+    if (!symbol.is_type && symbol.get_type().is_code())
     {
       // makes sure there is an empty function
       // for every function symbol and fixes
@@ -80,7 +80,7 @@ bool read_bin_goto_object(
       if (it == goto_functions.function_map.end())
         goto_functions.function_map.emplace(symbol.id, goto_functiont());
       goto_functions.function_map.at(symbol.id).type =
-        migrate_type(symbol.type);
+        migrate_type(symbol.get_type());
     }
 
     // Add functions only from the list if there is a whitelist

--- a/src/goto-programs/rw_set.cpp
+++ b/src/goto-programs/rw_set.cpp
@@ -36,7 +36,7 @@ void rw_sett::compute(const expr2tc &expr)
     if (is_symbol2t(code.function))
     {
       const symbolt *symbol = ns.lookup(to_symbol2t(code.function).thename);
-      if (symbol->value.is_nil() || symbol->name == "__VERIFIER_assert")
+      if (symbol->get_value().is_nil() || symbol->name == "__VERIFIER_assert")
         for (const expr2tc &arg : code.operands)
         {
           if (is_address_of2t(arg))
@@ -112,7 +112,7 @@ void rw_sett::read_write_rec(
 
     // C11 _Atomic variables are never involved in data races
     // (§5.1.2.4p4: concurrent accesses to atomic objects are not races).
-    if (symbol->type.get_bool("#atomic"))
+    if (symbol->get_type().get_bool("#atomic"))
       return;
 
     irep_idt object = id2string(symbol_expr.thename) + suffix;

--- a/src/goto-symex/builtin_functions/cpp_memory.cpp
+++ b/src/goto-symex/builtin_functions/cpp_memory.cpp
@@ -39,9 +39,9 @@ void goto_symext::symex_cpp_new(
                       ? type2tc(array_type2tc(renamedtype2, code.size, false))
                       : renamedtype2;
 
-  symbol.type = migrate_type_back(newtype);
+  symbol.get_type() = migrate_type_back(newtype);
 
-  symbol.type.dynamic(true);
+  symbol.get_type().dynamic(true);
 
   new_context.add(symbol);
 

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -42,15 +42,15 @@ expr2tc goto_symext::create_dynamic_memory_symbol(
   symbol.mode = "C";
 
   typet renamedtype = ns.follow(migrate_type_back(elem_type));
-  symbol.type = typet(typet::t_array);
-  symbol.type.subtype() = renamedtype;
-  symbol.type.size(migrate_expr_back(size_expr));
-  symbol.type.dynamic(true);
-  symbol.type.set(
+  symbol.get_type() = typet(typet::t_array);
+  symbol.get_type().subtype() = renamedtype;
+  symbol.get_type().size(migrate_expr_back(size_expr));
+  symbol.get_type().dynamic(true);
+  symbol.get_type().set(
     "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
 
   new_context.add(symbol);
-  type2tc new_type = migrate_type(symbol.type);
+  type2tc new_type = migrate_type(symbol.get_type());
   return symbol2tc(new_type, symbol.id);
 }
 
@@ -440,24 +440,24 @@ expr2tc goto_symext::symex_mem_inf(
 
   typet renamedtype = ns.follow(migrate_type_back(type));
 
-  symbol.type = array_typet(renamedtype, exprt("infinity", size_type()));
-  symbol.type.dynamic(true);
-  symbol.type.set(
+  symbol.get_type() = array_typet(renamedtype, exprt("infinity", size_type()));
+  symbol.get_type().dynamic(true);
+  symbol.get_type().set(
     "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
   symbol.mode = "C";
   new_context.add(symbol);
 
-  type2tc new_type = migrate_type(symbol.type);
+  type2tc new_type = migrate_type(symbol.get_type());
 
   type2tc rhs_type;
   expr2tc rhs_ptr_obj;
 
-  type2tc subtype = migrate_type(symbol.type.subtype());
+  type2tc subtype = migrate_type(symbol.get_type().subtype());
   expr2tc sym = symbol2tc(new_type, symbol.id);
   expr2tc idx_val = gen_long(size_type2(), 0L);
   expr2tc idx = index2tc(subtype, sym, idx_val);
   do_simplify(idx);
-  rhs_type = migrate_type(symbol.type.subtype());
+  rhs_type = migrate_type(symbol.get_type().subtype());
   rhs_ptr_obj = idx;
 
   expr2tc rhs_addrof = address_of2tc(rhs_type, rhs_ptr_obj);
@@ -562,41 +562,41 @@ expr2tc goto_symext::symex_mem(
 
   typet renamedtype = ns.follow(migrate_type_back(type));
   if (size_is_one)
-    symbol.type = renamedtype;
+    symbol.get_type() = renamedtype;
   else
   {
-    symbol.type = typet(typet::t_array);
-    symbol.type.subtype() = renamedtype;
-    symbol.type.size(migrate_expr_back(size));
+    symbol.get_type() = typet(typet::t_array);
+    symbol.get_type().subtype() = renamedtype;
+    symbol.get_type().size(migrate_expr_back(size));
   }
 
-  symbol.type.dynamic(true);
+  symbol.get_type().dynamic(true);
 
-  symbol.type.set(
+  symbol.get_type().set(
     "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
 
   symbol.mode = "C";
 
   new_context.add(symbol);
 
-  type2tc new_type = migrate_type(symbol.type);
+  type2tc new_type = migrate_type(symbol.get_type());
 
   type2tc rhs_type;
   expr2tc rhs_ptr_obj;
 
   if (size_is_one)
   {
-    rhs_type = migrate_type(symbol.type);
+    rhs_type = migrate_type(symbol.get_type());
     rhs_ptr_obj = symbol2tc(new_type, symbol.id);
   }
   else
   {
-    type2tc subtype = migrate_type(symbol.type.subtype());
+    type2tc subtype = migrate_type(symbol.get_type().subtype());
     expr2tc sym = symbol2tc(new_type, symbol.id);
     expr2tc idx_val = gen_long(size->type, 0L);
     expr2tc idx = index2tc(subtype, sym, idx_val);
     do_simplify(idx);
-    rhs_type = migrate_type(symbol.type.subtype());
+    rhs_type = migrate_type(symbol.get_type().subtype());
     rhs_ptr_obj = idx;
   }
 

--- a/src/goto-symex/builtin_functions/memory_ops.cpp
+++ b/src/goto-symex/builtin_functions/memory_ops.cpp
@@ -804,7 +804,9 @@ void goto_symext::intrinsic_memset(
     if (is_symbol2t(*base))
     {
       const symbolt *sym = ns.lookup(to_symbol2t(*base).thename);
-      if (sym != nullptr && sym->static_lifetime && sym->type.cmt_constant())
+      if (
+        sym != nullptr && sym->static_lifetime &&
+        sym->get_type().cmt_constant())
       {
         bump_call(func_call, "c:@F@__memset_impl");
         return;

--- a/src/goto-symex/builtin_functions/misc.cpp
+++ b/src/goto-symex/builtin_functions/misc.cpp
@@ -62,7 +62,7 @@ void goto_symext::volatile_check(expr2tc &expr)
   {
     const symbol2t &s = to_symbol2t(expr);
     const symbolt *sym = new_context.find_symbol(s.thename);
-    if (sym && sym->type.cmt_volatile())
+    if (sym && sym->get_type().cmt_volatile())
     {
       log_debug("volatile check", "variable: {}", sym->name.as_string());
       unsigned int &nondet_count = get_nondet_counter();

--- a/src/goto-symex/builtin_functions/object_size.cpp
+++ b/src/goto-symex/builtin_functions/object_size.cpp
@@ -99,7 +99,7 @@ void goto_symext::intrinsic_builtin_object_size(
             const symbol_type2t &symtype = to_symbol_type(ptr_subtype);
             const symbolt *symbol = ns.lookup(symtype.symbol_name);
             addressed_type = (symbol != nullptr)
-                               ? migrate_type(symbol->type)
+                               ? migrate_type(symbol->get_type())
                                : internal_deref_items.front().object->type;
           }
           else

--- a/src/goto-symex/builtin_functions/va_arg.cpp
+++ b/src/goto-symex/builtin_functions/va_arg.cpp
@@ -22,7 +22,7 @@ void goto_symext::symex_va_arg(
   const symbolt *s = new_context.find_symbol(id);
   if (s != nullptr)
   {
-    type2tc symbol_type = migrate_type(s->type);
+    type2tc symbol_type = migrate_type(s->get_type());
 
     va_rhs = symbol2tc(symbol_type, s->id);
     cur_state->top().level1.get_ident_name(va_rhs);

--- a/src/goto-symex/execution_state.cpp
+++ b/src/goto-symex/execution_state.cpp
@@ -897,7 +897,7 @@ void execution_statet::get_expr_globals(
     expr2tc p = expr;
     bool point_to_global = false;
     if (
-      symbol->type.is_pointer() && symbol->name != "invalid_object" &&
+      symbol->get_type().is_pointer() && symbol->name != "invalid_object" &&
       !symbol->static_lifetime)
     {
       expr2tc tmp = expr;
@@ -919,7 +919,8 @@ void execution_statet::get_expr_globals(
           const symbolt *s = ns.lookup(n);
           if (!s)
             continue;
-          point_to_global = s->static_lifetime || s->type.is_dynamic_set();
+          point_to_global =
+            s->static_lifetime || s->get_type().is_dynamic_set();
           p = to_object_descriptor2t(obj).object;
           /* Stop when the global symbol is found */
           if (point_to_global)
@@ -942,7 +943,7 @@ void execution_statet::get_expr_globals(
     // assertion-based race tests like increment_race flip to FAILED.
     const bool python_global = symbol->mode == "Python" && !symbol->file_local;
     if (
-      symbol->static_lifetime || symbol->type.is_dynamic_set() ||
+      symbol->static_lifetime || symbol->get_type().is_dynamic_set() ||
       point_to_global || python_global)
     {
       std::list<unsigned int> threadId_list;

--- a/src/goto-symex/reachability_tree.cpp
+++ b/src/goto-symex/reachability_tree.cpp
@@ -29,7 +29,7 @@ reachability_treet::reachability_treet(
 {
   // Put a few useful symbols in the symbol table.
   symbolt sym;
-  sym.type = bool_typet();
+  sym.get_type() = bool_typet();
   sym.id = "execution_statet::\\guard_exec";
   sym.name = "execution_statet::\\guard_exec";
   context.move(sym);

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -63,7 +63,7 @@ bool goto_symext::is_python_exception_subtype(
     return false;
 
   // Get the bases from the type metadata
-  const irept &bases = thrown_symbol->type.find("bases");
+  const irept &bases = thrown_symbol->get_type().find("bases");
 
   if (bases.is_nil())
     return false;
@@ -291,9 +291,9 @@ bool goto_symext::symex_throw_bad_cast()
     std::vector<irep_idt> exception_list;
     const std::string type_id = id2string(bad_cast_sym->id);
     exception_list.emplace_back(type_id.substr(4)); // "std::bad_cast"
-    if (bad_cast_sym->type.id() == "struct")
+    if (bad_cast_sym->get_type().id() == "struct")
     {
-      const struct_typet &st = to_struct_type(bad_cast_sym->type);
+      const struct_typet &st = to_struct_type(bad_cast_sym->get_type());
       const exprt &bases = static_cast<const exprt &>(st.find("bases"));
       if (bases.is_not_nil())
         for (const auto &base : bases.get_sub())
@@ -301,7 +301,7 @@ bool goto_symext::symex_throw_bad_cast()
     }
 
     // Build a nondet operand of bad_cast type for the thrown object.
-    type2tc bad_cast_type = migrate_type(bad_cast_sym->type);
+    type2tc bad_cast_type = migrate_type(bad_cast_sym->get_type());
     expr2tc nondet_op = sideeffect2tc(
       bad_cast_type,
       expr2tc(),
@@ -331,7 +331,7 @@ bool goto_symext::terminate_handler()
   // It'll call the current function handler
   if (!is_included)
   {
-    codet terminate_function = to_code(tmp->value.op0());
+    codet terminate_function = to_code(tmp->get_value().op0());
 
     // We only call it if the user replaced the default one
     if (terminate_function.op1().identifier() == "std::default_terminate()")
@@ -371,7 +371,7 @@ bool goto_symext::unexpected_handler()
 
     expr2tc the_call;
     code_function_callt unexpected_function;
-    unexpected_function.function() = handler->value;
+    unexpected_function.function() = handler->get_value();
     migrate_expr(unexpected_function, the_call);
 
     // Indicate there we're inside the unexpected flow
@@ -379,7 +379,7 @@ bool goto_symext::unexpected_handler()
 
     // Call the function
     symex_function_call(the_call);
-    unexpected_end = handler->value.identifier();
+    unexpected_end = handler->get_value().identifier();
     return true;
   }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -37,7 +37,7 @@ bool symex_dereference_statet::has_failed_symbol(
     const symbolt &ptr_symbol =
       *goto_symex.ns.lookup(to_symbol2t(expr).thename);
 
-    const irep_idt &failed_symbol = ptr_symbol.type.failed_symbol();
+    const irep_idt &failed_symbol = ptr_symbol.get_type().failed_symbol();
 
     if (failed_symbol == "")
       return false;

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -159,7 +159,7 @@ unsigned goto_symext::argument_assignments(
             const symbol_type2t &sym_type = to_symbol_type(ptr_subtype);
             symbolt const *sym = ns.lookup(sym_type.symbol_name);
             if (sym)
-              ptr_subtype = migrate_type(sym->type);
+              ptr_subtype = migrate_type(sym->get_type());
             else
               break;
           }
@@ -224,7 +224,7 @@ unsigned goto_symext::argument_assignments(
       symbolt symbol;
       symbol.id = identifier;
       symbol.name = "va_arg" + std::to_string(va_count);
-      symbol.type = migrate_type_back((*it1)->type);
+      symbol.get_type() = migrate_type_back((*it1)->type);
 
       if (new_context.move(symbol))
       {

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -438,7 +438,7 @@ void goto_symext::phi_function(const statet::goto_statet &goto_state)
     // changed!
     const symbolt &symbol = *ns.lookup(variable.base_name);
 
-    type2tc type = migrate_type(symbol.type);
+    type2tc type = migrate_type(symbol.get_type());
 
     expr2tc cur_state_rhs = symbol2tc(type, symbol.id);
     renaming::level2t::rename_to_record(cur_state_rhs, variable);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -1075,7 +1075,9 @@ void goto_symext::run_intrinsic(
     assert(list_object_symbol);
 
     symex_mem_inf(
-      func_call.ret, migrate_type(list_object_symbol->type), cur_state->guard);
+      func_call.ret,
+      migrate_type(list_object_symbol->get_type()),
+      cur_state->guard);
 
     return;
   }
@@ -1264,7 +1266,7 @@ void goto_symext::add_memory_leak_checks()
             i,
             e.identifier,
             e.suffix);
-          sym_expr2 = sym_expr2->with_type(migrate_type(sym->type));
+          sym_expr2 = sym_expr2->with_type(migrate_type(sym->get_type()));
 
           /* Rename so that it reflects the current state. */
           assert(cur_state->call_stack.size() >= 1);

--- a/src/goto-symex/symex_valid_object.cpp
+++ b/src/goto-symex/symex_valid_object.cpp
@@ -49,7 +49,7 @@ void goto_symext::replace_dynamic_allocation(expr2tc &expr)
         const symbolt &symbol = *ns.lookup(to_symbol2t(*identifier).thename);
 
         // dynamic?
-        if (symbol.type.dynamic())
+        if (symbol.get_type().dynamic())
         {
           // TODO
         }
@@ -90,7 +90,7 @@ bool goto_symext::is_valid_object(const symbolt &symbol)
     return true; // global
 
   // dynamic?
-  if (symbol.type.dynamic())
+  if (symbol.get_type().dynamic())
     return false;
 
 // current location?

--- a/src/goto-symex/xml_goto_trace.cpp
+++ b/src/goto-symex/xml_goto_trace.cpp
@@ -78,8 +78,8 @@ void convert(const namespacet &ns, const goto_tracet &goto_trace, xmlt &xml)
         base_name = symbol->name;
         display_name = symbol->name;
         if (type_string == "")
-          type_string =
-            from_type(ns, identifier, symbol->type, presentationt::WITNESS);
+          type_string = from_type(
+            ns, identifier, symbol->get_type(), presentationt::WITNESS);
 
         xml_assignment.new_element("mode").data =
           xmlt::escape(id2string(symbol->mode));

--- a/src/goto2c/expr2c.cpp
+++ b/src/goto2c/expr2c.cpp
@@ -1024,7 +1024,9 @@ std::string expr2ct::convert_code_decl(const codet &src, unsigned indent)
     else if (symbol->is_extern)
       dest += "extern ";
 
-    if (symbol->type.is_code() && to_code_type(symbol->type).get_inlined())
+    if (
+      symbol->get_type().is_code() &&
+      to_code_type(symbol->get_type()).get_inlined())
       dest += "inline ";
   }
 

--- a/src/goto2c/goto2c_preprocess.cpp
+++ b/src/goto2c/goto2c_preprocess.cpp
@@ -74,16 +74,16 @@ typet goto2ct::get_base_type(typet type, namespacet ns)
   if (type.id() == "symbol")
   {
     const symbolt *symbol = ns.lookup(type.identifier());
-    if (symbol && symbol->is_type && !symbol->type.is_nil())
-      return get_base_type(symbol->type, ns);
+    if (symbol && symbol->is_type && !symbol->get_type().is_nil())
+      return get_base_type(symbol->get_type(), ns);
   }
 
   // This is to deal with incomplete types and unions
   if (type.id() == "struct" || type.id() == "union")
   {
     const symbolt *symbol = ns.lookup(("tag-" + type.tag().as_string()));
-    if (symbol && symbol->is_type && !symbol->type.is_nil())
-      return symbol->type;
+    if (symbol && symbol->is_type && !symbol->get_type().is_nil())
+      return symbol->get_type();
   }
 
   return type;
@@ -157,12 +157,12 @@ void goto2ct::extract_symbol_tables()
     if (s.is_type)
     {
       if (sym_fun_name.empty())
-        global_types.push_back(s.type);
+        global_types.push_back(s.get_type());
       else
-        local_types[sym_fun_name].push_back(s.type);
+        local_types[sym_fun_name].push_back(s.get_type());
     }
     // This is a function declaration
-    else if (s.type.id() == "code")
+    else if (s.get_type().id() == "code")
       fun_decls.push_back(s);
     // This is an extern variable
     else if (s.is_extern)

--- a/src/goto2c/goto2c_translate.cpp
+++ b/src/goto2c/goto2c_translate.cpp
@@ -92,7 +92,7 @@ goto2ct::translate(std::string function_id, goto_functiont &goto_function)
   // Creating a function symbol
   symbolt fun_sym;
   fun_sym.id = function_id;
-  fun_sym.type = migrate_type_back(goto_function.type);
+  fun_sym.get_type() = migrate_type_back(goto_function.type);
   // Translating the function declaration
   out << expr2c(code_declt(symbol_expr(fun_sym)), ns) << "\n";
   // Translating the function body

--- a/src/jimple-frontend/AST/jimple_ast.h
+++ b/src/jimple-frontend/AST/jimple_ast.h
@@ -65,7 +65,7 @@ protected:
     symbol.mode = "C";
     symbol.module = module;
     symbol.location = std::move(get_location(module, function_name));
-    symbol.type = std::move(t);
+    symbol.get_type() = std::move(t);
     symbol.name = name;
     symbol.id = id;
     return symbol;
@@ -119,7 +119,7 @@ protected:
     code_type.arguments().push_back(uint_type());
     symbolt symbol;
     symbol.mode = "C";
-    symbol.type = code_type;
+    symbol.get_type() = code_type;
     symbol.name = allocation_function;
     symbol.id = allocation_function;
     symbol.is_extern = false;
@@ -143,7 +143,7 @@ protected:
     code_type.arguments().push_back(pointer_typet(empty_typet()));
     symbolt symbol;
     symbol.mode = "C";
-    symbol.type = code_type;
+    symbol.get_type() = code_type;
     symbol.name = func;
     symbol.id = func;
     symbol.is_extern = false;

--- a/src/jimple-frontend/AST/jimple_expr.cpp
+++ b/src/jimple-frontend/AST/jimple_expr.cpp
@@ -551,7 +551,7 @@ exprt jimple_static_member::to_exprt(
   // 1. Look over the local scope
   auto symbol_name = get_symbol_name(class_name, function_name, from);
   symbolt &s = *ctx.find_symbol(symbol_name);
-  member_exprt op(symbol_expr(s), "tag-" + field, s.type);
+  member_exprt op(symbol_expr(s), "tag-" + field, s.get_type());
   exprt &base = op.struct_op();
   if (base.type().is_pointer())
   {
@@ -579,7 +579,7 @@ exprt jimple_virtual_member::to_exprt(
   const std::string &function_name) const
 {
   auto result = gen_zero(type->to_typet(ctx));
-  auto struct_type = (*ctx.find_symbol("tag-" + from)).type;
+  auto struct_type = (*ctx.find_symbol("tag-" + from)).get_type();
 
   // 1. Look over the local scope
   auto symbol_name = get_symbol_name(class_name, function_name, variable);

--- a/src/jimple-frontend/AST/jimple_file.cpp
+++ b/src/jimple-frontend/AST/jimple_file.cpp
@@ -156,7 +156,7 @@ exprt jimple_file::to_exprt(contextt &ctx) const
 
   // Finally, the structure is ready. Lets add it
   t.set("width", total_size);
-  added_symbol->type = t;
+  added_symbol->get_type() = t;
 
   // Add the methods and definitions
   for (auto const &field : body)

--- a/src/jimple-frontend/AST/jimple_method.cpp
+++ b/src/jimple-frontend/AST/jimple_method.cpp
@@ -87,8 +87,8 @@ exprt jimple_method::to_exprt(
   if (!method_type.arguments().size())
     method_type.make_ellipsis();
 
-  added_symbol.type = method_type;
-  added_symbol.value = body->to_exprt(ctx, class_name, this->name);
+  added_symbol.get_type() = method_type;
+  added_symbol.get_value() = body->to_exprt(ctx, class_name, this->name);
 
   return dummy;
 }

--- a/src/jimple-frontend/AST/jimple_statement.cpp
+++ b/src/jimple-frontend/AST/jimple_statement.cpp
@@ -221,7 +221,7 @@ exprt jimple_assignment_field::to_exprt(
     // 1. Look over the local scope
   auto symbol_name = get_symbol_name(class_name, function_name, variable);
   symbolt &s = *ctx.find_symbol(symbol_name);
-  member_exprt op(symbol_expr(s), "tag-" + field, s.type);
+  member_exprt op(symbol_expr(s), "tag-" + field, s.get_type());
   exprt &base = op.struct_op();
   if(base.type().is_pointer())
   {

--- a/src/jimple-frontend/AST/jimple_type.cpp
+++ b/src/jimple-frontend/AST/jimple_type.cpp
@@ -25,7 +25,7 @@ typet jimple_type::get_base_type(const contextt &ctx) const
     auto symbol = ctx.find_symbol("tag-" + name);
     if (symbol == nullptr)
       throw "Type not found: " + name;
-    return pointer_typet(symbol->type);
+    return pointer_typet(symbol->get_type());
   }
 }
 

--- a/src/jimple-frontend/jimple-language.cpp
+++ b/src/jimple-frontend/jimple-language.cpp
@@ -50,17 +50,17 @@ unsigned jimple_languaget::default_flags(presentationt) const
 
 static inline void init_variable(codet &dest, const symbolt &sym)
 {
-  const exprt &value = sym.value;
+  const exprt &value = sym.get_value();
 
   if (value.is_nil())
     return;
 
   assert(!value.type().is_code());
 
-  exprt symbol("symbol", sym.type);
+  exprt symbol("symbol", sym.get_type());
   symbol.identifier(sym.id);
 
-  code_assignt code(symbol, sym.value);
+  code_assignt code(symbol, sym.get_value());
   code.location() = sym.location;
 
   dest.move_to_operands(code);
@@ -78,7 +78,7 @@ static inline void static_lifetime_init(const contextt &context, codet &dest)
 
   // call designated "initialization" functions
   context.foreach_operand_in_order([&dest](const symbolt &s) {
-    if (s.type.initialization() && s.type.is_code())
+    if (s.get_type().initialization() && s.get_type().is_code())
     {
       code_function_callt function_call;
       function_call.function() = symbol_expr(s);
@@ -94,7 +94,7 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
   std::string id = "c:@" + name;
   symbolt symbol;
   symbol.mode = "C";
-  symbol.type = std::move(t);
+  symbol.get_type() = std::move(t);
   symbol.name = name;
   symbol.id = id;
 
@@ -102,8 +102,8 @@ add_global_static_variable(contextt &ctx, const typet t, std::string name)
   symbol.static_lifetime = true;
   symbol.is_extern = false;
   symbol.file_local = false;
-  symbol.value = gen_zero(t, true);
-  symbol.value.zero_initializer(true);
+  symbol.get_value() = gen_zero(t, true);
+  symbol.get_value().zero_initializer(true);
 
   symbolt &added_symbol = *ctx.move_symbol_to_context(symbol);
   code_declt decl(symbol_expr(added_symbol));
@@ -139,7 +139,7 @@ void jimple_languaget::setup_main(contextt &context)
     if (s == nullptr)
       continue;
 
-    if (s->type.is_code())
+    if (s->get_type().is_code())
       matches.push_back(it->second);
   }
   if (matches.empty())
@@ -158,7 +158,7 @@ void jimple_languaget::setup_main(contextt &context)
 
   const symbolt &symbol = *s;
   // check if it has a body
-  if (symbol.value.is_nil())
+  if (symbol.get_value().is_nil())
   {
     log_error("Empty body for main");
     abort();
@@ -175,7 +175,7 @@ void jimple_languaget::setup_main(contextt &context)
   call.function() = symbol_expr(symbol);
 
   const code_typet::argumentst &arguments =
-    to_code_type(symbol.type).arguments();
+    to_code_type(symbol.get_type()).arguments();
 
   call.arguments().resize(
     arguments.size(), static_cast<const exprt &>(get_nil_irep()));
@@ -191,8 +191,8 @@ void jimple_languaget::setup_main(contextt &context)
 
   new_symbol.id = "__ESBMC_main";
   new_symbol.name = "__ESBMC_main";
-  new_symbol.type.swap(main_type);
-  new_symbol.value.swap(init_code);
+  new_symbol.get_type().swap(main_type);
+  new_symbol.get_value().swap(init_code);
 
   if (context.move(new_symbol))
   {

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -541,7 +541,7 @@ expr2tc dereferencet::make_failed_symbol(const type2tc &out_type)
   symbolt symbol;
   symbol.id = "symex::invalid_object" + i2string(invalid_counter++);
   symbol.name = "invalid_object";
-  symbol.type = migrate_type_back(the_type);
+  symbol.get_type() = migrate_type_back(the_type);
 
   // make it a lvalue, so we can assign to it
   symbol.lvalue = true;
@@ -2325,7 +2325,8 @@ void dereferencet::valid_check(
       }
 
       /* Writes to globals of const-qualified type are not allowed either. */
-      if (is_write(mode) && sym.static_lifetime && sym.type.cmt_constant())
+      if (
+        is_write(mode) && sym.static_lifetime && sym.get_type().cmt_constant())
       {
         dereference_failure(
           "pointer dereference",

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -23,7 +23,7 @@ bool goto_program_dereferencet::has_failed_symbol(
 
     const symbolt &ptr_symbol = *ns.lookup(migrate_expr_back(expr));
 
-    const irep_idt &failed_symbol = ptr_symbol.type.failed_symbol();
+    const irep_idt &failed_symbol = ptr_symbol.get_type().failed_symbol();
 
     if (failed_symbol == "")
       return false;

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -857,7 +857,7 @@ void value_sett::get_reference_set_rec(const expr2tc &expr, object_mapt &dest)
     {
       const symbolt *sym = ns.lookup(to_symbol2t(expr).thename);
       assert(sym);
-      const irept &a = sym->type.find("alignment");
+      const irept &a = sym->get_type().find("alignment");
       if (a.is_not_nil())
       {
         assert(a.is_constant());
@@ -1397,7 +1397,7 @@ void value_sett::do_function_call(
   const symbolt &symbol,
   const std::vector<expr2tc> &arguments)
 {
-  const code_typet &type = to_code_type(symbol.type);
+  const code_typet &type = to_code_type(symbol.get_type());
 
   type2tc tmp_migrated_type = migrate_type(type);
   const code_type2t &migrated_type =

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -65,7 +65,7 @@ void value_set_analysist::get_entries(
   const symbolt &symbol,
   std::list<value_sett::entryt> &dest)
 {
-  get_entries_rec(symbol.id.as_string(), "", symbol.type, dest);
+  get_entries_rec(symbol.id.as_string(), "", symbol.get_type(), dest);
 }
 
 void value_set_analysist::get_entries_rec(

--- a/src/python-frontend/complex_handler.cpp
+++ b/src/python-frontend/complex_handler.cpp
@@ -335,8 +335,8 @@ exprt complex_handler::handle_binary_op(
     if (rhs.is_symbol())
     {
       const symbolt *s = find_cached_symbol(rhs.identifier().as_string());
-      if (s && !s->value.is_nil())
-        resolved_rhs = s->value;
+      if (s && !s->get_value().is_nil())
+        resolved_rhs = s->get_value();
     }
     else if (
       rhs.id() == "+" || rhs.id() == "-" || rhs.id() == "*" || rhs.id() == "/")

--- a/src/python-frontend/converter/converter_binop.cpp
+++ b/src/python-frontend/converter/converter_binop.cpp
@@ -291,7 +291,7 @@ exprt python_converter::handle_membership_operator(
   {
     const symbolt *sym = symbol_table_.find_symbol(rhs.identifier());
     if (sym)
-      rhs_resolved_type = sym->type;
+      rhs_resolved_type = sym->get_type();
   }
 
   if (rhs_resolved_type.id() == "symbol")

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -24,13 +24,13 @@ exprt python_converter::make_enum_member_struct_expr(
 {
   // Get the struct type for the enum class (e.g. tag-TrafficLight)
   const symbolt *type_sym = symbol_table_.find_symbol("tag-" + class_name);
-  if (!type_sym || !type_sym->type.is_struct())
+  if (!type_sym || !type_sym->get_type().is_struct())
   {
     log_error("Enum class '{}' has no struct type in symbol table", class_name);
     abort();
   }
 
-  const struct_typet &st = to_struct_type(type_sym->type);
+  const struct_typet &st = to_struct_type(type_sym->get_type());
   if (st.components().size() < 2)
   {
     log_error(
@@ -49,8 +49,8 @@ exprt python_converter::make_enum_member_struct_expr(
     symbolt str_sym;
     str_sym.id = str_id;
     str_sym.name = "_name_" + member_name;
-    str_sym.type = str_val.type();
-    str_sym.value = str_val;
+    str_sym.get_type() = str_val.type();
+    str_sym.get_value() = str_val;
     str_sym.static_lifetime = true;
     str_sym.is_extern = false;
     str_sym.file_local = true;
@@ -105,7 +105,7 @@ exprt python_converter::create_member_expression(
   const typet &attr_type)
 {
   typet clean_type = clean_attribute_type(attr_type);
-  exprt source = symbol_exprt(symbol.id, symbol.type);
+  exprt source = symbol_exprt(symbol.id, symbol.get_type());
   if (source.type().is_pointer())
   {
     exprt deref("dereference");

--- a/src/python-frontend/converter/converter_compare.cpp
+++ b/src/python-frontend/converter/converter_compare.cpp
@@ -17,15 +17,15 @@ std::pair<exprt, exprt> python_converter::resolve_comparison_operands_internal(
   if (lhs.is_symbol() && lhs.type().is_array())
   {
     const symbolt *sym = symbol_table_.find_symbol(lhs.identifier());
-    if (sym && sym->value.is_constant())
-      resolved_lhs = sym->value;
+    if (sym && sym->get_value().is_constant())
+      resolved_lhs = sym->get_value();
   }
 
   if (rhs.is_symbol() && rhs.type().is_array())
   {
     const symbolt *sym = symbol_table_.find_symbol(rhs.identifier());
-    if (sym && sym->value.is_constant())
-      resolved_rhs = sym->value;
+    if (sym && sym->get_value().is_constant())
+      resolved_rhs = sym->get_value();
   }
 
   return {resolved_lhs, resolved_rhs};
@@ -143,13 +143,13 @@ exprt python_converter::handle_indexed_comparison_internal(
     const symbolt *symbol = symbol_table_.find_symbol(array.identifier());
     if (symbol)
     {
-      resolved_array = symbol->value;
-      if (symbol->value.is_symbol())
+      resolved_array = symbol->get_value();
+      if (symbol->get_value().is_symbol())
       {
         const symbolt *compound =
-          symbol_table_.find_symbol(symbol->value.identifier());
-        if (compound && compound->value.is_constant())
-          resolved_array = compound->value;
+          symbol_table_.find_symbol(symbol->get_value().identifier());
+        if (compound && compound->get_value().is_constant())
+          resolved_array = compound->get_value();
       }
     }
   }
@@ -577,10 +577,10 @@ exprt python_converter::handle_type_identity_check(
       {
         const symbol_exprt &sym = to_symbol_expr(expr);
         const symbolt *symbol = ns.lookup(sym.get_identifier());
-        if (symbol && symbol->value.is_constant())
+        if (symbol && symbol->get_value().is_constant())
         {
           std::string val =
-            to_constant_expr(symbol->value).get_value().as_string();
+            to_constant_expr(symbol->get_value()).get_value().as_string();
 
           if (type_utils::is_type_identifier(val))
           {

--- a/src/python-frontend/converter/converter_dunder.cpp
+++ b/src/python-frontend/converter/converter_dunder.cpp
@@ -109,7 +109,7 @@ static typet resolve_operand_type(
   {
     const symbolt *sym = symbol_table.find_symbol(operand.identifier());
     if (sym)
-      t = sym->type;
+      t = sym->get_type();
   }
   if (t.id() == "symbol")
     t = ns.follow(t);
@@ -168,7 +168,7 @@ exprt python_converter::dispatch_dunder_operator(
         symbolt *method = find_dunder_method(class_name, dunder);
         if (method)
         {
-          const code_typet &method_type = to_code_type(method->type);
+          const code_typet &method_type = to_code_type(method->get_type());
           if (is_other_param_compatible(method_type, rhs_type, ns))
           {
             side_effect_expr_function_callt call;
@@ -199,7 +199,7 @@ exprt python_converter::dispatch_dunder_operator(
         symbolt *method = find_dunder_method(class_name, rdunder);
         if (method)
         {
-          const code_typet &method_type = to_code_type(method->type);
+          const code_typet &method_type = to_code_type(method->get_type());
           if (is_other_param_compatible(method_type, lhs_type, ns))
           {
             side_effect_expr_function_callt call;
@@ -228,7 +228,7 @@ exprt python_converter::dispatch_unary_dunder_operator(
   {
     const symbolt *sym = symbol_table_.find_symbol(operand.identifier());
     if (sym)
-      operand_type = sym->type;
+      operand_type = sym->get_type();
   }
   if (operand_type.id() == "symbol")
     operand_type = ns.follow(operand_type);
@@ -263,7 +263,7 @@ exprt python_converter::dispatch_unary_dunder_operator(
   if (!method)
     return nil_exprt();
 
-  const code_typet &method_type = to_code_type(method->type);
+  const code_typet &method_type = to_code_type(method->get_type());
   side_effect_expr_function_callt call;
   call.function() = symbol_expr(*method);
   call.type() = method_type.return_type();

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -595,7 +595,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           symbol_id func_sid(current_python_file, "", var_name);
           symbolt *func_symbol =
             symbol_table_.find_symbol(func_sid.to_string());
-          if (func_symbol && func_symbol->type.is_code())
+          if (func_symbol && func_symbol->get_type().is_code())
           {
             expr = symbol_expr(*func_symbol);
             break;
@@ -631,7 +631,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
     // If the looked-up symbol is an enum class attribute with int type,
     // wrap it in the proper enum struct expression so callers that expect
     // the enum class type (e.g. function parameters) receive a struct value.
-    if (is_class_attr && symbol->type.is_signedbv() && element.contains("attr"))
+    if (
+      is_class_attr && symbol->get_type().is_signedbv() &&
+      element.contains("attr"))
     {
       std::string cn = var_name;
       if (cn.starts_with("C@"))
@@ -649,7 +651,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       const std::string &attr_name = element["attr"].get<std::string>();
 
       // Delegate complex attribute access (.real, .imag) to the handler.
-      if (is_complex_type(symbol->type))
+      if (is_complex_type(symbol->get_type()))
       {
         exprt result =
           complex_handler_.handle_attribute_access(expr, attr_name);
@@ -662,8 +664,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
 
       // Get object type name from symbol. e.g.: tag-MyClass
       std::string obj_type_name;
-      const typet &symbol_type =
-        (symbol->type.is_pointer()) ? symbol->type.subtype() : symbol->type;
+      const typet &symbol_type = (symbol->get_type().is_pointer())
+                                   ? symbol->get_type().subtype()
+                                   : symbol->get_type();
 
       // Handle union types
       if (symbol_type.is_array() && symbol_type.subtype() == char_type())
@@ -679,9 +682,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           if (target_class_symbol)
             return; // Already found
 
-          if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
+          if (s.id.as_string().find("tag-") == 0 && s.get_type().is_struct())
           {
-            const struct_typet &struct_type = to_struct_type(s.type);
+            const struct_typet &struct_type = to_struct_type(s.get_type());
             if (struct_type.has_component(attr_name))
               target_class_symbol = const_cast<symbolt *>(&s);
           }
@@ -695,16 +698,17 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         }
 
         // Create a typecast from char* to target_class*
-        typet target_ptr_type = gen_pointer_type(target_class_symbol->type);
+        typet target_ptr_type =
+          gen_pointer_type(target_class_symbol->get_type());
         exprt casted_expr = typecast_exprt(expr, target_ptr_type);
 
         // Dereference to get the object
-        exprt deref_expr("dereference", target_class_symbol->type);
+        exprt deref_expr("dereference", target_class_symbol->get_type());
         deref_expr.copy_to_operands(casted_expr);
 
         // Access the member on the object
         const struct_typet &target_struct =
-          to_struct_type(target_class_symbol->type);
+          to_struct_type(target_class_symbol->get_type());
         const typet &attr_type = target_struct.get_component(attr_name).type();
         typet clean_type = clean_attribute_type(attr_type);
 
@@ -739,9 +743,9 @@ exprt python_converter::get_expr(const nlohmann::json &element)
         symbol_table_.foreach_operand_in_order([&](const symbolt &s) {
           if (!fallback_class_id.empty())
             return;
-          if (s.id.as_string().find("tag-") == 0 && s.type.is_struct())
+          if (s.id.as_string().find("tag-") == 0 && s.get_type().is_struct())
           {
-            const struct_typet &st = to_struct_type(s.type);
+            const struct_typet &st = to_struct_type(s.get_type());
             if (st.has_component(attr_name))
               fallback_class_id = s.id.as_string();
           }
@@ -775,7 +779,7 @@ exprt python_converter::get_expr(const nlohmann::json &element)
       }
 
       struct_typet &class_type =
-        static_cast<struct_typet &>(class_symbol->type);
+        static_cast<struct_typet &>(class_symbol->get_type());
       auto build_member_expr_from_class = [&](const typet &attr_type) -> exprt {
         typet clean_type = clean_attribute_type(attr_type);
         exprt base = symbol_expr(*symbol);

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -43,17 +43,17 @@ exprt python_converter::get_resolved_value(const exprt &expr)
   const symbol_exprt &sym = to_symbol_expr(expr);
   const symbolt *symbol = symbol_table_.find_symbol(sym.get_identifier());
 
-  if (!symbol || symbol->value.is_nil())
+  if (!symbol || symbol->get_value().is_nil())
     return nil_exprt();
 
   // Return constant values directly
-  if (symbol->value.is_constant())
-    return symbol->value;
+  if (symbol->get_value().is_constant())
+    return symbol->get_value();
 
   // Handle function calls stored as code
-  if (symbol->value.is_code())
+  if (symbol->get_value().is_code())
   {
-    const codet &code = to_code(symbol->value);
+    const codet &code = to_code(symbol->get_value());
 
     if (code.get_statement() == "function_call" && code.operands().size() >= 3)
     {
@@ -80,17 +80,18 @@ exprt python_converter::resolve_function_call(
   const symbolt *func_symbol =
     symbol_table_.find_symbol(func_sym.get_identifier());
 
-  if (!func_symbol || func_symbol->value.is_nil())
+  if (!func_symbol || func_symbol->get_value().is_nil())
     return nil_exprt();
 
   // First check if this function returns a constant value
-  exprt constant_result = get_function_constant_return(func_symbol->value);
+  exprt constant_result =
+    get_function_constant_return(func_symbol->get_value());
   if (!constant_result.is_nil())
     return constant_result;
 
   // Then check if this function is an identity function (returns its parameter)
   if (!is_identity_function(
-        func_symbol->value, func_sym.get_identifier().as_string()))
+        func_symbol->get_value(), func_sym.get_identifier().as_string()))
     return nil_exprt();
 
   // Extract the first argument for identity functions
@@ -116,8 +117,8 @@ exprt python_converter::resolve_function_call(
   {
     const symbol_exprt &sym = to_symbol_expr(arg);
     const symbolt *symbol = symbol_table_.find_symbol(sym.get_identifier());
-    if (symbol && symbol->value.is_constant())
-      arg = symbol->value;
+    if (symbol && symbol->get_value().is_constant())
+      arg = symbol->get_value();
   }
 
   // Return string constants, array constants, and single character constants
@@ -531,7 +532,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     var_sid.set_object(func_name);
     symbolt *var_symbol = find_symbol(var_sid.to_string());
 
-    if (var_symbol && var_symbol->type.is_pointer())
+    if (var_symbol && var_symbol->get_type().is_pointer())
     {
       // This is an indirect call through function pointer
       side_effect_expr_function_callt call;
@@ -542,7 +543,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // so that the adjuster can dereference it to a code type (it calls
       // to_code_type on the dereferenced subtype, which would fail on void).
       exprt func_ptr_expr = symbol_expr(*var_symbol);
-      if (var_symbol->type == any_type())
+      if (var_symbol->get_type() == any_type())
         func_ptr_expr =
           typecast_exprt(func_ptr_expr, gen_pointer_type(code_typet()));
       call.function() = func_ptr_expr;
@@ -552,24 +553,25 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       // does not preserve the full code_typet (return type + arguments).
       bool resolved = false;
       if (
-        var_symbol->value.is_address_of() &&
-        !var_symbol->value.operands().empty() &&
-        var_symbol->value.operands()[0].is_symbol())
+        var_symbol->get_value().is_address_of() &&
+        !var_symbol->get_value().operands().empty() &&
+        var_symbol->get_value().operands()[0].is_symbol())
       {
         const symbolt *target_func = symbol_table_.find_symbol(
-          var_symbol->value.operands()[0].identifier());
-        if (target_func && target_func->type.is_code())
+          var_symbol->get_value().operands()[0].identifier());
+        if (target_func && target_func->get_type().is_code())
         {
-          const code_typet &func_type = to_code_type(target_func->type);
+          const code_typet &func_type = to_code_type(target_func->get_type());
           call.type() = func_type.return_type();
           resolved = true;
         }
       }
 
       // Try to get return type from the pointer's subtype
-      if (!resolved && var_symbol->type.subtype().is_code())
+      if (!resolved && var_symbol->get_type().subtype().is_code())
       {
-        const code_typet &func_type = to_code_type(var_symbol->type.subtype());
+        const code_typet &func_type =
+          to_code_type(var_symbol->get_type().subtype());
         call.type() = func_type.return_type();
         resolved = true;
       }
@@ -826,10 +828,10 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
       return;
 
     const symbolt *func_symbol = symbol_table_.find_symbol(func.identifier());
-    if (!func_symbol || !func_symbol->type.is_code())
+    if (!func_symbol || !func_symbol->get_type().is_code())
       return;
 
-    const code_typet &func_type = to_code_type(func_symbol->type);
+    const code_typet &func_type = to_code_type(func_symbol->get_type());
     const code_typet::argumentst &params = func_type.arguments();
 
     code_function_callt &call = static_cast<code_function_callt &>(call_expr);
@@ -1001,9 +1003,9 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
     if (func.is_symbol())
     {
       const symbolt *func_symbol = symbol_table_.find_symbol(func.identifier());
-      if (func_symbol && func_symbol->type.is_code())
+      if (func_symbol && func_symbol->get_type().is_code())
       {
-        const code_typet &func_type = to_code_type(func_symbol->type);
+        const code_typet &func_type = to_code_type(func_symbol->get_type());
         const code_typet::argumentst &params = func_type.arguments();
         auto &args = call.arguments();
         for (size_t i = 0; i < args.size() && i < params.size(); ++i)
@@ -1019,7 +1021,7 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
               symbol_table_.find_symbol(arg.identifier());
             if (arg_symbol)
             {
-              arg_actual_type = arg_symbol->type;
+              arg_actual_type = arg_symbol->get_type();
               // Follow symbol type references using namespace
               if (arg_actual_type.id() == "symbol")
                 arg_actual_type = ns.follow(arg_actual_type);
@@ -1112,7 +1114,7 @@ exprt python_converter::get_return_from_func(const char *func_symbol_id)
   symbolt *func_symbol = symbol_table_.find_symbol(func_symbol_id);
   assert(func_symbol);
 
-  const auto &operands = func_symbol->value.operands();
+  const auto &operands = func_symbol->get_value().operands();
 
   for (std::vector<exprt>::const_reverse_iterator it = operands.rbegin();
        it != operands.rend();

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -100,7 +100,7 @@ symbolt python_converter::create_return_temp_variable(
   symbolt temp_symbol;
   temp_symbol.id = temp_sid.to_string();
   temp_symbol.name = temp_sid.to_string();
-  temp_symbol.type = return_type;
+  temp_symbol.get_type() = return_type;
   temp_symbol.lvalue = true;
   temp_symbol.static_lifetime = false;
   temp_symbol.location = location;
@@ -609,7 +609,7 @@ void python_converter::process_function_arguments(
               {
                 symbolt *param_sym = symbol_table_.find_symbol(param_id);
                 if (param_sym)
-                  param_sym->type = default_expr.type();
+                  param_sym->get_type() = default_expr.type();
               }
             }
           }
@@ -666,7 +666,7 @@ void python_converter::process_function_arguments(
       {
         symbolt *param_sym = symbol_table_.find_symbol(param_id);
         if (param_sym)
-          param_sym->type = list_t;
+          param_sym->get_type() = list_t;
       }
     }
   }
@@ -702,7 +702,7 @@ void python_converter::process_function_arguments(
     {
       symbolt *param_sym = symbol_table_.find_symbol(param_id);
       if (param_sym)
-        param_sym->type = ptr_type;
+        param_sym->get_type() = ptr_type;
     }
   }
 }
@@ -994,7 +994,7 @@ void python_converter::get_function_definition(
         typet optional_type = type_handler_.build_optional_type(value_type);
         type.return_type() = optional_type;
         current_element_type = optional_type;
-        added_symbol->type = type;
+        added_symbol->get_type() = type;
       }
     }
     else
@@ -1005,7 +1005,7 @@ void python_converter::get_function_definition(
         type_handler_.build_optional_type(type.return_type());
       type.return_type() = optional_type;
       current_element_type = optional_type;
-      added_symbol->type = type;
+      added_symbol->get_type() = type;
     }
   }
 
@@ -1018,7 +1018,7 @@ void python_converter::get_function_definition(
     {
       type.return_type() = inferred_type;
       current_element_type = inferred_type;
-      added_symbol->type = type;
+      added_symbol->get_type() = type;
     }
   }
 
@@ -1039,7 +1039,7 @@ void python_converter::get_function_definition(
     if (!inferred_type.is_empty())
     {
       type.return_type() = inferred_type;
-      added_symbol->type = type; // Update the symbol's type
+      added_symbol->get_type() = type; // Update the symbol's type
     }
   }
 
@@ -1063,7 +1063,7 @@ void python_converter::get_function_definition(
           if (!ret_type.is_empty())
           {
             type.return_type() = ret_type;
-            added_symbol->type = type;
+            added_symbol->get_type() = type;
             break;
           }
         }
@@ -1089,7 +1089,7 @@ void python_converter::get_function_definition(
   // Validate return paths
   validate_return_paths(function_node, type, function_body);
 
-  added_symbol->value = function_body;
+  added_symbol->get_value() = function_body;
 
   scope_stack_.pop_back();
 

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -289,7 +289,7 @@ void python_converter::handle_assignment_type_adjustments(
   {
     rhs = address_of_exprt(rhs);
     if (lhs_symbol && !is_ctor_call)
-      lhs_symbol->value = rhs;
+      lhs_symbol->get_value() = rhs;
     return;
   }
 
@@ -303,7 +303,7 @@ void python_converter::handle_assignment_type_adjustments(
     rhs.type().subtype().is_code() &&
     !(lhs.type().is_pointer() && lhs.type().subtype().is_code()))
   {
-    lhs_symbol->type = rhs.type();
+    lhs_symbol->get_type() = rhs.type();
     lhs.type() = rhs.type();
   }
 
@@ -315,7 +315,7 @@ void python_converter::handle_assignment_type_adjustments(
   }
   // Handle tuple assignments with generic tuple annotation
   else if (
-    lhs_symbol && lhs_symbol->type.id() == "empty" &&
+    lhs_symbol && lhs_symbol->get_type().id() == "empty" &&
     rhs.type().id() == "struct")
   {
     const struct_typet &rhs_struct = to_struct_type(rhs.type());
@@ -324,9 +324,9 @@ void python_converter::handle_assignment_type_adjustments(
     if (rhs_struct.tag().as_string().find("tag-tuple") == 0)
     {
       // Update symbol type from empty to concrete tuple type
-      lhs_symbol->type = rhs.type();
+      lhs_symbol->get_type() = rhs.type();
       lhs.type() = rhs.type();
-      lhs_symbol->value = rhs;
+      lhs_symbol->get_value() = rhs;
     }
   }
   else if (lhs_symbol)
@@ -380,7 +380,7 @@ void python_converter::handle_assignment_type_adjustments(
         rhs = typecast_exprt(rhs, lhs.type());
       }
       if (!rhs.type().is_empty() && !is_ctor_call)
-        lhs_symbol->value = rhs;
+        lhs_symbol->get_value() = rhs;
       return;
     }
     // Handle string-to-string variable assignments
@@ -388,11 +388,11 @@ void python_converter::handle_assignment_type_adjustments(
     {
       symbolt *rhs_symbol = symbol_table_.find_symbol(rhs.identifier());
       if (
-        rhs_symbol && rhs_symbol->value.is_constant() &&
-        rhs_symbol->value.type().is_array())
+        rhs_symbol && rhs_symbol->get_value().is_constant() &&
+        rhs_symbol->get_value().type().is_array())
       {
-        rhs = rhs_symbol->value;
-        lhs_symbol->type = rhs.type();
+        rhs = rhs_symbol->get_value();
+        lhs_symbol->get_type() = rhs.type();
         lhs.type() = rhs.type();
       }
     }
@@ -403,7 +403,7 @@ void python_converter::handle_assignment_type_adjustments(
       // Should we model it uniformly using char* ?
       const typet &element_type = to_array_type(rhs.type()).subtype();
       typet pointer_type = gen_pointer_type(element_type);
-      lhs_symbol->type = pointer_type;
+      lhs_symbol->get_type() = pointer_type;
       lhs.type() = pointer_type;
       rhs = string_handler_.get_array_base_address(rhs);
     }
@@ -428,13 +428,14 @@ void python_converter::handle_assignment_type_adjustments(
         // when a prior declaration exists with the scalar type, as this
         // creates a type inconsistency in the GOTO program.
         bool is_incompatible =
-          rhs.type().is_array() && !lhs_symbol->type.is_array() &&
-          !lhs_symbol->type.is_pointer() && !lhs_symbol->type.id().empty() &&
-          !lhs_symbol->type.is_nil() &&
-          lhs_symbol->type != type_handler_.get_list_type();
+          rhs.type().is_array() && !lhs_symbol->get_type().is_array() &&
+          !lhs_symbol->get_type().is_pointer() &&
+          !lhs_symbol->get_type().id().empty() &&
+          !lhs_symbol->get_type().is_nil() &&
+          lhs_symbol->get_type() != type_handler_.get_list_type();
         if (!is_incompatible)
         {
-          lhs_symbol->type = rhs.type();
+          lhs_symbol->get_type() = rhs.type();
           lhs.type() = rhs.type();
         }
       }
@@ -442,7 +443,7 @@ void python_converter::handle_assignment_type_adjustments(
     else if (rhs.type() == none_type())
     {
       // Adjust pointer_type() to pointer_typet(empty_typet())
-      lhs_symbol->type = rhs.type();
+      lhs_symbol->get_type() = rhs.type();
       lhs.type() = rhs.type();
     }
     // No annotation or preprocessor-inferred Any: propagate rhs type to lhs.
@@ -454,12 +455,12 @@ void python_converter::handle_assignment_type_adjustments(
       !rhs.type().is_code() &&
       !(rhs.type().is_pointer() && rhs.type().subtype().id() == "empty"))
     {
-      lhs_symbol->type = rhs.type();
+      lhs_symbol->get_type() = rhs.type();
       lhs.type() = rhs.type();
     }
 
     if (!rhs.type().is_empty() && !is_ctor_call)
-      lhs_symbol->value = rhs;
+      lhs_symbol->get_value() = rhs;
   }
 }
 
@@ -758,7 +759,7 @@ std::string python_converter::infer_type_from_any_annotation(
     const symbolt *obj_sym = symbol_table_.find_symbol(obj_sid.to_string());
     if (obj_sym)
     {
-      typet obj_type = ns.follow(obj_sym->type);
+      typet obj_type = ns.follow(obj_sym->get_type());
       std::string class_name;
       if (obj_type.is_struct())
         class_name = to_struct_type(obj_type).tag().as_string();
@@ -772,9 +773,9 @@ std::string python_converter::infer_type_from_any_annotation(
     }
   }
 
-  if (func_symbol && func_symbol->type.is_code())
+  if (func_symbol && func_symbol->get_type().is_code())
   {
-    const code_typet &func_type = to_code_type(func_symbol->type);
+    const code_typet &func_type = to_code_type(func_symbol->get_type());
     const typet &ret_type = func_type.return_type();
 
     if (lhs_type == "Any")
@@ -920,7 +921,7 @@ symbolt *python_converter::create_symbol_for_unannotated_assign(
     bool is_dict_method =
       python_dict_handler::is_value_returning_method(method) &&
       obj_sym != nullptr &&
-      dict_handler_->is_dict_type(ns.follow(obj_sym->type));
+      dict_handler_->is_dict_type(ns.follow(obj_sym->get_type()));
 
     if (is_dict_method)
     {
@@ -1031,7 +1032,9 @@ void python_converter::handle_function_call_rhs(
     symbolt *func_symbol =
       symbol_table_.find_symbol(rhs.op1().identifier().c_str());
     assert(func_symbol);
-    if (!static_cast<code_typet &>(func_symbol->type).return_type().is_empty())
+    if (!static_cast<code_typet &>(func_symbol->get_type())
+           .return_type()
+           .is_empty())
     {
       if (auto ret = get_return_from_func(func_symbol->id.c_str());
           !ret.is_nil())
@@ -1591,7 +1594,7 @@ void python_converter::get_var_assign(
       annotation_types = tc.get_annotation_types(lhs_symbol->id.as_string());
       if (
         !annotation_types.empty() &&
-        !tc.should_skip_type_assertion(lhs_symbol->type))
+        !tc.should_skip_type_assertion(lhs_symbol->get_type()))
       {
         annotated_type = annotation_types.front();
         can_emit_annotation_check = true;
@@ -1620,7 +1623,7 @@ void python_converter::get_var_assign(
     is_converting_rhs = true;
 
     if (lhs_symbol)
-      rhs = get_rhs_with_dict_resolution(ast_node, lhs_symbol->type);
+      rhs = get_rhs_with_dict_resolution(ast_node, lhs_symbol->get_type());
     else
       rhs = get_expr(ast_node["value"]);
 
@@ -1666,12 +1669,13 @@ void python_converter::get_var_assign(
       if (expr.is_symbol())
       {
         if (const symbolt *sym = symbol_table_.find_symbol(expr.identifier()))
-          t = sym->type;
+          t = sym->get_type();
       }
       return try_follow_symbol_type(t);
     };
 
-    const typet lhs_runtime_type = lhs_symbol ? lhs_symbol->type : lhs.type();
+    const typet lhs_runtime_type =
+      lhs_symbol ? lhs_symbol->get_type() : lhs.type();
     const typet rhs_runtime_type = resolve_runtime_type(rhs);
     if (
       dict_handler_->is_dict_type(lhs_runtime_type) &&
@@ -1858,7 +1862,7 @@ void python_converter::get_var_assign(
       thetype.size().is_constant();
       assert(thetype.size().is_nil());
 #endif
-      lhs_symbol->type = rhs.type();
+      lhs_symbol->get_type() = rhs.type();
 
       code_declt decl(symbol_expr(*lhs_symbol), rhs);
       decl.location() = location_begin;
@@ -1888,8 +1892,8 @@ void python_converter::get_var_assign(
   }
   else
   {
-    lhs_symbol->value = gen_zero(current_element_type, true);
-    lhs_symbol->value.zero_initializer(true);
+    lhs_symbol->get_value() = gen_zero(current_element_type, true);
+    lhs_symbol->get_value().zero_initializer(true);
 
     code_declt decl(symbol_expr(*lhs_symbol));
     decl.location() = location_begin;
@@ -1940,7 +1944,7 @@ typet python_converter::resolve_variable_type(
 
   const symbolt *sym = symbol_table_.find_symbol(symbol_id);
   if (sym != nullptr)
-    return sym->type;
+    return sym->get_type();
   else
   {
     log_error(
@@ -2064,16 +2068,16 @@ void python_converter::get_compound_assign(
       if (symbol)
       {
         // Update the symbol's type to pointer if concatenated returns pointer
-        symbol->type = concatenated.type();
+        symbol->get_type() = concatenated.type();
 
         // Update LHS to be a symbol with the new type
-        lhs = symbol_exprt(symbol->id, symbol->type);
+        lhs = symbol_exprt(symbol->id, symbol->get_type());
 
         // For pointer results, don't update the value
         // (it will be assigned via the assignment statement)
         if (concatenated.type().is_array())
         {
-          symbol->value = concatenated;
+          symbol->get_value() = concatenated;
         }
       }
     }
@@ -2474,7 +2478,8 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
             if (!bool_object.is_symbol())
               bool_object =
                 store_call_result(bool_object, location, "cond_obj");
-            const code_typet &method_type = to_code_type(bool_method->type);
+            const code_typet &method_type =
+              to_code_type(bool_method->get_type());
             side_effect_expr_function_callt bool_call;
             bool_call.function() = symbol_expr(*bool_method);
             bool_call.type() = method_type.return_type();
@@ -3171,7 +3176,7 @@ void python_converter::get_delete_statement(
       {
         const symbolt *sym = symbol_table_.find_symbol(dict_expr.identifier());
         if (sym)
-          dict_type = sym->type;
+          dict_type = sym->get_type();
       }
 
       if (dict_type.id() == "symbol")
@@ -3217,8 +3222,9 @@ void python_converter::get_delete_statement(
       }
 
       // Determine the class struct type from the instance symbol type.
-      const typet &sym_type =
-        inst_sym->type.is_pointer() ? inst_sym->type.subtype() : inst_sym->type;
+      const typet &sym_type = inst_sym->get_type().is_pointer()
+                                ? inst_sym->get_type().subtype()
+                                : inst_sym->get_type();
       typet resolved = sym_type;
       if (resolved.id() == "symbol")
         resolved = ns.follow(resolved);
@@ -3237,7 +3243,8 @@ void python_converter::get_delete_statement(
       const std::string class_tag_id = "tag-" + class_tag;
       const symbolt *class_type_sym = symbol_table_.find_symbol(class_tag_id);
       const struct_typet &class_struct =
-        class_type_sym ? to_struct_type(class_type_sym->type) : struct_type;
+        class_type_sym ? to_struct_type(class_type_sym->get_type())
+                       : struct_type;
 
       // Find the class-level attribute symbol (the default value to restore).
       symbol_id class_sid = create_symbol_id();

--- a/src/python-frontend/converter/converter_symbols.cpp
+++ b/src/python-frontend/converter/converter_symbols.cpp
@@ -33,15 +33,15 @@ void python_converter::update_symbol(const exprt &expr) const
 
   // Update the type of the symbol and its value.
   const typet &expr_type = expr.type();
-  sym->type = expr_type;
-  sym->value.type() = expr_type;
+  sym->get_type() = expr_type;
+  sym->get_value().type() = expr_type;
 
   // Check if the symbol has a constant or bitvector value.
   if (
-    sym->value.is_constant() || sym->value.is_signedbv() ||
-    sym->value.is_unsignedbv())
+    sym->get_value().is_constant() || sym->get_value().is_signedbv() ||
+    sym->get_value().is_unsignedbv())
   {
-    const std::string &binary_value_str = sym->value.value().c_str();
+    const std::string &binary_value_str = sym->get_value().value().c_str();
 
     // Only attempt binary conversion if the string is non-empty and consists
     // solely of '0' and '1' characters (i.e., it is a valid binary string).
@@ -65,7 +65,7 @@ void python_converter::update_symbol(const exprt &expr) const
         exprt new_value = from_integer(int_val, expr_type);
 
         // Assign the new value to the symbol.
-        sym->value = new_value;
+        sym->get_value() = new_value;
       }
       catch (const std::exception &e)
       {
@@ -253,7 +253,7 @@ python_converter::find_nested_function_symbol(const std::string &name) const
       symbolt *nested_func_symbol =
         symbol_table_.find_symbol(nested_func_sid.to_string()))
     {
-      if (nested_func_symbol->type.is_code())
+      if (nested_func_symbol->get_type().is_code())
         return nested_func_symbol;
     }
 
@@ -360,7 +360,7 @@ symbolt &python_converter::create_tmp_symbol(
   cl.is_extern = false;
   cl.file_local = true;
   if (symbol_value != exprt())
-    cl.value = symbol_value;
+    cl.get_value() = symbol_value;
 
   return cl;
 }

--- a/src/python-frontend/converter/converter_util.cpp
+++ b/src/python-frontend/converter/converter_util.cpp
@@ -29,7 +29,7 @@ symbolt python_converter::create_symbol(
   symbol.mode = "Python";
   symbol.module = module;
   symbol.location = location;
-  symbol.type = type;
+  symbol.get_type() = type;
   symbol.name = name;
   symbol.id = id;
   return symbol;

--- a/src/python-frontend/function_call/builder.cpp
+++ b/src/python-frontend/function_call/builder.cpp
@@ -179,7 +179,7 @@ symbol_id function_call_builder::build_function_id() const
             python_file, current_class_name, current_function_name);
           var_sid.set_object(name);
           symbolt *var_symbol = converter_.find_symbol(var_sid.to_string());
-          return var_symbol ? var_symbol->type : typet();
+          return var_symbol ? var_symbol->get_type() : typet();
         }
         else if (node["_type"] == "Attribute")
         {
@@ -216,7 +216,7 @@ symbol_id function_call_builder::build_function_id() const
             cls_sid.set_object(attr);
             symbolt *cls_sym = converter_.find_symbol(cls_sid.to_string());
             if (cls_sym)
-              return cls_sym->type;
+              return cls_sym->get_type();
             return typet();
           }
           return typet();
@@ -394,7 +394,7 @@ symbol_id function_call_builder::build_function_id() const
       symbolt *var_symbol = converter_.find_symbol(var_sid.to_string());
 
       auto symbol_points_to_list = [&](const symbolt *sym) -> bool {
-        return sym && is_pylist_object_type(sym->type, converter_.ns);
+        return sym && is_pylist_object_type(sym->get_type(), converter_.ns);
       };
 
       const bool var_symbol_is_list = symbol_points_to_list(var_symbol);
@@ -445,9 +445,10 @@ symbol_id function_call_builder::build_function_id() const
       // Check if this is a tuple by looking up the variable's type
       if (var_type == "tuple" || var_type.empty())
       {
-        if (var_symbol && var_symbol->type.id() == "struct")
+        if (var_symbol && var_symbol->get_type().id() == "struct")
         {
-          const struct_typet &struct_type = to_struct_type(var_symbol->type);
+          const struct_typet &struct_type =
+            to_struct_type(var_symbol->get_type());
 
           // Check if this is a tuple by examining the tag
           if (struct_type.tag().as_string().find("tag-tuple") == 0)
@@ -545,9 +546,9 @@ symbol_id function_call_builder::build_function_id() const
       }
 
       // Extract class name from the type, following symbol references
-      typet var_type = var_symbol->type.is_pointer()
-                         ? var_symbol->type.subtype()
-                         : var_symbol->type;
+      typet var_type = var_symbol->get_type().is_pointer()
+                         ? var_symbol->get_type().subtype()
+                         : var_symbol->get_type();
 
       // Follow symbol type references using the converter's namespace
       var_type = converter_.ns.follow(var_type);
@@ -625,7 +626,7 @@ exprt function_call_builder::build() const
       if (arg_symbol)
       {
         auto list_struct =
-          try_get_pylist_struct_type(arg_symbol->type, converter_.ns);
+          try_get_pylist_struct_type(arg_symbol->get_type(), converter_.ns);
         if (list_struct)
         {
           code_typet list_size_type;

--- a/src/python-frontend/function_call/builtins.cpp
+++ b/src/python-frontend/function_call/builtins.cpp
@@ -263,9 +263,10 @@ exprt function_call_expr::handle_isinstance() const
     }
 
     const symbolt *var_symbol = converter_.ns.lookup(lookup_name);
-    if (var_symbol && var_symbol->value.is_constant())
+    if (var_symbol && var_symbol->get_value().is_constant())
     {
-      const constant_exprt &const_val = to_constant_expr(var_symbol->value);
+      const constant_exprt &const_val =
+        to_constant_expr(var_symbol->get_value());
       std::string value_str = const_val.get_value().as_string();
       // Check if this constant value is a type name
       if (type_utils::is_type_identifier(value_str))
@@ -928,8 +929,9 @@ exprt function_call_expr::handle_complex() const
       const symbolt *sym = lookup_python_symbol((*real_json)["id"]);
       if (sym)
       {
-        const typet &symbol_type =
-          sym->value.type().is_not_nil() ? sym->value.type() : sym->type;
+        const typet &symbol_type = sym->get_value().type().is_not_nil()
+                                     ? sym->get_value().type()
+                                     : sym->get_type();
         if (
           symbol_type.is_array() && symbol_type.subtype().is_unsignedbv() &&
           to_unsignedbv_type(symbol_type.subtype()).get_width() == 8)
@@ -973,19 +975,19 @@ exprt function_call_expr::handle_complex() const
 
           // Handle runtime conditionals that select between two string literals:
           // if cond then "a" else "b" -> if cond then complex(a) else complex(b).
-          const exprt &sym_val = sym->value;
+          const exprt &sym_val = sym->get_value();
           if (sym_val.id() == "if" && sym_val.operands().size() == 3)
           {
             const exprt &cond = sym_val.operands()[0];
 
             symbolt true_sym;
-            true_sym.value = sym_val.operands()[1];
-            true_sym.type = true_sym.value.type();
+            true_sym.get_value() = sym_val.operands()[1];
+            true_sym.get_type() = true_sym.get_value().type();
             auto true_text = extract_string_from_symbol(&true_sym);
 
             symbolt false_sym;
-            false_sym.value = sym_val.operands()[2];
-            false_sym.type = false_sym.value.type();
+            false_sym.get_value() = sym_val.operands()[2];
+            false_sym.get_type() = false_sym.get_value().type();
             auto false_text = extract_string_from_symbol(&false_sym);
 
             auto parse_complex_text =

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -482,7 +482,7 @@ exprt function_call_expr::build_constant_from_arg() const
     if (first_arg["_type"] == "Name")
     {
       const symbolt *sym = lookup_python_symbol(first_arg["id"]);
-      if (sym && sym->value.is_constant())
+      if (sym && sym->get_value().is_constant())
       {
         if (base_expr.is_nil())
         {
@@ -648,8 +648,8 @@ exprt function_call_expr::build_constant_from_arg() const
   {
     const symbolt *sym = lookup_python_symbol(arg["id"]);
     if (
-      sym && sym->value.is_constant() &&
-      type_utils::is_string_type(sym->value.type()))
+      sym && sym->get_value().is_constant() &&
+      type_utils::is_string_type(sym->get_value().type()))
       return handle_str_symbol_to_float(sym);
     else
     {
@@ -868,7 +868,7 @@ function_call_expr::get_object_list_symbol(std::string &display_name) const
     // a list, since list_type_map keys list-of-list types.  For non-list bases
     // (e.g. dicts whose value is a list) we fall through to the get_expr
     // dispatch below, which can also resolve dict-subscript receivers.
-    if (base_sym->type == list_type)
+    if (base_sym->get_type() == list_type)
     {
       // Constant index: resolve directly from list_type_map.
       if (
@@ -899,7 +899,7 @@ function_call_expr::get_object_list_symbol(std::string &display_name) const
       {
         const symbolt *sym =
           converter_.find_symbol(subscript_expr.identifier().as_string());
-        if (sym && sym->type == list_type)
+        if (sym && sym->get_type() == list_type)
         {
           const std::string idx_str = slice_node.contains("id")
                                         ? slice_node["id"].get<std::string>()
@@ -957,7 +957,7 @@ function_call_expr::get_object_list_symbol(std::string &display_name) const
     {
       const symbolt *sym =
         converter_.find_symbol(attr_expr.identifier().as_string());
-      if (sym && sym->type == list_type)
+      if (sym && sym->get_type() == list_type)
         return sym;
     }
 
@@ -1018,7 +1018,7 @@ function_call_expr::get_object_list_symbol(std::string &display_name) const
 // function is a no-op.
 void function_call_expr::materialize_list_symbol(const symbolt *sym) const
 {
-  if (!sym || sym->value.is_nil())
+  if (!sym || sym->get_value().is_nil())
     return;
   // Only emit a declaration for temp symbols produced by
   // get_object_list_symbol() from non-named receivers.  These are identified
@@ -1032,7 +1032,7 @@ void function_call_expr::materialize_list_symbol(const symbolt *sym) const
     name.find("$dict_list$") == std::string::npos)
     return;
   code_declt decl(symbol_expr(*sym));
-  decl.copy_to_operands(sym->value);
+  decl.copy_to_operands(sym->get_value());
   decl.location() = sym->location;
   converter_.current_block->copy_to_operands(decl);
 }
@@ -1085,7 +1085,7 @@ exprt to_value_expr(const exprt &arg, const namespacet &ns)
   {
     const symbolt *sym = ns.lookup(to_symbol_expr(func_expr));
     if (sym)
-      func_call.type() = to_code_type(sym->type).return_type();
+      func_call.type() = to_code_type(sym->get_type()).return_type();
   }
   if (func_call.type().is_nil() || func_call.type().id() == "empty")
     func_call.type() = arg.type();
@@ -1301,7 +1301,7 @@ bool function_call_expr::is_dict_method_call() const
     std::string dummy;
     const symbolt *sym = get_object_list_symbol(dummy);
     const typet list_type = type_handler_.get_list_type();
-    return sym == nullptr || sym->type != list_type;
+    return sym == nullptr || sym->get_type() != list_type;
   }
 
   return true;
@@ -1621,7 +1621,7 @@ bool function_call_expr::is_list_method_call() const
     std::string dummy;
     const symbolt *sym = get_object_list_symbol(dummy);
     const typet list_type = type_handler_.get_list_type();
-    return sym != nullptr && sym->type == list_type;
+    return sym != nullptr && sym->get_type() == list_type;
   }
 
   // "copy" is shared between list and dict. Treat as list.copy() only when
@@ -1640,7 +1640,7 @@ bool function_call_expr::is_list_method_call() const
     std::string dummy;
     const symbolt *sym = get_object_list_symbol(dummy);
     const typet list_type = type_handler_.get_list_type();
-    return sym != nullptr && sym->type == list_type;
+    return sym != nullptr && sym->get_type() == list_type;
   }
 
   return true;
@@ -2060,7 +2060,8 @@ function_call_expr::get_dispatch_table()
              side_effect_expr_function_callt model_call;
              model_call.function() = symbol_expr(*model_sym);
              model_call.arguments() = {z};
-             model_call.type() = to_code_type(model_sym->type).return_type();
+             model_call.type() =
+               to_code_type(model_sym->get_type()).return_type();
              model_call.location() = converter_.get_location_from_decl(call_);
              return model_call;
            }
@@ -2126,7 +2127,7 @@ function_call_expr::get_dispatch_table()
        side_effect_expr_function_callt model_call;
        model_call.function() = symbol_expr(*model_symbol);
        model_call.arguments() = {z};
-       model_call.type() = to_code_type(model_symbol->type).return_type();
+       model_call.type() = to_code_type(model_symbol->get_type()).return_type();
        model_call.location() = converter_.get_location_from_decl(call_);
 
        exprt zr = member_exprt(z, "real", double_type());
@@ -2702,14 +2703,16 @@ exprt function_call_expr::handle_general_function_call()
 
             const symbolt *elem_sym = converter_.find_symbol(elem_id);
             if (
-              !elem_sym || !elem_sym->value.is_constant() ||
-              !(elem_sym->type.is_signedbv() || elem_sym->type.is_unsignedbv()))
+              !elem_sym || !elem_sym->get_value().is_constant() ||
+              !(elem_sym->get_type().is_signedbv() ||
+                elem_sym->get_type().is_unsignedbv()))
             {
               all_constant_ints = false;
               break;
             }
 
-            BigInt key = binary2integer(elem_sym->value.value().c_str(), true);
+            BigInt key =
+              binary2integer(elem_sym->get_value().value().c_str(), true);
             elems.push_back({key, i});
           }
 
@@ -2852,35 +2855,37 @@ exprt function_call_expr::handle_general_function_call()
     symbol_id var_sid = converter_.create_symbol_id();
     var_sid.set_object(func_name);
     symbolt *var_symbol = symbol_table.find_symbol(var_sid.to_string());
-    if (var_symbol && !var_symbol->type.is_code())
+    if (var_symbol && !var_symbol->get_type().is_code())
     {
       side_effect_expr_function_callt call;
       call.location() = converter_.get_location_from_decl(call_);
       exprt func_expr = symbol_expr(*var_symbol);
       if (
-        !var_symbol->type.is_pointer() || !var_symbol->type.subtype().is_code())
+        !var_symbol->get_type().is_pointer() ||
+        !var_symbol->get_type().subtype().is_code())
         func_expr = typecast_exprt(func_expr, gen_pointer_type(code_typet()));
       call.function() = func_expr;
 
       bool resolved = false;
       if (
-        var_symbol->value.is_address_of() &&
-        !var_symbol->value.operands().empty() &&
-        var_symbol->value.op0().is_symbol())
+        var_symbol->get_value().is_address_of() &&
+        !var_symbol->get_value().operands().empty() &&
+        var_symbol->get_value().op0().is_symbol())
       {
         const symbolt *target_symbol =
-          symbol_table.find_symbol(var_symbol->value.op0().identifier());
-        if (target_symbol && target_symbol->type.is_code())
+          symbol_table.find_symbol(var_symbol->get_value().op0().identifier());
+        if (target_symbol && target_symbol->get_type().is_code())
         {
-          call.type() = to_code_type(target_symbol->type).return_type();
+          call.type() = to_code_type(target_symbol->get_type()).return_type();
           resolved = true;
         }
       }
       if (
-        !resolved && var_symbol->type.is_pointer() &&
-        var_symbol->type.subtype().is_code())
+        !resolved && var_symbol->get_type().is_pointer() &&
+        var_symbol->get_type().subtype().is_code())
       {
-        call.type() = to_code_type(var_symbol->type.subtype()).return_type();
+        call.type() =
+          to_code_type(var_symbol->get_type().subtype()).return_type();
         resolved = true;
       }
       if (!resolved)
@@ -3254,7 +3259,8 @@ exprt function_call_expr::handle_general_function_call()
   code_function_callt call;
   call.location() = location;
   call.function() = symbol_expr(*func_symbol);
-  const typet &return_type = to_code_type(func_symbol->type).return_type();
+  const typet &return_type =
+    to_code_type(func_symbol->get_type()).return_type();
   call.type() = return_type;
 
   auto bind_instance_receiver = [&](exprt receiver) -> exprt {
@@ -3407,7 +3413,7 @@ exprt function_call_expr::handle_general_function_call()
   {
     // Check if this is an instance method being called through the class
     // e.g., MyClass.method(instance) where the first param should be 'self'
-    const code_typet &func_type = to_code_type(func_symbol->type);
+    const code_typet &func_type = to_code_type(func_symbol->get_type());
     bool first_param_is_self = false;
 
     if (!func_type.arguments().empty())
@@ -3454,7 +3460,7 @@ exprt function_call_expr::handle_general_function_call()
   }
 
   // Get function type and parameters for Optional wrapping
-  const code_typet &func_type = to_code_type(func_symbol->type);
+  const code_typet &func_type = to_code_type(func_symbol->get_type());
   const auto &params = func_type.arguments();
 
   size_t arg_index = 0;
@@ -3676,7 +3682,7 @@ exprt function_call_expr::handle_general_function_call()
           converter_.ns.lookup(to_symbol_expr(func_expr));
         if (func_symbol != nullptr)
         {
-          const code_typet &func_type = to_code_type(func_symbol->type);
+          const code_typet &func_type = to_code_type(func_symbol->get_type());
           return_type = func_type.return_type();
 
           // Special handling for constructors
@@ -3716,7 +3722,7 @@ exprt function_call_expr::handle_general_function_call()
     {
       // Update list element type mapping for function parameters
       const code_typet &type =
-        static_cast<const code_typet &>(func_symbol->type);
+        static_cast<const code_typet &>(func_symbol->get_type());
       const std::string &arg_id =
         type.arguments().at(0).identifier().as_string();
 
@@ -4047,7 +4053,7 @@ function_call_expr::find_possible_class_types(const symbolt *obj_symbol) const
 
   try
   {
-    typet obj_type = obj_symbol->type;
+    typet obj_type = obj_symbol->get_type();
     if (obj_type.is_pointer())
       obj_type = obj_type.subtype();
     if (obj_type.id() == "symbol")
@@ -4359,7 +4365,7 @@ exprt function_call_expr::check_argument_types(
   if (!config.options.get_bool_option("strict-types"))
     return nil_exprt();
 
-  const code_typet &func_type = to_code_type(func_symbol->type);
+  const code_typet &func_type = to_code_type(func_symbol->get_type());
   const auto &params = func_type.arguments();
 
   // Determine parameter offset based on actual function signature

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -190,7 +190,7 @@ exprt function_call_expr::handle_chr(nlohmann::json &arg) const
         var_expr, loc);
     }
 
-    exprt val = sym->value;
+    exprt val = sym->get_value();
 
     if (!val.is_constant())
       val = converter_.get_resolved_value(val);
@@ -299,7 +299,7 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
         "NameError", "variable '" + var_name + "' is not defined");
     }
 
-    typet operand_type = sym->value.type();
+    typet operand_type = sym->get_value().type();
     std::string py_type = type_handler_.type_to_string(operand_type);
 
     if (operand_type != char_type() && py_type != "str")
@@ -310,7 +310,7 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     }
 
     // For runtime variables (mutable), try to extract constant value if available
-    if (sym->lvalue && !sym->value.is_nil())
+    if (sym->lvalue && !sym->get_value().is_nil())
     {
       auto value_opt = extract_string_from_symbol(sym);
       if (value_opt)
@@ -336,7 +336,7 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     }
 
     // Use runtime conversion for variables without constant value or failed extraction
-    if (sym->value.is_nil() || sym->lvalue)
+    if (sym->get_value().is_nil() || sym->lvalue)
     {
       exprt var_expr = converter_.get_expr(arg);
 
@@ -573,7 +573,7 @@ exprt function_call_expr::handle_oct(nlohmann::json &arg) const
 std::optional<std::string>
 function_call_expr::extract_string_from_symbol(const symbolt *sym) const
 {
-  const exprt &val = sym->value;
+  const exprt &val = sym->get_value();
   std::string result;
 
   if (val.id() == "if" && val.operands().size() == 3)
@@ -581,13 +581,13 @@ function_call_expr::extract_string_from_symbol(const symbolt *sym) const
     const exprt &cond = val.operands()[0];
 
     symbolt true_sym;
-    true_sym.value = val.operands()[1];
-    true_sym.type = true_sym.value.type();
+    true_sym.get_value() = val.operands()[1];
+    true_sym.get_type() = true_sym.get_value().type();
     auto true_text = extract_string_from_symbol(&true_sym);
 
     symbolt false_sym;
-    false_sym.value = val.operands()[2];
-    false_sym.type = false_sym.value.type();
+    false_sym.get_value() = val.operands()[2];
+    false_sym.get_type() = false_sym.get_value().type();
     auto false_text = extract_string_from_symbol(&false_sym);
 
     if (cond.is_true())

--- a/src/python-frontend/numpy_call_expr.cpp
+++ b/src/python-frontend/numpy_call_expr.cpp
@@ -321,7 +321,7 @@ void numpy_call_expr::broadcast_check(const nlohmann::json &operands) const
 
       // Retrieve the current operand's array shape.
       std::vector<int> current_shape =
-        converter_.type_handler_.get_array_type_shape(s->type);
+        converter_.type_handler_.get_array_type_shape(s->get_type());
 
       // For subsequent operands, compare shapes using broadcasting rules.
       if (!is_first_operand)

--- a/src/python-frontend/python_class_builder.cpp
+++ b/src/python-frontend/python_class_builder.cpp
@@ -60,7 +60,7 @@ bool python_class_builder::get_bases(struct_typet &st)
 
     ids.emplace_back(bsym->id);
 
-    auto &bty = static_cast<struct_typet &>(bsym->type);
+    auto &bty = static_cast<struct_typet &>(bsym->get_type());
     for (const auto &c : bty.components())
       st.components().push_back(c);
   }
@@ -192,11 +192,11 @@ void python_class_builder::gen_ctor(bool has_ud_base, struct_typet &st)
 
   symbolt ctor = conv_.create_symbol(
     mod, conv_.current_class_name_, sid.to_string(), loc, f);
-  ctor.value = code_blockt();
+  ctor.get_value() = code_blockt();
   ctor.lvalue = true;
 
   conv_.symbol_table_.add(ctor);
-  st.methods().emplace_back(ctor.name, ctor.type);
+  st.methods().emplace_back(ctor.name, ctor.get_type());
 }
 
 // Check if any base class is TypedDict
@@ -223,15 +223,15 @@ void python_class_builder::build(codet &out)
   // Exception: if the existing type is an empty struct (a model-file stub like
   // 'class List: pass' in models/typing.py), allow the user-defined class with
   // actual fields to override it.
-  if (!sym->type.incomplete())
+  if (!sym->get_type().incomplete())
   {
-    bool is_model_stub = sym->type.id() == "struct" &&
-                         to_struct_type(sym->type).components().empty();
+    bool is_model_stub = sym->get_type().id() == "struct" &&
+                         to_struct_type(sym->get_type()).components().empty();
     if (!is_model_stub)
       return;
   }
 
-  sym->type.remove(irept::a_incomplete);
+  sym->get_type().remove(irept::a_incomplete);
 
   // Handle TypedDict classes: they should be treated as dict types
   // TypedDict provides type hints for dictionaries but at runtime
@@ -241,7 +241,7 @@ void python_class_builder::build(codet &out)
     // Create a dict type alias for this TypedDict class
     // The dict handler provides the canonical dict struct type
     typet dict_type = conv_.get_dict_handler()->get_dict_struct_type();
-    sym->type = dict_type;
+    sym->get_type() = dict_type;
     conv_.current_class_name_.clear();
     return;
   }
@@ -256,13 +256,13 @@ void python_class_builder::build(codet &out)
   add_self_attrs(st);
 
   // Partial commit allows nested lookups while building members
-  sym->type = st;
+  sym->get_type() = st;
 
   // Add methods, class attributes, and default constructor
   get_members(st, out);
   gen_ctor(has_ud_base, st);
 
   // Finalize type and clear context
-  sym->type = st;
+  sym->get_type() = st;
   conv_.current_class_name_.clear();
 }

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -120,7 +120,7 @@ static void add_global_static_variable(
   std::string id = "c:@" + name;
   symbolt symbol;
   symbol.mode = "C";
-  symbol.type = std::move(t);
+  symbol.get_type() = std::move(t);
   symbol.name = name;
   symbol.id = id;
 
@@ -128,8 +128,8 @@ static void add_global_static_variable(
   symbol.static_lifetime = true;
   symbol.is_extern = false;
   symbol.file_local = false;
-  symbol.value = gen_zero(t, true);
-  symbol.value.zero_initializer(true);
+  symbol.get_value() = gen_zero(t, true);
+  symbol.get_value().zero_initializer(true);
 
   symbolt *added_symbol = ctx.move_symbol_to_context(symbol);
   assert(added_symbol);
@@ -189,7 +189,7 @@ void python_converter::create_builtin_symbols()
         integer2binary(BigInt(0), bv_width(char_type_ref)),
         integer2string(BigInt(0)),
         char_type_ref);
-      sym.value = value_expr;
+      sym.get_value() = value_expr;
 
       symbol_table_.add(sym);
     };
@@ -513,7 +513,7 @@ void python_converter::convert()
     call.function() = symbol_expr(*symbol);
 
     const code_typet::argumentst &arguments =
-      to_code_type(symbol->type).arguments();
+      to_code_type(symbol->get_type()).arguments();
 
     // Function args are nondet values
     for (const code_typet::argumentt &arg : arguments)
@@ -641,7 +641,7 @@ void python_converter::convert()
     symbolt init_symbol;
     init_symbol.id = "python_init";
     init_symbol.name = "python_init";
-    init_symbol.type = init_type;
+    init_symbol.get_type() = init_type;
     init_symbol.lvalue = true;
     init_symbol.is_extern = false;
     init_symbol.file_local = false;
@@ -655,7 +655,7 @@ void python_converter::convert()
     code_blockt init_body;
     init_body.copy_to_operands(esbmc_hide);
     init_body.copy_to_operands(init_code);
-    init_symbol.value.swap(init_body);
+    init_symbol.get_value().swap(init_body);
 
     if (symbol_table_.move(init_symbol))
     {
@@ -670,12 +670,12 @@ void python_converter::convert()
   symbolt user_main_symbol;
   user_main_symbol.id = "python_user_main";
   user_main_symbol.name = "python_user_main";
-  user_main_symbol.type = user_main_type;
+  user_main_symbol.get_type() = user_main_type;
   user_main_symbol.lvalue = true;
   user_main_symbol.is_extern = false;
   user_main_symbol.file_local = false;
   user_main_symbol.location = get_location_from_decl(*ast_json);
-  user_main_symbol.value = user_code;
+  user_main_symbol.get_value() = user_code;
 
   if (symbol_table_.move(user_main_symbol))
   {
@@ -690,7 +690,7 @@ void python_converter::convert()
   symbolt main_symbol;
   main_symbol.id = "__ESBMC_main";
   main_symbol.name = "__ESBMC_main";
-  main_symbol.type = main_type;
+  main_symbol.get_type() = main_type;
   main_symbol.lvalue = true;
   main_symbol.is_extern = false;
   main_symbol.file_local = false;
@@ -700,9 +700,9 @@ void python_converter::convert()
 
   // 1. Initialize static lifetime variables
   symbol_table_.foreach_operand_in_order([&main_body](const symbolt &s) {
-    if (s.static_lifetime && !s.value.is_nil() && !s.type.is_code())
+    if (s.static_lifetime && !s.get_value().is_nil() && !s.get_type().is_code())
     {
-      code_assignt assign(symbol_expr(s), s.value);
+      code_assignt assign(symbol_expr(s), s.get_value());
       assign.location() = s.location;
       main_body.copy_to_operands(assign);
     }
@@ -776,7 +776,7 @@ void python_converter::convert()
 
   main_body.copy_to_operands(make_hook_call("__ESBMC_pthread_end_main_hook"));
 
-  main_symbol.value.swap(main_body);
+  main_symbol.get_value().swap(main_body);
 
   if (symbol_table_.move(main_symbol))
   {

--- a/src/python-frontend/python_dict_handler.cpp
+++ b/src/python-frontend/python_dict_handler.cpp
@@ -89,7 +89,7 @@ struct_typet python_dict_handler::get_dict_struct_type()
   const std::string dict_type_name = "tag-__python_dict__";
   symbolt *existing = symbol_table_.find_symbol(dict_type_name);
   if (existing)
-    return to_struct_type(existing->type);
+    return to_struct_type(existing->get_type());
 
   struct_typet dict_struct;
   dict_struct.tag("__python_dict__");
@@ -107,7 +107,7 @@ struct_typet python_dict_handler::get_dict_struct_type()
   symbolt type_symbol;
   type_symbol.id = dict_type_name;
   type_symbol.name = dict_type_name;
-  type_symbol.type = dict_struct;
+  type_symbol.get_type() = dict_struct;
   type_symbol.mode = "Python";
   type_symbol.is_type = true;
   symbol_table_.add(type_symbol);
@@ -647,8 +647,8 @@ exprt python_dict_handler::handle_dict_subscript(
 
   exprt key_arg;
   if (
-    key_info.elem_symbol->type.is_pointer() &&
-    key_info.elem_symbol->type.subtype() == char_type())
+    key_info.elem_symbol->get_type().is_pointer() &&
+    key_info.elem_symbol->get_type().subtype() == char_type())
     key_arg = symbol_expr(*key_info.elem_symbol);
   else
     key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));
@@ -741,7 +741,7 @@ exprt python_dict_handler::handle_dict_subscript(
     const symbolt *elem_sym =
       symbol_table_.find_symbol(sym_type.get_identifier());
     if (elem_sym)
-      element_type = elem_sym->type;
+      element_type = elem_sym->get_type();
   }
 
   // Create dereference and explicitly set its type
@@ -953,8 +953,8 @@ void python_dict_handler::handle_dict_subscript_assign(
 
   exprt key_arg;
   if (
-    key_info.elem_symbol->type.is_pointer() &&
-    key_info.elem_symbol->type.subtype() == char_type())
+    key_info.elem_symbol->get_type().is_pointer() &&
+    key_info.elem_symbol->get_type().subtype() == char_type())
     key_arg = symbol_expr(*key_info.elem_symbol);
   else
     key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));
@@ -976,8 +976,8 @@ void python_dict_handler::handle_dict_subscript_assign(
 
   exprt value_arg;
   if (
-    value_info.elem_symbol->type.is_pointer() &&
-    value_info.elem_symbol->type.subtype() == char_type())
+    value_info.elem_symbol->get_type().is_pointer() &&
+    value_info.elem_symbol->get_type().subtype() == char_type())
     value_arg = symbol_expr(*value_info.elem_symbol);
   else
     value_arg = address_of_exprt(symbol_expr(*value_info.elem_symbol));
@@ -988,7 +988,7 @@ void python_dict_handler::handle_dict_subscript_assign(
   set_value_call.arguments().push_back(from_integer(BigInt(0), size_type()));
   set_value_call.arguments().push_back(from_integer(
     BigInt(converter_.get_type_handler().is_pointer_free(
-      value_info.elem_symbol->type)),
+      value_info.elem_symbol->get_type())),
     int_type()));
   set_value_call.type() = bool_type();
   set_value_call.location() = location;
@@ -1012,7 +1012,7 @@ void python_dict_handler::handle_dict_subscript_assign(
   push_key_call.arguments().push_back(from_integer(BigInt(0), size_type()));
   push_key_call.arguments().push_back(from_integer(
     BigInt(converter_.get_type_handler().is_pointer_free(
-      key_info.elem_symbol->type)),
+      key_info.elem_symbol->get_type())),
     int_type()));
   push_key_call.type() = bool_type();
   push_key_call.location() = location;
@@ -1028,7 +1028,7 @@ void python_dict_handler::handle_dict_subscript_assign(
   push_value_call.arguments().push_back(from_integer(BigInt(0), size_type()));
   push_value_call.arguments().push_back(from_integer(
     BigInt(converter_.get_type_handler().is_pointer_free(
-      value_info.elem_symbol->type)),
+      value_info.elem_symbol->get_type())),
     int_type()));
   push_value_call.type() = bool_type();
   push_value_call.location() = location;
@@ -1159,8 +1159,8 @@ void python_dict_handler::handle_dict_delete(
 
   exprt key_arg;
   if (
-    key_info.elem_symbol->type.is_pointer() &&
-    key_info.elem_symbol->type.subtype() == char_type())
+    key_info.elem_symbol->get_type().is_pointer() &&
+    key_info.elem_symbol->get_type().subtype() == char_type())
     key_arg = symbol_expr(*key_info.elem_symbol);
   else
     key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));
@@ -1532,7 +1532,7 @@ bool python_dict_handler::handle_subscript_assignment_check(
   {
     const symbolt *sym = symbol_table_.find_symbol(container_expr.identifier());
     if (sym)
-      container_type = sym->type;
+      container_type = sym->get_type();
   }
 
   // Use the namespace from converter, not a method that doesn't exist
@@ -1700,8 +1700,8 @@ exprt python_dict_handler::handle_dict_get(
 
   exprt key_arg;
   if (
-    key_info.elem_symbol->type.is_pointer() &&
-    key_info.elem_symbol->type.subtype() == char_type())
+    key_info.elem_symbol->get_type().is_pointer() &&
+    key_info.elem_symbol->get_type().subtype() == char_type())
     key_arg = symbol_expr(*key_info.elem_symbol);
   else
     key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));
@@ -1920,8 +1920,8 @@ exprt python_dict_handler::handle_dict_setdefault(
   // Build key arg
   exprt key_arg;
   if (
-    key_info.elem_symbol->type.is_pointer() &&
-    key_info.elem_symbol->type.subtype() == char_type())
+    key_info.elem_symbol->get_type().is_pointer() &&
+    key_info.elem_symbol->get_type().subtype() == char_type())
     key_arg = symbol_expr(*key_info.elem_symbol);
   else
     key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));
@@ -2058,7 +2058,7 @@ exprt python_dict_handler::handle_dict_setdefault(
     push_key_call.arguments().push_back(from_integer(BigInt(0), size_type()));
     push_key_call.arguments().push_back(from_integer(
       BigInt(converter_.get_type_handler().is_pointer_free(
-        key_info.elem_symbol->type)),
+        key_info.elem_symbol->get_type())),
       int_type()));
     push_key_call.type() = bool_type();
     push_key_call.location() = location;
@@ -2093,8 +2093,8 @@ exprt python_dict_handler::handle_dict_setdefault(
         list_handler.get_list_element_info(call_node, effective_default);
 
       if (
-        value_info.elem_symbol->type.is_pointer() &&
-        value_info.elem_symbol->type.subtype() == char_type())
+        value_info.elem_symbol->get_type().is_pointer() &&
+        value_info.elem_symbol->get_type().subtype() == char_type())
         value_arg = symbol_expr(*value_info.elem_symbol);
       else
         value_arg = address_of_exprt(symbol_expr(*value_info.elem_symbol));
@@ -2110,7 +2110,7 @@ exprt python_dict_handler::handle_dict_setdefault(
         from_integer(BigInt(0), size_type()));
       push_value_call.arguments().push_back(from_integer(
         BigInt(converter_.get_type_handler().is_pointer_free(
-          value_info.elem_symbol->type)),
+          value_info.elem_symbol->get_type())),
         int_type()));
       push_value_call.type() = bool_type();
       push_value_call.location() = location;
@@ -2287,8 +2287,8 @@ exprt python_dict_handler::handle_dict_pop(
 
   exprt key_arg;
   if (
-    key_info.elem_symbol->type.is_pointer() &&
-    key_info.elem_symbol->type.subtype() == char_type())
+    key_info.elem_symbol->get_type().is_pointer() &&
+    key_info.elem_symbol->get_type().subtype() == char_type())
     key_arg = symbol_expr(*key_info.elem_symbol);
   else
     key_arg = address_of_exprt(symbol_expr(*key_info.elem_symbol));

--- a/src/python-frontend/python_exception_handler.cpp
+++ b/src/python-frontend/python_exception_handler.cpp
@@ -430,7 +430,7 @@ symbolt python_exception_handler::create_assert_temp_variable(
   symbolt temp_symbol;
   temp_symbol.id = temp_sid_str;
   temp_symbol.name = temp_sid_str;
-  temp_symbol.type = bool_type();
+  temp_symbol.get_type() = bool_type();
   temp_symbol.lvalue = true;
   temp_symbol.static_lifetime = false;
   temp_symbol.location = location;

--- a/src/python-frontend/python_lambda.cpp
+++ b/src/python-frontend/python_lambda.cpp
@@ -37,14 +37,14 @@ void python_lambda::handle_lambda_assignment(
 
   const symbolt *lambda_func_symbol = context_.find_symbol(rhs.identifier());
 
-  if (!lambda_func_symbol || !lambda_func_symbol->type.is_code())
+  if (!lambda_func_symbol || !lambda_func_symbol->get_type().is_code())
   {
     throw std::runtime_error("Lambda function symbol does not have code type");
   }
 
   // Create function pointer type
-  typet func_ptr_type = gen_pointer_type(lambda_func_symbol->type);
-  lhs_symbol->type = func_ptr_type;
+  typet func_ptr_type = gen_pointer_type(lambda_func_symbol->get_type());
+  lhs_symbol->get_type() = func_ptr_type;
   lhs.type() = func_ptr_type;
 
   // Convert lambda symbol to address
@@ -180,7 +180,7 @@ symbolt python_lambda::create_symbol(
   symbolt symbol;
   symbol.id = id;
   symbol.name = name;
-  symbol.type = type;
+  symbol.get_type() = type;
   symbol.location = location;
   symbol.mode = "Python";
   symbol.module = module_name;
@@ -401,7 +401,7 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
         if (
           (actual_ret.is_pointer() && actual_ret.subtype().is_code()) ||
           is_optional_struct)
-          to_code_type(added_symbol->type).return_type() = actual_ret;
+          to_code_type(added_symbol->get_type()).return_type() = actual_ret;
       }
     }
 
@@ -436,7 +436,7 @@ exprt python_lambda::get_lambda_expr(const nlohmann::json &element)
       lambda_body = closure_body;
     }
 
-    added_symbol->value = lambda_body;
+    added_symbol->get_value() = lambda_body;
   }
 
   // Restore context only if we changed it (top-level lambda only)

--- a/src/python-frontend/python_list.cpp
+++ b/src/python-frontend/python_list.cpp
@@ -271,12 +271,13 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   // None type: store pointer directly without copying
   // Set size to 0 so memcpy is skipped and NULL is preserved
   if (
-    elem_symbol.type.is_pointer() && elem_symbol.type.subtype() == bool_type())
+    elem_symbol.get_type().is_pointer() &&
+    elem_symbol.get_type().subtype() == bool_type())
   {
     elem_size = from_integer(BigInt(0), size_type());
   }
   // For list pointers (PyListObj*), use pointer size
-  else if (elem_symbol.type == list_type)
+  else if (elem_symbol.get_type() == list_type)
   {
     // This is a pointer to PyListObj: use pointer size
     const size_t pointer_size_bytes = config.ansi_c.pointer_width() / 8;
@@ -286,14 +287,14 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   // The element type may be a symbol_typet reference (e.g. "tag-A") rather
   // than a plain struct_typet, so follow the type before checking is_struct().
   else if (
-    elem_symbol.type.is_struct() ||
-    (elem_symbol.type.id() == "symbol" &&
-     converter_.name_space().follow(elem_symbol.type).is_struct()))
+    elem_symbol.get_type().is_struct() ||
+    (elem_symbol.get_type().id() == "symbol" &&
+     converter_.name_space().follow(elem_symbol.get_type()).is_struct()))
   {
     const typet &resolved =
-      elem_symbol.type.is_struct()
-        ? elem_symbol.type
-        : converter_.name_space().follow(elem_symbol.type);
+      elem_symbol.get_type().is_struct()
+        ? elem_symbol.get_type()
+        : converter_.name_space().follow(elem_symbol.get_type());
     const struct_union_typet &struct_type = to_struct_union_type(resolved);
 
     // Sum the widths of all components to get the true struct size in bytes.
@@ -333,16 +334,17 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
   // pointer_typet has no width() attribute, so we must use pointer_width here
   // rather than falling to the generic else branch which calls width().
   else if (
-    elem_symbol.type.is_pointer() &&
-    elem_symbol.type.subtype() != char_type() &&
-    elem_symbol.type.subtype() != bool_type())
+    elem_symbol.get_type().is_pointer() &&
+    elem_symbol.get_type().subtype() != char_type() &&
+    elem_symbol.get_type().subtype() != bool_type())
   {
     const size_t pointer_size_bytes = config.ansi_c.pointer_width() / 8;
     elem_size = from_integer(BigInt(pointer_size_bytes), size_type());
   }
   // For string pointers (char*), calculate length at runtime using strlen
   else if (
-    elem_symbol.type.is_pointer() && elem_symbol.type.subtype() == char_type())
+    elem_symbol.get_type().is_pointer() &&
+    elem_symbol.get_type().subtype() == char_type())
   {
     // Call strlen to get actual string length
     const symbolt *strlen_symbol =
@@ -370,8 +372,8 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 
     // Add 1 for null terminator: size = strlen(s) + 1
     // Use strlen_result.type to ensure exact type match
-    exprt one_const = from_integer(1, strlen_result.type);
-    elem_size = exprt("+", strlen_result.type);
+    exprt one_const = from_integer(1, strlen_result.get_type());
+    elem_size = exprt("+", strlen_result.get_type());
     elem_size.copy_to_operands(symbol_expr(strlen_result), one_const);
   }
   else
@@ -383,13 +385,13 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
     size_t elem_size_bytes = DEFAULT_SIZE;
     try
     {
-      if (elem_symbol.type.is_array())
+      if (elem_symbol.get_type().is_array())
       {
         const size_t subtype_size_bits =
           std::stoull(elem.type().subtype().width().as_string(), nullptr, 10);
 
         const array_typet &array_type =
-          static_cast<const array_typet &>(elem_symbol.type);
+          static_cast<const array_typet &>(elem_symbol.get_type());
 
         const size_t array_length =
           std::stoull(array_type.size().value().as_string(), nullptr, 2);
@@ -399,7 +401,7 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
       else
       {
         const size_t type_width_bits =
-          std::stoull(elem_symbol.type.width().as_string(), nullptr, 10);
+          std::stoull(elem_symbol.get_type().width().as_string(), nullptr, 10);
 
         elem_size_bytes = type_width_bits / BITS_PER_BYTE;
       }
@@ -450,11 +452,11 @@ exprt python_list::build_push_list_call(
   // For other types (including other pointers such None/bool*), we must pass the address
   exprt element_arg;
   if (is_empty_user_class_object_type(
-        elem_info.elem_symbol->type, converter_.name_space()))
+        elem_info.elem_symbol->get_type(), converter_.name_space()))
   {
     // Python list stores object references. For class objects, store a pointer
     // to the object (not a byte copy of the struct payload).
-    typet obj_ptr_type = pointer_typet(elem_info.elem_symbol->type);
+    typet obj_ptr_type = pointer_typet(elem_info.elem_symbol->get_type());
     symbolt &obj_ptr_sym =
       converter_.create_tmp_symbol(op, "$list_obj_ref$", obj_ptr_type, exprt());
 
@@ -473,21 +475,21 @@ exprt python_list::build_push_list_call(
     elem_info.elem_size = from_integer(BigInt(pointer_size_bytes), size_type());
   }
   else if (
-    elem_info.elem_symbol->type.is_pointer() &&
-    elem_info.elem_symbol->type.subtype() == char_type())
+    elem_info.elem_symbol->get_type().is_pointer() &&
+    elem_info.elem_symbol->get_type().subtype() == char_type())
   {
     // For string type (char*), we must pass the pointer value itself
     element_arg = symbol_expr(*elem_info.elem_symbol);
   }
   else if (
-    elem_info.elem_symbol->type.is_pointer() &&
-    elem_info.elem_symbol->type.subtype() == bool_type())
+    elem_info.elem_symbol->get_type().is_pointer() &&
+    elem_info.elem_symbol->get_type().subtype() == bool_type())
   {
     // For None type (_Bool*), pass the pointer value itself
     // This allows direct NULL checks without dereferencing
     element_arg = symbol_expr(*elem_info.elem_symbol);
   }
-  else if (elem_info.elem_symbol->type.is_struct())
+  else if (elem_info.elem_symbol->get_type().is_struct())
   {
     // For structs (dictionaries), pass address of the struct directly
     element_arg = address_of_exprt(symbol_expr(*elem_info.elem_symbol));
@@ -496,7 +498,7 @@ exprt python_list::build_push_list_call(
   {
     // For bool types, cast to signed long int before taking address
     // This ensures proper storage and retrieval
-    if (elem_info.elem_symbol->type == bool_type())
+    if (elem_info.elem_symbol->get_type() == bool_type())
     {
       symbolt &bool_as_long = converter_.create_tmp_symbol(
         op,
@@ -535,7 +537,7 @@ exprt python_list::build_push_list_call(
   // __ESBMC_copy_value uses *(double*) copy in --ir mode (real sort).
   // enable_float_path=false skips this for dict values which use void* comparison.
   exprt float_type_id_arg =
-    (enable_float_path && elem_info.elem_symbol->type.is_floatbv())
+    (enable_float_path && elem_info.elem_symbol->get_type().is_floatbv())
       ? static_cast<exprt>(symbol_expr(*elem_info.elem_type_sym))
       : from_integer(BigInt(0), size_type());
   push_func_call.arguments().push_back(float_type_id_arg); // float_type_id
@@ -543,7 +545,8 @@ exprt python_list::build_push_list_call(
   // ptr_free gates the uint64 fast paths in __ESBMC_copy_value.
   push_func_call.arguments().push_back(from_integer(
     BigInt(
-      converter_.get_type_handler().is_pointer_free(elem_info.elem_symbol->type)
+      converter_.get_type_handler().is_pointer_free(
+        elem_info.elem_symbol->get_type())
         ? 1
         : 0),
     int_type()));
@@ -568,7 +571,7 @@ exprt python_list::build_insert_list_call(
     throw std::runtime_error("Insert function symbol not found");
 
   exprt float_type_id_arg =
-    elem_info.elem_symbol->type.is_floatbv()
+    elem_info.elem_symbol->get_type().is_floatbv()
       ? static_cast<exprt>(symbol_expr(*elem_info.elem_type_sym))
       : from_integer(BigInt(0), size_type());
 
@@ -583,7 +586,8 @@ exprt python_list::build_insert_list_call(
   insert_func_call.arguments().push_back(float_type_id_arg);
   insert_func_call.arguments().push_back(from_integer(
     BigInt(
-      converter_.get_type_handler().is_pointer_free(elem_info.elem_symbol->type)
+      converter_.get_type_handler().is_pointer_free(
+        elem_info.elem_symbol->get_type())
         ? 1
         : 0),
     int_type()));
@@ -1085,7 +1089,7 @@ exprt python_list::build_split_list(
     symbolt new_symbol;
     new_symbol.name = func_name;
     new_symbol.id = func_name;
-    new_symbol.type = func_type;
+    new_symbol.get_type() = func_type;
     new_symbol.mode = "C";
     new_symbol.module = "python";
     new_symbol.location = location;
@@ -1205,7 +1209,7 @@ const symbolt &python_list::get_str_slice_sym()
     slice_type.arguments().push_back(code_typet::argumentt(ll_type));
     slice_type.arguments().push_back(code_typet::argumentt(ll_type));
     slice_type.arguments().push_back(code_typet::argumentt(ll_type));
-    new_symbol.type = slice_type;
+    new_symbol.get_type() = slice_type;
     converter_.symbol_table().add(new_symbol);
     sym = converter_.symbol_table().find_symbol(id);
   }
@@ -2595,7 +2599,7 @@ exprt python_list::compare(
       typet list_ptr = converter_.get_type_handler().get_list_type();
       func_type.arguments().push_back(code_typet::argumentt(list_ptr));
       func_type.arguments().push_back(code_typet::argumentt(list_ptr));
-      new_symbol.type = func_type;
+      new_symbol.get_type() = func_type;
 
       converter_.symbol_table().add(new_symbol);
       set_eq_func =
@@ -2612,11 +2616,11 @@ exprt python_list::compare(
     set_eq_call.function() = symbol_expr(*set_eq_func);
     set_eq_call.lhs() = symbol_expr(eq_ret);
     set_eq_call.arguments().push_back(
-      lhs_symbol->type.is_pointer()
+      lhs_symbol->get_type().is_pointer()
         ? symbol_expr(*lhs_symbol)
         : address_of_exprt(symbol_expr(*lhs_symbol)));
     set_eq_call.arguments().push_back(
-      rhs_symbol->type.is_pointer()
+      rhs_symbol->get_type().is_pointer()
         ? symbol_expr(*rhs_symbol)
         : address_of_exprt(symbol_expr(*rhs_symbol)));
     set_eq_call.type() = bool_type();
@@ -2647,7 +2651,7 @@ exprt python_list::compare(
       if (has_map(direct_id))
         return direct_id;
 
-      const exprt &v = sym->value;
+      const exprt &v = sym->get_value();
       if (v.is_symbol())
       {
         const std::string alias_id = v.identifier().as_string();
@@ -2685,7 +2689,8 @@ exprt python_list::compare(
         const symbolt *elem_sym = converter_.find_symbol(entry.first);
         if (!elem_sym)
           return false;
-        if (!(is_numeric(elem_sym->type) || is_bool(elem_sym->type)))
+        if (!(is_numeric(elem_sym->get_type()) ||
+              is_bool(elem_sym->get_type())))
           return false;
       }
       return true;
@@ -2701,7 +2706,7 @@ exprt python_list::compare(
       for (const auto &entry : it->second)
       {
         const symbolt *elem_sym = converter_.find_symbol(entry.first);
-        const typet t = elem_sym ? elem_sym->type : entry.second;
+        const typet t = elem_sym ? elem_sym->get_type() : entry.second;
         if (t.is_floatbv())
           has_float = true;
         else if (t.is_signedbv() || t.is_unsignedbv())
@@ -2735,10 +2740,10 @@ exprt python_list::compare(
             const symbolt *lhs_elem_sym = converter_.find_symbol(lhs_elem_id);
             const symbolt *rhs_elem_sym = converter_.find_symbol(rhs_elem_id);
             const typet lhs_elem_type = lhs_elem_sym
-                                          ? lhs_elem_sym->type
+                                          ? lhs_elem_sym->get_type()
                                           : get_list_element_type(lhs_id, i);
             const typet rhs_elem_type = rhs_elem_sym
-                                          ? rhs_elem_sym->type
+                                          ? rhs_elem_sym->get_type()
                                           : get_list_element_type(rhs_id, i);
             if (lhs_elem_type.is_nil() || rhs_elem_type.is_nil())
             {
@@ -2817,7 +2822,7 @@ exprt python_list::compare(
       func_type.arguments().push_back(code_typet::argumentt(list_ptr));
       func_type.arguments().push_back(code_typet::argumentt(int_type()));
       func_type.arguments().push_back(code_typet::argumentt(size_type()));
-      new_symbol.type = func_type;
+      new_symbol.get_type() = func_type;
 
       converter_.symbol_table().add(new_symbol);
       list_lt_func_sym =
@@ -3002,14 +3007,14 @@ exprt python_list::list_repetition(
 
   auto parse_size_from_symbol = [&](symbolt *size_var, BigInt &out) -> bool {
     if (
-      size_var->value.is_code() || size_var->value.is_nil() ||
-      !size_var->value.is_constant())
+      size_var->get_value().is_code() || size_var->get_value().is_nil() ||
+      !size_var->get_value().is_constant())
     {
       return false;
     }
 
-    assert(is_integer_type(size_var->value.type()));
-    out = binary2integer(size_var->value.value().c_str(), true);
+    assert(is_integer_type(size_var->get_value().type()));
+    out = binary2integer(size_var->get_value().value().c_str(), true);
     return true;
   };
 
@@ -3317,7 +3322,7 @@ exprt python_list::contains(const exprt &item, const exprt &list)
   // For pointer types (e.g., string parameters), use the pointer directly
   // For value types, take the address
   exprt item_arg;
-  if (item_info.elem_symbol->type.is_pointer())
+  if (item_info.elem_symbol->get_type().is_pointer())
   {
     // String parameters are pointers - use the pointer value directly
     item_arg = symbol_expr(*item_info.elem_symbol);
@@ -3335,7 +3340,7 @@ exprt python_list::contains(const exprt &item, const exprt &list)
   exprt elem_size = item_info.elem_size;
 
   // Check if item is a void pointer (from loop iteration over strings)
-  if (item_info.elem_symbol->type == pointer_typet(empty_typet()))
+  if (item_info.elem_symbol->get_type() == pointer_typet(empty_typet()))
   {
     const std::string &list_name = list.identifier().as_string();
     auto type_map_it = list_type_map.find(list_name);
@@ -3386,8 +3391,8 @@ exprt python_list::contains(const exprt &item, const exprt &list)
             converter_.add_instruction(strlen_call);
 
             // Add 1 for null terminator: size = strlen(s) + 1
-            exprt one_const = from_integer(1, strlen_result.type);
-            elem_size = exprt("+", strlen_result.type);
+            exprt one_const = from_integer(1, strlen_result.get_type());
+            elem_size = exprt("+", strlen_result.get_type());
             elem_size.copy_to_operands(symbol_expr(strlen_result), one_const);
           }
 
@@ -4486,8 +4491,8 @@ exprt python_list::build_set_membership_call(
 
   exprt element_arg;
   if (
-    elem_info.elem_symbol->type.is_pointer() &&
-    elem_info.elem_symbol->type.subtype() == char_type())
+    elem_info.elem_symbol->get_type().is_pointer() &&
+    elem_info.elem_symbol->get_type().subtype() == char_type())
     element_arg = symbol_expr(*elem_info.elem_symbol);
   else
     element_arg = address_of_exprt(symbol_expr(*elem_info.elem_symbol));
@@ -4507,7 +4512,7 @@ exprt python_list::build_set_membership_call(
     add_type_info(
       set.id.as_string(),
       elem_info.elem_symbol->id.as_string(),
-      elem_info.elem_symbol->type);
+      elem_info.elem_symbol->get_type());
 
   return converter_.convert_expression_to_code(call);
 }
@@ -4528,10 +4533,10 @@ exprt python_list::build_remove_list_call(
 
   exprt element_arg;
   if (
-    elem_info.elem_symbol->type.is_pointer() &&
-    elem_info.elem_symbol->type.subtype() == char_type())
+    elem_info.elem_symbol->get_type().is_pointer() &&
+    elem_info.elem_symbol->get_type().subtype() == char_type())
     element_arg = symbol_expr(*elem_info.elem_symbol);
-  else if (elem_info.elem_symbol->type.is_struct())
+  else if (elem_info.elem_symbol->get_type().is_struct())
     element_arg = address_of_exprt(symbol_expr(*elem_info.elem_symbol));
   else
     element_arg = address_of_exprt(symbol_expr(*elem_info.elem_symbol));

--- a/src/python-frontend/python_math.cpp
+++ b/src/python-frontend/python_math.cpp
@@ -203,7 +203,7 @@ exprt python_math::resolve_symbol(const exprt &operand) const
   {
     symbolt *s = symbol_table.find_symbol(operand.identifier());
     assert(s && "Symbol not found in symbol table");
-    return s->value;
+    return s->get_value();
   }
   return operand;
 }

--- a/src/python-frontend/python_set.cpp
+++ b/src/python-frontend/python_set.cpp
@@ -351,7 +351,7 @@ exprt python_set::get_from_iterable(
       contains_call.function() = symbol_expr(*contains_func);
       contains_call.lhs() = symbol_expr(contains_result);
       contains_call.arguments().push_back(
-        set_symbol.type.is_pointer()
+        set_symbol.get_type().is_pointer()
           ? symbol_expr(set_symbol)
           : address_of_exprt(symbol_expr(set_symbol)));
 
@@ -397,7 +397,7 @@ exprt python_set::get_from_iterable(
       side_effect_expr_function_callt push_call;
       push_call.function() = symbol_expr(*push_obj_func);
       push_call.arguments().push_back(
-        set_symbol.type.is_pointer()
+        set_symbol.get_type().is_pointer()
           ? symbol_expr(set_symbol)
           : address_of_exprt(symbol_expr(set_symbol)));
       push_call.arguments().push_back(symbol_expr(*elem_obj_sym));

--- a/src/python-frontend/python_typechecking.cpp
+++ b/src/python-frontend/python_typechecking.cpp
@@ -176,7 +176,7 @@ exprt python_typechecking::build_isinstance_check(
     {
       const symbolt *symbol = ns.lookup(pointed_type);
       if (symbol != nullptr)
-        pointed_type = symbol->type;
+        pointed_type = symbol->get_type();
     }
 
     if (pointed_type.is_struct())

--- a/src/python-frontend/string/string_builder.cpp
+++ b/src/python-frontend/string/string_builder.cpp
@@ -72,10 +72,10 @@ std::vector<exprt> string_builder::extract_string_chars(
     symbolt *symbol =
       get_symbol_table().find_symbol(expr.identifier().as_string());
 
-    if (symbol && symbol->value.type().is_array())
+    if (symbol && symbol->get_value().type().is_array())
     {
       // Extract from the symbol's stored value
-      const exprt &value = symbol->value;
+      const exprt &value = symbol->get_value();
       for (size_t i = 0; i < value.operands().size(); ++i)
       {
         const exprt &ch = value.operands()[i];
@@ -251,9 +251,10 @@ exprt string_builder::concatenate_strings(
     symbolt *lhs_sym =
       converter_.find_symbol(to_symbol_expr(lhs).get_identifier().as_string());
     if (
-      lhs_sym && lhs_sym->value.is_not_nil() &&
-      lhs_sym->value.type().is_array() && lhs_sym->value.is_constant())
-      resolved_lhs = lhs_sym->value;
+      lhs_sym && lhs_sym->get_value().is_not_nil() &&
+      lhs_sym->get_value().type().is_array() &&
+      lhs_sym->get_value().is_constant())
+      resolved_lhs = lhs_sym->get_value();
   }
 
   if (rhs.is_symbol())
@@ -261,9 +262,10 @@ exprt string_builder::concatenate_strings(
     symbolt *rhs_sym =
       converter_.find_symbol(to_symbol_expr(rhs).get_identifier().as_string());
     if (
-      rhs_sym && rhs_sym->value.is_not_nil() &&
-      rhs_sym->value.type().is_array() && rhs_sym->value.is_constant())
-      resolved_rhs = rhs_sym->value;
+      rhs_sym && rhs_sym->get_value().is_not_nil() &&
+      rhs_sym->get_value().type().is_array() &&
+      rhs_sym->get_value().is_constant())
+      resolved_rhs = rhs_sym->get_value();
   }
 
   // Check if either operand contains non-deterministic/symbolic values
@@ -314,12 +316,12 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
       {
         symbolt *sym = converter_.find_symbol(
           to_symbol_expr(e).get_identifier().as_string());
-        if (sym && sym->value.is_constant())
+        if (sym && sym->get_value().is_constant())
         {
-          if (sym->value.type().is_bool())
-            return sym->value.is_true() ? 1 : 0;
+          if (sym->get_value().type().is_bool())
+            return sym->get_value().is_true() ? 1 : 0;
           BigInt val;
-          if (!to_integer(sym->value, val))
+          if (!to_integer(sym->get_value(), val))
             return val.to_int64();
         }
       }
@@ -339,10 +341,10 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
     {
       symbolt *sym =
         converter_.find_symbol(to_symbol_expr(e).get_identifier().as_string());
-      if (sym && sym->value.is_constant())
+      if (sym && sym->get_value().is_constant())
       {
         BigInt val;
-        if (!to_integer(sym->value, val) && val.is_int64())
+        if (!to_integer(sym->get_value(), val) && val.is_int64())
           return val.to_int64();
       }
     }
@@ -390,7 +392,7 @@ exprt string_builder::handle_string_repetition(exprt &lhs, exprt &rhs)
       repeat_type.arguments().push_back(arg1);
       repeat_type.arguments().push_back(arg2);
 
-      new_symbol.type = repeat_type;
+      new_symbol.get_type() = repeat_type;
       get_symbol_table().add(new_symbol);
       repeat_symbol = get_symbol_table().find_symbol(func_symbol_id);
     }
@@ -544,7 +546,7 @@ exprt string_builder::concatenate_strings_via_c_function(
     concat_type.arguments().push_back(arg1);
     concat_type.arguments().push_back(arg2);
 
-    new_symbol.type = concat_type;
+    new_symbol.get_type() = concat_type;
 
     get_symbol_table().add(new_symbol);
     concat_symbol = get_symbol_table().find_symbol(func_symbol_id);
@@ -579,7 +581,7 @@ exprt string_builder::build_runtime_str_conversion_call(
     code_typet fn_type;
     fn_type.return_type() = gen_pointer_type(char_type());
     fn_type.arguments().push_back(code_typet::argumentt(arg_type));
-    new_symbol.type = fn_type;
+    new_symbol.get_type() = fn_type;
 
     get_symbol_table().add(new_symbol);
     fn_symbol = get_symbol_table().find_symbol(func_symbol_id);

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -956,10 +956,12 @@ bool string_handler::try_extract_const_string_expr(
     const auto &sym_expr = to_symbol_expr(str_expr);
     const symbolt *symbol =
       find_cached_symbol(sym_expr.get_identifier().as_string());
-    if (!symbol || symbol->value.is_nil() || !symbol->value.type().is_array())
+    if (
+      !symbol || symbol->get_value().is_nil() ||
+      !symbol->get_value().type().is_array())
       return false;
 
-    out = extract_string_from_array_operands(symbol->value);
+    out = extract_string_from_array_operands(symbol->get_value());
     return true;
   }
 
@@ -989,9 +991,9 @@ BigInt string_handler::get_string_size(const exprt &expr)
     if (expr.is_symbol())
     {
       const symbolt *symbol = find_cached_symbol(expr.identifier().as_string());
-      if (symbol && symbol->type.is_array())
+      if (symbol && symbol->get_type().is_array())
       {
-        const auto &arr_type = to_array_type(symbol->type);
+        const auto &arr_type = to_array_type(symbol->get_type());
         return binary2integer(arr_type.size().value().as_string(), false);
       }
       // For non-array symbols, we need a reasonable default since we can't compute actual size
@@ -1242,8 +1244,8 @@ exprt string_handler::apply_format_specification(
             const symbolt *symbol =
               find_cached_symbol(sym_expr.get_identifier().as_string());
 
-            if (symbol && symbol->value.is_constant())
-              float_bits = &symbol->value.value().as_string();
+            if (symbol && symbol->get_value().is_constant())
+              float_bits = &symbol->get_value().value().as_string();
           }
 
           if (float_bits && float_bits->length() == float_width)
@@ -1295,12 +1297,14 @@ exprt string_handler::convert_to_string(const exprt &expr)
     if (symbol)
     {
       // If symbol has string type, return it
-      if (symbol->type.is_array() && symbol->type.subtype() == char_type())
+      if (
+        symbol->get_type().is_array() &&
+        symbol->get_type().subtype() == char_type())
         return expr;
 
       // If symbol has a constant value, convert that
-      if (symbol->value.is_constant())
-        return convert_to_string(symbol->value);
+      if (symbol->get_value().is_constant())
+        return convert_to_string(symbol->get_value());
     }
   }
 
@@ -1673,7 +1677,7 @@ exprt string_handler::handle_string_membership(
     const symbolt *sym = find_cached_symbol(lhs.get_string("identifier"));
     if (sym)
     {
-      const typet &value_type = sym->value.type();
+      const typet &value_type = sym->get_value().type();
       if (
         (value_type.is_signedbv() || value_type.is_unsignedbv()) &&
         bv_width(value_type) == char_width)
@@ -1701,7 +1705,7 @@ exprt string_handler::handle_string_membership(
       strchr_type.return_type() = char_ptr;
       strchr_type.arguments().push_back(code_typet::argumentt(char_ptr));
       strchr_type.arguments().push_back(code_typet::argumentt(int_type()));
-      new_symbol.type = strchr_type;
+      new_symbol.get_type() = strchr_type;
 
       symbol_table_.add(new_symbol);
       strchr_symbol = find_cached_c_function_symbol("c:@F@strchr");
@@ -1741,8 +1745,10 @@ exprt string_handler::handle_string_membership(
     if (e.is_symbol())
     {
       const symbolt *sym = find_cached_symbol(e.identifier().as_string());
-      if (sym && sym->value.is_constant() && sym->value.type().is_array())
-        return &sym->value;
+      if (
+        sym && sym->get_value().is_constant() &&
+        sym->get_value().type().is_array())
+        return &sym->get_value();
     }
     return nullptr;
   };
@@ -2155,10 +2161,12 @@ exprt string_handler::try_handle_len_string_fast_path(
     symbolt *arg_symbol = converter_.find_symbol(
       to_symbol_expr(arg_expr).get_identifier().as_string());
     if (
-      arg_symbol && arg_symbol->value.is_not_nil() &&
-      arg_symbol->value.type().is_array() && arg_symbol->value.is_constant())
+      arg_symbol && arg_symbol->get_value().is_not_nil() &&
+      arg_symbol->get_value().type().is_array() &&
+      arg_symbol->get_value().is_constant())
     {
-      const array_typet &arr_type = to_array_type(arg_symbol->value.type());
+      const array_typet &arr_type =
+        to_array_type(arg_symbol->get_value().type());
       if (
         type_utils::is_char_type(arr_type.subtype()) &&
         arr_type.size().is_constant())

--- a/src/python-frontend/string/string_method_handler.cpp
+++ b/src/python-frontend/string/string_method_handler.cpp
@@ -374,8 +374,8 @@ exprt string_handler::handle_string_lstrip(
       const symbolt *symbol =
         find_cached_symbol(str_expr.identifier().as_string());
       if (
-        symbol && symbol->value.is_constant() &&
-        symbol->value.type().is_array())
+        symbol && symbol->get_value().is_constant() &&
+        symbol->get_value().type().is_array())
         can_fold_constant = true;
     }
   }
@@ -419,8 +419,8 @@ exprt string_handler::handle_string_lstrip(
       {
         const symbolt *sym =
           find_cached_symbol(chars_arg.identifier().as_string());
-        chars_foldable =
-          sym && sym->value.is_constant() && sym->value.type().is_array();
+        chars_foldable = sym && sym->get_value().is_constant() &&
+                         sym->get_value().type().is_array();
       }
 
       if (chars_foldable)
@@ -566,8 +566,8 @@ exprt string_handler::handle_string_strip(
       const symbolt *symbol =
         find_cached_symbol(str_expr.identifier().as_string());
       if (
-        symbol && symbol->value.is_constant() &&
-        symbol->value.type().is_array())
+        symbol && symbol->get_value().is_constant() &&
+        symbol->get_value().type().is_array())
         can_fold_constant = true;
     }
   }
@@ -614,8 +614,8 @@ exprt string_handler::handle_string_strip(
       {
         const symbolt *sym =
           find_cached_symbol(chars_arg.identifier().as_string());
-        chars_foldable =
-          sym && sym->value.is_constant() && sym->value.type().is_array();
+        chars_foldable = sym && sym->get_value().is_constant() &&
+                         sym->get_value().type().is_array();
       }
 
       if (chars_foldable)
@@ -735,7 +735,8 @@ exprt string_handler::handle_string_rstrip(
     const symbolt *symbol =
       find_cached_symbol(str_expr.identifier().as_string());
     if (
-      symbol && symbol->value.is_constant() && symbol->value.type().is_array())
+      symbol && symbol->get_value().is_constant() &&
+      symbol->get_value().type().is_array())
       can_fold_constant = true;
   }
 
@@ -778,8 +779,8 @@ exprt string_handler::handle_string_rstrip(
       {
         const symbolt *sym =
           find_cached_symbol(chars_arg.identifier().as_string());
-        chars_foldable =
-          sym && sym->value.is_constant() && sym->value.type().is_array();
+        chars_foldable = sym && sym->get_value().is_constant() &&
+                         sym->get_value().type().is_array();
       }
 
       if (chars_foldable)

--- a/src/python-frontend/type_handler.cpp
+++ b/src/python-frontend/type_handler.cpp
@@ -113,7 +113,7 @@ bool type_handler::is_constructor_call(const nlohmann::json &json) const
   const contextt &symbol_table = converter_.symbol_table();
 
   symbol_table.foreach_operand([&](const symbolt &s) {
-    if (s.type.id() == "struct" && s.name == func_name)
+    if (s.get_type().id() == "struct" && s.name == func_name)
     {
       is_ctor_call = true;
       return;
@@ -497,7 +497,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
       symbolt type_symbol;
       type_symbol.id = complex_type_id;
       type_symbol.name = "complex";
-      type_symbol.type = get_complex_struct_type();
+      type_symbol.get_type() = get_complex_struct_type();
       type_symbol.mode = "Python";
       type_symbol.is_type = true;
       symbol_table.move_symbol_to_context(type_symbol);
@@ -595,7 +595,7 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   {
     symbolt *s = converter_.find_symbol(std::string("tag-" + ast_type));
     if (s)
-      return s->type;
+      return s->get_type();
   }
 
   // Check if it's a built-in type (handles tuple, list, dict, etc.)
@@ -965,7 +965,7 @@ typet type_handler::get_list_type(const nlohmann::json &list_value) const
     symbolt *func_symbol = converter_.find_symbol(sid.to_string());
 
     assert(func_symbol);
-    return static_cast<code_typet &>(func_symbol->type).return_type();
+    return static_cast<code_typet &>(func_symbol->get_type()).return_type();
   }
 
   if (list_value.contains("_type") && list_value["_type"] == "BinOp")

--- a/src/solidity-frontend/solidity_convert.cpp
+++ b/src/solidity-frontend/solidity_convert.cpp
@@ -847,7 +847,7 @@ bool solidity_convertert::populate_auxiliary_vars()
     s.static_lifetime = true; // static
     symbolt &_sym = *move_symbol_to_context(s);
     solidity_gen_typecast(ns, string, ct);
-    _sym.value = string;
+    _sym.get_value() = string;
   }
 
   /* populate _bind_cname_list
@@ -905,8 +905,8 @@ bool solidity_convertert::populate_auxiliary_vars()
     s.static_lifetime = true;
     s.lvalue = true;
     symbolt &sym = *move_symbol_to_context(s);
-    sym.value = gen_zero(get_complete_type(_t, ns), true);
-    sym.value.zero_initializer(true);
+    sym.get_value() = gen_zero(get_complete_type(_t, ns), true);
+    sym.get_value().zero_initializer(true);
 
     // f: initialize_bind_list
     std::string fname, fid;
@@ -952,7 +952,7 @@ bool solidity_convertert::populate_auxiliary_vars()
       fbody.copy_to_operands(ass_expr);
       ++i;
     }
-    fsym.value = fbody;
+    fsym.get_value() = fbody;
   }
 
   // pupulate a function call _sol_init_()
@@ -988,7 +988,7 @@ bool solidity_convertert::populate_auxiliary_vars()
   is_init_sym.lvalue = true;
   is_init_sym.file_local = true;
   is_init_sym.static_lifetime = true;
-  is_init_sym.value = false_exprt();
+  is_init_sym.get_value() = false_exprt();
   symbolt &final_is_init_sym = *move_symbol_to_context(is_init_sym);
 
   // 2. add body
@@ -1064,7 +1064,7 @@ bool solidity_convertert::populate_auxiliary_vars()
   init_func_body.move_to_operands(if_expr);
 
   // assign body to function symbol
-  final_init_func_sym.value = init_func_body;
+  final_init_func_sym.get_value() = init_func_body;
 
   // for mapping
   extract_new_contracts();

--- a/src/solidity-frontend/solidity_convert.h
+++ b/src/solidity-frontend/solidity_convert.h
@@ -1014,7 +1014,7 @@ static inline void static_lifetime_init(const contextt &context, codet &dest)
 
   // call designated "initialization" functions
   context.foreach_operand_in_order([&dest](const symbolt &s) {
-    if (s.type.initialization() && s.type.is_code())
+    if (s.get_type().initialization() && s.get_type().is_code())
     {
       code_function_callt function_call;
       function_call.function() = symbol_expr(s);

--- a/src/solidity-frontend/solidity_convert_builtin.cpp
+++ b/src/solidity-frontend/solidity_convert_builtin.cpp
@@ -241,12 +241,12 @@ void solidity_convertert::move_builtin_to_contract(
     abort();
   }
   symbolt &c_sym = *context.find_symbol(c_id);
-  assert(c_sym.type.is_struct());
+  assert(c_sym.get_type().is_struct());
 
   if (!is_method)
   {
     // check if it's already inserted
-    for (auto i : to_struct_type(c_sym.type).components())
+    for (auto i : to_struct_type(c_sym.get_type()).components())
     {
       if (i.identifier() == sym.identifier())
         return;
@@ -254,13 +254,13 @@ void solidity_convertert::move_builtin_to_contract(
 
     struct_typet::componentt comp(sym.name(), sym.name(), sym.type());
     comp.set_access(access);
-    comp.type().set("#member_name", c_sym.type.tag());
-    to_struct_type(c_sym.type).components().push_back(comp);
+    comp.type().set("#member_name", c_sym.get_type().tag());
+    to_struct_type(c_sym.get_type()).components().push_back(comp);
   }
   else
   {
     // check if it's already inserted
-    for (auto i : to_struct_type(c_sym.type).methods())
+    for (auto i : to_struct_type(c_sym.get_type()).methods())
     {
       if (i.identifier() == sym.identifier())
         return;
@@ -274,7 +274,7 @@ void solidity_convertert::move_builtin_to_contract(
     comp.pretty_name(sym.name());
     comp.set_access(access);
     comp.id("symbol");
-    to_struct_type(c_sym.type).methods().push_back(comp);
+    to_struct_type(c_sym.get_type()).methods().push_back(comp);
   }
 }
 
@@ -295,12 +295,12 @@ void solidity_convertert::get_builtin_symbol(
 
   symbolt sym;
   get_default_symbol(sym, "C++", t, name, id, l);
-  sym.type.set("#sol_state_var", "1");
+  sym.get_type().set("#sol_state_var", "1");
   sym.file_local = true;
   sym.lvalue = true;
   auto &added_sym = *move_symbol_to_context(sym);
   code_declt decl(symbol_expr(added_sym));
-  added_sym.value = val;
+  added_sym.get_value() = val;
   decl.operands().push_back(val);
   move_to_initializer(decl);
 
@@ -373,7 +373,7 @@ void solidity_convertert::get_aux_property_function(
   type.arguments().push_back(param);
 
   // populate param
-  added_symbol.type = type;
+  added_symbol.get_type() = type;
   // move to struct symbol
   move_builtin_to_contract(cname, symbol_expr(added_symbol), true);
 
@@ -454,7 +454,7 @@ void solidity_convertert::get_aux_property_function(
   _block.move_to_operands(ret_uint);
 
   // populate body
-  added_symbol.value = _block;
+  added_symbol.get_value() = _block;
 
   // do function call
   side_effect_expr_function_callt _call;

--- a/src/solidity-frontend/solidity_convert_call.cpp
+++ b/src/solidity-frontend/solidity_convert_call.cpp
@@ -747,7 +747,7 @@ bool solidity_convertert::get_high_level_member_access(
   ft.arguments().push_back(base_param);
   exprt new_base = symbol_expr(*context.find_symbol(base_id));
 
-  added_fsymbol.type = ft;
+  added_fsymbol.get_type() = ft;
   //! we need to move it to the struct symbol
   // this is because we use the member from the contract
   move_builtin_to_contract(cname, symbol_expr(added_fsymbol), true);
@@ -930,7 +930,7 @@ bool solidity_convertert::get_high_level_member_access(
     func_body.move_to_operands(_ret);
   }
 
-  added_fsymbol.value = func_body;
+  added_fsymbol.get_value() = func_body;
 
   // construct function call
   side_effect_expr_function_callt _call;
@@ -1552,7 +1552,7 @@ bool solidity_convertert::get_typed_call_definition(
 
     arg_param_ids.push_back(pid);
   }
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   // Body construction.
   code_blockt func_body;
@@ -1625,7 +1625,7 @@ bool solidity_convertert::get_typed_call_definition(
     func_body.move_to_operands(ret_false);
   }
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   out_sym = &added_symbol;
   return false;
 }
@@ -1859,7 +1859,7 @@ bool solidity_convertert::try_inline_delegate_shadow_helper_call(
     ls.lvalue = true;
     ls.file_local = true;
     auto &added_local = *move_symbol_to_context(ls);
-    added_local.value = arg_exprs[i];
+    added_local.get_value() = arg_exprs[i];
 
     code_declt decl(symbol_expr(added_local));
     decl.operands().push_back(arg_exprs[i]);
@@ -1888,7 +1888,7 @@ bool solidity_convertert::try_inline_delegate_shadow_helper_call(
       get_default_symbol(rs, debug_modulename, rt, rname, rid, loc);
       rs.lvalue = true;
       rs.file_local = true;
-      rs.value = gen_zero(get_complete_type(rt, ns), true);
+      rs.get_value() = gen_zero(get_complete_type(rt, ns), true);
       auto &added_ret = *move_symbol_to_context(rs);
       code_declt rdecl(symbol_expr(added_ret));
       rdecl.operands().push_back(gen_zero(get_complete_type(rt, ns), true));
@@ -2040,7 +2040,7 @@ bool solidity_convertert::try_get_delegate_shadow_call(
     ls.lvalue = true;
     ls.file_local = true;
     auto &added_local = *move_symbol_to_context(ls);
-    added_local.value = arg_exprs[i];
+    added_local.get_value() = arg_exprs[i];
 
     code_declt decl(symbol_expr(added_local));
     decl.operands().push_back(arg_exprs[i]);
@@ -2058,7 +2058,7 @@ bool solidity_convertert::try_get_delegate_shadow_call(
   ss.lvalue = true;
   ss.file_local = true;
   auto &added_succ = *move_symbol_to_context(ss);
-  added_succ.value = false_exprt();
+  added_succ.get_value() = false_exprt();
   {
     code_declt decl(symbol_expr(added_succ));
     decl.operands().push_back(false_exprt());
@@ -2139,7 +2139,7 @@ bool solidity_convertert::try_get_delegate_shadow_call(
         get_default_symbol(rs, debug_modulename, rt, rname, rid, loc);
         rs.lvalue = true;
         rs.file_local = true;
-        rs.value = gen_zero(get_complete_type(rt, ns), true);
+        rs.get_value() = gen_zero(get_complete_type(rt, ns), true);
         auto &added_ret = *move_symbol_to_context(rs);
         code_declt rdecl(symbol_expr(added_ret));
         rdecl.operands().push_back(gen_zero(get_complete_type(rt, ns), true));
@@ -2255,7 +2255,7 @@ bool solidity_convertert::try_get_signature_dispatched_call(
 
   side_effect_expr_function_callt call;
   call.function() = symbol_expr(*helper_sym);
-  call.type() = to_code_type(helper_sym->type).return_type();
+  call.type() = to_code_type(helper_sym->get_type()).return_type();
   call.location() = loc;
 
   exprt this_object;
@@ -2327,7 +2327,7 @@ bool solidity_convertert::get_call_definition(
   param.cmt_identifier(addr_id);
   t.arguments().push_back(param);
 
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   // body:
   /*
@@ -2369,7 +2369,7 @@ bool solidity_convertert::get_call_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.value = msg_sender;
+  added_old_sender.get_value() = msg_sender;
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -2450,7 +2450,7 @@ bool solidity_convertert::get_call_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -2511,7 +2511,7 @@ bool solidity_convertert::model_transaction(
     loc);
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.value = msg_value;
+  added_old_value.get_value() = msg_value;
   old_val_decl.operands().push_back(msg_value);
   front_block.move_to_operands(old_val_decl);
 
@@ -2602,7 +2602,7 @@ bool solidity_convertert::get_call_value_definition(
   param.cmt_identifier(val_id);
   t.arguments().push_back(param);
 
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   // body:
   /*
@@ -2658,7 +2658,7 @@ bool solidity_convertert::get_call_value_definition(
     locationt());
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.value = msg_value;
+  added_old_value.get_value() = msg_value;
   old_val_decl.operands().push_back(msg_value);
   func_body.move_to_operands(old_val_decl);
 
@@ -2673,7 +2673,7 @@ bool solidity_convertert::get_call_value_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.value = msg_sender;
+  added_old_sender.get_value() = msg_sender;
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -2804,7 +2804,7 @@ bool solidity_convertert::get_call_value_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -2853,7 +2853,7 @@ bool solidity_convertert::get_transfer_definition(
   param.cmt_identifier(val_id);
   t.arguments().push_back(param);
 
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   code_blockt func_body;
   exprt addr_expr = symbol_expr(addr_added_symbol);
@@ -2884,7 +2884,7 @@ bool solidity_convertert::get_transfer_definition(
     locationt());
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.value = msg_value;
+  added_old_value.get_value() = msg_value;
   old_val_decl.operands().push_back(msg_value);
   func_body.move_to_operands(old_val_decl);
 
@@ -2900,7 +2900,7 @@ bool solidity_convertert::get_transfer_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.value = msg_sender;
+  added_old_sender.get_value() = msg_sender;
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -3049,7 +3049,7 @@ bool solidity_convertert::get_transfer_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -3099,7 +3099,7 @@ bool solidity_convertert::get_send_definition(
   param.cmt_identifier(val_id);
   t.arguments().push_back(param);
 
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   code_blockt func_body;
   exprt addr_expr = symbol_expr(addr_added_symbol);
@@ -3129,7 +3129,7 @@ bool solidity_convertert::get_send_definition(
     locationt());
   symbolt &added_old_value = *move_symbol_to_context(old_value);
   code_declt old_val_decl(symbol_expr(added_old_value));
-  added_old_value.value = msg_value;
+  added_old_value.get_value() = msg_value;
   old_val_decl.operands().push_back(msg_value);
   func_body.move_to_operands(old_val_decl);
 
@@ -3144,7 +3144,7 @@ bool solidity_convertert::get_send_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.value = msg_sender;
+  added_old_sender.get_value() = msg_sender;
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -3277,7 +3277,7 @@ bool solidity_convertert::get_send_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   new_expr = symbol_expr(added_symbol);
 
   return false;
@@ -3317,7 +3317,7 @@ bool solidity_convertert::get_staticcall_definition(
   param.cmt_identifier(addr_id);
   t.arguments().push_back(param);
 
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   // body: same as call#0
   code_blockt func_body;
@@ -3344,7 +3344,7 @@ bool solidity_convertert::get_staticcall_definition(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.value = msg_sender;
+  added_old_sender.get_value() = msg_sender;
   old_sender_decl.operands().push_back(msg_sender);
   func_body.move_to_operands(old_sender_decl);
 
@@ -3380,7 +3380,7 @@ bool solidity_convertert::get_staticcall_definition(
         std::to_string(aux_counter++),
       locationt());
     symbolt &added_snap = *move_symbol_to_context(snap_sym);
-    added_snap.value = static_ins;
+    added_snap.get_value() = static_ins;
     code_declt snap_decl(symbol_expr(added_snap));
     snap_decl.operands().push_back(static_ins);
     then.move_to_operands(snap_decl);
@@ -3437,7 +3437,7 @@ bool solidity_convertert::get_staticcall_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   new_expr = symbol_expr(added_symbol);
   return false;
 }
@@ -3479,7 +3479,7 @@ bool solidity_convertert::get_delegatecall_definition(
   param.cmt_identifier(addr_id);
   t.arguments().push_back(param);
 
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   // body:
   // Unlike call, delegatecall does NOT change msg.sender or msg.value.
@@ -3554,7 +3554,7 @@ bool solidity_convertert::get_delegatecall_definition(
   return_expr.return_value() = false_exprt();
   func_body.move_to_operands(return_expr);
 
-  added_symbol.value = func_body;
+  added_symbol.get_value() = func_body;
   new_expr = symbol_expr(added_symbol);
   return false;
 }

--- a/src/solidity-frontend/solidity_convert_constructor.cpp
+++ b/src/solidity-frontend/solidity_convert_constructor.cpp
@@ -98,13 +98,13 @@ bool solidity_convertert::add_implicit_constructor(
   auto &sym = *move_symbol_to_context(symbol);
 
   code_blockt body_exprt = code_blockt();
-  sym.value = body_exprt;
+  sym.get_value() = body_exprt;
 
   // add this pointer
   get_function_this_pointer_param(
     contract_name, id, debug_modulename, location_begin, type);
 
-  sym.type = type;
+  sym.get_type() = type;
   return false;
 }
 
@@ -339,8 +339,8 @@ bool solidity_convertert::get_unbound_function(
     // no params
     h_type.make_ellipsis();
 
-    added_sym.type = h_type;
-    added_sym.value = func_body;
+    added_sym.get_type() = h_type;
+    added_sym.get_value() = func_body;
     h_sym = added_sym;
   }
 
@@ -475,7 +475,8 @@ bool solidity_convertert::move_initializer_to_ctor(
       {
         // auxiliary local variable we created
         exprt tmp = *it;
-        sym.value.operands().insert(sym.value.operands().begin(), tmp);
+        sym.get_value().operands().insert(
+          sym.get_value().operands().begin(), tmp);
         continue;
       }
       if (is_aux_ctor)
@@ -493,7 +494,7 @@ bool solidity_convertert::move_initializer_to_ctor(
         abort();
       }
       symbolt *symbol = context.find_symbol(comp.identifier());
-      exprt rhs = symbol->value;
+      exprt rhs = symbol->get_value();
       exprt _assign;
       if (
         get_sol_type(lhs.type()) == SolidityGrammar::SolType::STRING &&
@@ -517,7 +518,8 @@ bool solidity_convertert::move_initializer_to_ctor(
       convert_expression_to_code(_assign);
 
       // insert before the sym.value.operands
-      sym.value.operands().insert(sym.value.operands().begin(), _assign);
+      sym.get_value().operands().insert(
+        sym.get_value().operands().begin(), _assign);
 
       // we might need to insert some expression
       // due to the convert_type_expr and get_string_assignment
@@ -526,7 +528,8 @@ bool solidity_convertert::move_initializer_to_ctor(
         for (auto &op : ctor_frontBlockDecl.operands())
         {
           convert_expression_to_code(op);
-          sym.value.operands().insert(sym.value.operands().begin(), op);
+          sym.get_value().operands().insert(
+            sym.get_value().operands().begin(), op);
         }
         ctor_frontBlockDecl.clear();
       }
@@ -535,7 +538,8 @@ bool solidity_convertert::move_initializer_to_ctor(
     {
       exprt tmp = *it;
       convert_expression_to_code(tmp);
-      sym.value.operands().insert(sym.value.operands().begin(), tmp);
+      sym.get_value().operands().insert(
+        sym.get_value().operands().begin(), tmp);
     }
   }
 
@@ -549,7 +553,8 @@ bool solidity_convertert::move_initializer_to_ctor(
     code_labelt label;
     label.set_label("__ESBMC_HIDE");
     label.code() = code_skipt();
-    sym.value.operands().insert(sym.value.operands().begin(), label);
+    sym.get_value().operands().insert(
+      sym.get_value().operands().begin(), label);
   }
 
   // _sol_init_
@@ -557,7 +562,8 @@ bool solidity_convertert::move_initializer_to_ctor(
   get_library_function_call_no_args(
     "_sol_init_", "sol:@F@_sol_init_", empty_typet(), locationt(), init_call);
   convert_expression_to_code(init_call);
-  sym.value.operands().insert(sym.value.operands().begin(), init_call);
+  sym.get_value().operands().insert(
+    sym.get_value().operands().begin(), init_call);
 
   return false;
 }
@@ -688,10 +694,10 @@ bool solidity_convertert::move_inheritance_to_ctor(
           contract_name, c_name, c_args_list_node, added_ctor_symbol);
 
         // copy value e.g.  this.data = X.data
-        struct_typet type_complete =
-          to_struct_type(context.find_symbol(prefix + contract_name)->type);
+        struct_typet type_complete = to_struct_type(
+          context.find_symbol(prefix + contract_name)->get_type());
         struct_typet c_type_complete =
-          to_struct_type(context.find_symbol(prefix + c_name)->type);
+          to_struct_type(context.find_symbol(prefix + c_name)->get_type());
 
         exprt lhs;
         exprt rhs;
@@ -724,8 +730,8 @@ bool solidity_convertert::move_inheritance_to_ctor(
               }
 
               convert_expression_to_code(_assign);
-              sym.value.operands().insert(
-                sym.value.operands().begin(), _assign);
+              sym.get_value().operands().insert(
+                sym.get_value().operands().begin(), _assign);
               break;
             }
           }
@@ -733,8 +739,9 @@ bool solidity_convertert::move_inheritance_to_ctor(
 
         // insert ctor call
         code_declt dl(symbol_expr(added_ctor_symbol));
-        dl.operands().push_back(added_ctor_symbol.value);
-        sym.value.operands().insert(sym.value.operands().begin(), dl);
+        dl.operands().push_back(added_ctor_symbol.get_value());
+        sym.get_value().operands().insert(
+          sym.get_value().operands().begin(), dl);
       }
     }
   }

--- a/src/solidity-frontend/solidity_convert_contract.cpp
+++ b/src/solidity-frontend/solidity_convert_contract.cpp
@@ -142,7 +142,7 @@ void solidity_convertert::add_static_contract_instance(const std::string c_name)
     abort();
   }
 
-  added_sym.value = ctor;
+  added_sym.get_value() = ctor;
 }
 
 void solidity_convertert::get_inherit_static_contract_instance_name(
@@ -240,7 +240,7 @@ void solidity_convertert::get_inherit_ctor_definition(
   param.cmt_identifier(aid);
   param.location() = l;
   ft.arguments().push_back(param);
-  add_sym.type = ft;
+  add_sym.get_type() = ft;
 
   // body
   exprt func_body = code_blockt();
@@ -292,7 +292,7 @@ void solidity_convertert::get_inherit_ctor_definition(
   current_functionDecl = old_current_functionDecl;
   current_functionName = old_current_functionName;
 
-  add_sym.value = func_body;
+  add_sym.get_value() = func_body;
 
   new_expr = symbol_expr(add_sym);
   move_builtin_to_contract(c_name, new_expr, "public", true);
@@ -393,7 +393,7 @@ void solidity_convertert::get_inherit_static_contract_instance(
   call.location().line(1);
   exprt val;
   get_temporary_object(call, val);
-  added_ctor_symbol.value = val;
+  added_ctor_symbol.get_value() = val;
   sym = added_ctor_symbol;
 
   log_debug("solidity", "finish get_inherit_static_contract_instance");
@@ -468,7 +468,7 @@ bool solidity_convertert::get_high_level_call_wrapper(
     locationt());
   symbolt &added_old_sender = *move_symbol_to_context(old_sender);
   code_declt old_sender_decl(symbol_expr(added_old_sender));
-  added_old_sender.value = msg_sender;
+  added_old_sender.get_value() = msg_sender;
   old_sender_decl.operands().push_back(msg_sender);
   front_block.move_to_operands(old_sender_decl);
 
@@ -653,8 +653,8 @@ bool solidity_convertert::multi_transaction_verification(
   // no params
   main_type.make_ellipsis();
 
-  main_sym.type = main_type;
-  main_sym.value = func_body;
+  main_sym.get_type() = main_type;
+  main_sym.get_value() = func_body;
 
   // set "_ESBMC_Main_X" as the main function
   // this will be overwrite in multi-contract mode.
@@ -733,8 +733,8 @@ bool solidity_convertert::register_harness_main(
 
   symbolt &added_symbol = *context.move_symbol_to_context(new_symbol);
   main_type.make_ellipsis();
-  added_symbol.type = main_type;
-  added_symbol.value = func_body;
+  added_symbol.get_type() = main_type;
+  added_symbol.get_value() = func_body;
   config.main = sol_name;
   return false;
 }

--- a/src/solidity-frontend/solidity_convert_decl.cpp
+++ b/src/solidity-frontend/solidity_convert_decl.cpp
@@ -360,8 +360,8 @@ bool solidity_convertert::get_var_decl(
   if (!set_init && !(is_mapping && is_new_expr && is_byte_static))
   {
     // for both state and non-state variables, set default value as zero
-    symbol.value = gen_zero(get_complete_type(t, ns), true);
-    symbol.value.zero_initializer(true);
+    symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
+    symbol.get_value().zero_initializer(true);
   }
 
   // 6. add symbol into the context
@@ -386,8 +386,8 @@ bool solidity_convertert::get_var_decl(
     len_sym.static_lifetime = true;
     len_sym.file_local = true;
     len_sym.is_extern = false;
-    len_sym.value = gen_zero(unsignedbv_typet(256));
-    len_sym.value.zero_initializer(true);
+    len_sym.get_value() = gen_zero(unsignedbv_typet(256));
+    len_sym.get_value().zero_initializer(true);
     move_symbol_to_context(len_sym);
   }
 
@@ -408,8 +408,8 @@ bool solidity_convertert::get_var_decl(
     len_sym.static_lifetime = true;
     len_sym.file_local = true;
     len_sym.is_extern = false;
-    len_sym.value = gen_zero(unsignedbv_typet(256));
-    len_sym.value.zero_initializer(true);
+    len_sym.get_value() = gen_zero(unsignedbv_typet(256));
+    len_sym.get_value().zero_initializer(true);
     move_symbol_to_context(len_sym);
   }
 
@@ -485,7 +485,7 @@ bool solidity_convertert::get_var_decl(
       solidity_gen_typecast(ns, acpy_call, t);
       acpy_call.type().set("#sol_array_size", arr_size);
       // set as rvalue
-      added_symbol.value = acpy_call;
+      added_symbol.get_value() = acpy_call;
       decl.operands().push_back(acpy_call);
     }
     else
@@ -498,7 +498,7 @@ bool solidity_convertert::get_var_decl(
       // typecast
       solidity_gen_typecast(ns, calc_call, t);
       // set as rvalue
-      added_symbol.value = calc_call;
+      added_symbol.get_value() = calc_call;
       decl.operands().push_back(calc_call);
     }
   }
@@ -524,11 +524,11 @@ bool solidity_convertert::get_var_decl(
       const symbolt *len_sym = context.find_symbol(len_id);
       assert(len_sym);
       symbolt &len_mut = const_cast<symbolt &>(*len_sym);
-      len_mut.value = size_expr;
+      len_mut.get_value() = size_expr;
     }
     // Zero-initialize the infinite array so elements read as 0
-    added_symbol.value = gen_zero(get_complete_type(t, ns), true);
-    added_symbol.value.zero_initializer(true);
+    added_symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
+    added_symbol.get_value().zero_initializer(true);
   }
   else if (t_sol_type == SolidityGrammar::SolType::DYNARRAY && set_init)
   {
@@ -547,7 +547,7 @@ bool solidity_convertert::get_var_decl(
       //=> uint* zz = (uint *)calloc(10, sizeof(uint));
       //=> uint* zz = (uint *)calloc(len, sizeof(uint));
       solidity_gen_typecast(ns, val, t);
-      added_symbol.value = val;
+      added_symbol.get_value() = val;
       decl.operands().push_back(val);
 
       // get rhs size, e.g. 10
@@ -561,7 +561,7 @@ bool solidity_convertert::get_var_decl(
       exprt func_call;
       if (is_state_var)
         store_update_dyn_array(
-          member_exprt(this_expr, added_symbol.name, added_symbol.type),
+          member_exprt(this_expr, added_symbol.name, added_symbol.get_type()),
           size_expr,
           func_call);
       else
@@ -597,14 +597,14 @@ bool solidity_convertert::get_var_decl(
       // typecast
       solidity_gen_typecast(ns, acpy_call, t);
       // set as rvalue
-      added_symbol.value = acpy_call;
+      added_symbol.get_value() = acpy_call;
       decl.operands().push_back(acpy_call);
 
       // store length
       exprt func_call;
       if (is_state_var)
         store_update_dyn_array(
-          member_exprt(this_expr, added_symbol.name, added_symbol.type),
+          member_exprt(this_expr, added_symbol.name, added_symbol.get_type()),
           size_expr,
           func_call);
       else
@@ -647,11 +647,11 @@ bool solidity_convertert::get_var_decl(
     arr_s.file_local = true;
     arr_s.lvalue = true;
     auto &add_added_s = *move_symbol_to_context(arr_s);
-    add_added_s.value = gen_zero(get_complete_type(arr_t, ns), true);
+    add_added_s.get_value() = gen_zero(get_complete_type(arr_t, ns), true);
 
     // 2. construct mapping_t struct instance's value
     typet map_t;
-    map_t = context.find_symbol(lib_prefix + "mapping_t")->type;
+    map_t = context.find_symbol(lib_prefix + "mapping_t")->get_type();
 
     assert(map_t.is_struct());
     exprt inits = gen_zero(map_t);
@@ -677,7 +677,7 @@ bool solidity_convertert::get_var_decl(
     solidity_gen_typecast(ns, addr_expr, comps[addr_idx].type());
     inits.operands()[addr_idx] = addr_expr;
 
-    added_symbol.value = inits;
+    added_symbol.get_value() = inits;
     decl.operands().push_back(inits);
   }
   else if (!set_init && is_byte_static)
@@ -693,7 +693,7 @@ bool solidity_convertert::get_var_decl(
     exprt len = from_integer(
       std::stoul(t.get("#sol_bytesn_size").as_string()), uint_type());
     call.arguments().push_back(len);
-    added_symbol.value = call;
+    added_symbol.get_value() = call;
     decl.operands().push_back(call);
   }
   // now we have rule out other special cases
@@ -701,7 +701,7 @@ bool solidity_convertert::get_var_decl(
   {
     if (get_init_expr(init_value, literal_type, t, val))
       return true;
-    added_symbol.value = val;
+    added_symbol.get_value() = val;
     decl.operands().push_back(val);
   }
 
@@ -882,7 +882,7 @@ bool solidity_convertert::get_struct_class(const nlohmann::json &struct_def)
   }
 
   t.location() = location_begin;
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   return false;
 }
@@ -1322,7 +1322,7 @@ bool solidity_convertert::get_error_definition(const nlohmann::json &ast_node)
       type.arguments().push_back(param);
     }
   }
-  added_symbol.type = type;
+  added_symbol.get_type() = type;
 
   // construct a "__ESBMC_assume(false)" statement
   typet return_type = empty_typet();
@@ -1339,7 +1339,7 @@ bool solidity_convertert::get_error_definition(const nlohmann::json &ast_node)
   // insert it to the body
   code_blockt body;
   body.operands().push_back(call);
-  added_symbol.value = body;
+  added_symbol.get_value() = body;
 
   // restore
   current_functionDecl = old_functionDecl;

--- a/src/solidity-frontend/solidity_convert_expr.cpp
+++ b/src/solidity-frontend/solidity_convert_expr.cpp
@@ -362,7 +362,7 @@ bool solidity_convertert::get_expr(
         arr_sym.file_local = true;
         arr_sym.lvalue = true;
         auto &added = *move_symbol_to_context(arr_sym);
-        added.value = gen_zero(get_complete_type(arr_t, ns), true);
+        added.get_value() = gen_zero(get_complete_type(arr_t, ns), true);
       }
 
       new_expr = symbol_expr(*context.find_symbol(arr_id));
@@ -593,7 +593,7 @@ bool solidity_convertert::get_expr(
             continue;
 
           exprt &arg = call.arguments()[i];
-          if (arg.type() != out_sym->type)
+          if (arg.type() != out_sym->get_type())
             continue;
 
           move_to_back_block(code_assignt(arg, symbol_expr(*out_sym)));
@@ -1840,7 +1840,7 @@ bool solidity_convertert::get_contract_member_call_expr(
         locationt());
       symbolt &added_old_sender = *move_symbol_to_context(old_sender);
       code_declt old_sender_decl(symbol_expr(added_old_sender));
-      added_old_sender.value = msg_sender;
+      added_old_sender.get_value() = msg_sender;
       old_sender_decl.operands().push_back(msg_sender);
       move_to_front_block(old_sender_decl);
 
@@ -2026,7 +2026,7 @@ bool solidity_convertert::get_index_access_expr(
       temp_sym.file_local = true;
       temp_sym.lvalue = true;
       auto &tmp_added_sym = *move_symbol_to_context(temp_sym);
-      tmp_added_sym.value = array;
+      tmp_added_sym.get_value() = array;
       code_declt decl(symbol_expr(tmp_added_sym));
       decl.operands().push_back(array);
       move_to_front_block(decl);
@@ -2047,7 +2047,7 @@ bool solidity_convertert::get_index_access_expr(
           get_call);
         get_call.arguments().push_back(address_of_exprt(arg_val));
         get_call.arguments().push_back(pos);
-        added_sym.value = get_call;
+        added_sym.get_value() = get_call;
 
         code_declt decl(symbol_expr(added_sym));
         decl.operands().push_back(get_call);
@@ -2091,7 +2091,7 @@ bool solidity_convertert::get_index_access_expr(
         get_call.arguments().push_back(address_of_exprt(arg_val));
         get_call.arguments().push_back(dynamic_pool);
         get_call.arguments().push_back(pos);
-        added_sym.value = get_call;
+        added_sym.get_value() = get_call;
 
         code_declt decl(symbol_expr(added_sym));
         decl.operands().push_back(get_call);
@@ -3242,7 +3242,7 @@ bool solidity_convertert::get_unary_operator_expr(
     {
       const symbolt *s = ns.lookup(resolved_type.identifier());
       if (s)
-        resolved_type = s->type;
+        resolved_type = s->get_type();
     }
 
     exprt zero = gen_zero(resolved_type);

--- a/src/solidity-frontend/solidity_convert_mapping.cpp
+++ b/src/solidity-frontend/solidity_convert_mapping.cpp
@@ -427,7 +427,7 @@ bool solidity_convertert::get_new_mapping_index_access(
     get_call.arguments().push_back(address_of_exprt(array));
     get_call.arguments().push_back(pos);
     solidity_gen_typecast(ns, get_call, aux_type);
-    added_sym.value = get_call;
+    added_sym.get_value() = get_call;
     decl.operands().push_back(get_call);
     move_to_front_block(decl);
 
@@ -475,7 +475,7 @@ bool solidity_convertert::get_new_mapping_index_access(
       value_t, struct_contract_name, call, map_struct_get);
 
     // struct temp = map_users_get(&array, pos);
-    added_sym.value = map_struct_get;
+    added_sym.get_value() = map_struct_get;
     decl.operands().push_back(map_struct_get);
     move_to_front_block(decl);
 
@@ -556,7 +556,7 @@ void solidity_convertert::get_mapping_struct_function(
   // for typcast
   side_effect_expr_function_callt temp_call = gen_call;
   solidity_gen_typecast(ns, temp_call, aux_type);
-  added_sym.value = temp_call;
+  added_sym.get_value() = temp_call;
   decl.operands().push_back(temp_call);
   // move to func body
   func_body.operands().push_back(decl);
@@ -584,7 +584,7 @@ void solidity_convertert::get_mapping_struct_function(
   code_declt decl2(symbol_expr(added_sym2));
   // zero value
   exprt inits = gen_zero(get_complete_type(aux_type2, ns), true);
-  added_sym2.value = inits;
+  added_sym2.get_value() = inits;
   decl2.operands().push_back(inits);
   // move to func body
   func_body.operands().push_back(decl2);
@@ -602,7 +602,7 @@ void solidity_convertert::get_mapping_struct_function(
   ret.return_value() = if_expr;
   func_body.operands().push_back(ret);
 
-  func_sym.value = func_body;
+  func_sym.get_value() = func_body;
 
   // func call
   call.function() = symbol_expr(func_sym);

--- a/src/solidity-frontend/solidity_convert_modifier.cpp
+++ b/src/solidity-frontend/solidity_convert_modifier.cpp
@@ -175,7 +175,7 @@ bool solidity_convertert::get_function_definition(
     }
   }
 
-  added_symbol.type = type;
+  added_symbol.get_type() = type;
 
   // 11.3 Declare named return parameters as local variables.
   // Solidity allows `returns (uint result) { result = 42; }` where `result`
@@ -305,13 +305,14 @@ bool solidity_convertert::get_function_definition(
         get_default_symbol(
           out_sym,
           debug_modulename,
-          param_sym->type,
+          param_sym->get_type(),
           p_name + "$out",
           out_id,
           location_begin);
         out_sym.static_lifetime = true;
         out_sym.lvalue = true;
-        out_sym.value = gen_zero(get_complete_type(param_sym->type, ns), true);
+        out_sym.get_value() =
+          gen_zero(get_complete_type(param_sym->get_type(), ns), true);
         move_symbol_to_context(out_sym);
       }
 
@@ -320,7 +321,7 @@ bool solidity_convertert::get_function_definition(
     }
   }
 
-  added_symbol.value = body_exprt;
+  added_symbol.get_value() = body_exprt;
 
   // 13. Restore current_functionDecl
   log_debug("solidity", "@@@ Finish parsing function {}", current_functionName);
@@ -583,7 +584,7 @@ bool solidity_convertert::get_func_modifier(
         return true;
       aux_type.arguments().push_back(arg);
     }
-    a_sym.type = aux_type;
+    a_sym.get_type() = aux_type;
     move_builtin_to_contract(c_name, symbol_expr(a_sym), "internal", true);
 
     // same as origin function body
@@ -665,7 +666,7 @@ bool solidity_convertert::get_func_modifier(
       mod_body.move_to_operands(return_expr);
     }
 
-    a_sym.value = mod_body;
+    a_sym.get_value() = mod_body;
 
     // reset
     current_functionDecl = old_decl;

--- a/src/solidity-frontend/solidity_convert_ref.cpp
+++ b/src/solidity-frontend/solidity_convert_ref.cpp
@@ -680,7 +680,7 @@ bool solidity_convertert::get_sol_builtin_ref(
             aux_sym.file_local = true;
 
             auto &inserted = *move_symbol_to_context(aux_sym);
-            inserted.value = default_value;
+            inserted.get_value() = default_value;
 
             code_declt decl(symbol_expr(inserted));
             decl.operands().push_back(default_value);
@@ -714,7 +714,7 @@ bool solidity_convertert::get_sol_builtin_ref(
               l);
             auto &added_aux = *move_symbol_to_context(aux_idx);
             code_declt decl(symbol_expr(added_aux));
-            added_aux.value = args;
+            added_aux.get_value() = args;
             decl.operands().push_back(args);
             move_to_front_block(decl);
             args = address_of_exprt(symbol_expr(added_aux));
@@ -834,7 +834,7 @@ bool solidity_convertert::get_sol_builtin_ref(
 
           side_effect_expr_function_callt first;
           get_library_function_call_no_args(
-            "string_concat", "c:@F@string_concat", sym->type, l, first);
+            "string_concat", "c:@F@string_concat", sym->get_type(), l, first);
           first.arguments().push_back(args[0]);
           first.arguments().push_back(args[1]);
 
@@ -843,7 +843,7 @@ bool solidity_convertert::get_sol_builtin_ref(
           {
             side_effect_expr_function_callt next;
             get_library_function_call_no_args(
-              "string_concat", "c:@F@string_concat", sym->type, l, next);
+              "string_concat", "c:@F@string_concat", sym->get_type(), l, next);
             next.arguments().push_back(result);
             next.arguments().push_back(args[i]);
             result = next;
@@ -865,7 +865,7 @@ bool solidity_convertert::get_sol_builtin_ref(
           get_library_function_call_no_args(
             "bytes_dynamic_concat",
             "c:@F@bytes_dynamic_concat",
-            sym->type,
+            sym->get_type(),
             l,
             first);
           first.arguments().push_back(args[0]);
@@ -879,7 +879,7 @@ bool solidity_convertert::get_sol_builtin_ref(
             get_library_function_call_no_args(
               "bytes_dynamic_concat",
               "c:@F@bytes_dynamic_concat",
-              sym->type,
+              sym->get_type(),
               l,
               next);
             next.arguments().push_back(result);
@@ -913,13 +913,13 @@ bool solidity_convertert::get_sol_builtin_ref(
     {
       symbolt &sym = *context.find_symbol(id_var);
 
-      if (sym.value.is_empty() || sym.value.is_zero())
+      if (sym.get_value().is_empty() || sym.get_value().is_zero())
       {
         // update: set the value to rand (default 0）
         // since all the current support built-in vars are uint type.
         // we just set the value to c:@F@nondet_uint
         symbolt &r = *context.find_symbol("c:@F@nondet_uint");
-        sym.value = r.value;
+        sym.get_value() = r.get_value();
       }
       new_expr = symbol_expr(sym);
     }

--- a/src/solidity-frontend/solidity_convert_stmt.cpp
+++ b/src/solidity-frontend/solidity_convert_stmt.cpp
@@ -739,10 +739,10 @@ bool solidity_convertert::get_statement(
         {
           const symbolt &sym =
             *context.find_symbol(var_decl.op0().identifier());
-          symbol_exprt sym_expr(sym.id, sym.type);
+          symbol_exprt sym_expr(sym.id, sym.get_type());
 
           exprt nondet_val;
-          get_nondet_expr(sym.type, nondet_val);
+          get_nondet_expr(sym.get_type(), nondet_val);
 
           code_assignt assign(sym_expr, nondet_val);
           assign.location() = loc;
@@ -785,9 +785,9 @@ bool solidity_convertert::get_statement(
           {
             const symbolt &sym =
               *context.find_symbol(var_decl.op0().identifier());
-            symbol_exprt sym_expr(sym.id, sym.type);
+            symbol_exprt sym_expr(sym.id, sym.get_type());
             exprt nondet_val;
-            get_nondet_expr(sym.type, nondet_val);
+            get_nondet_expr(sym.get_type(), nondet_val);
             code_assignt assign(sym_expr, nondet_val);
             assign.location() = loc;
             catch_block.copy_to_operands(var_decl);

--- a/src/solidity-frontend/solidity_convert_tuple.cpp
+++ b/src/solidity-frontend/solidity_convert_tuple.cpp
@@ -101,7 +101,7 @@ bool solidity_convertert::get_tuple_definition(const nlohmann::json &ast_node)
   }
 
   t.location() = location_begin;
-  added_symbol.type = t;
+  added_symbol.get_type() = t;
 
   return false;
 }
@@ -117,7 +117,7 @@ bool solidity_convertert::get_tuple_instance(
     return true;
 
   // get type
-  typet t = context.find_symbol(id)->type;
+  typet t = context.find_symbol(id)->get_type();
   set_sol_type(t, SolidityGrammar::SolType::TUPLE_INSTANCE);
   assert(t.id() == typet::id_struct);
 
@@ -139,8 +139,8 @@ bool solidity_convertert::get_tuple_instance(
   symbol.static_lifetime = true;
   symbol.file_local = true;
 
-  symbol.value = gen_zero(get_complete_type(t, ns), true);
-  symbol.value.zero_initializer(true);
+  symbol.get_value() = gen_zero(get_complete_type(t, ns), true);
+  symbol.get_value().zero_initializer(true);
   symbolt &added_symbol = *move_symbol_to_context(symbol);
   new_expr = symbol_expr(added_symbol);
   new_expr.identifier(id);
@@ -315,7 +315,7 @@ void solidity_convertert::get_llc_ret_tuple(symbolt &s)
   }
   const symbolt &struct_sym = *context.find_symbol(_id);
 
-  typet sym_t = struct_sym.type;
+  typet sym_t = struct_sym.get_type();
   set_sol_type(sym_t, SolidityGrammar::SolType::TUPLE_INSTANCE);
 
   std::string name, id;
@@ -330,7 +330,7 @@ void solidity_convertert::get_llc_ret_tuple(symbolt &s)
   auto &added_sym = *move_symbol_to_context(symbol);
 
   // value
-  typet t = struct_sym.type;
+  typet t = struct_sym.get_type();
   exprt inits = gen_zero(t);
   // Cast nondet_bool to match the struct field type (C frontend compiles
   // _Bool/bool as unsigned int in struct layout due to padding)
@@ -342,7 +342,7 @@ void solidity_convertert::get_llc_ret_tuple(symbolt &s)
   }
   inits.op0() = bool_val;
   inits.op1() = nondet_uint_expr;
-  added_sym.value = inits;
+  added_sym.get_value() = inits;
   s = added_sym;
 }
 

--- a/src/solidity-frontend/solidity_convert_util.cpp
+++ b/src/solidity-frontend/solidity_convert_util.cpp
@@ -192,7 +192,7 @@ void solidity_convertert::get_default_symbol(
   symbol.mode = mode;
   symbol.module = module_name;
   symbol.location = std::move(location);
-  symbol.type = std::move(type);
+  symbol.get_type() = std::move(type);
   symbol.name = name;
   symbol.id = id;
 }
@@ -676,7 +676,7 @@ void solidity_convertert::get_aux_array(
 
   symbolt &added_symbol = *move_symbol_to_context(sym);
 
-  added_symbol.value = new_src_expr;
+  added_symbol.get_value() = new_src_expr;
   new_expr = symbol_expr(added_symbol);
 }
 
@@ -795,7 +795,7 @@ exprt solidity_convertert::make_aux_var(exprt &val, const locationt &location)
   aux_sym.file_local = true;
 
   auto &added_sym = *move_symbol_to_context(aux_sym);
-  added_sym.value = val;
+  added_sym.get_value() = val;
 
   code_declt decl(symbol_expr(added_sym));
   decl.operands().push_back(val);

--- a/src/solidity-frontend/solidity_language.cpp
+++ b/src/solidity-frontend/solidity_language.cpp
@@ -363,8 +363,8 @@ bool solidity_languaget::typecheck(contextt &context, const std::string &module)
   // adjusted by c2goto's clang_c_adjust).
   std::unordered_map<std::string, exprt> saved_values;
   new_context.Foreach_operand([&](symbolt &s) {
-    if (lib_symbols.count(s.id.as_string()) && s.value.is_not_nil())
-      saved_values[s.id.as_string()] = s.value;
+    if (lib_symbols.count(s.id.as_string()) && s.get_value().is_not_nil())
+      saved_values[s.id.as_string()] = s.get_value();
   });
 
   clang_cpp_adjust adjuster(new_context);
@@ -376,7 +376,7 @@ bool solidity_languaget::typecheck(contextt &context, const std::string &module)
   {
     symbolt *s = new_context.find_symbol(id);
     if (s)
-      s->value = std::move(val);
+      s->get_value() = std::move(val);
   }
 
   if (c_link(

--- a/src/solvers/smt/smt_memspace.cpp
+++ b/src/solvers/smt/smt_memspace.cpp
@@ -220,7 +220,7 @@ void smt_convt::renumber_symbol_address(
 
   const typet *t = nullptr;
   if (const symbolt *s = ns.lookup(sym.thename))
-    t = &s->type;
+    t = &s->get_type();
 
   // Two different approaches if we do or don't have an address-of pointer
   // variable already.
@@ -520,7 +520,7 @@ smt_astt smt_convt::convert_addr_of(const expr2tc &expr)
 
     const typet *t = nullptr;
     if (const symbolt *s = ns.lookup(symbol.thename))
-      t = &s->type;
+      t = &s->get_type();
 
     return convert_identifier_pointer(obj.ptr_obj, symbol.get_symbol_name(), t);
   }

--- a/src/util/array2string.cpp
+++ b/src/util/array2string.cpp
@@ -3,23 +3,23 @@
 
 bool array2string(const symbolt &src, exprt &dest)
 {
-  if (src.type.id() != irept::id_array)
+  if (src.get_type().id() != irept::id_array)
     return true;
 
-  if (bv_width(src.type.subtype()) != 8) // TODO: handle wide strings
+  if (bv_width(src.get_type().subtype()) != 8) // TODO: handle wide strings
     return true;
 
   std::string value_str;
   size_t cnt = 0;
-  forall_operands (it, src.value)
+  forall_operands (it, src.get_value())
   {
     std::string op_str = it->cformat().as_string();
-    if (cnt < src.value.operands().size() - 1)
+    if (cnt < src.get_value().operands().size() - 1)
       value_str.push_back(op_str[1]);
     cnt++;
   }
 
-  exprt new_expr("string-constant", src.type);
+  exprt new_expr("string-constant", src.get_type());
   new_expr.value(value_str);
   dest = new_expr;
   return false;

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -9,9 +9,9 @@ void base_type(type2tc &type, const namespacet &ns)
   {
     const symbolt *symbol = ns.lookup(to_symbol_type(type).symbol_name);
 
-    if (symbol && symbol->is_type && !symbol->type.is_nil())
+    if (symbol && symbol->is_type && !symbol->get_type().is_nil())
     {
-      type = migrate_type(symbol->type);
+      type = migrate_type(symbol->get_type());
       base_type(type, ns); // recursive call
       return;
     }
@@ -37,9 +37,9 @@ void base_type(typet &type, const namespacet &ns)
   {
     const symbolt *symbol = ns.lookup(type.identifier());
 
-    if (symbol && symbol->is_type && !symbol->type.is_nil())
+    if (symbol && symbol->is_type && !symbol->get_type().is_nil())
     {
-      type = symbol->type;
+      type = symbol->get_type();
       base_type(type, ns); // recursive call
       return;
     }
@@ -125,7 +125,7 @@ bool base_type_eqt::base_type_eq_rec(const type2tc &type1, const type2tc &type2)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    type2tc tmp = migrate_type(symbol->type);
+    type2tc tmp = migrate_type(symbol->get_type());
     return base_type_eq_rec(tmp, type2);
   }
 
@@ -137,7 +137,7 @@ bool base_type_eqt::base_type_eq_rec(const type2tc &type1, const type2tc &type2)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    type2tc tmp = migrate_type(symbol->type);
+    type2tc tmp = migrate_type(symbol->get_type());
     return base_type_eq_rec(type1, tmp);
   }
 
@@ -239,7 +239,7 @@ bool base_type_eqt::base_type_eq_rec(const typet &type1, const typet &type2)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    return base_type_eq_rec(symbol->type, type2);
+    return base_type_eq_rec(symbol->get_type(), type2);
   }
 
   if (type2.id() == "symbol")
@@ -250,7 +250,7 @@ bool base_type_eqt::base_type_eq_rec(const typet &type1, const typet &type2)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    return base_type_eq_rec(type1, symbol->type);
+    return base_type_eq_rec(type1, symbol->get_type());
   }
 
   if (type1.id() != type2.id())
@@ -450,7 +450,7 @@ static bool is_subclass_of_rec(
   {
     // look at the list of bases; see if the subclass name is a base of this
     // object. Currently, old-irep.
-    forall_irep (it, symbol->type.find("bases").get_sub())
+    forall_irep (it, symbol->get_type().find("bases").get_sub())
     {
       const std::string &basename = it->id_string();
       if (basename == supername)

--- a/src/util/c_expr2string.cpp
+++ b/src/util/c_expr2string.cpp
@@ -1725,7 +1725,9 @@ std::string c_expr2stringt::convert_code_decl(const codet &src, unsigned indent)
     else if (symbol->is_extern)
       dest += "extern ";
 
-    if (symbol->type.is_code() && to_code_type(symbol->type).get_inlined())
+    if (
+      symbol->get_type().is_code() &&
+      to_code_type(symbol->get_type()).get_inlined())
       dest += "inline ";
   }
 

--- a/src/util/c_link.cpp
+++ b/src/util/c_link.cpp
@@ -99,31 +99,31 @@ void c_linkt::duplicate(symbolt &in_context, symbolt &new_symbol)
 void c_linkt::duplicate_type(symbolt &in_context, symbolt &new_symbol)
 {
   // check if it is the same -- use base_type_eq
-  if (!base_type_eq(in_context.type, new_symbol.type, ns))
+  if (!base_type_eq(in_context.get_type(), new_symbol.get_type(), ns))
   {
     if (
-      in_context.type.id() == "incomplete_struct" &&
-      new_symbol.type.id() == "struct")
+      in_context.get_type().id() == "incomplete_struct" &&
+      new_symbol.get_type().id() == "struct")
     {
       // replace old symbol
-      in_context.type = new_symbol.type;
+      in_context.get_type() = new_symbol.get_type();
     }
     else if (
-      in_context.type.id() == "struct" &&
-      new_symbol.type.id() == "incomplete_struct")
+      in_context.get_type().id() == "struct" &&
+      new_symbol.get_type().id() == "incomplete_struct")
     {
       // ignore
     }
     else if (
-      ns.follow(in_context.type).id() == "incomplete_array" &&
-      ns.follow(new_symbol.type).is_array())
+      ns.follow(in_context.get_type()).id() == "incomplete_array" &&
+      ns.follow(new_symbol.get_type()).is_array())
     {
       // store new type
-      in_context.type = new_symbol.type;
+      in_context.get_type() = new_symbol.get_type();
     }
     else if (
-      ns.follow(in_context.type).is_array() &&
-      ns.follow(new_symbol.type).id() == "incomplete_array")
+      ns.follow(in_context.get_type()).is_array() &&
+      ns.follow(new_symbol.get_type()).id() == "incomplete_array")
     {
       // ignore
     }
@@ -147,8 +147,8 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
 {
   // see if it is a function or a variable
 
-  bool is_code_in_context = in_context.type.is_code();
-  bool is_code_new_symbol = new_symbol.type.is_code();
+  bool is_code_in_context = in_context.get_type().is_code();
+  bool is_code_new_symbol = new_symbol.get_type().is_code();
 
   if (is_code_in_context != is_code_new_symbol)
   {
@@ -159,9 +159,9 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       "new definition: {}\n"
       "Module: {}",
       in_context.name,
-      to_string(in_context.type),
+      to_string(in_context.get_type()),
       in_context.module,
-      to_string(new_symbol.type),
+      to_string(new_symbol.get_type()),
       new_symbol.module);
     abort();
   }
@@ -174,19 +174,20 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
 
     // care about code
 
-    if (!new_symbol.value.is_nil())
+    if (!new_symbol.get_value().is_nil())
     {
-      if (in_context.value.is_nil())
+      if (in_context.get_value().is_nil())
       {
         // the one with body wins!
-        in_context.value.swap(new_symbol.value);
-        in_context.type.swap(new_symbol.type); // for argument identifiers
+        in_context.get_value().swap(new_symbol.get_value());
+        in_context.get_type().swap(
+          new_symbol.get_type()); // for argument identifiers
       }
-      else if (in_context.type.inlined())
+      else if (in_context.get_type().inlined())
       {
         // ok
       }
-      else if (base_type_eq(in_context.type, new_symbol.type, ns))
+      else if (base_type_eq(in_context.get_type(), new_symbol.get_type(), ns))
       {
         // keep the one in in_context -- libraries come last!
         log_warning(
@@ -211,13 +212,13 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
           "  {}:{}:{}: location of the old definition in module {}\n"
           "  {}:{}:{}: location of the new definition in module {}",
           in_context.name,
-          in_context.value.location().file().c_str(),
-          in_context.value.location().line().c_str(),
-          in_context.value.location().column().c_str(),
+          in_context.get_value().location().file().c_str(),
+          in_context.get_value().location().line().c_str(),
+          in_context.get_value().location().column().c_str(),
           in_context.module,
-          new_symbol.value.location().file().c_str(),
-          new_symbol.value.location().line().c_str(),
-          new_symbol.value.location().column().c_str(),
+          new_symbol.get_value().location().file().c_str(),
+          new_symbol.get_value().location().line().c_str(),
+          new_symbol.get_value().location().column().c_str(),
           new_symbol.module);
       }
     }
@@ -226,20 +227,20 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
   {
     // both are variables
 
-    if (!base_type_eq(in_context.type, new_symbol.type, ns))
+    if (!base_type_eq(in_context.get_type(), new_symbol.get_type(), ns))
     {
-      const typet &old_type = ns.follow(in_context.type);
-      const typet &new_type = ns.follow(new_symbol.type);
+      const typet &old_type = ns.follow(in_context.get_type());
+      const typet &new_type = ns.follow(new_symbol.get_type());
 
       if (old_type.is_incomplete_array() && new_type.is_array())
       {
         // store new type
-        in_context.type = new_symbol.type;
+        in_context.get_type() = new_symbol.get_type();
       }
       else if (old_type.is_pointer() && new_type.is_array())
       {
         // store new type
-        in_context.type = new_symbol.type;
+        in_context.get_type() = new_symbol.get_type();
       }
       else if (old_type.is_array() && new_type.is_pointer())
       {
@@ -252,7 +253,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       else if (old_type.id() == "incomplete_struct" && new_type.is_struct())
       {
         // store new type
-        in_context.type = new_symbol.type;
+        in_context.get_type() = new_symbol.get_type();
       }
       else if (old_type.is_struct() && new_type.id() == "incomplete_struct")
       {
@@ -289,12 +290,12 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
           in_context.location.line().c_str(),
           in_context.location.column().c_str(),
           in_context.module,
-          to_string(in_context.type),
+          to_string(in_context.get_type()),
           new_symbol.location.file().c_str(),
           new_symbol.location.line().c_str(),
           new_symbol.location.column().c_str(),
           new_symbol.module,
-          to_string(new_symbol.type));
+          to_string(new_symbol.get_type()));
       }
     }
 
@@ -306,7 +307,7 @@ void c_linkt::duplicate_symbol(symbolt &in_context, symbolt &new_symbol)
       }
       else
       {
-        in_context.value.swap(new_symbol.value);
+        in_context.get_value().swap(new_symbol.get_value());
         in_context.is_extern = false;
       }
     }
@@ -346,7 +347,7 @@ void c_linkt::typecheck()
         subst.location() = s.location;
         symbol_fixer.insert(
           s.id, static_cast<const typet &>(static_cast<const irept &>(subst)));
-        subst.type() = s.type;
+        subst.type() = s.get_type();
         symbol_fixer.insert(s.id, subst);
       }
     }

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -125,14 +125,14 @@ symbolt *contextt::move_symbol_to_context(symbolt &symbol)
   else
   {
     // types that are code means functions
-    if (s->type.is_code())
+    if (s->get_type().is_code())
     {
-      if (symbol.value.is_not_nil() && !s->value.is_not_nil())
+      if (symbol.get_value().is_not_nil() && !s->get_value().is_not_nil())
         s->swap(symbol);
     }
     else if (s->is_type)
     {
-      if (symbol.type.is_not_nil() && !s->type.is_not_nil())
+      if (symbol.get_type().is_not_nil() && !s->get_type().is_not_nil())
         s->swap(symbol);
     }
     else if (s->is_extern && !symbol.is_extern)

--- a/src/util/cpp_expr2string.cpp
+++ b/src/util/cpp_expr2string.cpp
@@ -185,13 +185,14 @@ std::string cpp_expr2stringt::convert_rec(
     }
 
     if (
-      symbol->type.id() == "struct" || symbol->type.id() == "incomplete_struct")
+      symbol->get_type().id() == "struct" ||
+      symbol->get_type().id() == "incomplete_struct")
     {
       std::string dest = new_qualifiers.as_string();
 
-      if (symbol->type.get_bool("#class"))
+      if (symbol->get_type().get_bool("#class"))
         dest += "class";
-      else if (symbol->type.get_bool("#interface"))
+      else if (symbol->get_type().get_bool("#interface"))
         dest += "__interface"; // MS-specific
       else
         dest += "struct";
@@ -200,7 +201,7 @@ std::string cpp_expr2stringt::convert_rec(
       dest += d;
       return dest;
     }
-    if (symbol->type.id() == "c_enum")
+    if (symbol->get_type().id() == "c_enum")
     {
       std::string dest = new_qualifiers.as_string();
 

--- a/src/util/destructor.cpp
+++ b/src/util/destructor.cpp
@@ -18,7 +18,8 @@ code_function_callt get_destructor(const namespacet &ns, const typet &type)
       const symbolt *cpp_delete = ns.get_context().find_symbol(it->second);
 
       code_function_callt function_call;
-      function_call.function() = symbol_exprt(cpp_delete->id, cpp_delete->type);
+      function_call.function() =
+        symbol_exprt(cpp_delete->id, cpp_delete->get_type());
 
       return function_call;
     }

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -248,7 +248,7 @@ void gen_or(exprt &expr)
 
 exprt symbol_expr(const symbolt &symbol)
 {
-  exprt tmp("symbol", symbol.type);
+  exprt tmp("symbol", symbol.get_type());
   tmp.identifier(symbol.id);
   tmp.name(symbol.name);
   return tmp;

--- a/src/util/fix_symbol.cpp
+++ b/src/util/fix_symbol.cpp
@@ -6,8 +6,8 @@ void fix_symbolt::fix_symbol(symbolt &symbol)
   if (it != type_map.end())
     symbol.id = it->second.id();
 
-  replace(symbol.type);
-  replace(symbol.value);
+  replace(symbol.get_type());
+  replace(symbol.get_value());
 }
 
 void fix_symbolt::fix_context(contextt &context)

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -26,13 +26,13 @@ inline code_function_callt invoke_intrinsic(
 
   symbolt symbol;
   symbol.mode = "C";
-  symbol.type = code_type;
+  symbol.get_type() = code_type;
   symbol.name = name;
   symbol.id = name;
   symbol.is_extern = false;
   symbol.file_local = false;
 
-  exprt tmp("symbol", symbol.type);
+  exprt tmp("symbol", symbol.get_type());
   tmp.identifier(symbol.id);
   tmp.name(symbol.name);
 
@@ -534,7 +534,13 @@ expr2tc sym_name_to_symbol(const irep_idt &init, const type2tc &type)
     // Fix this by ensuring that /all/ symbols with the same name use the type
     // from the global symbol table.
     return symbol2tc(
-      migrate_type(sym->type), init, symbol_renaming_level::level0, 0, 0, 0, 0);
+      migrate_type(sym->get_type()),
+      init,
+      symbol_renaming_level::level0,
+      0,
+      0,
+      0,
+      0);
   }
   if (
     init.as_string().compare(0, 3, "cs$") == 0 ||

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -29,17 +29,17 @@ void namespacet::follow_symbol(irept &irep) const
 
     if (symbol->is_type)
     {
-      if (symbol->type.is_nil())
+      if (symbol->get_type().is_nil())
         return;
 
-      irep = symbol->type;
+      irep = symbol->get_type();
     }
     else
     {
-      if (symbol->value.is_nil())
+      if (symbol->get_value().is_nil())
         return;
 
-      irep = symbol->value;
+      irep = symbol->get_value();
     }
   }
 }
@@ -59,9 +59,9 @@ const typet &namespacet::follow(const typet &src) const
   {
     assert(symbol);
     assert(symbol->is_type);
-    if (!symbol->type.is_symbol())
-      return symbol->type;
-    const symbolt *next = lookup(symbol->type);
+    if (!symbol->get_type().is_symbol())
+      return symbol->get_type();
+    const symbolt *next = lookup(symbol->get_type());
     assert(next != symbol && "cycle of length 1 in ns.follow()");
     symbol = next;
   }

--- a/src/util/show_symbol_table.cpp
+++ b/src/util/show_symbol_table.cpp
@@ -22,11 +22,11 @@ void show_symbol_table_plain(const namespacet &ns, std::ostream &out)
     std::unique_ptr<languaget> p = language_from_symbol(s);
     std::string type_str, value_str;
 
-    if (s.type.is_not_nil())
-      p->from_type(s.type, type_str, ns);
+    if (s.get_type().is_not_nil())
+      p->from_type(s.get_type(), type_str, ns);
 
-    if (s.value.is_not_nil())
-      p->from_expr(s.value, value_str, ns);
+    if (s.get_value().is_not_nil())
+      p->from_expr(s.get_value(), value_str, ns);
 
     out << "Symbol......: " << s.id << "\n";
     out << "Module......: " << s.module << "\n";

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -12,8 +12,6 @@
 class symbolt
 {
 public:
-  typet type;
-  exprt value;
   locationt location;
   irep_idt id;
   irep_idt module;
@@ -32,6 +30,29 @@ public:
 
   symbolt();
 
+  // Accessors for the (now private) `type`/`value` fields. Introduced for the
+  // IREP2 symbol-table migration (esbmc/esbmc#4715, B2): all access goes
+  // through these so the storage can later become IREP2-native without touching
+  // every caller again. The mutable overloads are a transitional convenience
+  // (writes/swaps); a later step routes writes through a setter so the IREP2
+  // form can be kept in sync.
+  const typet &get_type() const
+  {
+    return type;
+  }
+  typet &get_type()
+  {
+    return type;
+  }
+  const exprt &get_value() const
+  {
+    return value;
+  }
+  exprt &get_value()
+  {
+    return value;
+  }
+
   void clear();
 
   void swap(symbolt &b);
@@ -43,6 +64,10 @@ public:
   void from_irep(const irept &src);
 
   irep_idt get_function_name() const;
+
+private:
+  typet type;
+  exprt value;
 };
 
 std::ostream &operator<<(std::ostream &out, const symbolt &symbol);

--- a/src/util/symbol_generator.cpp
+++ b/src/util/symbol_generator.cpp
@@ -14,7 +14,7 @@ symbolt &symbol_generator::new_symbol(
     new_symbol.name = name_prefix + i2string(++counter);
     new_symbol.id = prefix + id2string(new_symbol.name);
     new_symbol.lvalue = true;
-    new_symbol.type = type;
+    new_symbol.get_type() = type;
   } while (context.move(new_symbol, symbol_ptr));
 
   return *symbol_ptr;

--- a/src/util/symbolic_types.cpp
+++ b/src/util/symbolic_types.cpp
@@ -18,8 +18,8 @@ static void complete_type(typet &type, const namespacet &ns)
     const symbolt *sym = ns.lookup(type.identifier());
     assert(sym);
     assert(sym->is_type);
-    assert(!sym->type.is_symbol());
-    type = sym->type;
+    assert(!sym->get_type().is_symbol());
+    type = sym->get_type();
     return complete_type(type, ns);
   }
 }

--- a/src/util/type_eq.cpp
+++ b/src/util/type_eq.cpp
@@ -13,7 +13,7 @@ bool type_eq(const typet &type1, const typet &type2, const namespacet &ns)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    return type_eq(symbol->type, type2, ns);
+    return type_eq(symbol->get_type(), type2, ns);
   }
 
   if (type2.id() == "symbol")
@@ -23,7 +23,7 @@ bool type_eq(const typet &type1, const typet &type2, const namespacet &ns)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    return type_eq(type1, symbol->type, ns);
+    return type_eq(type1, symbol->get_type(), ns);
   }
 
   return false;

--- a/unit/python-frontend/complex_type_test.cpp
+++ b/unit/python-frontend/complex_type_test.cpp
@@ -82,12 +82,12 @@ TEST_CASE("complex type helpers", "[python-frontend][complex]")
     REQUIRE(complex_type_symbol != nullptr);
     REQUIRE(complex_type_symbol->is_type);
     REQUIRE(complex_type_symbol->id.as_string() == "tag-complex");
-    REQUIRE(is_complex_type(complex_type_symbol->type));
+    REQUIRE(is_complex_type(complex_type_symbol->get_type()));
 
     // Generic paths build named type lookups as "tag-" + struct_tag.
     // Keep struct tag as "complex" so this resolves to "tag-complex".
     const struct_typet &stored_struct =
-      to_struct_type(complex_type_symbol->type);
+      to_struct_type(complex_type_symbol->get_type());
     const std::string derived_lookup = "tag-" + stored_struct.tag().as_string();
     REQUIRE(derived_lookup == "tag-complex");
   }

--- a/unit/python-frontend/function_call_expr_error_test.cpp
+++ b/unit/python-frontend/function_call_expr_error_test.cpp
@@ -599,8 +599,8 @@ TEST_CASE(
       make_char('\0'));
 
     symbolt sym;
-    sym.value = value;
-    sym.type = arr_t;
+    sym.get_value() = value;
+    sym.get_type() = arr_t;
 
     auto extracted =
       function_call_expr_test_access::extract_string_from_symbol(fce, &sym);
@@ -618,8 +618,8 @@ TEST_CASE(
       make_char('\0'));
 
     symbolt sym;
-    sym.value = value;
-    sym.type = arr_t;
+    sym.get_value() = value;
+    sym.get_type() = arr_t;
 
     auto extracted =
       function_call_expr_test_access::extract_string_from_symbol(fce, &sym);

--- a/unit/util/migrate.test.cpp
+++ b/unit/util/migrate.test.cpp
@@ -38,7 +38,7 @@ contextt &test_context()
   {
     symbolt x;
     x.id = x.name = "x";
-    x.type = migrate_type_back(get_int_type(32));
+    x.get_type() = migrate_type_back(get_int_type(32));
     x.lvalue = true;
     ctx.add(x);
     initialised = true;


### PR DESCRIPTION
First step (**S0**) of the symbol-table boundary (B2) in the IREP2 migration (#4715), per the plan in `docs/irep2-symbol-table-migration-plan.md` (#4723).

Makes `symbolt::type`/`value` **private** and routes every access through `get_type()`/`get_value()` accessors (const + mutable). This centralises symbol field access so the storage can later become IREP2-native (S1–S5) without touching every caller again.

## How to review
A **mechanical, compiler-verified** change, best reviewed by pattern + CI rather than line-by-line:
- The only non-mechanical change is `src/util/symbol.h` (fields → private, four accessors added).
- Every other hunk is `x.type` → `x.get_type()` / `x.value` → `x.get_value()` on a `symbolt`.
- Private fields mean the compiler **rejects both missed sites and wrong rewrites** (a non-`symbolt` `.type` has no `get_type()`), so completeness is guaranteed by the green build. Edits were column-precise from compiler diagnostics, so sibling `.type` on `expr2t`/`goto_functiont` are untouched.

## Validation
- Full build green (all targets incl. unit tests).
- Unit tests pass (`migratetest`, `irep2test`, `base_typetest`).
- Sane verdicts on representative C / Python inputs.
- Behaviour-preserving **by construction**: accessors return the existing fields, so the generated goto program is unchanged.

~870 call sites across 114 files. No functional change. Follow-ups: S1 (IREP2 cache + cross-check), S2 readers, S3 writers, S4 native flip, S5 drop legacy field.