### PR TITLE
[util] add set_symbol_type and route writers through it (B2 S3)

### DIFF
--- a/src/goto-programs/abstract-interpretation/gcse.cpp
+++ b/src/goto-programs/abstract-interpretation/gcse.cpp
@@ -481,7 +481,7 @@ inline symbolt goto_cse::create_cse_symbol(
   const goto_programt::const_targett &to)
 {
   symbolt symbol;
-  symbol.get_type() = migrate_type_back(t);
+  set_symbol_type(symbol, t);
   symbol.id = fmt::format("{}${}", prefix, symbol_counter++);
   symbol.name = symbol.id;
   symbol.mode = "C";

--- a/src/goto-programs/add_race_assertions.cpp
+++ b/src/goto-programs/add_race_assertions.cpp
@@ -78,7 +78,7 @@ void w_guardst::add_initialization(goto_programt &goto_program)
   symbolt new_symbol;
   new_symbol.id = identifier;
   new_symbol.name = identifier;
-  new_symbol.get_type() = migrate_type_back(arrayt);
+  set_symbol_type(new_symbol, arrayt);
   new_symbol.static_lifetime = true;
   new_symbol.get_value().make_false();
   context.move_symbol_to_context(new_symbol);

--- a/src/goto-programs/contracts/contracts.cpp
+++ b/src/goto-programs/contracts/contracts.cpp
@@ -1727,7 +1727,7 @@ expr2tc code_contractst::extract_struct_members_to_temps(
         symbolt temp_symbol;
         temp_symbol.name = temp_id;
         temp_symbol.id = temp_id;
-        temp_symbol.get_type() = migrate_type_back(member.type);
+        set_symbol_type(temp_symbol, member.type);
         temp_symbol.lvalue = true;
         temp_symbol.static_lifetime = false;
         temp_symbol.location = location;
@@ -2142,7 +2142,7 @@ code_contractst::materialize_ptr_field_snapshots(
         symbolt snap_sym_obj;
         snap_sym_obj.name = snap_name;
         snap_sym_obj.id = snap_name;
-        snap_sym_obj.get_type() = migrate_type_back(ftype);
+        set_symbol_type(snap_sym_obj, ftype);
         snap_sym_obj.lvalue = true;
         snap_sym_obj.static_lifetime = false;
         snap_sym_obj.file_local = false;
@@ -2328,7 +2328,7 @@ code_contractst::materialize_ptr_deref_snapshots(
         symbolt snap_obj;
         snap_obj.name = snap_name;
         snap_obj.id = snap_name;
-        snap_obj.get_type() = migrate_type_back(ftype);
+        set_symbol_type(snap_obj, ftype);
         snap_obj.lvalue = true;
         snap_obj.static_lifetime = false;
         snap_obj.file_local = false;
@@ -2366,7 +2366,7 @@ code_contractst::materialize_ptr_deref_snapshots(
       symbolt snap_obj;
       snap_obj.name = snap_name;
       snap_obj.id = snap_name;
-      snap_obj.get_type() = migrate_type_back(pointee);
+      set_symbol_type(snap_obj, pointee);
       snap_obj.lvalue = true;
       snap_obj.static_lifetime = false;
       snap_obj.file_local = false;
@@ -2498,7 +2498,7 @@ code_contractst::materialize_arr_elem_snapshots(
     symbolt j_obj;
     j_obj.name = j_sym_name;
     j_obj.id = j_sym_name;
-    j_obj.get_type() = migrate_type_back(j_type);
+    set_symbol_type(j_obj, j_type);
     j_obj.lvalue = true;
     j_obj.static_lifetime = false;
     j_obj.file_local = false;
@@ -2537,7 +2537,7 @@ code_contractst::materialize_arr_elem_snapshots(
     symbolt snap_obj;
     snap_obj.name = snap_sym_name;
     snap_obj.id = snap_sym_name;
-    snap_obj.get_type() = migrate_type_back(elem_type);
+    set_symbol_type(snap_obj, elem_type);
     snap_obj.lvalue = true;
     snap_obj.static_lifetime = false;
     snap_obj.file_local = false;
@@ -3760,7 +3760,7 @@ void code_contractst::add_pointer_validity_assumptions(
         symbolt harness_sym;
         harness_sym.name = harness_var_name;
         harness_sym.id = harness_var_name;
-        harness_sym.get_type() = migrate_type_back(resolved_type);
+        set_symbol_type(harness_sym, resolved_type);
         harness_sym.lvalue = true;
         harness_sym.static_lifetime = false;
         harness_sym.location = location;

--- a/src/goto-programs/frame_enforcer.cpp
+++ b/src/goto-programs/frame_enforcer.cpp
@@ -359,7 +359,7 @@ expr2tc frame_enforcert::create_snapshot_symbol(
   symbolt snapshot_symbol;
   snapshot_symbol.name = snapshot_name;
   snapshot_symbol.id = snapshot_name;
-  snapshot_symbol.get_type() = migrate_type_back(original->type);
+  set_symbol_type(snapshot_symbol, original->type);
   snapshot_symbol.lvalue = true;
   snapshot_symbol.static_lifetime = false;
   snapshot_symbol.file_local = false;

--- a/src/goto-symex/builtin_functions/cpp_memory.cpp
+++ b/src/goto-symex/builtin_functions/cpp_memory.cpp
@@ -39,7 +39,7 @@ void goto_symext::symex_cpp_new(
                       ? type2tc(array_type2tc(renamedtype2, code.size, false))
                       : renamedtype2;
 
-  symbol.get_type() = migrate_type_back(newtype);
+  set_symbol_type(symbol, newtype);
 
   symbol.get_type().dynamic(true);
 

--- a/src/goto-symex/symex_function.cpp
+++ b/src/goto-symex/symex_function.cpp
@@ -224,7 +224,7 @@ unsigned goto_symext::argument_assignments(
       symbolt symbol;
       symbol.id = identifier;
       symbol.name = "va_arg" + std::to_string(va_count);
-      symbol.get_type() = migrate_type_back((*it1)->type);
+      set_symbol_type(symbol, (*it1)->type);
 
       if (new_context.move(symbol))
       {

--- a/src/goto2c/goto2c_translate.cpp
+++ b/src/goto2c/goto2c_translate.cpp
@@ -92,7 +92,7 @@ goto2ct::translate(std::string function_id, goto_functiont &goto_function)
   // Creating a function symbol
   symbolt fun_sym;
   fun_sym.id = function_id;
-  fun_sym.get_type() = migrate_type_back(goto_function.type);
+  set_symbol_type(fun_sym, goto_function.type);
   // Translating the function declaration
   out << expr2c(code_declt(symbol_expr(fun_sym)), ns) << "\n";
   // Translating the function body

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -541,7 +541,7 @@ expr2tc dereferencet::make_failed_symbol(const type2tc &out_type)
   symbolt symbol;
   symbol.id = "symex::invalid_object" + i2string(invalid_counter++);
   symbol.name = "invalid_object";
-  symbol.get_type() = migrate_type_back(the_type);
+  set_symbol_type(symbol, the_type);
 
   // make it a lvalue, so we can assign to it
   symbol.lvalue = true;

--- a/src/util/migrate.cpp
+++ b/src/util/migrate.cpp
@@ -414,6 +414,13 @@ void migrate_symbol_value(const symbolt &sym, expr2tc &dest)
 #endif
 }
 
+void set_symbol_type(symbolt &sym, const type2tc &t)
+{
+  // Today: back-migrate and store the legacy field. When storage flips to
+  // IREP2-native (S4) only this function changes -- the 14+ callers stay put.
+  sym.get_type() = migrate_type_back(t);
+}
+
 static const typet &decide_on_expr_type(const exprt &side1, const exprt &side2)
 {
   // For some arithmetic expr, decide on the result of operating on them.

--- a/src/util/migrate.h
+++ b/src/util/migrate.h
@@ -34,6 +34,13 @@ type2tc migrate_symbol_type(const symbolt &sym);
 // forward only (see unit/util/migrate.test.cpp); nil values are skipped too.
 void migrate_symbol_value(const symbolt &sym, expr2tc &dest);
 
+// Set a symbol's type from an IREP2 form (esbmc/esbmc#4715, B2 S3). The
+// chokepoint for symbol-type writes: today it back-migrates to the legacy
+// field, but when storage flips to IREP2-native (S4) only this function
+// changes, not its 14+ callers. Replaces the previous round-trip pattern
+// `sym.get_type() = migrate_type_back(t)` at the call sites.
+void set_symbol_type(symbolt &sym, const type2tc &t);
+
 typet migrate_type_back(const type2tc &ref);
 exprt migrate_expr_back(const expr2tc &ref);
 


### PR DESCRIPTION
S3 of the symbol-table migration (#4715). **Stacked on #4727 (S2)** — review/merge that first; this targets the S2 branch and will be rebased to master once S2 lands.

Adds `set_symbol_type()` — the chokepoint for symbol-type **writes** — and migrates the 14 round-trip writer sites of the form `sym.get_type() = migrate_type_back(t)` to use it instead. Today the setter back-migrates and stores the legacy field; at S4 (the native flip) **only this one function changes**, not its 14+ callers.

## Why this matters
This is the value the merged plan called "kills the contracts B6 round-trips": the explicit `migrate_type_back` at every writer is now centralised in one place. The census decreases by 13 in the goto pipeline.

## Touched files
`contracts/contracts.cpp` (8), `frame_enforcer.cpp`, `abstract-interpretation/gcse.cpp`, `add_race_assertions.cpp`, `pointer-analysis/dereference.cpp`, `goto2c/goto2c_translate.cpp`, `goto-symex/symex_function.cpp`, `goto-symex/builtin_functions/cpp_memory.cpp` — plus `util/migrate.{h,cpp}` for the function.

## Validation
- Debug build green; sanity verdicts unchanged on C assert (SUCCESSFUL), C OOB (FAILED), and data-race (SUCCESSFUL).
- Behaviour-preserving by construction: `set_symbol_type(sym, t)` is exactly `sym.get_type() = migrate_type_back(t)`, just centralised.

## Scope note
S3 in the plan also mentioned migrating frontend writers from legacy to IREP2 directly — that is a much larger, per-frontend effort that does not have round-trips to "kill" today (frontends write legacy directly). It can come as separate slices when needed (or naturally with S4s storage flip). This PR delivers the focused B6 round-trip elimination.