### PR TITLE
[util] add migrate_symbol_value with guarded cross-check (B2 S2)

### DIFF
--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -496,7 +496,7 @@ expr2tc code_contractst::extract_requires_clause(const symbolt &contract_symbol)
   // For now, return the entire value as requires
   // TODO: Parse structured contract data if needed
   expr2tc req;
-  migrate_expr(contract_symbol.get_value(), req);
+  migrate_symbol_value(contract_symbol, req);
   return req;
 }
 

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -393,6 +393,27 @@ type2tc migrate_symbol_type(const symbolt &sym)
   return result;
 }
 
+void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
+{
+  migrate_expr(sym.get_value(), dest);
+#ifndef NDEBUG
+  // Cross-check is guarded: function bodies skip because migrate_expr_back
+  // cannot reconstruct a code_block (a body is migrated forward only -- see
+  // unit/util/migrate.test.cpp); nil values are vacuous. For everything else
+  // (initialisers, contract requires/ensures, ...) assert IREP2-side
+  // idempotence -- the property that makes deriving the legacy field from
+  // IREP2 lossless for non-body symbol values.
+  if (!sym.get_type().is_code() && !sym.get_value().is_nil())
+  {
+    expr2tc roundtrip;
+    migrate_expr(migrate_expr_back(dest), roundtrip);
+    assert(
+      roundtrip == dest &&
+      "symbol value not stable under IREP2<->irept round-trip");
+  }
+#endif
+}
+
 static const typet &decide_on_expr_type(const exprt &side1, const exprt &side2)
 {
   // For some arithmetic expr, decide on the result of operating on them.

--- a/src/util/migrate.h
+++ b/src/util/migrate.h
@@ -27,6 +27,13 @@ void migrate_expr(const exprt &expr, expr2tc &new_expr);
 // real symbol type the pipeline reads.
 type2tc migrate_symbol_type(const symbolt &sym);
 
+// IREP2 form of a symbol's value. Value-side counterpart of
+// migrate_symbol_type (esbmc/esbmc#4715, B2 S2). The debug cross-check is
+// *guarded*: function bodies (sym.get_type().is_code()) are skipped because
+// migrate_expr_back cannot reconstruct a code_block -- a body is migrated
+// forward only (see unit/util/migrate.test.cpp); nil values are skipped too.
+void migrate_symbol_value(const symbolt &sym, expr2tc &dest);
+
 typet migrate_type_back(const type2tc &ref);
 exprt migrate_expr_back(const expr2tc &ref);
 


### PR DESCRIPTION
S2 of the symbol-table migration (#4715). **Stacked on #4725 (S1)** — review/merge that first; this targets the S1 branch and will be rebased to master once S1 lands.

Adds `migrate_symbol_value()` — the value-side counterpart to `migrate_symbol_type` from S1 — and routes the one pipeline value-read site through it (`contracts.cpp:499` in `code_contractst::extract_requires_clause`).

Why one site: the goto pipeline reads `symbol.value` once at goto-convert time (lowered to expr2tc instructions in the goto program), then operates on the goto program directly. The remaining `.get_value()` usages in the pipeline are legacy predicates (`.is_nil()`, `.is_code()`, `to_code(...)`) or writes for S3 — none migrate to IREP2, so they do not need a wrapper.

## Cross-check is guarded
Function bodies (`sym.get_type().is_code()`) are **skipped** because `migrate_expr_back` cannot reconstruct a `code_block` — a body migrates forward only (proven for synthetic types in `unit/util/migrate.test.cpp`, #4722). Nil values are skipped too. For everything else (initialisers, contract requires/ensures), it asserts IREP2-side idempotence — extending S1s evidence to value-side conversions.

## Validation
- Debug build green; cross-check never fired across C / data-race / Python sanity inputs.
- Behaviour-preserving by construction: `migrate_symbol_value(sym, dest)` is equivalent to `migrate_expr(sym.get_value(), dest)` plus the guarded debug-only assertion.
- The migrated site is in `extract_requires_clause`, which currently has no caller in regression (work-in-progress feature), so the cross-check on this specific site will be exercised by future contract-applying tests.