### PR TITLE
[util] add migrate_symbol_type with round-trip cross-check (B2 S1)

### DIFF
--- a/src/goto-programs/abstract-interpretation/interval_domain.cpp
+++ b/src/goto-programs/abstract-interpretation/interval_domain.cpp
@@ -949,7 +949,7 @@ void interval_domaint::transform(
   {
     // After a return, all function arguments becomes nondet
     const symbolt *current_function = ns.lookup(instruction.function);
-    type2tc t = migrate_type(current_function->get_type());
+    type2tc t = migrate_symbol_type(*current_function);
     const code_type2t &function = to_code_type(t);
 
     for (size_t i = 0; i < function.arguments.size(); i++)

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -91,7 +91,7 @@ void w_guardst::add_initialization(goto_programt &goto_program)
     migrate_expr(symbol, new_sym);
 
     expr2tc falsity = s.get_type().is_array()
-                        ? gen_zero(migrate_type(s.get_type()), true)
+                        ? gen_zero(migrate_symbol_type(s), true)
                         : gen_false_expr();
     t = goto_program.insert(t);
     t->type = ASSIGN;

--- a/src/goto-programs/assign_params_as_non_det.cpp
+++ b/src/goto-programs/assign_params_as_non_det.cpp
@@ -24,7 +24,7 @@ symbolt *assign_params_as_non_det::get_default_symbol(
 /// Build an irep2 symbol expression referring to @p sym.
 static expr2tc sym_to_expr2tc(const symbolt &sym)
 {
-  return symbol2tc(migrate_type(sym.get_type()), sym.id);
+  return symbol2tc(migrate_symbol_type(sym), sym.id);
 }
 
 /// Append @p instr (with location and function copied from @p it) before @p it
@@ -132,7 +132,7 @@ bool assign_params_as_non_det::runOnFunction(
     insert_before(
       goto_program,
       it,
-      code_decl2tc(migrate_type(flag_sym->get_type()), flag_sym->id),
+      code_decl2tc(migrate_symbol_type(*flag_sym), flag_sym->id),
       DECL,
       l);
 
@@ -149,7 +149,7 @@ bool assign_params_as_non_det::runOnFunction(
     insert_before(
       goto_program,
       it,
-      code_decl2tc(migrate_type(obj_sym->get_type()), obj_sym->id),
+      code_decl2tc(migrate_symbol_type(*obj_sym), obj_sym->id),
       DECL,
       l);
 

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -699,7 +699,7 @@ void code_contractst::havoc_static_globals(
       return;
 
     // Build LHS symbol expression
-    type2tc global_type = migrate_type(s.get_type());
+    type2tc global_type = migrate_symbol_type(s);
     expr2tc lhs = symbol2tc(global_type, s.id);
 
     // Do not assign nondeterministic values to pointers when value-set based
@@ -916,7 +916,7 @@ void code_contractst::enforce_contracts(
     goto_functiont new_func;
     new_func.body = wrapper;
     if (func_sym->get_type().is_code())
-      new_func.type = migrate_type(func_sym->get_type());
+      new_func.type = migrate_symbol_type(*func_sym);
     new_func.body_available = true;
     new_func.update_instructions_function(original_id);
 
@@ -1338,7 +1338,7 @@ goto_programt code_contractst::generate_checking_wrapper(
   {
     const code_typet &code_type = to_code_type(original_func.get_type());
     // Convert function type to irep2
-    type2tc func_type = migrate_type(original_func.get_type());
+    type2tc func_type = migrate_symbol_type(original_func);
 
     // Build parameter list
     std::vector<expr2tc> arguments;

--- a/src/goto-programs/frame_enforcer.cpp
+++ b/src/goto-programs/frame_enforcer.cpp
@@ -244,7 +244,7 @@ frame_enforcert::collect_global_variables(const contextt &context)
       return;
 
     // Build symbol expression
-    type2tc global_type = migrate_type(s.get_type());
+    type2tc global_type = migrate_symbol_type(s);
     expr2tc sym_expr = symbol2tc(global_type, s.id);
 
     // Skip pointer types (consistent with loop frame rule behavior)

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -870,7 +870,7 @@ expr2tc goto_checkt::build_python_type_operand(const typet &type) const
     const symbolt *symbol = ns.lookup(followed);
     if (symbol == nullptr)
       return expr2tc();
-    type2tc symbol_type = migrate_type(symbol->get_type());
+    type2tc symbol_type = migrate_symbol_type(*symbol);
     return symbol2tc(symbol_type, symbol->id);
   }
 

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -97,7 +97,7 @@ void goto_convert_functionst::convert_function(symbolt &symbol)
     functions.function_map.emplace(identifier, goto_functiont());
 
   goto_functiont &f = functions.function_map.at(identifier);
-  f.type = migrate_type(symbol.get_type());
+  f.type = migrate_symbol_type(symbol);
   f.body_available = symbol.get_value().is_not_nil();
 
   if (!f.body_available)

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -80,7 +80,7 @@ bool read_bin_goto_object(
       if (it == goto_functions.function_map.end())
         goto_functions.function_map.emplace(symbol.id, goto_functiont());
       goto_functions.function_map.at(symbol.id).type =
-        migrate_type(symbol.get_type());
+        migrate_symbol_type(symbol);
     }
 
     // Add functions only from the list if there is a whitelist

--- a/src/goto-symex/builtin_functions/memory_alloc.cpp
+++ b/src/goto-symex/builtin_functions/memory_alloc.cpp
@@ -50,7 +50,7 @@ expr2tc goto_symext::create_dynamic_memory_symbol(
     "alignment", constant_exprt(config.ansi_c.max_alignment(), size_type()));
 
   new_context.add(symbol);
-  type2tc new_type = migrate_type(symbol.get_type());
+  type2tc new_type = migrate_symbol_type(symbol);
   return symbol2tc(new_type, symbol.id);
 }
 
@@ -447,7 +447,7 @@ expr2tc goto_symext::symex_mem_inf(
   symbol.mode = "C";
   new_context.add(symbol);
 
-  type2tc new_type = migrate_type(symbol.get_type());
+  type2tc new_type = migrate_symbol_type(symbol);
 
   type2tc rhs_type;
   expr2tc rhs_ptr_obj;
@@ -579,14 +579,14 @@ expr2tc goto_symext::symex_mem(
 
   new_context.add(symbol);
 
-  type2tc new_type = migrate_type(symbol.get_type());
+  type2tc new_type = migrate_symbol_type(symbol);
 
   type2tc rhs_type;
   expr2tc rhs_ptr_obj;
 
   if (size_is_one)
   {
-    rhs_type = migrate_type(symbol.get_type());
+    rhs_type = migrate_symbol_type(symbol);
     rhs_ptr_obj = symbol2tc(new_type, symbol.id);
   }
   else

--- a/src/goto-symex/builtin_functions/object_size.cpp
+++ b/src/goto-symex/builtin_functions/object_size.cpp
@@ -99,7 +99,7 @@ void goto_symext::intrinsic_builtin_object_size(
             const symbol_type2t &symtype = to_symbol_type(ptr_subtype);
             const symbolt *symbol = ns.lookup(symtype.symbol_name);
             addressed_type = (symbol != nullptr)
-                               ? migrate_type(symbol->get_type())
+                               ? migrate_symbol_type(*symbol)
                                : internal_deref_items.front().object->type;
           }
           else

--- a/src/goto-symex/builtin_functions/va_arg.cpp
+++ b/src/goto-symex/builtin_functions/va_arg.cpp
@@ -22,7 +22,7 @@ void goto_symext::symex_va_arg(
   const symbolt *s = new_context.find_symbol(id);
   if (s != nullptr)
   {
-    type2tc symbol_type = migrate_type(s->get_type());
+    type2tc symbol_type = migrate_symbol_type(*s);
 
     va_rhs = symbol2tc(symbol_type, s->id);
     cur_state->top().level1.get_ident_name(va_rhs);

--- a/src/goto-symex/symex_catch.cpp
+++ b/src/goto-symex/symex_catch.cpp
@@ -301,7 +301,7 @@ bool goto_symext::symex_throw_bad_cast()
     }
 
     // Build a nondet operand of bad_cast type for the thrown object.
-    type2tc bad_cast_type = migrate_type(bad_cast_sym->get_type());
+    type2tc bad_cast_type = migrate_symbol_type(*bad_cast_sym);
     expr2tc nondet_op = sideeffect2tc(
       bad_cast_type,
       expr2tc(),

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -159,7 +159,7 @@ unsigned goto_symext::argument_assignments(
             const symbol_type2t &sym_type = to_symbol_type(ptr_subtype);
             symbolt const *sym = ns.lookup(sym_type.symbol_name);
             if (sym)
-              ptr_subtype = migrate_type(sym->get_type());
+              ptr_subtype = migrate_symbol_type(*sym);
             else
               break;
           }

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -438,7 +438,7 @@ void goto_symext::phi_function(const statet::goto_statet &goto_state)
     // changed!
     const symbolt &symbol = *ns.lookup(variable.base_name);
 
-    type2tc type = migrate_type(symbol.get_type());
+    type2tc type = migrate_symbol_type(symbol);
 
     expr2tc cur_state_rhs = symbol2tc(type, symbol.id);
     renaming::level2t::rename_to_record(cur_state_rhs, variable);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -1076,7 +1076,7 @@ void goto_symext::run_intrinsic(
 
     symex_mem_inf(
       func_call.ret,
-      migrate_type(list_object_symbol->get_type()),
+      migrate_symbol_type(*list_object_symbol),
       cur_state->guard);
 
     return;
@@ -1266,7 +1266,7 @@ void goto_symext::add_memory_leak_checks()
             i,
             e.identifier,
             e.suffix);
-          sym_expr2 = sym_expr2->with_type(migrate_type(sym->get_type()));
+          sym_expr2 = sym_expr2->with_type(migrate_symbol_type(*sym));
 
           /* Rename so that it reflects the current state. */
           assert(cur_state->call_stack.size() >= 1);

--- a/src/util/base_type.cpp
+++ b/src/util/base_type.cpp
@@ -11,7 +11,7 @@ void base_type(type2tc &type, const namespacet &ns)
 
     if (symbol && symbol->is_type && !symbol->get_type().is_nil())
     {
-      type = migrate_type(symbol->get_type());
+      type = migrate_symbol_type(*symbol);
       base_type(type, ns); // recursive call
       return;
     }
@@ -125,7 +125,7 @@ bool base_type_eqt::base_type_eq_rec(const type2tc &type1, const type2tc &type2)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    type2tc tmp = migrate_type(symbol->get_type());
+    type2tc tmp = migrate_symbol_type(*symbol);
     return base_type_eq_rec(tmp, type2);
   }
 
@@ -137,7 +137,7 @@ bool base_type_eqt::base_type_eq_rec(const type2tc &type1, const type2tc &type2)
     if (!symbol->is_type)
       throw "symbol " + id2string(symbol->name) + " is not a type";
 
-    type2tc tmp = migrate_type(symbol->get_type());
+    type2tc tmp = migrate_symbol_type(*symbol);
     return base_type_eq_rec(type1, tmp);
   }
 

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -377,6 +377,22 @@ type2tc migrate_type(const typet &type)
   return ty2;
 }
 
+type2tc migrate_symbol_type(const symbolt &sym)
+{
+  type2tc result = migrate_type(sym.get_type());
+#ifndef NDEBUG
+  // The IREP2 form of a real symbol's type must be stable under a round-trip
+  // through legacy irept (migrate_type_back then migrate_type). This is the
+  // property unit/util/migrate.test.cpp proves for synthetic types; asserting
+  // it here exercises it on every symbol type the pipeline reads, which is what
+  // makes deriving the legacy field from IREP2 lossless once storage flips.
+  assert(
+    migrate_type(migrate_type_back(result)) == result &&
+    "symbol type not stable under IREP2<->irept round-trip");
+#endif
+  return result;
+}
+
 static const typet &decide_on_expr_type(const exprt &side1, const exprt &side2)
 {
   // For some arithmetic expr, decide on the result of operating on them.

--- a/src/util/migrate.h
+++ b/src/util/migrate.h
@@ -11,10 +11,21 @@
 
 // Don't ask
 class namespacet;
+class symbolt;
 extern const namespacet *migrate_namespace_lookup;
 
 type2tc migrate_type(const typet &type);
 void migrate_expr(const exprt &expr, expr2tc &new_expr);
+
+// IREP2 form of a symbol's type. Single chokepoint for the symbol-table
+// migration (esbmc/esbmc#4715, B2 S1): equivalent to
+// migrate_type(sym.get_type()) today, but centralised so the storage can later
+// become IREP2-native without touching callers again. In debug builds it also
+// asserts the IREP2 form is stable under a round-trip through legacy irept --
+// the property (proven for synthetic types in unit/util/migrate.test.cpp) that
+// makes deriving the legacy field from IREP2 lossless, now checked on every
+// real symbol type the pipeline reads.
+type2tc migrate_symbol_type(const symbolt &sym);
 
 typet migrate_type_back(const type2tc &ref);
 exprt migrate_expr_back(const expr2tc &ref);


### PR DESCRIPTION
S1 of the symbol-table migration (#4715). **Stacked on #4724 (S0)** — review/merge that first; this targets the S0 branch and will be rebased to master once S0 lands.

Adds `migrate_symbol_type()` — a single chokepoint for the IREP2 form of a symbol type — and routes the ~16 pipeline type readers through it (previously `migrate_type(sym.get_type())`).

In **debug builds** it asserts the IREP2 form is stable under an irept round-trip (`migrate_type(migrate_type_back(R)) == R`) — the property proven for synthetic types in `unit/util/migrate.test.cpp` (#4722), now checked on **every real symbol type the pipeline reads**. This is the evidence gate that deriving the legacy field from IREP2 (later steps) will be lossless.

## Validation
- Debug build (cross-check active) green; cross-check did **not** fire across representative C / struct+pointer / data-race / Python / C++ inputs; verdicts sane.
- Behaviour-preserving: `migrate_symbol_type(s)` returns exactly `migrate_type(s.get_type())`; the only added effect is the debug-only assertion.

Type side only — the value side (function bodies need care: `migrate_expr_back` cannot reconstruct a `code_block`) comes in a later step.